### PR TITLE
[JSC][DFG][x86_64] String.prototype.substr INT_MIN length clamp miscompile creates invalid JSString length   and Release abort/OOB-read evidence

### DIFF
--- a/JSTests/stress/string-substr-int-min-length-clamp.js
+++ b/JSTests/stress/string-substr-int-min-length-clamp.js
@@ -1,0 +1,33 @@
+// Regression test for https://bugs.webkit.org/show_bug.cgi?id=317480
+//
+// The DFG's inlined String.prototype.substr clamps the length with
+// size = max(0, min(length, len - start)). On x86_64 the second clamp lowered
+// to `test; xorl reg, reg; cmov`, and the flag-clobbering xorl (materializing
+// the zero immediate) corrupted the sign flag the cmov depended on. A negative
+// length such as INT_MIN was therefore not clamped to zero and produced an
+// invalid JSString with length 2147483648.
+
+function shouldBe(actual, expected) {
+    if (!Object.is(actual, expected))
+        throw new Error(`Bad value: ${actual}, expected: ${expected}`);
+}
+
+function f(s, n) {
+    return s.substr(2, n);
+}
+noInline(f);
+
+const s = "x".repeat(64);
+for (let i = 0; i < testLoopCount; ++i) {
+    const r = f(s, -2147483648);
+    shouldBe(r.length, 0);
+    shouldBe(r, "");
+}
+
+// Materializing a bounded substring from the (previously malformed) result must
+// not expose any code units beyond the actual source extent.
+const bad = f(s, -2147483648);
+const copied = bad.substr(0, 80);
+shouldBe(bad.length, 0);
+shouldBe(copied.length, 0);
+shouldBe(copied, "");

--- a/Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h
@@ -2681,6 +2681,16 @@ public:
             m_assembler.movq_rr(src, dest);
     }
 
+    void moveWithoutClobberingFlags(TrustedImm32 imm, RegisterID dest)
+    {
+        m_assembler.movl_i32r(imm.m_value, dest);
+    }
+
+    void moveWithoutClobberingFlags(TrustedImm64 imm, RegisterID dest)
+    {
+        m_assembler.movq_i64r(imm.m_value, dest);
+    }
+
     void move(TrustedImmPtr imm, RegisterID dest)
     {
         if (!imm.m_value)
@@ -2929,10 +2939,10 @@ public:
         m_assembler.cmpl_ir(right.m_value, left);
 
         if (elseCase == dest) {
-            move(thenCase, scratchRegister());
+            moveWithoutClobberingFlags(thenCase, scratchRegister());
             cmov(x86Condition(cond), scratchRegister(), dest);
         } else {
-            move(thenCase, dest);
+            moveWithoutClobberingFlags(thenCase, dest);
             cmov(x86Condition(invert(cond)), elseCase, dest);
         }
     }
@@ -2969,10 +2979,10 @@ public:
         m_assembler.testl_rr(right, left);
 
         if (elseCase == dest) {
-            move(thenCase, scratchRegister());
+            moveWithoutClobberingFlags(thenCase, scratchRegister());
             cmov(x86Condition(cond), scratchRegister(), dest);
         } else {
-            move(thenCase, dest);
+            moveWithoutClobberingFlags(thenCase, dest);
             cmov(x86Condition(invert(cond)), elseCase, dest);
         }
     }
@@ -3009,10 +3019,10 @@ public:
         test32(testReg, mask);
 
         if (elseCase == dest) {
-            move(thenCase, scratchRegister());
+            moveWithoutClobberingFlags(thenCase, scratchRegister());
             cmov(x86Condition(cond), scratchRegister(), dest);
         } else {
-            move(thenCase, dest);
+            moveWithoutClobberingFlags(thenCase, dest);
             cmov(x86Condition(invert(cond)), elseCase, dest);
         }
     }


### PR DESCRIPTION
#### 12196a032b7678f9b8f60a483ae22c01cc14af97
<pre>
[JSC][DFG][x86_64] String.prototype.substr INT_MIN length clamp miscompile creates invalid JSString length   and Release abort/OOB-read evidence
<a href="https://bugs.webkit.org/show_bug.cgi?id=317480">https://bugs.webkit.org/show_bug.cgi?id=317480</a>
<a href="https://rdar.apple.com/180105216">rdar://180105216</a>

Reviewed by Sosuke Suzuki.

x86_64 move(TrustedImm32, register) uses xor for 0 creation, which
clobbers cflag, causing a problem if cflag is used with cmov etc.
This patch adds moveWithoutClobberingFlags and use it when we need to
care about clfag. While moveWithoutClobberingFlags with TrustedImm64 is
not used right now, we may need it due to the exact same reason so
adding it.

Test: JSTests/stress/string-substr-int-min-length-clamp.js

* JSTests/stress/string-substr-int-min-length-clamp.js: Added.
(shouldBe):
* Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h:
(JSC::MacroAssemblerX86_64::moveWithoutClobberingFlags):
(JSC::MacroAssemblerX86_64::moveConditionally32):
(JSC::MacroAssemblerX86_64::moveConditionallyTest32):

Canonical link: <a href="https://commits.webkit.org/317364@main">https://commits.webkit.org/317364@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c19eb9cd4d8bc5d36bd01d61ca9ff1c460dcc5ca

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175050 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48983 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42764 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184635 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/132958 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50275 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48666 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136249 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/132958 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178008 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39679 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157033 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116727 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38320 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/36709 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33108 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/5542 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148743 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36525 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187056 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/36312 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/40595 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/40911 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145190 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48650 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145046 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49330 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/33146 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115153 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26611 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39903 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/121481 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/212142 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47836 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11498 "Passed tests") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/55339 "Found 12 jsc stress test failures: stress/promise-prototype-catch-on-non-promise.js.default, stress/regexp-dot-star-enclosure-contains-capturing-terms-out-of-stack.js.bytecode-cache, stress/regexp-prototype-symbol-search-on-non-regexp.js.default, stress/regexp-prototype-test-on-non-regexp.js.default, stress/string-replace-regexp-with-own-property.js.default ..., JSC test binary failure: testapi") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47239 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47469 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47296 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->