### PR TITLE
[MSE] Don't evict playable data across gaps small enough to bridge during playback

### DIFF
--- a/LayoutTests/media/media-source/media-source-evict-ignorable-gap-expected.txt
+++ b/LayoutTests/media/media-source/media-source-evict-ignorable-gap-expected.txt
@@ -1,0 +1,21 @@
+This tests that memory-pressure eviction keeps a playable segment spanning a gap small enough to be ignored during playback, while still evicting data located after that segment.
+RUN(video.src = URL.createObjectURL(source))
+RUN(video.disableRemotePlayback = true)
+EVENT(sourceopen)
+RUN(sourceBuffer = source.addSourceBuffer("video/mock; codecs=mock"))
+RUN(initSegment = makeAInit(20, [makeATrack(1, 'mock', TRACK_KIND.VIDEO)]))
+RUN(sourceBuffer.appendBuffer(initSegment))
+EVENT(updateend)
+RUN(sourceBuffer.appendBuffer(samplesBetween(0, 2000, 1)))
+EVENT(updateend)
+RUN(sourceBuffer.appendBuffer(samplesBetween(2100, 5000, 1)))
+EVENT(updateend)
+RUN(sourceBuffer.appendBuffer(samplesBetween(10000, 12000, 1)))
+EVENT(updateend)
+EXPECTED (bufferedRanges() == '[ 0...2, 2.1...5, 10...12 ]') OK
+RUN(internals.beginSimulatedMemoryPressure())
+EVENT(bufferedchange)
+RUN(internals.endSimulatedMemoryPressure())
+EXPECTED (bufferedRanges() == '[ 0...2, 2.1...5 ]') OK
+END OF TEST
+

--- a/LayoutTests/media/media-source/media-source-evict-ignorable-gap.html
+++ b/LayoutTests/media/media-source/media-source-evict-ignorable-gap.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ ManagedMediaSourceEnabled=true MediaSourceEnabled=true ] -->
+<html>
+<head>
+    <title>media-source-evict-ignorable-gap</title>
+    <script src="mock-media-source.js"></script>
+    <script src="../../media/video-test.js"></script>
+    <script src="../../media/utilities.js"></script>
+    <script>
+    var source;
+    var sourceBuffer;
+    var initSegment;
+
+    if (window.internals)
+        internals.initializeMockMediaSource();
+
+    // Samples every 100 ms, each 100 ms long, on trackID.
+    function samplesBetween(startMs, endMs, trackID) {
+        var samples = [];
+        for (var pts = startMs; pts < endMs; pts += 100)
+            samples.push(makeASample(pts, pts, 100, 1000, trackID, SAMPLE_FLAG.SYNC));
+        return concatenateSamples(samples);
+    }
+
+    function bufferedRanges() {
+        var str = '[ ';
+        var ranges = sourceBuffer.buffered;
+        for (var i = 0; i < ranges.length; i++) {
+            if (i)
+                str += ', ';
+            str += ranges.start(i) + '...' + ranges.end(i);
+        }
+        return str + ' ]';
+    }
+
+    window.addEventListener('load', async event => {
+        findMediaElement();
+
+        source = new ManagedMediaSource();
+        run('video.src = URL.createObjectURL(source)');
+        run('video.disableRemotePlayback = true');
+        await waitFor(source, 'sourceopen');
+        waitFor(video, 'error').then(failTest);
+
+        run('sourceBuffer = source.addSourceBuffer("video/mock; codecs=mock")');
+        run("initSegment = makeAInit(20, [makeATrack(1, 'mock', TRACK_KIND.VIDEO)])");
+        run('sourceBuffer.appendBuffer(initSegment)');
+        await waitFor(sourceBuffer, 'updateend');
+
+        // Keep the buffer large enough that appending never triggers eviction.
+        await internals.setMaximumSourceBufferSize(sourceBuffer, 1024 * 1024);
+
+        // [0, 2] then a 100 ms gap (< 125 ms mid-stream tolerance, bridged by
+        // playback) then [2.1, 5]: a single playable segment from currentTime.
+        // Then a 5 s real gap and [10, 12]: a segment after the playable range.
+        run('sourceBuffer.appendBuffer(samplesBetween(0, 2000, 1))');
+        await waitFor(sourceBuffer, 'updateend');
+        run('sourceBuffer.appendBuffer(samplesBetween(2100, 5000, 1))');
+        await waitFor(sourceBuffer, 'updateend');
+        run('sourceBuffer.appendBuffer(samplesBetween(10000, 12000, 1))');
+        await waitFor(sourceBuffer, 'updateend');
+
+        testExpected('bufferedRanges()', '[ 0...2, 2.1...5, 10...12 ]');
+
+        // currentTime = 0 sits in the bridged playable segment [0, 5].
+        run('internals.beginSimulatedMemoryPressure()');
+        await waitFor(sourceBuffer, 'bufferedchange');
+        run('internals.endSimulatedMemoryPressure()');
+
+        // The after-gap segment [10, 12] is evicted; the playable segment
+        // (both sub-ranges bridged by the 100 ms gap) is retained, not truncated.
+        testExpected('bufferedRanges()', '[ 0...2, 2.1...5 ]');
+
+        endTest();
+    });
+    </script>
+</head>
+<body>
+    This tests that memory-pressure eviction keeps a playable segment spanning a gap small enough to be ignored during playback, while still evicting data located after that segment.
+    <video controls></video>
+</body>
+</html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1810,6 +1810,7 @@ media/media-source/media-managedmse-memorypressure.html [ Timeout ]
 media/media-source/media-managedmse-memorypressure-inactive.html [ Timeout ]
 media/media-source/media-managedmse-eviction.html [ Timeout ]
 media/media-source/media-source-evict-invalid-time-crash.html [ Timeout ]
+media/media-source/media-source-evict-ignorable-gap.html [ Skip ]
 
 webkit.org/b/211995 fast/images/animated-image-mp4.html [ Timeout ]
 

--- a/Source/WebCore/platform/graphics/MediaSourcePrivate.cpp
+++ b/Source/WebCore/platform/graphics/MediaSourcePrivate.cpp
@@ -625,8 +625,12 @@ void MediaSourcePrivate::shutdown()
 
 MediaTime MediaSourcePrivate::nextStallTime(const MediaTime& currentTime) const
 {
+    return nextStallTime(currentTime, buffered());
+}
+
+MediaTime MediaSourcePrivate::nextStallTime(const MediaTime& currentTime, const PlatformTimeRanges& ranges) const
+{
     auto stallAtTime = duration();
-    auto ranges = buffered();
     size_t index = ranges.find(currentTime);
     if (index == notFound)
         return stallAtTime;

--- a/Source/WebCore/platform/graphics/MediaSourcePrivate.h
+++ b/Source/WebCore/platform/graphics/MediaSourcePrivate.h
@@ -164,7 +164,14 @@ public:
     bool isBuffered(const PlatformTimeRanges&) const;
     PlatformTimeRanges seekable() const;
 
+    // Returns the time at which playback starting from currentTime would first
+    // stall: walk forward from the range containing currentTime, bridging gaps
+    // within the gap policy, stopping at the first larger gap (or media end).
+    // The overload taking ranges lets callers (e.g. per-SourceBuffer coded frame
+    // eviction) evaluate the stall against their own buffered ranges rather than
+    // the cross-SourceBuffer intersection.
     MediaTime nextStallTime(const MediaTime& currentTime) const;
+    MediaTime nextStallTime(const MediaTime& currentTime, const PlatformTimeRanges&) const;
     bool hasBufferedData() const;
     bool hasCurrentTime() const;
     bool hasFutureTime() const;

--- a/Source/WebCore/platform/graphics/SourceBufferPrivate.cpp
+++ b/Source/WebCore/platform/graphics/SourceBufferPrivate.cpp
@@ -639,25 +639,20 @@ void SourceBufferPrivate::computeEvictionData(ComputeEvictionDataRule rule)
             if (!buffered.length())
                 return evictableSize;
 
-            // We can evict everything from currentTime+timeChunk (3s) to the end of the buffer, not contiguous in current range.
-            auto rangeStartAfterCurrentTime = currentTime + timeChunk;
+            // Playback bridges gaps within the media source gap policy, so only
+            // data located after the current playable segment is evictable. That
+            // segment ends at the next real stall (nextStallTime evaluated against
+            // this SourceBuffer's ranges).
+            // When currentTime is not buffered here there is no playable segment,
+            // so keep currentTime + timeChunk of look-ahead.
+            const bool currentTimeBuffered = buffered.contain(currentTime);
+            const MediaTime currentPlayableEnd = currentTimeBuffered ? mediaSource->nextStallTime(currentTime, buffered) : MediaTime::invalidTime();
+            const auto rangeStartAfterCurrentTime = currentTimeBuffered ? currentPlayableEnd : currentTime + timeChunk;
             const auto rangeEndAfterCurrentTime = buffered.maximumBufferedTime();
             ASSERT(rangeEndAfterCurrentTime.isValid());
 
             if (rangeStartAfterCurrentTime >= rangeEndAfterCurrentTime)
                 return evictableSize;
-
-            // Do not evict data from the time range that contains currentTime.
-            size_t currentTimeRange = buffered.find(currentTime);
-            size_t startTimeRange = buffered.find(rangeStartAfterCurrentTime);
-            if (currentTimeRange != notFound && startTimeRange == currentTimeRange) {
-                currentTimeRange++;
-                if (currentTimeRange == buffered.length())
-                    return evictableSize;
-                rangeStartAfterCurrentTime = buffered.start(currentTimeRange);
-                if (rangeStartAfterCurrentTime >= rangeEndAfterCurrentTime)
-                    return evictableSize;
-            }
 
             iterateTrackBuffers([&](auto& trackBuffer) {
                 evictableSize += trackBuffer.codedFramesIntervalSize(rangeStartAfterCurrentTime, rangeEndAfterCurrentTime);
@@ -1789,16 +1784,27 @@ bool SourceBufferPrivate::evictFrames(uint64_t newDataSize, const MediaTime& cur
     if (!isBufferFull)
         return false;
 
+    RefPtr mediaSource = m_mediaSource.get();
+
     timeChunkAsMilliseconds = evictionAlgorithmInitialTimeChunk;
     do {
         const auto timeChunk = MediaTime(timeChunkAsMilliseconds, 1000);
-        const auto minimumRangeStartAfterCurrentTime = currentTime + timeChunk;
 
         do {
             PlatformTimeRanges buffered { currentTime, MediaTime::positiveInfiniteTime() };
             iterateTrackBuffers([&](const TrackBuffer& trackBuffer) {
                 buffered.intersectWith(trackBuffer.buffered());
             });
+
+            // Playback bridges gaps within the media source gap policy, so only
+            // data located after the current playable segment is evictable. That
+            // segment ends at the next real stall (nextStallTime evaluated against
+            // this SourceBuffer's ranges).
+            // When currentTime is not buffered here there is no playable segment,
+            // so keep currentTime + timeChunk of look-ahead.
+            const bool currentTimeBuffered = mediaSource && buffered.contain(currentTime);
+            const MediaTime currentPlayableEnd = currentTimeBuffered ? mediaSource->nextStallTime(currentTime, buffered) : MediaTime::invalidTime();
+            const auto minimumRangeStartAfterCurrentTime = currentTimeBuffered ? currentPlayableEnd : currentTime + timeChunk;
 
             auto rangeEndAfterCurrentTime = buffered.maximumBufferedTime();
             if (!buffered.length())
@@ -1812,18 +1818,6 @@ bool SourceBufferPrivate::evictFrames(uint64_t newDataSize, const MediaTime& cur
 
             if (rangeStartAfterCurrentTime >= rangeEndAfterCurrentTime)
                 break;
-
-            // Do not evict data from the time range that contains currentTime.
-            size_t currentTimeRange = buffered.find(currentTime);
-            size_t startTimeRange = buffered.find(rangeStartAfterCurrentTime);
-            if (currentTimeRange != notFound && startTimeRange == currentTimeRange) {
-                currentTimeRange++;
-                if (currentTimeRange == buffered.length())
-                    break;
-                rangeStartAfterCurrentTime = buffered.start(currentTimeRange);
-                if (rangeStartAfterCurrentTime >= rangeEndAfterCurrentTime)
-                    break;
-            }
 
             // 4. For each range in removal ranges, run the coded frame removal algorithm with start and
             // end equal to the removal range start and end timestamp respectively.


### PR DESCRIPTION
#### 26464484bd534565e631ce3ea7e9ac56dae1138a
<pre>
[MSE] Don&apos;t evict playable data across gaps small enough to bridge during playback
<a href="https://bugs.webkit.org/show_bug.cgi?id=319584">https://bugs.webkit.org/show_bug.cgi?id=319584</a>
<a href="https://rdar.apple.com/182414037">rdar://182414037</a>

Reviewed by Jer Noble.

The coded frame eviction algorithm (phase 2, past currentTime) protected the
buffered segment the playhead was in and only evicted data after it. It worked
out that segment with a raw TimeRanges::find(), which treated every sub-range
boundary as the end of the segment.

Since we loosened the gap tolerance during playback in 316146@main, playback now plays
straight through small gaps (&lt;= 125ms, or 250ms when audio covers them), so a
buffer like [0,2][2.1,5] is really one playable run. But find() still saw two
ranges, so eviction (and evictableSize) happily trimmed into [2.1,5] — throwing
away data the player would have reached without stalling. In other cases the
same logic bailed out early and left evictable data behind.

Fix it by asking where playback would actually stall. Added a nextStallTime()
overload that walks a given set of ranges, bridging gaps the same way the gap
policy does, and use it in both evictFrames() and computeEvictionData() against
this SourceBuffer&apos;s own buffered ranges. We now protect everything up to the
next real stall and only evict past it. When currentTime isn&apos;t buffered there&apos;s
no segment to protect, so we keep the previous &quot;currentTime + timeChunk&quot;
look-ahead.

Note this is evaluated per-SourceBuffer, so in the multi-track case we may keep
a bit more than strictly necessary (a gap this track bridges that another track
doesn&apos;t), but we never truncate data this track can play through.

Test: media/media-source/media-source-evict-ignorable-gap.html

* LayoutTests/media/media-source/media-source-evict-ignorable-gap-expected.txt: Added.
* LayoutTests/media/media-source/media-source-evict-ignorable-gap.html: Added.
* Source/WebCore/platform/graphics/MediaSourcePrivate.cpp:
(WebCore::MediaSourcePrivate::nextStallTime const):
* Source/WebCore/platform/graphics/MediaSourcePrivate.h:
* Source/WebCore/platform/graphics/SourceBufferPrivate.cpp:
(WebCore::SourceBufferPrivate::computeEvictionData):
(WebCore::SourceBufferPrivate::evictFrames):

Canonical link: <a href="https://commits.webkit.org/317602@main">https://commits.webkit.org/317602@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/494fdba0ddec2ffcce700f7df1f357dbbe7aeff7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175203 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49135 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42916 "Build is in progress. Recent messages:OS: Tahoe (26.5.1), Xcode: 26.5; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings); Compiled WebKit (warnings)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184788 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/133245 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/177067 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50427 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48818 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136378 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/133245 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178160 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39804 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157151 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116857 "Passed tests") | | ⏳ 🛠 vision-apple 
| [❌ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/174525 "webkitpy-tests (failure)") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38445 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36826 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33261 "Build is in progress. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; Compiled WebKit (warnings)") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/5660 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148868 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36644 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Running apply-patch; Checked out pull request; Running run-layout-tests-in-stress-mode; 344 new passes 8 flakes") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187209 "Built successfully") | | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/36464 "Build was cancelled. Recent messages:OS: Tahoe (26.5.1), Xcode: 26.5; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled JSC (warnings); jscore-tests (cancelled)") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/40822 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41029 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145324 "Passed tests") | | 
| [❌ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/174603 "Failed resultsdbpy unit tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48802 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/156707 "") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145181 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39242 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49482 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33265 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115350 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40022 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/121668 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/212294 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47988 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11617 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Running apply-patch; Checked out pull request; Uploaded test results") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/55401 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47391 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47621 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47448 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->