### PR TITLE
css/css-masking/clip-path/clip-path-shape-011.html fails

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -3065,7 +3065,6 @@ imported/w3c/web-platform-tests/css/css-masking/mask-image/mask-origin-3.html [ 
 
 imported/w3c/web-platform-tests/css/css-masking/animations/clip-path-interpolation-shape-arc-direction-agnostic-radius.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-polygon-014.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-shape-011.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-url-reference-empty-while-loading.tentative.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-url-reference-external.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-masking/mask-image/mask-composite-1c.html [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-shape-011.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-shape-011.html
@@ -5,7 +5,7 @@
   <link rel="help" href="https://drafts.csswg.org/css-shapes-2/#funcdef-shape">
   <link rel="match" href="reference/clip-path-shape-arc-ref.html">
   <meta name="assert" content="When providing one radius value with percentage, the percentage should be relative to the diagonal.">
-<meta name="fuzzy" content="maxDifference=0-67;totalPixels=0-128">
+  <meta name="fuzzy" content="maxDifference=0-98;totalPixels=0-136">
 </head>
 <style>
 #shape {

--- a/Source/WebCore/style/values/shapes/StyleShapeFunction.cpp
+++ b/Source/WebCore/style/values/shapes/StyleShapeFunction.cpp
@@ -42,6 +42,20 @@
 namespace WebCore {
 namespace Style {
 
+// https://drafts.csswg.org/css-shapes-1/#typedef-shape-arc-command
+static FloatSize resolveArcCommandRadius(const ArcCommand::SizeOfEllipse& size, FloatSize boxSize, ZoomFactor zoom)
+{
+    // If only one <length-percentage> is provided, both radiuses use the provided value.
+    // In that case, <percentage> values are resolved against the direction-agnostic size
+    // the reference box (similar to the circle() function).
+    if (size.width() == size.height()) {
+        auto directionAgnosticSize = boxSize.diagonalLength() / std::numbers::sqrt2_v<float>;
+        auto radius = evaluate<float>(size.width(), directionAgnosticSize, zoom);
+        return { radius, radius };
+    }
+    return evaluate<FloatSize>(size, boxSize, zoom);
+}
+
 // MARK: - Shape
 
 Shape::Shape(std::optional<FillRule> fillRule, Position&& startingPoint, Commands&& commands)
@@ -228,7 +242,7 @@ private:
     {
         auto& arcCommand = currentValue<ArcCommand>();
 
-        auto radius = evaluate<FloatSize>(arcCommand.size, m_boxSize, m_zoom);
+        auto radius = resolveArcCommandRadius(arcCommand.size, m_boxSize, m_zoom);
         return ArcToSegment {
             .rx = radius.width(),
             .ry = radius.height(),
@@ -905,7 +919,7 @@ AcceleratedEffectShapeFunction::ArcCommand Evaluation<ArcCommand, AcceleratedEff
                 return evaluate<AcceleratedEffectShapeFunction::ArcCommand::By>(by, rect, zoom);
             }
         ),
-        .size = evaluate<FloatSize>(value.size, rect.size(), zoom),
+        .size = resolveArcCommandRadius(value.size, rect.size(), zoom),
         .arcSweep = std::holds_alternative<CSS::Keyword::Cw>(value.arcSweep) ? AcceleratedEffectShapeFunction::ArcSweep::Cw : AcceleratedEffectShapeFunction::ArcSweep::Ccw,
         .arcSize = std::holds_alternative<CSS::Keyword::Large>(value.arcSize) ? AcceleratedEffectShapeFunction::ArcSize::Large : AcceleratedEffectShapeFunction::ArcSize::Small,
         .rotation = value.rotation.value,


### PR DESCRIPTION
#### feca486c220ec1dc5ea637cd00bb8f023777fcc1
<pre>
css/css-masking/clip-path/clip-path-shape-011.html fails
<a href="https://bugs.webkit.org/show_bug.cgi?id=319616">https://bugs.webkit.org/show_bug.cgi?id=319616</a>
<a href="https://rdar.apple.com/182443333">rdar://182443333</a>

Reviewed by Alan Baradlay.

This test had arcs with a single radius, requiring us to implement the single-radius
logic &lt;<a href="https://drafts.csswg.org/css-shapes-1/#typedef-shape-arc-command">https://drafts.csswg.org/css-shapes-1/#typedef-shape-arc-command</a>&gt;.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-shape-011.html:
* Source/WebCore/style/values/shapes/StyleShapeFunction.cpp:
(WebCore::Style::resolveArcCommandRadius):
(WebCore::Style::AcceleratedEffectShapeFunction::ArcCommand&gt;::operator):

Canonical link: <a href="https://commits.webkit.org/317397@main">https://commits.webkit.org/317397@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9f13e05a2bfe761df2291d9ece1a58e80497bb23

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175101 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49034 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42815 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184686 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/133009 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176966 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50326 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48717 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136286 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96134 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ae6f6862-152b-45c0-872a-b9bce1bb691c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178059 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39723 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157072 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116765 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/07ab480a-a696-4d11-b491-cae2da727ec6) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38364 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36752 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33160 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148787 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36565 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187107 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/40687 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/40955 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145232 "Found 1 new test failure: compositing/framesets/composited-frame-alignment.html (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48701 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/156628 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145088 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39110 "Built successfully and passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49381 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33185 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115215 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39948 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/121545 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47887 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11537 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47290 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47520 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47347 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->