### PR TITLE
Revert 315959@main

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -3627,26 +3627,12 @@ GetUserMediaRequiresFocus:
     WebCore:
       default: true
 
-GlobalPrivacyControlFeatureEnabled:
+GlobalPrivacyControlEnabled:
   type: bool
   status: testable
   category: privacy
-  humanReadableName: "Global Privacy Control Feature"
-  humanReadableDescription: "Enable Global Privacy Control (GPC) Feature"
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
-
-GlobalPrivacyControlStatus:
-  type: bool
-  status: developer
-  category: privacy
-  humanReadableName: "Global Privacy Control API"
-  humanReadableDescription: "Expose the status of Global Privacy Control (GPC) API (navigtor.gloabalPrivacyControl)"
+  humanReadableName: "Global Privacy Control"
+  humanReadableDescription: "Enable Global Privacy Control (GPC) signal"
   defaultValue:
     WebKitLegacy:
       default: false

--- a/Source/WebCore/page/NavigatorGlobalPrivacyControl.cpp
+++ b/Source/WebCore/page/NavigatorGlobalPrivacyControl.cpp
@@ -33,20 +33,20 @@
 
 namespace WebCore {
 
-bool NavigatorGlobalPrivacyControl::globalPrivacyControlStatus(Navigator& navigator)
+bool NavigatorGlobalPrivacyControl::globalPrivacyControlEnabled(Navigator& navigator)
 {
     auto* frame = navigator.frame();
     if (!frame)
         return false;
-    return frame->settings().globalPrivacyControlStatus();
+    return frame->settings().globalPrivacyControlEnabled();
 }
 
-bool NavigatorGlobalPrivacyControl::globalPrivacyControlStatus(WorkerNavigator& navigator)
+bool NavigatorGlobalPrivacyControl::globalPrivacyControlEnabled(WorkerNavigator& navigator)
 {
     RefPtr scope = navigator.scriptExecutionContext();
     if (!scope)
         return false;
-    return scope->settingsValues().globalPrivacyControlStatus;
+    return scope->settingsValues().globalPrivacyControlEnabled;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/page/NavigatorGlobalPrivacyControl.h
+++ b/Source/WebCore/page/NavigatorGlobalPrivacyControl.h
@@ -32,7 +32,7 @@ class WorkerNavigator;
 
 class NavigatorGlobalPrivacyControl {
 public:
-    static bool globalPrivacyControlStatus(Navigator&);
-    static bool globalPrivacyControlStatus(WorkerNavigator&);
+    static bool globalPrivacyControlEnabled(Navigator&);
+    static bool globalPrivacyControlEnabled(WorkerNavigator&);
 };
 }

--- a/Source/WebCore/page/NavigatorGlobalPrivacyControl.idl
+++ b/Source/WebCore/page/NavigatorGlobalPrivacyControl.idl
@@ -24,8 +24,8 @@
  */
 
 // https://www.w3.org/TR/gpc/
-[
-    ImplementedBy=NavigatorGlobalPrivacyControl
-] interface mixin NavigatorGlobalPrivacyControl {
-    [ImplementedAs=globalPrivacyControlStatus] readonly attribute boolean globalPrivacyControl;
+[                                                                                                                           
+    ImplementedBy=NavigatorGlobalPrivacyControl                                                                          
+] interface mixin NavigatorGlobalPrivacyControl {         
+    [ImplementedAs=globalPrivacyControlEnabled] readonly attribute boolean globalPrivacyControl;
 };

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.h
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.h
@@ -130,7 +130,7 @@ struct NetworkResourceLoadParameters {
 
     bool isInitiatorPrefetch { false };
     bool isInitiatedByDedicatedWorker { false };
-    bool globalPrivacyControlStatus { false };
+    bool globalPrivacyControlEnabled { false };
     bool shouldConsiderEnhancedSecurityForInsecureResponse { false };
 };
 

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.serialization.in
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.serialization.in
@@ -108,7 +108,7 @@ enum class WebKit::NavigatingToAppBoundDomain : bool;
 
     bool isInitiatorPrefetch;
     bool isInitiatedByDedicatedWorker;
-    bool globalPrivacyControlStatus;
+    bool globalPrivacyControlEnabled;
     bool shouldConsiderEnhancedSecurityForInsecureResponse;
 };
 

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
@@ -465,7 +465,7 @@ void NetworkResourceLoader::startNetworkLoad(ResourceRequest&& request, FirstLoa
     if (networkSession->shouldSendPrivateTokenIPCForTesting())
         connectionToWebProcess().networkProcess().parentProcessConnection()->send(Messages::NetworkProcessProxy::DidAllowPrivateTokenUsageByThirdPartyForTesting(sessionID(), request.isPrivateTokenUsageByThirdPartyAllowed(), request.url()), 0);
 
-    if (m_parameters.globalPrivacyControlStatus) {
+    if (m_parameters.globalPrivacyControlEnabled) {
         auto requestOrigin = SecurityOrigin::create(request.url());
         if (requestOrigin->isPotentiallyTrustworthy())
             request.addHTTPHeaderFieldIfNotPresent(HTTPHeaderName::SecGPC, "1"_s);

--- a/Source/WebKit/Shared/WebsitePoliciesData.cpp
+++ b/Source/WebKit/Shared/WebsitePoliciesData.cpp
@@ -202,8 +202,8 @@ void WebsitePoliciesData::applyToDocumentLoader(WebsitePoliciesData&& websitePol
         frame->settings().setTouchEventDOMAttributesEnabled(*overrideValue);
 #endif
 
-    if (auto overrideValue = websitePolicies.globalPrivacyControlStatus)
-        frame->settings().setGlobalPrivacyControlStatus(*overrideValue);
+    if (auto overrideValue = websitePolicies.globalPrivacyControlEnabled)
+        frame->settings().setGlobalPrivacyControlEnabled(*overrideValue);
 
     documentLoader.applyPoliciesToSettings();
 }

--- a/Source/WebKit/Shared/WebsitePoliciesData.h
+++ b/Source/WebKit/Shared/WebsitePoliciesData.h
@@ -70,7 +70,7 @@ public:
 #if ENABLE(TOUCH_EVENTS)
     std::optional<bool> overrideTouchEventDOMAttributesEnabled;
 #endif
-    std::optional<bool> globalPrivacyControlStatus;
+    std::optional<bool> globalPrivacyControlEnabled;
     WebsiteAutoplayPolicy autoplayPolicy { WebsiteAutoplayPolicy::Default };
     WebsitePopUpPolicy popUpPolicy { WebsitePopUpPolicy::Default };
     WebsiteMetaViewportPolicy metaViewportPolicy { WebsiteMetaViewportPolicy::Default };

--- a/Source/WebKit/Shared/WebsitePoliciesData.serialization.in
+++ b/Source/WebKit/Shared/WebsitePoliciesData.serialization.in
@@ -70,7 +70,7 @@ struct WebKit::WebsitePoliciesData {
 #if ENABLE(TOUCH_EVENTS)
     std::optional<bool> overrideTouchEventDOMAttributesEnabled;
 #endif
-    std::optional<bool> globalPrivacyControlStatus;
+    std::optional<bool> globalPrivacyControlEnabled;
     WebKit::WebsiteAutoplayPolicy autoplayPolicy;
     WebKit::WebsitePopUpPolicy popUpPolicy;
     WebKit::WebsiteMetaViewportPolicy metaViewportPolicy;

--- a/Source/WebKit/UIProcess/API/APIWebsitePolicies.h
+++ b/Source/WebKit/UIProcess/API/APIWebsitePolicies.h
@@ -138,8 +138,8 @@ public:
     bool allowPrivacyProxy() const { return m_data.allowPrivacyProxy; }
     void setAllowPrivacyProxy(bool allow) { m_data.allowPrivacyProxy = allow; }
 
-    std::optional<bool> globalPrivacyControlStatus() const { return m_data.globalPrivacyControlStatus; }
-    void setGlobalPrivacyControlStatus(std::optional<bool> enabled) { m_data.globalPrivacyControlStatus = enabled; }
+    std::optional<bool> globalPrivacyControlEnabled() const { return m_data.globalPrivacyControlEnabled; }
+    void setGlobalPrivacyControlEnabled(std::optional<bool> enabled) { m_data.globalPrivacyControlEnabled = enabled; }
 
     WebCore::HTTPSByDefaultMode httpsByDefaultMode() const { return m_data.httpsByDefaultMode; }
     void setHTTPSByDefault(WebCore::HTTPSByDefaultMode mode) { m_data.httpsByDefaultMode = mode; }

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences+Extras.swift
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences+Extras.swift
@@ -62,7 +62,7 @@ extension WKWebpagePreferences {
 
         self.alternateRequest = wrapped.alternateRequest
         self.overrideReferrer = wrapped.overrideReferrer
-        self.globalPrivacyControlStatus = wrapped.globalPrivacyControlStatus
+        self.globalPrivacyControlEnabled = wrapped.isGlobalPrivacyControlEnabled
     }
 }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.h
@@ -145,6 +145,6 @@ WK_CLASS_AVAILABLE(macos(10.15), ios(13.0))
  @discussion The default value is NO. When enabled, both navigator.globalPrivacyControl and the
  Sec-GPC: 1 request header are active for the main frame, its subframes, and their subresources.
  */
-@property (nonatomic) BOOL globalPrivacyControlStatus WK_API_AVAILABLE(macos(27.0), ios(27.0), visionos(27.0));
+@property (nonatomic) BOOL globalPrivacyControlEnabled WK_API_AVAILABLE(macos(27.0), ios(27.0), visionos(27.0));
 
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.mm
@@ -555,14 +555,14 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
     return _websitePolicies->allowPrivacyProxy();
 }
 
-- (void)setGlobalPrivacyControlStatus:(BOOL)enabled
+- (void)setGlobalPrivacyControlEnabled:(BOOL)enabled
 {
-    _websitePolicies->setGlobalPrivacyControlStatus(enabled);
+    _websitePolicies->setGlobalPrivacyControlEnabled(enabled);
 }
 
-- (BOOL)globalPrivacyControlStatus
+- (BOOL)globalPrivacyControlEnabled
 {
-    return protect(*_websitePolicies)->globalPrivacyControlStatus().value_or(false);
+    return protect(*_websitePolicies)->globalPrivacyControlEnabled().value_or(false);
 }
 
 - (_WKWebsiteColorSchemePreference)_colorSchemePreference

--- a/Source/WebKit/UIProcess/API/Swift/WebPage+NavigationPreferences.swift
+++ b/Source/WebKit/UIProcess/API/Swift/WebPage+NavigationPreferences.swift
@@ -148,7 +148,7 @@ extension WebPage {
         @available(anyAppleOSAndDownlevels 27.0, *)
         @available(watchOS, unavailable)
         @available(tvOS, unavailable)
-        public var globalPrivacyControlStatus: Bool = false
+        public var isGlobalPrivacyControlEnabled: Bool = false
     }
 }
 
@@ -209,7 +209,7 @@ extension WebPage.NavigationPreferences {
 
         self.alternateRequest = wrapped.alternateRequest
         self.overrideReferrer = wrapped.overrideReferrer
-        self.globalPrivacyControlStatus = wrapped.globalPrivacyControlStatus
+        self.isGlobalPrivacyControlEnabled = wrapped.globalPrivacyControlEnabled
     }
 }
 

--- a/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
+++ b/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
@@ -402,7 +402,7 @@ static void addParametersShared(const LocalFrame* frame, NetworkResourceLoadPara
         parameters.isClearSiteDataHeaderEnabled = document->settings().clearSiteDataHTTPHeaderEnabled();
         parameters.isClearSiteDataExecutionContextEnabled = document->settings().clearSiteDataExecutionContextsSupportEnabled();
         parameters.mayBlockNetworkRequest = !isMainFrameNavigation && document->settings().scriptTrackingPrivacyNetworkRequestBlockingEnabled();
-        parameters.globalPrivacyControlStatus = document->settings().globalPrivacyControlStatus();
+        parameters.globalPrivacyControlEnabled = document->settings().globalPrivacyControlEnabled();
     }
 
     if (RefPtr page = frame->page()) {

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebsitePolicies.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebsitePolicies.mm
@@ -2290,7 +2290,7 @@ TEST(WebpagePreferences, GlobalPrivacyControlNavigatorAPI)
 
     __block BOOL nextNavigationGPC = YES;
     navigationDelegate.get().decidePolicyForNavigationActionWithPreferences = ^(WKNavigationAction *action, WKWebpagePreferences *preferences, void (^decisionHandler)(WKNavigationActionPolicy, WKWebpagePreferences *)) {
-        [preferences setGlobalPrivacyControlStatus:nextNavigationGPC];
+        [preferences setGlobalPrivacyControlEnabled:nextNavigationGPC];
         decisionHandler(WKNavigationActionPolicyAllow, preferences);
     };
     [webView setNavigationDelegate:navigationDelegate.get()];
@@ -2341,7 +2341,7 @@ TEST(WebpagePreferences, GlobalPrivacyControlRequestHeader)
     webView.get().navigationDelegate = delegate.get();
 
     delegate.get().decidePolicyForNavigationActionWithPreferences = ^(WKNavigationAction *, WKWebpagePreferences *preferences, void (^completionHandler)(WKNavigationActionPolicy, WKWebpagePreferences *)) {
-        [preferences setGlobalPrivacyControlStatus:YES];
+        [preferences setGlobalPrivacyControlEnabled:YES];
         completionHandler(WKNavigationActionPolicyAllow, preferences);
     };
     [webView loadRequest:server.requestWithLocalhost("/main"_s)];
@@ -2366,7 +2366,7 @@ TEST(WebpagePreferences, GlobalPrivacyControlNavigatorAPIInSubframe)
     RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     delegate.get().decidePolicyForNavigationActionWithPreferences = ^(WKNavigationAction *action, WKWebpagePreferences *preferences, void (^completionHandler)(WKNavigationActionPolicy, WKWebpagePreferences *)) {
         if (action.targetFrame.mainFrame)
-            [preferences setGlobalPrivacyControlStatus:YES];
+            [preferences setGlobalPrivacyControlEnabled:YES];
         completionHandler(WKNavigationActionPolicyAllow, preferences);
     };
     [webView setNavigationDelegate:delegate.get()];
@@ -2413,7 +2413,7 @@ TEST(WebpagePreferences, GlobalPrivacyControlRequestHeaderInSubframe)
 
     delegate.get().decidePolicyForNavigationActionWithPreferences = ^(WKNavigationAction *action, WKWebpagePreferences *preferences, void (^completionHandler)(WKNavigationActionPolicy, WKWebpagePreferences *)) {
         if (action.targetFrame.mainFrame)
-            [preferences setGlobalPrivacyControlStatus:YES];
+            [preferences setGlobalPrivacyControlEnabled:YES];
         completionHandler(WKNavigationActionPolicyAllow, preferences);
     };
     [webView loadRequest:server.requestWithLocalhost("/main"_s)];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WebPage/WebPageTests.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WebPage/WebPageTests.swift
@@ -100,10 +100,10 @@ struct WebPageTests {
     }
 
     @Test(arguments: [true, false])
-    func globalPrivacyControlStatusForNavigation(enabled: Bool) async throws {
+    func globalPrivacyControlEnabledForNavigation(enabled: Bool) async throws {
         let decider = TestNavigationDecider()
         decider.preferencesMutation = { preferences in
-            preferences.globalPrivacyControlStatus = enabled
+            preferences.isGlobalPrivacyControlEnabled = enabled
         }
 
         let page = WebPage(navigationDecider: decider)

--- a/Tools/WebKitTestRunner/TestController.cpp
+++ b/Tools/WebKitTestRunner/TestController.cpp
@@ -1460,8 +1460,7 @@ void TestController::resetPreferencesToConsistentValues(const TestOptions& optio
         WKPreferencesSetMinimumFontSize(preferences, 0);
 
         WKPreferencesSetBoolValueForKeyForTesting(preferences, options.allowTestOnlyIPC(), toWK("AllowTestOnlyIPC").get());
-        WKPreferencesSetBoolValueForKeyForTesting(preferences, false, toWK("GlobalPrivacyControlStatus").get());
-        WKPreferencesSetBoolValueForKeyForTesting(preferences, false, toWK("GlobalPrivacyControlFeatureEnabled").get());
+        WKPreferencesSetBoolValueForKeyForTesting(preferences, false, toWK("GlobalPrivacyControlEnabled").get());
         WKPreferencesSetBoolValueForKeyForTesting(preferences, options.allowTestOnlyMockContentFilterIPC(), toWK("AllowTestOnlyMockContentFilterIPC").get());
         WKPreferencesSetBoolValueForKeyForTesting(preferences, options.allowTestOnlyOriginAccessAllowListIPC(), toWK("AllowTestOnlyOriginAccessAllowListIPC").get());
 

--- a/Tools/WebKitTestRunner/TestInvocation.cpp
+++ b/Tools/WebKitTestRunner/TestInvocation.cpp
@@ -1358,12 +1358,12 @@ WKRetainPtr<WKTypeRef> TestInvocation::didReceiveSynchronousMessageFromInjectedB
     }
 
     if (WKStringIsEqualToUTF8CString(messageName, "GetGlobalPrivacyControl")) {
-        bool value = WKPreferencesGetBoolValueForKeyForTesting(TestController::singleton().platformPreferences(), toWK("GlobalPrivacyControlStatus").get());
+        bool value = WKPreferencesGetBoolValueForKeyForTesting(TestController::singleton().platformPreferences(), toWK("GlobalPrivacyControlEnabled").get());
         return adoptWK(WKBooleanCreate(value)).leakRef();
     }
 
     if (WKStringIsEqualToUTF8CString(messageName, "SetGlobalPrivacyControl")) {
-        WKPreferencesSetBoolValueForKeyForTesting(TestController::singleton().platformPreferences(), booleanValue(messageBody), toWK("GlobalPrivacyControlStatus").get());
+        WKPreferencesSetBoolValueForKeyForTesting(TestController::singleton().platformPreferences(), booleanValue(messageBody), toWK("GlobalPrivacyControlEnabled").get());
         return nullptr;
     }
 


### PR DESCRIPTION
#### 25ba66d2fe02bff2155ae87164fc68091c8c83b1
<pre>
Revert 315959@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=319600">https://bugs.webkit.org/show_bug.cgi?id=319600</a>
<a href="https://rdar.apple.com/182372273">rdar://182372273</a>

Unreviewed.

It renamed public API.

Tests: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebsitePolicies.mm
       Tools/TestWebKitAPI/Tests/WebKit/WebPage/WebPageTests.swift

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/page/NavigatorGlobalPrivacyControl.cpp:
(WebCore::NavigatorGlobalPrivacyControl::globalPrivacyControlEnabled):
(WebCore::NavigatorGlobalPrivacyControl::globalPrivacyControlStatus): Deleted.
* Source/WebCore/page/NavigatorGlobalPrivacyControl.h:
* Source/WebCore/page/NavigatorGlobalPrivacyControl.idl:
* Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.h:
* Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.serialization.in:
* Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp:
(WebKit::NetworkResourceLoader::startNetworkLoad):
* Source/WebKit/Shared/WebsitePoliciesData.cpp:
(WebKit::WebsitePoliciesData::applyToDocumentLoader):
* Source/WebKit/Shared/WebsitePoliciesData.h:
* Source/WebKit/Shared/WebsitePoliciesData.serialization.in:
* Source/WebKit/UIProcess/API/APIWebsitePolicies.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences+Extras.swift:
* Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.mm:
(-[WKWebpagePreferences setGlobalPrivacyControlEnabled:]):
(-[WKWebpagePreferences globalPrivacyControlEnabled]):
(-[WKWebpagePreferences setGlobalPrivacyControlStatus:]): Deleted.
(-[WKWebpagePreferences globalPrivacyControlStatus]): Deleted.
* Source/WebKit/UIProcess/API/Swift/WebPage+NavigationPreferences.swift:
(isGlobalPrivacyControlEnabled):
(globalPrivacyControlStatus): Deleted.
* Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp:
(WebKit::addParametersShared):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebsitePolicies.mm:
* Tools/TestWebKitAPI/Tests/WebKit/WebPage/WebPageTests.swift:
(WebPageTests.globalPrivacyControlEnabledForNavigation(_:)):
(WebPageTests.globalPrivacyControlStatusForNavigation(_:)): Deleted.
* Tools/WebKitTestRunner/TestController.cpp:
(WTR::TestController::resetPreferencesToConsistentValues):
* Tools/WebKitTestRunner/TestInvocation.cpp:
(WTR::TestInvocation::didReceiveSynchronousMessageFromInjectedBundle):

Canonical link: <a href="https://commits.webkit.org/317335@main">https://commits.webkit.org/317335@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bac0df6a06e40e5910a5cf8d0e94f500a285b016

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175034 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48967 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/42748 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184615 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/132942 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9fa235bb-7d8f-4aa4-a6ee-6946382d244d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176899 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50259 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48650 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/136234 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/132942 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8cfa32d0-5ac9-4690-8bf2-e9f96ec8498e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177992 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/39676 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/157027 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/116713 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/280b8dbc-6b0b-4163-8628-0ae65febf66a) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/38317 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/36698 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33092 "Built successfully") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/218/builds/5536 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/148740 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/36519 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187039 "Built successfully") | | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/36296 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/40568 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/40900 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/145173 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48634 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/156583 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145036 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49314 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/33140 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115132 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26585 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/39895 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/121463 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/212126 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47820 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/11492 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/55332 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47223 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47453 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47280 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->