### PR TITLE
REGRESSION(316891@main): web env dismissal animation is jarring on navigation

### DIFF
--- a/LayoutTests/model-element/immersive/model-element-immersive-bfcache-expected.txt
+++ b/LayoutTests/model-element/immersive/model-element-immersive-bfcache-expected.txt
@@ -1,0 +1,15 @@
+A page whose <model> is immersive should reset its immersive state when restored from the back/forward cache, so its UI is not stuck active and re-entry works.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS document.immersiveElement is model
+Navigating away to place the page in the back/forward cache.
+Restored from the back/forward cache.
+PASS document.immersiveElement is null
+PASS document.immersiveElement is model
+PASS Re-entered the immersive environment after restoring from the back/forward cache.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/model-element/immersive/model-element-immersive-bfcache.html
+++ b/LayoutTests/model-element/immersive/model-element-immersive-bfcache.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ ModelElementEnabled=true ModelProcessEnabled=true ModelElementImmersiveEnabled=true shouldAcceptImmersiveEnvironmentRequests=true UsesBackForwardCache=true allowTestOnlyIPC=true ] -->
+<html>
+<head>
+<meta charset="utf-8">
+<script src="../../resources/js-test.js"></script>
+</head>
+<script>
+jsTestIsAsync = true;
+internals.disableModelLoadDelaysForTesting();
+
+let model;
+
+function requestImmersiveWithUserGesture() {
+    return new Promise((resolve, reject) => {
+        internals.withUserGesture(() => {
+            model.requestImmersive().then(resolve, reject);
+        });
+    });
+}
+
+window.addEventListener("pageshow", async (event) => {
+    if (!event.persisted)
+        return;
+
+    debug("Restored from the back/forward cache.");
+    shouldBeNull("document.immersiveElement");
+
+    try {
+        await requestImmersiveWithUserGesture();
+        shouldBe("document.immersiveElement", "model");
+        testPassed("Re-entered the immersive environment after restoring from the back/forward cache.");
+    } catch (error) {
+        testFailed("Could not re-enter the immersive environment after restore: " + error);
+    }
+
+    finishJSTest();
+});
+
+addEventListener("load", async () => {
+    if (!window.testRunner)
+        return;
+
+    description("A page whose &lt;model&gt; is immersive should reset its immersive state when restored from the back/forward cache, so its UI is not stuck active and re-entry works.");
+
+    model = document.getElementById("model");
+    await model.ready;
+
+    await requestImmersiveWithUserGesture();
+    shouldBe("document.immersiveElement", "model");
+
+    debug("Navigating away to place the page in the back/forward cache.");
+    window.location.href = "../resources/go-back-on-load.html";
+});
+</script>
+<body>
+<model id="model"><source src="../resources/cube.usdz"></model>
+<div id="console"></div>
+</body>
+</html>

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -7632,11 +7632,6 @@ void Document::setBackForwardCacheState(BackForwardCacheState state)
         exitPointerLock();
 #endif
 
-#if ENABLE(MODEL_ELEMENT_IMMERSIVE)
-        if (RefPtr immersive = immersiveIfExists())
-            immersive->clearForBackForwardCache();
-#endif
-
         styleScope().clearResolver();
         m_styleRecalcTimer.stop();
 
@@ -7735,6 +7730,13 @@ void Document::resume(ReasonForSuspension reason)
 
     if (settings().serviceWorkersEnabled() && reason == ReasonForSuspension::BackForwardCache)
         setServiceWorkerConnection(&ServiceWorkerProvider::singleton().serviceWorkerConnection());
+
+#if ENABLE(MODEL_ELEMENT_IMMERSIVE)
+    if (reason == ReasonForSuspension::BackForwardCache) {
+        if (RefPtr immersive = immersiveIfExists())
+            immersive->didResumeFromBackForwardCache();
+    }
+#endif
 }
 
 void Document::registerForDocumentSuspensionCallbacks(Element& element)

--- a/Source/WebCore/dom/DocumentImmersive.cpp
+++ b/Source/WebCore/dom/DocumentImmersive.cpp
@@ -468,8 +468,9 @@ void DocumentImmersive::clear()
     clearPendingEvents();
 }
 
-void DocumentImmersive::clearForBackForwardCache()
+void DocumentImmersive::didResumeFromBackForwardCache()
 {
+    // The ImmersiveSpace was dismissed by the navigation, clean-up state.
     RefPtr previouslyImmersiveElement = m_immersiveElement;
 
     clear();

--- a/Source/WebCore/dom/DocumentImmersive.h
+++ b/Source/WebCore/dom/DocumentImmersive.h
@@ -66,7 +66,7 @@ public:
     void dispatchPendingEvents();
     void queueImmersiveEventForElement(EventType, Element&);
     void clear();
-    void clearForBackForwardCache();
+    void didResumeFromBackForwardCache();
 
 protected:
     friend class Document;


### PR DESCRIPTION
#### 95a3baf67f8b4e1db929e2f9c4779fcb52d6bd67
<pre>
REGRESSION(316891@main): web env dismissal animation is jarring on navigation
<a href="https://bugs.webkit.org/show_bug.cgi?id=319629">https://bugs.webkit.org/show_bug.cgi?id=319629</a>
&lt;<a href="https://rdar.apple.com/182258311">rdar://182258311</a>&gt;

Reviewed by Mike Wyrzykowski.

The previous fix cleaned-up the Immersive Model&apos;s state when entering
bfcache, causing it to stop rendering during the dismissal animation.

Instead, do the clean-up when _restoring_ from the bfcache.

Test: model-element/immersive/model-element-immersive-bfcache.html

* LayoutTests/model-element/immersive/model-element-immersive-bfcache-expected.txt: Added.
* LayoutTests/model-element/immersive/model-element-immersive-bfcache.html: Added.
Add a test covering the bfcache scenario.

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::setBackForwardCacheState):
(WebCore::Document::resume):
Move the call from the entering code path to the resume code path.

* Source/WebCore/dom/DocumentImmersive.cpp:
(WebCore::DocumentImmersive::didResumeFromBackForwardCache):
(WebCore::DocumentImmersive::clearForBackForwardCache): Deleted.
* Source/WebCore/dom/DocumentImmersive.h:
Rename the method to make it clearer.

Canonical link: <a href="https://commits.webkit.org/317382@main">https://commits.webkit.org/317382@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/447f51389e37ac9d8988f707e1fe28c7d3b766ee

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175098 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49031 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42812 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184683 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/133006 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9666a329-00d7-4ed8-bc0f-67fa18404e6e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176963 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50323 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48714 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136285 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96132 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/15321e6d-dd0e-4785-877e-d609ac83c4ac) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178056 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39719 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157074 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116764 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/52e04b43-662c-4fdf-aab1-48b1c78dd6c8) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38360 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36747 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33157 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148783 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36567 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187104 "Built successfully") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/36360 "Build is in progress. Recent messages:") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/40682 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/40950 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145229 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48698 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/156630 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145085 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39104 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49378 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/33187 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115212 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39943 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/121542 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47884 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11539 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47287 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47517 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47344 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->