### PR TITLE
[mac][ios][win] CodecDelay webm field isn't being honored

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -103,7 +103,6 @@ media/encrypted-media/encrypted-media-append-encrypted-unencrypted.html [ Skip ]
 media/media-source/media-source-append-play-corrupt-aac.html [ Skip ]
 media/media-source/media-source-mp4ttsimple.html [ Skip ]
 media/media-source/media-source-inband-cea608-track.html [ Skip ]
-media/media-source/media-source-changetype-tracks.html [ Skip ]
 media/modern-media-controls/ios-inline-media-controls/touch [ Skip ]
 media/modern-media-controls/overflow-support [ Skip ]
 media/modern-media-controls/visionos-inline-media-controls [ Skip ]
@@ -6487,9 +6486,6 @@ webkit.org/b/245905 imported/w3c/web-platform-tests/css/css-text/line-breaking/l
 
 # This test can cause OOM error, depending on device and memory usage, and there is no guarantee. Ignore console log, which appears when OOM happens since what we would like to ensure is just no crash.
 js/dom/Promise-reject-large-string.html [ DumpJSConsoleLogInStdErr ]
-
-# Fails and should be fixed on all platforms except glib
-webkit.org/b/254222 media/media-source/media-webm-opus-codecdelay.html [ Failure ]
 
 webkit.org/b/251624 fast/images/animated-heics-verify.html [ Skip ]
 

--- a/LayoutTests/media/media-source/media-webm-opus-codecdelay.html
+++ b/LayoutTests/media/media-source/media-webm-opus-codecdelay.html
@@ -38,7 +38,7 @@
             run('sourceBuffer.appendBuffer(loader.mediaSegment(0).slice(0, loader.mediaSegmentSize(0)/2))');
             await waitFor(sourceBuffer, 'update');
             testExpected('sourceBuffer.buffered.length', '1');
-            testExpected('sourceBuffer.buffered.end(0)', '3.9545');
+            consoleWrite(`sourceBuffer.buffered.end(0) = ${sourceBuffer.buffered.end(0)}`);
 
             endTest();
         } catch (e) {

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -601,11 +601,6 @@ media/media-source/media-source-inband-cea608-track.html [ Pass ]
 
 media/media-source/media-source-video-seek-pause.html [ Failure Pass ]
 
-media/media-source/media-source-changetype-tracks.html [ Pass ]
-
-# Only GStreamer is honoring the CodecDelay field
-webkit.org/b/254222 media/media-source/media-webm-opus-codecdelay.html [ Pass ]
-
 # GStreamer seeks to the wrong frame
 webkit.org/b/261335 media/media-source/media-managedmse-seek.html [ ImageOnlyFailure ]
 

--- a/LayoutTests/platform/glib/media/media-source/media-webm-opus-codecdelay-expected.txt
+++ b/LayoutTests/platform/glib/media/media-source/media-webm-opus-codecdelay-expected.txt
@@ -10,6 +10,6 @@ Append a partial media segment
 RUN(sourceBuffer.appendBuffer(loader.mediaSegment(0).slice(0, loader.mediaSegmentSize(0)/2)))
 EVENT(update)
 EXPECTED (sourceBuffer.buffered.length == '1') OK
-sourceBuffer.buffered.end(0) = 3.9535
+sourceBuffer.buffered.end(0) = 3.9545
 END OF TEST
 


### PR DESCRIPTION
#### 334f673f46746a9f95b3f4663262853b740ca4e6
<pre>
[mac][ios][win] CodecDelay webm field isn&apos;t being honored
<a href="https://bugs.webkit.org/show_bug.cgi?id=254222">https://bugs.webkit.org/show_bug.cgi?id=254222</a>
<a href="https://rdar.apple.com/107261068">rdar://107261068</a>

Reviewed by Youenn Fablet.

Codec delay was added in 262837@main (2023-04-11).

* LayoutTests/platform/glib/media/media-source/media-webm-opus-codecdelay-expected.txt: FFmpeg&apos;s gstreamer calculate differently the duration of the last frame (webm doesn&apos;t define it)
* LayoutTests/TestExpectations:
* LayoutTests/media/media-source/media-webm-opus-codecdelay-expected.txt:
* LayoutTests/media/media-source/media-webm-opus-codecdelay.html:
* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/glib/media/media-source/media-webm-opus-codecdelay-expected.txt: Copied from LayoutTests/media/media-source/media-webm-opus-codecdelay-expected.txt.

Canonical link: <a href="https://commits.webkit.org/317579@main">https://commits.webkit.org/317579@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0d6a45b420d36ed194fc567573c8615b0d3af092

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175248 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49180 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42961 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184833 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/133595 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f2f3708e-1cd8-45e1-8d62-c04258444c56) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50472 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48863 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136415 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/133595 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7552f17a-42d2-4177-b70e-0dd05afce458) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178205 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39836 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157184 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116894 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/37455201-e483-41f8-b2e5-0e1d02204953) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38477 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36858 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33306 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148900 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36677 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187254 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41061 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145363 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48847 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/156740 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145219 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39226 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49527 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33298 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/held.https.any.sharedworker.html (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115406 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40055 "Passed tests") | | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48033 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11650 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47436 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47666 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47493 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->