### PR TITLE
[Custom Highlight] ::highlight() and ::target-text ignore text-underline-offset.

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -3922,7 +3922,6 @@ imported/w3c/web-platform-tests/css/css-pseudo/selection-originating-decoration-
 imported/w3c/web-platform-tests/css/css-pseudo/selection-text-decoration-currentcolor.html [ ImageOnlyFailure ]
 
 imported/w3c/web-platform-tests/css/css-highlight-api/painting/invalidation/css-highlight-invalidation-001.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-highlight-api/painting/css-highlight-painting-underline-offset-001.html [ ImageOnlyFailure ]
 
 webkit.org/b/177799,webkit.org/b/290781 accessibility/table-detection.html [ Pass Failure Timeout ]
 
@@ -5721,7 +5720,6 @@ webkit.org/b/217931 imported/w3c/web-platform-tests/html/semantics/scripting-1/t
 webkit.org/b/220325 imported/w3c/web-platform-tests/css/css-highlight-api/highlight-text-cascade.html [ ImageOnlyFailure ]
 
 # Tests need updating relating to Highlight Spec
-imported/w3c/web-platform-tests/css/css-highlight-api/painting/css-target-text-decoration-001.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-highlight-api/painting/custom-highlight-container-metrics-001.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-highlight-api/painting/custom-highlight-container-metrics-002.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-highlight-api/painting/custom-highlight-container-metrics-003.html [ ImageOnlyFailure ]

--- a/Source/WebCore/rendering/StyledMarkedText.cpp
+++ b/Source/WebCore/rendering/StyledMarkedText.cpp
@@ -55,6 +55,7 @@ static void computeStyleForPseudoElementStyle(StyledMarkedText::Style& style, co
         style.textDecorationStyles.underline.color = color;
         style.textDecorationStyles.underline.decorationStyle = decorationStyle;
         style.textDecorationStyles.underline.thickness = thickness;
+        style.textDecorationStyles.underlineOffset = pseudoElementStyle->textUnderlineOffset();
     }
     if (decorations.hasOverline()) {
         style.textDecorationStyles.overline.color = color;
@@ -181,6 +182,7 @@ static TextDecorationPainter::Styles NODELETE computeStylesForTextDecorations(co
         textDecorationStyles.underline.color = currentTextDecorationStyles.underline.color;
         textDecorationStyles.underline.decorationStyle = currentTextDecorationStyles.underline.decorationStyle;
         textDecorationStyles.underline.thickness = currentTextDecorationStyles.underline.thickness;
+        textDecorationStyles.underlineOffset = currentTextDecorationStyles.underlineOffset;
     }
     if (textDecorations.hasOverline()) {
         textDecorationStyles.overline.color = currentTextDecorationStyles.overline.color;

--- a/Source/WebCore/rendering/TextBoxPainter.cpp
+++ b/Source/WebCore/rendering/TextBoxPainter.cpp
@@ -1011,7 +1011,7 @@ void TextBoxPainter::paintBackgroundDecorations(TextDecorationPainter& decoratio
             auto underlineOffset = [&] {
                 if (!computedTextDecorationType.hasUnderline())
                     return 0.f;
-                auto baseOffset = underlineOffsetForTextBoxPainting(*decoratingBox.inlineBox, decoratingBox.style.get());
+                auto baseOffset = underlineOffsetForTextBoxPainting(*decoratingBox.inlineBox, decoratingBox.style.get(), decoratingBox.textDecorationStyles.underlineOffset);
                 auto wavyOffset = decoratingBox.textDecorationStyles.underline.decorationStyle == TextDecorationStyle::Wavy ? wavyOffsetFromDecoration() : 0.f;
                 return baseOffset + wavyOffset;
             };

--- a/Source/WebCore/rendering/TextDecorationPainter.cpp
+++ b/Source/WebCore/rendering/TextDecorationPainter.cpp
@@ -180,6 +180,7 @@ bool TextDecorationPainter::Styles::operator==(const Styles& other) const
     return underline.color == other.underline.color && overline.color == other.overline.color && linethrough.color == other.linethrough.color
         && underline.decorationStyle == other.underline.decorationStyle && overline.decorationStyle == other.overline.decorationStyle && linethrough.decorationStyle == other.linethrough.decorationStyle
         && underline.thickness == other.underline.thickness && overline.thickness == other.overline.thickness && linethrough.thickness == other.linethrough.thickness
+        && underlineOffset == other.underlineOffset
         && inset == other.inset && boxDecorationBreak == other.boxDecorationBreak;
 }
 

--- a/Source/WebCore/rendering/TextDecorationPainter.h
+++ b/Source/WebCore/rendering/TextDecorationPainter.h
@@ -29,6 +29,7 @@
 #include "RenderStyleConstants.h"
 #include "StyleTextDecorationInset.h"
 #include "StyleTextDecorationThickness.h"
+#include "StyleTextUnderlineOffset.h"
 #include <wtf/OptionSet.h>
 
 namespace WebCore {
@@ -62,6 +63,8 @@ public:
         DecorationStyleAndColor underline;
         DecorationStyleAndColor overline;
         DecorationStyleAndColor linethrough;
+
+        std::optional<Style::TextUnderlineOffset> underlineOffset;
 
         std::optional<Style::TextDecorationInset> inset;
         BoxDecorationBreak boxDecorationBreak { BoxDecorationBreak::Slice };

--- a/Source/WebCore/style/InlineTextBoxStyle.cpp
+++ b/Source/WebCore/style/InlineTextBoxStyle.cpp
@@ -43,6 +43,7 @@ namespace WebCore {
 struct UnderlineOffsetArguments {
     const Style::ComputedStyle& lineStyle;
     std::optional<TextUnderlinePositionUnder> textUnderlinePositionUnder { };
+    std::optional<Style::TextUnderlineOffset> offsetOverride { };
 };
 
 static bool NODELETE isAncestorAndWithinBlock(const RenderInline& ancestor, const RenderObject* child)
@@ -129,6 +130,7 @@ static float computedUnderlineOffset(const UnderlineOffsetArguments& context, co
         return fontMetrics.intAscent();
     };
     auto underlineOffset = 0.f;
+    auto textUnderlineOffset = context.offsetOverride.value_or(styleToUse.textUnderlineOffset());
     auto textUnderlinePosition = styleToUse.textUnderlinePosition();
 
     if (isAlignedForUnder(styleToUse)) {
@@ -136,17 +138,17 @@ static float computedUnderlineOffset(const UnderlineOffsetArguments& context, co
         // FIXME: This needs to be flipped for sideways-lr.
         if (styleToUse.writingMode().isVerticalTypographic() && textUnderlinePosition.verticalTypographySide() == Style::TextUnderlinePosition::Side::Right) {
             // In vertical typographic modes, the underline is aligned as for under, except it is always aligned to the right edge of the text.
-            underlineOffset = 0.f - (styleToUse.textUnderlineOffset().resolve(styleToUse) + defaultGap(styleToUse));
+            underlineOffset = 0.f - (textUnderlineOffset.resolve(styleToUse) + defaultGap(styleToUse));
         } else {
             // Position underline relative to the bottom edge of the lowest element's content box.
             auto desiredOffset = context.textUnderlinePositionUnder->textRunLogicalHeight + std::max(context.textUnderlinePositionUnder->textRunOffsetFromBottomMost, 0.f);
-            desiredOffset += styleToUse.textUnderlineOffset().resolve(styleToUse) + defaultGap(styleToUse);
+            desiredOffset += textUnderlineOffset.resolve(styleToUse) + defaultGap(styleToUse);
             underlineOffset = std::max<float>(desiredOffset, ascent());
         }
     } else if (textUnderlinePosition.isFromFont())
-        underlineOffset = ascent() + fontMetrics.underlinePosition().value_or(0) + styleToUse.textUnderlineOffset().resolve(styleToUse);
+        underlineOffset = ascent() + fontMetrics.underlinePosition().value_or(0) + textUnderlineOffset.resolve(styleToUse);
     else
-        underlineOffset = ascent() + styleToUse.textUnderlineOffset().resolve(styleToUse, defaultGap(styleToUse));
+        underlineOffset = ascent() + textUnderlineOffset.resolve(styleToUse, defaultGap(styleToUse));
     return underlineOffset;
 }
 
@@ -317,15 +319,15 @@ float textBoxEdgeAdjustmentForUnderline(const Style::ComputedStyle& style)
     }
 }
 
-float underlineOffsetForTextBoxPainting(const InlineIterator::InlineBox& inlineBox, const Style::ComputedStyle& style)
+float underlineOffsetForTextBoxPainting(const InlineIterator::InlineBox& inlineBox, const Style::ComputedStyle& style, std::optional<Style::TextUnderlineOffset> offsetOverride)
 {
     auto underlineOffset = 0.f;
     auto& renderer = inlineBox.renderer();
     if (!isAlignedForUnder(style))
-        underlineOffset = computedUnderlineOffset({ style, { } }, &renderer);
+        underlineOffset = computedUnderlineOffset({ style, { }, offsetOverride }, &renderer);
     else {
         auto textRunOffset = boxOffsetFromBottomMost(inlineBox.lineBox(), renderer, inlineBox.logicalTop(), inlineBox.logicalBottom());
-        underlineOffset = computedUnderlineOffset({ style, TextUnderlinePositionUnder { inlineBoxContentBoxHeight(inlineBox), textRunOffset } }, &renderer);
+        underlineOffset = computedUnderlineOffset({ style, TextUnderlinePositionUnder { inlineBoxContentBoxHeight(inlineBox), textRunOffset }, offsetOverride }, &renderer);
     }
 
     return underlineOffset - (!inlineBox.isRootInlineBox() ? textBoxEdgeAdjustmentForUnderline(style) : 0.f);

--- a/Source/WebCore/style/InlineTextBoxStyle.h
+++ b/Source/WebCore/style/InlineTextBoxStyle.h
@@ -28,6 +28,7 @@
 #include "InlineIteratorInlineBox.h"
 #include "InlineIteratorLineBox.h"
 #include "RenderStyleConstants.h"
+#include "StyleTextUnderlineOffset.h"
 
 namespace WebCore {
 
@@ -74,7 +75,7 @@ InkOverflowForDecorations inkOverflowForDecorations(const Style::ComputedStyle&)
 InkOverflowForDecorations inkOverflowForDecorations(const Style::ComputedStyle&, TextUnderlinePositionUnder);
 bool NODELETE isAlignedForUnder(const Style::ComputedStyle& decoratingBoxStyle);
 
-float underlineOffsetForTextBoxPainting(const InlineIterator::InlineBox&, const Style::ComputedStyle&);
+float underlineOffsetForTextBoxPainting(const InlineIterator::InlineBox&, const Style::ComputedStyle&, std::optional<Style::TextUnderlineOffset> offsetOverride);
 float overlineOffsetForTextBoxPainting(const InlineIterator::InlineBox&, const Style::ComputedStyle&);
 float textBoxEdgeAdjustmentForUnderline(const Style::ComputedStyle&);
 


### PR DESCRIPTION
#### bba5a8d070c5f6d54de3a1143d894a7b8ba8a3a1
<pre>
[Custom Highlight] ::highlight() and ::target-text ignore text-underline-offset.
<a href="https://bugs.webkit.org/show_bug.cgi?id=319645">https://bugs.webkit.org/show_bug.cgi?id=319645</a>
<a href="https://rdar.apple.com/182466757">rdar://182466757</a>

Reviewed by Jessica Cheung.

::highlight() and ::target-text overlays dropped text-underline-offset: unlike the decoration&apos;s color, style, and thickness, the offset was never carried on
TextDecorationPainter::Styles, so at paint time it was read from the originating box&apos;s style and the pseudo&apos;s value was lost. Carry it as an optional override on
the decoration styles — set from the pseudo in computeStyleForPseudoElementStyle, propagated through the same-range decoration coalesce, and threaded into
underlineOffsetForTextBoxPainting, defaulting to the painting box&apos;s own value so non-highlighted text is unchanged.

imported/w3c/web-platform-tests/css/css-highlight-api/painting/css-highlight-painting-underline-offset-001.html
imported/w3c/web-platform-tests/css/css-highlight-api/painting/css-target-text-decoration-001.html

* LayoutTests/TestExpectations:
* Source/WebCore/rendering/StyledMarkedText.cpp:
(WebCore::computeStyleForPseudoElementStyle):
(WebCore::computeStylesForTextDecorations):
* Source/WebCore/rendering/TextBoxPainter.cpp:
(WebCore::TextBoxPainter::paintBackgroundDecorations):
* Source/WebCore/rendering/TextDecorationPainter.cpp:
(WebCore::TextDecorationPainter::Styles::operator== const):
* Source/WebCore/rendering/TextDecorationPainter.h:
* Source/WebCore/style/InlineTextBoxStyle.cpp:
(WebCore::computedUnderlineOffset):
(WebCore::underlineOffsetForTextBoxPainting):
* Source/WebCore/style/InlineTextBoxStyle.h:

Canonical link: <a href="https://commits.webkit.org/317440@main">https://commits.webkit.org/317440@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/93040dabaaab1bf4b0531dde41b4b15dbfff7015

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175160 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49092 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42873 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184745 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/133067 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f85fb7d2-5d5b-45e5-9172-cffb11b14d96) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/177024 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50384 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48775 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136335 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96168 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/eefef6f1-d5df-4528-ac5e-b2929c684cb7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178117 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39769 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157121 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116814 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3c14f45d-d4e8-4ff7-9e75-1dbd836e13ad) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38410 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36798 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33218 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148833 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36614 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187165 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/40772 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41001 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145282 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48759 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/156677 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145138 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39130 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49439 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33234 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115274 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39993 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/121672 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47945 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11587 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47348 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47578 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47405 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->