### PR TITLE
Cover more cases for correcting issues with AOP inserts on sites with rich text editors.

### DIFF
--- a/Source/WebCore/page/writing-tools/WritingToolsController.mm
+++ b/Source/WebCore/page/writing-tools/WritingToolsController.mm
@@ -1339,8 +1339,10 @@ std::optional<SimpleRange> WritingToolsController::validatedRangeForSuggestionMa
     auto sessionPlainText = plainText(sessionRange);
     auto staleOffset = characterRange(sessionRange, rangeToReplace).location;
 
+    // Re-anchoring is a heuristic, so reject it when ambiguous (a tie) or when it collides with another suggestion's marker.
     size_t bestMatch = notFound;
     uint64_t bestDistance = std::numeric_limits<uint64_t>::max();
+    uint64_t secondBestDistance = std::numeric_limits<uint64_t>::max();
     unsigned searchStart = 0;
     while (true) {
         auto matchIndex = sessionPlainText.find(expectedCurrentText, searchStart);
@@ -1348,9 +1350,11 @@ std::optional<SimpleRange> WritingToolsController::validatedRangeForSuggestionMa
             break;
         uint64_t distance = matchIndex > staleOffset ? matchIndex - staleOffset : staleOffset - matchIndex;
         if (distance < bestDistance) {
+            secondBestDistance = bestDistance;
             bestDistance = distance;
             bestMatch = matchIndex;
-        }
+        } else if (distance < secondBestDistance)
+            secondBestDistance = distance;
         searchStart = static_cast<unsigned>(matchIndex + 1);
     }
 
@@ -1359,7 +1363,34 @@ std::optional<SimpleRange> WritingToolsController::validatedRangeForSuggestionMa
         return std::nullopt;
     }
 
-    return resolveCharacterRange(sessionRange, { bestMatch, expectedCurrentText.length() });
+    if (secondBestDistance == bestDistance) {
+        RELEASE_LOG(WritingTools, "WritingToolsController::validatedRangeForSuggestionMarker bailing - ambiguous match for expected text of length %u", expectedCurrentText.length());
+        return std::nullopt;
+    }
+
+    CharacterRange resolvedCharacterRange { bestMatch, expectedCurrentText.length() };
+
+    auto suggestionID = std::get<DocumentMarker::WritingToolsTextSuggestionData>(marker.data()).suggestionID;
+    bool overlapsOtherSuggestion = false;
+    if (RefPtr document = this->document()) {
+        document->markers().forEach(sessionRange, { DocumentMarkerType::WritingToolsTextSuggestion }, [&](auto& otherNode, auto& otherMarker) {
+            if (std::get<DocumentMarker::WritingToolsTextSuggestionData>(otherMarker.data()).suggestionID == suggestionID)
+                return false;
+            auto otherRange = characterRange(sessionRange, makeSimpleRange(otherNode, otherMarker));
+            if (resolvedCharacterRange.location < otherRange.location + otherRange.length && otherRange.location < resolvedCharacterRange.location + resolvedCharacterRange.length) {
+                overlapsOtherSuggestion = true;
+                return true;
+            }
+            return false;
+        });
+    }
+
+    if (overlapsOtherSuggestion) {
+        RELEASE_LOG(WritingTools, "WritingToolsController::validatedRangeForSuggestionMarker bailing - re-anchored range overlaps another suggestion marker");
+        return std::nullopt;
+    }
+
+    return resolveCharacterRange(sessionRange, resolvedCharacterRange);
 }
 
 std::optional<std::tuple<Node&, DocumentMarker&>> WritingToolsController::findTextSuggestionMarkerContainingRange(const SimpleRange& range) const

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WritingTools.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WritingTools.mm
@@ -1058,6 +1058,53 @@ TEST(WritingTools, ProofreadingReviewDoesNotWriteIntoDriftedMarker)
     TestWebKitAPI::Util::run(&finished);
 }
 
+TEST(WritingTools, ProofreadingReviewBailsOnAmbiguousDriftedMarker)
+{
+    RetainPtr session = adoptNS([[WTSession alloc] initWithType:WTSessionTypeProofreading textViewDelegate:nil]);
+
+    RetainPtr webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body contenteditable><p id='first'>wug xx wug yy wug</p></body>"]);
+    [webView focusDocumentBodyAndSelectAll];
+
+    NSString *originalText = @"wug xx wug yy wug";
+    NSString *mutatedText = @"wug xx wZg yy wug";
+
+    __block bool finished = false;
+
+    [(id)[webView writingToolsDelegate] willBeginWritingToolsSession:session forProofreadingReview:YES requestContexts:^(NSArray<WTContext *> *contexts) {
+        EXPECT_EQ(1UL, contexts.count);
+        EXPECT_WK_STREQ(originalText, contexts.firstObject.attributedText.string);
+
+        [[webView writingToolsDelegate] didBeginWritingToolsSession:session contexts:contexts];
+
+        // Target the middle "wug"; the same text also appears at [0, 3) and [14, 17).
+        RetainPtr suggestion = adoptNS([[WTTextSuggestion alloc] initWithOriginalRange:NSMakeRange(7, 3) replacement:@"bug"]);
+
+        [[webView writingToolsDelegate] proofreadingSession:session didReceiveSuggestions:@[ suggestion.get() ] processedRange:NSMakeRange(0, originalText.length) inContext:contexts.firstObject finished:YES];
+        [webView waitForProofreadingSuggestionsToBeReplaced];
+
+        EXPECT_WK_STREQ(originalText, [webView contentsAsString]);
+
+        // Corrupt the marked word in place so its offsets go stale but the two other "wug"s stay put, equidistant from the stale offset.
+        [webView stringByEvaluatingJavaScript:@"document.getElementById('first').firstChild.replaceData(8, 1, 'Z')"];
+        [webView waitForNextPresentationUpdate];
+
+        EXPECT_WK_STREQ(mutatedText, [webView contentsAsString]);
+
+        // The two matches are equally close, so the controller must bail rather than guess.
+        [[webView writingToolsDelegate] proofreadingSession:session didUpdateState:WTTextSuggestionStateAccepted forSuggestionWithUUID:[suggestion uuid] inContext:contexts.firstObject];
+        [webView waitForProofreadingSuggestionsToBeReplaced];
+
+        EXPECT_WK_STREQ(mutatedText, [webView contentsAsString]);
+
+        [[webView writingToolsDelegate] didEndWritingToolsSession:session accepted:YES];
+        [webView waitForProofreadingSuggestionsToBeReplaced];
+
+        finished = true;
+    }];
+
+    TestWebKitAPI::Util::run(&finished);
+}
+
 TEST(WritingTools, CompositionWithAttemptedEditing)
 {
     RetainPtr session = adoptNS([[WTSession alloc] initWithType:WTSessionTypeComposition textViewDelegate:nil]);


### PR DESCRIPTION
#### 262e8c14578baaa683bc124f2f0fcc90f6671bb0
<pre>
Cover more cases for correcting issues with AOP inserts on sites with rich text editors.
<a href="https://bugs.webkit.org/show_bug.cgi?id=319612">https://bugs.webkit.org/show_bug.cgi?id=319612</a>
<a href="https://rdar.apple.com/182439644">rdar://182439644</a>

Reviewed by Wenson Hsieh.

Reworked the closest-match resolution in validatedRangeForSuggestionMarker so re-anchoring only commits when it&apos;s
confident. It now bails on an ambiguous tie (two occurrences equidistant from the stale offset) and when the
re-anchored range overlaps a different suggestion&apos;s marker, instead of silently taking the nearest one. A lone
non-overlapping wrong match can still slip through — inherent to a text search — but the two detectable cases are
covered now.

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WritingTools.mm

* Source/WebCore/page/writing-tools/WritingToolsController.mm:
(WebCore::WritingToolsController::validatedRangeForSuggestionMarker const):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WritingTools.mm:
(TEST(WritingTools, ProofreadingReviewBailsOnAmbiguousDriftedMarker)):

Canonical link: <a href="https://commits.webkit.org/317412@main">https://commits.webkit.org/317412@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/535f4145ed462576cf66ba68d100297a40de7535

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175263 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49195 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42976 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184848 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/133628 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bf754a15-87a2-452a-b807-b720cafc51e4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/177127 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50487 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48878 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136428 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/133628 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f1704ef6-5f0e-4fc1-84fd-3fd0f3c98104) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178220 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/39851 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/157196 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116907 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c08b0e39-2f4c-407f-aee2-8d6816029980) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/38492 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/36870 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33321 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/148915 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36689 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187269 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/40882 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/41074 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145376 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48862 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145232 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39118 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49542 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/33310 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115421 "Built successfully") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/40069 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/121735 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48048 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11662 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47451 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47681 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47508 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->