### PR TITLE
[WPE] HeadlessViewBackend crops the snapshot at HiDPI

### DIFF
--- a/Tools/wpe/backends/fdo/HeadlessViewBackendFdo.cpp
+++ b/Tools/wpe/backends/fdo/HeadlessViewBackendFdo.cpp
@@ -25,6 +25,7 @@
 
 #include "HeadlessViewBackend.h"
 
+#include <algorithm>
 #include <cassert>
 #include <fcntl.h>
 #include <mutex>
@@ -175,28 +176,23 @@ void HeadlessViewBackend::updateSnapshot(PlatformBuffer exportedBuffer)
             return;
     }
 
-    auto info = SkImageInfo::MakeN32Premul(m_width, m_height, SkColorSpace::MakeSRGB());
+    uint32_t width = std::max(0, wl_shm_buffer_get_width(shmBuffer));
+    uint32_t height = std::max(0, wl_shm_buffer_get_height(shmBuffer));
+    if (!width || !height)
+        return;
+
+    auto info = SkImageInfo::MakeN32Premul(width, height, SkColorSpace::MakeSRGB());
     uint32_t bufferStride = info.minRowBytes();
-    uint8_t* buffer = new uint8_t[bufferStride * m_height];
-    memset(buffer, 0, bufferStride * m_height);
+    uint32_t stride = std::max(0, wl_shm_buffer_get_stride(shmBuffer));
+    if (bufferStride != stride)
+        return;
 
+    uint8_t* buffer = new uint8_t[bufferStride * height];
     {
-        uint32_t width = std::min<uint32_t>(m_width, std::max(0, wl_shm_buffer_get_width(shmBuffer)));
-        uint32_t height = std::min<uint32_t>(m_height, std::max(0, wl_shm_buffer_get_height(shmBuffer)));
-        uint32_t stride = std::max(0, wl_shm_buffer_get_stride(shmBuffer));
-
         wl_shm_buffer_begin_access(shmBuffer);
         auto* data = static_cast<uint8_t*>(wl_shm_buffer_get_data(shmBuffer));
 
-        for (uint32_t y = 0; y < height; ++y) {
-            for (uint32_t x = 0; x < width; ++x) {
-                buffer[bufferStride * y + 4 * x + 0] = data[stride * y + 4 * x + 0];
-                buffer[bufferStride * y + 4 * x + 1] = data[stride * y + 4 * x + 1];
-                buffer[bufferStride * y + 4 * x + 2] = data[stride * y + 4 * x + 2];
-                buffer[bufferStride * y + 4 * x + 3] = data[stride * y + 4 * x + 3];
-            }
-        }
-
+        std::copy_n(data, bufferStride * height, buffer);
         wl_shm_buffer_end_access(shmBuffer);
     }
 


### PR DESCRIPTION
#### 82d0f0ede2bc63b864cc149219e9968d49f4d8a8
<pre>
[WPE] HeadlessViewBackend crops the snapshot at HiDPI
<a href="https://bugs.webkit.org/show_bug.cgi?id=319628">https://bugs.webkit.org/show_bug.cgi?id=319628</a>

Reviewed by NOBODY (OOPS!).

updateSnapshot sized the snapshot from the backend&apos;s logical
m_width/m_height and copied the exported SHM buffer clamped to it, so at
deviceScaleFactor &gt; 1 (where the exported buffer is scaled) it cropped to
the top-left corner. Snapshot the buffer&apos;s actual dimensions instead.

* Tools/wpe/backends/fdo/HeadlessViewBackendFdo.cpp:
(WPEToolingBackends::HeadlessViewBackend::updateSnapshot):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/82d0f0ede2bc63b864cc149219e9968d49f4d8a8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175103 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49036 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42817 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184688 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/133011 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176968 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50328 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48719 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136289 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96135 "4 flakes 4 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178061 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39724 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157075 "Found 1 new API test failure: TestWebKitAPI.SiteIsolation.CrossProcessHistoryTraversalCoalesce (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116768 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38365 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36750 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33162 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148788 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36568 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187109 "Built successfully") | 
| [⏳ 🛠 🧪 jsc-debug-arm64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-O3-Debug-arm64-EWS "Waiting in queue, processing has not started yet") | | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40953 "Found 1 new test failure: http/tests/websocket/tests/hybi/no-subprotocol.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145234 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48703 "Built successfully") | | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145090 "Found 1 new API test failure: WebKitGTK/TestWebKitSettings:/webkit/WebKitSettings/user-agent (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49383 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33188 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115217 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39949 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47889 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11547 "") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47292 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47522 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47349 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->