### PR TITLE
[AppKit Gestures] Fix incorrect logic in `PositionInformationManager::invokeAndRemovePendingHandlers` that could result in a reentrancy UAF

### DIFF
--- a/Source/WebKit/UIProcess/mac/PositionInformationManager.cpp
+++ b/Source/WebKit/UIProcess/mac/PositionInformationManager.cpp
@@ -134,13 +134,16 @@ bool PositionInformationManager::hasValidOutstandingRequest(const InteractionInf
     }).value_or(false);
 }
 
-void PositionInformationManager::invokeAndRemovePendingHandlers(Function<bool(InteractionInformationRequest)>&& matches, const std::optional<InteractionInformationAtPosition>& information)
+void PositionInformationManager::invokeAndRemovePendingHandlers(Function<bool(const InteractionInformationRequest&)>&& matches, const std::optional<InteractionInformationAtPosition>& information)
 {
     ++m_callbackDepth;
 
-    for (auto& slot : m_pendingHandlers) {
+    // This is intentionally not a range-based for-loop as doing so can result in a reentrancy UAF due to stale iterator pointers.
+    for (size_t index = 0; index < m_pendingHandlers.size(); ++index) {
+        auto& slot = m_pendingHandlers[index];
         if (!slot)
             continue;
+
         if (!matches(slot->request))
             continue;
 

--- a/Source/WebKit/UIProcess/mac/PositionInformationManager.h
+++ b/Source/WebKit/UIProcess/mac/PositionInformationManager.h
@@ -86,7 +86,7 @@ private:
     // Invokes (exactly once) and removes every queued callback whose request satisfies `matches`,
     // passing `information` to each. Reentrancy-safe: callbacks may re-enter and mutate the queue, so
     // consumed slots are left as tombstones and only compacted once the outermost invocation unwinds.
-    void invokeAndRemovePendingHandlers(Function<bool(InteractionInformationRequest)>&& matches, const std::optional<InteractionInformationAtPosition>&);
+    void invokeAndRemovePendingHandlers(Function<bool(const InteractionInformationRequest&)>&& matches, const std::optional<InteractionInformationAtPosition>&);
 
     struct RequestAndCallback {
         InteractionInformationRequest request;


### PR DESCRIPTION
#### 94c5f976f8554fe62e2a274e713c22031507a0bf
<pre>
[AppKit Gestures] Fix incorrect logic in `PositionInformationManager::invokeAndRemovePendingHandlers` that could result in a reentrancy UAF
<a href="https://bugs.webkit.org/show_bug.cgi?id=319631">https://bugs.webkit.org/show_bug.cgi?id=319631</a>
<a href="https://rdar.apple.com/182455133">rdar://182455133</a>

Reviewed by Megan Gardner and Abrar Rahman Protyasha.

This logic was originally changed to use a range-based for loop instead of an index-based one since
it was non-obvious that there could be functional differences between the two.

`invokeAndRemovePendingHandlers()` iterates m_pendingHandlers with a range-based for loop, which caches
the Vector&apos;s begin/end raw pointers. The invoked callback can synchronously re-enter doAfterUpdate()
(the design explicitly supports reentrancy via m_callbackDepth and tombstone slots), and doAfterUpdate()
calls m_pendingHandlers.constructAndAppend(), which reallocates the backing buffer once capacity is
exceeded. That reallocation invalidates the cached loop iterators and the live slot reference, causing
a use-after-free read/write as the loop continues over freed memory.

Fix by restoring the index-based loop since it re-reads size() and re-indexes each iteration to survive reallocation.

* Source/WebKit/UIProcess/mac/PositionInformationManager.cpp:
(WebKit::PositionInformationManager::invokeAndRemovePendingHandlers):
* Source/WebKit/UIProcess/mac/PositionInformationManager.h:

Canonical link: <a href="https://commits.webkit.org/317401@main">https://commits.webkit.org/317401@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0f26e378bcb7f6155a48235445fcf66ca7715831

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175105 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49038 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42819 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184690 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/133013 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176970 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50330 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48721 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136291 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96136 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178063 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39726 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157079 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116770 "Passed tests") | | ⏳ 🛠 vision-apple 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/174427 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38367 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36754 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33164 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/5588 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148790 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36572 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187111 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/36367 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/40692 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/40957 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145235 "Passed tests") | | 
| [❌ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/174505 "Failed resultsdbpy unit tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48705 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/156635 "") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145091 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49385 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33192 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115219 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26635 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39950 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/121549 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/212197 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47891 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11544 "") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/55355 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47294 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47524 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47351 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->