### PR TITLE
[Damage][Skia] Limit every content draw to the target's repaint region

### DIFF
--- a/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp
@@ -41,6 +41,7 @@
 #include "SkiaCompositingLayer3DRenderingContext.h"
 #include "SkiaCompositingLayerFilters.h"
 #include "SkiaCompositingLayerOverlapRegions.h"
+#include "SkiaDamageRegion.h"
 #include "SkiaUtilities.h"
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
 #include <skia/core/SkFont.h>
@@ -498,7 +499,7 @@ bool SkiaCompositingLayer::computeTransformsAndAnimations(const TransformationMa
     return hasRunningAnimations;
 }
 
-bool SkiaCompositingLayer::paint(SkCanvas& canvas, std::optional<Damage>& frameDamage)
+bool SkiaCompositingLayer::paint(SkCanvas& canvas, std::optional<Damage>& frameDamage, const std::optional<Damage>& priorTargetDamage)
 {
     // Both walks below assume the animations have been applied and the transforms computed.
     bool hasRunningAnimations = computeTransformsAndAnimations({ }, { }, MonotonicTime::now());
@@ -529,9 +530,35 @@ bool SkiaCompositingLayer::paint(SkCanvas& canvas, std::optional<Damage>& frameD
     UNUSED_PARAM(frameDamage);
 #endif
 
-    PaintContext context;
-    recursivePaint(canvas, context);
-    context.imageSetBatch.flushIfNeeded(canvas);
+    // The region this target must redraw is the damage still on its record from before combined with
+    // this frame's. No prior damage means the target cannot be trusted, so repaint the whole of it.
+    std::optional<SkiaDamageRegion> damageRegion;
+#if ENABLE(DAMAGE_TRACKING)
+    if (priorTargetDamage) {
+        // The damage is in device space, so the surface size the region is tested against must be too.
+        // m_size is in layer coordinates, which the root transform scales to the device by the device
+        // pixel ratio - use the canvas device size instead, as the collect walk above already does.
+        const auto deviceSize = canvas.getBaseLayerSize();
+        const IntSize surfaceSize(deviceSize.width(), deviceSize.height());
+        if (frameDamage) {
+            auto repaintRegion = *priorTargetDamage;
+            repaintRegion.add(*frameDamage);
+            damageRegion = SkiaDamageRegion::create(repaintRegion, surfaceSize);
+        } else
+            damageRegion = SkiaDamageRegion::create(*priorTargetDamage, surfaceSize);
+    }
+#else
+    UNUSED_PARAM(priorTargetDamage);
+#endif
+
+    // An empty region means the target already holds the frame, so draw nothing.
+    if (!damageRegion || !damageRegion->isEmpty()) {
+        PaintContext context;
+        context.compositingDamageRegion = WTF::move(damageRegion);
+
+        recursivePaint(canvas, context);
+        context.imageSetBatch.flushIfNeeded(canvas);
+    }
 
     recursiveCleanUpAfterPaint();
 
@@ -587,6 +614,13 @@ TransformationMatrix SkiaCompositingLayer::combinedTransform(const PaintContext&
 
 void SkiaCompositingLayer::paintContents(SkCanvas& canvas, PaintContext& context)
 {
+    // Important: the walk does not clip the canvas to the damage, so every content draw below limits
+    // itself, with drawRectRestricted() or drawImageRectRestricted() when it draws now, or by passing the
+    // region to the batch when it draws later. A draw that does not paints over undamaged pixels and
+    // composites translucent content twice, so any content type added here has to limit itself too. A set
+    // region is never empty, because paint() turns an empty one into a no-op.
+    ASSERT(!context.compositingDamageRegion || !context.compositingDamageRegion->isEmpty());
+
     const SkM44 transform(combinedTransform(context));
 
     const auto ctm = transform.asM33();
@@ -621,14 +655,14 @@ void SkiaCompositingLayer::paintContents(SkCanvas& canvas, PaintContext& context
     };
 
     if (m_backingStore)
-        context.imageSetBatch.addImageSet(canvas, *m_backingStore, transform, context.opacity, enableAntialias, nullptr, setupPaint());
+        context.imageSetBatch.addImageSet(canvas, *m_backingStore, transform, context.opacity, enableAntialias, context.damageRegionOrNull(), setupPaint());
 
     if (m_contentsSolidColor.isValid() && m_contentsSolidColor.isVisible()) {
         ScopedFlush autoFlush(canvas, context.imageSetBatch, ScopedFlush::Mode::FlushBefore);
         canvas.concat(transform);
         SkPaint paint = setupPaint();
         paint.setColor(SkColor(m_contentsSolidColor.colorWithAlphaMultipliedBy(context.opacity)));
-        canvas.drawRect(m_contentsRect, paint);
+        drawRectRestricted(canvas, context.damageRegionOrNull(), SkRect(m_contentsRect), paint);
     } else if (m_contentsBuffer || m_imageBackingStore) {
         bool shouldPaintNow = [&] {
             if (m_contentsClippingRect.hasNonZeroRadii())
@@ -668,7 +702,7 @@ void SkiaCompositingLayer::paintContents(SkCanvas& canvas, PaintContext& context
 #endif
                 SkPaint paint = setupPaint();
                 paint.setBlendMode(SkBlendMode::kClear);
-                canvas.drawRect(SkRect(m_contentsRect), paint);
+                drawRectRestricted(canvas, context.damageRegionOrNull(), SkRect(m_contentsRect), paint);
             } else
 #endif // ENABLE(VIDEO)
                 image = m_contentsBuffer->skiaImage();
@@ -681,21 +715,21 @@ void SkiaCompositingLayer::paintContents(SkCanvas& canvas, PaintContext& context
                 matrix.postTranslate(m_contentsRect.x() - m_contentsTiling.phase.width(), m_contentsRect.y() - m_contentsTiling.phase.height());
                 SkPaint paint = setupPaint();
                 paint.setShader(tileImage->makeShader(SkTileMode::kRepeat, SkTileMode::kRepeat, SkSamplingOptions(SkFilterMode::kLinear, SkMipmapMode::kNone), matrix));
-                canvas.drawRect(m_contentsRect, paint);
+                drawRectRestricted(canvas, context.damageRegionOrNull(), SkRect(m_contentsRect), paint);
             }
         }
 
         if (image) {
             if (shouldPaintNow) {
                 SkPaint paint = setupPaint();
-                canvas.drawImageRect(image, SkRect::MakeSize(SkSize::Make(image->dimensions())), SkRect(m_contentsRect),
-                    SkSamplingOptions(SkFilterMode::kLinear, SkMipmapMode::kNone), &paint, SkCanvas::kFast_SrcRectConstraint);
+                drawImageRectRestricted(canvas, context.damageRegionOrNull(), image.get(), SkRect::MakeSize(SkSize::Make(image->dimensions())), SkRect(m_contentsRect),
+                    SkSamplingOptions(SkFilterMode::kLinear, SkMipmapMode::kNone), &paint);
             } else {
                 // The contents image composites over the backing store, so it must use SrcOver always.
                 if (forcedSrcBlendMode && m_backingStore)
                     context.imageSetBatch.updatePaintProperties(canvas, context.colorFilter, context.blendMode);
 
-                context.imageSetBatch.addImage(canvas, image, m_contentsRect, transform, context.opacity, enableAntialias, nullptr, setupPaint());
+                context.imageSetBatch.addImage(canvas, image, m_contentsRect, transform, context.opacity, enableAntialias, context.damageRegionOrNull(), setupPaint());
             }
         }
     }
@@ -1001,11 +1035,20 @@ void SkiaCompositingLayer::paintWithIntermediateSurface(SkCanvas& canvas, PaintC
     surfaceCanvas->clear(SK_ColorTRANSPARENT);
     surfaceCanvas->translate(-surfaceRect.x(), -surfaceRect.y());
     SetForScope scopedOffset(context.offset, toIntSize(surfaceRect.location()));
-    paintFunction(*surfaceCanvas, context);
-    context.imageSetBatch.flushIfNeeded(*surfaceCanvas);
+
+    {
+        // The filter may sample outside the damage, so paint the whole subtree and limit only the composite.
+        SetForScope scopedNoDamageRestriction(context.compositingDamageRegion, std::nullopt);
+        paintFunction(*surfaceCanvas, context);
+        context.imageSetBatch.flushIfNeeded(*surfaceCanvas);
+    }
     grContext->flushAndSubmit(surface.get(), GrSyncCpu::kNo);
 
-    canvas.drawImageRect(surface->makeImageSnapshot(), SkRect::MakeWH(surfaceRect.width(), surfaceRect.height()), SkRect::Make(surfaceRect), SkSamplingOptions(SkFilterMode::kNearest, SkMipmapMode::kNone), paint, SkCanvas::kFast_SrcRectConstraint);
+    auto snapshot = surface->makeImageSnapshot();
+    const auto sampling = SkSamplingOptions(SkFilterMode::kNearest, SkMipmapMode::kNone);
+
+    drawImageRectRestricted(canvas, context.damageRegionOrNull(), snapshot.get(), SkRect::MakeWH(surfaceRect.width(), surfaceRect.height()),
+        SkRect::Make(surfaceRect), sampling, paint);
 }
 
 void SkiaCompositingLayer::paintBackdrop(SkCanvas& canvas, PaintContext& context)

--- a/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.h
@@ -37,6 +37,7 @@
 #include "IntSize.h"
 #include "SkiaCompositingLayerImageSetBatch.h"
 #include "SkiaCompositingLayerOverlapRegions.h"
+#include "SkiaDamageRegion.h"
 #include "TextureMapperAnimation.h"
 #include "TransformationMatrix.h"
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
@@ -115,9 +116,10 @@ public:
     FloatRect effectiveLayerRect() const { return FloatRect({ }, m_size); }
 
     // Applies the animations, computes the transforms, then walks the tree. When a frame damage is passed,
-    // it is collected first in a walk that draws nothing, before the walk that draws into the canvas.
-    // Returns whether any animation is still running.
-    bool paint(SkCanvas&, std::optional<Damage>& frameDamage);
+    // it is collected first in a walk that draws nothing, before the walk that draws. The draw is limited
+    // to the region the target must redraw - the target's prior owed damage combined with this frame's - and
+    // no prior damage repaints the whole target. Returns whether any animation is still running.
+    bool paint(SkCanvas&, std::optional<Damage>& frameDamage, const std::optional<Damage>& priorTargetDamage = std::nullopt);
 
 private:
     using ScopedFlush = SkiaCompositingLayerImageSetBatch::ScopedFlush;
@@ -192,6 +194,8 @@ private:
 
         bool shouldDraw() const { return !collectState; }
 #endif
+        std::optional<SkiaDamageRegion> compositingDamageRegion;
+        const SkiaDamageRegion* damageRegionOrNull() const { return compositingDamageRegion ? &*compositingDamageRegion : nullptr; }
         float opacity { 1 };
         std::optional<SkBlendMode> blendMode;
         IntSize offset;

--- a/Source/WebCore/platform/graphics/skia/SkiaDamageRegion.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaDamageRegion.h
@@ -29,6 +29,7 @@
 
 #include "Damage.h"
 #include "IntRect.h"
+#include <optional>
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
 #include <skia/core/SkCanvas.h>
 #include <skia/core/SkMatrix.h>
@@ -44,19 +45,42 @@ namespace WebCore {
 // and clip with - built once per frame.
 class SkiaDamageRegion {
 public:
-    static SkiaDamageRegion create(const Damage& damage)
+    static std::optional<SkiaDamageRegion> create(const Damage& repaintRegion, const IntSize& surfaceSize)
     {
-        const auto damageRects = damage.rectsForPainting().map([](const IntRect& rect) -> SkIRect {
+        if (repaintRegion.isEmpty())
+            return SkiaDamageRegion { };
+
+        auto damageRects = repaintRegion.rectsForPainting().map([](const IntRect& rect) -> SkIRect {
             return rect;
         });
 
         SkiaDamageRegion damageRegion;
         damageRegion.m_region.setRects(damageRects.span().data(), damageRects.size());
-        damageRegion.m_rects = damageRects.map([](const SkIRect& rect) -> SkRect {
-            return SkRect::Make(rect);
-        });
+        damageRegion.m_rects = WTF::move(damageRects);
+
+        // Ask the region, not its bounds, because two rects in opposite corners of the surface span a
+        // bounding box that covers it while the rects themselves cover almost none of it.
+        if (damageRegion.m_region.contains(SkIRect::MakeWH(surfaceSize.width(), surfaceSize.height())))
+            return std::nullopt;
 
         return damageRegion;
+    }
+
+    SkiaDamageRegion(const SkiaDamageRegion&) = default;
+    SkiaDamageRegion& operator=(const SkiaDamageRegion&) = default;
+
+    // SkRegion declares a copy constructor and a destructor, so it has no move constructor and would deep
+    // copy its run array on every move. swap() exchanges pointers instead.
+    SkiaDamageRegion(SkiaDamageRegion&& other)
+    {
+        *this = WTF::move(other);
+    }
+
+    SkiaDamageRegion& operator=(SkiaDamageRegion&& other)
+    {
+        m_rects = WTF::move(other.m_rects);
+        m_region.swap(other.m_region);
+        return *this;
     }
 
     bool isEmpty() const { return m_rects.isEmpty(); }
@@ -95,7 +119,7 @@ public:
         const auto dstToSrc = SkMatrix::RectToRect(dstRectFull, srcRectFull);
 
         for (const auto& rect : m_rects) {
-            SkRect damaged = rect;
+            auto damaged = SkRect::Make(rect);
             if (!damaged.intersect(deviceRect))
                 continue;
             if (damaged == deviceRect) {
@@ -105,6 +129,31 @@ public:
             SkRect dstSubRect;
             inverseCtm.mapRect(&dstSubRect, damaged);
             emit(dstToSrc.mapRect(dstSubRect), dstSubRect);
+        }
+    }
+
+    template<typename DrawFunction>
+    void restrictDraw(SkCanvas& canvas, const SkRect& srcRectFull, const SkRect& dstRectFull, NOESCAPE const DrawFunction& draw) const
+    {
+        ASSERT(!isEmpty());
+
+        const auto ctm = canvas.getLocalToDeviceAs3x3();
+        SkRect deviceRect;
+        ctm.mapRect(&deviceRect, dstRectFull);
+
+        SkMatrix inverse;
+        switch (planDraw(ctm, deviceRect, inverse)) {
+        case DrawDamageStrategy::Skip:
+            return;
+        case DrawDamageStrategy::SplitByRect:
+            forEachDamagedSubRect(deviceRect, dstRectFull, srcRectFull, inverse, draw);
+            return;
+        case DrawDamageStrategy::ClipToDamage: {
+            SkAutoCanvasRestore autoRestore(&canvas, true);
+            clipCanvasInDeviceSpace(canvas);
+            draw(srcRectFull, dstRectFull);
+            return;
+        }
         }
     }
 
@@ -126,9 +175,33 @@ public:
 private:
     SkiaDamageRegion() = default;
 
-    Vector<SkRect> m_rects;
+    Vector<SkIRect> m_rects;
     SkRegion m_region;
 };
+
+inline void drawRectRestricted(SkCanvas& canvas, const SkiaDamageRegion* damageRegion, const SkRect& rect, const SkPaint& paint)
+{
+    if (!damageRegion) {
+        canvas.drawRect(rect, paint);
+        return;
+    }
+
+    damageRegion->restrictDraw(canvas, rect, rect, [&](const SkRect&, const SkRect& dstSubRect) {
+        canvas.drawRect(dstSubRect, paint);
+    });
+}
+
+inline void drawImageRectRestricted(SkCanvas& canvas, const SkiaDamageRegion* damageRegion, const SkImage* image, const SkRect& srcRectFull, const SkRect& dstRectFull, const SkSamplingOptions& sampling, const SkPaint* paint)
+{
+    if (!damageRegion) {
+        canvas.drawImageRect(image, srcRectFull, dstRectFull, sampling, paint, SkCanvas::kFast_SrcRectConstraint);
+        return;
+    }
+
+    damageRegion->restrictDraw(canvas, srcRectFull, dstRectFull, [&](const SkRect& srcSubRect, const SkRect& dstSubRect) {
+        canvas.drawImageRect(image, srcSubRect, dstSubRect, sampling, paint, SkCanvas::kFast_SrcRectConstraint);
+    });
+}
 
 } // namespace WebCore
 

--- a/Tools/TestWebKitAPI/Tests/WebCore/glib/SkiaCompositingLayerDamage.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/glib/SkiaCompositingLayerDamage.cpp
@@ -34,6 +34,8 @@
 #include <WebCore/SkiaCompositingLayer.h>
 #include <WebCore/TransformationMatrix.h>
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
+#include <skia/core/SkColor.h>
+#include <skia/core/SkPixmap.h>
 #include <skia/core/SkSurface.h>
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 
@@ -202,6 +204,53 @@ static Ref<SkiaCompositingLayer> createSolidColorLayer(const FloatSize& size, co
     layer->setContentsSolidColor(Color::green);
     layer->setContentsRect({ 0, 0, size.width(), size.height() });
     return layer;
+}
+
+// The target's repaint region is in device coordinates, so the surface size paint() tests it against for
+// whole-surface coverage must be device sized too. A layer's own size is in layer coordinates, which the
+// root transform scales to the device by the device pixel ratio. Passing the layer size here would treat a
+// region that merely spans the layer-sized rect as covering the whole target, dropping the restriction and
+// repainting everything. Under a 2x scale the device target is 800x600 while the root's own size is
+// 400x300, so a region covering exactly the 400x300 rect is a partial repaint, not a full one.
+TEST(SkiaCompositingLayerDamage, PartialRepaintRegionUnderHiDPIRestrictsToTheDamageRect)
+{
+    constexpr SkColor untouched = SkColorSetARGB(0xFF, 0xFF, 0x00, 0x00);
+
+    auto surface = SkSurfaces::Raster(SkImageInfo::MakeN32Premul(800, 600));
+    ASSERT_TRUE(surface);
+    surface->getCanvas()->clear(untouched);
+
+    auto root = SkiaCompositingLayer::create();
+    root->setDamagePropagationEnabled(true);
+    root->setSize({ 400, 300 });
+
+    TransformationMatrix deviceScale;
+    deviceScale.scale(2);
+    root->setTransform(deviceScale);
+
+    // Painted from the top-left and scaled up, the child reaches past the damage rect, so a full repaint
+    // colours pixels outside the damage while a restricted one leaves them alone.
+    auto child = createSolidColorLayer({ 400, 300 }, { 0, 0 });
+    Vector<Ref<SkiaCompositingLayer>> children;
+    children.append(child.copyRef());
+    root->setChildren(WTF::move(children));
+
+    // The damage rect is exactly the root's own 400x300 size, in device coordinates. It does not cover the
+    // 800x600 device target, so a draw landing outside it - but still within the surface - must be left out.
+    Damage priorTargetDamage(IntSize { 800, 600 });
+    priorTargetDamage.add(IntRect { 0, 0, 400, 300 });
+
+    std::optional<Damage> noFrameDamage;
+    root->paint(*surface->getCanvas(), noFrameDamage, priorTargetDamage);
+
+    SkPixmap pixmap;
+    ASSERT_TRUE(surface->peekPixels(&pixmap));
+
+    // Inside the damage rect the child paints, so the pixel changes. At (500, 350) the child still covers
+    // the pixel but the damage does not, so a correct restriction leaves it as it was. Treating the region
+    // as whole-surface coverage instead repaints everything and colours it too, which this catches.
+    EXPECT_NE(pixmap.getColor(200, 150), untouched);
+    EXPECT_EQ(pixmap.getColor(500, 350), untouched);
 }
 
 static SettledTree createSettledTree(SkCanvas& canvas, const FloatPoint& position)


### PR DESCRIPTION
#### be7c8392af688ba6d450a87ceeafbd63a7d70c20
<pre>
[Damage][Skia] Limit every content draw to the target&apos;s repaint region
<a href="https://bugs.webkit.org/show_bug.cgi?id=319615">https://bugs.webkit.org/show_bug.cgi?id=319615</a>

Reviewed by Alejandro G. Castro.

Take a damage region in paint() and limit the draws to it. No region paints
everything, as before. An empty region paints nothing, because the target already
holds the frame. Otherwise every content draw limits itself to the region&apos;s rects:
the backing store&apos;s tiles and the contents image split by rect and stay batched,
the solid color, the hole punch and the tiled shader draw once per rect, and the
composite of a filtered or masked layer&apos;s intermediate surface is limited the same
way.

The walk deliberately does not clip the canvas to the damage, because a clip of more
than one rect cannot be a scissor, so Skia would build a mask for it and break the
batching. Each draw limits itself instead, which is a convention every content type
added here has to follow. The subtree of a filtered layer keeps painting in full,
because the filter samples outside the damage, and only the composite of its result
is limited.

A region that covers the whole surface is dropped for a full repaint. The region
itself decides that, not its bounding box: two rects in opposite corners span a box
that covers the surface while the rects cover almost none of it.

The compositor still passes no region, so nothing is restricted yet.
Added a new API test to cover damaging + HiDPI.

* Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp:
(WebCore::SkiaCompositingLayer::paint):
(WebCore::SkiaCompositingLayer::paintContents):
(WebCore::SkiaCompositingLayer::paintWithIntermediateSurface):
* Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.h:
* Source/WebCore/platform/graphics/skia/SkiaDamageRegion.h:
(WebCore::SkiaDamageRegion::create):
(WebCore::SkiaDamageRegion::SkiaDamageRegion):
(WebCore::SkiaDamageRegion::operator=):
(WebCore::SkiaDamageRegion::forEachDamagedSubRect const):
(WebCore::SkiaDamageRegion::restrictDraw const):
(WebCore::drawRectRestricted):
(WebCore::drawImageRectRestricted):
* Tools/TestWebKitAPI/Tests/WebCore/glib/SkiaCompositingLayerDamage.cpp:
(TestWebKitAPI::TEST(SkiaCompositingLayerDamage, PartialRepaintRegionUnderHiDPIRestrictsToTheDamageRect)):

Canonical link: <a href="https://commits.webkit.org/317387@main">https://commits.webkit.org/317387@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/73ede8d82c2d6c759902b2ee26aa4962060fc840

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175230 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49162 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/42943 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184815 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/133334 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/177094 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50454 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48845 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136400 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/133334 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178187 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/39820 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/157171 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116879 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/38461 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/36845 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33288 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/148884 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/36664 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187236 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/40849 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/41048 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/145347 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48829 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/156727 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145204 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/49509 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/33285 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115385 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26628 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/49509 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/121701 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48015 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/11637 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/47418 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/47648 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/47475 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->