### PR TITLE
[CISupport] download-built-product hangs for hours on a collapsed connection

### DIFF
--- a/Tools/CISupport/download-built-product
+++ b/Tools/CISupport/download-built-product
@@ -51,7 +51,18 @@ def main():
         urllib_urlretrieve(url, archivePath)
         return 0
 
-    return subprocess.call(["curl", "--fail", "--output", archivePath, urllib_quote(url, safe=':/')])
+    # A single TCP flow to S3 can collapse and stay collapsed for hours, while curl's
+    # progress meter keeps buildbot's inactivity timeout from ever firing. Give up on a
+    # transfer that stays under 100 KB/s for 60s and reconnect instead. The retry outlasts
+    # curl's 60s DNS cache, so each attempt re-resolves and may land on a different S3 host.
+    curlCommand = ["curl", "--fail",
+                   "--retry", "3",
+                   "--retry-delay", "5",
+                   "--speed-limit", "102400",
+                   "--speed-time", "60",
+                   "--output", archivePath, urllib_quote(url, safe=':/')]
+
+    return subprocess.call(curlCommand)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
#### 73cb0de3225e21121063a3afb6733e9db3b4f64f
<pre>
[CISupport] download-built-product hangs for hours on a collapsed connection
<a href="https://bugs.webkit.org/show_bug.cgi?id=319611">https://bugs.webkit.org/show_bug.cgi?id=319611</a>

Reviewed by Carlos Alberto Lopez Perez.

curl is invoked with no resilience options, so a single degraded TCP flow stalls a
build indefinitely. On WPE-WK2-Tests-EWS build 136197 a 248 MB archive downloaded
at ~30 KB/s for 95 minutes, ETA 2:21:29, while a fresh curl from the same pod
fetched the same URL at 6.4 MB/s. Nothing terminates such a transfer: the step&apos;s
1200s timeout is an inactivity timeout, kept alive by curl&apos;s own progress meter.

Give curl a speed floor so a collapsed flow aborts and retries on a new
connection. All options predate curl 7.12.3 (released 2004), so macOS and Linux
should both be fine.

* Tools/CISupport/download-built-product:
(main): Pass --retry, --retry-delay, --speed-limit and --speed-time to curl.

Co-Authored-By: Claude Opus 4.8 (1M context) &lt;noreply@anthropic.com&gt;
Canonical link: <a href="https://commits.webkit.org/317360@main">https://commits.webkit.org/317360@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fedb5a6c58a1c2856339850c1e598b8f67ca8bc5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175056 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48989 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42770 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184641 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/132964 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176921 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50281 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48672 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136246 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/132964 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178014 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39686 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157042 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116724 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38327 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/36711 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33114 "Built successfully") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/5551 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148750 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36534 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187062 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/40611 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/40913 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145193 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48656 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145049 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39091 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49336 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/33155 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115159 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39906 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/121495 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47842 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11507 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47245 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47475 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47302 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->