### PR TITLE
Intrinsic width of a multicol container multiplies column spanners by column-count

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -5421,10 +5421,7 @@ imported/w3c/web-platform-tests/css/css-multicol/fixed-in-nested-multicol-with-t
 imported/w3c/web-platform-tests/css/css-multicol/fixedpos-static-pos-with-viewport-cb-001.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-multicol/fixedpos-static-pos-with-viewport-cb-002.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-multicol/fixedpos-static-pos-with-viewport-cb-003.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-multicol/intrinsic-size-002.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-multicol/intrinsic-size-003.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-multicol/intrinsic-size-004.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-multicol/intrinsic-size-005.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-multicol/columnfill-auto-max-height-001.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-multicol/columnfill-auto-max-height-002.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-multicol/multicol-breaking-000.html [ ImageOnlyFailure ]
@@ -5465,7 +5462,6 @@ imported/w3c/web-platform-tests/css/css-multicol/multicol-span-all-margin-nested
 imported/w3c/web-platform-tests/css/css-multicol/multicol-span-all-margin-nested-002.xht [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-multicol/multicol-span-all-rule-001.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-multicol/multicol-under-vertical-rl-scroll.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-multicol/multicol-width-004.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-multicol/multicol-width-005.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-multicol/orthogonal-writing-mode-shrink-to-fit.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-multicol/with-custom-layout-on-same-element.https.html

--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -2333,6 +2333,12 @@ std::pair<LayoutUnit, LayoutUnit> RenderBlock::computeBlockIntrinsicLogicalWidth
         if (childBox.isOutOfFlowPositioned() || childBox.isExcludedAndPlacedInBorder())
             continue;
 
+        // Column spanners occupy the full multicol width and must contribute ×1, not
+        // ×columnCount. They are folded back in by adjustIntrinsicLogicalWidthsForColumns().
+        if (childBox.style().columnSpan() == ColumnSpan::All
+            && is<RenderBlockFlow>(*this) && downcast<RenderBlockFlow>(*this).multiColumnFlow())
+            continue;
+
         // Either the box itself of its content avoids floats.
         auto childAvoidsFloats = childBox.avoidsFloats() || (childBox.isAnonymousBlock() && childBox.childrenInline());
         if (childBox.isFloating() || childAvoidsFloats) {

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -335,26 +335,41 @@ void RenderBlockFlow::rebuildFloatingObjectSetFromIntrudingFloats()
 
 void RenderBlockFlow::adjustIntrinsicLogicalWidthsForColumns(LayoutUnit& minLogicalWidth, LayoutUnit& maxLogicalWidth) const
 {
-    if (!style().columnCount().isAuto() || !style().columnWidth().isAuto()) {
-        // The min/max intrinsic widths calculated really tell how much space elements need when
-        // laid out inside the columns. In order to eventually end up with the desired column width,
-        // we need to convert them to values pertaining to the multicol container.
-        int columnCount = style().columnCount().tryValue().value_or(1).value;
-        LayoutUnit columnWidth;
-        LayoutUnit colGap = columnGap();
-        LayoutUnit gapExtra = (columnCount - 1) * colGap;
-        if (auto columnWidthLength = style().columnWidth().tryLength()) {
-            columnWidth = Style::evaluate<LayoutUnit>(*columnWidthLength, style().usedZoomForLength());
-            minLogicalWidth = std::min(minLogicalWidth, columnWidth);
-        } else
-            minLogicalWidth = minLogicalWidth * columnCount + gapExtra;
-        // FIXME: If column-count is auto here, we should resolve it to calculate the maximum
-        // intrinsic width, instead of pretending that it's 1. The only way to do that is by
-        // performing a layout pass, but this is not an appropriate time or place for layout. The
-        // good news is that if height is unconstrained and there are no explicit breaks, the
-        // resolved column-count really should be 1.
-        maxLogicalWidth = std::max(maxLogicalWidth, columnWidth) * columnCount + gapExtra;
+    if (style().columnCount().isAuto() && style().columnWidth().isAuto())
+        return;
+
+    // The min/max intrinsic widths calculated really tell how much space elements need when
+    // laid out inside the columns. In order to eventually end up with the desired column width,
+    // we need to convert them to values pertaining to the multicol container.
+
+    // Spanners were excluded from the base widths (see computeBlockIntrinsicLogicalWidths()); a
+    // spanner spans all columns, so it contributes ×1 (no column-count multiplication, no gaps).
+    LayoutUnit spannerMinLogicalWidth;
+    LayoutUnit spannerMaxLogicalWidth;
+    for (auto& child : childrenOfType<RenderBox>(*this)) {
+        if (child.style().columnSpan() != ColumnSpan::All || child.isOutOfFlowPositioned())
+            continue;
+        auto [childMin, childMax] = computeChildIntrinsicLogicalWidths(const_cast<RenderBox&>(child));
+        auto [marginStart, marginEnd] = intrinsicLogicalMarginStartAndEnd(child);
+        spannerMinLogicalWidth = std::max(spannerMinLogicalWidth, childMin + marginStart + marginEnd);
+        spannerMaxLogicalWidth = std::max(spannerMaxLogicalWidth, childMax + marginStart + marginEnd);
     }
+
+    int columnCount = style().columnCount().tryValue().value_or(1).value;
+    LayoutUnit columnWidth;
+    LayoutUnit colGap = columnGap();
+    LayoutUnit gapExtra = (columnCount - 1) * colGap;
+    if (auto columnWidthLength = style().columnWidth().tryLength()) {
+        columnWidth = Style::evaluate<LayoutUnit>(*columnWidthLength, style().usedZoomForLength());
+        minLogicalWidth = std::min(minLogicalWidth, columnWidth);
+    } else
+        minLogicalWidth = minLogicalWidth * columnCount + gapExtra;
+    // FIXME: If column-count is auto here, we should resolve it to calculate the maximum
+    // intrinsic width, instead of pretending that it's 1.
+    maxLogicalWidth = std::max(maxLogicalWidth, columnWidth) * columnCount + gapExtra;
+
+    minLogicalWidth = std::max(minLogicalWidth, spannerMinLogicalWidth);
+    maxLogicalWidth = std::max(maxLogicalWidth, spannerMaxLogicalWidth);
 }
 
 std::pair<LayoutUnit, LayoutUnit> RenderBlockFlow::computeIntrinsicLogicalWidths() const


### PR DESCRIPTION
#### 2ab374d7518b6c74aeb3c73828b26ef2fd2d89ed
<pre>
Intrinsic width of a multicol container multiplies column spanners by column-count
<a href="https://bugs.webkit.org/show_bug.cgi?id=319601">https://bugs.webkit.org/show_bug.cgi?id=319601</a>
<a href="https://rdar.apple.com/182431203">rdar://182431203</a>

Reviewed by NOBODY (OOPS!).

RenderBlockFlow::adjustIntrinsicLogicalWidthsForColumns() converts the
intrinsic widths of the multicol content into container-relative widths by
multiplying them by the used column-count and adding the inter-column gaps.
This multiplication was applied unconditionally to the aggregate min/max
widths computed by computeBlockIntrinsicLogicalWidths(), which folds every
in-flow child — including hoisted column-span:all spanners — into a single
max.

A spanner occupies the full width of the multicol container, so its intrinsic
contribution should count once (×1, no gaps), not ×column-count. As a result
a container with a spanner wider than (column content × column-count) reported
an inflated intrinsic width.

Fix this by keeping the spanner contribution out of the multiplied base and
folding it back in afterwards:

- computeBlockIntrinsicLogicalWidths() now skips column-span:all children when
  the block establishes a multicol context; the spanner placeholder left behind
  in the flow already contributes zero, so the base width is pure column content.

- adjustIntrinsicLogicalWidthsForColumns() gathers the widest spanner&apos;s min/max
  intrinsic width (plus margins) separately, multiplies only the column content
  by the column-count, and then takes the max of the two. The result is
  max(columnContent × columnCount + gaps, widestSpanner) for both min and max.

This does not address the pre-existing FIXME for the column-count:auto
max-content case (resolving the true column count needs a layout pass); that is
orthogonal to spanner handling.

* Source/WebCore/rendering/RenderBlock.cpp:
(WebCore::RenderBlock::computeBlockIntrinsicLogicalWidths const): Skip
column-span:all children in a multicol container.
* Source/WebCore/rendering/RenderBlockFlow.cpp:
(WebCore::RenderBlockFlow::adjustIntrinsicLogicalWidthsForColumns const):
Account for spanners at ×1 instead of ×column-count.
* LayoutTests/TestExpectations: Unskip Passing Tests
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2ab374d7518b6c74aeb3c73828b26ef2fd2d89ed

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175036 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48969 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42750 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184617 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132944 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3b536b6b-08df-4f95-92eb-0c234ff374ba) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176901 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50261 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48652 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136226 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-contain/contain-inline-size-multicol.html imported/w3c/web-platform-tests/css/css-multicol/multicol-width-004.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96109 "1 flakes 6 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/71671e73-0333-4a1f-af1b-90c0bafc9de3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177994 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39667 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157020 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116705 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6ce664b6-6841-43ed-acb5-996846a17eae) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38308 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-contain/contain-inline-size-multicol.html (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36694 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33094 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148731 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36512 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-contain/contain-inline-size-multicol.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187041 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/40570 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40896 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-contain/contain-inline-size-multicol.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145175 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48636 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/156576 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145030 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49316 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33133 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-contain/contain-inline-size-multicol.html (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115134 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39890 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/121493 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47822 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11485 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47225 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47455 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47282 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->