### PR TITLE
Fix extension sidebar code

### DIFF
--- a/Source/WebKit/Platform/cocoa/CocoaHelpers.h
+++ b/Source/WebKit/Platform/cocoa/CocoaHelpers.h
@@ -87,6 +87,14 @@ inline std::optional<RetainPtr<T>> toOptional(T *maybeNil)
     return std::nullopt;
 }
 
+template<typename T>
+inline std::optional<Ref<T>> toOptional(RefPtr<T> maybeNull)
+{
+    if (maybeNull)
+        return maybeNull.releaseNonNull();
+    return std::nullopt;
+}
+
 inline std::optional<String> toOptional(NSString *maybeNil)
 {
     if (maybeNil)

--- a/Source/WebKit/Shared/Extensions/WebExtensionPermission.cpp
+++ b/Source/WebKit/Shared/Extensions/WebExtensionPermission.cpp
@@ -97,12 +97,12 @@ String WebExtensionPermission::scripting()
     return "scripting"_s;
 }
 
-#if ENABLE(WK_WEB_EXTENSION_SIDEBAR)
+#if ENABLE(WK_WEB_EXTENSIONS_SIDEBAR)
 String WebExtensionPermission::sidePanel()
 {
     return "sidePanel"_s;
 }
-#endif // ENABLE(WK_WEB_EXTENSION_SIDEBAR)
+#endif // ENABLE(WK_WEB_EXTENSIONS_SIDEBAR)
 
 String WebExtensionPermission::storage()
 {

--- a/Source/WebKit/Shared/Extensions/WebExtensionPermission.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionPermission.h
@@ -49,9 +49,9 @@ public:
     static String nativeMessaging();
     static String notifications();
     static String scripting();
-#if ENABLE(WK_WEB_EXTENSION_SIDEBAR)
+#if ENABLE(WK_WEB_EXTENSIONS_SIDEBAR)
     static String sidePanel();
-#endif // ENABLE(WK_WEB_EXTENSION_SIDEBAR)
+#endif
     static String storage();
     static String tabs();
     static String unlimitedStorage();

--- a/Source/WebKit/Shared/Extensions/WebExtensionSidebarParameters.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionSidebarParameters.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2024-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/Source/WebKit/Shared/Extensions/WebExtensionSidebarParameters.serialization.in
+++ b/Source/WebKit/Shared/Extensions/WebExtensionSidebarParameters.serialization.in
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 Apple Inc. All rights reserved.
+# Copyright (C) 2024-2026 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionSidebar.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionSidebar.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2024-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -46,19 +46,20 @@ WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(_WKWebExtensionSidebar, WebExtensionSideba
 
 - (WKWebExtensionContext *)webExtensionContext
 {
-    return _webExtensionSidebar->extensionContext()
-        .transform([](auto const& context) { return context->wrapper(); })
-        .value_or(nil);
+    RefPtr context = _webExtensionSidebar->extensionContext();
+    return context ? context->wrapper() : nil;
 }
 
 - (NSString *)title
 {
-    return _webExtensionSidebar->title();
+    return _webExtensionSidebar->title().createNSString().get();
 }
 
 - (CocoaImage *)iconForSize:(CGSize)size
 {
-    return WebKit::toCocoaImage(_webExtensionSidebar->icon(WebCore::FloatSize(size)));
+    return _webExtensionSidebar->icon(WebCore::FloatSize(size))
+        .transform([](Ref<WebCore::Icon> icon) { return WebKit::toCocoaImage(icon.ptr()); })
+        .value_or(nullptr);
 }
 
 - (SidebarViewControllerType *)viewController

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPISidebarCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPISidebarCocoa.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2024-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -64,7 +64,10 @@ static Expected<Ref<WebExtensionSidebar>, WebExtensionError> getSidebarWithIdent
         if (!tab)
             return makeUnexpected(@"the tab was not found");
         return context.getSidebar(*tab)
-            .or_else([&] { return context.getSidebar(*(tab->window())); })
+            .or_else([&] -> std::optional<Ref<WebExtensionSidebar>> {
+                RefPtr window = tab->window();
+                return window ? context.getSidebar(*window) : std::nullopt;
+            })
             .value_or(context.defaultSidebar());
     }
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionSidebarCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionSidebarCocoa.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2024-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -49,14 +49,6 @@
 
 #import <wtf/BlockPtr.h>
 
-template <typename T>
-ALWAYS_INLINE std::optional<Ref<T>> toOptionalRef(RefPtr<T> ptr)
-{
-    if (ptr)
-        return *ptr;
-    return std::nullopt;
-}
-
 @interface _WKWebExtensionSidebarWebViewDelegate : NSObject <WKNavigationDelegatePrivate>
 @end
 
@@ -77,12 +69,11 @@ ALWAYS_INLINE std::optional<Ref<T>> toOptionalRef(RefPtr<T> ptr)
 - (void)webView:(WKWebView *)webView decidePolicyForNavigationAction:(WKNavigationAction *)navigationAction decisionHandler:(void (^)(WKNavigationActionPolicy))decisionHandler
 {
     RefPtr currentSidebar = _webExtensionSidebar.get();
-    if (!currentSidebar || !currentSidebar->extensionContext()) {
+    RefPtr context = currentSidebar ? currentSidebar->extensionContext() : nullptr;
+    if (!context) {
         decisionHandler(WKNavigationActionPolicyCancel);
         return;
     }
-
-    Ref context = currentSidebar->extensionContext().value();
     NSURL *targetURL = navigationAction.request.URL;
     bool isURLForThisExtension = context->isURLForThisExtension(targetURL);
 
@@ -90,9 +81,9 @@ ALWAYS_INLINE std::optional<Ref<T>> toOptionalRef(RefPtr<T> ptr)
         std::optional currentWindow = currentSidebar->window();
         std::optional currentTab = currentSidebar->tab();
         if (!currentWindow && currentTab)
-            currentWindow = toOptionalRef(currentTab.value()->window());
+            currentWindow = toOptional(currentTab.value()->window());
         else if (!currentWindow && !currentTab)
-            currentWindow = toOptionalRef(context->frontmostWindow());
+            currentWindow = toOptional(context->frontmostWindow());
 
         WebKit::WebExtensionTabParameters tabParameters;
         tabParameters.url = targetURL;
@@ -114,22 +105,20 @@ ALWAYS_INLINE std::optional<Ref<T>> toOptionalRef(RefPtr<T> ptr)
         return;
     }
 
-    ASSERT(navigationAction.targetFrame.isMainFrame);
-    ASSERT(isURLForThisExtension);
-
     decisionHandler(WKNavigationActionPolicyAllow);
 }
 
 #if PLATFORM(MAC)
 - (void)webView:(WKWebView *)webView runOpenPanelWithParameters:(WKOpenPanelParameters *)parameters initiatedByFrame:(WKFrameInfo *)frame completionHandler:(void (^)(NSArray<NSURL *> *URLs))completionHandler
 {
-    auto extensionContext = _webExtensionSidebar ? _webExtensionSidebar->extensionContext() : std::nullopt;
+    RefPtr sidebar = _webExtensionSidebar.get();
+    RefPtr extensionContext = sidebar ? sidebar->extensionContext() : nullptr;
     if (!extensionContext) {
         completionHandler(nil);
         return;
     }
 
-    extensionContext.value()->runOpenPanel(webView, parameters, completionHandler);
+    extensionContext->runOpenPanel(webView, parameters, completionHandler);
 }
 #endif // PLATFORM(MAC)
 
@@ -152,13 +141,13 @@ using WTF::WeakPtr;
     if (!(self = [super init]))
         return nil;
 
-    std::optional<Ref<WebExtensionContext>> extensionContext = sidebar.extensionContext();
+    RefPtr extensionContext = sidebar.extensionContext();
     if (!extensionContext)
         return nil;
 
     _webExtensionSidebar = sidebar;
     self.view = sidebar.webView();
-    self.title = extensionContext.value()->extension().displayName();
+    self.title = extensionContext->extension().displayName().createNSString().get();
 
     return self;
 }
@@ -228,17 +217,7 @@ namespace WebKit {
 static NSString * const fallbackPath = @"about:blank";
 static NSString * const fallbackTitle = @"";
 
-static std::optional<String> getDefaultSidebarTitleFromExtension(WebExtension& extension)
-{
-    return toOptional(extension.sidebarTitle());
-}
-
-static std::optional<String> getDefaultSidebarPathFromExtension(WebExtension& extension)
-{
-    return toOptional(extension.sidebarDocumentPath());
-}
-
-static std::optional<RefPtr<JSON::Value>> getDefaultIconsDictFromExtension(WebExtension& extensions)
+static std::optional<Ref<JSON::Object>> getDefaultIconsDictFromExtension(WebExtension& extensions)
 {
     // FIXME: <https://webkit.org/b/276833> implement this
     return std::nullopt;
@@ -258,8 +237,8 @@ WebExtensionSidebar::WebExtensionSidebar(WebExtensionContext& context, std::opti
     // if this is the default action, initialize with default sidebar path / title if present
     if (isDefaultSidebar()) {
         auto& extension = context.extension();
-        m_titleOverride = getDefaultSidebarTitleFromExtension(extension);
-        m_sidebarPathOverride = getDefaultSidebarPathFromExtension(extension);
+        m_titleOverride = extension.sidebarTitle();
+        m_sidebarPathOverride = extension.sidebarDocumentPath();
         m_iconsOverride = getDefaultIconsDictFromExtension(extension);
         m_isEnabled = true;
     }
@@ -274,31 +253,37 @@ WebExtensionSidebar::WebExtensionSidebar(WebExtensionContext& context, std::opti
         parent.value()->addChild(*this);
 }
 
-std::optional<Ref<WebExtensionContext>> WebExtensionSidebar::extensionContext() const
+RefPtr<WebExtensionContext> WebExtensionSidebar::extensionContext() const
 {
-    if (auto *context = m_extensionContext.get())
-        return *context;
-    return std::nullopt;
+    return m_extensionContext.get();
 }
 
 const std::optional<Ref<WebExtensionTab>> WebExtensionSidebar::tab() const
 {
-    return m_tab.and_then([](WeakPtr<WebExtensionTab> const& maybeTabPtr) { return toOptionalRef(RefPtr(maybeTabPtr.get())); });
+    return m_tab.and_then([](WeakPtr<WebExtensionTab> const& maybeTabPtr) {
+        return toOptional(RefPtr(maybeTabPtr.get()));
+    });
 }
 
 const std::optional<Ref<WebExtensionWindow>> WebExtensionSidebar::window() const
 {
-    return m_window.and_then([](WeakPtr<WebExtensionWindow> const& maybeWindowPtr) { return toOptionalRef(RefPtr(maybeWindowPtr.get())); });
+    return m_window.and_then([](WeakPtr<WebExtensionWindow> const& maybeWindowPtr) {
+        return toOptional(RefPtr(maybeWindowPtr.get()));
+    });
 }
 
 std::optional<Ref<WebExtensionSidebar>> WebExtensionSidebar::parent() const
 {
-    if (!extensionContext() || isDefaultSidebar())
+    RefPtr context = extensionContext();
+    if (!context || isDefaultSidebar())
         return std::nullopt;
 
-    return tab().and_then([this](Ref<WebExtensionTab> const& tab) -> std::optional<Ref<WebExtensionSidebar>> {
-        return tab->window() ? m_extensionContext->getSidebar(*(tab->window())) : std::nullopt;
-    }).value_or(m_extensionContext->defaultSidebar());
+    return tab().and_then([&](Ref<WebExtensionTab> const& tab) -> std::optional<Ref<WebExtensionSidebar>> {
+        RefPtr window = tab->window();
+        return window ? context->getSidebar(*window) : std::nullopt;
+    }).or_else([&] -> std::optional<Ref<WebExtensionSidebar>> {
+        return Ref { context->defaultSidebar() };
+    });
 }
 
 void WebExtensionSidebar::propertiesDidChange()
@@ -309,51 +294,64 @@ void WebExtensionSidebar::propertiesDidChange()
         notifyDelegateOfPropertyUpdate();
 }
 
-RefPtr<WebCore::Icon> WebExtensionSidebar::icon(WebCore::FloatSize size)
+std::optional<Ref<WebCore::Icon>> WebExtensionSidebar::icon(WebCore::FloatSize size)
 {
-    if (!extensionContext())
-        return nil;
+    RefPtr context = extensionContext();
+    if (!context)
+        return std::nullopt;
 
-    auto& context = extensionContext().value().get();
     return m_iconsOverride
-        .and_then([&](RefPtr<JSON::Value> icons) -> std::optional<RefPtr<WebCore::Icon>> {
-            return toOptional(context.extension().bestIcon(icons, size, [](NSError *error) { }));
+        .and_then([&](Ref<JSON::Object> icons) -> std::optional<Ref<WebCore::Icon>> {
+            return toOptional(context->extension().bestIcon(icons.ptr(), size, [](Ref<API::Error> error) { }));
         })
-        .or_else([&] -> std::optional<RefPtr<WebCore::Icon>> {
-            return parent().transform([&](auto const& parent) { return parent.get().icon(size); });
+        .or_else([&] -> std::optional<Ref<WebCore::Icon>> {
+            return parent().and_then([&](auto const& parent) {
+                return parent.get().icon(size);
+            });
         })
-        // using .or_else(..).value() is more efficient than value_or, since value_or will evaluate its argument
-        // regardless of whether or not it's used. by switching to or_else(..).value() we instead lazily evaluate
+        // using .or_else(..) is more efficient than value_or, since value_or will evaluate its argument
+        // regardless of whether or not it's used. by switching to or_else(..) we instead lazily evaluate
         // the fallback value
-        .or_else([&] { return std::optional { context.extension().actionIcon(size) }; })
-        .value();
+        .or_else([&] {
+            return toOptional(context->extension().actionIcon(size));
+        });
 }
 
-void WebExtensionSidebar::setIconsDictionary(RefPtr<JSON::Object> icons)
+void WebExtensionSidebar::setIconsDictionary(std::optional<Ref<JSON::Object>> icons)
 {
-    if (!icons || !icons.count) {
+    if (!icons || !icons.value()->size()) {
         m_iconsOverride = std::nullopt;
         return;
     }
 
-    if (m_iconsOverride && m_iconsOverride.value() == icons)
+    if (m_iconsOverride && m_iconsOverride.value() == icons.value())
         return;
 
-    m_iconsOverride = icons;
+    m_iconsOverride = WTF::move(icons);
     propertiesDidChange();
 }
 
 String WebExtensionSidebar::title() const
 {
+    // Per the sidebar_action spec, when no title is set anywhere the effective title is the extension's name.
     return m_titleOverride
-        .or_else([this] { return parent().transform([](auto const& parent) { return parent->title(); }); })
-        .value_or(fallbackTitle);
+        .or_else([this] {
+            return parent().transform([](auto const& parent) {
+                return parent->title();
+            });
+        })
+        .or_else([this] -> std::optional<String> {
+            RefPtr context = extensionContext();
+            return context ? context->extension().displayName() : String { fallbackTitle };
+        })
+        .value();
 }
 
 void WebExtensionSidebar::setTitle(std::optional<String> titleOverride)
 {
-    if (!titleOverride && isDefaultSidebar() && extensionContext())
-        m_titleOverride = getDefaultSidebarTitleFromExtension(extensionContext().value()->extension());
+    RefPtr context = extensionContext();
+    if (!titleOverride && isDefaultSidebar() && context)
+        m_titleOverride = context->extension().sidebarTitle();
     else
         m_titleOverride = titleOverride;
 
@@ -373,17 +371,25 @@ void WebExtensionSidebar::setEnabled(bool enabled)
     propertiesDidChange();
 }
 
+std::optional<String> WebExtensionSidebar::resolvedSidebarPath() const
+{
+    return m_sidebarPathOverride.or_else([this] {
+        return parent().and_then([](auto const& parent) {
+            return parent->resolvedSidebarPath();
+        });
+    });
+}
+
 String WebExtensionSidebar::sidebarPath() const
 {
-    return m_sidebarPathOverride
-        .or_else([this] { return parent().transform([](auto const& parent) { return parent->sidebarPath(); }); })
-        .value_or(fallbackPath);
+    return resolvedSidebarPath().value_or(fallbackPath);
 }
 
 void WebExtensionSidebar::setSidebarPath(std::optional<String> sidebarPath)
 {
-    if (!sidebarPath && isDefaultSidebar() && extensionContext())
-        m_sidebarPathOverride = getDefaultSidebarPathFromExtension(extensionContext().value()->extension());
+    RefPtr context = extensionContext();
+    if (!sidebarPath && isDefaultSidebar() && context)
+        m_sidebarPathOverride = context->extension().sidebarDocumentPath();
     else
         m_sidebarPathOverride = sidebarPath;
 
@@ -442,7 +448,7 @@ void WebExtensionSidebar::removeChild(WebExtensionSidebar const& child)
 void WebExtensionSidebar::didReceiveUserInteraction()
 {
     auto currentTab = tab();
-    auto currentContext = extensionContext();
+    RefPtr currentContext = extensionContext();
 
     ASSERT(isOpen());
     ASSERT(currentTab);
@@ -450,7 +456,7 @@ void WebExtensionSidebar::didReceiveUserInteraction()
     if (!(isOpen() && currentTab && currentContext))
         return;
 
-    currentContext.value()->userGesturePerformed(currentTab.value());
+    currentContext->userGesturePerformed(currentTab.value());
 }
 
 RetainPtr<SidebarViewControllerType> WebExtensionSidebar::viewController()
@@ -471,10 +477,9 @@ WKWebView *WebExtensionSidebar::webView()
     if (!m_tab)
         return nil;
 
-    std::optional<Ref<WebExtensionContext>> maybeContext;
-    if (!opensSidebar() || !(maybeContext = extensionContext()))
+    RefPtr context = extensionContext();
+    if (!opensSidebar() || !context)
         return nil;
-    Ref<WebExtensionContext> context = WTF::move(maybeContext.value());
 
     if (m_webView)
         return m_webView.get();
@@ -482,7 +487,7 @@ WKWebView *WebExtensionSidebar::webView()
     auto *webViewConfiguration = context->webViewConfiguration(WebExtensionContext::WebViewPurpose::Sidebar);
     m_webView = [[_WKWebExtensionSidebarWebView alloc] initWithFrame:CGRectZero configuration:webViewConfiguration webExtensionSidebar:*this];
     m_webView.get().inspectable = context->isInspectable();
-    m_webView.get().accessibilityLabel = title();
+    m_webView.get().accessibilityLabel = title().createNSString().get();
     m_webViewDelegate = [[_WKWebExtensionSidebarWebViewDelegate alloc] initWithWebExtensionSidebar:*this];
     m_webView.get().navigationDelegate = m_webViewDelegate.get();
 
@@ -516,10 +521,9 @@ void WebExtensionSidebar::notifyChildrenOfPropertyUpdate(ShouldReloadWebView sho
 
 void WebExtensionSidebar::notifyDelegateOfPropertyUpdate()
 {
-    std::optional<Ref<WebExtensionContext>> maybeContext = extensionContext();
-    if (!maybeContext)
+    RefPtr context = extensionContext();
+    if (!context)
         return;
-    Ref<WebExtensionContext> context = WTF::move(maybeContext.value());
 
     RefPtr extensionController = context->extensionController();
     if (!extensionController)
@@ -544,8 +548,12 @@ void WebExtensionSidebar::reloadWebView()
     if (!m_webView)
         return;
 
-    auto url = URL { extensionContext().value()->baseURL(), sidebarPath() };
-    [m_webView loadRequest:[NSURLRequest requestWithURL:url]];
+    RefPtr context = extensionContext();
+    if (!context)
+        return;
+
+    auto url = URL { context->baseURL(), sidebarPath() };
+    [m_webView loadRequest:[NSURLRequest requestWithURL:url.createNSURL().get()]];
 }
 
 }

--- a/Source/WebKit/UIProcess/Extensions/WebExtension.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtension.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2024 Igalia S.L. All rights reserved.
- * Copyright (C) 2024-2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2024-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -1565,13 +1565,13 @@ RefPtr<WebCore::Icon> WebExtension::sidebarIcon(WebCore::FloatSize idealSize)
     return nullptr;
 }
 
-const String& WebExtension::sidebarDocumentPath()
+const std::optional<String>& WebExtension::sidebarDocumentPath()
 {
     populateSidebarPropertiesIfNeeded();
     return m_sidebarDocumentPath;
 }
 
-const String& WebExtension::sidebarTitle()
+const std::optional<String>& WebExtension::sidebarTitle()
 {
     populateSidebarPropertiesIfNeeded();
     return m_sidebarTitle;
@@ -1593,28 +1593,35 @@ void WebExtension::populateSidebarPropertiesIfNeeded()
     // sidebarAction documentation: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/sidebar_action
 
     if (RefPtr sidebarActionObject = manifestObject->getObject(sidebarActionManifestKey)) {
-        populateSidebarActionProperties(sidebarActionObject);
+        populateSidebarActionProperties(*sidebarActionObject);
         return;
     }
 
     if (RefPtr sidePanelObject = manifestObject->getObject(sidePanelManifestKey))
-        populateSidePanelProperties(sidePanelObject);
+        populateSidePanelProperties(*sidePanelObject);
+}
+
+static std::optional<String> toOptionalString(String&& string)
+{
+    if (string.isNull())
+        return std::nullopt;
+    return WTF::move(string);
 }
 
 void WebExtension::populateSidebarActionProperties(const JSON::Object& sidebarActionObject)
 {
     // FIXME: <https://webkit.org/b/276833> implement sidebar icon parsing
-    m_sidebarIconsCache = nullptr;
-    m_sidebarTitle = sidebarActionObject.getString(sidebarActionTitleManifestKey);
-    m_sidebarDocumentPath = sidebarActionObject.getString(sidebarActionPathManifestKey);
+    m_sidebarIconsCache = std::nullopt;
+    m_sidebarTitle = toOptionalString(sidebarActionObject.getString(sidebarActionTitleManifestKey));
+    m_sidebarDocumentPath = toOptionalString(sidebarActionObject.getString(sidebarActionPathManifestKey));
 }
 
 void WebExtension::populateSidePanelProperties(const JSON::Object& sidePanelObject)
 {
-    // Since sidePanel cannot set a default title or icon from the manifest, setting these to null here is intentional.
-    m_sidebarIconsCache = nullptr;
-    m_sidebarTitle = nullString();
-    m_sidebarDocumentPath = sidePanelObject.getString(sidePanelPathManifestKey);
+    // Since sidePanel cannot set a default title or icon from the manifest, setting these to nullopt here is intentional.
+    m_sidebarIconsCache = std::nullopt;
+    m_sidebarTitle = std::nullopt;
+    m_sidebarDocumentPath = toOptionalString(sidePanelObject.getString(sidePanelPathManifestKey));
 }
 #endif // ENABLE(WK_WEB_EXTENSIONS_SIDEBAR)
 

--- a/Source/WebKit/UIProcess/Extensions/WebExtension.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtension.h
@@ -278,8 +278,8 @@ public:
     bool hasSidePanel();
     bool hasAnySidebar();
     RefPtr<WebCore::Icon> sidebarIcon(WebCore::FloatSize idealSize);
-    const Sring& sidebarDocumentPath();
-    const String& sidebarTitle();
+    const std::optional<String>& sidebarDocumentPath();
+    const std::optional<String>& sidebarTitle();
 #endif
 
     Expected<Ref<WebCore::Icon>, RefPtr<API::Error>> iconForPath(const String&, WebCore::FloatSize sizeForResizing = { }, std::optional<double> displayScale = std::nullopt);
@@ -383,8 +383,8 @@ private:
     void populateExternallyConnectableIfNeeded();
 #if ENABLE(WK_WEB_EXTENSIONS_SIDEBAR)
     void populateSidebarPropertiesIfNeeded();
-    void populateSidebarActionProperties(RetainPtr<NSDictionary>);
-    void populateSidePanelProperties(RetainPtr<NSDictionary>);
+    void populateSidebarActionProperties(const JSON::Object&);
+    void populateSidePanelProperties(const JSON::Object&);
 #endif
 
     URL resourceFileURLForPath(const String&);
@@ -436,9 +436,9 @@ private:
     String m_actionPopupPath;
 
 #if ENABLE(WK_WEB_EXTENSIONS_SIDEBAR)
-    IconsCache m_sidebarIconsCache;
-    String m_sidebarDocumentPath;
-    String m_sidebarTitle;
+    std::optional<IconsCache> m_sidebarIconsCache;
+    std::optional<String> m_sidebarDocumentPath;
+    std::optional<String> m_sidebarTitle;
 #endif
 
     String m_contentSecurityPolicy;

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionSidebar.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionSidebar.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2024-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -38,6 +38,7 @@ using SidebarViewControllerType = NSViewController;
 #if ENABLE(WK_WEB_EXTENSIONS_SIDEBAR)
 
 #include "APIObject.h"
+#include <WebCore/Icon.h>
 #include <wtf/Forward.h>
 #include <wtf/WeakHashSet.h>
 #include <wtf/WeakPtr.h>
@@ -73,7 +74,7 @@ public:
 
     bool operator==(const WebExtensionSidebar&) const;
 
-    std::optional<Ref<WebExtensionContext>> extensionContext() const;
+    RefPtr<WebExtensionContext> extensionContext() const;
     const std::optional<Ref<WebExtensionTab>> tab() const;
     const std::optional<Ref<WebExtensionWindow>> window() const;
     std::optional<Ref<WebExtensionSidebar>> parent() const;
@@ -81,8 +82,8 @@ public:
     void propertiesDidChange();
 
     /// `icon()` will return the overridden icon of this sidebar, or the icon of the first parent sidebar in which the icon is set
-    RefPtr<WebCore::Icon> icon(WebCore::FloatSize);
-    void setIconsDictionary(RefPtr<JSON::Object>);
+    std::optional<Ref<WebCore::Icon>> icon(WebCore::FloatSize);
+    void setIconsDictionary(std::optional<Ref<JSON::Object>>);
 
     /// `title()` will return the overridden title of this sidebar, or the title of the first parent sidebar in which the title is set
     String title() const;
@@ -92,7 +93,11 @@ public:
     void setEnabled(bool);
 
     bool isOpen() const { return m_isOpen; }
-    bool opensSidebar() { return !sidebarPath().isEmpty(); };
+    bool opensSidebar()
+    {
+        auto path = resolvedSidebarPath();
+        return path && !path->isEmpty();
+    }
 
     /// `sidebarPath()` will return the overriden path of this sidebar, or the path of the first parent sidebar in which the path is set
     String sidebarPath() const;
@@ -130,7 +135,10 @@ private:
 
     void reloadWebView();
 
-    std::optional<RefPtr<JSON::Object>> m_iconsOverride;
+    /// The configured panel path from this sidebar's override/parent chain
+    std::optional<String> resolvedSidebarPath() const;
+
+    std::optional<Ref<JSON::Object>> m_iconsOverride;
     std::optional<String> m_titleOverride;
     std::optional<String> m_sidebarPathOverride;
     std::optional<bool> m_isEnabled;

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPISidePanelCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPISidePanelCocoa.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2024-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -38,42 +38,47 @@
 #import "WebExtensionAPISidebarAction.h"
 #import "WebExtensionActionClickBehavior.h"
 #import "WebExtensionContextMessages.h"
+#import "WebExtensionPermission.h"
 #import "WebProcess.h"
 
 namespace WebKit {
 
 
-static ParseResult parseTabIdentifier(NSDictionary *options)
+static Expected<std::optional<WebExtensionTabIdentifier>, WebExtensionError> parseTabIdentifier(NSDictionary *options)
 {
     id maybeTabId = [options objectForKey:tabIdKey];
 
     if (!maybeTabId || [maybeTabId isKindOfClass:NSNull.class])
-        return std::monostate();
+        return { std::nullopt };
 
     if ([maybeTabId isKindOfClass:NSNumber.class]) {
         auto tabId = toWebExtensionTabIdentifier(((NSNumber *) maybeTabId).doubleValue);
-        return isValid(tabId) ? ParseResult(tabId.value()) : ParseResult(toErrorString(nullString(), @"options", @"'tabId' is invalid"));
+        if (!isValid(tabId))
+            return makeUnexpected(toErrorString(nullString(), @"options", @"'tabId' is invalid"));
+        return std::optional(tabId.value());
     }
 
-    return toErrorString(nullString(), @"options", @"'tabId' must be a number");
+    return makeUnexpected(toErrorString(nullString(), @"options", @"'tabId' must be a number"));
 }
 
-static ParseResult parseWindowIdentifier(NSDictionary *options)
+static Expected<std::optional<WebExtensionWindowIdentifier>, WebExtensionError> parseWindowIdentifier(NSDictionary *options)
 {
     id maybeWindowId = [options objectForKey:windowIdKey];
 
     if (!maybeWindowId || [maybeWindowId isKindOfClass:NSNull.class])
-        return std::monostate();
+        return { std::nullopt };
 
     if ([maybeWindowId isKindOfClass:NSNumber.class]) {
         auto windowId = toWebExtensionWindowIdentifier(((NSNumber *) maybeWindowId).doubleValue);
-        return isValid(windowId) ? ParseResult(windowId.value()) : ParseResult(toErrorString(nullString(), @"options", @"'windowId' is invalid"));
+        if (!isValid(windowId))
+            return makeUnexpected(toErrorString(nullString(), @"options", @"'windowId' is invalid"));
+        return std::optional(windowId.value());
     }
 
-    return toErrorString(nullString(), @"options", @"'windowId' must be a number");
+    return makeUnexpected(toErrorString(nullString(), @"options", @"'windowId' must be a number"));
 }
 
-static Variant<WebExtensionActionClickBehavior, SidebarError> parseActionClickBehavior(NSDictionary *behavior)
+static Expected<std::optional<WebExtensionActionClickBehavior>, WebExtensionError> parseActionClickBehavior(NSDictionary *behavior)
 {
     static NSDictionary<NSString *, id> *types = @{
         actionClickBehaviorKey: @YES.class,
@@ -81,12 +86,12 @@ static Variant<WebExtensionActionClickBehavior, SidebarError> parseActionClickBe
 
     NSString *exceptionString;
     if (!validateDictionary(behavior, @"behavior", nil, types, &exceptionString))
-        return exceptionString;
+        return makeUnexpected(exceptionString);
 
     NSNumber *actionClickBehavior = behavior[actionClickBehaviorKey];
-    if (actionClickBehavior.boolValue)
-        return WebExtensionActionClickBehavior::OpenSidebar;
-    return WebExtensionActionClickBehavior::OpenPopup;
+    if (!actionClickBehavior)
+        return { std::nullopt };
+    return { actionClickBehavior.boolValue ? WebExtensionActionClickBehavior::OpenSidebar : WebExtensionActionClickBehavior::OpenPopup };
 }
 
 static NSDictionary<NSString *, id> *serializeSidebarParameters(WebExtensionSidebarParameters const& parameters)
@@ -94,7 +99,7 @@ static NSDictionary<NSString *, id> *serializeSidebarParameters(WebExtensionSide
     NSMutableDictionary *serializedParameters = [NSMutableDictionary new];
 
     serializedParameters[@"enabled"] = @(parameters.enabled);
-    serializedParameters[@"path"] = parameters.panelPath;
+    serializedParameters[@"path"] = parameters.panelPath.createNSString().get();
 
     if (parameters.tabIdentifier)
         serializedParameters[@"tabId"] = @(toWebAPI(parameters.tabIdentifier.value()));
@@ -114,8 +119,8 @@ static Expected<WebExtensionSidebarParameters, WebExtensionError> deserializeSid
 
     auto tabIdentifierResult = parseTabIdentifier(serializedParameters);
     if (NSString *error = indicatesError(tabIdentifierResult).get())
-        return toWebExtensionError(nil, @"details", error);
-    parameters.tabIdentifier = toOptional<WebExtensionTabIdentifier>(tabIdentifierResult);
+        return toWebExtensionError(nullString(), @"details", error);
+    parameters.tabIdentifier = WTF::move(tabIdentifierResult.value());
 
     return parameters;
 }
@@ -126,16 +131,16 @@ void WebExtensionAPISidePanel::getOptions(NSDictionary *options, Ref<WebExtensio
     if ((*outExceptionString = indicatesError(result).get()))
         return;
 
-    const auto tabId = toOptional<WebExtensionTabIdentifier>(result);
+    const auto tabId = WTF::move(result.value());
 
     WebProcess::singleton()
         .sendWithAsyncReply(Messages::WebExtensionContext::SidebarGetOptions(std::nullopt, tabId), [protectedThis = Ref { *this }, callback = WTF::move(callback)](Expected<WebExtensionSidebarParameters, WebExtensionError>&& result) {
             if (!result) {
-                callback->reportError(result.error());
+                callback->reportError(result.error().createNSString().get());
                 return;
             }
 
-            callback->call(serializeSidebarParameters(result.value()));
+            callback->call(toJSValueRef(callback->globalContext(), serializeSidebarParameters(result.value())));
         }, extensionContext().identifier());
 }
 
@@ -143,7 +148,7 @@ void WebExtensionAPISidePanel::setOptions(NSDictionary *options, Ref<WebExtensio
 {
     auto result = deserializeSidebarParameters(options);
     if (!result) {
-        *outExceptionString = result.error();
+        *outExceptionString = result.error().createNSString().get();
         return;
     }
 
@@ -151,7 +156,7 @@ void WebExtensionAPISidePanel::setOptions(NSDictionary *options, Ref<WebExtensio
 
     WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::SidebarSetOptions(std::nullopt, result->tabIdentifier, panelPath, result->enabled), [protectedThis = Ref { *this }, callback = WTF::move(callback)](Expected<void, WebExtensionError>&& result) {
         if (!result) {
-            callback->reportError(result.error());
+            callback->reportError(result.error().createNSString().get());
             return;
         }
 
@@ -163,14 +168,14 @@ void WebExtensionAPISidePanel::getPanelBehavior(Ref<WebExtensionCallbackHandler>
 {
     WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::SidebarGetActionClickBehavior(), [protectedThis = Ref { *this }, callback = WTF::move(callback)](Expected<WebExtensionActionClickBehavior, WebExtensionError>&& result) {
         if (!result) {
-            callback->reportError(result.error());
+            callback->reportError(result.error().createNSString().get());
             return;
         }
 
         bool openPanelOnActionClick = result.value() == WebExtensionActionClickBehavior::OpenSidebar;
-        callback->call(@{
+        callback->call(toJSValueRef(callback->globalContext(), @{
             actionClickBehaviorKey: @(openPanelOnActionClick),
-        });
+        }));
     }, extensionContext().identifier());
 }
 
@@ -180,11 +185,16 @@ void WebExtensionAPISidePanel::setPanelBehavior(NSDictionary *behavior, Ref<WebE
     if ((*outExceptionString = indicatesError(result).get()))
         return;
 
-    auto actionClickBehavior = std::get<WebExtensionActionClickBehavior>(result);
+    std::optional maybeClickBehavior = WTF::move(result.value());
+    if (!maybeClickBehavior) {
+        // setPanelBehavior is an upsert; if `openPanelOnActionClick` is omitted then the current behavior is unchanged
+        callback->call({ });
+        return;
+    }
 
-    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::SidebarSetActionClickBehavior(actionClickBehavior), [protectedThis = Ref { *this }, callback = WTF::move(callback)](Expected<void, WebExtensionError>&& result) {
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::SidebarSetActionClickBehavior(*maybeClickBehavior), [protectedThis = Ref { *this }, callback = WTF::move(callback)](Expected<void, WebExtensionError>&& result) {
         if (!result) {
-            callback->reportError(result.error());
+            callback->reportError(result.error().createNSString().get());
             return;
         }
 
@@ -195,8 +205,8 @@ void WebExtensionAPISidePanel::setPanelBehavior(NSDictionary *behavior, Ref<WebE
 void WebExtensionAPISidePanel::open(NSDictionary *options, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
 {
     if (!WebCore::UserGestureIndicator::processingUserGesture()) {
-        // In chrome, this error manifests as a rejected promise, so match this behavior
-        callback->reportError(toErrorString(@"sidePanel.open()", nil, @"it must be called during a user gesture"));
+        // In Chrome, this error manifests as a rejected promise, so match this behavior.
+        callback->reportError(toErrorString(@"sidePanel.open()", nullString(), @"it must be called during a user gesture").createNSString().get());
         return;
     }
 
@@ -204,22 +214,22 @@ void WebExtensionAPISidePanel::open(NSDictionary *options, Ref<WebExtensionCallb
     if ((*outExceptionString = indicatesError(tabResult).get()))
         return;
 
-    auto tabId = toOptional<WebExtensionTabIdentifier>(tabResult);
+    auto tabId = WTF::move(tabResult.value());
 
     auto windowResult = parseWindowIdentifier(options);
     if ((*outExceptionString = indicatesError(windowResult).get()))
         return;
 
-    auto windowId = toOptional<WebExtensionWindowIdentifier>(windowResult);
+    auto windowId = WTF::move(windowResult.value());
 
     if (!windowId && !tabId) {
-        *outExceptionString = toErrorString(nullString(), @"details", @"it must specify at least one of 'tabId' or 'windowId'");
+        *outExceptionString = toErrorString(nullString(), @"details", @"it must specify at least one of 'tabId' or 'windowId'").createNSString().get();
         return;
     }
 
     WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::SidebarOpen(windowId, tabId), [protectedThis = Ref { *this }, callback = WTF::move(callback)](Expected<void, WebExtensionError>&& result) {
         if (!result) {
-            callback->reportError(result.error());
+            callback->reportError(result.error().createNSString().get());
             return;
         }
 

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPISidebarActionCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPISidebarActionCocoa.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2024-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -49,68 +49,73 @@ static ParseResult parseSidebarActionDetails(NSDictionary *details)
     id maybeWindowId = [details objectForKey:windowIdKey];
 
     if (maybeTabId && maybeWindowId)
-        return toErrorString(nullString(), @"details", @"it cannot specify both 'tabId' and 'windowId'");
+        return makeUnexpected(toErrorString(nullString(), @"details", @"it cannot specify both 'tabId' and 'windowId'"));
 
     if (maybeTabId && ![maybeTabId isKindOfClass:NSNumber.class])
-        return toErrorString(nullString(), @"details", @"'tabId' must be a number");
+        return makeUnexpected(toErrorString(nullString(), @"details", @"'tabId' must be a number"));
 
     if (maybeWindowId && ![maybeWindowId isKindOfClass:NSNumber.class])
-        return toErrorString(nullString(), @"details", @"'windowId' must be a number");
+        return makeUnexpected(toErrorString(nullString(), @"details", @"'windowId' must be a number"));
 
     if (maybeTabId) {
         auto tabId = toWebExtensionTabIdentifier(((NSNumber *) maybeTabId).doubleValue);
-        return isValid(tabId) ? ParseResult(tabId.value()) : ParseResult(toErrorString(nullString(), @"details", @"'tabId' is invalid"));
+        return isValid(tabId) ? ParseResult(tabId.value()) : makeUnexpected(toErrorString(nullString(), @"details", @"'tabId' is invalid"));
     }
 
     if (maybeWindowId) {
         auto windowId = toWebExtensionWindowIdentifier(((NSNumber *) maybeWindowId).doubleValue);
-        return isValid(windowId) ? ParseResult(windowId.value()) : ParseResult(toErrorString(nullString(), @"details", @"'windowId' is invalid"));
+        return isValid(windowId) ? ParseResult(windowId.value()) : makeUnexpected(toErrorString(nullString(), @"details", @"'windowId' is invalid"));
     }
 
-    return std::monostate();
+    return ParseResult(std::nullopt);
 }
 
-static Variant<std::monostate, String, SidebarError> parseDetailsStringFromKey(NSDictionary *dict, NSString *key, bool required = false)
+static Expected<std::optional<String>, WebExtensionError> parseDetailsStringFromKey(NSDictionary *dict, NSString *key, bool required = false)
 {
     RetainPtr<id> maybeValue = [dict objectForKey:key];
     if (!maybeValue && required)
-        return SidebarError { toErrorString(nullString(), @"details", makeString("'"_s, String(key), "' is required"_s)) };
+        return makeUnexpected(toErrorString(nullString(), @"details", makeString("'"_s, String(key), "' is required"_s)));
 
     if ([maybeValue isKindOfClass:NSNull.class]) {
         if (required)
-            return SidebarError { toErrorString(nullString(), @"details", makeString("'"_s, String(key), "' is required"_s)) };
-        return std::monostate();
+            return makeUnexpected(toErrorString(nullString(), @"details", makeString("'"_s, String(key), "' is required"_s)));
+        return { std::nullopt };
     }
 
     RetainPtr nsStringValue = dynamic_objc_cast<NSString>(maybeValue.get());
     if (!nsStringValue) {
         if (required)
-            return SidebarError { toErrorString(nullString(), @"details", makeString("'"_s, String(key), "' must be of type 'string'"_s)) };
-        return SidebarError { toErrorString(nullString(), @"details", makeString("'"_s, String(key), "' must be of type 'string' or 'null'"_s)) };
+            return makeUnexpected(toErrorString(nullString(), @"details", makeString("'"_s, String(key), "' must be of type 'string'"_s)));
+        return makeUnexpected(toErrorString(nullString(), @"details", makeString("'"_s, String(key), "' must be of type 'string' or 'null'"_s)));
     }
 
-    return String(nsStringValue.get());
+    return { String(nsStringValue.get()) };
 }
 
 template<typename VariantType>
-static std::tuple<std::optional<WebExtensionWindowIdentifier>, std::optional<WebExtensionTabIdentifier>> getIdentifiers(VariantType& variant)
+static std::tuple<std::optional<WebExtensionWindowIdentifier>, std::optional<WebExtensionTabIdentifier>> getIdentifiers(std::optional<VariantType>& maybeVariant)
 {
     static_assert(isVariantMember<WebExtensionWindowIdentifier, VariantType>::value);
     static_assert(isVariantMember<WebExtensionTabIdentifier, VariantType>::value);
 
-    return std::make_tuple(WTF::move(toOptional<WebExtensionWindowIdentifier>(variant)), WTF::move(toOptional<WebExtensionTabIdentifier>(variant)));
+    if (!maybeVariant.has_value())
+        return std::make_tuple(std::nullopt, std::nullopt);
+
+    auto& variant = maybeVariant.value();
+
+    return std::make_tuple(toOptional<WebExtensionWindowIdentifier>(variant), toOptional<WebExtensionTabIdentifier>(variant));
 }
 
 void WebExtensionAPISidebarAction::open(Ref<WebExtensionCallbackHandler>&& callback , NSString **outExceptionString)
 {
     if (!WebCore::UserGestureIndicator::processingUserGesture()) {
-        *outExceptionString = toErrorString(nullString(), nil, @"it must be called during a user gesture");
+        *outExceptionString = toErrorString(nullString(), nullString(), @"it must be called during a user gesture").createNSString().get();
         return;
     }
 
     WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::SidebarOpen(std::nullopt, std::nullopt), [protectedThis = Ref { *this }, callback = WTF::move(callback)](Expected<void, WebExtensionError>&& result) {
         if (!result) {
-            callback->reportError(result.error());
+            callback->reportError(result.error().createNSString().get());
             return;
         }
 
@@ -121,13 +126,13 @@ void WebExtensionAPISidebarAction::open(Ref<WebExtensionCallbackHandler>&& callb
 void WebExtensionAPISidebarAction::close(Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
 {
     if (!WebCore::UserGestureIndicator::processingUserGesture()) {
-        *outExceptionString = toErrorString(nullString(), nil, @"it must be called during a user gesture");
+        *outExceptionString = toErrorString(nullString(), nullString(), @"it must be called during a user gesture").createNSString().get();
         return;
     }
 
     WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::SidebarClose(), [protectedThis = Ref { *this }, callback = WTF::move(callback)](Expected<void, WebExtensionError>&& result) {
         if (!result) {
-            callback->reportError(result.error());
+            callback->reportError(result.error().createNSString().get());
             return;
         }
 
@@ -138,13 +143,13 @@ void WebExtensionAPISidebarAction::close(Ref<WebExtensionCallbackHandler>&& call
 void WebExtensionAPISidebarAction::toggle(Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
 {
     if (!WebCore::UserGestureIndicator::processingUserGesture()) {
-        *outExceptionString = toErrorString(nullString(), nil, @"it must be called during a user gesture");
+        *outExceptionString = toErrorString(nullString(), nullString(), @"it must be called during a user gesture").createNSString().get();
         return;
     }
 
     WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::SidebarToggle(), [protectedThis = Ref { *this }, callback = WTF::move(callback)](Expected<void, WebExtensionError>&& result) {
         if (!result) {
-            callback->reportError(result.error());
+            callback->reportError(result.error().createNSString().get());
             return;
         }
 
@@ -157,23 +162,23 @@ void WebExtensionAPISidebarAction::isOpen(NSDictionary *details, Ref<WebExtensio
     // we don't use parseSidebarActionDetails here because we only need windowId for isOpen
     id maybeWindowId = details[windowIdKey];
     if (maybeWindowId && ![maybeWindowId isKindOfClass:NSNumber.class]) {
-        *outExceptionString = toErrorString(nullString(), @"details", @"'windowId' must be a number");
+        *outExceptionString = toErrorString(nullString(), @"details", @"'windowId' must be a number").createNSString().get();
         return;
     }
 
     std::optional<WebExtensionWindowIdentifier> windowId = maybeWindowId ? toWebExtensionWindowIdentifier(((NSNumber *) maybeWindowId).doubleValue) : std::nullopt;
-    if (windowId && !isValid(windowId)) {
-        *outExceptionString = toErrorString(nullString(), @"details", @"'windowId' is invalid");
+    if (maybeWindowId && !isValid(windowId)) {
+        *outExceptionString = toErrorString(nullString(), @"details", @"'windowId' is invalid").createNSString().get();
         return;
     }
 
     WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::SidebarIsOpen(windowId), [protectedThis = Ref { *this }, callback = WTF::move(callback)](Expected<bool, WebExtensionError>&& result) {
         if (!result) {
-            callback->reportError(result.error());
+            callback->reportError(result.error().createNSString().get());
             return;
         }
 
-        callback->call(@(result.value()));
+        callback->call(JSValueMakeBoolean(callback->globalContext(), result.value()));
     }, extensionContext().identifier());
 }
 
@@ -184,15 +189,15 @@ void WebExtensionAPISidebarAction::getPanel(NSDictionary *details, Ref<WebExtens
     if ((*outExceptionString = indicatesError(result).get()))
         return;
 
-    const auto [windowId, tabId] = getIdentifiers(result);
+    const auto [windowId, tabId] = getIdentifiers(result.value());
 
     WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::SidebarGetOptions(windowId, tabId), [protectedThis = Ref { *this }, callback = WTF::move(callback)](Expected<WebExtensionSidebarParameters, WebExtensionError>&& result) {
         if (!result) {
-            callback->reportError(result.error());
+            callback->reportError(result.error().createNSString().get());
             return;
         }
 
-        callback->call(result.value().panelPath);
+        callback->call(toJSValueRef(callback->globalContext(), result.value().panelPath));
     }, extensionContext().identifier());
 }
 
@@ -202,17 +207,17 @@ void WebExtensionAPISidebarAction::setPanel(NSDictionary *details, Ref<WebExtens
     if ((*outExceptionString = indicatesError(panelResult).get()))
         return;
 
-    const auto panelPath = toOptional<String>(panelResult);
+    const auto panelPath = panelResult.value();
 
     auto result = parseSidebarActionDetails(details);
     if ((*outExceptionString = indicatesError(result).get()))
         return;
 
-    const auto [windowId, tabId] = getIdentifiers(result);
+    const auto [windowId, tabId] = getIdentifiers(result.value());
 
     WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::SidebarSetOptions(windowId, tabId, panelPath, std::nullopt), [protectedThis = Ref { *this }, callback = WTF::move(callback)](Expected<void, WebExtensionError>&& result) {
         if (!result) {
-            callback->reportError(result.error());
+            callback->reportError(result.error().createNSString().get());
             return;
         }
 
@@ -226,15 +231,15 @@ void WebExtensionAPISidebarAction::getTitle(NSDictionary *details, Ref<WebExtens
     if ((*outExceptionString = indicatesError(result).get()))
         return;
 
-    const auto [windowId, tabId] = getIdentifiers(result);
+    const auto [windowId, tabId] = getIdentifiers(result.value());
 
     WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::SidebarGetTitle(windowId, tabId), [protectedThis = Ref { *this }, callback = WTF::move(callback)](Expected<String, WebExtensionError>&& result) {
         if (!result) {
-            callback->reportError(result.error());
+            callback->reportError(result.error().createNSString().get());
             return;
         }
 
-        callback->call(result.value());
+        callback->call(toJSValueRef(callback->globalContext(), result.value()));
     }, extensionContext().identifier());
 }
 
@@ -244,17 +249,17 @@ void WebExtensionAPISidebarAction::setTitle(NSDictionary *details, Ref<WebExtens
     if ((*outExceptionString = indicatesError(titleResult).get()))
         return;
 
-    const auto title = toOptional<String>(titleResult);
+    const auto title = WTF::move(titleResult.value());
 
     auto result = parseSidebarActionDetails(details);
     if ((*outExceptionString = indicatesError(result).get()))
         return;
 
-    const auto [windowId, tabId] = getIdentifiers(result);
+    const auto [windowId, tabId] = getIdentifiers(result.value());
 
     WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::SidebarSetTitle(windowId, tabId, title), [protectedThis = Ref { *this }, callback = WTF::move(callback)](Expected<void, WebExtensionError>&& result) {
         if (!result) {
-            callback->reportError(result.error());
+            callback->reportError(result.error().createNSString().get());
             return;
         }
 

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPISidebarAction.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPISidebarAction.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2024-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -35,9 +35,7 @@ OBJC_CLASS NSString;
 
 namespace WebKit {
 
-using SidebarError = RetainPtr<NSString>;
-// In this variant, `monostate` indicates that we have neither a window or tab identifier, but no error
-using ParseResult = Variant<std::monostate, WebExtensionTabIdentifier, WebExtensionWindowIdentifier, SidebarError>;
+using ParseResult = Expected<std::optional<Variant<WebExtensionTabIdentifier, WebExtensionWindowIdentifier>>, WebExtensionError>;
 
 template<typename T, typename VARIANT_T>
 struct isVariantMember;
@@ -52,14 +50,12 @@ std::optional<OptType> toOptional(Variant<Types...>& variant)
     return std::nullopt;
 }
 
-template<typename VariantType>
-SidebarError indicatesError(const VariantType& variant)
+template<typename SuccessType>
+RetainPtr<NSString> indicatesError(const Expected<SuccessType, WebExtensionError>& result)
 {
-    static_assert(isVariantMember<SidebarError, VariantType>::value);
-
-    if (std::holds_alternative<SidebarError>(variant))
-        return WTF::move(std::get<SidebarError>(variant));
-    return nil;
+    if (result.has_value())
+        return nil;
+    return result.error().createNSString();
 }
 
 class WebExtensionAPISidebarAction : public WebExtensionAPIObject, public JSWebExtensionWrappable {

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPISidebar.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPISidebar.mm
@@ -85,6 +85,28 @@ static auto *sidePanelManifest = @{
     },
 };
 
+static auto *sidePanelNoPathManifest = @{
+    @"manifest_version": @3,
+
+    @"name": @"SidePanel No Path Test",
+    @"description": @"SidePanel No Path Test",
+    @"version": @"1",
+
+    @"permissions": @[ @"sidePanel" ],
+    @"background": @{
+        @"scripts": @[ @"background.js" ],
+        @"type": @"module",
+        @"persistent": @NO,
+    },
+
+    @"side_panel": @{ },
+
+    @"action": @{
+        @"default_title": @"Test Action",
+        @"default_popup": @"popup.html",
+    },
+};
+
 static auto *sidebarActionAndPanelManifest = @{
     @"manifest_version": @3,
 
@@ -132,7 +154,7 @@ class WKWebExtensionAPISidebar : public testing::Test {
 protected:
     WKWebExtensionAPISidebar()
     {
-        sidebarConfig = WKWebExtensionControllerConfiguration.nonPersistantConfiguration;
+        sidebarConfig = WKWebExtensionControllerConfiguration.nonPersistentConfiguration;
         if (!sidebarConfig.webViewConfiguration)
             sidebarConfig.webViewConfiguration = [[WKWebViewConfiguration alloc] init];
 
@@ -1372,6 +1394,43 @@ TEST_F(WKWebExtensionAPISidebar, SidePanelOpensSidebarOnActionClickWhenConfigure
     [manager run];
 
     EXPECT_EQ(presentSidebarCallCount, 1);
+    EXPECT_EQ(presentActionPopupCallCount, 1);
+}
+
+// Ensure we don't open a sidebar on about:blank if the extension has not configured a target URL
+TEST_F(WKWebExtensionAPISidebar, SidePanelActionClickDoesNotOpenPathlessSidebar)
+{
+    auto *script = @[
+        @"await browser.sidePanel.setPanelBehavior({ openPanelOnActionClick: true })",
+        @"browser.test.sendMessage('Perform action')",
+    ];
+
+    auto *resources = @{
+        @"background.js": Util::constructScript(script),
+        @"popup.html": @"<h1>Popup</h1>",
+    };
+
+    int presentSidebarCallCount = 0;
+    int *presentSidebarCallCountPtr = &presentSidebarCallCount;
+    int presentActionPopupCallCount = 0;
+    int *presentActionPopupCallCountPtr = &presentActionPopupCallCount;
+
+    auto manager = getManagerFor(resources, sidePanelNoPathManifest);
+    manager.get().internalDelegate.presentSidebar = ^(_WKWebExtensionSidebar *) {
+        (*presentSidebarCallCountPtr)++;
+    };
+    manager.get().internalDelegate.presentPopupForAction = ^(WKWebExtensionAction *) {
+        (*presentActionPopupCallCountPtr)++;
+        [manager done];
+    };
+
+    [manager load];
+    [manager runUntilTestMessage:@"Perform action"];
+
+    [manager.get().context performActionForTab:manager.get().defaultTab];
+    [manager run];
+
+    EXPECT_EQ(presentSidebarCallCount, 0);
     EXPECT_EQ(presentActionPopupCallCount, 1);
 }
 


### PR DESCRIPTION
#### d72f14c26732a3c34010616e9015baded054e9f5
<pre>
Fix extension sidebar code
<a href="https://rdar.apple.com/156534472">rdar://156534472</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=296398">https://bugs.webkit.org/show_bug.cgi?id=296398</a>

Reviewed by Timothy Hatcher.

This patch fixes a myriad of compiler errors which prevent Webkit from building with
ENABLE_WK_WEB_EXTENSIONS_SIDEBAR turned on. It also somewhat simplifies some of the parsing logic in
WebExtensionAPISidePanelCocoa.mm and WebExtensionAPISidebarActionCocoa.mm. Fix several places where
we were checking whether a weak pointer is nil and then using it without retaining a strong
reference between check and use. A manifest that configures no panel path no longer resolves to
about:blank and reports itself as openable, so an action click falls through instead of opening a
blank sidebar. Make getTitle() fall back to the extension name when no title is set.

* Source/WebKit/Platform/cocoa/CocoaHelpers.h:
(WebKit::toOptional): Add implementation of RefPtr&lt;T&gt; -&gt; std::optional&lt;Ref&lt;T&gt;&gt;
* Source/WebKit/Shared/Extensions/WebExtensionPermission.cpp: Fix feature guard
* Source/WebKit/Shared/Extensions/WebExtensionPermission.h: Fix feature guard
* Source/WebKit/Shared/Extensions/WebExtensionSidebarParameters.h:
* Source/WebKit/Shared/Extensions/WebExtensionSidebarParameters.serialization.in:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionSidebar.mm:
(-[_WKWebExtensionSidebar webExtensionContext]):
(-[_WKWebExtensionSidebar title]): Convert String to NSString
(-[_WKWebExtensionSidebar iconForSize:]): Handle WebExtensionSidebar::icon returning an optional
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPISidebarCocoa.mm:
(WebKit::getSidebarWithIdentifiers): Null-check the tab&apos;s window before dereferencing it.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionSidebarCocoa.mm:
(-[_WKWebExtensionSidebarWebViewDelegate webView:decidePolicyForNavigationAction:decisionHandler:]):
(-[_WKWebExtensionSidebarWebViewDelegate webView:runOpenPanelWithParameters:initiatedByFrame:completionHandler:]):
(-[_WKWebExtensionSidebarViewController initWithWebExtensionSidebar:]): Convert String to NSString
(WebKit::getDefaultIconsDictFromExtension): Fix return type
(WebKit::WebExtensionSidebar::WebExtensionSidebar): Remove helper functions, directly get title and
document path since these are now returned as optionals.
(WebKit::WebExtensionSidebar::extensionContext const):
(WebKit::WebExtensionSidebar::tab const):
(WebKit::WebExtensionSidebar::window const):
(WebKit::WebExtensionSidebar::parent const):
(WebKit::WebExtensionSidebar::icon): Return optional&lt;Ref&gt; rather than nullable RefPtr, fix types
(WebKit::WebExtensionSidebar::setIconsDictionary): Take optional&lt;Ref&gt; rather than nullable RefPtr
(WebKit::WebExtensionSidebar::title const):
(WebKit::WebExtensionSidebar::setTitle): Remove helper function, directly get optional title
(WebKit::WebExtensionSidebar::resolvedSidebarPath const):
(WebKit::WebExtensionSidebar::sidebarPath const):
(WebKit::WebExtensionSidebar::setSidebarPath): Remove helper function, directly get optional path
(WebKit::WebExtensionSidebar::didReceiveUserInteraction):
(WebKit::WebExtensionSidebar::webView): Convert String to NSString for accessibility label
(WebKit::WebExtensionSidebar::notifyDelegateOfPropertyUpdate):
(WebKit::WebExtensionSidebar::reloadWebView): Convert URL to NSURL for loadRequest
(toOptionalRef): Deleted.
(WebKit::getDefaultSidebarTitleFromExtension): Deleted.
(WebKit::getDefaultSidebarPathFromExtension): Deleted.
* Source/WebKit/UIProcess/Extensions/WebExtension.cpp:
(WebKit::WebExtension::sidebarDocumentPath): Return optional&lt;String&gt; rather than nullable String
(WebKit::WebExtension::sidebarTitle): Return optional&lt;String&gt; rather than nullable String
(WebKit::WebExtension::populateSidebarPropertiesIfNeeded): Dereference sidebarActionObject and
sidePanelObject to pass reference directly
(WebKit::toOptionalString):
(WebKit::WebExtension::populateSidebarActionProperties): Use nullopt instead of null
(WebKit::WebExtension::populateSidePanelProperties): Use nullopt instead of null
* Source/WebKit/UIProcess/Extensions/WebExtension.h: Fix types, make many things optional
instead of nullable.
* Source/WebKit/UIProcess/Extensions/WebExtensionSidebar.h: Fix types, make many things optional
instead of nullable.
(WebKit::WebExtensionSidebar::opensSidebar):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPISidePanelCocoa.mm:
(WebKit::parseTabIdentifier): Simplify parsing, remove SidebarError, use Expected&lt;optional&lt;...&gt;, ...&gt;
instead of Variant.
(WebKit::parseWindowIdentifier): Simplify parsing, remove SidebarError, use Expected&lt;optional&lt;...&gt;, ...&gt;
instead of Variant.
(WebKit::parseActionClickBehavior): Miscellaneous type fixes.
(WebKit::serializeSidebarParameters): Miscellaneous type fixes.
(WebKit::deserializeSidebarParameters): Miscellaneous type fixes.
(WebKit::WebExtensionAPISidePanel::getOptions): Convert String to NSString.
(WebKit::WebExtensionAPISidePanel::setOptions): Convert String to NSString.
(WebKit::WebExtensionAPISidePanel::getPanelBehavior): Convert String to NSString.
(WebKit::WebExtensionAPISidePanel::setPanelBehavior): Convert String to NSString.
(WebKit::WebExtensionAPISidePanel::open): Convert String to NSString, remove uses of toOptional.
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPISidebarActionCocoa.mm:
(WebKit::parseSidebarActionDetails): Use Expected instead of Variant, miscellaneous fixes.
(WebKit::parseDetailsStringFromKey): Use Expected instead of Variant, miscellaneous fixes.
(WebKit::getIdentifiers): Take parameter which is an optional variant instead of just variant
(WebKit::WebExtensionAPISidebarAction::open): Convert String to NSString.
(WebKit::WebExtensionAPISidebarAction::close): Convert String to NSString.
(WebKit::WebExtensionAPISidebarAction::toggle): Convert String to NSString.
(WebKit::WebExtensionAPISidebarAction::isOpen): Convert String to NSString.
(WebKit::WebExtensionAPISidebarAction::getPanel): Convert String to NSString, use Expected instead
of Variant.
(WebKit::WebExtensionAPISidebarAction::setPanel): Convert String to NSString, use Expected instead
of Variant.
(WebKit::WebExtensionAPISidebarAction::getTitle): Convert String to NSString, use Expected instead
of Variant.
(WebKit::WebExtensionAPISidebarAction::setTitle): Convert String to NSString, use Expected instead
of Variant.
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPISidebarAction.h:
(WebKit::indicatesError): Utility function which checks if an Expected contains an error, and
returns it as a RetainPtr&lt;NSString&gt; if so.
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPISidebar.mm:
(TestWebKitAPI::WKWebExtensionAPISidebar::WKWebExtensionAPISidebar): Fix `nonPersistant` typo.
(TestWebKitAPI::TEST_F(WKWebExtensionAPISidebar, SidePanelActionClickDoesNotOpenPathlessSidebar)):

Canonical link: <a href="https://commits.webkit.org/317441@main">https://commits.webkit.org/317441@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ebe6fbe95fb97cb12389f2c5447cadd4ebf0781f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175246 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49178 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42959 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184831 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/133591 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bf8fcfa7-c634-440d-ba0c-434ffe9fbf89) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/177110 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50470 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48861 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136414 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/133591 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/38dbacd3-d8a1-4af3-920f-333175931456) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178203 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39834 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157182 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116893 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8458ee16-18bf-4118-8468-0b5b811efb79) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38475 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36861 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33304 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148898 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36675 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187252 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/40865 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/41064 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145361 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48845 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145217 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49525 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/33296 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/115404 "The change is no longer eligible for processing.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26651 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40052 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/121718 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48031 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11648 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47434 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47664 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47491 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->