### PR TITLE
[iOS] Video playback remains active on a wireless device after switching back to local playback

### DIFF
--- a/LayoutTests/media/wireless-playback-media-player/route-deactivate-pauses-playback-expected.txt
+++ b/LayoutTests/media/wireless-playback-media-player/route-deactivate-pauses-playback-expected.txt
@@ -1,0 +1,17 @@
+
+Test that deactivating the active MediaDeviceRoute pauses the video element.
+
+RUN(internals.mockMediaDeviceRouteController.activateRoute(route))
+RUN(video.src = findMediaFile('video', '../content/test'))
+RUN(route.playbackRate = 1)
+RUN(route.timeRange = { start: 0, duration: 60 })
+RUN(video.play())
+RUN(route.ready = true)
+EVENT(playing)
+RUN(route.currentPlaybackPosition = 10)
+RUN(internals.mockMediaDeviceRouteController.deactivateRoute(route))
+EVENT(pause)
+EXPECTED (video.paused == 'true') OK
+EXPECTED (internals.elementEffectivePlaybackRate(video) == '0') OK
+END OF TEST
+

--- a/LayoutTests/media/wireless-playback-media-player/route-deactivate-pauses-playback.html
+++ b/LayoutTests/media/wireless-playback-media-player/route-deactivate-pauses-playback.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html><!-- webkit-test-runner [ WirelessPlaybackMediaPlayerEnabled=true ] -->
+<html>
+    <head>
+        <script src='../media-file.js'></script>
+        <script src='../video-test.js'></script>
+        <script>
+            var route;
+            var video;
+
+            async function start()
+            {
+                if (window.internals)
+                    internals.mockMediaDeviceRouteController.enabled = true;
+
+                route = internals.mockMediaDeviceRouteController.createMockMediaDeviceRoute();
+                run(`internals.mockMediaDeviceRouteController.activateRoute(route)`);
+
+                const urlPromise = new Promise((resolve) => {
+                    route.setURLCallback(async (url) => {
+                        resolve(url);
+                    });
+                });
+
+                video = document.getElementsByTagName('video')[0];
+                run(`video.src = findMediaFile('video', '../content/test')`);
+                run(`route.playbackRate = 1`);
+                run(`route.timeRange = { start: 0, duration: 60 }`);
+                run(`video.play()`);
+                await urlPromise;
+
+                const playingPromise = waitFor(video, 'playing');
+                run(`route.ready = true`);
+                await playingPromise;
+
+                run(`route.currentPlaybackPosition = 10`);
+                await waitForConditionOrTimeout('video.currentTime >= 10', true, 3000);
+
+                const pausePromise = waitFor(video, 'pause');
+                run(`internals.mockMediaDeviceRouteController.deactivateRoute(route)`);
+                await pausePromise;
+                testExpected(`video.paused`, true);
+                testExpected(`internals.elementEffectivePlaybackRate(video)`, 0);
+
+                endTest();
+            }
+        </script>
+    </head>
+    <body onload='start()'>
+        <video controls></video>
+        <p>Test that deactivating the active MediaDeviceRoute pauses the video element.</p>
+    </body>
+</html>

--- a/LayoutTests/media/wireless-playback-media-player/route-switch-disconnects-previous-route-expected.txt
+++ b/LayoutTests/media/wireless-playback-media-player/route-switch-disconnects-previous-route-expected.txt
@@ -1,0 +1,22 @@
+
+Test that activating a new MediaDeviceRoute disconnects the previously active route.
+
+RUN(internals.mockMediaDeviceRouteController.activateRoute(route1))
+RUN(video.src = findMediaFile('video', '../content/test'))
+RUN(route1.playbackRate = 1)
+RUN(route1.timeRange = { start: 0, duration: 60 })
+RUN(route1.audioOptions = [{ displayName: 'Audio', identifier: 'audio' }])
+RUN(video.play())
+RUN(route1.ready = true)
+EVENT(playing)
+EXPECTED (route1.connected == 'true') OK
+EXPECTED (internals.mediaUsageState(video).hasAudio == 'true') OK
+RUN(route2.playbackRate = 1)
+RUN(route2.timeRange = { start: 0, duration: 60 })
+RUN(route2.audioOptions = [{ displayName: 'Audio', identifier: 'audio' }])
+RUN(internals.mockMediaDeviceRouteController.activateRoute(route2))
+RUN(route2.ready = true)
+EXPECTED (route1.connected == 'false') OK
+EXPECTED (route2.connected == 'true') OK
+END OF TEST
+

--- a/LayoutTests/media/wireless-playback-media-player/route-switch-disconnects-previous-route.html
+++ b/LayoutTests/media/wireless-playback-media-player/route-switch-disconnects-previous-route.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html><!-- webkit-test-runner [ WirelessPlaybackMediaPlayerEnabled=true ] -->
+<html>
+    <head>
+        <script src='../media-file.js'></script>
+        <script src='../video-test.js'></script>
+        <script>
+            var route1;
+            var route2;
+            var video;
+
+            function nextURLCallback(route)
+            {
+                return new Promise((resolve) => {
+                    route.setURLCallback(async (url) => {
+                        resolve(url);
+                    });
+                });
+            }
+
+            async function start()
+            {
+                if (window.internals)
+                    internals.mockMediaDeviceRouteController.enabled = true;
+
+                route1 = internals.mockMediaDeviceRouteController.createMockMediaDeviceRoute();
+                let urlPromise = nextURLCallback(route1);
+                run(`internals.mockMediaDeviceRouteController.activateRoute(route1)`);
+
+                video = document.getElementsByTagName('video')[0];
+                run(`video.src = findMediaFile('video', '../content/test')`);
+                run(`route1.playbackRate = 1`);
+                run(`route1.timeRange = { start: 0, duration: 60 }`);
+                run(`route1.audioOptions = [{ displayName: 'Audio', identifier: 'audio' }]`);
+                run(`video.play()`);
+                await urlPromise;
+
+                const playingPromise = waitFor(video, 'playing');
+                run(`route1.ready = true`);
+                await playingPromise;
+
+                await waitForConditionOrTimeout('route1.connected', true);
+                testExpected(`route1.connected`, true);
+
+                await testExpectedEventually('internals.mediaUsageState(video).hasAudio', true);
+
+                route2 = internals.mockMediaDeviceRouteController.createMockMediaDeviceRoute();
+                urlPromise = nextURLCallback(route2);
+                run(`route2.playbackRate = 1`);
+                run(`route2.timeRange = { start: 0, duration: 60 }`);
+                run(`route2.audioOptions = [{ displayName: 'Audio', identifier: 'audio' }]`);
+                run(`internals.mockMediaDeviceRouteController.activateRoute(route2)`);
+                await urlPromise;
+
+                run(`route2.ready = true`);
+                await waitForConditionOrTimeout('route2.connected', true);
+
+                await waitForConditionOrTimeout('!route1.connected', true);
+                testExpected(`route1.connected`, false);
+                testExpected(`route2.connected`, true);
+
+                endTest();
+            }
+        </script>
+    </head>
+    <body onload='start()'>
+        <video controls></video>
+        <p>Test that activating a new MediaDeviceRoute disconnects the previously active route.</p>
+    </body>
+</html>

--- a/Source/WebCore/PAL/pal/spi/cocoa/AVFoundationSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/AVFoundationSPI.h
@@ -134,10 +134,15 @@ typedef NS_OPTIONS(NSUInteger, AVOutputDeviceFeatures) {
     AVOutputDeviceFeatureVideo = (1UL << 2),
 };
 
+typedef NS_ENUM(NSInteger, AVOutputDeviceType) {
+    AVOutputDeviceTypeCustomProtocol = 5,
+};
+
 @interface AVOutputDevice : NSObject
 @property (nonatomic, readonly) NSString *name;
 @property (nonatomic, readonly) NSString *deviceName;
 @property (nonatomic, readonly) AVOutputDeviceFeatures deviceFeatures;
+@property (nonatomic, readonly) AVOutputDeviceType deviceType;
 @end
 
 #if !PLATFORM(IOS_FAMILY)

--- a/Source/WebCore/platform/audio/ios/MediaSessionHelperIOS.mm
+++ b/Source/WebCore/platform/audio/ios/MediaSessionHelperIOS.mm
@@ -260,27 +260,27 @@ void MediaSessionHelper::activeRoutesDidChange(MediaDeviceRouteController& route
     ASSERT(&MediaDeviceRouteController::singleton() == &routeController);
 
     Ref target = MediaPlaybackTargetCocoa::create();
+    RefPtr mostRecentActiveRoute = routeController.mostRecentActiveRoute();
 
-    if (RefPtr mostRecentActiveRoute = routeController.mostRecentActiveRoute()) {
-#if HAVE(AVROUTING_FRAMEWORK)
-        bool hasAirPlayDevice = target->hasAirPlayDevice();
-        RELEASE_LOG(Media, "MediaSessionHelper::activeRoutesDidChange: hasAirPlayDevice = %d", hasAirPlayDevice);
-        if (!hasAirPlayDevice)
-            return;
-
-        auto wirelessPlaybackTarget = dynamicDowncast<MediaPlaybackTargetWirelessPlayback>(m_playbackTarget.get());
-        if (wirelessPlaybackTarget && wirelessPlaybackTarget->route() == mostRecentActiveRoute.get())
-            return;
+    bool supportsVideo = [&] {
+#if PLATFORM(IOS_FAMILY_SIMULATOR)
+        return true;
+#else
+        return target->supportsCustomProtocolVideoPlayback();
 #endif
+    }();
 
-        activeVideoRouteDidChange(SupportsAirPlayVideo::Yes, MediaPlaybackTargetWirelessPlayback::create(*mostRecentActiveRoute));
+    RELEASE_LOG(Media, "MediaSessionHelper::activeRoutesDidChange: mostRecentActiveRoute=%d, supportsVideo=%d", !!mostRecentActiveRoute, supportsVideo);
+
+    if (!mostRecentActiveRoute || !supportsVideo) {
+        activeAudioRouteDidChange(ShouldPause::Yes);
+        activeVideoRouteDidChange(SupportsAirPlayVideo::No, WTF::move(target));
         return;
     }
 
-#if PLATFORM(IOS_FAMILY_SIMULATOR)
-    activeAudioRouteDidChange(ShouldPause::Yes);
-    activeVideoRouteDidChange(SupportsAirPlayVideo::No, WTF::move(target));
-#endif
+    auto wirelessPlaybackTarget = dynamicDowncast<MediaPlaybackTargetWirelessPlayback>(m_playbackTarget.get());
+    if (!wirelessPlaybackTarget || wirelessPlaybackTarget->route() != mostRecentActiveRoute.get())
+        activeVideoRouteDidChange(SupportsAirPlayVideo::Yes, MediaPlaybackTargetWirelessPlayback::create(*mostRecentActiveRoute));
 }
 #endif // ENABLE(WIRELESS_PLAYBACK_MEDIA_PLAYER)
 
@@ -602,22 +602,7 @@ void MediaSessionHelperIOS::externalOutputDeviceAvailableDidChange()
 
         callback->updateCarPlayIsConnected();
         callback->activeAudioRouteDidChange(shouldPause);
-
-        Ref target = MediaPlaybackTargetCocoa::create();
-
-#if HAVE(AVROUTING_FRAMEWORK)
-        bool hasAirPlayDevice = target->hasAirPlayDevice();
-        RELEASE_LOG(Media, "-[WebMediaSessionHelper activeOutputDeviceDidChange:]: hasAirPlayDevice = %d", hasAirPlayDevice);
-        if (hasAirPlayDevice) {
-            RefPtr mostRecentActiveRoute = MediaDeviceRouteController::singleton().mostRecentActiveRoute();
-            auto wirelessPlaybackTarget = dynamicDowncast<MediaPlaybackTargetWirelessPlayback>(callback->playbackTarget());
-            if (!wirelessPlaybackTarget || wirelessPlaybackTarget->route() != mostRecentActiveRoute.get())
-                callback->activeVideoRouteDidChange(MediaPlaybackTargetWirelessPlayback::create(*mostRecentActiveRoute));
-            return;
-        }
-#endif
-
-        callback->activeVideoRouteDidChange(WTF::move(target));
+        callback->activeVideoRouteDidChange(MediaPlaybackTargetCocoa::create());
     });
 }
 

--- a/Source/WebCore/platform/graphics/MediaPlayerPrivateWirelessPlayback.cpp
+++ b/Source/WebCore/platform/graphics/MediaPlayerPrivateWirelessPlayback.cpp
@@ -185,6 +185,11 @@ void MediaPlayerPrivateWirelessPlayback::setWirelessPlaybackTarget(Ref<MediaPlay
 
     ALWAYS_LOG(LOGIDENTIFIER, playbackTarget->type());
 
+    if (RefPtr route = this->route()) {
+        route->disconnectFromSession();
+        route->setClient(nullptr);
+    }
+
     m_playbackTarget = WTF::move(playbackTarget);
 
     if (!wirelessPlaybackTarget())

--- a/Source/WebCore/platform/graphics/avfoundation/MediaPlaybackTargetCocoa.h
+++ b/Source/WebCore/platform/graphics/avfoundation/MediaPlaybackTargetCocoa.h
@@ -46,9 +46,7 @@ public:
 
     RetainPtr<AVOutputContext> outputContext() const { return m_outputContext.get(); }
 
-#if HAVE(AVROUTING_FRAMEWORK)
-    bool hasAirPlayDevice() const;
-#endif
+    bool supportsCustomProtocolVideoPlayback() const;
 
     // MediaPlaybackTarget
     bool supportsRemoteVideoPlayback() const final;

--- a/Source/WebCore/platform/graphics/avfoundation/MediaPlaybackTargetCocoa.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/MediaPlaybackTargetCocoa.mm
@@ -30,10 +30,6 @@
 
 #import <pal/spi/cocoa/AVFoundationSPI.h>
 
-#if HAVE(AVROUTING_FRAMEWORK)
-#import <WebKitAdditions/MediaPlaybackTargetCocoaAdditions.mm>
-#endif
-
 #import <pal/cocoa/AVFoundationSoftLink.h>
 
 namespace WebCore {
@@ -78,6 +74,18 @@ bool MediaPlaybackTargetCocoa::hasActiveRoute() const
             return outputDevice.deviceFeatures & (AVOutputDeviceFeatureVideo | AVOutputDeviceFeatureAudio);
     }
     return m_outputContext.get().deviceName;
+}
+
+// FIXME: This check is only needed temporarily. Once rdar://181927768 is resolved,
+// AVSystemRouting will not even notify us of routes that do no support the video feature.
+bool MediaPlaybackTargetCocoa::supportsCustomProtocolVideoPlayback() const
+{
+    for (AVOutputDevice *outputDevice in [m_outputContext outputDevices]) {
+        if (outputDevice.deviceType == AVOutputDeviceTypeCustomProtocol && outputDevice.deviceFeatures & AVOutputDeviceFeatureVideo)
+            return true;
+    }
+
+    return false;
 }
 
 bool MediaPlaybackTargetCocoa::supportsRemoteVideoPlayback() const


### PR DESCRIPTION
#### 165c11e88f109c66d6b3edb325dd67660c1c650f
<pre>
[iOS] Video playback remains active on a wireless device after switching back to local playback
<a href="https://bugs.webkit.org/show_bug.cgi?id=319638">https://bugs.webkit.org/show_bug.cgi?id=319638</a>
<a href="https://rdar.apple.com/182125629">rdar://182125629</a>

Reviewed by Jer Noble.

Two bugs led to video playback remaining active on a wireless device after the user switches back
to local playback in Safari:

1. On routes that support video URL casting but not real-time audio streaming, an
   AVAudioSessionRouteChangeNotification notification is not dispatched when that route is selected
   or deselected. This bypassed the logic in -[WebMediaSessionHelper activeOutputDeviceDidChange:]
   that would reconfigure the media engine for local playback.
2. In MediaPlayerPrivateWirelessPlayback::setWirelessPlaybackTarget, we would not disconnect the
   old playback target&apos;s route session prior to switching to the new playback target. This resulted
   in playback continuing on the wireless route.

Resolved (1) by consolidating the logic for switching between wireless and local routes into
MediaSessionHelper::activeRoutesDidChange, since that function is called whether or not the
wireless route supports real-time audio streaming. Resolved (2) by disconnecting the outgoing route
from its playback session and clearing ourselves as the route client in
MediaPlayerPrivateWirelessPlayback::setWirelessPlaybackTarget.

Tests: media/wireless-playback-media-player/route-deactivate-pauses-playback.html
       media/wireless-playback-media-player/route-switch-disconnects-previous-route.html

* LayoutTests/media/wireless-playback-media-player/route-deactivate-pauses-playback-expected.txt: Added.
* LayoutTests/media/wireless-playback-media-player/route-deactivate-pauses-playback.html: Added.
* LayoutTests/media/wireless-playback-media-player/route-switch-disconnects-previous-route-expected.txt: Added.
* LayoutTests/media/wireless-playback-media-player/route-switch-disconnects-previous-route.html: Added.
* Source/WebCore/PAL/pal/spi/cocoa/AVFoundationSPI.h:
* Source/WebCore/platform/audio/ios/MediaSessionHelperIOS.mm:
(MediaSessionHelper::activeRoutesDidChange):
(-[WebMediaSessionHelper activeOutputDeviceDidChange:]):
* Source/WebCore/platform/graphics/MediaPlayerPrivateWirelessPlayback.cpp:
(WebCore::MediaPlayerPrivateWirelessPlayback::setWirelessPlaybackTarget):
* Source/WebCore/platform/graphics/avfoundation/MediaPlaybackTargetCocoa.h:
* Source/WebCore/platform/graphics/avfoundation/MediaPlaybackTargetCocoa.mm:
(WebCore::MediaPlaybackTargetCocoa::supportsCustomProtocolVideoPlayback const):

Canonical link: <a href="https://commits.webkit.org/317433@main">https://commits.webkit.org/317433@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b409d41a5b8b8ece9375403a5b4261c8b5e68d55

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175327 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49259 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43040 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184913 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/137444 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/177191 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50551 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48942 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/136491 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/137444 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178284 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/39903 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/157240 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116969 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0fb4e855-d022-4313-a4ea-2542ca64748e) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/38544 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/36929 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/148967 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36733 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33388 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/40946 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/41133 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187337 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48926 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/156796 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/145463 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39127 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49606 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/33355 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145296 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40105 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/121799 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115485 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48112 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11706 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47515 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47745 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47572 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->