### PR TITLE
[IndexedDB] Opening a 'nextunique'/'prevunique' cursor over an empty key range fails with an UnknownError

### DIFF
--- a/LayoutTests/storage/indexeddb/modern/cursor-unique-direction-empty-range-expected.txt
+++ b/LayoutTests/storage/indexeddb/modern/cursor-unique-direction-empty-range-expected.txt
@@ -1,0 +1,26 @@
+This tests that opening a cursor with a 'nextunique'/'prevunique' direction over a key range that matches no records succeeds with a null result, instead of firing an error. See rdar://182231936.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+indexedDB = self.indexedDB || self.webkitIndexedDB || self.mozIndexedDB || self.msIndexedDB || self.OIndexedDB;
+
+indexedDB.deleteDatabase(dbname)
+indexedDB.open(dbname)
+Initial upgrade needed: Old version - 0 New version - 1
+
+Opening index cursor with direction 'nextunique' over an empty range
+PASS request.result is null
+
+Opening index cursor with direction 'prevunique' over an empty range
+PASS request.result is null
+
+Opening index cursor with direction 'next' over an empty range
+PASS request.result is null
+
+Opening object store cursor with direction 'nextunique' over an empty range
+PASS request.result is null
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/storage/indexeddb/modern/cursor-unique-direction-empty-range-private-expected.txt
+++ b/LayoutTests/storage/indexeddb/modern/cursor-unique-direction-empty-range-private-expected.txt
@@ -1,0 +1,26 @@
+This tests that opening a cursor with a 'nextunique'/'prevunique' direction over a key range that matches no records succeeds with a null result, instead of firing an error. See rdar://182231936.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+indexedDB = self.indexedDB || self.webkitIndexedDB || self.mozIndexedDB || self.msIndexedDB || self.OIndexedDB;
+
+indexedDB.deleteDatabase(dbname)
+indexedDB.open(dbname)
+Initial upgrade needed: Old version - 0 New version - 1
+
+Opening index cursor with direction 'nextunique' over an empty range
+PASS request.result is null
+
+Opening index cursor with direction 'prevunique' over an empty range
+PASS request.result is null
+
+Opening index cursor with direction 'next' over an empty range
+PASS request.result is null
+
+Opening object store cursor with direction 'nextunique' over an empty range
+PASS request.result is null
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/storage/indexeddb/modern/cursor-unique-direction-empty-range-private.html
+++ b/LayoutTests/storage/indexeddb/modern/cursor-unique-direction-empty-range-private.html
@@ -1,0 +1,11 @@
+<!-- webkit-test-runner [ useEphemeralSession=true ] -->
+<html>
+<head>
+<script src="../../../resources/js-test.js"></script>
+<script src="../resources/shared.js"></script>
+</head>
+<body>
+
+<script src="resources/cursor-unique-direction-empty-range.js"></script>
+</body>
+</html>

--- a/LayoutTests/storage/indexeddb/modern/cursor-unique-direction-empty-range.html
+++ b/LayoutTests/storage/indexeddb/modern/cursor-unique-direction-empty-range.html
@@ -1,0 +1,10 @@
+<html>
+<head>
+<script src="../../../resources/js-test.js"></script>
+<script src="../resources/shared.js"></script>
+</head>
+<body>
+
+<script src="resources/cursor-unique-direction-empty-range.js"></script>
+</body>
+</html>

--- a/LayoutTests/storage/indexeddb/modern/resources/cursor-unique-direction-empty-range.js
+++ b/LayoutTests/storage/indexeddb/modern/resources/cursor-unique-direction-empty-range.js
@@ -1,0 +1,99 @@
+description("This tests that opening a cursor with a 'nextunique'/'prevunique' direction over a key range that matches no records succeeds with a null result, instead of firing an error. See rdar://182231936.");
+
+indexedDBTest(prepareDatabase, openSuccess);
+
+function done()
+{
+    finishJSTest();
+}
+
+var database;
+
+// shouldBeNull() evaluates its argument in the global scope, so `request` must be a
+// global for it to be visible there rather than scoped to the enclosing test function.
+var request;
+
+function prepareDatabase(event)
+{
+    debug("Initial upgrade needed: Old version - " + event.oldVersion + " New version - " + event.newVersion);
+
+    var db = event.target.result;
+    var objectStore = db.createObjectStore("TestObjectStore");
+    objectStore.createIndex("TestIndex", "bar");
+
+    objectStore.put({ bar: "A" }, 1);
+    objectStore.put({ bar: "B" }, 2);
+}
+
+function openSuccess(event)
+{
+    database = event.target.result;
+    runNextTest();
+}
+
+var tests = [
+    testIndexCursor("nextunique"),
+    testIndexCursor("prevunique"),
+    testIndexCursor("next"),
+    testObjectStoreCursor("nextunique"),
+];
+
+function runNextTest()
+{
+    if (!tests.length) {
+        done();
+        return;
+    }
+
+    tests.shift()();
+}
+
+// A key range that cannot match any record ("bar" values used are only "A" and "B").
+function emptyIndexRange()
+{
+    return IDBKeyRange.bound("X", "Z");
+}
+
+// A key range that cannot match any record (object store keys used are only 1 and 2).
+function emptyObjectStoreRange()
+{
+    return IDBKeyRange.lowerBound(1000);
+}
+
+function testIndexCursor(direction)
+{
+    return function() {
+        debug("");
+        debug("Opening index cursor with direction '" + direction + "' over an empty range");
+
+        var transaction = database.transaction("TestObjectStore", "readonly");
+        request = transaction.objectStore("TestObjectStore").index("TestIndex").openCursor(emptyIndexRange(), direction);
+        request.onsuccess = function() {
+            shouldBeNull("request.result");
+            runNextTest();
+        };
+        request.onerror = function(event) {
+            testFailed("Error function called unexpectedly: (" + event.target.error.name + ") " + event.target.error.message);
+            runNextTest();
+        };
+    };
+}
+
+function testObjectStoreCursor(direction)
+{
+    return function() {
+        debug("");
+        debug("Opening object store cursor with direction '" + direction + "' over an empty range");
+
+        var transaction = database.transaction("TestObjectStore", "readonly");
+        request = transaction.objectStore("TestObjectStore").openCursor(emptyObjectStoreRange(), direction);
+        request.onsuccess = function() {
+            shouldBeNull("request.result");
+            runNextTest();
+        };
+        request.onerror = function(event) {
+            testFailed("Error function called unexpectedly: (" + event.target.error.name + ") " + event.target.error.message);
+            runNextTest();
+        };
+    };
+}

--- a/Source/WebCore/Modules/indexeddb/server/SQLiteIDBCursor.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/SQLiteIDBCursor.cpp
@@ -442,12 +442,11 @@ bool SQLiteIDBCursor::fetch()
 
     while (fetchNextRecord(m_fetchedRecords.last())) {
         m_fetchedRecordsSize += m_fetchedRecords.last().record.size();
+        if (m_fetchedRecords.last().completed)
+            return true;
 
         if (m_currentKeyForUniqueness != m_fetchedRecords.last().record.key)
             return true;
-
-        if (m_fetchedRecords.last().completed)
-            return false;
 
         m_fetchedRecordsSize -= m_fetchedRecords.last().record.size();
     }


### PR DESCRIPTION
#### 63d90a92e5abed765bad3cb59b4dc7598d092c4d
<pre>
[IndexedDB] Opening a &apos;nextunique&apos;/&apos;prevunique&apos; cursor over an empty key range fails with an UnknownError
<a href="https://bugs.webkit.org/show_bug.cgi?id=319640">https://bugs.webkit.org/show_bug.cgi?id=319640</a>
<a href="https://rdar.apple.com/182231936">rdar://182231936</a>

Reviewed by Rupin Mittal.

When opening an IDBCursor with &apos;nextunique&apos; or &apos;prevunique&apos; direction over a key range that matches
no records, SQLiteIDBCursor::fetch() incorrectly reported failure instead of a legitimate empty
result. Its dedup loop checked whether the newly fetched record&apos;s key differed from
m_currentKeyForUniqueness before checking whether the fetch had reached the end of the result set.
On a freshly created cursor, m_currentKeyForUniqueness is default-constructed (Invalid type), which
compares equal to the terminal record&apos;s also-default-constructed key, so the key-mismatch check did
not fire and control fell through to the completed check, which returned false.
SQLiteIDBBackingStore::openCursor() treated that false as cursor-creation failure and surfaced an
UnknownError, even though a range with no matching records is a case the IndexedDB spec requires to
succeed with a null result.

Check completed first, before the key-mismatch check, and return true in that case, matching how the
non-unique (next/prev) path already reports end-of-results as success rather than failure. This only
changes behavior for the empty-range case: whenever m_currentKeyForUniqueness holds a real key from
a previously fetched record, the key-mismatch check already returned true ahead of the completed
check, since a real key can never equal the terminal record&apos;s default Invalid key.

Tests: storage/indexeddb/modern/cursor-unique-direction-empty-range-private.html
       storage/indexeddb/modern/cursor-unique-direction-empty-range.html

* LayoutTests/storage/indexeddb/modern/cursor-unique-direction-empty-range-expected.txt: Added.
* LayoutTests/storage/indexeddb/modern/cursor-unique-direction-empty-range-private-expected.txt: Added.
* LayoutTests/storage/indexeddb/modern/cursor-unique-direction-empty-range-private.html: Added.
* LayoutTests/storage/indexeddb/modern/cursor-unique-direction-empty-range.html: Added.
* LayoutTests/storage/indexeddb/modern/resources/cursor-unique-direction-empty-range.js: Added.
(done):
(prepareDatabase):
(runNextTest):
(emptyIndexRange):
(emptyObjectStoreRange):
(testIndexCursor.request.onsuccess):
(testIndexCursor.request.onerror):
(testIndexCursor):
(testObjectStoreCursor.request.onsuccess):
(testObjectStoreCursor.request.onerror):
(testObjectStoreCursor):
* Source/WebCore/Modules/indexeddb/server/SQLiteIDBCursor.cpp:
(WebCore::IDBServer::SQLiteIDBCursor::fetch):

Canonical link: <a href="https://commits.webkit.org/317559@main">https://commits.webkit.org/317559@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/872125f4b4ea5474bebdb5e7f414bc02783873cc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175147 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49079 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42860 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184732 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/133054 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/970b11a3-0529-46d1-a9d8-e7734304953d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/177011 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50371 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48762 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136328 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96160 "5 failures") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8b3a1c67-60f2-4a4b-9817-a305d79ea9dd) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178104 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39761 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157115 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116807 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6e556fdd-7bf0-4aea-b2d2-97c7df8acaa5) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38402 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36784 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33205 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148825 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36608 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187152 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/40750 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40987 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145269 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48746 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/156671 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145125 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39214 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49426 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33228 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115261 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39985 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/121599 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47932 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11581 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47335 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47565 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47392 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->