### PR TITLE
[Text Extraction] Add a way for clients to issue interactions by passing in a WKJSHandle

### DIFF
--- a/Source/WebCore/page/text-extraction/TextExtractionTypes.h
+++ b/Source/WebCore/page/text-extraction/TextExtractionTypes.h
@@ -64,6 +64,7 @@ struct Interaction {
     String text;
     std::optional<FloatPoint> locationInRootView;
     std::optional<NodeIdentifier> nodeIdentifier;
+    std::optional<JSHandleIdentifier> targetNodeHandleIdentifier;
     FloatSize scrollDelta;
     bool replaceAll { false };
     bool scrollToVisible { false };

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -4861,6 +4861,7 @@ header: <WebCore/TextExtractionTypes.h>
     String text;
     std::optional<WebCore::FloatPoint> locationInRootView;
     std::optional<WebCore::NodeIdentifier> nodeIdentifier;
+    std::optional<WebCore::JSHandleIdentifier> targetNodeHandleIdentifier;
     WebCore::FloatSize scrollDelta;
     bool replaceAll;
     bool scrollToVisible;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView+TextExtraction.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView+TextExtraction.mm
@@ -442,7 +442,11 @@ static WebKit::TextExtractionOutputFormat textExtractionOutputFormat(_WKTextExtr
         }
     }();
 
-    if (auto identifiers = WebKit::parseExtractedNodeInfo(nodeIdentifierString)) {
+    if (RetainPtr elementHandle = [wkInteraction elementHandle]) {
+        const auto& info = elementHandle->_ref->info();
+        interaction.targetNodeHandleIdentifier = info.identifier;
+        frameIdentifier = info.frameInfo.frameID;
+    } else if (auto identifiers = WebKit::parseExtractedNodeInfo(nodeIdentifierString)) {
         interaction.nodeIdentifier = { WTF::move(identifiers->nodeIdentifier) };
         frameIdentifier = WTF::move(identifiers->frameIdentifier);
     }
@@ -460,7 +464,7 @@ static WebKit::TextExtractionOutputFormat textExtractionOutputFormat(_WKTextExtr
     interaction.replaceAll = wkInteraction.replaceAll;
     interaction.scrollToVisible = wkInteraction.scrollToVisible;
     interaction.scrollDelta = WebCore::FloatSize { wkInteraction.scrollDelta };
-    if (!interaction.nodeIdentifier) {
+    if (!interaction.nodeIdentifier && !interaction.targetNodeHandleIdentifier) {
         if (RetainPtr context = [wkInteraction extractionContext]) {
             auto result = [context resolveContainerForSearchText:wkInteraction.text];
             if (!result.has_value())
@@ -904,7 +908,7 @@ static OptionSet<WebCore::DataDetectorType> NODELETE coreDataDetectorTypes(_WKTe
     if (!protect(page->preferences())->textExtractionEnabled())
         return completionHandler(nil, [NSError errorWithDomain:WKErrorDomain code:WKErrorUnknown userInfo:nil]);
 
-    auto nodeIdentifierString = String { wkInteraction.nodeIdentifier };
+    auto nodeIdentifierString = wkInteraction.elementHandle ? emptyString() : String { wkInteraction.nodeIdentifier };
     auto conversionResult = [self _convertToWebCoreInteraction:wkInteraction nodeIdentifier:nodeIdentifierString];
     if (!conversionResult)
         return completionHandler(nil, [NSError errorWithDomain:WKErrorDomain code:WKErrorUnknown userInfo:@{ NSDebugDescriptionErrorKey: conversionResult.error().get() }]);

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -7170,7 +7170,7 @@ static Vector<Ref<API::TargetedElementInfo>> elementsFromWKElements(NSArray<_WKT
     if (!protect(page->preferences())->textExtractionEnabled())
         return completionHandler(adoptNS([[_WKTextExtractionInteractionResult alloc] initWithErrorDescription:@"Text extraction is unavailable" summary:nil interactedElementBounds:CGRectNull]).get());
 
-    auto nodeIdentifierString = String { wkInteraction.nodeIdentifier };
+    auto nodeIdentifierString = wkInteraction.elementHandle ? emptyString() : String { wkInteraction.nodeIdentifier };
     auto conversionResult = [self _convertToWebCoreInteraction:wkInteraction nodeIdentifier:nodeIdentifierString];
     if (!conversionResult) {
         RELEASE_LOG_ERROR(TextExtraction, "<%@: %p> Interaction conversion failed", [self class], self);

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.h
@@ -326,6 +326,13 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 - (void)debugDescriptionInWebView:(WKWebView *)webView completionHandler:(void (^)(NSString * _Nullable, NSError * _Nullable))completionHandler;
 
 @property (nonatomic, readonly) _WKTextExtractionAction action;
+
+/*!
+ A direct handle to the target element.
+ When set, this takes precedence over `nodeIdentifier`.
+ */
+@property (nonatomic, copy, nullable) WKJSHandle *elementHandle WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+
 @property (nonatomic, copy, nullable) NSString *nodeIdentifier;
 @property (nonatomic, copy, nullable) NSString *text;
 @property (nonatomic) BOOL replaceAll;

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.mm
@@ -282,6 +282,7 @@
 
 @implementation _WKTextExtractionInteraction {
     RetainPtr<NSString> _nodeIdentifier;
+    RetainPtr<_WKJSHandle> _elementHandle;
     RetainPtr<NSString> _text;
     RetainPtr<_WKTextExtractionResult> _extractionContext;
 }
@@ -317,6 +318,16 @@
 - (void)setNodeIdentifier:(NSString *)nodeIdentifier
 {
     _nodeIdentifier = adoptNS(nodeIdentifier.copy);
+}
+
+- (_WKJSHandle *)elementHandle
+{
+    return _elementHandle.get();
+}
+
+- (void)setElementHandle:(_WKJSHandle *)elementHandle
+{
+    _elementHandle = adoptNS([elementHandle copy]);
 }
 
 - (NSString *)text

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -1785,13 +1785,25 @@ void WebFrame::takeSnapshotOfExtractedText(TextExtraction::ExtractedText&& extra
     completion(TextIndicator::createWithRange(*range, options, TextIndicatorPresentationTransition::None));
 }
 
+static TextExtraction::Interaction interactionWithResolvedTargetNode(TextExtraction::Interaction interaction)
+{
+    if (interaction.nodeIdentifier || !interaction.targetNodeHandleIdentifier)
+        return interaction;
+
+    if (RefPtr node = nodeFromJSHandleIdentifier(*interaction.targetNodeHandleIdentifier))
+        interaction.nodeIdentifier = node->nodeIdentifier();
+
+    return interaction;
+}
+
 void WebFrame::describeTextExtractionInteraction(TextExtraction::Interaction&& interaction, CompletionHandler<void(TextExtraction::InteractionDescription&&)>&& completion)
 {
     RefPtr frame = coreLocalFrame();
     if (!frame)
         return completion({ { }, { }, false });
 
-    completion(TextExtraction::interactionDescription(interaction, *frame));
+    auto resolvedInteraction = interactionWithResolvedTargetNode(WTF::move(interaction));
+    completion(TextExtraction::interactionDescription(resolvedInteraction, *frame));
 }
 
 void WebFrame::handleTextExtractionInteraction(TextExtraction::Interaction&& interaction, CompletionHandler<void(bool, String&&, FloatRect)>&& completion)
@@ -1800,8 +1812,9 @@ void WebFrame::handleTextExtractionInteraction(TextExtraction::Interaction&& int
     if (!frame)
         return completion(false, "Browsing context is unavailable"_s, { });
 
-    auto summary = TextExtraction::interactionDescription(interaction, *frame, TextExtraction::Tense::Past).description;
-    TextExtraction::handleInteraction(WTF::move(interaction), *frame, [completion = WTF::move(completion), summary = WTF::move(summary)](bool success, String&& message, FloatRect interactedElementBounds) mutable {
+    auto resolvedInteraction = interactionWithResolvedTargetNode(WTF::move(interaction));
+    auto summary = TextExtraction::interactionDescription(resolvedInteraction, *frame, TextExtraction::Tense::Past).description;
+    TextExtraction::handleInteraction(WTF::move(resolvedInteraction), *frame, [completion = WTF::move(completion), summary = WTF::move(summary)](bool success, String&& message, FloatRect interactedElementBounds) mutable {
         if (success && message.isEmpty())
             message = WTF::move(summary);
         completion(success, WTF::move(message), interactedElementBounds);

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/TextExtractionTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/TextExtractionTests.mm
@@ -1274,6 +1274,49 @@ TEST(TextExtractionTests, ResolveTargetNodeFromSelectorData)
     EXPECT_WK_STREQ(debugText.get(), @"root\n\tlabel=Heading 'Subject'");
 }
 
+TEST(TextExtractionTests, ClickInteractionWithElementHandle)
+{
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    [[configuration preferences] _setTextExtractionEnabled:YES];
+
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration]);
+    [webView synchronouslyLoadHTMLString:@R"HTML(
+        <!DOCTYPE html>
+        <html>
+        <head><meta name='viewport' content='width=device-width, initial-scale=1'></head>
+        <body>
+            <button id='submit' onclick="document.getElementById('result').textContent = 'clicked'">Submit</button>
+            <div id='result'>none</div>
+        </body>
+        </html>
+    )HTML"];
+
+    RetainPtr world = [WKContentWorld _worldWithConfiguration:^{
+        RetainPtr worldConfiguration = adoptNS([_WKContentWorldConfiguration new]);
+        [worldConfiguration setAllowJSHandleCreation:YES];
+        return worldConfiguration.autorelease();
+    }()];
+
+    RetainPtr buttonHandle = [webView querySelector:@"#submit" frame:nil world:world];
+    RetainPtr selectorData = [webView synchronouslyGetSelectorPathDataForNode:buttonHandle];
+    RetainPtr elementHandle = [webView synchronouslyGetNodeForSelectorPathData:selectorData];
+    EXPECT_NOT_NULL(elementHandle);
+
+    RetainPtr click = adoptNS([[_WKTextExtractionInteraction alloc] initWithAction:_WKTextExtractionActionClick]);
+    [click setElementHandle:elementHandle];
+    [click setNodeIdentifier:@"0_99999"]; // Intentionally invalid node UID.
+
+    NSError *error = nil;
+    RetainPtr description = [click debugDescriptionInWebView:webView error:&error];
+    EXPECT_NULL(error);
+    EXPECT_TRUE([description containsString:@"Submit"]);
+
+    RetainPtr result = [webView synchronouslyPerformInteraction:click];
+    EXPECT_NULL([result error]);
+
+    EXPECT_WK_STREQ("clicked", [webView stringByEvaluatingJavaScript:@"document.getElementById('result').textContent"]);
+}
+
 #if HAVE(SAFARI_SAFE_BROWSING_NAMESPACED_LISTS)
 
 typedef void(^WKSafeBrowsingNamespacedListBlock)(NSDictionary<NSString *, NSArray<NSString *> *> *, NSError *);


### PR DESCRIPTION
#### b773985374b46f18027933645166d0ad194e0d38
<pre>
[Text Extraction] Add a way for clients to issue interactions by passing in a WKJSHandle
<a href="https://bugs.webkit.org/show_bug.cgi?id=319636">https://bugs.webkit.org/show_bug.cgi?id=319636</a>
<a href="https://rdar.apple.com/182459757">rdar://182459757</a>

Reviewed by Megan Gardner and Abrar Rahman Protyasha.

Add support for creating interactions with a JS handle, representing the targeted element. This
allows clients to drive interactions based on the results of script evaluation (e.g. using
`document.querySelector`).

* Source/WebCore/page/text-extraction/TextExtractionTypes.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView+TextExtraction.mm:
(-[WKWebView _convertToWebCoreInteraction:nodeIdentifier:]):
(-[WKWebView _describeInteraction:completionHandler:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _performInteraction:completionHandler:]):
* Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.mm:
(-[_WKTextExtractionInteraction elementHandle]):
(-[_WKTextExtractionInteraction setElementHandle:]):
* Source/WebKit/WebProcess/WebPage/WebFrame.cpp:
(WebKit::interactionWithResolvedTargetNode):
(WebKit::WebFrame::describeTextExtractionInteraction):
(WebKit::WebFrame::handleTextExtractionInteraction):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/TextExtractionTests.mm:
(TestWebKitAPI::ClickInteractionWithElementHandle)):
(TestWebKitAPI::FilteringRules)): Deleted.
(TestWebKitAPI::FilteringRulesAreIsolated)): Deleted.
(TestWebKitAPI::SubframeInteractions)): Deleted.
(TestWebKitAPI::SubframeOriginInDebugText)): Deleted.
(TestWebKitAPI::ClickInteractionWithTextOnly)): Deleted.
(TestWebKitAPI::ScrollToRevealFallsBackToFullDocumentWhenNodeMisses)): Deleted.

Canonical link: <a href="https://commits.webkit.org/317444@main">https://commits.webkit.org/317444@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/158e1b4e2758d915f3b16d94c84b0cc59d28c1c1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175225 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49157 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42938 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184810 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/133323 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a201d11d-6013-449d-bde9-5948344c519b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/177089 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50449 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48840 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136395 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/133323 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/665374df-93ed-41f0-af37-f884703a4aef) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178182 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39810 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157167 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116874 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/35b78c3c-fecc-4bf1-9a39-1723095bad75) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38451 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36839 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33283 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148874 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36660 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187231 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/40844 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/41042 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145342 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48824 "Built successfully") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145199 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; run-api-tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39133 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49504 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33281 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115380 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40035 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/121694 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48010 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11633 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47413 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47643 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47470 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->