### PR TITLE
[JSC] Skip stress tests using `numberOfDFGCompiles` when JIT is unavailable

### DIFF
--- a/JSTests/stress/promise-prototype-catch-on-non-promise.js
+++ b/JSTests/stress/promise-prototype-catch-on-non-promise.js
@@ -1,3 +1,4 @@
+//@ skip if not $jitTests
 //@ runDefault("--validateOptions=true", "--useConcurrentJIT=0")
 
 // PromisePrototypeCatchIntrinsic guards the receiver with Check(PromiseObjectUse),

--- a/JSTests/stress/regexp-prototype-symbol-search-on-non-regexp.js
+++ b/JSTests/stress/regexp-prototype-symbol-search-on-non-regexp.js
@@ -1,3 +1,4 @@
+//@ skip if not $jitTests
 //@ runDefault("--validateOptions=true", "--useConcurrentJIT=0")
 
 // RegExpSearchIntrinsic guards the receiver with Check(RegExpObjectUse), which

--- a/JSTests/stress/regexp-prototype-test-on-non-regexp.js
+++ b/JSTests/stress/regexp-prototype-test-on-non-regexp.js
@@ -1,3 +1,4 @@
+//@ skip if not $jitTests
 //@ runDefault("--validateOptions=true", "--useConcurrentJIT=0")
 
 // RegExpTestIntrinsic guards the receiver with Check(RegExpObjectUse), which

--- a/JSTests/stress/string-replace-regexp-with-own-property.js
+++ b/JSTests/stress/string-replace-regexp-with-own-property.js
@@ -1,3 +1,4 @@
+//@ skip if not $jitTests
 //@ runDefault("--validateOptions=true", "--useConcurrentJIT=0")
 
 // FixupPhase guards StringReplace(RegExp) with a CheckStructure on the original


### PR DESCRIPTION
#### 5b2603cac2fb410d3b8262f84b6daee4be199f7a
<pre>
[JSC] Skip stress tests using `numberOfDFGCompiles` when JIT is unavailable
<a href="https://bugs.webkit.org/show_bug.cgi?id=319613">https://bugs.webkit.org/show_bug.cgi?id=319613</a>

Reviewed by Keith Miller.

Add &quot;//@ skip if not $jitTests&quot; for skipping stress tests using
`numberOfDFGComples` when JIT is unavailable to fix ARMv7 EWS.

* JSTests/stress/promise-prototype-catch-on-non-promise.js:
* JSTests/stress/regexp-prototype-symbol-search-on-non-regexp.js:
* JSTests/stress/regexp-prototype-test-on-non-regexp.js:
* JSTests/stress/string-replace-regexp-with-own-property.js:

Canonical link: <a href="https://commits.webkit.org/317393@main">https://commits.webkit.org/317393@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f7c5a7742dc5832051b4dbb4f8e57fa89363f30b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175059 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48992 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42773 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184644 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132967 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50284 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48675 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136251 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96118 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178017 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39689 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157038 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116729 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38330 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36714 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33117 "Built successfully") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/5547 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148753 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36530 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187065 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/36321 "Built successfully and passed tests") | | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40916 "Found 1 new test failure: imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audionode-interface/audionode-channel-rules.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145196 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48659 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145052 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39108 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49339 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33151 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115163 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39910 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/212151 "Built successfully") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47845 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11503 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/55342 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47248 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47478 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47305 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->