### PR TITLE
[Damage][Skia] Composite only the damage

### DIFF
--- a/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp
@@ -246,6 +246,10 @@ FloatRect SkiaCompositingLayer::paintedLayerRect() const
     if (m_backdrop.filter)
         rect.unite(m_backdrop.clipRect.rect());
 
+    // A debug border is stroked on the edges of what the layer paints, respect that.
+    if (m_debugBorder)
+        rect.inflate(m_debugBorder->width / 2);
+
     // A filter such as a blur spreads what the layer paints past its bounds, unless something clips it
     // back in, which mirrors what computeOverlapRegions() does with the same outsets.
     auto filter = this->filter();
@@ -353,12 +357,16 @@ void SkiaCompositingLayer::resolveBackdropDamage(const Vector<FloatRect>& backdr
 
 void SkiaCompositingLayer::setDebugIndicators(Color&& debugBorderColor, std::optional<float> debugBorderWidth, std::optional<unsigned> repaintCount)
 {
+    std::optional<DebugBorder> debugBorder;
     if (debugBorderColor.isValid())
-        m_debugBorder = { WTF::move(debugBorderColor), debugBorderWidth.value_or(1) };
-    else
-        m_debugBorder = std::nullopt;
+        debugBorder = { WTF::move(debugBorderColor), debugBorderWidth.value_or(1) };
 
+    if (m_debugBorder == debugBorder && m_repaintCount == repaintCount)
+        return;
+
+    m_debugBorder = WTF::move(debugBorder);
     m_repaintCount = repaintCount;
+    damageWholeLayer();
 }
 
 const TransformationMatrix& SkiaCompositingLayer::localTransform() const
@@ -499,7 +507,7 @@ bool SkiaCompositingLayer::computeTransformsAndAnimations(const TransformationMa
     return hasRunningAnimations;
 }
 
-bool SkiaCompositingLayer::paint(SkCanvas& canvas, std::optional<Damage>& frameDamage, const std::optional<Damage>& priorTargetDamage)
+bool SkiaCompositingLayer::paint(SkCanvas& canvas, std::optional<Damage>& frameDamage, const std::optional<Damage>& priorTargetDamage, std::optional<SkColor> clearColor)
 {
     // Both walks below assume the animations have been applied and the transforms computed.
     bool hasRunningAnimations = computeTransformsAndAnimations({ }, { }, MonotonicTime::now());
@@ -551,8 +559,21 @@ bool SkiaCompositingLayer::paint(SkCanvas& canvas, std::optional<Damage>& frameD
     UNUSED_PARAM(priorTargetDamage);
 #endif
 
-    // An empty region means the target already holds the frame, so draw nothing.
-    if (!damageRegion || !damageRegion->isEmpty()) {
+    // An empty region means the target already holds the frame, so draw nothing and skip the clear.
+    const bool skipDraw = damageRegion && damageRegion->isEmpty();
+    if (!skipDraw) {
+        // Clear what will be redrawn - only the damage rects when compositing from the damage, which keeps
+        // undamaged content and composites translucent content once, or the whole target otherwise.
+        if (clearColor) {
+            if (damageRegion) {
+                SkPaint clearPaint;
+                clearPaint.setColor(*clearColor);
+                clearPaint.setBlendMode(SkBlendMode::kSrc);
+                damageRegion->fillCanvasInDeviceSpace(canvas, clearPaint);
+            } else
+                canvas.clear(*clearColor);
+        }
+
         PaintContext context;
         context.compositingDamageRegion = WTF::move(damageRegion);
 

--- a/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.h
@@ -119,7 +119,7 @@ public:
     // it is collected first in a walk that draws nothing, before the walk that draws. The draw is limited
     // to the region the target must redraw - the target's prior owed damage combined with this frame's - and
     // no prior damage repaints the whole target. Returns whether any animation is still running.
-    bool paint(SkCanvas&, std::optional<Damage>& frameDamage, const std::optional<Damage>& priorTargetDamage = std::nullopt);
+    bool paint(SkCanvas&, std::optional<Damage>& frameDamage, const std::optional<Damage>& priorTargetDamage = std::nullopt, std::optional<SkColor> clearColor = std::nullopt);
 
 private:
     using ScopedFlush = SkiaCompositingLayerImageSetBatch::ScopedFlush;
@@ -281,6 +281,8 @@ private:
     struct DebugBorder {
         Color color;
         float width { 0 };
+
+        friend bool operator==(const DebugBorder&, const DebugBorder&) = default;
     };
 
     Vector<Ref<SkiaCompositingLayer>> m_children;

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperLayer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperLayer.cpp
@@ -1433,6 +1433,51 @@ void TextureMapperLayer::setOpacity(float opacity)
     m_state.opacity = opacity;
 }
 
+void TextureMapperLayer::setShowDebugBorder(bool showDebugBorder)
+{
+#if ENABLE(DAMAGE_TRACKING)
+    if (m_damagePropagationEnabled && m_state.showDebugBorders != showDebugBorder)
+        damageWholeLayer();
+#endif
+    m_state.showDebugBorders = showDebugBorder;
+}
+
+void TextureMapperLayer::setDebugBorderColor(Color debugBorderColor)
+{
+#if ENABLE(DAMAGE_TRACKING)
+    if (m_damagePropagationEnabled && m_state.showDebugBorders && m_state.debugBorderColor != debugBorderColor)
+        damageWholeLayer();
+#endif
+    m_state.debugBorderColor = debugBorderColor;
+}
+
+void TextureMapperLayer::setDebugBorderWidth(float debugBorderWidth)
+{
+#if ENABLE(DAMAGE_TRACKING)
+    if (m_damagePropagationEnabled && m_state.showDebugBorders && m_state.debugBorderWidth != debugBorderWidth)
+        damageWholeLayer();
+#endif
+    m_state.debugBorderWidth = debugBorderWidth;
+}
+
+void TextureMapperLayer::setShowRepaintCounter(bool showRepaintCounter)
+{
+#if ENABLE(DAMAGE_TRACKING)
+    if (m_damagePropagationEnabled && m_state.showRepaintCounter != showRepaintCounter)
+        damageWholeLayer();
+#endif
+    m_state.showRepaintCounter = showRepaintCounter;
+}
+
+void TextureMapperLayer::setRepaintCount(int repaintCount)
+{
+#if ENABLE(DAMAGE_TRACKING)
+    if (m_damagePropagationEnabled && m_state.showRepaintCounter && m_state.repaintCount != repaintCount)
+        damageWholeLayer();
+#endif
+    m_state.repaintCount = repaintCount;
+}
+
 void TextureMapperLayer::setSolidColor(const Color& color)
 {
 #if ENABLE(DAMAGE_TRACKING)

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperLayer.h
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperLayer.h
@@ -95,12 +95,12 @@ public:
         return !m_currentFilters.isEmpty();
     }
 
-    void setShowDebugBorder(bool showDebugBorder) { m_state.showDebugBorders = showDebugBorder; }
-    void setDebugBorderColor(Color debugBorderColor) { m_state.debugBorderColor = debugBorderColor; }
-    void setDebugBorderWidth(float debugBorderWidth) { m_state.debugBorderWidth = debugBorderWidth; }
+    void setShowDebugBorder(bool);
+    void setDebugBorderColor(Color);
+    void setDebugBorderWidth(float);
 
-    void setShowRepaintCounter(bool showRepaintCounter) { m_state.showRepaintCounter = showRepaintCounter; }
-    void setRepaintCount(int repaintCount) { m_state.repaintCount = repaintCount; }
+    void setShowRepaintCounter(bool);
+    void setRepaintCount(int);
 
     WEBCORE_EXPORT void setContentsLayer(TextureMapperPlatformLayer*);
     void setAnimations(const TextureMapperAnimations&);

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.cpp
@@ -38,7 +38,6 @@
 #include <WebCore/Region.h>
 #include <WebCore/Settings.h>
 #include <WebCore/ShareableBitmap.h>
-#include <WebCore/SkiaDamageRegion.h>
 #include <array>
 #include <fcntl.h>
 #include <unistd.h>
@@ -915,7 +914,7 @@ void AcceleratedSurface::SwapChainDamageTracker::didPresent(RenderTarget& target
     // The target is now current, so start a fresh, empty record. NoMaxRectangles keeps the grid as
     // fine as the mode allows, since on a wide, short surface the threshold would collapse it into a
     // few full-height cells.
-    target.setDamage(Damage(m_swapChain.size(), m_needsFineGrainedDamage ? Damage::Mode::Rectangles : Damage::Mode::BoundingBox, Damage::NoMaxRectangles));
+    target.setDamage(Damage(m_swapChain.size(), needsFineGrainedDamage() ? Damage::Mode::Rectangles : Damage::Mode::BoundingBox, Damage::NoMaxRectangles));
 }
 #endif
 
@@ -1068,37 +1067,35 @@ void AcceleratedSurface::willRenderFrame(const IntSize& size)
         glViewport(0, 0, size.width(), size.height());
 }
 
-static void clearCanvas(SkCanvas& canvas, SkColor color, const SkiaDamageRegion* damageRegion)
+std::optional<Color> AcceleratedSurface::backgroundColor()
 {
-    if (!damageRegion) {
-        canvas.clear(color);
-        return;
-    }
-
-    SkPaint paint;
-    paint.setColor(color);
-    paint.setBlendMode(SkBlendMode::kSrc);
-    damageRegion->fillCanvasInDeviceSpace(canvas, paint);
+    Locker locker { m_backgroundColorLock };
+    return m_backgroundColor;
 }
 
-void AcceleratedSurface::clear(const OptionSet<WebCore::CompositionReason>& reasons, const SkiaDamageRegion* damageRegion)
+std::optional<SkColor> AcceleratedSurface::skiaClearColor(const OptionSet<WebCore::CompositionReason>& reasons)
 {
-    std::optional<Color> backgroundColor;
-    {
-        Locker locker { m_backgroundColorLock };
-        backgroundColor = m_backgroundColor;
-    }
+    const auto backgroundColor = this->backgroundColor();
+    if (backgroundColor && !backgroundColor->isOpaque())
+        return SK_ColorTRANSPARENT;
 
+    if (reasons.contains(CompositionReason::AsyncScrolling))
+        return backgroundColor ? SkColor(*backgroundColor) : SK_ColorWHITE;
+
+    return std::nullopt;
+}
+
+void AcceleratedSurface::clear(const OptionSet<WebCore::CompositionReason>& reasons)
+{
     if (m_useSkia) {
-        if (auto* canvas = this->canvas()) {
-            if (backgroundColor && !backgroundColor->isOpaque())
-                clearCanvas(*canvas, SK_ColorTRANSPARENT, damageRegion);
-            else if (reasons.contains(CompositionReason::AsyncScrolling))
-                clearCanvas(*canvas, backgroundColor ? SkColor(*backgroundColor) : SK_ColorWHITE, damageRegion);
+        if (auto clearColor = skiaClearColor(reasons)) {
+            if (auto* canvas = this->canvas())
+                canvas->clear(*clearColor);
         }
         return;
     }
 
+    const auto backgroundColor = this->backgroundColor();
     if (backgroundColor && !backgroundColor->isOpaque()) {
         glClearColor(0, 0, 0, 0);
         glClear(GL_COLOR_BUFFER_BIT);

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.h
@@ -33,6 +33,7 @@
 #include <WebCore/DMABufBuffer.h>
 #include <WebCore/Damage.h>
 #include <WebCore/IntSize.h>
+#include <atomic>
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
 #include <skia/core/SkSurface.h>
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
@@ -46,7 +47,6 @@ WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 
 #if USE(GBM) || OS(ANDROID)
 #include "RendererBufferFormat.h"
-#include <atomic>
 #endif
 
 #if USE(GBM)
@@ -76,7 +76,6 @@ class BitmapTexture;
 class GLFence;
 class ShareableBitmap;
 class ShareableBitmapHandle;
-class SkiaDamageRegion;
 }
 
 namespace WebKit {
@@ -85,6 +84,14 @@ class AcceleratedSurface;
 
 namespace WebKit {
 class WebPage;
+
+// Whether the target holds the frame it was meant to hold once rendering ends. A frame that painted
+// nothing because the target was already current is still Valid.
+enum class TargetContents : bool {
+    // Nothing was drawn, so the next use of this target must repaint it in full.
+    Invalid,
+    Valid
+};
 
 class AcceleratedSurface final : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<AcceleratedSurface, WTF::DestructionThread::MainRunLoop>, public CanMakeThreadSafeCheckedPtr<AcceleratedSurface>
 #if PLATFORM(GTK) || ENABLE(WPE_PLATFORM)
@@ -133,17 +140,14 @@ public:
     void willDestroyGLContext();
     void willRenderFrame(const WebCore::IntSize&);
 
-    enum class TargetContents : bool {
-        // The next use of this target must repaint it in full, because either nothing was drawn or what
-        // was drawn contains pixels the layer tree will not reproduce, like a debug overlay.
-        Invalid,
-        Valid
-    };
     void didRenderFrame(TargetContents = TargetContents::Valid);
     void sendFrame();
-    void clear(const OptionSet<WebCore::CompositionReason>&, const WebCore::SkiaDamageRegion* = nullptr);
+    void clear(const OptionSet<WebCore::CompositionReason>&);
+
+    std::optional<SkColor> skiaClearColor(const OptionSet<WebCore::CompositionReason>&);
 
 #if ENABLE(DAMAGE_TRACKING)
+    void setDamageUsedForCompositing(bool used) { m_damageTracker.setDamageUsedForCompositing(used); }
     void setFrameDamage(WebCore::Damage&& damage) { m_damageTracker.recordFrameDamage(WTF::move(damage), SwapChainDamageTracker::AccumulateIntoSwapChain::Yes); }
 
     void setFrameDamageForPlatformOnly(WebCore::Damage&& damage) { m_damageTracker.recordFrameDamage(WTF::move(damage), SwapChainDamageTracker::AccumulateIntoSwapChain::No); }
@@ -171,6 +175,7 @@ private:
 #endif
     bool useSkia() const { return m_useSkia; }
     bool isOpaque() const;
+    std::optional<WebCore::Color> backgroundColor();
 
 #if PLATFORM(GTK) || ENABLE(WPE_PLATFORM)
     // IPC::MessageReceiver.
@@ -434,15 +439,16 @@ private:
     class SwapChainDamageTracker {
         WTF_MAKE_NONCOPYABLE(SwapChainDamageTracker);
     public:
-        // needsFineGrainedDamage tells whether the records need individual rects, which is only worth
-        // building when someone iterates them, and no GL consumer does, reading nothing but the bounds.
-        SwapChainDamageTracker(SwapChain& swapChain, bool needsFineGrainedDamage)
+        // A record needs individual rects only when a consumer walks them - the platform on the non-GL
+        // path, and the Skia compositor when it draws just the damage. Everyone else reads the bounds.
+        SwapChainDamageTracker(SwapChain& swapChain, bool platformWalksDamageRects)
             : m_swapChain(swapChain)
-            , m_needsFineGrainedDamage(needsFineGrainedDamage)
+            , m_platformWalksDamageRects(platformWalksDamageRects)
         {
         }
 
         void setRectangleThreshold(unsigned threshold) { m_rectangleThreshold = threshold; }
+        void setDamageUsedForCompositing(bool used) { m_damageUsedForCompositing = used; }
 
         enum class AccumulateIntoSwapChain : bool { No, Yes };
 
@@ -464,8 +470,11 @@ private:
         }
 
     private:
+        bool needsFineGrainedDamage() const { return m_platformWalksDamageRects || m_damageUsedForCompositing; }
+
         SwapChain& m_swapChain;
-        const bool m_needsFineGrainedDamage;
+        const bool m_platformWalksDamageRects;
+        std::atomic<bool> m_damageUsedForCompositing { false };
         std::optional<WebCore::Damage> m_frameDamage;
         // The most rects takeFrameDamageRects() will return. Once the frame damage holds more than
         // this many rects, they all collapse into their single bounding box, trading precision for a

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp
@@ -57,11 +57,30 @@
 #include <wtf/SystemTracing.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/glib/RunLoopSourcePriority.h>
+#include <wtf/text/StringToIntegerConversion.h>
 
 namespace WebKit {
 using namespace WebCore;
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(LayerTreeHost);
+
+#if ENABLE(DAMAGE_TRACKING)
+static bool damageOverlayForcesPropagation(const Settings& settings)
+{
+    // WEBKIT_SHOW_DAMAGE draws the damage the layers report, so it needs propagation on even when the
+    // propagateDamagingInformation setting that normally turns it on is off. Only the Skia accumulated-damage
+    // overlay is handled here. The non-Skia TextureMapperDamageVisualizer draws off the propagation flags instead.
+    if (!settings.useSkiaForComposition())
+        return false;
+
+    const auto* showDamageEnvvar = getenv("WEBKIT_SHOW_DAMAGE");
+    if (!showDamageEnvvar)
+        return false;
+
+    auto value = parseInteger<unsigned>(StringView::fromLatin1(showDamageEnvvar));
+    return value && *value;
+}
+#endif
 
 std::unique_ptr<LayerTreeHost> LayerTreeHost::create(WebPage& webPage)
 {
@@ -75,8 +94,10 @@ LayerTreeHost::LayerTreeHost(WebPage& webPage)
     {
         auto& rootLayer = m_sceneState->rootLayer();
 #if ENABLE(DAMAGE_TRACKING)
-        rootLayer.setDamagePropagationEnabled(webPage.corePage()->settings().propagateDamagingInformation());
-        if (webPage.corePage()->settings().propagateDamagingInformation()) {
+        const auto& settings = webPage.corePage()->settings();
+        const bool propagateDamage = settings.propagateDamagingInformation() || damageOverlayForcesPropagation(settings);
+        rootLayer.setDamagePropagationEnabled(propagateDamage);
+        if (propagateDamage) {
             m_damageInGlobalCoordinateSpace = std::make_shared<Damage>(m_webPage->size());
             rootLayer.setDamageInGlobalCoordinateSpace(m_damageInGlobalCoordinateSpace);
         }
@@ -320,7 +341,7 @@ void LayerTreeHost::backgroundColorDidChange()
 void LayerTreeHost::attachLayer(CoordinatedPlatformLayer& layer)
 {
 #if ENABLE(DAMAGE_TRACKING)
-    layer.setDamagePropagationEnabled(m_webPage->corePage()->settings().propagateDamagingInformation());
+    layer.setDamagePropagationEnabled(!!m_damageInGlobalCoordinateSpace);
     if (m_damageInGlobalCoordinateSpace)
         layer.setDamageInGlobalCoordinateSpace(m_damageInGlobalCoordinateSpace);
 #endif

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.cpp
@@ -40,6 +40,7 @@
 #include <WebCore/PlatformDisplay.h>
 #include <WebCore/Settings.h>
 #include <WebCore/SkiaCompositingLayer.h>
+#include <WebCore/SkiaDamageRegion.h>
 #include <WebCore/TextureMapperLayer.h>
 #include <WebCore/TransformationMatrix.h>
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
@@ -92,13 +93,11 @@ ThreadedCompositor::ThreadedCompositor(WebPage& webPage, LayerTreeHost& layerTre
     initializeFPSCounter();
 #if ENABLE(DAMAGE_TRACKING)
     if (m_useSkia) {
-        // WEBKIT_SHOW_DAMAGE=N renders the frame damage rects, insetting them
-        // by N-1 pixels (mirrors TextureMapperDamageVisualizer's behavior).
-        if (const auto* showDamageVariable = getenv("WEBKIT_SHOW_DAMAGE")) {
-            if (auto value = parseInteger<unsigned>(StringView::fromLatin1(showDamageVariable)); value && *value) {
-                m_damage.showSkiaDamage = true;
-                m_damage.skiaDamageMargin = *value - 1;
-            }
+        // The margin TextureMapperDamageVisualizer takes means nothing here, since the overlay fills the
+        // damage as a region, but the same variable enables both so it does not depend on the compositor.
+        if (const auto* showDamageEnvvar = getenv("WEBKIT_SHOW_DAMAGE")) {
+            if (auto value = parseInteger<unsigned>(StringView::fromLatin1(showDamageEnvvar)); value && *value)
+                m_damage.showAccumulatedDamageOverlay = true;
         }
     } else
         m_damage.visualizer = TextureMapperDamageVisualizer::create();
@@ -287,16 +286,31 @@ void ThreadedCompositor::setSize(const IntSize& size, float deviceScaleFactor)
 void ThreadedCompositor::setDamagePropagationSettings(std::optional<OptionSet<DamagePropagationFlags>> flags, unsigned rectangleThreshold)
 {
     m_damage.flags = flags;
-    if ((m_damage.visualizer || m_damage.showSkiaDamage) && m_damage.flags) {
-        // We don't use damage when rendering layers if the visualizer is enabled, because we need to make sure the whole
-        // frame is invalidated in the next paint so that previous damage rects are cleared.
-        m_damage.flags->remove(DamagePropagationFlags::UseForCompositing);
-    }
 
     rectangleThreshold = Damage::clampRectangleThreshold(rectangleThreshold);
-    m_damage.rectangleThreshold = rectangleThreshold;
-    if (m_surface)
+    if (m_surface) {
         m_surface->setFrameDamageRectangleThreshold(rectangleThreshold);
+        m_surface->setDamageUsedForCompositing(damageUsedForCompositing());
+    }
+}
+
+bool ThreadedCompositor::damageUsedForCompositing() const
+{
+    // Only the Skia compositor draws just the damage rects. TextureMapper scissors with the damage
+    // bounds, which needs neither fine-grained records nor swap-chain accumulation.
+    return m_useSkia && m_damage.flags && m_damage.flags->contains(DamagePropagationFlags::UseForCompositing);
+}
+
+bool ThreadedCompositor::drawsOverlay() const
+{
+    // The damage overlay is drawn by paintToSkiaCanvas(), the visualizer by paintToTextureMapper(), so
+    // each path only has its own. Both draw over the damage itself, and damaging what they drew would
+    // feed their own rects back into what they show next, growing until they cover the surface. So the
+    // frame repaints in full instead. The FPS counter has no such loop and damages its own box.
+    if (m_useSkia)
+        return m_damage.showAccumulatedDamageOverlay;
+
+    return !!m_damage.visualizer;
 }
 
 void ThreadedCompositor::enableFrameDamageNotificationForTesting()
@@ -320,12 +334,13 @@ void ThreadedCompositor::flushCompositingState(const OptionSet<CompositionReason
     m_sceneState->flushCompositingState(reasons, m_useSkia);
 }
 
-void ThreadedCompositor::paintToCurrentGLContext(const TransformationMatrix& matrix, const IntSize& size, const OptionSet<CompositionReason>& reasons)
+TargetContents ThreadedCompositor::paintToCurrentGLContext(const TransformationMatrix& matrix, const IntSize& size, const OptionSet<CompositionReason>& reasons)
 {
     if (m_useSkia)
-        paintToSkiaCanvas(matrix, size, reasons);
-    else
-        paintToTextureMapper(matrix, size, reasons);
+        return paintToSkiaCanvas(matrix, size, reasons);
+
+    paintToTextureMapper(matrix, size, reasons);
+    return TargetContents::Valid;
 }
 
 void ThreadedCompositor::paintToTextureMapper(const TransformationMatrix& matrix, const IntSize& size, const OptionSet<CompositionReason>& reasons)
@@ -350,18 +365,19 @@ void ThreadedCompositor::paintToTextureMapper(const TransformationMatrix& matrix
         currentRootLayer.collectDamage(*m_textureMapper, frameDamage);
         WTFEndSignpost(this, CollectDamage);
 
-        if (m_damage.shouldNotifyFrameDamageForTesting && m_layerTreeHost)
-            m_layerTreeHost->notifyFrameDamageForTesting(frameDamage.regionForTesting());
-
-        if (!frameDamage.isEmpty())
-            m_surface->setFrameDamage(WTF::move(frameDamage));
+        recordFrameDamage(WTF::move(frameDamage));
 
         if (m_damage.flags->contains(DamagePropagationFlags::UseForCompositing)) {
-            const auto& damageSinceLastSurfaceUse = m_surface->renderTargetDamage();
-            if (damageSinceLastSurfaceUse && !FloatRect(damageSinceLastSurfaceUse->bounds()).contains(clipRect))
-                rectContainingRegionThatActuallyChanged = FloatRoundedRect(damageSinceLastSurfaceUse->bounds());
+            if (drawsOverlay()) {
+                // No damage means repaint the whole frame, so skip the scissor below too.
+                m_textureMapper->setDamage(std::nullopt);
+            } else {
+                const auto& damageSinceLastSurfaceUse = m_surface->renderTargetDamage();
+                if (damageSinceLastSurfaceUse && !FloatRect(damageSinceLastSurfaceUse->bounds()).contains(clipRect))
+                    rectContainingRegionThatActuallyChanged = FloatRoundedRect(damageSinceLastSurfaceUse->bounds());
 
-            m_textureMapper->setDamage(damageSinceLastSurfaceUse);
+                m_textureMapper->setDamage(damageSinceLastSurfaceUse);
+            }
         }
     }
 
@@ -385,7 +401,7 @@ void ThreadedCompositor::paintToTextureMapper(const TransformationMatrix& matrix
         m_damage.visualizer->paintDamage(*m_textureMapper, m_surface->frameDamage());
         // When damage visualizer is active, we cannot send the original damage to the platform as in this case
         // the damage rects visualized previous frame may not get erased if platform actually uses damage.
-        m_surface->setFrameDamage(Damage(size, Damage::Mode::Full));
+        m_surface->setFrameDamageForPlatformOnly(Damage(size, Damage::Mode::Full));
     }
 #endif
 
@@ -396,45 +412,88 @@ void ThreadedCompositor::paintToTextureMapper(const TransformationMatrix& matrix
         requestComposition(CompositionReason::Animation);
 }
 
-void ThreadedCompositor::paintToSkiaCanvas(const TransformationMatrix& matrix, const IntSize& size, const OptionSet<CompositionReason>& reasons)
+#if ENABLE(DAMAGE_TRACKING)
+void ThreadedCompositor::recordFrameDamage(Damage&& damage)
+{
+    if (m_damage.shouldNotifyFrameDamageForTesting && m_layerTreeHost)
+        m_layerTreeHost->notifyFrameDamageForTesting(damage.regionForTesting());
+
+    // Nothing changed this frame: an empty damage contributes nothing to the targets, since Damage::add()
+    // ignores empty damage. Skip it rather than replace the recorded frame damage with an empty one.
+    if (damage.isEmpty())
+        return;
+
+    m_surface->setFrameDamage(WTF::move(damage));
+}
+
+static void drawDamageOverlay(SkCanvas& canvas, const Damage& damage, const IntSize& size, SkColor color)
+{
+    SkPaint paint;
+    paint.setStyle(SkPaint::kFill_Style);
+    paint.setColor(color);
+
+    // Drawn as a region, so the translucent overlay composites once even where the rects touch. No region
+    // means the damage covers the whole surface, which the overlay has to show as such.
+    if (auto damageRegion = SkiaDamageRegion::create(damage, size))
+        damageRegion->fillCanvasInDeviceSpace(canvas, paint);
+    else
+        canvas.drawPaint(paint);
+}
+#endif
+
+TargetContents ThreadedCompositor::paintToSkiaCanvas(const TransformationMatrix& matrix, const IntSize& size, const OptionSet<CompositionReason>& reasons)
 {
     auto* canvas = m_surface->canvas();
     if (!canvas)
-        return;
+        return TargetContents::Invalid;
 
     auto& rootLayer = m_sceneState->rootLayer().ensureSkiaTarget();
     rootLayer.setTransform(matrix);
 
+    // paint() collects this frame's damage into frameDamage, and limits the draw to what this target must
+    // redraw: priorTargetDamage - what changed since the target was last current, read before this frame
+    // is recorded - folded with frameDamage. An unset priorTargetDamage repaints the whole target.
     std::optional<Damage> frameDamage;
+    std::optional<Damage> priorTargetDamage;
+    const std::optional<SkColor> clearColor = m_surface->skiaClearColor(reasons);
+
 #if ENABLE(DAMAGE_TRACKING)
-    // The damage is collected by a walk of its own, which draws nothing, before the walk that draws.
-    if (m_damage.flags)
-        frameDamage = Damage(size, m_damage.flags->contains(DamagePropagationFlags::Unified) ? Damage::Mode::BoundingBox : Damage::Mode::Rectangles);
+    // Also collect for the accumulated-damage overlay, so it works with the compositing feature off.
+    if (m_damage.flags || m_damage.showAccumulatedDamageOverlay)
+        frameDamage = Damage(size, m_damage.flags && m_damage.flags->contains(DamagePropagationFlags::Unified) ? Damage::Mode::BoundingBox : Damage::Mode::Rectangles);
+
+    // No layer damages the counter's box, so seed it here, before paint() collects.
+    if (frameDamage && m_fpsCounter.drawsFPS)
+        frameDamage->add(takeFPSCounterDamage());
+
+    // Read the target's record before this frame is recorded into it.
+    if (damageUsedForCompositing() && !drawsOverlay())
+        priorTargetDamage = m_surface->renderTargetDamage();
 #endif
 
-    m_surface->clear(reasons);
-
     canvas->save();
-    const bool hasRunningAnimations = rootLayer.paint(*canvas, frameDamage);
+    const bool hasRunningAnimations = rootLayer.paint(*canvas, frameDamage, priorTargetDamage, clearColor);
     canvas->restore();
 
 #if ENABLE(DAMAGE_TRACKING)
-    if (frameDamage) {
-        if (m_damage.shouldNotifyFrameDamageForTesting && m_layerTreeHost)
-            m_layerTreeHost->notifyFrameDamageForTesting(frameDamage->regionForTesting());
+    // Record into every target, so each one repaints this frame's damage the next time it is used.
+    if (frameDamage)
+        recordFrameDamage(WTF::move(*frameDamage));
 
-        if (!frameDamage->isEmpty())
-            m_surface->setFrameDamage(WTF::move(*frameDamage));
+    if (m_damage.showAccumulatedDamageOverlay) {
+        if (const auto& damage = m_surface->renderTargetDamage(); damage && !damage->isEmpty()) {
+            drawDamageOverlay(*canvas, *damage, size, SkColorSetARGB(128, 0, 255, 0));
+
+            // Schedule one more composition, so that once damage stops the next frame repaints the
+            // overlay away instead of leaving it frozen on an idle page.
+            requestComposition(CompositionReason::Animation);
+        }
     }
 
-    if (m_damage.showSkiaDamage) {
-        if (auto damage = m_surface->frameDamage())
-            drawSkiaDamage(*canvas, damage);
-
-        // When the damage visualizer is active we cannot send the original damage to the platform, as the
-        // damage rects visualized in the previous frame may not get erased if the platform uses damage.
-        m_surface->setFrameDamage(Damage(size, Damage::Mode::Full));
-    }
+    // An overlay is redrawn every frame and is in no layer's damage, so tell the platform the whole
+    // surface changed. Otherwise it may leave the previous frame's overlay on screen.
+    if (drawsOverlay())
+        m_surface->setFrameDamageForPlatformOnly(Damage(size, Damage::Mode::Full));
 #endif
 
     if (m_fpsCounter.drawsFPS)
@@ -445,6 +504,8 @@ void ThreadedCompositor::paintToSkiaCanvas(const TransformationMatrix& matrix, c
 
     if (hasRunningAnimations)
         requestComposition(CompositionReason::Animation);
+
+    return TargetContents::Valid;
 }
 
 #if HAVE(OS_SIGNPOST) || USE(SYSPROF_CAPTURE)
@@ -527,7 +588,7 @@ void ThreadedCompositor::renderLayerTree()
     WTFEndSignpost(this, FlushCompositingState);
 
     WTFBeginSignpost(this, PaintToGLContext);
-    paintToCurrentGLContext(viewportTransform, viewportSize, reasons);
+    const auto targetContents = paintToCurrentGLContext(viewportTransform, viewportSize, reasons);
     WTFEndSignpost(this, PaintToGLContext);
 
     updateFPSCounter();
@@ -542,7 +603,7 @@ void ThreadedCompositor::renderLayerTree()
     else
         PlatformDisplay::sharedDisplay().skiaGLContext()->swapBuffers();
 
-    m_surface->didRenderFrame();
+    m_surface->didRenderFrame(targetContents);
     m_surface->sendFrame();
 
     RunLoop::mainSingleton().dispatch([this, protectedThis = Ref { *this }] {
@@ -705,7 +766,7 @@ void ThreadedCompositor::updateFPSCounter()
         m_fpsCounter.fps = std::nullopt;
 }
 
-void ThreadedCompositor::drawFPSCounter(SkCanvas& canvas)
+static const SkFont& fpsCounterFont()
 {
     static SkFont font = [] {
         constexpr unsigned defaultFontSize = 14;
@@ -720,21 +781,58 @@ void ThreadedCompositor::drawFPSCounter(SkCanvas& canvas)
         f.setSubpixel(true);
         return f;
     }();
+    return font;
+}
 
-    // Scale the box padding with the font size so the overlay stays
-    // proportionate at large WEBKIT_DRAW_FPS_FONT_SIZE values
-    // (~3px at the default size of 14).
-    const float padding = font.getSize() * 0.2f;
+// Scale the box padding with the font size so the overlay stays proportionate at large
+// WEBKIT_DRAW_FPS_FONT_SIZE values (~3px at the default size of 14).
+static float fpsCounterPadding()
+{
+    return fpsCounterFont().getSize() * 0.2f;
+}
 
-    if (m_fpsCounter.lastFPS != m_fpsCounter.displayedFPS) {
-        m_fpsCounter.displayedFPS = m_fpsCounter.lastFPS;
-        m_fpsCounter.fpsString = String::number(m_fpsCounter.lastFPS).ascii();
-        SkRect textBounds;
-        font.measureText(m_fpsCounter.fpsString.data(), m_fpsCounter.fpsString.length(), SkTextEncoding::kUTF8, &textBounds);
-        m_fpsCounter.backgroundWidth = textBounds.width() + padding * 2;
-        m_fpsCounter.backgroundHeight = textBounds.height() + padding * 2;
-        m_fpsCounter.textBaseline = -textBounds.fTop + padding;
-    }
+FloatRect ThreadedCompositor::fpsCounterRect() const
+{
+    return FloatRect(0, 0, m_fpsCounter.backgroundWidth, m_fpsCounter.backgroundHeight);
+}
+
+void ThreadedCompositor::updateFPSCounterGeometry()
+{
+    if (m_fpsCounter.lastFPS == m_fpsCounter.displayedFPS)
+        return;
+
+    m_fpsCounter.displayedFPS = m_fpsCounter.lastFPS;
+    m_fpsCounter.fpsString = String::number(m_fpsCounter.lastFPS).ascii();
+
+    const auto& font = fpsCounterFont();
+    SkRect textBounds;
+    font.measureText(m_fpsCounter.fpsString.data(), m_fpsCounter.fpsString.length(), SkTextEncoding::kUTF8, &textBounds);
+
+    const float padding = fpsCounterPadding();
+    m_fpsCounter.backgroundWidth = textBounds.width() + padding * 2;
+    m_fpsCounter.backgroundHeight = textBounds.height() + padding * 2;
+    m_fpsCounter.textBaseline = -textBounds.fTop + padding;
+}
+
+#if ENABLE(DAMAGE_TRACKING)
+IntRect ThreadedCompositor::takeFPSCounterDamage()
+{
+    // Nothing to repaint on the frames between counts, and drawFPSCounter() redraws the box regardless.
+    if (m_fpsCounter.lastFPS == m_fpsCounter.displayedFPS)
+        return { };
+
+    updateFPSCounterGeometry();
+
+    // The box drawn last frame is damaged too, since it shrinks when the count gets shorter.
+    auto damage = enclosingIntRect(fpsCounterRect());
+    damage.unite(std::exchange(m_fpsCounter.lastDrawnRect, damage));
+    return damage;
+}
+#endif
+
+void ThreadedCompositor::drawFPSCounter(SkCanvas& canvas)
+{
+    updateFPSCounterGeometry();
 
     // Drawn in device space at the top-left corner, matching the debug repaint
     // counter style used by SkiaCompositingLayer.
@@ -744,26 +842,13 @@ void ThreadedCompositor::drawFPSCounter(SkCanvas& canvas)
     SkPaint backgroundPaint;
     backgroundPaint.setColor(SK_ColorBLACK);
     backgroundPaint.setStyle(SkPaint::kFill_Style);
-    canvas.drawRect(SkRect::MakeXYWH(0, 0, m_fpsCounter.backgroundWidth, m_fpsCounter.backgroundHeight), backgroundPaint);
+    canvas.drawRect(SkRect(fpsCounterRect()), backgroundPaint);
 
     SkPaint textPaint;
     textPaint.setColor(SK_ColorWHITE);
     textPaint.setAntiAlias(true);
-    canvas.drawString(m_fpsCounter.fpsString.data(), padding, m_fpsCounter.textBaseline, font, textPaint);
+    canvas.drawString(m_fpsCounter.fpsString.data(), fpsCounterPadding(), m_fpsCounter.textBaseline, fpsCounterFont(), textPaint);
 }
-
-#if ENABLE(DAMAGE_TRACKING)
-void ThreadedCompositor::drawSkiaDamage(SkCanvas& canvas, const std::optional<WebCore::Damage>& damage)
-{
-    SkPaint paint;
-    paint.setStyle(SkPaint::kFill_Style);
-    paint.setColor(SkColorSetARGB(200, 255, 0, 0));
-
-    const auto margin = static_cast<SkScalar>(m_damage.skiaDamageMargin);
-    for (const auto& rect : *damage)
-        canvas.drawRect(SkRect::MakeXYWH(rect.x() - margin, rect.y() - margin, rect.width() + margin * 2, rect.height() + margin * 2), paint);
-}
-#endif
 
 void ThreadedCompositor::fillGLInformation(RenderProcessInfo&& info, CompletionHandler<void(RenderProcessInfo&&)>&& completionHandler)
 {

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.h
@@ -29,7 +29,9 @@
 #include <WebCore/CoordinatedCompositionReason.h>
 #include <WebCore/Damage.h>
 #include <WebCore/DisplayUpdate.h>
+#include <WebCore/FloatRect.h>
 #include <WebCore/GLContext.h>
+#include <WebCore/IntRect.h>
 #include <WebCore/IntSize.h>
 #include <WebCore/RunLoopObserver.h>
 #include <WebCore/TextureMapperDamageVisualizer.h>
@@ -61,6 +63,7 @@ enum class Critical : bool;
 
 namespace WebKit {
 class AcceleratedSurface;
+enum class TargetContents : bool;
 class CoordinatedSceneState;
 class LayerTreeHost;
 class WebPage;
@@ -122,9 +125,9 @@ private:
     void scheduleUpdateLocked();
     void flushCompositingState(const OptionSet<WebCore::CompositionReason>&);
     void renderLayerTree();
-    void paintToCurrentGLContext(const WebCore::TransformationMatrix&, const WebCore::IntSize&, const OptionSet<WebCore::CompositionReason>&);
+    TargetContents paintToCurrentGLContext(const WebCore::TransformationMatrix&, const WebCore::IntSize&, const OptionSet<WebCore::CompositionReason>&);
     void paintToTextureMapper(const WebCore::TransformationMatrix&, const WebCore::IntSize&, const OptionSet<WebCore::CompositionReason>&);
-    void paintToSkiaCanvas(const WebCore::TransformationMatrix&, const WebCore::IntSize&, const OptionSet<WebCore::CompositionReason>&);
+    TargetContents paintToSkiaCanvas(const WebCore::TransformationMatrix&, const WebCore::IntSize&, const OptionSet<WebCore::CompositionReason>&);
     void frameComplete();
 
     void didCompositeRunLoopObserverFired();
@@ -133,9 +136,15 @@ private:
 
     void initializeFPSCounter();
     void updateFPSCounter();
+    void updateFPSCounterGeometry();
+    WebCore::FloatRect fpsCounterRect() const;
     void drawFPSCounter(SkCanvas&);
 #if ENABLE(DAMAGE_TRACKING)
-    void drawSkiaDamage(SkCanvas&, const std::optional<WebCore::Damage>&);
+    bool drawsOverlay() const;
+
+    WebCore::IntRect takeFPSCounterDamage();
+    void recordFrameDamage(WebCore::Damage&&);
+    bool damageUsedForCompositing() const;
 #endif
 
     const Ref<WorkQueue> m_workQueue;
@@ -192,17 +201,14 @@ private:
         float backgroundWidth { 0 };
         float backgroundHeight { 0 };
         float textBaseline { 0 };
+        WebCore::IntRect lastDrawnRect;
     } m_fpsCounter;
 
 #if ENABLE(DAMAGE_TRACKING)
     struct {
         std::optional<OptionSet<DamagePropagationFlags>> flags;
-        unsigned rectangleThreshold { 4 };
         std::unique_ptr<WebCore::TextureMapperDamageVisualizer> visualizer;
-
-        bool showSkiaDamage { false };
-        unsigned skiaDamageMargin { 0 };
-
+        bool showAccumulatedDamageOverlay { false };
         std::atomic<bool> shouldNotifyFrameDamageForTesting { false };
     } m_damage;
 #endif


### PR DESCRIPTION
#### 48a050966d899df1be64b7b2d1860267742769cf
<pre>
[Damage][Skia] Composite only the damage
<a href="https://bugs.webkit.org/show_bug.cgi?id=315990">https://bugs.webkit.org/show_bug.cgi?id=315990</a>

Reviewed by Alejandro G. Castro.

Wire the pieces together and start painting from the damage, if the feature
&apos;UseDamagingInformationForCompositing&apos; is turned on (not yet on by default).

Each frame&apos;s damage is recorded for the platform and into every swap-chain target,
and the target, the frame is drawn into, brings its own record of what changed since
it was last current. The two together are the region the frame is painted against:
everything when there is no record or it covers the surface, nothing when the target
already holds the frame, and otherwise the clear and every draw are limited to its rects.

paint() collects and draws in one call, so the compositor reads the target&apos;s record
before painting and passes it as priorTargetDamage, to be folded there with this
frame&apos;s freshly collected damage. Recording into the swap chain happens after paint()
returns, which is the same as recording before it, since paint() only reads the target
it draws into.

Debug borders and repaint counters are painted by the layer tree, but their setters
stored the new state without damaging, unlike every other layer setter. Nothing
repainted them when they appeared or changed, and the frame that switched them off
reported no damage for them at all, so they stayed on the targets. They now damage the
layer like any other state change, on both the Skia and the TextureMapper side, which
is what lets a frame stay restricted to its damage while they show.

The FPS counter is drawn on top of the layer tree, so no layer damages it either, but
it is a fixed box in the corner rather than something that can be anywhere. It damages
its own box on the frames the count changes, together with the box drawn before, which
is larger when the count gets shorter. Its geometry therefore has to be computed before
the frame is painted rather than while it is drawn. A counter that repainted more than
its box would hide the cost it is there to measure - so we need to avoid that.

The damage visualizer and the overlay below cannot do the same, because they draw over
the damage itself: damaging what they drew would feed their own rects back into what
they show next, until it covers the surface. They repaint the frame in full instead,
and the platform is told the whole surface changed - that&apos;s okay, since it&apos;s debug-only.

WEBKIT_SHOW_DAMAGE keeps its name on the Skia path, so one variable shows the damage
whichever compositor is in use. It now draws a target&apos;s whole accumulated damage as a
translucent green overlay, rather than the frame damage the compositor no longer paints
from. Since it repaints in full, it shows what the damage is, not the compositor
honouring it.

* Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp:
(WebCore::SkiaCompositingLayer::paintedLayerRect const):
(WebCore::SkiaCompositingLayer::setDebugIndicators):
(WebCore::SkiaCompositingLayer::paint):
* Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.h:
* Source/WebCore/platform/graphics/texmap/TextureMapperLayer.cpp:
(WebCore::TextureMapperLayer::setShowDebugBorder):
(WebCore::TextureMapperLayer::setDebugBorderColor):
(WebCore::TextureMapperLayer::setDebugBorderWidth):
(WebCore::TextureMapperLayer::setShowRepaintCounter):
(WebCore::TextureMapperLayer::setRepaintCount):
* Source/WebCore/platform/graphics/texmap/TextureMapperLayer.h:
(WebCore::TextureMapperLayer::setShowDebugBorder): Deleted.
(WebCore::TextureMapperLayer::setDebugBorderColor): Deleted.
(WebCore::TextureMapperLayer::setDebugBorderWidth): Deleted.
(WebCore::TextureMapperLayer::setShowRepaintCounter): Deleted.
(WebCore::TextureMapperLayer::setRepaintCount): Deleted.
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.cpp:
(WebKit::AcceleratedSurface::SwapChainDamageTracker::didPresent):
(WebKit::AcceleratedSurface::backgroundColor):
(WebKit::AcceleratedSurface::skiaClearColor):
(WebKit::AcceleratedSurface::clear):
(WebKit::clearCanvas): Deleted.
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.h:
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp:
(WebKit::damageOverlayForcesPropagation):
(WebKit::LayerTreeHost::LayerTreeHost):
(WebKit::LayerTreeHost::attachLayer):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.cpp:
(WebKit::m_renderTimer):
(WebKit::ThreadedCompositor::setDamagePropagationSettings):
(WebKit::ThreadedCompositor::damageUsedForCompositing const):
(WebKit::ThreadedCompositor::drawsOverlay const):
(WebKit::ThreadedCompositor::paintToCurrentGLContext):
(WebKit::ThreadedCompositor::paintToTextureMapper):
(WebKit::ThreadedCompositor::recordFrameDamage):
(WebKit::drawDamageOverlay):
(WebKit::ThreadedCompositor::paintToSkiaCanvas):
(WebKit::ThreadedCompositor::renderLayerTree):
(WebKit::fpsCounterFont):
(WebKit::fpsCounterPadding):
(WebKit::ThreadedCompositor::fpsCounterRect const):
(WebKit::ThreadedCompositor::updateFPSCounterGeometry):
(WebKit::ThreadedCompositor::takeFPSCounterDamage):
(WebKit::ThreadedCompositor::drawFPSCounter):
(WebKit::ThreadedCompositor::drawSkiaDamage): Deleted.
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.h:

Canonical link: <a href="https://commits.webkit.org/317400@main">https://commits.webkit.org/317400@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d98e81c7a5b6377eafea6a3161e6b6172fded199

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175247 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49179 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/42960 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184832 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/133593 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/177111 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50471 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48862 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136413 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/133593 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178204 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/39833 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/157189 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116892 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/38474 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/36856 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33305 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/148897 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/36682 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187253 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/40866 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/41059 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145362 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48846 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/156745 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/145240 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49526 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/33303 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115405 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26634 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/40054 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/121719 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48032 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/11655 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/47435 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/47665 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/47492 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->