### PR TITLE
[libpas] Add AllocationZeroingTests: functional zeroed-reuse tests

### DIFF
--- a/Source/bmalloc/libpas/libpas.xcodeproj/project.pbxproj
+++ b/Source/bmalloc/libpas/libpas.xcodeproj/project.pbxproj
@@ -441,6 +441,7 @@
 		0FDBB07722B877FA006BA5FC /* pas_local_allocator_inlines.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FDBB07622B877FA006BA5FC /* pas_local_allocator_inlines.h */; };
 		0FDBB07922B98054006BA5FC /* pas_segregated_page_config_inlines.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FDBB07822B98054006BA5FC /* pas_segregated_page_config_inlines.h */; };
 		0FDBB07B22BBFF83006BA5FC /* pas_allocator_counts.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FDBB07A22BBFF83006BA5FC /* pas_allocator_counts.h */; };
+		DA5E0A0126010001004CE5AA /* AllocationZeroingTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DA5E0A0026010001004CE5AA /* AllocationZeroingTests.cpp */; };
 		0FDEA461228B651B0085E340 /* BitfieldVectorTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FDEA45D228B651B0085E340 /* BitfieldVectorTests.cpp */; };
 		0FE672B725C21D53006F60A2 /* pas_segregated_exclusive_view_inlines.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FE672B625C21D53006F60A2 /* pas_segregated_exclusive_view_inlines.h */; };
 		0FE672C725C21F67006F60A2 /* pas_segregated_view_allocator_inlines.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FE672C625C21F67006F60A2 /* pas_segregated_view_allocator_inlines.h */; };
@@ -1240,6 +1241,7 @@
 		0FDEA41B228B64320085E340 /* pas_utility_heap_config.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pas_utility_heap_config.h; sourceTree = "<group>"; };
 		0FDEA423228B64330085E340 /* pas_utility_heap_config.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pas_utility_heap_config.c; sourceTree = "<group>"; };
 		0FDEA42B228B64330085E340 /* pas_alignment.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pas_alignment.h; sourceTree = "<group>"; };
+		DA5E0A0026010001004CE5AA /* AllocationZeroingTests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AllocationZeroingTests.cpp; sourceTree = "<group>"; };
 		0FDEA45D228B651B0085E340 /* BitfieldVectorTests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = BitfieldVectorTests.cpp; sourceTree = "<group>"; };
 		0FDEA46D228B65430085E340 /* pas_zero_mode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pas_zero_mode.h; sourceTree = "<group>"; };
 		0FDEA576228E23440085E340 /* pas_simple_type.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pas_simple_type.h; sourceTree = "<group>"; };
@@ -1463,6 +1465,7 @@
 			isa = PBXGroup;
 			children = (
 				BE5700E51A2B3C4D5E6F708E /* xctest */,
+				DA5E0A0026010001004CE5AA /* AllocationZeroingTests.cpp */,
 				0FDEA45D228B651B0085E340 /* BitfieldVectorTests.cpp */,
 				2CE2AE34275A953E00D02BBC /* BitfitTests.cpp */,
 				0F53181022C954ED003F7B6A /* BitvectorTests.cpp */,
@@ -1525,14 +1528,6 @@
 				BB00000006000000000000BB /* bmalloc_heap_utils.h */,
 				2C11E8902728A893002162D0 /* bmalloc_type.c */,
 				2C11E88C2728A783002162D0 /* bmalloc_type.h */,
-				EF8A805F25EECC1C00790B4A /* tagged_bmalloc_heap.c */,
-				EF8A806025EECC1C00790B4A /* tagged_bmalloc_heap.h */,
-				EF8A806125EECC1C00790B4A /* tagged_bmalloc_heap_config.c */,
-				EF8A806225EECC1C00790B4A /* tagged_bmalloc_heap_config.h */,
-				EF8A805E25EECC1C00790B4A /* tagged_bmalloc_heap_inlines.h */,
-				EF8A806425EECC1D00790B4A /* tagged_bmalloc_heap_innards.h */,
-				EB00000002000000000000BB /* tagged_bmalloc_heap_utils.c */,
-				EB00000006000000000000BB /* tagged_bmalloc_heap_utils.h */,
 				0F8A80FE25F6A79500790B4A /* hotbit_heap.c */,
 				0F8A80FF25F6A79500790B4A /* hotbit_heap.h */,
 				0F8A80FB25F6A79500790B4A /* hotbit_heap_config.c */,
@@ -2035,6 +2030,14 @@
 				0F78088822FA534100F37451 /* pas_virtual_range_min_heap.h */,
 				0F99999B26AAAA0000111111 /* pas_zero_memory.h */,
 				0FDEA46D228B65430085E340 /* pas_zero_mode.h */,
+				EF8A805F25EECC1C00790B4A /* tagged_bmalloc_heap.c */,
+				EF8A806025EECC1C00790B4A /* tagged_bmalloc_heap.h */,
+				EF8A806125EECC1C00790B4A /* tagged_bmalloc_heap_config.c */,
+				EF8A806225EECC1C00790B4A /* tagged_bmalloc_heap_config.h */,
+				EF8A805E25EECC1C00790B4A /* tagged_bmalloc_heap_inlines.h */,
+				EF8A806425EECC1D00790B4A /* tagged_bmalloc_heap_innards.h */,
+				EB00000002000000000000BB /* tagged_bmalloc_heap_utils.c */,
+				EB00000006000000000000BB /* tagged_bmalloc_heap_utils.h */,
 				0F8700A225B0A8C2000E1ABF /* thingy_heap.c */,
 				0F8700A325B0A8C2000E1ABF /* thingy_heap.h */,
 				0F8700A425B0A8C2000E1ABF /* thingy_heap_config.c */,
@@ -2152,11 +2155,6 @@
 				0F8A806A25EECC1D00790B4A /* bmalloc_heap_ref.h in Headers */,
 				BB00000005000000000000BB /* bmalloc_heap_utils.h in Headers */,
 				2C11E88E2728A783002162D0 /* bmalloc_type.h in Headers */,
-				EF8A806725EECC1D00790B4A /* tagged_bmalloc_heap.h in Headers */,
-				EF8A806925EECC1D00790B4A /* tagged_bmalloc_heap_config.h in Headers */,
-				EF8A806525EECC1D00790B4A /* tagged_bmalloc_heap_inlines.h in Headers */,
-				EF8A806B25EECC1D00790B4A /* tagged_bmalloc_heap_innards.h in Headers */,
-				EB00000005000000000000BB /* tagged_bmalloc_heap_utils.h in Headers */,
 				0F8A810525F6A79500790B4A /* hotbit_heap.h in Headers */,
 				0F8A810325F6A79500790B4A /* hotbit_heap_config.h in Headers */,
 				0F8A810625F6A79500790B4A /* hotbit_heap_inlines.h in Headers */,
@@ -2503,6 +2501,11 @@
 				0F78088422FA22D200F37451 /* pas_virtual_range.h in Headers */,
 				0F78088E22FA534100F37451 /* pas_virtual_range_min_heap.h in Headers */,
 				0FE7EE3B22960142004F4166 /* pas_zero_mode.h in Headers */,
+				EF8A806725EECC1D00790B4A /* tagged_bmalloc_heap.h in Headers */,
+				EF8A806925EECC1D00790B4A /* tagged_bmalloc_heap_config.h in Headers */,
+				EF8A806525EECC1D00790B4A /* tagged_bmalloc_heap_inlines.h in Headers */,
+				EF8A806B25EECC1D00790B4A /* tagged_bmalloc_heap_innards.h in Headers */,
+				EB00000005000000000000BB /* tagged_bmalloc_heap_utils.h in Headers */,
 				0F8700A825B0A8C2000E1ABF /* thingy_heap.h in Headers */,
 				0F8700AA25B0A8C3000E1ABF /* thingy_heap_config.h in Headers */,
 				0F8700A625B0A8C2000E1ABF /* thingy_heap_prefix.h in Headers */,
@@ -2780,6 +2783,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DA5E0A0126010001004CE5AA /* AllocationZeroingTests.cpp in Sources */,
 				0FDEA461228B651B0085E340 /* BitfieldVectorTests.cpp in Sources */,
 				2CE2AE35275A953E00D02BBC /* BitfitTests.cpp in Sources */,
 				0F53181122C954ED003F7B6A /* BitvectorTests.cpp in Sources */,
@@ -2829,9 +2833,6 @@
 				AA00000005000000000000AA /* bmalloc_heap_iso.c in Sources */,
 				BB00000001000000000000BB /* bmalloc_heap_utils.c in Sources */,
 				2C11E8912728A893002162D0 /* bmalloc_type.c in Sources */,
-				EF8A806625EECC1D00790B4A /* tagged_bmalloc_heap.c in Sources */,
-				EF8A806825EECC1D00790B4A /* tagged_bmalloc_heap_config.c in Sources */,
-				EB00000001000000000000BB /* tagged_bmalloc_heap_utils.c in Sources */,
 				0F8A810425F6A79500790B4A /* hotbit_heap.c in Sources */,
 				0F8A810125F6A79500790B4A /* hotbit_heap_config.c in Sources */,
 				0FE7EE76229F010F004F4166 /* iso_heap.c in Sources */,
@@ -2978,6 +2979,9 @@
 				0FE7EDD822960142004F4166 /* pas_utils.c in Sources */,
 				0F9A1CFD2559961700C8D11B /* pas_versioned_field.c in Sources */,
 				0F78088522FA22D200F37451 /* pas_virtual_range.c in Sources */,
+				EF8A806625EECC1D00790B4A /* tagged_bmalloc_heap.c in Sources */,
+				EF8A806825EECC1D00790B4A /* tagged_bmalloc_heap_config.c in Sources */,
+				EB00000001000000000000BB /* tagged_bmalloc_heap_utils.c in Sources */,
 				0F8700A725B0A8C2000E1ABF /* thingy_heap.c in Sources */,
 				0F8700A925B0A8C3000E1ABF /* thingy_heap_config.c in Sources */,
 			);

--- a/Source/bmalloc/libpas/src/test/AllocationZeroingTests.cpp
+++ b/Source/bmalloc/libpas/src/test/AllocationZeroingTests.cpp
@@ -1,0 +1,355 @@
+/*
+ * Copyright (c) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "TestHarness.h"
+
+#include "bmalloc_heap.h"
+#include "bmalloc_heap_config.h"
+#include "pas_internal_config.h"
+#include "tagged_bmalloc_heap.h"
+#include <cstdint>
+#include <vector>
+
+#if PAS_ENABLE_BMALLOC
+
+namespace {
+
+// The bmalloc heap's minimum alignment for small objects, and hence its
+// smallest object size (16 bytes).
+constexpr size_t bmallocMinAlign = static_cast<size_t>(1) << BMALLOC_MINALIGN_SHIFT;
+
+// The size at and above which zeroing switches from memset to the large-heap
+// virtual-memory path.
+constexpr size_t vaZeroThreshold = static_cast<size_t>(1) << PAS_VA_BASED_ZERO_MEMORY_SHIFT;
+
+// Interior sample sizes are taken as a page divided by a small factor, so they
+// fall a fraction of the way into a page-based regime rather than on a boundary,
+// and track the page constants if a config changes. A larger factor gives a
+// smaller object (more per page); pageFractionDivisor is the usual choice.
+constexpr size_t pageFractionDivisor = 16;
+
+// Half of pageFractionDivisor, i.e. twice the sample size, used where the usual
+// fraction would coincide with another size already covered in the same group.
+constexpr size_t coarsePageFractionDivisor = pageFractionDivisor / 2;
+
+// A small, deliberately non-aligned amount (odd and below bmallocMinAlign) added
+// to interior page-fraction samples so the requested size is not a multiple of
+// the allocation quantum. The zeroed path zeroes exactly the requested size, so
+// a non-aligned size lets the whole-buffer check catch a regression that rounded
+// the zeroing length down to an alignment or page boundary; a round size would
+// mask it. Boundary and regime-max samples stay exact.
+constexpr size_t oddSizeDelta = bmallocMinAlign - 1;
+
+// Fill the buffer with a non-zero, offset-varying pattern so that any byte left
+// behind by a later allocation is detectable.
+void dirtyBuffer(void* ptr, size_t size)
+{
+    uint8_t* bytes = static_cast<uint8_t*>(ptr);
+    for (size_t i = 0; i < size; ++i)
+        bytes[i] = static_cast<uint8_t>(0x80 | (i & 0x7f));
+}
+
+// Return the offset of the first non-zero byte, or size if every byte is zero.
+size_t firstNonZeroByte(const void* ptr, size_t size)
+{
+    const uint8_t* bytes = static_cast<const uint8_t*>(ptr);
+    for (size_t offset = 0; offset < size; ++offset) {
+        if (bytes[offset])
+            return offset;
+    }
+    return size;
+}
+
+// The two axes varied below, in addition to size and alignment. Untagged vs
+// tagged selects the two families of zeroed entry points. Plain vs
+// with-alignment selects entry points that take different internal paths even
+// when the requested alignment is the natural minimum.
+enum class HeapVariant { Untagged, Tagged };
+enum class AlignmentApi { Plain, WithAlignment };
+
+// Whether reuse goes straight through (WithoutScavenge) or forces a synchronous
+// scavenge between free and reuse, so the region is decommitted and must be
+// recommitted to serve the second allocation (WithScavenge). Unlike the axes
+// above, this is chosen once per test rather than varied within a run.
+enum class Reuse { WithoutScavenge, WithScavenge };
+
+const char* variantName(HeapVariant variant)
+{
+    return variant == HeapVariant::Tagged ? "tagged" : "untagged";
+}
+
+const char* alignmentApiName(AlignmentApi api)
+{
+    return api == AlignmentApi::WithAlignment ? "with-alignment" : "plain";
+}
+
+void* allocateZeroed(HeapVariant variant, AlignmentApi api, size_t size, size_t alignment)
+{
+    switch (variant) {
+    case HeapVariant::Untagged:
+        if (api == AlignmentApi::WithAlignment)
+            return bmalloc_try_allocate_zeroed_with_alignment(size, alignment, pas_non_compact_allocation_mode);
+        return bmalloc_try_allocate_zeroed(size, pas_non_compact_allocation_mode);
+    case HeapVariant::Tagged:
+        if (api == AlignmentApi::WithAlignment)
+            return tagged_bmalloc_try_allocate_zeroed_with_alignment(size, alignment);
+        return tagged_bmalloc_try_allocate_zeroed(size);
+    }
+    CHECK(!"Invalid variant");
+    return nullptr;
+}
+
+void deallocateVariant(HeapVariant variant, void* ptr)
+{
+    if (variant == HeapVariant::Tagged)
+        tagged_bmalloc_deallocate(ptr);
+    else
+        bmalloc_deallocate(ptr);
+}
+
+// Print the parameters that identify a failing case, so a zero-check or
+// alignment failure points at the exact size/alignment/variant/phase.
+void reportParameters(HeapVariant variant, AlignmentApi api, size_t size, size_t alignment, const char* phase)
+{
+    std::cout << "  params: variant=" << variantName(variant) << " api=" << alignmentApiName(api)
+              << " size=" << size << " alignment=" << alignment << " phase=" << phase << std::endl;
+}
+
+// Require every byte to be zero, reporting the identifying parameters and the
+// first offending offset/value on failure.
+void checkIsZeroed(const void* ptr, size_t size, HeapVariant variant, AlignmentApi api,
+                   size_t alignment, const char* phase)
+{
+    size_t offset = firstNonZeroByte(ptr, size);
+    if (offset < size) {
+        const uint8_t* bytes = static_cast<const uint8_t*>(ptr);
+        reportParameters(variant, api, size, alignment, phase);
+        std::cout << "  first non-zero byte at offset " << offset << " is 0x" << std::hex
+                  << static_cast<unsigned>(bytes[offset]) << std::dec << "." << std::endl;
+    }
+    CHECK_EQUAL(offset, size);
+}
+
+void checkIsAligned(const void* ptr, size_t size, HeapVariant variant, AlignmentApi api,
+                    size_t alignment, const char* phase)
+{
+    uintptr_t address = reinterpret_cast<uintptr_t>(ptr);
+    if (address % alignment)
+        reportParameters(variant, api, size, alignment, phase);
+    CHECK_EQUAL(address % alignment, static_cast<uintptr_t>(0));
+}
+
+// One case of the run: zeroed-alloc, verify zero (and alignment), dirty, free,
+// then zeroed-alloc the same size again and verify the reused region is zero.
+// With Reuse::WithScavenge, a synchronous scavenge runs after the free so the
+// region is decommitted and the reuse must go through recommit rather than a
+// straight free-list handback.
+void zeroingReuse(HeapVariant variant, AlignmentApi api, size_t size, size_t alignment,
+                  Reuse reuse)
+{
+    void* first = allocateZeroed(variant, api, size, alignment);
+    if (!first)
+        reportParameters(variant, api, size, alignment, "fresh");
+    CHECK(first);
+    checkIsZeroed(first, size, variant, api, alignment, "fresh");
+    if (api == AlignmentApi::WithAlignment)
+        checkIsAligned(first, size, variant, api, alignment, "fresh");
+
+    dirtyBuffer(first, size);
+    deallocateVariant(variant, first);
+
+    // Force the just-freed region to be decommitted (its physical pages returned
+    // to the OS) before reuse, so the second allocation must recommit and
+    // re-fault -- and hence re-zero -- those pages instead of reusing them
+    // straight off a free list. Decommit does not zero on its own, so a correct
+    // result depends entirely on the allocator re-zeroing.
+    if (reuse == Reuse::WithScavenge)
+        pas_scavenger_run_synchronously_now();
+
+    void* second = allocateZeroed(variant, api, size, alignment);
+    if (!second)
+        reportParameters(variant, api, size, alignment, "reused");
+    CHECK(second);
+    // Same-size reuse from the large heap returns the same region, so a
+    // different region here means the re-zeroing did not act on the dirtied
+    // backing. Smaller regimes legitimately hand back a different free-list entry,
+    // so only the large-heap sizes make this worth noting.
+    if (size >= vaZeroThreshold && second != first) {
+        std::cout << "Note: reuse returned a different region for size " << size
+                  << "; dirtied-backing reuse not exercised." << std::endl;
+    }
+    checkIsZeroed(second, size, variant, api, alignment, "reused");
+    if (api == AlignmentApi::WithAlignment)
+        checkIsAligned(second, size, variant, api, alignment, "reused");
+
+    deallocateVariant(variant, second);
+}
+
+// Run zeroingReuse across both heap variants and both alignment-API forms,
+// for each requested size. The plain form runs once per size at the natural
+// minimum alignment; the with-alignment form runs across a range of alignments.
+// The background scavenger is suspended so the reuse path is deterministic: a
+// WithoutScavenge case reuses its still-committed region, and a WithScavenge case
+// decommits only at the forced scavenge, not at some unpredictable
+// background point.
+void runZeroingReuse(const std::vector<size_t>& sizes, Reuse reuse = Reuse::WithoutScavenge)
+{
+    pas_scavenger_suspend();
+
+    static const HeapVariant variants[] = { HeapVariant::Untagged, HeapVariant::Tagged };
+    static const size_t alignments[] = { 16, 512, 4096, 16384 };
+
+    for (HeapVariant variant : variants) {
+        for (size_t size : sizes) {
+            zeroingReuse(variant, AlignmentApi::Plain, size, bmallocMinAlign, reuse);
+            for (size_t alignment : alignments)
+                zeroingReuse(variant, AlignmentApi::WithAlignment, size, alignment, reuse);
+        }
+    }
+}
+
+// The size groups below sample every regime of the zeroed-malloc path. Sizes
+// are derived from the config's page-size and threshold constants rather than
+// hard-coded, so the run keeps hitting the interesting boundaries if a config
+// changes. The subsystem for a given size is chosen by the runtime config, but
+// these ranges are representative: a size at a fraction of a page lands inside
+// that page's subsystem, and one near page/PAS_MIN_OBJECTS_PER_PAGE sits near
+// that subsystem's largest object. Segregated and bitfit pages both zero via
+// memset, the large heap zeroes via memset below the virtual-memory threshold,
+// and via the virtual-memory path at and above it.
+
+std::vector<size_t> segregatedRegimeSizes()
+{
+    // Small- and medium-segregated pages (memset), starting at the smallest
+    // object the heap serves and climbing toward each subsystem's largest object
+    // at page/PAS_MIN_OBJECTS_PER_PAGE.
+    return {
+        bmallocMinAlign,
+        PAS_SMALL_PAGE_DEFAULT_SIZE / pageFractionDivisor + oddSizeDelta,
+        PAS_SMALL_PAGE_DEFAULT_SIZE / PAS_MIN_OBJECTS_PER_PAGE,
+        PAS_MEDIUM_PAGE_DEFAULT_SIZE / pageFractionDivisor + oddSizeDelta,
+        PAS_MEDIUM_PAGE_DEFAULT_SIZE / PAS_MIN_OBJECTS_PER_PAGE,
+    };
+}
+
+std::vector<size_t> bitfitRegimeSizes()
+{
+    // Medium-bitfit and marge-bitfit pages (memset). The first size exceeds the
+    // medium-segregated max object, so it rolls into bitfit; the tagged ceiling
+    // is included because it is where the tagged variant stops using the
+    // MTE-taggable path.
+    return {
+        PAS_SMALL_PAGE_DEFAULT_SIZE,
+        PAS_MAX_MTE_TAGGABLE_OBJECT_SIZE,
+        // Coarser fraction here: the usual one would equal the tagged ceiling above.
+        PAS_MEDIUM_BITFIT_PAGE_DEFAULT_SIZE / coarsePageFractionDivisor + oddSizeDelta,
+        PAS_MARGE_PAGE_DEFAULT_SIZE / pageFractionDivisor + oddSizeDelta,
+    };
+}
+
+std::vector<size_t> largeMemsetRegimeSizes()
+{
+    // Large heap below the virtual-memory threshold (memset): a size past the
+    // marge-bitfit max object, and one just below the threshold.
+    return {
+        PAS_MEDIUM_BITFIT_PAGE_DEFAULT_SIZE,
+        vaZeroThreshold - PAS_SMALL_PAGE_DEFAULT_SIZE,
+    };
+}
+
+std::vector<size_t> largeVirtualMemoryRegimeSizes()
+{
+    // Large heap around the virtual-memory threshold: one size just below (still
+    // memset) to bracket the boundary, the threshold itself and just above (both
+    // virtual-memory zeroing), and a multi-megabyte object.
+    return {
+        vaZeroThreshold - bmallocMinAlign,
+        vaZeroThreshold,
+        vaZeroThreshold + bmallocMinAlign,
+        4 * vaZeroThreshold,
+    };
+}
+
+void testZeroingReuseSegregatedSizes()
+{
+    runZeroingReuse(segregatedRegimeSizes());
+}
+
+void testZeroingReuseBitfitSizes()
+{
+    runZeroingReuse(bitfitRegimeSizes());
+}
+
+void testZeroingReuseLargeMemsetSizes()
+{
+    runZeroingReuse(largeMemsetRegimeSizes());
+}
+
+void testZeroingReuseLargeVirtualMemorySizes()
+{
+    runZeroingReuse(largeVirtualMemoryRegimeSizes());
+}
+
+// Same reuse check, but forcing a synchronous scavenge between free and reuse so
+// the region is decommitted and must be recommitted (and re-zeroed) to serve the
+// second allocation. This exercises the decommit/recommit reuse path across the
+// same regimes.
+void testZeroingReuseWithScavengeSegregatedSizes()
+{
+    runZeroingReuse(segregatedRegimeSizes(), Reuse::WithScavenge);
+}
+
+void testZeroingReuseWithScavengeBitfitSizes()
+{
+    runZeroingReuse(bitfitRegimeSizes(), Reuse::WithScavenge);
+}
+
+void testZeroingReuseWithScavengeLargeMemsetSizes()
+{
+    runZeroingReuse(largeMemsetRegimeSizes(), Reuse::WithScavenge);
+}
+
+void testZeroingReuseWithScavengeLargeVirtualMemorySizes()
+{
+    runZeroingReuse(largeVirtualMemoryRegimeSizes(), Reuse::WithScavenge);
+}
+
+} // anonymous namespace
+
+#endif // PAS_ENABLE_BMALLOC
+
+void addAllocationZeroingTests()
+{
+#if PAS_ENABLE_BMALLOC
+    ADD_TEST(testZeroingReuseSegregatedSizes());
+    ADD_TEST(testZeroingReuseBitfitSizes());
+    ADD_TEST(testZeroingReuseLargeMemsetSizes());
+    ADD_TEST(testZeroingReuseLargeVirtualMemorySizes());
+    ADD_TEST(testZeroingReuseWithScavengeSegregatedSizes());
+    ADD_TEST(testZeroingReuseWithScavengeBitfitSizes());
+    ADD_TEST(testZeroingReuseWithScavengeLargeMemsetSizes());
+    ADD_TEST(testZeroingReuseWithScavengeLargeVirtualMemorySizes());
+#endif // PAS_ENABLE_BMALLOC
+}

--- a/Source/bmalloc/libpas/src/test/TestHarness.cpp
+++ b/Source/bmalloc/libpas/src/test/TestHarness.cpp
@@ -360,6 +360,7 @@ int childSuccessReportingPipe = -1;
 
 } // anonymous namespace
 
+void addAllocationZeroingTests();
 void addBitfieldVectorTests();
 void addBitfitTests();
 void addBitvectorTests();
@@ -855,6 +856,7 @@ int main(int argc, char** argv)
     ADD_SUITE(ThingyAndUtilityHeapAllocation);
 
     // Run the rest of the tests in alphabetical order.
+    ADD_SUITE(AllocationZeroing);
     ADD_SUITE(BitfieldVector);
     ADD_SUITE(Bitfit);
     ADD_SUITE(Bitvector);

--- a/Source/bmalloc/libpas/src/test/xctest/LibpasTests.mm
+++ b/Source/bmalloc/libpas/src/test/xctest/LibpasTests.mm
@@ -188,6 +188,7 @@
 // to track down failures.
 LIBPAS_SUITE(ThingyAndUtilityHeapAllocation_WithVerifier, "ThingyAndUtilityHeapAllocation/install-verifier", 0)
 LIBPAS_SUITE(ThingyAndUtilityHeapAllocation_SansVerifier, "ThingyAndUtilityHeapAllocation/no-verifier", 0)
+SIMPLE_LIBPAS_SUITE(AllocationZeroing)
 SIMPLE_LIBPAS_SUITE(BitfieldVector)
 SIMPLE_LIBPAS_SUITE(Bitfit)
 SIMPLE_LIBPAS_SUITE(Bitvector)


### PR DESCRIPTION
#### ca5e69e829722666caa292025996d15c3fa077aa
<pre>
[libpas] Add AllocationZeroingTests: functional zeroed-reuse tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=319599">https://bugs.webkit.org/show_bug.cgi?id=319599</a>
<a href="https://rdar.apple.com/182424502">rdar://182424502</a>

Reviewed by Marcus Plutowski.

Add a functional test file that drives the real bmalloc public zeroing API
end to end and verifies the zeroed allocation path always returns
fully-zeroed memory, including when a freed region is reused.

Each case does zeroed-alloc / verify-zero / dirty / free /
reallocate-same-size / verify-zero, run across several axes:

- Size: representative points for every regime of the zeroed-malloc path --
    small- and medium-segregated, medium- and marge-bitfit, and the large
    heap&apos;s memset and virtual-memory zeroing paths. Sizes are derived from
    the config&apos;s page-size and threshold constants, so the run keeps hitting
    the interesting boundaries if a config changes.
- Alignment: the natural minimum plus a range of explicit alignments.
- Variant: the untagged and tagged zeroed entry points.
- Reuse: both immediate free-list reuse and forced decommit/recommit (a
    synchronous scavenge between free and reuse).

Registers the suite in TestHarness.cpp, the Xcode project, and the xctest
suite list.

Test: Source/bmalloc/libpas/src/test/AllocationZeroingTests.cpp

* Source/bmalloc/libpas/libpas.xcodeproj/project.pbxproj:
* Source/bmalloc/libpas/src/test/AllocationZeroingTests.cpp: Added.
(std::dirtyBuffer):
(std::firstNonZeroByte):
(std::variantName):
(std::alignmentApiName):
(std::allocateZeroed):
(std::deallocateVariant):
(std::reportParameters):
(std::checkIsZeroed):
(std::checkIsAligned):
(std::zeroingReuse):
(std::runZeroingReuse):
(std::segregatedRegimeSizes):
(std::bitfitRegimeSizes):
(std::largeMemsetRegimeSizes):
(std::largeVirtualMemoryRegimeSizes):
(std::testZeroingReuseSegregatedSizes):
(std::testZeroingReuseBitfitSizes):
(std::testZeroingReuseLargeMemsetSizes):
(std::testZeroingReuseLargeVirtualMemorySizes):
(std::testZeroingReuseWithScavengeSegregatedSizes):
(std::testZeroingReuseWithScavengeBitfitSizes):
(std::testZeroingReuseWithScavengeLargeMemsetSizes):
(std::testZeroingReuseWithScavengeLargeVirtualMemorySizes):
(addAllocationZeroingTests):
* Source/bmalloc/libpas/src/test/TestHarness.cpp:
(main):
* Source/bmalloc/libpas/src/test/xctest/LibpasTests.mm:

Canonical link: <a href="https://commits.webkit.org/317336@main">https://commits.webkit.org/317336@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/781a454f75cf0bf4cf4b12c33372a17c7ce1795a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175008 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48941 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42722 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184589 "Built successfully") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132916 "Failed to checkout and rebase branch from PR 69576") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/82e9bde2-3560-4cc5-a6bf-9da636fe6eee) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50233 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48624 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/136207 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/132916 "Failed to checkout and rebase branch from PR 69576") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2d2f073f-78ad-4790-9f5e-257bdf953ce2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177966 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39646 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156998 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116686 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/48137577-aa3a-47ba-8525-68f5ffa292d9) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38287 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/36670 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33066 "Built successfully") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/218/builds/5507 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148710 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36490 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187013 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/36270 "Built successfully and passed tests") | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/40872 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145146 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48608 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145003 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49288 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/33111 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115106 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26586 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39869 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/212100 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47794 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11463 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/55320 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47197 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47427 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47254 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->