### PR TITLE
corner-shape: Implement trimBezierToRect() to clip a cubic Bézier to a rectangle

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -2452,6 +2452,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/graphics/AudioTrackPrivate.h
     platform/graphics/AudioTrackPrivateClient.h
     platform/graphics/AudioVideoRenderer.h
+    platform/graphics/BezierUtilities.h
     platform/graphics/BifurcatedGraphicsContext.h
     platform/graphics/BitmapImage.h
     platform/graphics/CachedSubimage.h

--- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
+++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
@@ -937,7 +937,7 @@
 		22441CD42FEB275500BD3B41 /* CornerShapeUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = 22441CD32FEB273C00BD3B41 /* CornerShapeUtilities.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		225A16B50D5C11E900090295 /* WebEventRegion.h in Headers */ = {isa = PBXBuildFile; fileRef = 225A16B30D5C11E900090295 /* WebEventRegion.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		228C284510D82500009D0D0E /* ScriptWrappable.h in Headers */ = {isa = PBXBuildFile; fileRef = 228C284410D82500009D0D0E /* ScriptWrappable.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		22F021A02FFF3E3500B13642 /* BezierUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = BE21E01000000000000000B1 /* BezierUtilities.h */; };
+		22F021A02FFF3E3500B13642 /* BezierUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = BE21E01000000000000000B1 /* BezierUtilities.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		23CED0538221E00106965803 /* Play.svg in Copy Modern Media Controls Images */ = {isa = PBXBuildFile; fileRef = DC8EA0C37B0638710AE9B150 /* Play.svg */; platformFilters = (macos, ); };
 		244447FB2ECD1F8E00EED177 /* WebTransportReliabilityMode.h in Headers */ = {isa = PBXBuildFile; fileRef = FAC3C3EF2A996700001E2EB8 /* WebTransportReliabilityMode.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		2444CEB42ECC4E7F00C09DC6 /* WebTransportConnectionInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = 2444CEB32ECC4E7F00C09DC6 /* WebTransportConnectionInfo.h */; settings = {ATTRIBUTES = (Private, ); }; };

--- a/Source/WebCore/platform/graphics/BezierUtilities.cpp
+++ b/Source/WebCore/platform/graphics/BezierUtilities.cpp
@@ -26,20 +26,235 @@
 #include "BezierUtilities.h"
 
 #include "FloatPoint.h"
+#include "FloatRect.h"
+#include "GeometryUtilities.h"
+#include "RectEdges.h"
+#include <algorithm>
+#include <cmath>
+#include <numbers>
+#include <utility>
 
 namespace WebCore {
 
-Vector<BezierIntersection> intersectBezierAndLine(const CubicBezier&, const FloatPoint&, const FloatPoint&)
+namespace {
+
+// Parameters within this of an interval boundary are snapped to it
+constexpr double parameterEpsilon = 1e-7;
+constexpr double nearZeroEpsilon = 1e-12;
+struct BezierIntersection {
+    float positionOnCurve { 0 };
+    float positionOnLine { 0 };
+    FloatPoint point;
+};
+
+// Solves cubic equation where roots are the parameters t at which a cubic Bézier curve crosses a line
+Vector<double, 3> solveCubicForParametersInUnitInterval(double cubicCoefficient, double quadraticCoefficient, double linearCoefficient, double constantCoefficient)
 {
-    // TODO: solve the cubic for the curve's intersections with the (infinite) line, then keep the
-    // roots whose parameter falls within both the curve and the line segment.
-    return { };
+    Vector<double, 3> parametersInUnitInterval;
+    auto addRoot = [&](double root) {
+        if (root < -parameterEpsilon || root > 1.0 + parameterEpsilon)
+            return;
+        parametersInUnitInterval.append(std::clamp(root, 0.0, 1.0));
+    };
+
+    // Nearly-zero cubic term, solve for quadratic
+    if (std::abs(cubicCoefficient) < nearZeroEpsilon) {
+        if (std::abs(quadraticCoefficient) < nearZeroEpsilon) {
+            // Linear linearCoefficient·t + constantCoefficient = 0.
+            if (std::abs(linearCoefficient) >= nearZeroEpsilon)
+                addRoot(-constantCoefficient / linearCoefficient);
+            return parametersInUnitInterval;
+        }
+        double discriminant = linearCoefficient * linearCoefficient - 4 * quadraticCoefficient * constantCoefficient;
+        if (discriminant < 0)
+            return parametersInUnitInterval;
+        double sqrtDiscriminant = std::sqrt(discriminant);
+        addRoot((-linearCoefficient + sqrtDiscriminant) / (2 * quadraticCoefficient));
+        addRoot((-linearCoefficient - sqrtDiscriminant) / (2 * quadraticCoefficient));
+        return parametersInUnitInterval;
+    }
+
+    // Make the cubic monic, depress it to y^3 + depressedLinear·y + depressedConstant = 0, and solve via Cardano / Viète.
+    double monicQuadratic = quadraticCoefficient / cubicCoefficient;
+    double monicLinear = linearCoefficient / cubicCoefficient;
+    double monicConstant = constantCoefficient / cubicCoefficient;
+
+    double shift = monicQuadratic / 3.0;
+    double depressedLinear = monicLinear - monicQuadratic * monicQuadratic / 3.0;
+    double depressedConstant = 2.0 * monicQuadratic * monicQuadratic * monicQuadratic / 27.0 - monicQuadratic * monicLinear / 3.0 + monicConstant;
+
+    double discriminant = depressedConstant * depressedConstant / 4.0 + depressedLinear * depressedLinear * depressedLinear / 27.0;
+
+    if (discriminant > 0) {
+        // One real root (Cardano).
+        double sqrtDiscriminant = std::sqrt(discriminant);
+        double firstCubeRoot = std::cbrt(-depressedConstant / 2.0 + sqrtDiscriminant);
+        double secondCubeRoot = std::cbrt(-depressedConstant / 2.0 - sqrtDiscriminant);
+        addRoot(firstCubeRoot + secondCubeRoot - shift);
+        return parametersInUnitInterval;
+    }
+
+    if (std::abs(discriminant) <= nearZeroEpsilon) {
+        // Repeated roots.
+        double cubeRoot = std::cbrt(-depressedConstant / 2.0);
+        addRoot(2.0 * cubeRoot - shift);
+        addRoot(-cubeRoot - shift);
+        return parametersInUnitInterval;
+    }
+
+    // Three distinct real roots — trigonometric (Viète) form.
+    double magnitude = 2.0 * std::sqrt(-depressedLinear / 3.0);
+    double cosineArgument = std::clamp(3.0 * depressedConstant / (depressedLinear * magnitude), -1.0, 1.0);
+    double angle = std::acos(cosineArgument);
+    constexpr double twoPi = 2.0 * std::numbers::pi;
+    for (int rootIndex = 0; rootIndex < 3; ++rootIndex)
+        addRoot(magnitude * std::cos((angle - twoPi * rootIndex) / 3.0) - shift);
+    return parametersInUnitInterval;
 }
 
-std::pair<CubicBezier, CubicBezier> splitBezier(const CubicBezier&, float)
+FloatPoint pointOnBezierAtParameter(const BezierSegment& curve, double parameter)
 {
-    // TODO: de Casteljau subdivision at `parameter` into two sub-curves.
-    return { };
+    double oneMinusParameter = 1.0 - parameter;
+    double weightStart = oneMinusParameter * oneMinusParameter * oneMinusParameter;
+    double weightControl1 = 3.0 * oneMinusParameter * oneMinusParameter * parameter;
+    double weightControl2 = 3.0 * oneMinusParameter * parameter * parameter;
+    double weightEnd = parameter * parameter * parameter;
+    return {
+        static_cast<float>(curve.start.x() * weightStart + curve.controlPoint1.x() * weightControl1 + curve.controlPoint2.x() * weightControl2 + curve.end.x() * weightEnd),
+        static_cast<float>(curve.start.y() * weightStart + curve.controlPoint1.y() * weightControl1 + curve.controlPoint2.y() * weightControl2 + curve.end.y() * weightEnd),
+    };
+}
+
+Vector<BezierIntersection> intersectBezierAndLine(const BezierSegment& curve, const FloatPoint& lineStart, const FloatPoint& lineEnd)
+{
+    double directionX = lineEnd.x() - lineStart.x();
+    double directionY = lineEnd.y() - lineStart.y();
+
+    // Control points' signed distances = Bernstein coefficients of the distance-from-line cubic in t (scale doesn't affect roots).
+    double distanceStart = signedDistanceToLine(curve.start, lineStart, lineEnd);
+    double distanceControl1 = signedDistanceToLine(curve.controlPoint1, lineStart, lineEnd);
+    double distanceControl2 = signedDistanceToLine(curve.controlPoint2, lineStart, lineEnd);
+    double distanceEnd = signedDistanceToLine(curve.end, lineStart, lineEnd);
+
+    // Convert the Bernstein cubic to power form
+    double cubicCoefficient = -distanceStart + 3 * distanceControl1 - 3 * distanceControl2 + distanceEnd;
+    double quadraticCoefficient = 3 * distanceStart - 6 * distanceControl1 + 3 * distanceControl2;
+    double linearCoefficient = -3 * distanceStart + 3 * distanceControl1;
+    double constantCoefficient = distanceStart;
+
+    auto parameters = solveCubicForParametersInUnitInterval(cubicCoefficient, quadraticCoefficient, linearCoefficient, constantCoefficient);
+
+    double lineLengthSquared = directionX * directionX + directionY * directionY;
+
+    Vector<BezierIntersection> intersections;
+    for (double parameter : parameters) {
+        auto point = pointOnBezierAtParameter(curve, parameter);
+
+        // Parameter of the crossing along the (finite) line segment.
+        double positionOnLine = lineLengthSquared > 0
+            ? ((point.x() - lineStart.x()) * directionX + (point.y() - lineStart.y()) * directionY) / lineLengthSquared
+            : 0.0;
+
+        // Keep only crossings that fall within the segment as well as the curve.
+        if (positionOnLine < -parameterEpsilon || positionOnLine > 1.0 + parameterEpsilon)
+            continue;
+
+        intersections.append({ float(parameter), float(std::clamp(positionOnLine, 0.0, 1.0)), point });
+    }
+
+    std::sort(intersections.begin(), intersections.end(), [](const BezierIntersection& lhs, const BezierIntersection& rhs) {
+        return lhs.positionOnCurve < rhs.positionOnCurve;
+    });
+    return intersections;
+}
+
+// De Casteljau's algorithm
+std::pair<BezierSegment, BezierSegment> splitBezier(const BezierSegment& curve, float parameter)
+{
+    auto startToControl1 = linearInterpolation(curve.start, curve.controlPoint1, parameter);
+    auto control1ToControl2 = linearInterpolation(curve.controlPoint1, curve.controlPoint2, parameter);
+    auto control2ToEnd = linearInterpolation(curve.controlPoint2, curve.end, parameter);
+    auto leftControl2 = linearInterpolation(startToControl1, control1ToControl2, parameter);
+    auto rightControl1 = linearInterpolation(control1ToControl2, control2ToEnd, parameter);
+    auto splitPoint = linearInterpolation(leftControl2, rightControl1, parameter);
+
+    BezierSegment before { curve.start, startToControl1, leftControl2, splitPoint };
+    BezierSegment after { splitPoint, rightControl1, control2ToEnd, curve.end };
+    return { before, after };
+}
+
+Vector<BezierSegment> trimBezierToLine(const BezierSegment& curve, const FloatPoint& lineStart, const FloatPoint& lineEnd, bool keepLeftOfLine)
+{
+    auto crossings = intersectBezierAndLine(curve, lineStart, lineEnd);
+
+    // Between successive crossings the pieces alternate sides of the line, so keep those whose midpoint is on the requested side.
+    Vector<BezierSegment> kept;
+    auto remaining = curve;
+    float consumedParameter = 0.0f;
+    for (const auto& crossing : crossings) {
+        // Re-map the crossing parameter into the shrinking `remaining` curve's own [0, 1] range.
+        float localParameter = (crossing.positionOnCurve - consumedParameter) / (1.0f - consumedParameter);
+        localParameter = std::clamp(localParameter, 0.0f, 1.0f);
+        auto [piece, rest] = splitBezier(remaining, localParameter);
+
+        bool pieceOnLeft = signedDistanceToLine(pointOnBezierAtParameter(piece, 0.5), lineStart, lineEnd) > 0;
+        if (pieceOnLeft == keepLeftOfLine)
+            kept.append(piece);
+
+        remaining = rest;
+        consumedParameter = crossing.positionOnCurve;
+    }
+    bool tailOnLeft = signedDistanceToLine(pointOnBezierAtParameter(remaining, 0.5), lineStart, lineEnd) > 0;
+    if (tailOnLeft == keepLeftOfLine)
+        kept.append(remaining);
+
+    return kept;
+}
+
+// Inclusive overlap test, zero-area boxes (e.g. an axis-aligned line) and touching edges count as overlapping.
+static bool boxesTouchOrOverlap(const FloatRect& first, const FloatRect& second)
+{
+    return first.maxX() >= second.x() && first.x() <= second.maxX()
+        && first.maxY() >= second.y() && first.y() <= second.maxY();
+}
+
+} // namespace
+
+Vector<BezierSegment> trimBezierToRect(const BezierSegment& curve, const FloatRect& rect)
+{
+    // The curve stays within its control points' convex hull
+    FloatRect controlBounds { curve.start, FloatSize { } };
+    controlBounds.extend(curve.controlPoint1);
+    controlBounds.extend(curve.controlPoint2);
+    controlBounds.extend(curve.end);
+
+    // Inside -> no trim; disjoint -> empty. Inclusive test keeps zero-area (axis-aligned line) bounds.
+    if (rect.contains(controlBounds))
+        return { curve };
+    if (!boxesTouchOrOverlap(controlBounds, rect))
+        return { };
+
+    FloatPoint center = rect.center();
+    RectEdges<std::pair<FloatPoint, FloatPoint>> edges {
+        { rect.minXMinYCorner(), rect.maxXMinYCorner() }, // top
+        { rect.maxXMinYCorner(), rect.maxXMaxYCorner() }, // right
+        { rect.maxXMaxYCorner(), rect.minXMaxYCorner() }, // bottom
+        { rect.minXMaxYCorner(), rect.minXMinYCorner() }, // left
+    };
+
+    Vector<BezierSegment> curves;
+    curves.append(curve);
+    for (auto side : allBoxSides) {
+        const auto& edge = edges.at(side);
+        bool keepCenterSide = signedDistanceToLine(center, edge.first, edge.second) > 0;
+        Vector<BezierSegment> clipped;
+        for (const auto& piece : curves) {
+            for (const auto& keptCurve : trimBezierToLine(piece, edge.first, edge.second, keepCenterSide))
+                clipped.append(keptCurve);
+        }
+        curves = clipped;
+    }
+    return curves;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/BezierUtilities.h
+++ b/Source/WebCore/platform/graphics/BezierUtilities.h
@@ -25,27 +25,18 @@
 #pragma once
 
 #include <WebCore/FloatPoint.h>
-#include <array>
-#include <utility>
+#include <WebCore/FloatRect.h>
 #include <wtf/Vector.h>
 
 namespace WebCore {
 
-// A cubic Bézier curve segment, ordered { start, control1, control2, end }
-using CubicBezier = std::array<FloatPoint, 4>;
-
-struct BezierIntersection {
-    float parameterOnFirst { 0 };
-    float parameterOnSecond { 0 };
-    FloatPoint point;
+struct BezierSegment {
+    FloatPoint start;
+    FloatPoint controlPoint1;
+    FloatPoint controlPoint2;
+    FloatPoint end;
 };
 
-// TODO: implement.
-Vector<BezierIntersection> intersectBezierAndLine(const CubicBezier&, const FloatPoint& lineStart, const FloatPoint& lineEnd);
-
-// Splits `curve` at `parameter` (a fraction in [0, 1]) into two sub-curves that together retrace
-// the original, using de Casteljau subdivision.
-// TODO: implement.
-std::pair<CubicBezier, CubicBezier> splitBezier(const CubicBezier& curve, float parameter);
+WEBCORE_EXPORT Vector<BezierSegment> trimBezierToRect(const BezierSegment& curve, const FloatRect&);
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/CornerShapeUtilities.cpp
+++ b/Source/WebCore/platform/graphics/CornerShapeUtilities.cpp
@@ -26,9 +26,11 @@
 #include "CornerShapeUtilities.h"
 
 #include "FloatPoint.h"
+#include "FloatRect.h"
 #include "FloatSize.h"
 #include "GeometryUtilities.h"
 #include "Path.h"
+#include <WebCore/BezierUtilities.h>
 
 #include <algorithm>
 #include <cmath>
@@ -301,7 +303,16 @@ static void addCurvedCorner(Path& path, const Corner& corner)
         return;
     }
 
-    // TODO: squircle and the general superellipse curve
+    // TODO: squircle and the general superellipse curve.
+    // FIXME (bug 319603 follow-up): stub in-framework consumer of trimBezierToRect() while the
+    // real superellipse trimming is developed. Behavior is unchanged (still a sharp vertex);
+    // the clipped result is intentionally unused for now.
+    BezierSegment cornerSegment { corner.start, corner.outer, corner.outer, corner.end };
+    FloatRect cornerBounds { corner.start, FloatSize { } };
+    cornerBounds.extend(corner.outer);
+    cornerBounds.extend(corner.end);
+    trimBezierToRect(cornerSegment, cornerBounds);
+
     path.addLineTo(corner.start);
     path.addLineTo(corner.outer);
     path.addLineTo(corner.end);

--- a/Tools/TestWebKitAPI/CMakeLists.txt
+++ b/Tools/TestWebKitAPI/CMakeLists.txt
@@ -215,6 +215,7 @@ if (ENABLE_WEBCORE)
 
         Tests/WebCore/AffineTransform.cpp
         Tests/WebCore/AudioSampleFormat.cpp
+        Tests/WebCore/BezierUtilitiesTests.cpp
         Tests/WebCore/CSSParser.cpp
         Tests/WebCore/CSSTokenizerTests.cpp
         Tests/WebCore/CachedMatchFinder.cpp

--- a/Tools/TestWebKitAPI/Tests/WebCore/BezierUtilitiesTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/BezierUtilitiesTests.cpp
@@ -1,0 +1,191 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#include <WebCore/BezierUtilities.h>
+#include <WebCore/FloatPoint.h>
+#include <WebCore/FloatRect.h>
+#include <WebCore/FloatSize.h>
+
+namespace TestWebKitAPI {
+using namespace WebCore;
+
+// A cubic Bézier whose control points are evenly spaced, so it's exactly the straight line start->end (crossings are hand-computable).
+static BezierSegment lineCurve(FloatPoint start, FloatPoint end)
+{
+    FloatSize delta = end - start;
+    return { start, start + delta * (1.0f / 3.0f), start + delta * (2.0f / 3.0f), end };
+}
+
+static void expectPointNear(const FloatPoint& actual, float expectedX, float expectedY, float tolerance = 0.05f)
+{
+    EXPECT_NEAR(actual.x(), expectedX, tolerance);
+    EXPECT_NEAR(actual.y(), expectedY, tolerance);
+}
+
+// A curve entirely inside the rect is returned unchanged (single piece, all four control points intact).
+TEST(BezierUtilities, TrimReturnsStraightCurveInsideUnchanged)
+{
+    auto curve = lineCurve({ 5, 10 }, { 15, 10 });
+    auto result = trimBezierToRect(curve, FloatRect(0, 0, 20, 20));
+
+    ASSERT_EQ(1u, result.size());
+    expectPointNear(result[0].start, 5, 10);
+    expectPointNear(result[0].controlPoint1, curve.controlPoint1.x(), curve.controlPoint1.y());
+    expectPointNear(result[0].controlPoint2, curve.controlPoint2.x(), curve.controlPoint2.y());
+    expectPointNear(result[0].end, 15, 10);
+}
+
+// A curved Bézier fully inside the rect is returned unchanged (exercises the real cubic solve finding no crossing in [0, 1]).
+TEST(BezierUtilities, TrimReturnsCurvedBezierInsideUnchanged)
+{
+    BezierSegment curve { { 5, 10 }, { 8, 5 }, { 12, 5 }, { 15, 10 } };
+    auto result = trimBezierToRect(curve, FloatRect(0, 0, 20, 20));
+
+    ASSERT_EQ(1u, result.size());
+    expectPointNear(result[0].start, 5, 10);
+    expectPointNear(result[0].controlPoint1, 8, 5);
+    expectPointNear(result[0].controlPoint2, 12, 5);
+    expectPointNear(result[0].end, 15, 10);
+}
+
+// A curve entirely outside the rect yields nothing.
+TEST(BezierUtilities, TrimReturnsEmptyForCurveOutside)
+{
+    auto curve = lineCurve({ 5, 30 }, { 15, 30 }); // above the rect (y = 30 > 20)
+    EXPECT_TRUE(trimBezierToRect(curve, FloatRect(0, 0, 20, 20)).isEmpty());
+}
+
+// A line spanning the rect horizontally is clipped to both the left and right edges.
+TEST(BezierUtilities, TrimClipsSpanningLineToLeftAndRightEdges)
+{
+    auto curve = lineCurve({ -10, 10 }, { 30, 10 }); // enters left edge (x=0), exits right edge (x=20)
+    auto result = trimBezierToRect(curve, FloatRect(0, 0, 20, 20));
+
+    ASSERT_EQ(1u, result.size());
+    expectPointNear(result[0].start, 0, 10);
+    expectPointNear(result[0].end, 20, 10);
+}
+
+// A line starting inside and exiting one edge keeps the original inside endpoint and clips the far end.
+TEST(BezierUtilities, TrimKeepsInsideEndpointAndClipsCrossedEdge)
+{
+    auto curve = lineCurve({ 5, 10 }, { 30, 10 }); // starts inside, exits right edge at x = 20
+    auto result = trimBezierToRect(curve, FloatRect(0, 0, 20, 20));
+
+    ASSERT_EQ(1u, result.size());
+    expectPointNear(result[0].start, 5, 10); // unchanged inside endpoint
+    expectPointNear(result[0].end, 20, 10); // clipped onto the right edge
+}
+
+// A diagonal line from (10,10) to (40,20) exits the right edge (x=20) at t=1/3, where y = 13.333.
+TEST(BezierUtilities, TrimClipsDiagonalLineAtEdgeCrossing)
+{
+    auto curve = lineCurve({ 10, 10 }, { 40, 20 });
+    auto result = trimBezierToRect(curve, FloatRect(0, 0, 20, 20));
+
+    ASSERT_EQ(1u, result.size());
+    expectPointNear(result[0].start, 10, 10);
+    expectPointNear(result[0].end, 20, 13.333f, 0.1f);
+}
+
+// A curved Bézier that dips through the top edge and back: clipped to the interior arc, both endpoints land on the edge (solver finds two real roots).
+TEST(BezierUtilities, TrimClipsCurveDippingThroughTopEdge)
+{
+    // Endpoints above the rect (y = -5); control points pull the middle down to B(0.5) = (10, 10), inside.
+    BezierSegment curve { { 5, -5 }, { 5, 15 }, { 15, 15 }, { 15, -5 } };
+    auto result = trimBezierToRect(curve, FloatRect(0, 0, 20, 20));
+
+    ASSERT_EQ(1u, result.size());
+    EXPECT_NEAR(result[0].start.y(), 0, 0.05f); // enters through the top edge (y = 0)
+    EXPECT_NEAR(result[0].end.y(), 0, 0.05f); // exits through the top edge
+    EXPECT_GT(result[0].start.x(), 0);
+    EXPECT_LT(result[0].end.x(), 20);
+}
+
+// A vertical line spanning the rect is clipped to the top and bottom edges (the symmetric
+// case of the horizontal span: its control bounds have zero width, which must not be
+// treated as disjoint from the rect).
+TEST(BezierUtilities, TrimClipsVerticalSpanningLineToTopAndBottomEdges)
+{
+    auto curve = lineCurve({ 10, -10 }, { 10, 30 }); // enters top edge (y=0), exits bottom edge (y=20)
+    auto result = trimBezierToRect(curve, FloatRect(0, 0, 20, 20));
+
+    ASSERT_EQ(1u, result.size());
+    expectPointNear(result[0].start, 10, 0);
+    expectPointNear(result[0].end, 10, 20);
+}
+
+// A vertical line starting inside and exiting the bottom edge keeps the inside endpoint
+// and clips the far end onto the edge.
+TEST(BezierUtilities, TrimKeepsInsideEndpointAndClipsVerticalCrossedEdge)
+{
+    auto curve = lineCurve({ 10, 5 }, { 10, 30 }); // starts inside, exits bottom edge at y = 20
+    auto result = trimBezierToRect(curve, FloatRect(0, 0, 20, 20));
+
+    ASSERT_EQ(1u, result.size());
+    expectPointNear(result[0].start, 10, 5); // unchanged inside endpoint
+    expectPointNear(result[0].end, 10, 20); // clipped onto the bottom edge
+}
+
+// A degenerate curve collapsed to a single point inside the rect is returned unchanged
+// (zero-width and zero-height control bounds must still count as contained).
+TEST(BezierUtilities, TrimReturnsSinglePointCurveInsideUnchanged)
+{
+    BezierSegment curve { { 10, 10 }, { 10, 10 }, { 10, 10 }, { 10, 10 } };
+    auto result = trimBezierToRect(curve, FloatRect(0, 0, 20, 20));
+
+    ASSERT_EQ(1u, result.size());
+    expectPointNear(result[0].start, 10, 10);
+    expectPointNear(result[0].end, 10, 10);
+}
+
+// A degenerate single-point curve outside the rect yields nothing.
+TEST(BezierUtilities, TrimReturnsEmptyForSinglePointCurveOutside)
+{
+    BezierSegment curve { { 30, 30 }, { 30, 30 }, { 30, 30 }, { 30, 30 } };
+    EXPECT_TRUE(trimBezierToRect(curve, FloatRect(0, 0, 20, 20)).isEmpty());
+}
+
+// A horizontal line entirely to the left of the rect is disjoint and yields nothing, even
+// though its control bounds are zero-height (guards the inclusive disjoint early-out).
+TEST(BezierUtilities, TrimReturnsEmptyForHorizontalLineLeftOfRect)
+{
+    auto curve = lineCurve({ -30, 10 }, { -5, 10 });
+    EXPECT_TRUE(trimBezierToRect(curve, FloatRect(0, 0, 20, 20)).isEmpty());
+}
+
+// A line lying exactly along the top edge is coincident with the rect boundary; its
+// zero-height bounds sit on the edge, so it is retained rather than discarded as disjoint.
+TEST(BezierUtilities, TrimKeepsLineLyingAlongTopEdge)
+{
+    auto curve = lineCurve({ 5, 0 }, { 15, 0 });
+    auto result = trimBezierToRect(curve, FloatRect(0, 0, 20, 20));
+
+    EXPECT_FALSE(result.isEmpty());
+}
+
+} // namespace TestWebKitAPI


### PR DESCRIPTION
#### f5eba498b2d50f4e6721ae2db870cf61715a050e
<pre>
corner-shape: Implement trimBezierToRect() to clip a cubic Bézier to a rectangle
<a href="https://bugs.webkit.org/show_bug.cgi?id=319603">https://bugs.webkit.org/show_bug.cgi?id=319603</a>
<a href="https://rdar.apple.com/182432597">rdar://182432597</a>

Reviewed by Simon Fraser.

This is infrastructure for CSS corner-shape rendering. Drawing corner shapes
using Bezier Curves requires clipping the Bézier segments that describe a
corner to the corner&apos;s bounding box, so that a curve extending past the box
is trimmed to just the portion inside it. BezierUtilities is where that
geometry lives, but it previously exposed only unimplemented stubs
(intersectBezierAndLine, splitBezier). This fills in the logic and replaces
those stubs with a single public entry point, trimBezierToRect(), which
returns the sub-curves of a cubic Bézier that lie inside a given FloatRect.

BezierUtilities.h is a private framework header, so it is included via
&lt;WebCore/BezierUtilities.h&gt; (the framework form) rather than a quoted include,
so that the WebCore_Private module picks it up.

Test: Tools/TestWebKitAPI/Tests/WebCore/BezierUtilitiesTests.cpp

* Source/WebCore/Headers.cmake:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/graphics/BezierUtilities.cpp:
(WebCore::trimBezierToRect):
(WebCore::intersectBezierAndLine): Deleted.
(WebCore::splitBezier): Deleted.
* Source/WebCore/platform/graphics/BezierUtilities.h:
(): Deleted.
* Tools/TestWebKitAPI/CMakeLists.txt:
* Tools/TestWebKitAPI/Tests/WebCore/BezierUtilitiesTests.cpp: Added.
(TestWebKitAPI::lineCurve):
(TestWebKitAPI::expectPointNear):
(TestWebKitAPI::TEST(BezierUtilities, TrimReturnsStraightCurveInsideUnchanged)):
(TestWebKitAPI::TEST(BezierUtilities, TrimReturnsCurvedBezierInsideUnchanged)):
(TestWebKitAPI::TEST(BezierUtilities, TrimReturnsEmptyForCurveOutside)):
(TestWebKitAPI::TEST(BezierUtilities, TrimClipsSpanningLineToLeftAndRightEdges)):
(TestWebKitAPI::TEST(BezierUtilities, TrimKeepsInsideEndpointAndClipsCrossedEdge)):
(TestWebKitAPI::TEST(BezierUtilities, TrimClipsDiagonalLineAtEdgeCrossing)):
(TestWebKitAPI::TEST(BezierUtilities, TrimClipsCurveDippingThroughTopEdge)):
(TestWebKitAPI::TEST(BezierUtilities, TrimClipsVerticalSpanningLineToTopAndBottomEdges)):
(TestWebKitAPI::TEST(BezierUtilities, TrimKeepsInsideEndpointAndClipsVerticalCrossedEdge)):
(TestWebKitAPI::TEST(BezierUtilities, TrimReturnsSinglePointCurveInsideUnchanged)):
(TestWebKitAPI::TEST(BezierUtilities, TrimReturnsEmptyForSinglePointCurveOutside)):
(TestWebKitAPI::TEST(BezierUtilities, TrimReturnsEmptyForHorizontalLineLeftOfRect)):
(TestWebKitAPI::TEST(BezierUtilities, TrimKeepsLineLyingAlongTopEdge)):
* Source/WebCore/platform/graphics/CornerShapeUtilities.cpp:

Canonical link: <a href="https://commits.webkit.org/317488@main">https://commits.webkit.org/317488@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3f62fd99f53451716123cff506fc2674ac5b2507

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175377 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49309 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43090 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184963 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/137503 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/177241 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50601 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48992 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136530 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/137503 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178334 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39949 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157287 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117008 "Passed tests") | 
| [⏳ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/WebKitPy-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38591 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36975 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149013 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36780 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33438 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/40996 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41179 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187388 "Built successfully") | 
| [⏳ 🧪 services](https://ews-build.webkit.org/#/builders/Services-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48976 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145496 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39160 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49656 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33402 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145337 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40153 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/121849 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115541 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48162 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11753 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47565 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47795 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47622 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->