### PR TITLE
Expose navigator.globalPrivacyControl only when enabled through the WKWebpagePreferences API

### DIFF
--- a/LayoutTests/fast/dom/navigator-detached-no-crash-expected.txt
+++ b/LayoutTests/fast/dom/navigator-detached-no-crash-expected.txt
@@ -10,7 +10,6 @@ navigator.clipboard is OK
 navigator.contacts is OK
 navigator.cookieEnabled is OK
 navigator.credentials is OK
-navigator.globalPrivacyControl is OK
 navigator.gpu is OK
 navigator.hardwareConcurrency is OK
 navigator.javaEnabled() is OK
@@ -41,7 +40,6 @@ navigator.clipboard is OK
 navigator.contacts is OK
 navigator.cookieEnabled is OK
 navigator.credentials is OK
-navigator.globalPrivacyControl is OK
 navigator.gpu is OK
 navigator.hardwareConcurrency is OK
 navigator.javaEnabled() is OK

--- a/LayoutTests/platform/gtk/fast/dom/navigator-detached-no-crash-expected.txt
+++ b/LayoutTests/platform/gtk/fast/dom/navigator-detached-no-crash-expected.txt
@@ -7,7 +7,6 @@ navigator.clearAppBadge() is OK
 navigator.clipboard is OK
 navigator.contacts is OK
 navigator.cookieEnabled is OK
-navigator.globalPrivacyControl is OK
 navigator.gpu is OK
 navigator.hardwareConcurrency is OK
 navigator.javaEnabled() is OK
@@ -44,7 +43,6 @@ navigator.clearAppBadge() is OK
 navigator.clipboard is OK
 navigator.contacts is OK
 navigator.cookieEnabled is OK
-navigator.globalPrivacyControl is OK
 navigator.gpu is OK
 navigator.hardwareConcurrency is OK
 navigator.javaEnabled() is OK

--- a/LayoutTests/platform/mac-wk2/fast/dom/navigator-detached-no-crash-expected.txt
+++ b/LayoutTests/platform/mac-wk2/fast/dom/navigator-detached-no-crash-expected.txt
@@ -10,7 +10,6 @@ navigator.clipboard is OK
 navigator.contacts is OK
 navigator.cookieEnabled is OK
 navigator.credentials is OK
-navigator.globalPrivacyControl is OK
 navigator.gpu is OK
 navigator.hardwareConcurrency is OK
 navigator.isLoggedIn() is OK
@@ -53,7 +52,6 @@ navigator.clipboard is OK
 navigator.contacts is OK
 navigator.cookieEnabled is OK
 navigator.credentials is OK
-navigator.globalPrivacyControl is OK
 navigator.gpu is OK
 navigator.hardwareConcurrency is OK
 navigator.isLoggedIn() is OK

--- a/LayoutTests/platform/win/fast/dom/navigator-detached-no-crash-expected.txt
+++ b/LayoutTests/platform/win/fast/dom/navigator-detached-no-crash-expected.txt
@@ -7,7 +7,6 @@ navigator.clearAppBadge() is OK
 navigator.clipboard is OK
 navigator.contacts is OK
 navigator.cookieEnabled is OK
-navigator.globalPrivacyControl is OK
 navigator.gpu is OK
 navigator.hardwareConcurrency is OK
 navigator.javaEnabled() is OK
@@ -41,7 +40,6 @@ navigator.clearAppBadge() is OK
 navigator.clipboard is OK
 navigator.contacts is OK
 navigator.cookieEnabled is OK
-navigator.globalPrivacyControl is OK
 navigator.gpu is OK
 navigator.hardwareConcurrency is OK
 navigator.javaEnabled() is OK

--- a/LayoutTests/platform/wpe/fast/dom/navigator-detached-no-crash-expected.txt
+++ b/LayoutTests/platform/wpe/fast/dom/navigator-detached-no-crash-expected.txt
@@ -7,7 +7,6 @@ navigator.clearAppBadge() is OK
 navigator.clipboard is OK
 navigator.contacts is OK
 navigator.cookieEnabled is OK
-navigator.globalPrivacyControl is OK
 navigator.gpu is OK
 navigator.hardwareConcurrency is OK
 navigator.javaEnabled() is OK
@@ -44,7 +43,6 @@ navigator.clearAppBadge() is OK
 navigator.clipboard is OK
 navigator.contacts is OK
 navigator.cookieEnabled is OK
-navigator.globalPrivacyControl is OK
 navigator.gpu is OK
 navigator.hardwareConcurrency is OK
 navigator.javaEnabled() is OK

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -3674,18 +3674,13 @@ GetUserMediaRequiresFocus:
       default: true
 
 GlobalPrivacyControlEnabled:
-  type: bool
-  status: testable
-  category: privacy
+  type: "std::optional<bool>"
+  status: embedder
   humanReadableName: "Global Privacy Control"
   humanReadableDescription: "Enable Global Privacy Control (GPC) signal"
   defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
     WebCore:
-      default: false
+      default: std::nullopt
 
 GoogleAntiFlickerOptimizationQuirkEnabled:
   type: bool

--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -1533,6 +1533,8 @@ void DocumentLoader::applyPoliciesToSettings()
 
     if (m_inlineMediaPlaybackPolicy != InlineMediaPlaybackPolicy::Default)
         m_frame->settings().setInlineMediaPlaybackRequiresPlaysInlineAttribute(m_inlineMediaPlaybackPolicy == InlineMediaPlaybackPolicy::RequiresPlaysInlineAttribute);
+
+    m_frame->settings().setGlobalPrivacyControlEnabled(m_globalPrivacyControlEnabled);
 }
 
 ColorSchemePreference NODELETE DocumentLoader::colorSchemePreference() const

--- a/Source/WebCore/loader/DocumentLoader.h
+++ b/Source/WebCore/loader/DocumentLoader.h
@@ -500,6 +500,9 @@ public:
     OptionSet<AdvancedPrivacyProtections> navigationalAdvancedPrivacyProtections() const { return m_originatorAdvancedPrivacyProtections.value_or(m_advancedPrivacyProtections); }
     std::optional<OptionSet<AdvancedPrivacyProtections>> originatorAdvancedPrivacyProtections() const { return m_originatorAdvancedPrivacyProtections; }
 
+    void setGlobalPrivacyControlEnabled(std::optional<bool> enabled) { m_globalPrivacyControlEnabled = enabled; }
+    std::optional<bool> globalPrivacyControlEnabled() const { return m_globalPrivacyControlEnabled; }
+
     void setIdempotentModeAutosizingOnlyHonorsPercentages(bool idempotentModeAutosizingOnlyHonorsPercentages) { m_idempotentModeAutosizingOnlyHonorsPercentages = idempotentModeAutosizingOnlyHonorsPercentages; }
     bool idempotentModeAutosizingOnlyHonorsPercentages() const { return m_idempotentModeAutosizingOnlyHonorsPercentages; }
 
@@ -767,6 +770,7 @@ private:
 
     OptionSet<AdvancedPrivacyProtections> m_advancedPrivacyProtections;
     std::optional<OptionSet<AdvancedPrivacyProtections>> m_originatorAdvancedPrivacyProtections;
+    std::optional<bool> m_globalPrivacyControlEnabled;
     AutoplayPolicy m_autoplayPolicy { AutoplayPolicy::Default };
     OptionSet<AutoplayQuirk> m_allowedAutoplayQuirks;
     PopUpPolicy m_popUpPolicy { PopUpPolicy::Default };

--- a/Source/WebCore/page/NavigatorGlobalPrivacyControl.cpp
+++ b/Source/WebCore/page/NavigatorGlobalPrivacyControl.cpp
@@ -38,7 +38,7 @@ bool NavigatorGlobalPrivacyControl::globalPrivacyControlEnabled(Navigator& navig
     auto* frame = navigator.frame();
     if (!frame)
         return false;
-    return frame->settings().globalPrivacyControlEnabled();
+    return frame->settings().globalPrivacyControlEnabled().value_or(false);
 }
 
 bool NavigatorGlobalPrivacyControl::globalPrivacyControlEnabled(WorkerNavigator& navigator)
@@ -46,7 +46,7 @@ bool NavigatorGlobalPrivacyControl::globalPrivacyControlEnabled(WorkerNavigator&
     RefPtr scope = navigator.scriptExecutionContext();
     if (!scope)
         return false;
-    return scope->settingsValues().globalPrivacyControlEnabled;
+    return scope->settingsValues().globalPrivacyControlEnabled.value_or(false);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/page/NavigatorGlobalPrivacyControl.idl
+++ b/Source/WebCore/page/NavigatorGlobalPrivacyControl.idl
@@ -27,5 +27,5 @@
 [                                                                                                                           
     ImplementedBy=NavigatorGlobalPrivacyControl                                                                          
 ] interface mixin NavigatorGlobalPrivacyControl {         
-    [ImplementedAs=globalPrivacyControlEnabled] readonly attribute boolean globalPrivacyControl;
+    [EnabledBySetting=GlobalPrivacyControlEnabled, ImplementedAs=globalPrivacyControlEnabled] readonly attribute boolean globalPrivacyControl;
 };

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -5190,7 +5190,7 @@ ModelPlayerProvider& Page::modelPlayerProvider()
     return m_modelPlayerProvider.get();
 }
 
-void Page::setupForRemoteWorker(const URL& scriptURL, const SecurityOriginData& topOrigin, const String& referrerPolicy, OptionSet<AdvancedPrivacyProtections> advancedPrivacyProtections)
+void Page::setupForRemoteWorker(const URL& scriptURL, const SecurityOriginData& topOrigin, const String& referrerPolicy, OptionSet<AdvancedPrivacyProtections> advancedPrivacyProtections, std::optional<bool> globalPrivacyControlEnabled)
 {
     RefPtr localMainFrame = this->localMainFrame();
     if (!localMainFrame)
@@ -5208,6 +5208,8 @@ void Page::setupForRemoteWorker(const URL& scriptURL, const SecurityOriginData& 
 
     if (auto* documentLoader = localMainFrame->loader().documentLoader())
         documentLoader->setAdvancedPrivacyProtections(advancedPrivacyProtections);
+
+    settings().setGlobalPrivacyControlEnabled(globalPrivacyControlEnabled);
 
     document->setStorageBlockingPolicy(document->settings().storageBlockingPolicy());
 

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -388,7 +388,7 @@ public:
     WEBCORE_EXPORT static void updateStyleForAllPagesAfterGlobalChangeInEnvironment();
     WEBCORE_EXPORT static void clearPreviousItemFromAllPages(BackForwardFrameItemIdentifier);
 
-    WEBCORE_EXPORT void setupForRemoteWorker(const URL& scriptURL, const SecurityOriginData& topOrigin, const String& referrerPolicy, OptionSet<AdvancedPrivacyProtections>);
+    WEBCORE_EXPORT void setupForRemoteWorker(const URL& scriptURL, const SecurityOriginData& topOrigin, const String& referrerPolicy, OptionSet<AdvancedPrivacyProtections>, std::optional<bool> globalPrivacyControlEnabled);
 
     WEBCORE_EXPORT void updateStyleAfterChangeInEnvironment();
 

--- a/Source/WebCore/workers/Worker.cpp
+++ b/Source/WebCore/workers/Worker.cpp
@@ -245,7 +245,8 @@ void Worker::notifyFinished(std::optional<ScriptExecutionContextIdentifier> main
         scriptLoader->takeServiceWorkerData(),
         m_clientIdentifier,
         scriptLoader->advancedPrivacyProtections(),
-        context->userAgent(scriptLoader->responseURL())
+        context->userAgent(scriptLoader->responseURL()),
+        scriptLoader->globalPrivacyControlEnabled()
     };
     m_contextProxy.startWorkerGlobalScope(scriptLoader->responseURL(), *sessionID, m_options.name, WTF::move(initializationData), scriptLoader->script(), contentSecurityPolicyResponseHeaders, m_shouldBypassMainWorldContentSecurityPolicy, scriptLoader->crossOriginEmbedderPolicy(), m_workerCreationTime, referrerPolicy, m_options.type, m_options.credentials, m_runtimeFlags);
 

--- a/Source/WebCore/workers/WorkerInitializationData.h
+++ b/Source/WebCore/workers/WorkerInitializationData.h
@@ -39,6 +39,7 @@ struct WorkerInitializationData {
     std::optional<ScriptExecutionContextIdentifier> clientIdentifier;
     OptionSet<WebCore::AdvancedPrivacyProtections> advancedPrivacyProtections;
     String userAgent;
+    std::optional<bool> globalPrivacyControlEnabled;
 
     WorkerInitializationData isolatedCopy() const;
 };
@@ -49,7 +50,8 @@ inline WorkerInitializationData WorkerInitializationData::isolatedCopy() const
         crossThreadCopy(serviceWorkerData),
         clientIdentifier,
         advancedPrivacyProtections,
-        userAgent.isolatedCopy()
+        userAgent.isolatedCopy(),
+        globalPrivacyControlEnabled
     };
 }
 

--- a/Source/WebCore/workers/WorkerScriptLoader.cpp
+++ b/Source/WebCore/workers/WorkerScriptLoader.cpp
@@ -82,6 +82,7 @@ std::optional<Exception> WorkerScriptLoader::loadSynchronously(ScriptExecutionCo
     m_destination = FetchOptions::Destination::Script;
     m_isCOEPEnabled = scriptExecutionContext->settingsValues().crossOriginEmbedderPolicyEnabled;
     m_advancedPrivacyProtections = scriptExecutionContext->advancedPrivacyProtections();
+    m_globalPrivacyControlEnabled = scriptExecutionContext->settingsValues().globalPrivacyControlEnabled;
 
     RefPtr serviceWorkerGlobalScope = dynamicDowncast<ServiceWorkerGlobalScope>(workerGlobalScope);
     if (serviceWorkerGlobalScope) {
@@ -138,6 +139,7 @@ void WorkerScriptLoader::loadAsynchronously(ScriptExecutionContext& scriptExecut
     m_isCOEPEnabled = scriptExecutionContext.settingsValues().crossOriginEmbedderPolicyEnabled;
     m_clientIdentifier = clientIdentifier;
     m_advancedPrivacyProtections = scriptExecutionContext.advancedPrivacyProtections();
+    m_globalPrivacyControlEnabled = scriptExecutionContext.settingsValues().globalPrivacyControlEnabled;
 
     ASSERT(scriptRequest.httpMethod() == "GET"_s);
 

--- a/Source/WebCore/workers/WorkerScriptLoader.h
+++ b/Source/WebCore/workers/WorkerScriptLoader.h
@@ -77,6 +77,7 @@ public:
     void deref() const final { RefCounted::deref(); }
 
     OptionSet<AdvancedPrivacyProtections> advancedPrivacyProtections() const { return m_advancedPrivacyProtections; }
+    std::optional<bool> globalPrivacyControlEnabled() const { return m_globalPrivacyControlEnabled; }
 
     const ScriptBuffer& script() const LIFETIME_BOUND { return m_script; }
     const ContentSecurityPolicyResponseHeaders& contentSecurityPolicy() const LIFETIME_BOUND { return m_contentSecurityPolicy; }
@@ -169,6 +170,7 @@ private:
     WeakPtr<ScriptExecutionContext> m_context;
     String m_userAgentForSharedWorker;
     OptionSet<AdvancedPrivacyProtections> m_advancedPrivacyProtections;
+    std::optional<bool> m_globalPrivacyControlEnabled;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/workers/service/ServiceWorkerClientData.cpp
+++ b/Source/WebCore/workers/service/ServiceWorkerClientData.cpp
@@ -60,12 +60,12 @@ static ServiceWorkerClientFrameType toServiceWorkerClientFrameType(ScriptExecuti
 
 ServiceWorkerClientData ServiceWorkerClientData::isolatedCopy() const &
 {
-    return { identifier, type, frameType, url.isolatedCopy(), ownerURL.isolatedCopy(), pageIdentifier, frameIdentifier, lastNavigationWasAppInitiated, advancedPrivacyProtections, isVisible, isFocused, focusOrder, crossThreadCopy(ancestorOrigins) };
+    return { identifier, type, frameType, url.isolatedCopy(), ownerURL.isolatedCopy(), pageIdentifier, frameIdentifier, lastNavigationWasAppInitiated, advancedPrivacyProtections, isVisible, isFocused, focusOrder, crossThreadCopy(ancestorOrigins), globalPrivacyControlEnabled };
 }
 
 ServiceWorkerClientData ServiceWorkerClientData::isolatedCopy() &&
 {
-    return { identifier, type, frameType, WTF::move(url).isolatedCopy(), WTF::move(ownerURL).isolatedCopy(), pageIdentifier, frameIdentifier, lastNavigationWasAppInitiated, advancedPrivacyProtections, isVisible, isFocused, focusOrder, crossThreadCopy(WTF::move(ancestorOrigins)) };
+    return { identifier, type, frameType, WTF::move(url).isolatedCopy(), WTF::move(ownerURL).isolatedCopy(), pageIdentifier, frameIdentifier, lastNavigationWasAppInitiated, advancedPrivacyProtections, isVisible, isFocused, focusOrder, crossThreadCopy(WTF::move(ancestorOrigins)), globalPrivacyControlEnabled };
 }
 
 ServiceWorkerClientData ServiceWorkerClientData::from(ScriptExecutionContext& context)
@@ -94,7 +94,8 @@ ServiceWorkerClientData ServiceWorkerClientData::from(ScriptExecutionContext& co
             !document->hidden(),
             document->hasFocus(),
             0,
-            WTF::move(ancestorOrigins)
+            WTF::move(ancestorOrigins),
+            context.settingsValues().globalPrivacyControlEnabled
         };
     }
 
@@ -113,7 +114,8 @@ ServiceWorkerClientData ServiceWorkerClientData::from(ScriptExecutionContext& co
         false,
         false,
         0,
-        { }
+        { },
+        context.settingsValues().globalPrivacyControlEnabled
     };
 }
 

--- a/Source/WebCore/workers/service/ServiceWorkerClientData.h
+++ b/Source/WebCore/workers/service/ServiceWorkerClientData.h
@@ -57,6 +57,7 @@ struct ServiceWorkerClientData {
     bool isFocused { false };
     uint64_t focusOrder { 0 };
     Vector<String> ancestorOrigins;
+    std::optional<bool> globalPrivacyControlEnabled;
 
     WEBCORE_EXPORT ServiceWorkerClientData isolatedCopy() const &;
     WEBCORE_EXPORT ServiceWorkerClientData isolatedCopy() &&;

--- a/Source/WebCore/workers/service/ServiceWorkerContextData.cpp
+++ b/Source/WebCore/workers/service/ServiceWorkerContextData.cpp
@@ -47,7 +47,8 @@ ServiceWorkerContextData ServiceWorkerContextData::isolatedCopy() const &
         crossThreadCopy(scriptResourceMap),
         serviceWorkerPageIdentifier,
         crossThreadCopy(navigationPreloadState),
-        crossThreadCopy(routes)
+        crossThreadCopy(routes),
+        globalPrivacyControlEnabled
     };
 }
 
@@ -69,7 +70,8 @@ ServiceWorkerContextData ServiceWorkerContextData::isolatedCopy() &&
         crossThreadCopy(WTF::move(scriptResourceMap)),
         serviceWorkerPageIdentifier,
         crossThreadCopy(WTF::move(navigationPreloadState)),
-        crossThreadCopy(WTF::move(routes))
+        crossThreadCopy(WTF::move(routes)),
+        globalPrivacyControlEnabled
     };
 }
 
@@ -91,7 +93,8 @@ ServiceWorkerContextData ServiceWorkerContextData::copy() const
         scriptResourceMap,
         serviceWorkerPageIdentifier,
         navigationPreloadState,
-        map(routes, [](auto& route) { return route.copy(); })
+        map(routes, [](auto& route) { return route.copy(); }),
+        globalPrivacyControlEnabled
     };
 }
 

--- a/Source/WebCore/workers/service/ServiceWorkerContextData.h
+++ b/Source/WebCore/workers/service/ServiceWorkerContextData.h
@@ -61,6 +61,7 @@ struct ServiceWorkerContextData {
     std::optional<ScriptExecutionContextIdentifier> serviceWorkerPageIdentifier;
     NavigationPreloadState navigationPreloadState;
     Vector<ServiceWorkerRoute> routes;
+    std::optional<bool> globalPrivacyControlEnabled;
 
     using ImportedScript = ServiceWorkerImportedScript;
 

--- a/Source/WebCore/workers/service/server/SWRegistrationDatabase.cpp
+++ b/Source/WebCore/workers/service/server/SWRegistrationDatabase.cpp
@@ -514,7 +514,7 @@ Vector<ServiceWorkerContextData> SWRegistrationDatabase::collectRegistrationsFro
         auto registrationIdentifier = ServiceWorkerRegistrationIdentifier::generate();
         auto serviceWorkerData = ServiceWorkerData { workerIdentifier, registrationIdentifier, scriptURL, ServiceWorkerState::Activated, *workerType };
         auto registration = ServiceWorkerRegistrationData { WTF::move(*key), registrationIdentifier, WTF::move(scopeURL), *updateViaCache, lastUpdateCheckTime, std::nullopt, std::nullopt, WTF::move(serviceWorkerData) };
-        auto contextData = ServiceWorkerContextData { std::nullopt, WTF::move(registration), workerIdentifier, ScriptBuffer(), WTF::move(*certificateInfo), WTF::move(*contentSecurityPolicy), WTF::move(*coep), WTF::move(referrerPolicy), WTF::move(scriptURL), *workerType, true, LastNavigationWasAppInitiated::Yes, WTF::move(scriptResourceMap), std::nullopt, WTF::move(*navigationPreloadState), WTF::move(*routes) };
+        auto contextData = ServiceWorkerContextData { std::nullopt, WTF::move(registration), workerIdentifier, ScriptBuffer(), WTF::move(*certificateInfo), WTF::move(*contentSecurityPolicy), WTF::move(*coep), WTF::move(referrerPolicy), WTF::move(scriptURL), *workerType, true, LastNavigationWasAppInitiated::Yes, WTF::move(scriptResourceMap), std::nullopt, WTF::move(*navigationPreloadState), WTF::move(*routes), std::nullopt };
 
         registrations.append(WTF::move(contextData));
     }

--- a/Source/WebCore/workers/service/server/SWServer.cpp
+++ b/Source/WebCore/workers/service/server/SWServer.cpp
@@ -1019,7 +1019,7 @@ void SWServer::unregisterServiceWorkerConnection(Connection& connection, Service
 
 void SWServer::updateWorker(const ServiceWorkerJobDataIdentifier& jobDataIdentifier, const std::optional<ProcessIdentifier>& requestingProcessIdentifier, SWServerRegistration& registration, const URL& url, const ScriptBuffer& script, const CertificateInfo& certificateInfo, const ContentSecurityPolicyResponseHeaders& contentSecurityPolicy, const CrossOriginEmbedderPolicy& coep, const String& referrerPolicy, WorkerType type, MemoryCompactRobinHoodHashMap<URL, ServiceWorkerContextData::ImportedScript>&& scriptResourceMap, std::optional<ScriptExecutionContextIdentifier> serviceWorkerPageIdentifier)
 {
-    tryInstallContextData(requestingProcessIdentifier, ServiceWorkerContextData { jobDataIdentifier, registration.data(), ServiceWorkerIdentifier::generate(), script, certificateInfo, contentSecurityPolicy, coep, referrerPolicy, url, type, false, clientIsAppInitiatedForRegistrableDomain(RegistrableDomain(url)), WTF::move(scriptResourceMap), serviceWorkerPageIdentifier, { }, { } });
+    tryInstallContextData(requestingProcessIdentifier, ServiceWorkerContextData { jobDataIdentifier, registration.data(), ServiceWorkerIdentifier::generate(), script, certificateInfo, contentSecurityPolicy, coep, referrerPolicy, url, type, false, clientIsAppInitiatedForRegistrableDomain(RegistrableDomain(url)), WTF::move(scriptResourceMap), serviceWorkerPageIdentifier, { }, { }, { } });
 }
 
 LastNavigationWasAppInitiated SWServer::clientIsAppInitiatedForRegistrableDomain(const RegistrableDomain& domain)
@@ -1117,6 +1117,16 @@ OptionSet<AdvancedPrivacyProtections> SWServer::advancedPrivacyProtectionsFromCl
     return result;
 }
 
+std::optional<bool> SWServer::globalPrivacyControlEnabledFromClient(const ClientOrigin& origin) const
+{
+    std::optional<bool> result;
+    forEachClientForOrigin(origin, [&result](auto& clientData) {
+        if (clientData.globalPrivacyControlEnabled)
+            result = result.value_or(false) || *clientData.globalPrivacyControlEnabled;
+    });
+    return result;
+}
+
 void SWServer::addRoutes(ServiceWorkerRegistrationIdentifier identifier, Vector<ServiceWorkerRoute>&& routes, CompletionHandler<void(Expected<void, ExceptionData>&&)>&& callback)
 {
     RefPtr registration = getRegistration(identifier);
@@ -1167,7 +1177,9 @@ void SWServer::installContextData(const ServiceWorkerContextData& data)
     auto result = m_runningOrTerminatingWorkers.add(data.serviceWorkerIdentifier, worker.copyRef());
     ASSERT_UNUSED(result, result.isNewEntry);
 
-    connection->installServiceWorkerContext(data, worker->data(), userAgent, worker->workerThreadMode(), advancedPrivacyProtectionsFromClient(worker->registrationKey().clientOrigin()));
+    auto contextData = data.copy();
+    contextData.globalPrivacyControlEnabled = globalPrivacyControlEnabledFromClient(worker->registrationKey().clientOrigin());
+    connection->installServiceWorkerContext(contextData, worker->data(), userAgent, worker->workerThreadMode(), advancedPrivacyProtectionsFromClient(worker->registrationKey().clientOrigin()));
 }
 
 void SWServer::runServiceWorkerIfNecessary(ServiceWorkerIdentifier identifier, RunServiceWorkerCallback&& callback)
@@ -1255,7 +1267,9 @@ bool SWServer::runServiceWorker(SWServerWorker& worker)
     RefPtr contextConnection = worker.contextConnection();
     ASSERT(contextConnection);
 
-    contextConnection->installServiceWorkerContext(worker.contextData(), worker.data(), worker.userAgent(), worker.workerThreadMode(), advancedPrivacyProtectionsFromClient(worker.registrationKey().clientOrigin()));
+    auto contextData = worker.contextData();
+    contextData.globalPrivacyControlEnabled = globalPrivacyControlEnabledFromClient(worker.registrationKey().clientOrigin());
+    contextConnection->installServiceWorkerContext(contextData, worker.data(), worker.userAgent(), worker.workerThreadMode(), advancedPrivacyProtectionsFromClient(worker.registrationKey().clientOrigin()));
 
     return true;
 }

--- a/Source/WebCore/workers/service/server/SWServer.h
+++ b/Source/WebCore/workers/service/server/SWServer.h
@@ -304,6 +304,7 @@ public:
     WEBCORE_EXPORT void postMessageToServiceWorkerClient(ScriptExecutionContextIdentifier, const MessageWithMessagePorts&, ServiceWorkerIdentifier, const SecurityOriginData&, NOESCAPE const Function<void(ScriptExecutionContextIdentifier, const MessageWithMessagePorts&, const ServiceWorkerData&, const SecurityOriginData&)>&);
 
     WEBCORE_EXPORT OptionSet<AdvancedPrivacyProtections> advancedPrivacyProtectionsFromClient(const ClientOrigin&) const;
+    WEBCORE_EXPORT std::optional<bool> globalPrivacyControlEnabledFromClient(const ClientOrigin&) const;
 
     bool isProcessTerminationDelayEnabled() const { return m_isProcessTerminationDelayEnabled; }
 

--- a/Source/WebCore/workers/service/server/SWServerWorker.cpp
+++ b/Source/WebCore/workers/service/server/SWServerWorker.cpp
@@ -90,7 +90,11 @@ ServiceWorkerContextData SWServerWorker::contextData() const
     RefPtr registration = m_registration.get();
     ASSERT(registration);
 
-    return { std::nullopt, registration->data(), m_data.identifier, script(), m_certificateInfo, m_contentSecurityPolicy, m_crossOriginEmbedderPolicy, m_referrerPolicy, m_data.scriptURL, m_data.type, false, m_lastNavigationWasAppInitiated, m_scriptResourceMap, registration->serviceWorkerPageIdentifier(), registration->navigationPreloadState(), WTF::map(m_routes, [](auto& route) { return route.copy(); }) };
+    return {
+        std::nullopt, registration->data(), m_data.identifier, script(), m_certificateInfo, m_contentSecurityPolicy, m_crossOriginEmbedderPolicy, m_referrerPolicy, m_data.scriptURL, m_data.type, false, m_lastNavigationWasAppInitiated, m_scriptResourceMap, registration->serviceWorkerPageIdentifier(), registration->navigationPreloadState(),
+        WTF::map(m_routes, [](auto& route) { return route.copy(); }),
+        std::nullopt
+    };
 }
 
 void SWServerWorker::updateAppInitiatedValue(LastNavigationWasAppInitiated lastNavigationWasAppInitiated)

--- a/Source/WebCore/workers/shared/SharedWorkerScriptLoader.cpp
+++ b/Source/WebCore/workers/shared/SharedWorkerScriptLoader.cpp
@@ -103,7 +103,8 @@ void SharedWorkerScriptLoader::notifyFinished(std::optional<ScriptExecutionConte
         m_loader->takeServiceWorkerData(),
         m_loader->clientIdentifier(),
         m_loader->advancedPrivacyProtections(),
-        m_loader->userAgentForSharedWorker()
+        m_loader->userAgentForSharedWorker(),
+        m_loader->globalPrivacyControlEnabled()
     }); // deletes this.
 }
 

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.cpp
@@ -232,7 +232,7 @@ void WebSWServerConnection::controlClient(const NetworkResourceLoadParameters& p
 
     auto ancestorOrigins = map(parameters.frameAncestorOrigins, [](auto& origin) { return origin->toString(); });
     auto advancedPrivacyProtections = server->advancedPrivacyProtectionsFromClient(registration.key().clientOrigin());
-    ServiceWorkerClientData data { clientIdentifier, clientType, ServiceWorkerClientFrameType::None, request.url(), URL(), parameters.webPageID, parameters.webFrameID, request.isAppInitiated() ? WebCore::LastNavigationWasAppInitiated::Yes : WebCore::LastNavigationWasAppInitiated::No, advancedPrivacyProtections, false, false, 0, WTF::move(ancestorOrigins) };
+    ServiceWorkerClientData data { clientIdentifier, clientType, ServiceWorkerClientFrameType::None, request.url(), URL(), parameters.webPageID, parameters.webFrameID, request.isAppInitiated() ? WebCore::LastNavigationWasAppInitiated::Yes : WebCore::LastNavigationWasAppInitiated::No, advancedPrivacyProtections, false, false, 0, WTF::move(ancestorOrigins), parameters.globalPrivacyControlEnabled };
 
     registerServiceWorkerClientInternal(ClientOrigin { registration.key().topOrigin(), SecurityOriginData::fromURLWithoutStrictOpaqueness(request.url()) }, WTF::move(data), registration.identifier(), request.httpUserAgent(), WebCore::SWServer::IsBeingCreatedClient::Yes);
 }

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -3634,6 +3634,7 @@ struct WebCore::ServiceWorkerClientData {
     bool isFocused;
     uint64_t focusOrder;
     Vector<String> ancestorOrigins;
+    std::optional<bool> globalPrivacyControlEnabled;
 };
 
 struct WebCore::ServiceWorkerClientQueryOptions {
@@ -4139,6 +4140,7 @@ struct WebCore::WorkerInitializationData {
     std::optional<WebCore::ScriptExecutionContextIdentifier> clientIdentifier;
     OptionSet<WebCore::AdvancedPrivacyProtections> advancedPrivacyProtections;
     String userAgent;
+    std::optional<bool> globalPrivacyControlEnabled;
 };
 
 struct WebCore::WorkerFetchResult {
@@ -4212,6 +4214,7 @@ struct WebCore::ServiceWorkerContextData {
     std::optional<WebCore::ScriptExecutionContextIdentifier> serviceWorkerPageIdentifier;
     WebCore::NavigationPreloadState navigationPreloadState;
     Vector<WebCore::ServiceWorkerRoute> routes;
+    std::optional<bool> globalPrivacyControlEnabled;
 };
 
 #if HAVE(SCREEN_CAPTURE_KIT)

--- a/Source/WebKit/Shared/WebsitePoliciesData.cpp
+++ b/Source/WebKit/Shared/WebsitePoliciesData.cpp
@@ -155,6 +155,7 @@ void WebsitePoliciesData::applyToDocumentLoader(WebsitePoliciesData&& websitePol
     documentLoader.setAdvancedPrivacyProtections(websitePolicies.advancedPrivacyProtections);
     if (!documentLoader.originatorAdvancedPrivacyProtections())
         documentLoader.setOriginatorAdvancedPrivacyProtections(websitePolicies.advancedPrivacyProtections);
+    documentLoader.setGlobalPrivacyControlEnabled(websitePolicies.globalPrivacyControlEnabled);
     documentLoader.setIdempotentModeAutosizingOnlyHonorsPercentages(websitePolicies.idempotentModeAutosizingOnlyHonorsPercentages);
     documentLoader.setHTTPSByDefaultMode(websitePolicies.httpsByDefaultMode);
 
@@ -201,9 +202,6 @@ void WebsitePoliciesData::applyToDocumentLoader(WebsitePoliciesData&& websitePol
     if (auto overrideValue = websitePolicies.overrideTouchEventDOMAttributesEnabled)
         frame->settings().setTouchEventDOMAttributesEnabled(*overrideValue);
 #endif
-
-    if (auto overrideValue = websitePolicies.globalPrivacyControlEnabled)
-        frame->settings().setGlobalPrivacyControlEnabled(*overrideValue);
 
     documentLoader.applyPoliciesToSettings();
 }

--- a/Source/WebKit/UIProcess/API/C/WKWebsitePolicies.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKWebsitePolicies.cpp
@@ -58,6 +58,16 @@ bool WKWebsitePoliciesGetContentBlockersEnabled(WKWebsitePoliciesRef websitePoli
     return toImpl(websitePolicies)->contentExtensionEnablement().first == WebCore::ContentExtensionDefaultEnablement::Enabled;
 }
 
+void WKWebsitePoliciesSetGlobalPrivacyControlEnabled(WKWebsitePoliciesRef websitePolicies, bool enabled)
+{
+    toImpl(websitePolicies)->setGlobalPrivacyControlEnabled(enabled);
+}
+
+bool WKWebsitePoliciesGetGlobalPrivacyControlEnabled(WKWebsitePoliciesRef websitePolicies)
+{
+    return toImpl(websitePolicies)->globalPrivacyControlEnabled().value_or(false);
+}
+
 WK_EXPORT WKDictionaryRef WKWebsitePoliciesCopyCustomHeaderFields(WKWebsitePoliciesRef)
 {
     return nullptr;

--- a/Source/WebKit/UIProcess/API/C/WKWebsitePolicies.h
+++ b/Source/WebKit/UIProcess/API/C/WKWebsitePolicies.h
@@ -60,6 +60,9 @@ WK_EXPORT WKWebsitePoliciesRef WKWebsitePoliciesCreate();
 WK_EXPORT bool WKWebsitePoliciesGetContentBlockersEnabled(WKWebsitePoliciesRef);
 WK_EXPORT void WKWebsitePoliciesSetContentBlockersEnabled(WKWebsitePoliciesRef, bool);
 
+WK_EXPORT bool WKWebsitePoliciesGetGlobalPrivacyControlEnabled(WKWebsitePoliciesRef);
+WK_EXPORT void WKWebsitePoliciesSetGlobalPrivacyControlEnabled(WKWebsitePoliciesRef, bool);
+
 WK_EXPORT WKDictionaryRef WKWebsitePoliciesCopyCustomHeaderFields(WKWebsitePoliciesRef) WK_C_API_DEPRECATED;
 WK_EXPORT void WKWebsitePoliciesSetCustomHeaderFields(WKWebsitePoliciesRef, WKDictionaryRef) WK_C_API_DEPRECATED;
 

--- a/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
+++ b/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
@@ -402,7 +402,7 @@ static void addParametersShared(const LocalFrame* frame, NetworkResourceLoadPara
         parameters.isClearSiteDataHeaderEnabled = document->settings().clearSiteDataHTTPHeaderEnabled();
         parameters.isClearSiteDataExecutionContextEnabled = document->settings().clearSiteDataExecutionContextsSupportEnabled();
         parameters.mayBlockNetworkRequest = !isMainFrameNavigation && document->settings().scriptTrackingPrivacyNetworkRequestBlockingEnabled();
-        parameters.globalPrivacyControlEnabled = document->settings().globalPrivacyControlEnabled();
+        parameters.globalPrivacyControlEnabled = document->settings().globalPrivacyControlEnabled().value_or(false);
     }
 
     if (RefPtr page = frame->page()) {

--- a/Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.cpp
+++ b/Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.cpp
@@ -196,7 +196,7 @@ void WebSWContextManagerConnection::installServiceWorker(ServiceWorkerContextDat
         if (WebProcess::singleton().isLockdownModeEnabled())
             WebPage::adjustSettingsForLockdownMode(page->settings(), m_preferencesStore ? &m_preferencesStore.value() : nullptr);
 
-        page->setupForRemoteWorker(contextData.scriptURL, contextData.registration.key.topOrigin(), contextData.referrerPolicy, advancedPrivacyProtections);
+        page->setupForRemoteWorker(contextData.scriptURL, contextData.registration.key.topOrigin(), contextData.referrerPolicy, advancedPrivacyProtections, contextData.globalPrivacyControlEnabled);
 
         std::unique_ptr<WebCore::NotificationClient> notificationClient;
 #if ENABLE(NOTIFICATIONS)

--- a/Source/WebKit/WebProcess/Storage/WebSharedWorkerContextManagerConnection.cpp
+++ b/Source/WebKit/WebProcess/Storage/WebSharedWorkerContextManagerConnection.cpp
@@ -136,7 +136,7 @@ void WebSharedWorkerContextManagerConnection::launchSharedWorker(WebCore::Client
     if (!initializationData.clientIdentifier)
         initializationData.clientIdentifier = WebCore::ScriptExecutionContextIdentifier::generate();
 
-    page->setupForRemoteWorker(workerFetchResult.responseURL, origin.topOrigin, workerFetchResult.referrerPolicy, initializationData.advancedPrivacyProtections);
+    page->setupForRemoteWorker(workerFetchResult.responseURL, origin.topOrigin, workerFetchResult.referrerPolicy, initializationData.advancedPrivacyProtections, initializationData.globalPrivacyControlEnabled);
 
     auto sharedWorkerThreadProxy = WebCore::SharedWorkerThreadProxy::create(Ref { page }, sharedWorkerIdentifier, origin, WTF::move(workerFetchResult), WTF::move(workerOptions), WTF::move(initializationData), WebProcess::singleton().cacheStorageProvider());
 

--- a/Tools/TestRunnerShared/TestFeatures.cpp
+++ b/Tools/TestRunnerShared/TestFeatures.cpp
@@ -163,6 +163,11 @@ static bool shouldEnableTouchEventRegions(const std::string& pathOrURL)
     return pathContains(pathOrURL, "touch-event-regions-layer-tree/");
 }
 
+static bool shouldEnableGlobalPrivacyControl(const std::string& pathOrURL)
+{
+    return pathContains(pathOrURL, "/gpc/");
+}
+
 TestFeatures hardcodedFeaturesBasedOnPathForTest(const TestCommand& command)
 {
     TestFeatures features;
@@ -198,6 +203,8 @@ TestFeatures hardcodedFeaturesBasedOnPathForTest(const TestCommand& command)
         features.boolWebPreferenceFeatures.insert({ "MutationEventsEnabled", false });
     if (shouldEnableTouchEventRegions(command.pathOrURL))
         features.boolWebPreferenceFeatures.insert({ "AlwaysUseTouchEventRegions", true });
+    if (shouldEnableGlobalPrivacyControl(command.pathOrURL))
+        features.boolTestRunnerFeatures.insert({ "globalPrivacyControl", true });
 
     return features;
 }

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebsitePolicies.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebsitePolicies.mm
@@ -2304,6 +2304,13 @@ TEST(WebpagePreferences, GlobalPrivacyControlNavigatorAPI)
     EXPECT_WK_STREQ([webView _test_waitForAlert], "false");
 }
 
+TEST(WebpagePreferences, GlobalPrivacyControlNavigatorAPINotSet)
+{
+    RetainPtr webView = adoptNS([TestWKWebView new]);
+    [webView loadHTMLString:@"<script>alert(String(navigator.globalPrivacyControl))</script>" baseURL:nil];
+    EXPECT_WK_STREQ([webView _test_waitForAlert], "undefined");
+}
+
 TEST(WebpagePreferences, GlobalPrivacyControlRequestHeader)
 {
     using namespace TestWebKitAPI;

--- a/Tools/WebKitTestRunner/TestController.cpp
+++ b/Tools/WebKitTestRunner/TestController.cpp
@@ -1461,7 +1461,6 @@ void TestController::resetPreferencesToConsistentValues(const TestOptions& optio
         WKPreferencesSetAllowsPictureInPictureMediaPlayback(preferences, true);
 
         WKPreferencesSetBoolValueForKeyForTesting(preferences, options.allowTestOnlyIPC(), toWK("AllowTestOnlyIPC").get());
-        WKPreferencesSetBoolValueForKeyForTesting(preferences, false, toWK("GlobalPrivacyControlEnabled").get());
         WKPreferencesSetBoolValueForKeyForTesting(preferences, options.allowTestOnlyMockContentFilterIPC(), toWK("AllowTestOnlyMockContentFilterIPC").get());
         WKPreferencesSetBoolValueForKeyForTesting(preferences, options.allowTestOnlyOriginAccessAllowListIPC(), toWK("AllowTestOnlyOriginAccessAllowListIPC").get());
 
@@ -1483,6 +1482,8 @@ bool TestController::resetStateToConsistentValues(const TestOptions& options, Re
 {
     SetForScope changeState(m_state, Resetting);
     m_beforeUnloadReturnValue = true;
+
+    m_globalPrivacyControlEnabled = std::nullopt;
 
     for (auto& auxiliaryWebView : std::exchange(m_auxiliaryWebViews, { }))
         WKPageClose(auxiliaryWebView->page());
@@ -4556,12 +4557,18 @@ void TestController::decidePolicyForNavigationAction(WKPageRef page, WKNavigatio
     WKRetainPtr<WKFramePolicyListenerRef> retainedListener { listener };
     WKRetainPtr<WKNavigationActionRef> retainedNavigationAction { navigationAction };
     const bool shouldIgnore { m_policyDelegateEnabled && !m_policyDelegatePermissive };
+
+    auto globalPrivacyControlEnabled = m_globalPrivacyControlEnabled;
+    if (!globalPrivacyControlEnabled && m_currentInvocation && protectedCurrentInvocation()->options().globalPrivacyControl())
+        globalPrivacyControlEnabled = false;
+
     auto decisionFunction = [
         shouldIgnore,
         retainedListener,
         retainedNavigationAction,
         shouldSwapToEphemeralSessionOnNextNavigation = m_shouldSwapToEphemeralSessionOnNextNavigation,
         shouldSwapToDefaultSessionOnNextNavigation = m_shouldSwapToDefaultSessionOnNextNavigation,
+        globalPrivacyControlEnabled,
         page = WKRetainPtr { page }
     ] {
         if (shouldIgnore)
@@ -4573,6 +4580,8 @@ void TestController::decidePolicyForNavigationAction(WKPageRef page, WKNavigatio
                 ASSERT(shouldSwapToEphemeralSessionOnNextNavigation != shouldSwapToDefaultSessionOnNextNavigation);
                 WKRetainPtr policies = adoptWK(WKWebsitePoliciesCreate());
                 WKWebsitePoliciesSetAllowsJSHandleCreationInPageWorld(policies.get(), true);
+                if (globalPrivacyControlEnabled)
+                    WKWebsitePoliciesSetGlobalPrivacyControlEnabled(policies.get(), *globalPrivacyControlEnabled);
                 WKRetainPtr<WKWebsiteDataStoreRef> newSession = TestController::defaultWebsiteDataStore();
                 if (shouldSwapToEphemeralSessionOnNextNavigation)
                     newSession = adoptWK(WKWebsiteDataStoreCreateNonPersistentDataStore());
@@ -4581,6 +4590,8 @@ void TestController::decidePolicyForNavigationAction(WKPageRef page, WKNavigatio
             } else {
                 WKRetainPtr policies = WKPageConfigurationGetDefaultWebsitePolicies(adoptWK(WKPageCopyPageConfiguration(page.get())).get());
                 WKWebsitePoliciesSetAllowsJSHandleCreationInPageWorld(policies.get(), true);
+                if (globalPrivacyControlEnabled)
+                    WKWebsitePoliciesSetGlobalPrivacyControlEnabled(policies.get(), *globalPrivacyControlEnabled);
                 WKFramePolicyListenerUseWithPolicies(retainedListener.get(), policies.get());
             }
         }

--- a/Tools/WebKitTestRunner/TestController.h
+++ b/Tools/WebKitTestRunner/TestController.h
@@ -217,6 +217,9 @@ public:
     void setShouldSwapToEphemeralSessionOnNextNavigation(bool value) { m_shouldSwapToEphemeralSessionOnNextNavigation = value; }
     void setShouldSwapToDefaultSessionOnNextNavigation(bool value) { m_shouldSwapToDefaultSessionOnNextNavigation = value; }
 
+    void setGlobalPrivacyControl(bool value) { m_globalPrivacyControlEnabled = value; }
+    bool globalPrivacyControl() const { return m_globalPrivacyControlEnabled.value_or(false); }
+
     void setBlockAllPlugins(bool shouldBlock);
     void setPluginSupportedMode(const String&);
 
@@ -905,6 +908,7 @@ private:
     bool m_allowsAnySSLCertificate { true };
     bool m_shouldSwapToEphemeralSessionOnNextNavigation { false };
     bool m_shouldSwapToDefaultSessionOnNextNavigation { false };
+    std::optional<bool> m_globalPrivacyControlEnabled;
     
 #if PLATFORM(COCOA)
     bool m_hasSetApplicationBundleIdentifier { false };

--- a/Tools/WebKitTestRunner/TestInvocation.cpp
+++ b/Tools/WebKitTestRunner/TestInvocation.cpp
@@ -1358,12 +1358,12 @@ WKRetainPtr<WKTypeRef> TestInvocation::didReceiveSynchronousMessageFromInjectedB
     }
 
     if (WKStringIsEqualToUTF8CString(messageName, "GetGlobalPrivacyControl")) {
-        bool value = WKPreferencesGetBoolValueForKeyForTesting(TestController::singleton().platformPreferences(), toWK("GlobalPrivacyControlEnabled").get());
+        bool value = TestController::singleton().globalPrivacyControl();
         return adoptWK(WKBooleanCreate(value)).leakRef();
     }
 
     if (WKStringIsEqualToUTF8CString(messageName, "SetGlobalPrivacyControl")) {
-        WKPreferencesSetBoolValueForKeyForTesting(TestController::singleton().platformPreferences(), booleanValue(messageBody), toWK("GlobalPrivacyControlEnabled").get());
+        TestController::singleton().setGlobalPrivacyControl(booleanValue(messageBody));
         return nullptr;
     }
 

--- a/Tools/WebKitTestRunner/TestOptions.cpp
+++ b/Tools/WebKitTestRunner/TestOptions.cpp
@@ -222,6 +222,7 @@ const TestFeatures& TestOptions::defaults()
             { "enableMetalShaderValidation", false },
             { "pageTopColorSamplingEnabled", false },
             { "enhancedSecurityEnabled", false },
+            { "globalPrivacyControl", false },
         };
         features.doubleTestRunnerFeatures = {
             { "contentInset.top", 0 },

--- a/Tools/WebKitTestRunner/TestOptions.h
+++ b/Tools/WebKitTestRunner/TestOptions.h
@@ -98,6 +98,7 @@ public:
     bool enableMetalShaderValidation() const { return boolTestRunnerFeatureValue("enableMetalShaderValidation"); }
     bool pageTopColorSamplingEnabled() const { return boolTestRunnerFeatureValue("pageTopColorSamplingEnabled"); }
     bool enhancedSecurityEnabled() const { return boolTestRunnerFeatureValue("enhancedSecurityEnabled"); }
+    bool globalPrivacyControl() const { return boolTestRunnerFeatureValue("globalPrivacyControl"); }
     bool shouldDumpResourceLoadCallbacks() const { return boolTestRunnerFeatureValue("dumpResourceLoadCallbacks"); }
     std::string resourceResponseMIMETypesToDump() const { return stringTestRunnerFeatureValue("dumpResourceResponseMIMETypes"); }
 


### PR DESCRIPTION
#### c7b5fcf1c50e97c4206bc674c6efd8fbd52dcb4e
<pre>
Expose navigator.globalPrivacyControl only when enabled through the WKWebpagePreferences API
<a href="https://bugs.webkit.org/show_bug.cgi?id=319630">https://bugs.webkit.org/show_bug.cgi?id=319630</a>
<a href="https://rdar.apple.com/182454821">rdar://182454821</a>

Reviewed by Matthew Finkel.

Consolidate GlobalPrivacyControl onto a single control surface. Previously it could be toggled both
by the API and by the GlobalPrivacyControlEnabled preference.

The GlobalPrivacyControlEnabled preference is converted from a WKPreferences knob into a
WebCore-only std::optional&lt;bool&gt; setting written only by the API path, and the IDL attribute is
gated with [EnabledBySetting]. As a result navigator.globalPrivacyControl is not surfaced unless the
embedder opts in, and is surfaced as true/false when it does.

Because the value is now a per-navigation API value rather than a globally synced preference, it no
longer reaches service/shared worker contexts for free, so it is carried to them via
ServiceWorkerContextData and WorkerInitializationData and applied in Page::setupForRemoteWorker,
mirroring advancedPrivacyProtections.

WebKitTestRunner enables it via the website-policies API for tests served under the
web-platform-tests gpc/ directory.

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebsitePolicies.mm

* LayoutTests/fast/dom/navigator-detached-no-crash-expected.txt:
* LayoutTests/platform/gtk/fast/dom/navigator-detached-no-crash-expected.txt:
* LayoutTests/platform/mac-wk2/fast/dom/navigator-detached-no-crash-expected.txt:
* LayoutTests/platform/win/fast/dom/navigator-detached-no-crash-expected.txt:
* LayoutTests/platform/wpe/fast/dom/navigator-detached-no-crash-expected.txt:
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::DocumentLoader::applyPoliciesToSettings):
* Source/WebCore/loader/DocumentLoader.h:
(WebCore::DocumentLoader::setGlobalPrivacyControlEnabled):
(WebCore::DocumentLoader::globalPrivacyControlEnabled const):
* Source/WebCore/page/NavigatorGlobalPrivacyControl.cpp:
(WebCore::NavigatorGlobalPrivacyControl::globalPrivacyControlEnabled):
* Source/WebCore/page/NavigatorGlobalPrivacyControl.idl:
* Source/WebCore/page/Page.cpp:
(WebCore::Page::setupForRemoteWorker):
* Source/WebCore/page/Page.h:
* Source/WebCore/workers/WorkerInitializationData.h:
(WebCore::WorkerInitializationData::isolatedCopy const):
* Source/WebCore/workers/WorkerScriptLoader.cpp:
(WebCore::WorkerScriptLoader::loadSynchronously):
(WebCore::WorkerScriptLoader::loadAsynchronously):
* Source/WebCore/workers/WorkerScriptLoader.h:
* Source/WebCore/workers/service/ServiceWorkerClientData.cpp:
(WebCore::ServiceWorkerClientData::isolatedCopy const):
(WebCore::ServiceWorkerClientData::isolatedCopy):
(WebCore::ServiceWorkerClientData::from):
* Source/WebCore/workers/service/ServiceWorkerClientData.h:
* Source/WebCore/workers/service/ServiceWorkerContextData.cpp:
(WebCore::ServiceWorkerContextData::isolatedCopy const):
(WebCore::ServiceWorkerContextData::isolatedCopy):
(WebCore::ServiceWorkerContextData::copy const):
* Source/WebCore/workers/service/ServiceWorkerContextData.h:
* Source/WebCore/workers/service/server/SWServer.cpp:
(WebCore::SWServer::globalPrivacyControlEnabledFromClient const):
(WebCore::SWServer::installContextData):
(WebCore::SWServer::runServiceWorker):
* Source/WebCore/workers/service/server/SWServer.h:
* Source/WebCore/workers/shared/SharedWorkerScriptLoader.cpp:
(WebCore::SharedWorkerScriptLoader::notifyFinished):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/Shared/WebsitePoliciesData.cpp:
(WebKit::WebsitePoliciesData::applyToDocumentLoader):
* Source/WebKit/UIProcess/API/C/WKWebsitePolicies.cpp:
(WKWebsitePoliciesSetGlobalPrivacyControlEnabled):
(WKWebsitePoliciesGetGlobalPrivacyControlEnabled):
* Source/WebKit/UIProcess/API/C/WKWebsitePolicies.h:
* Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp:
(WebKit::addParametersShared):
* Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.cpp:
(WebKit::WebSWContextManagerConnection::installServiceWorker):
* Source/WebKit/WebProcess/Storage/WebSharedWorkerContextManagerConnection.cpp:
(WebKit::WebSharedWorkerContextManagerConnection::launchSharedWorker):
* Tools/TestRunnerShared/TestFeatures.cpp:
(WTR::shouldEnableGlobalPrivacyControl):
(WTR::hardcodedFeaturesBasedOnPathForTest):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebsitePolicies.mm:
* Tools/WebKitTestRunner/TestController.cpp:
(WTR::TestController::resetPreferencesToConsistentValues):
(WTR::TestController::resetStateToConsistentValues):
* Tools/WebKitTestRunner/TestController.h:
(WTR::TestController::setGlobalPrivacyControl):
(WTR::TestController::globalPrivacyControl const):
* Tools/WebKitTestRunner/TestInvocation.cpp:
(WTR::TestInvocation::didReceiveSynchronousMessageFromInjectedBundle):
* Tools/WebKitTestRunner/TestOptions.cpp:
(WTR::TestOptions::defaults):
* Tools/WebKitTestRunner/TestOptions.h:
(WTR::TestOptions::globalPrivacyControl const):

Canonical link: <a href="https://commits.webkit.org/317802@main">https://commits.webkit.org/317802@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c10989e985013f833d6b8f2d30101ac96273ea45

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175148 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49080 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42861 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184733 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/133055 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1dc55d99-147f-43e6-b676-f066066b8b8d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/177012 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50372 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48763 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136331 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96161 "1 flakes 5 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fd14dc30-d9e0-4bbb-82af-ff141def7853) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178105 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39764 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157116 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116810 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/032068c9-ee3b-4017-bfc7-d4f58e3b7514) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38405 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36788 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33206 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/5625 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148828 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36609 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187153 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/36409 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/40767 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40991 "Found 1 new test failure: http/tests/workers/service/service-worker-download-task-uaf.https.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145274 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48747 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145130 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49427 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33229 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115262 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26780 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39987 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/121632 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/212239 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47933 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11582 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/55384 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47336 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47566 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47393 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->