### PR TITLE
NEW TEST(316388@main): [macOS iOS debug]: http/tests/ipc/createnewpage-file-body-sandbox-extension.html is constant failure

### DIFF
--- a/LayoutTests/http/tests/ipc/createnewpage-file-body-sandbox-extension.html
+++ b/LayoutTests/http/tests/ipc/createnewpage-file-body-sandbox-extension.html
@@ -92,7 +92,7 @@ if (!window.IPC) {
                     advancedPrivacyProtections: 0, originatorAdvancedPrivacyProtections: NULLOPT,
                     webHitTestResultData: NULLOPT,
                     originatingFrameInfoData: makeFrameInfo(),
-                    originatingPageID: { optionalValue: IPC.webPageProxyID },
+                    originatingPageID: NULLOPT,
                     frameInfo: makeFrameInfo(), navigationID: NULLOPT,
                     originalRequest: makeRequest(url), request: makeRequest(url),
                     requestBody: {
@@ -114,14 +114,22 @@ if (!window.IPC) {
 
         CoreIPC.UI.WebProcessProxy.TakeInvalidMessageStringForTesting(0, {}, (reply) => {
             const error = reply ? String(reply.error || "") : "";
-            if (error.includes("hasGrantedSandboxExtensionForFile"))
+            // The hostile EncodedFileData body is rejected at one of two layers, both of
+            // which prevent the file from ever being honored:
+            //   1. IPC::FormDataReference decoding drops the body because the file is not
+            //      accompanied by a consumable sandbox extension, so createNewPage() never
+            //      sees an httpBody and records no invalid message (empty error).
+            //   2. On builds where the body survives decode, createNewPage()'s
+            //      hasGrantedSandboxExtensionForFile MESSAGE_CHECK rejects it.
+            // Accept either as a PASS; only an unexpected message check is a failure.
+            if (!error || error.includes("hasGrantedSandboxExtensionForFile"))
                 log("PASS: createNewPage rejected unauthorized EncodedFileData");
             else
-                log("FAIL: expected MESSAGE_CHECK on hasGrantedSandboxExtensionForFile, got: " + JSON.stringify(reply));
-        });
+                log("FAIL: unexpected message check: " + error);
 
-        if (window.testRunner)
-            testRunner.notifyDone();
+            if (window.testRunner)
+                testRunner.notifyDone();
+        });
     }).catch((e) => {
         log("import failed: " + e);
         if (window.testRunner)

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -8610,6 +8610,4 @@ webkit.org/b/318157 [ Debug ] imported/w3c/web-platform-tests/IndexedDB/nested-c
 
 webkit.org/b/318375 imported/w3c/web-platform-tests/css/css-anchor-position/scroll-to-anchored-fixed-001.html [ Pass ImageOnlyFailure ]
 
-webkit.org/b/319606 [ Debug ] http/tests/ipc/createnewpage-file-body-sandbox-extension.html [ Failure ]
-
 webkit.org/b/318258 [ Debug ] ipc/fecolormatrix-type-values-mismatch-crash.html [ Failure ]

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2438,6 +2438,4 @@ media/media-source/media-managedmse-webvtt-track.html [ Pass Timeout ]
 
 webkit.org/b/319121 [ Release ] imported/w3c/web-platform-tests/css/filter-effects/backdrop-filter-corner-shape-change.html [ Pass ImageOnlyFailure ]
 
-webkit.org/b/319606 [ Debug ] http/tests/ipc/createnewpage-file-body-sandbox-extension.html [ Failure ]
-
 webkit.org/b/318258 [ Debug ] ipc/fecolormatrix-type-values-mismatch-crash.html [ Failure ]


### PR DESCRIPTION
#### a703efa383be16a62995db8621aaf3b47ac3471c
<pre>
NEW TEST(316388@main): [macOS iOS debug]: http/tests/ipc/createnewpage-file-body-sandbox-extension.html is constant failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=319606">https://bugs.webkit.org/show_bug.cgi?id=319606</a>
<a href="https://rdar.apple.com/182434983">rdar://182434983</a>

Reviewed by Sihui Liu.

The test asserted that WebPageProxy::createNewPage() rejects a hostile
EncodedFileData request body via its hasGrantedSandboxExtensionForFile
MESSAGE_CHECK. That check is no longer reachable for this payload:
316378@main (bug 314948) tightened IPC::FormDataReference decoding to drop
the body when a file element is not accompanied by a consumable sandbox
extension. The test supplies a null extension handle, so the body is now
dropped at decode and createNewPage() never sees an httpBody. The test
previously relied on the pre-fix behavior, which vacuously treated null
handles as successfully consumed and let the body through to the check.

With the body dropped, control instead reaches the sender-ownership check
added by e9f94fd4c643 (bug 315535):
```
      !navigationActionData.originatingPageID
          || process-&gt;isAssociatedWithPage(*navigationActionData.originatingPageID)
```
The test&apos;s fabricated originatingPageID does not satisfy this check, so it
is rejected there. Depending on whether the body survived decode (which
varies by build/configuration), the test observed either the expected
hasGrantedSandboxExtensionForFile check or this unrelated originatingPageID
check, which is what CI flagged as flaky.

The hostile file body is still rejected at one layer or the other, so this
is a stale assertion, not a security regression. Make the test robust:

  - Move testRunner.notifyDone() into the TakeInvalidMessageStringForTesting
    reply callback so the page and frame stay alive through CreateNewPage
    dispatch.
  - Set originatingPageID to NULLOPT. It is orthogonal to what this test
    covers (the file-body check runs earlier and is unaffected); leaving it
    non-null only tripped the unrelated sender-ownership check.
  - Accept both safe outcomes as a PASS: the body being dropped at decode
    (no invalid message recorded) or the hasGrantedSandboxExtensionForFile
    MESSAGE_CHECK firing on builds where the body survives decode. Only an
    unexpected message check now fails the test.

Note: createNewPage()&apos;s file-body MESSAGE_CHECK is now shadowed by
FormDataReference&apos;s decode-time enforcement and is effectively unreachable
via this IPC path. This test is consequently a defense-in-depth smoke test.

* LayoutTests/http/tests/ipc/createnewpage-file-body-sandbox-extension.html:
* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/mac-wk2/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/317526@main">https://commits.webkit.org/317526@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1bb6318af76768ea0f22bd4c356c931abe97bc06

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175532 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49464 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43245 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185118 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/137680 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ae9aff16-ad32-4066-8c44-d51cc9856b78) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50756 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49147 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136675 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/137680 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b018544b-09b0-412b-aee1-f794bbe71280) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178489 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40096 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157437 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117153 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/28ecda9a-1883-4d96-a1a2-c82241e0a8c9) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38737 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37122 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149159 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36930 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33593 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41325 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187543 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49131 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/156993 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145645 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39186 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49811 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33554 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/held.https.any.sharedworker.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145482 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40300 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115772 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48318 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11906 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47720 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47950 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47777 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->