### PR TITLE
[GFC] Remove GridItemHasPercentOrCalcPadding avoidance reason

### DIFF
--- a/LayoutTests/fast/css-grid-layout/grid-item-with-calc-padding-track-sizing-expected.html
+++ b/LayoutTests/fast/css-grid-layout/grid-item-with-calc-padding-track-sizing-expected.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+/* Reference: draw each grid item as an absolutely positioned box so the layout
+   never touches grid track sizing. The padding is each calc() resolved against
+   the 150px grid area inline size (2% == 3px), hardcoded here in px.
+   box-sizing: border-box keeps the padding inside the 150px cell, matching a
+   stretched grid item, so content lands at (paddingLeft, paddingTop). */
+.grid {
+    position: relative;
+    width: 300px;
+    height: 300px;
+    background-color: green;
+}
+.item {
+    position: absolute;
+    box-sizing: border-box;
+    width: 150px;
+    height: 150px;
+    background-color: blue;
+}
+.topLeft {
+    left: 0;
+    top: 0;
+    padding: 5px 8px 11px 14px;
+}
+.topRight {
+    left: 150px;
+    top: 0;
+    padding: 13px;
+}
+.bottomLeft {
+    left: 0;
+    top: 150px;
+    padding: 19px 10px;
+}
+.bottomRight {
+    left: 150px;
+    top: 150px;
+    padding: 15px;
+}
+.topLeftContent {
+    width: 20px;
+    height: 20px;
+    background-color: red;
+}
+.topRightContent {
+    width: 20px;
+    height: 40px;
+    background-color: red;
+}
+.bottomLeftContent {
+    width: 40px;
+    height: 20px;
+    background-color: red;
+}
+.bottomRightContent {
+    width: 40px;
+    height: 40px;
+    background-color: red;
+}
+</style>
+</head>
+<body>
+<div class="grid">
+    <div class="item topLeft"><div class="topLeftContent"></div></div>
+    <div class="item topRight"><div class="topRightContent"></div></div>
+    <div class="item bottomLeft"><div class="bottomLeftContent"></div></div>
+    <div class="item bottomRight"><div class="bottomRightContent"></div></div>
+</div>
+</body>
+</html>

--- a/LayoutTests/fast/css-grid-layout/grid-item-with-calc-padding-track-sizing.html
+++ b/LayoutTests/fast/css-grid-layout/grid-item-with-calc-padding-track-sizing.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.grid {
+    display: grid;
+    /* justify-items: normal keeps the stretch layout but moves the grid off the
+       legacy alignment path so it uses the modern GridFormattingContext. */
+    justify-items: normal;
+    width: 300px;
+    height: 300px;
+    grid-template-columns: 150px 150px;
+    grid-template-rows: 150px 150px;
+    background-color: green;
+}
+/* Verify calc() padding mixing a fixed length and a percentage resolves the
+   percentage against the 150px grid area inline size (2% == 3px), positioning
+   content at (paddingLeft, paddingTop). */
+.topLeft {
+    grid-row: 1 / 2;
+    grid-column: 1 / 2;
+    padding: calc(2px + 2%) calc(2px + 4%) calc(2px + 6%) calc(2px + 8%);
+    background-color: blue;
+}
+.topRight {
+    grid-row: 1 / 2;
+    grid-column: 2 / 3;
+    padding: calc(10px + 2%);
+    background-color: blue;
+}
+.bottomLeft {
+    grid-row: 2 / 3;
+    grid-column: 1 / 2;
+    padding: calc(4px + 10%) calc(4px + 4%);
+    background-color: blue;
+}
+.bottomRight {
+    grid-row: 2 / 3;
+    grid-column: 2 / 3;
+    padding: calc(6px + 6%);
+    background-color: blue;
+}
+.topLeftContent {
+    width: 20px;
+    height: 20px;
+    background-color: red;
+}
+.topRightContent {
+    width: 20px;
+    height: 40px;
+    background-color: red;
+}
+.bottomLeftContent {
+    width: 40px;
+    height: 20px;
+    background-color: red;
+}
+.bottomRightContent {
+    width: 40px;
+    height: 40px;
+    background-color: red;
+}
+</style>
+</head>
+<body>
+<div class="grid">
+    <div class="topLeft"><div class="topLeftContent"></div></div>
+    <div class="topRight"><div class="topRightContent"></div></div>
+    <div class="bottomLeft"><div class="bottomLeftContent"></div></div>
+    <div class="bottomRight"><div class="bottomRightContent"></div></div>
+</div>
+</body>
+</html>

--- a/LayoutTests/fast/css-grid-layout/grid-item-with-percent-padding-track-sizing-expected.html
+++ b/LayoutTests/fast/css-grid-layout/grid-item-with-percent-padding-track-sizing-expected.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+/* Reference: draw each grid item as an absolutely positioned box so the layout
+   never touches grid track sizing. The padding is the percentage resolved
+   against the 150px grid area inline size (2% == 3px), hardcoded here in px.
+   box-sizing: border-box keeps the padding inside the 150px cell, matching a
+   stretched grid item, so content lands at (paddingLeft, paddingTop). */
+.grid {
+    position: relative;
+    width: 300px;
+    height: 300px;
+    background-color: green;
+}
+.item {
+    position: absolute;
+    box-sizing: border-box;
+    width: 150px;
+    height: 150px;
+    background-color: blue;
+}
+.topLeft {
+    left: 0;
+    top: 0;
+    padding: 3px 6px 9px 12px;
+}
+.topRight {
+    left: 150px;
+    top: 0;
+    padding: 12px 9px 6px 3px;
+}
+.bottomLeft {
+    left: 0;
+    top: 150px;
+    padding: 15px 6px 15px 6px;
+}
+.bottomRight {
+    left: 150px;
+    top: 150px;
+    padding: 9px;
+}
+.topLeftContent {
+    width: 20px;
+    height: 20px;
+    background-color: red;
+}
+.topRightContent {
+    width: 20px;
+    height: 40px;
+    background-color: red;
+}
+.bottomLeftContent {
+    width: 40px;
+    height: 20px;
+    background-color: red;
+}
+.bottomRightContent {
+    width: 40px;
+    height: 40px;
+    background-color: red;
+}
+</style>
+</head>
+<body>
+<div class="grid">
+    <div class="item topLeft"><div class="topLeftContent"></div></div>
+    <div class="item topRight"><div class="topRightContent"></div></div>
+    <div class="item bottomLeft"><div class="bottomLeftContent"></div></div>
+    <div class="item bottomRight"><div class="bottomRightContent"></div></div>
+</div>
+</body>
+</html>

--- a/LayoutTests/fast/css-grid-layout/grid-item-with-percent-padding-track-sizing.html
+++ b/LayoutTests/fast/css-grid-layout/grid-item-with-percent-padding-track-sizing.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.grid {
+    display: grid;
+    /* justify-items: normal keeps the stretch layout but moves the grid off the
+       legacy alignment path so it uses the modern GridFormattingContext. */
+    justify-items: normal;
+    width: 300px;
+    height: 300px;
+    grid-template-columns: 150px 150px;
+    grid-template-rows: 150px 150px;
+    background-color: green;
+}
+/* Verify percentage padding resolves against the 150px grid area inline size
+   (not the 300px grid container), so 2% == 3px, positioning content at
+   (paddingLeft, paddingTop). */
+.topLeft {
+    grid-row: 1 / 2;
+    grid-column: 1 / 2;
+    padding: 2% 4% 6% 8%;
+    background-color: blue;
+}
+.topRight {
+    grid-row: 1 / 2;
+    grid-column: 2 / 3;
+    padding: 8% 6% 4% 2%;
+    background-color: blue;
+}
+.bottomLeft {
+    grid-row: 2 / 3;
+    grid-column: 1 / 2;
+    padding: 10% 4% 10% 4%;
+    background-color: blue;
+}
+.bottomRight {
+    grid-row: 2 / 3;
+    grid-column: 2 / 3;
+    padding: 6%;
+    background-color: blue;
+}
+.topLeftContent {
+    width: 20px;
+    height: 20px;
+    background-color: red;
+}
+.topRightContent {
+    width: 20px;
+    height: 40px;
+    background-color: red;
+}
+.bottomLeftContent {
+    width: 40px;
+    height: 20px;
+    background-color: red;
+}
+.bottomRightContent {
+    width: 40px;
+    height: 40px;
+    background-color: red;
+}
+</style>
+</head>
+<body>
+<div class="grid">
+    <div class="topLeft"><div class="topLeftContent"></div></div>
+    <div class="topRight"><div class="topRightContent"></div></div>
+    <div class="bottomLeft"><div class="bottomLeftContent"></div></div>
+    <div class="bottomRight"><div class="bottomRightContent"></div></div>
+</div>
+</body>
+</html>

--- a/LayoutTests/fast/css-grid-layout/multi-span-content-sized-columns-padding-expected.html
+++ b/LayoutTests/fast/css-grid-layout/multi-span-content-sized-columns-padding-expected.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+<link href="resources/grid.css" rel="stylesheet">
+<!-- The spanner's border box is 40 + 40 + 20 = 100px wide (split evenly across
+     two columns) and 20 + 10 + 30 = 60px tall. Reproduce the marker positions
+     with author-specified fixed track sizes instead of content-based sizing. -->
+<style>
+.grid {
+    width: 100px;
+    grid-template-columns: 50px 50px;
+    grid-template-rows: 60px 20px;
+    justify-items: normal;
+}
+
+.leftColumnMarker {
+    grid-column: 1 / 2;
+    grid-row: 2 / 3;
+    height: 20px;
+    background-color: blue;
+}
+
+.rightColumnMarker {
+    grid-column: 2 / 3;
+    grid-row: 2 / 3;
+    height: 20px;
+    background-color: red;
+}
+</style>
+
+<body>
+    <div class="grid">
+        <div class="leftColumnMarker"></div>
+        <div class="rightColumnMarker"></div>
+    </div>
+</body>
+</html>

--- a/LayoutTests/fast/css-grid-layout/multi-span-content-sized-columns-padding.html
+++ b/LayoutTests/fast/css-grid-layout/multi-span-content-sized-columns-padding.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html>
+<link href="resources/grid.css" rel="stylesheet">
+<!-- A grid item spanning two content-sized columns distributes its size
+     contribution (including its padding) across those columns (CSS Grid
+     Layout 1 §12.5, #algo-spanning-items). With distinct padding on every
+     edge, the left+right padding must feed column sizing and the top+bottom
+     padding must feed the row height. justify-items: normal keeps the grid on
+     the modern GridFormattingContext path and lets the second-row markers
+     stretch to reveal each computed column width. -->
+<style>
+.grid {
+    /* Sized to the content so there is no free space for the "Stretch auto
+       Tracks" step (§11.8) to distribute; the auto columns then keep their
+       content-based sizes (50px each) instead of stretching. */
+    width: 100px;
+    grid-template-columns: auto auto;
+    justify-items: normal;
+}
+
+.spanner {
+    grid-column: 1 / 3;
+    grid-row: 1 / 2;
+    box-sizing: content-box;
+    width: 40px;
+    height: 20px;
+    padding: 10px 20px 30px 40px;
+}
+
+.leftColumnMarker {
+    grid-column: 1 / 2;
+    grid-row: 2 / 3;
+    height: 20px;
+    background-color: blue;
+}
+
+.rightColumnMarker {
+    grid-column: 2 / 3;
+    grid-row: 2 / 3;
+    height: 20px;
+    background-color: red;
+}
+</style>
+
+<body>
+    <div class="grid">
+        <div class="spanner"></div>
+        <div class="leftColumnMarker"></div>
+        <div class="rightColumnMarker"></div>
+    </div>
+</body>
+</html>

--- a/LayoutTests/fast/css-grid-layout/multi-span-content-sized-rows-padding-expected.html
+++ b/LayoutTests/fast/css-grid-layout/multi-span-content-sized-rows-padding-expected.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+<link href="resources/grid.css" rel="stylesheet">
+<!-- The spanner's border box is 40 + 40 + 20 = 100px wide and 20 + 10 + 30 =
+     60px tall (split evenly across two rows). Reproduce the marker positions
+     with author-specified fixed track sizes instead of content-based sizing. -->
+<style>
+.grid {
+    width: 130px;
+    grid-template-columns: 100px 30px;
+    grid-template-rows: 30px 30px;
+    justify-items: normal;
+}
+
+.topRowMarker {
+    grid-column: 2 / 3;
+    grid-row: 1 / 2;
+    width: 30px;
+    background-color: blue;
+}
+
+.bottomRowMarker {
+    grid-column: 2 / 3;
+    grid-row: 2 / 3;
+    width: 30px;
+    background-color: red;
+}
+</style>
+
+<body>
+    <div class="grid">
+        <div class="topRowMarker"></div>
+        <div class="bottomRowMarker"></div>
+    </div>
+</body>
+</html>

--- a/LayoutTests/fast/css-grid-layout/multi-span-content-sized-rows-padding.html
+++ b/LayoutTests/fast/css-grid-layout/multi-span-content-sized-rows-padding.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html>
+<link href="resources/grid.css" rel="stylesheet">
+<!-- Companion to multi-span-content-sized-columns-padding.html for the block
+     axis: a grid item spanning two content-sized rows distributes its size
+     contribution (including top+bottom padding) across those rows (CSS Grid
+     Layout 1 §12.5, #algo-spanning-items). The second-column markers reveal
+     each computed row height. -->
+<style>
+.grid {
+    /* Sized to the content so the auto columns do not stretch: column 1 keeps
+       the spanner's 100px contribution and column 2 keeps the markers' 30px,
+       leaving the second-column markers at x = 100px. */
+    width: 130px;
+    grid-template-rows: auto auto;
+    justify-items: normal;
+}
+
+.spanner {
+    grid-column: 1 / 2;
+    grid-row: 1 / 3;
+    box-sizing: content-box;
+    width: 40px;
+    height: 20px;
+    padding: 10px 20px 30px 40px;
+}
+
+.topRowMarker {
+    grid-column: 2 / 3;
+    grid-row: 1 / 2;
+    width: 30px;
+    background-color: blue;
+}
+
+.bottomRowMarker {
+    grid-column: 2 / 3;
+    grid-row: 2 / 3;
+    width: 30px;
+    background-color: red;
+}
+</style>
+
+<body>
+    <div class="grid">
+        <div class="spanner"></div>
+        <div class="topRowMarker"></div>
+        <div class="bottomRowMarker"></div>
+    </div>
+</body>
+</html>

--- a/Source/WebCore/layout/integration/grid/LayoutIntegrationGridCoverage.cpp
+++ b/Source/WebCore/layout/integration/grid/LayoutIntegrationGridCoverage.cpp
@@ -71,7 +71,6 @@ enum class GridAvoidanceReason : uint8_t {
     GridHasUnsupportedMaxHeight,
     GridItemHasNonInitialMaxWidth,
     GridItemHasNonInitialMaxHeight,
-    GridItemHasPercentOrCalcPadding,
     GridItemHasMargin,
     GridItemHasBorderBoxSizing,
     GridItemHasUnsupportedWritingMode,
@@ -507,18 +506,6 @@ static EnumSet<GridAvoidanceReason> gridLayoutAvoidanceReason(const RenderGrid& 
         if (!gridItemStyle->maxHeight().isNone())
             ADD_REASON_AND_RETURN_IF_NEEDED(GridAvoidanceReason::GridItemHasNonInitialMaxHeight, reasons, reasonCollectionMode);
 
-        // Fixed padding is threaded into item and track sizing as part of the border-box size and lays
-        // out identically to legacy RenderGrid. Percentage and calc() padding resolve against the grid
-        // item's grid area, which needs additional plumbing, so keep those items on the legacy path.
-        // FIXME: Support percentage and calc() padding on grid items and remove this restriction.
-        auto gridItemHasUnsupportedPadding = [&] {
-            return gridItemStyle->paddingBox().anyOf([](const Style::PaddingEdge& paddingEdge) {
-                return paddingEdge.isPercentOrCalculated();
-            });
-        };
-        if (gridItemHasUnsupportedPadding())
-            ADD_REASON_AND_RETURN_IF_NEEDED(GridAvoidanceReason::GridItemHasPercentOrCalcPadding, reasons, reasonCollectionMode);
-
         auto gridItemHasMargins = [&] {
             return gridItemStyle->marginBox().anyOf([](const Style::MarginEdge& marginEdge) {
                 return marginEdge.isAuto() || marginEdge.isCalculated() || !marginEdge.isPossiblyZero();
@@ -770,9 +757,6 @@ static void printReason(GridAvoidanceReason reason, TextStream& stream)
         break;
     case GridAvoidanceReason::GridItemHasNonInitialMaxHeight:
         stream << "grid item has non-initial max-height";
-        break;
-    case GridAvoidanceReason::GridItemHasPercentOrCalcPadding:
-        stream << "grid item has percent or calc padding";
         break;
     case GridAvoidanceReason::GridItemHasMargin:
         stream << "grid item has margin";


### PR DESCRIPTION
#### b12061eca549a68aa3bf16de2ba53484754fec65
<pre>
[GFC] Remove GridItemHasPercentOrCalcPadding avoidance reason
<a href="https://bugs.webkit.org/show_bug.cgi?id=319687">https://bugs.webkit.org/show_bug.cgi?id=319687</a>
&lt;<a href="https://rdar.apple.com/182532662">rdar://182532662</a>&gt;

Reviewed by Sammy Gill.

The machinery to resolve percentage/calc() padding for grid items against
their grid area landed in bug 319913. Remove the coverage gate so grid
items with percentage/calc() padding use the modern GridFormattingContext
instead of falling back to legacy RenderGrid.

* LayoutTests/fast/css-grid-layout/grid-item-with-calc-padding-track-sizing-expected.html: Added.
* LayoutTests/fast/css-grid-layout/grid-item-with-calc-padding-track-sizing.html: Added.
* LayoutTests/fast/css-grid-layout/grid-item-with-percent-padding-track-sizing-expected.html: Added.
* LayoutTests/fast/css-grid-layout/grid-item-with-percent-padding-track-sizing.html: Added.
* LayoutTests/fast/css-grid-layout/multi-span-content-sized-columns-padding-expected.html: Added.
* LayoutTests/fast/css-grid-layout/multi-span-content-sized-columns-padding.html: Added.
* LayoutTests/fast/css-grid-layout/multi-span-content-sized-rows-padding-expected.html: Added.
* LayoutTests/fast/css-grid-layout/multi-span-content-sized-rows-padding.html: Added.
* Source/WebCore/layout/integration/grid/LayoutIntegrationGridCoverage.cpp:
(WebCore::LayoutIntegration::gridLayoutAvoidanceReason):
(WebCore::LayoutIntegration::printReason):

Canonical link: <a href="https://commits.webkit.org/318011@main">https://commits.webkit.org/318011@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/112b91730adafdf977ec4fa27f30820c923d6e96

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177077 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/51014 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/44809 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/186680 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140313 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178940 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/52307 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/50700 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/186680 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140313 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180033 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/52307 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/44809 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/186680 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/52307 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/50700 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/186680 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/44809 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/52307 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/44809 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/35148 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/42788 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/50700 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/189106 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/50681 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/44809 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/189106 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/51364 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/44809 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/189106 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26851 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/51364 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/123578 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/117865 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/49869 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/44809 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/49268 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/49505 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/49329 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->