### PR TITLE
[CMake][JSC] Support mac-rosetta configuration

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -252,6 +252,38 @@
             }
         },
         {
+            "name": "mac-rosetta",
+            "hidden": true,
+            "cacheVariables": {
+                "CMAKE_OSX_ARCHITECTURES": {
+                    "type": "STRING",
+                    "value": "x86_64"
+                }
+            }
+        },
+        {
+            "name": "mac-rosetta-release",
+            "displayName": "macOS x86_64/Rosetta Release",
+            "inherits": ["mac-rosetta", "mac-release"],
+            "binaryDir": "WebKitBuild/cmake-mac-rosetta/Release"
+        },
+        {
+            "name": "mac-rosetta-debug",
+            "displayName": "macOS x86_64/Rosetta Debug",
+            "inherits": ["mac-rosetta", "mac-debug"],
+            "binaryDir": "WebKitBuild/cmake-mac-rosetta/Debug"
+        },
+        {
+            "name": "mac-rosetta-dev-release",
+            "displayName": "macOS x86_64/Rosetta Development (Release, ccache, compile_commands)",
+            "inherits": ["mac-rosetta-release", "dev"]
+        },
+        {
+            "name": "mac-rosetta-dev-debug",
+            "displayName": "macOS x86_64/Rosetta Development (Debug, ccache, compile_commands)",
+            "inherits": ["mac-rosetta-debug", "dev"]
+        },
+        {
             "name": "ios",
             "hidden": true,
             "generator": "Ninja",
@@ -422,6 +454,26 @@
             "name": "mac-tsan",
             "displayName": "macOS TSan",
             "configurePreset": "mac-tsan"
+        },
+        {
+            "name": "mac-rosetta-release",
+            "displayName": "macOS x86_64/Rosetta Release",
+            "configurePreset": "mac-rosetta-release"
+        },
+        {
+            "name": "mac-rosetta-debug",
+            "displayName": "macOS x86_64/Rosetta Debug",
+            "configurePreset": "mac-rosetta-debug"
+        },
+        {
+            "name": "mac-rosetta-dev-release",
+            "displayName": "macOS x86_64/Rosetta Development Release",
+            "configurePreset": "mac-rosetta-dev-release"
+        },
+        {
+            "name": "mac-rosetta-dev-debug",
+            "displayName": "macOS x86_64/Rosetta Development Debug",
+            "configurePreset": "mac-rosetta-dev-debug"
         },
         {
             "name": "gtk-release",

--- a/Source/cmake/OptionsMac.cmake
+++ b/Source/cmake/OptionsMac.cmake
@@ -185,6 +185,11 @@ if (CMAKE_OSX_DEPLOYMENT_TARGET)
     unset(_arch_count)
 endif ()
 
+# Building x86_64 on an Apple Silicon host means the result only ever runs under Rosetta.
+if (CMAKE_OSX_ARCHITECTURES STREQUAL "x86_64" AND WTF_HOST_SYSTEM_MACHINE STREQUAL "arm64")
+    add_compile_definitions(HAVE_CPU_TRANSLATION_CAPABILITY=0)
+endif ()
+
 # Fail loudly if an ASan build dir lost its CMakeCache.txt and reconfigured
 # without ENABLE_SANITIZERS — otherwise the tree silently rebuilds uninstrumented.
 get_filename_component(_bindir_name "${CMAKE_BINARY_DIR}" NAME)

--- a/Source/cmake/WebKitCommon.cmake
+++ b/Source/cmake/WebKitCommon.cmake
@@ -135,11 +135,23 @@ if (NOT HAS_RUN_WEBKIT_COMMON)
     # -----------------------------------------------------------------------------
     # Use MSVC_CXX_ARCHITECTURE_ID instead of CMAKE_SYSTEM_PROCESSOR when defined,
     # since the later one just resolves to the host processor on Windows.
+    #
+    # Likewise, on Apple platforms CMAKE_SYSTEM_PROCESSOR resolves to the host,
+    # while CMAKE_OSX_ARCHITECTURES selects the target -- these differ when
+    # building x86_64 under Rosetta on an Apple Silicon host. Prefer
+    # CMAKE_OSX_ARCHITECTURES when it names a single architecture so that the
+    # CPU detection below (and everything keyed off WTF_CPU_*, e.g. the
+    # offlineasm backend) matches the code the compiler actually emits. Universal
+    # builds (multiple architectures) fall back to CMAKE_SYSTEM_PROCESSOR.
+    list(LENGTH CMAKE_OSX_ARCHITECTURES _osx_architectures_count)
     if (MSVC_CXX_ARCHITECTURE_ID)
         string(TOLOWER ${MSVC_CXX_ARCHITECTURE_ID} LOWERCASE_CMAKE_SYSTEM_PROCESSOR)
+    elseif (APPLE AND _osx_architectures_count EQUAL 1)
+        string(TOLOWER "${CMAKE_OSX_ARCHITECTURES}" LOWERCASE_CMAKE_SYSTEM_PROCESSOR)
     else ()
         string(TOLOWER ${CMAKE_SYSTEM_PROCESSOR} LOWERCASE_CMAKE_SYSTEM_PROCESSOR)
     endif ()
+    unset(_osx_architectures_count)
     if (LOWERCASE_CMAKE_SYSTEM_PROCESSOR MATCHES "^(arm|aarch32|cortex-(a(5|7|8|9|1[2-7]|32)|m[0-9]|r[0-9]([^0-9]|$)))"
             AND NOT LOWERCASE_CMAKE_SYSTEM_PROCESSOR MATCHES "^(aarch64|arm64)")
         set(WTF_CPU_ARM 1)

--- a/Source/cmake/WebKitXcodeSDK.cmake
+++ b/Source/cmake/WebKitXcodeSDK.cmake
@@ -121,11 +121,20 @@ function(WEBKIT_PROCESS_ENTITLEMENTS _target)
         set(_arg_PRODUCT_NAME ${_target})
     endif ()
     set(_xcent ${CMAKE_CURRENT_BINARY_DIR}/${_target}.xcent)
+    set(_env_args
+        WK_PROCESSED_XCENT_FILE=${_xcent}
+        WK_PLATFORM_NAME=${WEBKIT_SDK_NAME}
+        PRODUCT_NAME=${_arg_PRODUCT_NAME}
+    )
+    # An x86_64 build on Apple Silicon runs under Rosetta, where the arm64e
+    # JIT-hardening entitlements (com.apple.private.verified-jit,
+    # com.apple.security.cs.single-jit) prevent the process from launching.
+    if (CMAKE_OSX_ARCHITECTURES STREQUAL "x86_64")
+        list(APPEND _env_args SKIP_ROSETTA_BREAKING_ENTITLEMENTS=1)
+    endif ()
     add_custom_command(TARGET ${_target} POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E env
-            WK_PROCESSED_XCENT_FILE=${_xcent}
-            WK_PLATFORM_NAME=${WEBKIT_SDK_NAME}
-            PRODUCT_NAME=${_arg_PRODUCT_NAME}
+            ${_env_args}
             ${CMAKE_SOURCE_DIR}/Source/${_arg_PROJECT}/Scripts/process-entitlements.sh
         COMMAND codesign --force --sign - --entitlements ${_xcent} $<TARGET_FILE:${_target}>
         VERBATIM


### PR DESCRIPTION
#### 5bb1c6d49c5ad5a6a5effb44de65327e2c186d44
<pre>
[CMake][JSC] Support mac-rosetta configuration
<a href="https://bugs.webkit.org/show_bug.cgi?id=319646">https://bugs.webkit.org/show_bug.cgi?id=319646</a>
<a href="https://rdar.apple.com/182468053">rdar://182468053</a>

Reviewed by Elliott Williams.

This patch adds mac-rosetta family of configurations, which is modeled
after ios-sim family (e.g. mac-rosetta-dev-release). This brings
build-jsc --rosetta equivalent config to CMake builds, building x86_64
arch on ARM64 macOS.

* CMakePresets.json:
* Source/cmake/OptionsCocoa.cmake:
* Source/cmake/WebKitCommon.cmake:
* Source/cmake/WebKitEntitlements.cmake:

Canonical link: <a href="https://commits.webkit.org/321359@main">https://commits.webkit.org/321359@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/406dbe73c6278366dc91e063237b767084b2400f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/187766 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/61584 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/55313 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/197959 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/152299 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/63000 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/61306 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/146604 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/152299 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/190721 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/50340 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/167066 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/127122 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/49077 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/46891 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/8755 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/15615 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/159343 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/46699 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/9068 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/48892 "Built successfully and passed tests") | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/51485 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/200008 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/61184 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/156302 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/61905 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/43186 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/155947 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28513 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/50247 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/131657 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/60272 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/21682 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/59681 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/59868 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/59840 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->