### PR TITLE
[CMake] Make JavaScriptCore a real Clang module for the Mac Swift importer

### DIFF
--- a/Source/JavaScriptCore/PlatformMac.cmake
+++ b/Source/JavaScriptCore/PlatformMac.cmake
@@ -13,3 +13,65 @@ list(APPEND JavaScriptCore_PUBLIC_FRAMEWORK_HEADERS
     API/JSVirtualMachine.h
     API/JavaScriptCore.h
 )
+
+# Private headers the JavaScriptCore_Private module map needs to parse.
+# Mirrors the list in PlatformIOS.cmake.
+list(APPEND JavaScriptCore_PRIVATE_FRAMEWORK_HEADERS
+    API/MARReportCrashPrivate.h
+    API/PASReportCrashPrivate.h
+    API/WorkAround173516139.h
+
+    assembler/MacroAssemblerPrinter.h
+
+    debugger/DebuggerEvalEnabler.h
+
+    disassembler/Disassembler.h
+
+    heap/CodeBlockSet.h
+    heap/ConservativeRoots.h
+    heap/GCIncomingRefCountedSetInlines.h
+    heap/HeapSnapshot.h
+    heap/JITStubRoutineSet.h
+    heap/VerifierSlotVisitorScope.h
+    heap/WriteBarrierSupport.h
+
+    inspector/augmentable/AlternateDispatchableAgent.h
+    inspector/augmentable/AugmentableInspectorController.h
+
+    jit/BinarySwitch.h
+    jit/ExecutableAllocationFuzz.h
+    jit/GdbJIT.h
+    jit/JITExceptions.h
+    jit/JSInterfaceJIT.h
+
+    parser/ModuleScopeData.h
+
+    runtime/PinballHandlerContext.h
+
+    tools/JSDollarVM.h
+
+    yarr/YarrJITRegisters.h
+)
+
+# Stage the module maps into the framework bundle so the Swift Clang importer
+# finds JavaScriptCore / JavaScriptCore_Private as modules via -F. Otherwise
+# <JavaScriptCore/*.h> is parsed textually and collides with other importers.
+set(_jsc_modules_dir "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/JavaScriptCore.framework/Versions/A/Modules")
+add_custom_command(
+    OUTPUT "${_jsc_modules_dir}/module.modulemap"
+    COMMAND ${CMAKE_COMMAND} -E make_directory "${_jsc_modules_dir}"
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+        "${JAVASCRIPTCORE_DIR}/JavaScriptCore.modulemap" "${_jsc_modules_dir}/module.modulemap"
+    MAIN_DEPENDENCY "${JAVASCRIPTCORE_DIR}/JavaScriptCore.modulemap"
+    VERBATIM)
+add_custom_command(
+    OUTPUT "${_jsc_modules_dir}/module.private.modulemap"
+    COMMAND ${CMAKE_COMMAND} -E make_directory "${_jsc_modules_dir}"
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+        "${JAVASCRIPTCORE_DIR}/JavaScriptCore_Private.modulemap" "${_jsc_modules_dir}/module.private.modulemap"
+    MAIN_DEPENDENCY "${JAVASCRIPTCORE_DIR}/JavaScriptCore_Private.modulemap"
+    VERBATIM)
+add_custom_target(JavaScriptCore_CopyModules ALL DEPENDS
+    "${_jsc_modules_dir}/module.modulemap"
+    "${_jsc_modules_dir}/module.private.modulemap")
+add_dependencies(JavaScriptCore JavaScriptCore_CopyModules)

--- a/Source/WebCore/PlatformMac.cmake
+++ b/Source/WebCore/PlatformMac.cmake
@@ -35,6 +35,23 @@ WEBKIT_COPY_FILES(WebCore_CopyBundleResources
     FLATTENED NO_SYMLINK)
 add_dependencies(WebCore WebCore_CopyBundleResources)
 
+# Stage the in-tree WebCore_Private module map into the framework bundle so the
+# Swift Clang importer finds it as a real module via -F (as JavaScriptCore does,
+# and as iOS does in PlatformIOS.cmake).
+if (ENABLE_BACK_FORWARD_LIST_SWIFT)
+    set(_webcore_modules_dir "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/WebCore.framework/Versions/A/Modules")
+    add_custom_command(
+        OUTPUT "${_webcore_modules_dir}/module.private.modulemap"
+        COMMAND ${CMAKE_COMMAND} -E make_directory "${_webcore_modules_dir}"
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+            "${WEBCORE_DIR}/WebCore_Private.modulemap" "${_webcore_modules_dir}/module.private.modulemap"
+        MAIN_DEPENDENCY "${WEBCORE_DIR}/WebCore_Private.modulemap"
+        VERBATIM)
+    add_custom_target(WebCore_CopyPrivateModuleMap ALL DEPENDS
+        "${_webcore_modules_dir}/module.private.modulemap")
+    add_dependencies(WebCore WebCore_CopyPrivateModuleMap)
+endif ()
+
 # Modern media controls button icons. RenderThemeCocoa::mediaControlsImageDataForIconNameAndType
 # loads these at runtime from WebCore.framework/Resources/modern-media-controls/images/<name>.<type>;
 # without them every media-control button loads an empty blob and logs "Button failed to load".

--- a/Source/WebKit/CMakeLists.txt
+++ b/Source/WebKit/CMakeLists.txt
@@ -857,13 +857,16 @@ set(WebKit_GENERATED_SERIALIZERS_SUFFIX cpp)
 set(WebKit_SWIFT_INTEROP_MODULE_PATH "${WEBKIT_DIR}/Modules/Internal")
 set(WebKit_SWIFT_INTEROP_MODULE_PATH_SWIFT_ONLY TRUE)
 
-# WebCore_Private.modulemap in-tree is a `framework module` that umbrellas the
-# Xcode framework's PrivateHeaders/. CMake stages those headers as a flat
-# directory instead, and umbrellaing it pulls in headers (ANGLEHeaders.h etc.)
-# whose own dependencies aren't on the Swift Clang importer's search path.
-# Expose only what WebBackForwardList.swift names directly; the rest of the
-# WebCore:: types it uses are reachable transitively via WebKit_Internal headers.
-if (ENABLE_BACK_FORWARD_LIST_SWIFT)
+# WebKit's Swift code names WebCore:: types via the WebCore_Private module. On
+# Apple this is staged from the in-tree map into the WebCore framework bundle by
+# PlatformMac.cmake and found by the Swift Clang importer via -F (same as
+# JavaScriptCore). The non-Apple ports build no framework bundles, so there is no
+# -F module to discover; the in-tree map is also a `framework module` that needs
+# the framework layout. Synthesize a plain module map exposing only what
+# WebBackForwardList.swift names directly (the rest of the WebCore:: types it uses
+# are reachable transitively via WebKit_Internal headers) and put it on the
+# importer's search path below.
+if (ENABLE_BACK_FORWARD_LIST_SWIFT AND NOT USE_FRAMEWORK_BUNDLES)
     set(WebCore_Private_SWIFT_MODULEMAP_DIR "${CMAKE_BINARY_DIR}/WebKit/SwiftModules/WebCorePrivate")
     file(MAKE_DIRECTORY "${WebCore_Private_SWIFT_MODULEMAP_DIR}")
     file(CONFIGURE OUTPUT "${WebCore_Private_SWIFT_MODULEMAP_DIR}/module.modulemap" CONTENT
@@ -886,6 +889,10 @@ WEBKIT_ADD_TARGET_UNSAFE_BUFFER_WARNINGS(WebKit)
 # the C++ target's include directories to swiftc's Clang importer so those
 # resolve. cmakeconfig.h is force-included because the headers assume the
 # project's prefix header has already defined ENABLE()/HAVE() values.
+#
+# WebCore_DERIVED_SOURCES_DIR and style/computed complete the search path for the
+# WebCore_Private umbrella. Inert on Apple (PlatformMac.cmake applies the live Mac
+# copy) but kept in sync for the non-Apple path below.
 set(WebKit_SWIFT_CLANG_INCLUDE_DIRS
     ${CMAKE_BINARY_DIR}
     ${WebKit_DERIVED_SOURCES_DIR}
@@ -893,7 +900,8 @@ set(WebKit_SWIFT_CLANG_INCLUDE_DIRS
     ${bmalloc_FRAMEWORK_HEADERS_DIR}
     ${PAL_FRAMEWORK_HEADERS_DIR}
     ${ICU_INCLUDE_DIRS}
-    ${WebCore_Private_SWIFT_MODULEMAP_DIR}
+    ${WebCore_DERIVED_SOURCES_DIR}
+    ${WEBCORE_DIR}/style/computed
 )
 if (NOT USE_FRAMEWORK_BUNDLES)
     list(APPEND WebKit_SWIFT_CLANG_INCLUDE_DIRS
@@ -903,6 +911,9 @@ if (NOT USE_FRAMEWORK_BUNDLES)
         ${JavaScriptCore_PRIVATE_FRAMEWORK_HEADERS_DIR}
         ${WebKit_PRIVATE_INCLUDE_DIRECTORIES}
     )
+    if (ENABLE_BACK_FORWARD_LIST_SWIFT)
+        list(APPEND WebKit_SWIFT_CLANG_INCLUDE_DIRS ${WebCore_Private_SWIFT_MODULEMAP_DIR})
+    endif ()
 endif ()
 
 if (NOT APPLE AND SWIFT_REQUIRED)

--- a/Source/WebKit/PlatformMac.cmake
+++ b/Source/WebKit/PlatformMac.cmake
@@ -105,6 +105,11 @@ list(APPEND WebKit_COMPILE_OPTIONS "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-no-warnin
 # the C++ target's include directories to swiftc's Clang importer so those
 # resolve. cmakeconfig.h is force-included because the headers assume the
 # project's prefix header has already defined ENABLE()/HAVE() values.
+#
+# The last two entries complete the search path for the WebCore_Private umbrella:
+# its PrivateHeaders/ quote-include generated WebCore headers
+# (WebCore_DERIVED_SOURCES_DIR) and style/computed source inlines. This is the
+# live Mac importer list; the CMakeLists.txt copy is inert on Apple.
 set(WebKit_SWIFT_CLANG_INCLUDE_DIRS
     ${CMAKE_BINARY_DIR}
     ${WebKit_FRAMEWORK_HEADERS_DIR}
@@ -116,8 +121,9 @@ set(WebKit_SWIFT_CLANG_INCLUDE_DIRS
     ${bmalloc_FRAMEWORK_HEADERS_DIR}
     ${PAL_FRAMEWORK_HEADERS_DIR}
     ${ICU_INCLUDE_DIRS}
-    ${WebCore_Private_SWIFT_MODULEMAP_DIR}
     ${WebKit_PRIVATE_INCLUDE_DIRECTORIES}
+    ${WebCore_DERIVED_SOURCES_DIR}
+    ${WEBCORE_DIR}/style/computed
 )
 
 # -Xcc -D/-f flags shared with PAL/WebGPU come from


### PR DESCRIPTION
#### c2b3dcb3f9522bff14378bce042dcadeca6502d4
<pre>
[CMake] Make JavaScriptCore a real Clang module for the Mac Swift importer
<a href="https://bugs.webkit.org/show_bug.cgi?id=319625">https://bugs.webkit.org/show_bug.cgi?id=319625</a>
<a href="https://rdar.apple.com/182449652">rdar://182449652</a>

Reviewed by Adrian Taylor.

The CMake Mac build stages JavaScriptCore&apos;s headers flat with no module
map, so every &lt;JavaScriptCore/*.h&gt; include is parsed textually. Expanding
WebCore_Private to a full umbrella (for the Swift back-forward list work,
bug 312083) makes a second Swift-imported module cover those JSC headers
alongside WebKit_Internal, so Clang sees each JSC type defined twice and
errors with &quot;&apos;JSC::X&apos; has different definitions in different modules.&quot;

Stage JavaScriptCore&apos;s existing module maps into the built framework
bundle so the Swift Clang importer discovers JavaScriptCore and
JavaScriptCore_Private as real modules via -F, giving every consumer a
single owner for JSC headers. Also install the private headers the
private module map needs to parse standalone (matching the set iOS
already stages).

With JSC owning its headers, provide WebCore_Private the same way: stage
the in-tree Source/WebCore/WebCore_Private.modulemap into the WebCore
framework bundle (as iOS does in PlatformIOS.cmake) instead of generating
a separate umbrella map in the build dir, and add the WebCore
DerivedSources and style/computed directories to the importer&apos;s search
path so that umbrella parses standalone.

This mirrors Xcode, where all frameworks ship module maps.

* Source/JavaScriptCore/PlatformMac.cmake:
* Source/WebKit/CMakeLists.txt:
* Source/WebKit/PlatformMac.cmake:
* Source/WebCore/PlatformMac.cmake:

Canonical link: <a href="https://commits.webkit.org/317797@main">https://commits.webkit.org/317797@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b5040de84f164ed3b84b8e8e83606de2cafdb83d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176211 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50146 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43936 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185807 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/138450 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178074 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51438 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49830 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137242 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/138450 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179167 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40719 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158022 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117717 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39368 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37734 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/6531 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149784 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37519 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34276 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/37479 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41866 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41945 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188231 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49811 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146267 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39379 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50494 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34137 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146088 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40872 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122699 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/116675 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48999 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12491 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48401 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48635 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48459 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->