### PR TITLE
[libpas] Add small-object page-batching zeroing to AllocationZeroingTests

### DIFF
--- a/Source/bmalloc/libpas/src/test/AllocationZeroingTests.cpp
+++ b/Source/bmalloc/libpas/src/test/AllocationZeroingTests.cpp
@@ -336,6 +336,75 @@ void testZeroingReuseWithScavengeLargeVirtualMemorySizes()
     runZeroingReuse(largeVirtualMemoryRegimeSizes(), Reuse::WithScavenge);
 }
 
+// Small objects are batched many-per-page: a segregated page holds at least
+// PAS_MIN_OBJECTS_PER_PAGE objects, so one page's backing serves many
+// allocations and those objects are zeroed per object, not per page. Fill
+// several pages so that many objects are co-resident on shared pages, verifying
+// each is independently zero -- both when first carved from a page and when a
+// freed object is reused.
+void smallPageBatching(HeapVariant variant, size_t size)
+{
+    // Enough objects to span several pages, computed per size so the packed and
+    // sparse cases both cross page boundaries. objectsPerPage is approximate (the
+    // object size is rounded up to a size class, and page headers take space),
+    // which only over-counts, so the span is at least this many pages.
+    constexpr size_t pagesToSpan = 4;
+    size_t objectsPerPage = PAS_SMALL_PAGE_DEFAULT_SIZE / size;
+    if (!objectsPerPage)
+        objectsPerPage = 1;
+    size_t count = objectsPerPage * pagesToSpan;
+
+    std::vector<void*> objects;
+    objects.reserve(count);
+
+    // Fill: allocate many co-resident objects sharing pages; each must be zero.
+    // Dirty each so that once they are freed the recycled objects hold non-zero
+    // bytes, making the refill check meaningful.
+    for (size_t i = 0; i < count; ++i) {
+        void* object = allocateZeroed(variant, AlignmentApi::Plain, size, bmallocMinAlign);
+        if (!object)
+            reportParameters(variant, AlignmentApi::Plain, size, bmallocMinAlign, "fill");
+        CHECK(object);
+        checkIsZeroed(object, size, variant, AlignmentApi::Plain, bmallocMinAlign, "fill");
+        dirtyBuffer(object, size);
+        objects.push_back(object);
+    }
+
+    // Free all, then refill: the freed objects are recycled to serve the new
+    // allocations, so each reallocated object must be re-zeroed individually rather
+    // than relying on the initial page commit.
+    for (void* object : objects)
+        deallocateVariant(variant, object);
+    for (size_t i = 0; i < count; ++i) {
+        void* object = allocateZeroed(variant, AlignmentApi::Plain, size, bmallocMinAlign);
+        if (!object)
+            reportParameters(variant, AlignmentApi::Plain, size, bmallocMinAlign, "recycled");
+        CHECK(object);
+        checkIsZeroed(object, size, variant, AlignmentApi::Plain, bmallocMinAlign, "recycled");
+        objects[i] = object;
+    }
+    for (void* object : objects)
+        deallocateVariant(variant, object);
+}
+
+// Verify per-object zeroing when many small objects share batched pages, on both
+// fresh page commits and object recycling.
+void testSmallZeroingPageBatching()
+{
+    // Small sizes bracketing the batching density: the smallest object (the most
+    // per page) and the largest small-segregated object (the fewest per page, but
+    // still at least PAS_MIN_OBJECTS_PER_PAGE).
+    static const size_t sizes[] = {
+        bmallocMinAlign,
+        PAS_SMALL_PAGE_DEFAULT_SIZE / PAS_MIN_OBJECTS_PER_PAGE,
+    };
+    static const HeapVariant variants[] = { HeapVariant::Untagged, HeapVariant::Tagged };
+    for (HeapVariant variant : variants) {
+        for (size_t size : sizes)
+            smallPageBatching(variant, size);
+    }
+}
+
 } // anonymous namespace
 
 #endif // PAS_ENABLE_BMALLOC
@@ -351,5 +420,6 @@ void addAllocationZeroingTests()
     ADD_TEST(testZeroingReuseWithScavengeBitfitSizes());
     ADD_TEST(testZeroingReuseWithScavengeLargeMemsetSizes());
     ADD_TEST(testZeroingReuseWithScavengeLargeVirtualMemorySizes());
+    ADD_TEST(testSmallZeroingPageBatching());
 #endif // PAS_ENABLE_BMALLOC
 }


### PR DESCRIPTION
#### 68abd570b559737b6ecedc0a69747fe4215e9b06
<pre>
[libpas] Add small-object page-batching zeroing to AllocationZeroingTests
<a href="https://bugs.webkit.org/show_bug.cgi?id=319614">https://bugs.webkit.org/show_bug.cgi?id=319614</a>
<a href="https://rdar.apple.com/182442861">rdar://182442861</a>

Reviewed by Marcus Plutowski.

Small objects are batched many-per-page: a segregated page holds at least
PAS_MIN_OBJECTS_PER_PAGE objects, so one page&apos;s backing serves many
allocations, and those objects are zeroed per object rather than per page.
The size-regime reuse tests mostly keep one object live at a time and so
do not exercise many co-resident objects on a shared page.

Add a test that fills several pages with small zeroed objects and checks
each is independently zero, then frees them all and refills so the freed
objects are recycled, checking each reallocated object is zero. It runs
over both heap variants and two sizes bracketing the per-page object
density.

* Source/bmalloc/libpas/src/test/AllocationZeroingTests.cpp:
(addAllocationZeroingTests):

Canonical link: <a href="https://commits.webkit.org/317347@main">https://commits.webkit.org/317347@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/18f987bccfb6ecb609d2f2bcecace013a3e41ac2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175060 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48993 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42774 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184645 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/132968 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2ccce446-e804-4b3c-8fe2-b5ae66c0e9f9) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50285 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48676 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136253 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/132968 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178018 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/39690 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157041 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116731 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4dcdb394-a6d0-49c0-8fd4-486db24ff775) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38331 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/36715 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33118 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/5550 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/148754 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36533 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187066 "Built successfully") | | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/36322 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/40917 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/145198 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48660 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145054 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49340 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/33154 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115166 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26594 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39911 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/212152 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47846 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/11506 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/55343 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47249 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47479 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47306 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->