### PR TITLE
AX: Coalesce redundant live region snapshot recomputations within a run loop iteration

### DIFF
--- a/LayoutTests/accessibility/mac/live-regions/live-region-changes-coalesced-expected.txt
+++ b/LayoutTests/accessibility/mac/live-regions/live-region-changes-coalesced-expected.txt
@@ -1,0 +1,29 @@
+This tests that many changes to distinct descendants of the same live region within a single run loop iteration are coalesced, so the region's snapshot is recomputed only once rather than once per change.
+
+
+Changed 10 distinct descendants of the live region in one run loop iteration.
+Snapshot recomputations: 1
+
+PASS buildCount is 1
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Updated 0
+
+Updated 1
+
+Updated 2
+
+Updated 3
+
+Updated 4
+
+Updated 5
+
+Updated 6
+
+Updated 7
+
+Updated 8
+
+Updated 9

--- a/LayoutTests/accessibility/mac/live-regions/live-region-changes-coalesced.html
+++ b/LayoutTests/accessibility/mac/live-regions/live-region-changes-coalesced.html
@@ -1,0 +1,71 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ IsAriaLiveRegionManagementEnabled=true ] -->
+<html>
+<head>
+<script src="../../../resources/js-test.js"></script>
+<script src="../../../resources/accessibility-helper.js"></script>
+</head>
+<body>
+
+<div id="region" aria-live="polite">
+    <p id="item0">Item 0</p>
+    <p id="item1">Item 1</p>
+    <p id="item2">Item 2</p>
+    <p id="item3">Item 3</p>
+    <p id="item4">Item 4</p>
+    <p id="item5">Item 5</p>
+    <p id="item6">Item 6</p>
+    <p id="item7">Item 7</p>
+    <p id="item8">Item 8</p>
+    <p id="item9">Item 9</p>
+</div>
+
+<script>
+var output = "This tests that many changes to distinct descendants of the same live region within a single run loop iteration are coalesced, so the region's snapshot is recomputed only once rather than once per change.\n\n";
+
+var itemCount = 10;
+var announcements = [];
+var buildCount = -1;
+
+function notificationCallback(object, notification, userInfo) {
+    if (notification == "AXAnnouncementRequested")
+        announcements.push(true);
+}
+
+async function runTest() {
+    accessibilityController.addNotificationListener(notificationCallback);
+
+    // Ensure the accessibility tree exists and the live region is registered before we start.
+    accessibilityController.accessibleElementById("region");
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    // Start counting snapshot recomputations from a clean slate (ignore registration-time builds).
+    internals.resetLiveRegionSnapshotBuildCount();
+
+    // Change the text of every child within a single run loop iteration. Each change walks up to the
+    // same live region; without coalescing, the region's snapshot is recomputed once per change.
+    for (var i = 0; i < itemCount; i++)
+        document.getElementById("item" + i).textContent = "Updated " + i;
+
+    // Wait for the accessibility cache to process the changes (no forced updates).
+    await waitFor(() => announcements.length > 0);
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    buildCount = internals.liveRegionSnapshotBuildCount();
+
+    debug(output);
+    debug(`Changed ${itemCount} distinct descendants of the live region in one run loop iteration.`);
+    debug(`Snapshot recomputations: ${buildCount}`);
+    debug("");
+    shouldBe("buildCount", "1");
+
+    accessibilityController.removeNotificationListener();
+    finishJSTest();
+}
+
+if (window.accessibilityController && window.internals) {
+    window.jsTestIsAsync = true;
+    runTest();
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/mac/live-regions/live-region-types.html
+++ b/LayoutTests/accessibility/mac/live-regions/live-region-types.html
@@ -21,14 +21,17 @@ var notificationCount = 0;
 var testFinished = false;
 
 function notificationCallback(object, notification, userInfo) {
-    if (notification == "AXAnnouncementRequested") {
-        output += `Received announcement request:\n`;
-        output += formatAnnouncementUserInfo(userInfo);
-        output += `\n`;
+    // Only react to announcements. Other notifications (e.g. AXLayoutComplete) can fire repeatedly;
+    // running the logic below on them would re-set textContent in a loop and coalesce/duplicate announcements.
+    if (notification != "AXAnnouncementRequested")
+        return;
 
-        notificationCount++;  
-    }
-	
+    output += `Received announcement request:\n`;
+    output += formatAnnouncementUserInfo(userInfo);
+    output += `\n`;
+
+    notificationCount++;
+
     if (notificationCount == 1)
         document.getElementById('assertive-region').textContent = "Count: 5";
     else if (notificationCount == 2)

--- a/Source/WebCore/accessibility/AXLiveRegionManager.cpp
+++ b/Source/WebCore/accessibility/AXLiveRegionManager.cpp
@@ -183,6 +183,8 @@ static constexpr size_t maximumSnapshotObjects = 512;
 
 LiveRegionSnapshot AXLiveRegionManager::buildLiveRegionSnapshot(AccessibilityObject& object) const
 {
+    ++m_snapshotBuildCount;
+
     LiveRegionSnapshot snapshot;
     snapshot.liveRegionStatus = stringToLiveRegionStatus(object.liveRegionStatus());
     snapshot.liveRegionRelevant = stringToLiveRegionRelevant(object.liveRegionRelevant());

--- a/Source/WebCore/accessibility/AXLiveRegionManager.h
+++ b/Source/WebCore/accessibility/AXLiveRegionManager.h
@@ -53,6 +53,11 @@ public:
     void unregisterLiveRegion(AXID axID) { m_liveRegions.remove(axID); }
 
     void handleLiveRegionChange(AccessibilityObject&, AnnouncementContents = AnnouncementContents::Changes);
+
+    // Testing-only: number of times a live region snapshot has been (re)computed. Used to verify
+    // that redundant changes to the same region within a run loop iteration are coalesced.
+    unsigned snapshotBuildCount() const { return m_snapshotBuildCount; }
+    void resetSnapshotBuildCount() { m_snapshotBuildCount = 0; }
 private:
     struct LiveRegionDiff {
         Vector<LiveRegionObject> added;
@@ -68,6 +73,7 @@ private:
 
     CheckedRef<AXObjectCache> m_cache;
     HashMap<AXID, LiveRegionSnapshot> m_liveRegions;
+    mutable unsigned m_snapshotBuildCount { 0 };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -3304,15 +3304,30 @@ void AXObjectCache::frameLoadingEventNotification(LocalFrame* frame, AXLoadingEv
     }
 }
 
-void AXObjectCache::postLiveRegionChangeNotification(AccessibilityObject& object)
+unsigned AXObjectCache::liveRegionSnapshotBuildCount() const
 {
 #if PLATFORM(COCOA)
-    if (m_liveRegionManager) {
-        m_liveRegionManager->handleLiveRegionChange(object);
-        return;
-    }
+    if (m_liveRegionManager)
+        return m_liveRegionManager->snapshotBuildCount();
 #endif
+    return 0;
+}
 
+void AXObjectCache::resetLiveRegionSnapshotBuildCount()
+{
+#if PLATFORM(COCOA)
+    if (m_liveRegionManager)
+        m_liveRegionManager->resetSnapshotBuildCount();
+#endif
+}
+
+void AXObjectCache::postLiveRegionChangeNotification(AccessibilityObject& object)
+{
+    // Consolidate multiple live region changes to the same object within a run loop iteration.
+    // Web content (e.g. rebuilding a large calendar) can fire hundreds of text changes that each
+    // walk up to a live-region ancestor; deduplicating here and processing once when the timer fires
+    // collapses that into a single snapshot rebuild per region. On COCOA, the timer drives
+    // AXLiveRegionManager; elsewhere it posts a LiveRegionChanged notification.
     if (m_liveRegionChangedPostTimer.isActive())
         m_liveRegionChangedPostTimer.stop();
 
@@ -3329,6 +3344,15 @@ void AXObjectCache::liveRegionChangedNotificationPostTimerFired()
 
     if (m_changedLiveRegions.isEmpty())
         return;
+
+#if PLATFORM(COCOA)
+    if (m_liveRegionManager) {
+        for (auto& object : m_changedLiveRegions)
+            m_liveRegionManager->handleLiveRegionChange(object.get());
+        m_changedLiveRegions.clear();
+        return;
+    }
+#endif
 
     for (auto& object : m_changedLiveRegions)
         postNotification(object.ptr(), protect(object->document()).get(), AXNotification::LiveRegionChanged);

--- a/Source/WebCore/accessibility/AXObjectCache.h
+++ b/Source/WebCore/accessibility/AXObjectCache.h
@@ -690,6 +690,10 @@ public:
     void postTextStateChangeNotification(const Position&, const AXTextStateChangeIntent&, const VisibleSelection&);
     void postLiveRegionChangeNotification(AccessibilityObject&);
 
+    // Testing-only: number of times a live region snapshot has been (re)computed since the last reset.
+    WEBCORE_EXPORT unsigned liveRegionSnapshotBuildCount() const;
+    WEBCORE_EXPORT void resetLiveRegionSnapshotBuildCount();
+
     void frameLoadingEventNotification(LocalFrame*, AXLoadingEvent);
 
     void prepareForDocumentDestruction(const Document&);

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -4770,6 +4770,23 @@ void Internals::forceAXObjectCacheUpdate() const
     }
 }
 
+unsigned Internals::liveRegionSnapshotBuildCount() const
+{
+    if (RefPtr document = contextDocument()) {
+        if (CheckedPtr cache = document->axObjectCache())
+            return cache->liveRegionSnapshotBuildCount();
+    }
+    return 0;
+}
+
+void Internals::resetLiveRegionSnapshotBuildCount() const
+{
+    if (RefPtr document = contextDocument()) {
+        if (CheckedPtr cache = document->axObjectCache())
+            cache->resetLiveRegionSnapshotBuildCount();
+    }
+}
+
 void Internals::setShouldMockParentSearchResultsForTesting(bool enabled)
 {
     WebCore::setShouldMockParentSearchResultsForTesting(enabled);

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -791,6 +791,8 @@ public:
     String toolTipFromElement(Element&) const;
 
     void forceAXObjectCacheUpdate() const;
+    unsigned liveRegionSnapshotBuildCount() const;
+    void resetLiveRegionSnapshotBuildCount() const;
     void setShouldMockParentSearchResultsForTesting(bool);
     void setShouldMockChildFrameSearchResultsForTesting(bool);
     void forceReload(bool endToEnd);

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -1014,6 +1014,8 @@ enum ContentsFormat {
     undefined setUsesOverlayScrollbars(boolean enabled);
 
     undefined forceAXObjectCacheUpdate();
+    unsigned long liveRegionSnapshotBuildCount();
+    undefined resetLiveRegionSnapshotBuildCount();
     undefined setShouldMockParentSearchResultsForTesting(boolean enabled);
     undefined setShouldMockChildFrameSearchResultsForTesting(boolean enabled);
     undefined forceReload(boolean endToEnd);


### PR DESCRIPTION
#### c45fe212d9c8dce9cf9bfa1c1647743c5db0e88d
<pre>
AX: Coalesce redundant live region snapshot recomputations within a run loop iteration
<a href="https://bugs.webkit.org/show_bug.cgi?id=319607">https://bugs.webkit.org/show_bug.cgi?id=319607</a>
<a href="https://rdar.apple.com/178549889">rdar://178549889</a>

Reviewed by Tyler Wilcock and Andres Gonzalez.

The AXObjectCache walks every ancestor of every changed node and posts
a live region change for each ancestor that supports live
regions. Rebuilding a large subtree fires hundreds of such changes,
all resolving to the same live region.

With the fix, postLiveRegionChangeNotification() adds the region to
m_changedLiveRegions (deduplicated) and starts a zero-delay timer
instead of processing inline. When the timer fires,
liveRegionChangedNotificationPostTimerFired() drives
AXLiveRegionManager once per unique region. Hundreds of changes to the
same region in a single run loop iteration now collapse into a single
snapshot rebuild and a single announcement covering the net change.

Test: accessibility/mac/live-regions/live-region-changes-coalesced.html

* LayoutTests/accessibility/mac/live-regions/live-region-changes-coalesced-expected.txt: Added.
* LayoutTests/accessibility/mac/live-regions/live-region-changes-coalesced.html: Added.
* LayoutTests/accessibility/mac/live-regions/live-region-types.html:
* Source/WebCore/accessibility/AXLiveRegionManager.cpp:
(WebCore::AXLiveRegionManager::buildLiveRegionSnapshot const):
* Source/WebCore/accessibility/AXLiveRegionManager.h:
(WebCore::AXLiveRegionManager::snapshotBuildCount const):
(WebCore::AXLiveRegionManager::resetSnapshotBuildCount):
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::liveRegionSnapshotBuildCount const):
(WebCore::AXObjectCache::resetLiveRegionSnapshotBuildCount):
(WebCore::AXObjectCache::postLiveRegionChangeNotification):
(WebCore::AXObjectCache::liveRegionChangedNotificationPostTimerFired):
* Source/WebCore/accessibility/AXObjectCache.h:
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::liveRegionSnapshotBuildCount const):
(WebCore::Internals::resetLiveRegionSnapshotBuildCount const):
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:

Canonical link: <a href="https://commits.webkit.org/317496@main">https://commits.webkit.org/317496@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9d48087123603da69b9885b81bfb4f2f72071903

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175229 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49161 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42942 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184814 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/133332 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3874ac9f-03f5-4f6a-a7f5-6877902f97e9) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/177093 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50453 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48844 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136398 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/133332 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/72578e5a-a481-474e-bc45-b0fdee5b8d69) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178186 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39818 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157170 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116877 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38459 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36843 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33287 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148882 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36663 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187235 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/40848 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41046 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145346 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48828 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/156726 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145203 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39164 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49508 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33284 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115384 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40036 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/121700 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48014 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11636 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47417 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47647 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47474 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->