### PR TITLE
Add API WebPage.NavigationPreferences.allowsJSHandleCreationInPageWorld

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences+Extras.swift
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences+Extras.swift
@@ -63,6 +63,7 @@ extension WKWebpagePreferences {
         self.alternateRequest = wrapped.alternateRequest
         self.overrideReferrer = wrapped.overrideReferrer
         self.globalPrivacyControlEnabled = wrapped.isGlobalPrivacyControlEnabled
+        self.allowsJSHandleCreationInPageWorld = wrapped.allowsJSHandleCreationInPageWorld
     }
 }
 

--- a/Source/WebKit/UIProcess/API/Swift/WebPage+NavigationPreferences.swift
+++ b/Source/WebKit/UIProcess/API/Swift/WebPage+NavigationPreferences.swift
@@ -149,6 +149,13 @@ extension WebPage {
         @available(watchOS, unavailable)
         @available(tvOS, unavailable)
         public var isGlobalPrivacyControlEnabled: Bool = false
+
+        /// Indicates whether `window.webkit.createJSHandle` will be available in `WKContentWorld.page`
+        /// The default value of this property is `false`.
+        @available(anyAppleOSAndDownlevels 27.0, *)
+        @available(watchOS, unavailable)
+        @available(tvOS, unavailable)
+        public var allowsJSHandleCreationInPageWorld: Bool = false
     }
 }
 
@@ -210,6 +217,7 @@ extension WebPage.NavigationPreferences {
         self.alternateRequest = wrapped.alternateRequest
         self.overrideReferrer = wrapped.overrideReferrer
         self.isGlobalPrivacyControlEnabled = wrapped.globalPrivacyControlEnabled
+        self.allowsJSHandleCreationInPageWorld = wrapped.allowsJSHandleCreationInPageWorld
     }
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WebPage/WebPageTests.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WebPage/WebPageTests.swift
@@ -117,6 +117,23 @@ struct WebPageTests {
         #expect(result == enabled)
     }
 
+    @Test(arguments: [true, false])
+    func allowsJSHandleCreationInPageWorld(enabled: Bool) async throws {
+        let decider = TestNavigationDecider()
+        decider.preferencesMutation = { preferences in
+            preferences.allowsJSHandleCreationInPageWorld = enabled
+        }
+        let page = WebPage(navigationDecider: decider)
+        try await page.load(html: "hi", baseURL: URL(string: "http://webkit.org")!).wait()
+
+        let result = try await page.callJavaScript(returning: Bool.self) {
+            """
+            return !!window.webkit && !!window.webkit.createJSHandle;
+            """
+        }
+        #expect(result == enabled)
+    }
+
     @Test
     func javaScriptEvaluation() async throws {
         let page = WebPage()


### PR DESCRIPTION
#### 65b70880778549ab974f4a722411129dcbf8fda6
<pre>
Add API WebPage.NavigationPreferences.allowsJSHandleCreationInPageWorld
<a href="https://bugs.webkit.org/show_bug.cgi?id=319622">https://bugs.webkit.org/show_bug.cgi?id=319622</a>
<a href="https://rdar.apple.com/182372719">rdar://182372719</a>

Reviewed by Richard Robinson.

This mirrors the WKWebpagePreferences property.

Test: Tools/TestWebKitAPI/Tests/WebKit/WebPage/WebPageTests.swift

* Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences+Extras.swift:
* Source/WebKit/UIProcess/API/Swift/WebPage+NavigationPreferences.swift:
(allowsJSHandleCreationInPageWorld):
* Tools/TestWebKitAPI/Tests/WebKit/WebPage/WebPageTests.swift:
(WebPageTests.allowsJSHandleCreationInPageWorld(_:)):

Canonical link: <a href="https://commits.webkit.org/317405@main">https://commits.webkit.org/317405@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f21276688a3e8fba61f7f5334b65e03cde0750f2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175075 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49008 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42789 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184660 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132983 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176940 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50300 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48691 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136267 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96123 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/77fd4f3f-e2b0-4888-b697-e0feab53d369) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178033 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39701 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157058 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116745 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38342 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36731 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33133 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/5567 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148765 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36550 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187081 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/40656 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40934 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145211 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48675 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145067 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49355 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33171 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115181 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26636 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39925 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/121514 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47861 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11523 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47264 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47494 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47321 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->