### PR TITLE
[JSC][Temporal] Extract GetTemporalCalendarIdentifierWithISODefault as a shared helper

### DIFF
--- a/Source/JavaScriptCore/runtime/TemporalCalendar.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalCalendar.cpp
@@ -55,6 +55,35 @@ std::optional<CalendarID> isBuiltinCalendar(StringView string)
     return entry->value;
 }
 
+// https://tc39.es/proposal-temporal/#sec-temporal-gettemporalcalendarslotvaluewithisodefault
+CalendarID getTemporalCalendarIdentifierWithISODefault(JSGlobalObject* globalObject, JSObject* item)
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    // Step 1: If item has an [[InitializedTemporalDate/DateTime/MonthDay/YearMonth/ZonedDateTime]]
+    // internal slot, return item.[[Calendar]].
+    if (auto* pd = dynamicDowncast<TemporalPlainDate>(item))
+        return pd->calendarID();
+    if (auto* pdt = dynamicDowncast<TemporalPlainDateTime>(item))
+        return pdt->calendarID();
+    if (auto* pmd = dynamicDowncast<TemporalPlainMonthDay>(item))
+        return pmd->calendarID();
+    if (auto* pym = dynamicDowncast<TemporalPlainYearMonth>(item))
+        return pym->calendarID();
+    if (auto* zdt = dynamicDowncast<TemporalZonedDateTime>(item))
+        return zdt->calendarID();
+
+    // Step 2: Let calendarLike be ? Get(item, "calendar").
+    JSValue calendarLike = item->get(globalObject, vm.propertyNames->calendar);
+    RETURN_IF_EXCEPTION(scope, iso8601CalendarID());
+    // Step 3: If calendarLike is undefined, return "iso8601".
+    if (calendarLike.isUndefined())
+        return iso8601CalendarID();
+    // Step 4: Return ? ToTemporalCalendarIdentifier(calendarLike).
+    RELEASE_AND_RETURN(scope, toTemporalCalendarIdentifier(globalObject, calendarLike));
+}
+
 // https://tc39.es/proposal-temporal/#sec-temporal-calendarresolvefields
 static void calendarResolveFields(JSGlobalObject* globalObject, std::optional<int32_t> year, unsigned month, std::optional<ParsedMonthCode> monthCode, TemporalDateFormat format, CalendarID calendarId)
 {
@@ -89,26 +118,12 @@ static void calendarResolveFields(JSGlobalObject* globalObject, std::optional<in
 
 // temporal_rs: CalendarFields::from_prop_bag
 // https://tc39.es/proposal-temporal/#sec-temporal-preparecalendarfields
-template<FieldSetType type, CalendarRead calendarRead>
-TemporalCore::CalendarFieldsIn readCalendarFieldsFromObject(JSGlobalObject* globalObject, JSObject* bag, CalendarID& outCalendarId)
+template<FieldSetType type>
+TemporalCore::CalendarFieldsIn readCalendarFieldsFromObject(JSGlobalObject* globalObject, JSObject* bag, CalendarID calendarId)
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
     TemporalCore::CalendarFieldsIn fields;
-
-    // Alphabetical order per spec: calendar, day, era, eraYear, month, monthCode, year.
-
-    // calendar
-    if constexpr (calendarRead == CalendarRead::Read) {
-        outCalendarId = iso8601CalendarID();
-        JSValue calProp = bag->get(globalObject, vm.propertyNames->calendar);
-        RETURN_IF_EXCEPTION(scope, fields);
-        if (!calProp.isUndefined()) {
-            outCalendarId = toTemporalCalendarIdentifier(globalObject, calProp);
-            RETURN_IF_EXCEPTION(scope, fields);
-        }
-        // For non-ISO calendars, monthCode validation is handled by the ICU calendar.
-    }
 
     // day (not read for YearMonth per spec)
     if constexpr (type != FieldSetType::YearMonth) {
@@ -126,7 +141,7 @@ TemporalCore::CalendarFieldsIn readCalendarFieldsFromObject(JSGlobalObject* glob
     }
 
     // era, eraYear (only for calendars with eras)
-    if (TemporalCore::calendarHasEras(outCalendarId)) {
+    if (TemporalCore::calendarHasEras(calendarId)) {
         JSValue eraProp = bag->get(globalObject, Identifier::fromString(vm, "era"_s));
         RETURN_IF_EXCEPTION(scope, fields);
         if (!eraProp.isUndefined()) {
@@ -216,26 +231,12 @@ TemporalCore::CalendarFieldsIn readCalendarFieldsFromObject(JSGlobalObject* glob
 // mode == Full: from() — timeZone is the only required field; day/year/month checked later
 //               in CalendarDateFromFields/CalendarResolveFields.
 // mode == Partial: with() — all fields optional; anyFieldSet tracks whether anything was present.
-template<ZonedDateTimeFieldMode mode, CalendarRead calendarRead>
-ZonedDateTimeFields readZonedDateTimeFieldsFromObject(JSGlobalObject* globalObject, JSObject* bag, CalendarID& outCalendarId)
+template<ZonedDateTimeFieldMode mode>
+ZonedDateTimeFields readZonedDateTimeFieldsFromObject(JSGlobalObject* globalObject, JSObject* bag, CalendarID calendarId)
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
     ZonedDateTimeFields result; // step 6: all fields ~unset~, step 7: any = false
-
-    // Steps 2-8: calendar read first (per ToTemporalZonedDateTime step 4.b), then fields in
-    // lexicographic order (step 8). Steps 1/5 are static assertions; steps 3-4/6-7 are trivial.
-
-    // calendar — outside PrepareCalendarFields proper (ToTemporalZonedDateTime step 4.b).
-    if constexpr (calendarRead == CalendarRead::Read) {
-        outCalendarId = iso8601CalendarID();
-        JSValue calProp = bag->get(globalObject, vm.propertyNames->calendar);
-        RETURN_IF_EXCEPTION(scope, result);
-        if (!calProp.isUndefined()) {
-            outCalendarId = toTemporalCalendarIdentifier(globalObject, calProp);
-            RETURN_IF_EXCEPTION(scope, result);
-        }
-    }
 
     // Step 9: for each field in lexicographic order — Get, convert (step 9.c), check required (step 9.d).
 
@@ -259,7 +260,7 @@ ZonedDateTimeFields readZonedDateTimeFieldsFromObject(JSGlobalObject* globalObje
 
     // era (~to-string~), eraYear (~to-integer-with-truncation~)
     // CalendarExtraFields contributes these for era-based calendars (alphabetically between day and hour).
-    if (TemporalCore::calendarHasEras(outCalendarId)) {
+    if (TemporalCore::calendarHasEras(calendarId)) {
         JSValue eraVal = bag->get(globalObject, Identifier::fromString(vm, "era"_s));
         RETURN_IF_EXCEPTION(scope, result);
         if (!eraVal.isUndefined()) {
@@ -565,14 +566,11 @@ ISO8601::Duration calendarDateUntil(CalendarID calendarId, const ISO8601::PlainD
     return *result;
 }
 
-template TemporalCore::CalendarFieldsIn readCalendarFieldsFromObject<FieldSetType::Date, CalendarRead::Read>(JSGlobalObject*, JSObject*, CalendarID&);
-template TemporalCore::CalendarFieldsIn readCalendarFieldsFromObject<FieldSetType::Date, CalendarRead::Skip>(JSGlobalObject*, JSObject*, CalendarID&);
-template TemporalCore::CalendarFieldsIn readCalendarFieldsFromObject<FieldSetType::YearMonth, CalendarRead::Read>(JSGlobalObject*, JSObject*, CalendarID&);
-template TemporalCore::CalendarFieldsIn readCalendarFieldsFromObject<FieldSetType::YearMonth, CalendarRead::Skip>(JSGlobalObject*, JSObject*, CalendarID&);
-template TemporalCore::CalendarFieldsIn readCalendarFieldsFromObject<FieldSetType::MonthDay, CalendarRead::Read>(JSGlobalObject*, JSObject*, CalendarID&);
-template TemporalCore::CalendarFieldsIn readCalendarFieldsFromObject<FieldSetType::MonthDay, CalendarRead::Skip>(JSGlobalObject*, JSObject*, CalendarID&);
+template TemporalCore::CalendarFieldsIn readCalendarFieldsFromObject<FieldSetType::Date>(JSGlobalObject*, JSObject*, CalendarID);
+template TemporalCore::CalendarFieldsIn readCalendarFieldsFromObject<FieldSetType::YearMonth>(JSGlobalObject*, JSObject*, CalendarID);
+template TemporalCore::CalendarFieldsIn readCalendarFieldsFromObject<FieldSetType::MonthDay>(JSGlobalObject*, JSObject*, CalendarID);
 
-template ZonedDateTimeFields readZonedDateTimeFieldsFromObject<ZonedDateTimeFieldMode::Full, CalendarRead::Read>(JSGlobalObject*, JSObject*, CalendarID&);
-template ZonedDateTimeFields readZonedDateTimeFieldsFromObject<ZonedDateTimeFieldMode::Partial, CalendarRead::Skip>(JSGlobalObject*, JSObject*, CalendarID&);
+template ZonedDateTimeFields readZonedDateTimeFieldsFromObject<ZonedDateTimeFieldMode::Full>(JSGlobalObject*, JSObject*, CalendarID);
+template ZonedDateTimeFields readZonedDateTimeFieldsFromObject<ZonedDateTimeFieldMode::Partial>(JSGlobalObject*, JSObject*, CalendarID);
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/TemporalCalendar.h
+++ b/Source/JavaScriptCore/runtime/TemporalCalendar.h
@@ -41,6 +41,8 @@ namespace JSC {
 
 JS_EXPORT_PRIVATE std::optional<CalendarID> isBuiltinCalendar(StringView);
 
+CalendarID getTemporalCalendarIdentifierWithISODefault(JSGlobalObject*, JSObject* item);
+
 std::optional<ParsedMonthCode> parseMonthCode(JSGlobalObject*, JSValue argument);
 
 ISO8601::PlainDate isoDateFromFields(JSGlobalObject*, TemporalDateFormat, int32_t, uint32_t, uint32_t, std::optional<ParsedMonthCode>, TemporalOverflow, CalendarID = iso8601CalendarID());
@@ -52,9 +54,8 @@ ISO8601::PlainDate calendarDateAdd(JSGlobalObject*, CalendarID, const ISO8601::P
 ISO8601::Duration calendarDateUntil(CalendarID, const ISO8601::PlainDate&, const ISO8601::PlainDate&, TemporalUnit);
 
 enum class FieldSetType { Date, YearMonth, MonthDay };
-enum class CalendarRead { Read, Skip };
-template<FieldSetType type = FieldSetType::Date, CalendarRead calendarRead = CalendarRead::Read>
-TemporalCore::CalendarFieldsIn readCalendarFieldsFromObject(JSGlobalObject*, JSObject* bag, CalendarID& outCalendarId);
+template<FieldSetType type = FieldSetType::Date>
+TemporalCore::CalendarFieldsIn readCalendarFieldsFromObject(JSGlobalObject*, JSObject*, CalendarID);
 
 // Fields read from a ZonedDateTime property bag (from() or with()).
 struct ZonedDateTimeFields {
@@ -84,7 +85,7 @@ enum class ZonedDateTimeFieldMode {
     Partial, // with(): all fields optional, anyFieldSet is tracked (~partial~ mode)
 };
 
-template<ZonedDateTimeFieldMode mode = ZonedDateTimeFieldMode::Full, CalendarRead calendarRead = CalendarRead::Read>
-ZonedDateTimeFields readZonedDateTimeFieldsFromObject(JSGlobalObject*, JSObject* bag, CalendarID& outCalendarId);
+template<ZonedDateTimeFieldMode mode = ZonedDateTimeFieldMode::Full>
+ZonedDateTimeFields readZonedDateTimeFieldsFromObject(JSGlobalObject*, JSObject*, CalendarID);
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/TemporalDuration.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalDuration.cpp
@@ -265,19 +265,13 @@ static RelativeToRecord toRelativeTemporalObject(JSGlobalObject* globalObject, J
             return RelativeToRecord { nullptr, pdt->plainDate(), true, pdt->calendarID() };
         }
         // Step 5.d: calendar = ? GetTemporalCalendarIdentifierWithISODefault(value).
+        CalendarID calendarId = getTemporalCalendarIdentifierWithISODefault(globalObject, obj);
+        RETURN_IF_EXCEPTION(scope, { });
+
         // Step 5.e: fields = ? PrepareCalendarFields(calendar, value,
         //   «year,month,month-code,day», «hour,...,nanosecond,offset,time-zone», «»).
         //   requiredFieldNames = «» → no field is required during PrepareCalendarFields.
         //   All fields read in alphabetical order.
-
-        // calendar
-        CalendarID calendarId = iso8601CalendarID();
-        JSValue calendarProperty = obj->get(globalObject, vm.propertyNames->calendar);
-        RETURN_IF_EXCEPTION(scope, { });
-        if (!calendarProperty.isUndefined()) {
-            calendarId = toTemporalCalendarIdentifier(globalObject, calendarProperty);
-            RETURN_IF_EXCEPTION(scope, { });
-        }
 
         // day (~to-positive-integer-with-truncation~)
         // NOTE: not in requiredFieldNames; CalendarResolveFields enforces presence later.

--- a/Source/JavaScriptCore/runtime/TemporalPlainDate.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainDate.cpp
@@ -198,8 +198,10 @@ static TemporalPlainDate* fromImpl(JSGlobalObject* globalObject, JSValue itemVal
         }
 
         // Step 2.d: calendar = ? GetTemporalCalendarIdentifierWithISODefault(item).
+        CalendarID calendarId = getTemporalCalendarIdentifierWithISODefault(globalObject, asObject(itemValue));
+        RETURN_IF_EXCEPTION(scope, { });
+
         // Step 2.e: fields = ? PrepareCalendarFields(...). Fields before options (spec order).
-        CalendarID calendarId = iso8601CalendarID();
         auto fields = readCalendarFieldsFromObject(globalObject, asObject(itemValue), calendarId);
         RETURN_IF_EXCEPTION(scope, { });
 

--- a/Source/JavaScriptCore/runtime/TemporalPlainDatePrototype.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainDatePrototype.cpp
@@ -290,9 +290,8 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainDatePrototypeFuncWith, (JSGlobalObject* gl
     ISO8601::PlainDate result;
     if (isNonISO) {
         // Step 6: partialDate = ? PrepareCalendarFields(calendar, temporalDateLike, «year,month,monthCode,day», «», ~partial~).
-        //   CalendarRead::Skip — calendar is known from the receiver; step 3 already rejected a `calendar` property.
-        CalendarID unusedCalId = calendarId;
-        auto partialFields = readCalendarFieldsFromObject<FieldSetType::Date, CalendarRead::Skip>(globalObject, like, unusedCalId);
+        // Calendar comes from the receiver — step 3 already rejected a `calendar` property.
+        auto partialFields = readCalendarFieldsFromObject(globalObject, like, calendarId);
         RETURN_IF_EXCEPTION(scope, { });
         // ~partial~ throws TypeError if none of the requested fields are present with a non-undefined value.
         if (!partialFields.day && !partialFields.era && !partialFields.eraYear && !partialFields.month && !partialFields.monthCode && !partialFields.year) [[unlikely]]

--- a/Source/JavaScriptCore/runtime/TemporalPlainDateTime.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainDateTime.cpp
@@ -91,16 +91,11 @@ static TemporalPlainDateTime* fromImpl(JSGlobalObject* globalObject, JSValue ite
         JSObject* item = asObject(itemValue);
 
         // Step 2.d: GetTemporalCalendarIdentifierWithISODefault(item).
+        CalendarID extractedCalendarId = getTemporalCalendarIdentifierWithISODefault(globalObject, item);
+        RETURN_IF_EXCEPTION(scope, { });
+
         // Step 2.e: PrepareCalendarFields(calendar, item, {year,month,monthCode,day},
         //           {hour,minute,second,millisecond,microsecond,nanosecond}, {}) — alphabetical.
-        // calendar
-        CalendarID extractedCalendarId = iso8601CalendarID();
-        JSValue calendarProperty = item->get(globalObject, vm.propertyNames->calendar);
-        RETURN_IF_EXCEPTION(scope, { });
-        if (!calendarProperty.isUndefined()) {
-            extractedCalendarId = toTemporalCalendarIdentifier(globalObject, calendarProperty);
-            RETURN_IF_EXCEPTION(scope, { });
-        }
 
         // day
         JSValue dayProperty = item->get(globalObject, vm.propertyNames->day);

--- a/Source/JavaScriptCore/runtime/TemporalPlainMonthDay.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainMonthDay.cpp
@@ -178,9 +178,10 @@ TemporalPlainMonthDay* TemporalPlainMonthDay::from(JSGlobalObject* globalObject,
         }
 
         // Step 2.b: GetTemporalCalendarIdentifierWithISODefault(item).
+        CalendarID calendarId = getTemporalCalendarIdentifierWithISODefault(globalObject, asObject(itemValue));
+        RETURN_IF_EXCEPTION(scope, { });
+
         // Step 2.c: PrepareCalendarFields(calendar, item, {year,month,monthCode,day}, {}, {}).
-        // (Steps 2.b-c fused into readCalendarFieldsFromObject.)
-        CalendarID calendarId = iso8601CalendarID();
         auto fields = readCalendarFieldsFromObject<FieldSetType::MonthDay>(globalObject, asObject(itemValue), calendarId);
         RETURN_IF_EXCEPTION(scope, { });
 

--- a/Source/JavaScriptCore/runtime/TemporalPlainMonthDayPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainMonthDayPrototype.cpp
@@ -187,9 +187,8 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainMonthDayPrototypeFuncWith, (JSGlobalObject
 
     // Step 6: partialMonthDay = ? PrepareCalendarFields(calendar, temporalMonthDayLike,
     //         «year, month, monthCode, day», «», ~partial~).
-    //         CalendarRead::Skip — calendar is known from the receiver; Step 3 already rejected a `calendar` property.
-    CalendarID unusedCalId = calendarId;
-    auto partialFields = readCalendarFieldsFromObject<FieldSetType::MonthDay, CalendarRead::Skip>(globalObject, like, unusedCalId);
+    // Calendar comes from the receiver — Step 3 already rejected a `calendar` property.
+    auto partialFields = readCalendarFieldsFromObject<FieldSetType::MonthDay>(globalObject, like, calendarId);
     RETURN_IF_EXCEPTION(scope, { });
     // ~partial~ throws TypeError if none of the requested fields are present with a non-undefined value.
     if (!partialFields.day && !partialFields.month && !partialFields.monthCode

--- a/Source/JavaScriptCore/runtime/TemporalPlainYearMonth.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainYearMonth.cpp
@@ -182,9 +182,10 @@ TemporalPlainYearMonth* TemporalPlainYearMonth::from(JSGlobalObject* globalObjec
         }
 
         // Step 2.b: Let calendar be ? GetTemporalCalendarIdentifierWithISODefault(item).
+        CalendarID calendarId = getTemporalCalendarIdentifierWithISODefault(globalObject, asObject(item));
+        RETURN_IF_EXCEPTION(scope, { });
+
         // Step 2.c: Let fields be ? PrepareCalendarFields(calendar, item, «year, month, monthCode», «», «»).
-        //          (Steps 2.b-c fused into readCalendarFieldsFromObject.)
-        CalendarID calendarId = iso8601CalendarID();
         auto fields = readCalendarFieldsFromObject<FieldSetType::YearMonth>(globalObject, asObject(item), calendarId);
         RETURN_IF_EXCEPTION(scope, { });
 

--- a/Source/JavaScriptCore/runtime/TemporalPlainYearMonthPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainYearMonthPrototype.cpp
@@ -207,9 +207,8 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainYearMonthPrototypeFuncWith, (JSGlobalObjec
     // Step 4: calendar = plainYearMonth.[[Calendar]] — held on the receiver.
 
     // Step 6: partialYearMonth = ? PrepareCalendarFields(calendar, temporalYearMonthLike, « year, month, monthCode », « », ~partial~).
-    //   CalendarRead::Skip — calendar is known from the receiver; Step 3 already rejected a `calendar` property.
-    CalendarID unusedCalId = yearMonth->calendarID();
-    auto partialFields = readCalendarFieldsFromObject<FieldSetType::YearMonth, CalendarRead::Skip>(globalObject, like, unusedCalId);
+    // Calendar comes from the receiver — Step 3 already rejected a `calendar` property.
+    auto partialFields = readCalendarFieldsFromObject<FieldSetType::YearMonth>(globalObject, like, yearMonth->calendarID());
     RETURN_IF_EXCEPTION(scope, { });
     // ~partial~ throws TypeError if none of the requested fields are present with a non-undefined value.
     if (!partialFields.year && !partialFields.month && !partialFields.monthCode

--- a/Source/JavaScriptCore/runtime/TemporalZonedDateTime.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalZonedDateTime.cpp
@@ -268,9 +268,11 @@ static std::optional<ZDTEpochArgs> toEpochArgsFromPropertyBag(JSGlobalObject* gl
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    // Steps 4.b+4.c: GetTemporalCalendarIdentifierWithISODefault + PrepareCalendarFields
-    //                (all 15 ZDT fields read alphabetically in one pass).
-    CalendarID calendarID = iso8601CalendarID();
+    // Step 4.b: calendar = ? GetTemporalCalendarIdentifierWithISODefault(item).
+    CalendarID calendarID = getTemporalCalendarIdentifierWithISODefault(globalObject, bag);
+    RETURN_IF_EXCEPTION(scope, std::nullopt);
+
+    // Step 4.c: PrepareCalendarFields — all 15 ZDT fields read alphabetically in one pass.
     auto fields = readZonedDateTimeFieldsFromObject<ZonedDateTimeFieldMode::Full>(globalObject, bag, calendarID);
     RETURN_IF_EXCEPTION(scope, std::nullopt);
 

--- a/Source/JavaScriptCore/runtime/TemporalZonedDateTimePrototype.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalZonedDateTimePrototype.cpp
@@ -646,10 +646,8 @@ JSC_DEFINE_HOST_FUNCTION(temporalZonedDateTimePrototypeFuncWith, (JSGlobalObject
     //   (Fused with CalendarMergeFields below; current field values serve as the base.)
     // Step 17: partialZonedDateTime = ? PrepareCalendarFields(calendar, temporalZonedDateTimeLike,
     //          «year,month,month-code,day», «hour,...,nanosecond,offset», ~partial~).
-    //   CalendarRead::Skip — calendar already known from zdt; timeZone not read in with().
-    //   outCalendarId output is discarded (not used after this call).
-    CalendarID unusedCalId = zdt->calendarID();
-    auto partialFields = readZonedDateTimeFieldsFromObject<ZonedDateTimeFieldMode::Partial, CalendarRead::Skip>(globalObject, fields, unusedCalId);
+    // Calendar comes from `this`; timeZone is not read in with().
+    auto partialFields = readZonedDateTimeFieldsFromObject<ZonedDateTimeFieldMode::Partial>(globalObject, fields, zdt->calendarID());
     RETURN_IF_EXCEPTION(scope, { });
 
     // Step 18: fields = CalendarMergeFields(calendar, fields, partialZonedDateTime).


### PR DESCRIPTION
#### 615cb1ee94e2c1fc27ca7d12fe21da824d7f8e75
<pre>
[JSC][Temporal] Extract GetTemporalCalendarIdentifierWithISODefault as a shared helper
<a href="https://bugs.webkit.org/show_bug.cgi?id=319602">https://bugs.webkit.org/show_bug.cgi?id=319602</a>
<a href="https://rdar.apple.com/182431498">rdar://182431498</a>

Reviewed by Yusuke Suzuki.

Adds JSC::getTemporalCalendarIdentifierWithISODefault matching the spec AO at [1],
including step 1 (Temporal internal-slot fast path for PlainDate/PlainDateTime/
PlainMonthDay/PlainYearMonth/ZonedDateTime).

Callers of PrepareCalendarFields now invoke it explicitly at the call site
so each spec step is visible (step 2.d then step 2.e), mirroring the spec&apos;s
own two-AO sequence. Drops the CalendarRead template parameter from
readCalendarFieldsFromObject and readZonedDateTimeFieldsFromObject — the
Read branch was doing work that belongs to the caller per spec, and after
this refactor every caller passes an already-resolved calendarId in.

Pure refactoring.

[1] <a href="https://tc39.es/proposal-temporal/#sec-temporal-gettemporalcalendarslotvaluewithisodefault">https://tc39.es/proposal-temporal/#sec-temporal-gettemporalcalendarslotvaluewithisodefault</a>

Canonical link: <a href="https://commits.webkit.org/317365@main">https://commits.webkit.org/317365@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7bf01fda0a29cf1656f9cf7d3567315ae780c629

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175119 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49052 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42833 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184705 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/133027 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d6fb1633-3bcb-4135-8d7c-a432ea31a80d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176984 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50344 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48735 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/136305 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/133027 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8970f986-2dfd-4e62-8f80-0d040efa5aa8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178077 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/39746 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/157093 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116784 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0da38680-9b5b-47bc-a242-034a1a5b8671) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/174441 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/38387 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/36767 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33178 "Built successfully") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/218/builds/5602 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/148810 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36586 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187125 "Built successfully") | | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/36381 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/40717 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/40970 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/145250 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/174519 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48719 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/156649 "") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145106 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49399 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/33206 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115233 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26612 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39964 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/121570 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/212211 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47905 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/11559 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/55368 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47308 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47538 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47365 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->