### PR TITLE
[Sandboxing] Update sandbox profiles to allow the `*at` counterparts to some syscalls

### DIFF
--- a/Source/WebKit/GPUProcess/mac/com.apple.WebKit.GPUProcess.sb.in
+++ b/Source/WebKit/GPUProcess/mac/com.apple.WebKit.GPUProcess.sb.in
@@ -1497,6 +1497,7 @@
         SYS_necp_open
         SYS_open_dprotected_np
         SYS_open_nocancel
+        SYS_openat_dprotected_np
         SYS_pathconf
         SYS_pread
         SYS_proc_rlimit_control
@@ -1513,6 +1514,7 @@
         SYS_read_nocancel
         SYS_readlink
         SYS_rename
+        SYS_renameat
         SYS_sendto
         SYS_setrlimit
         SYS_setsockopt

--- a/Source/WebKit/NetworkProcess/mac/com.apple.WebKit.NetworkProcess.sb.in
+++ b/Source/WebKit/NetworkProcess/mac/com.apple.WebKit.NetworkProcess.sb.in
@@ -692,6 +692,7 @@
         SYS_open_dprotected_np
         SYS_open_nocancel
         SYS_openat
+        SYS_openat_dprotected_np
         SYS_os_fault_with_payload
         SYS_pathconf
         SYS_pipe
@@ -715,6 +716,7 @@
         SYS_recvfrom_nocancel
         SYS_recvmsg
         SYS_rename
+        SYS_renameat
         SYS_rmdir
         SYS_select
         SYS_select_nocancel

--- a/Source/WebKit/Shared/Sandbox/iOS/gpu-defines.sb
+++ b/Source/WebKit/Shared/Sandbox/iOS/gpu-defines.sb
@@ -330,6 +330,7 @@
         SYS_read_nocancel
         SYS_readlink
         SYS_rename
+        SYS_renameat
         SYS_sem_close
         SYS_sem_open
         SYS_sendto

--- a/Source/WebKit/Shared/Sandbox/iOS/networking-defines.sb
+++ b/Source/WebKit/Shared/Sandbox/iOS/networking-defines.sb
@@ -269,6 +269,7 @@
         SYS_open_dprotected_np
         SYS_open_nocancel
         SYS_openat
+        SYS_openat_dprotected_np
         SYS_os_fault_with_payload
         SYS_pathconf
         SYS_persona
@@ -294,6 +295,7 @@
         SYS_recvfrom_nocancel
         SYS_recvmsg
         SYS_rename
+        SYS_renameat
         SYS_rmdir
         SYS_select
         SYS_select_nocancel

--- a/Source/WebKit/Shared/Sandbox/iOS/webcontent-defines.sb
+++ b/Source/WebKit/Shared/Sandbox/iOS/webcontent-defines.sb
@@ -376,6 +376,7 @@
     SYS_mkdir
     SYS_msync
     SYS_rename
+    SYS_renameat
     SYS_sem_close
     SYS_sem_open
     SYS_shared_region_map_and_slide_2_np ;; <rdar://problem/60294880>
@@ -412,6 +413,7 @@
         SYS_getattrlistbulk ;; xpc_realpath and directory enumeration
         SYS_getgid
         SYS_open_dprotected_np
+        SYS_openat_dprotected_np
         SYS_setrlimit
 #if PLATFORM(WATCHOS)
         SYS_sigreturn

--- a/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
+++ b/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
@@ -1237,6 +1237,7 @@
         SYS_kqueue
         SYS_mkdirat
         SYS_open_dprotected_np
+        SYS_openat_dprotected_np
         SYS_setrlimit
         SYS_shared_region_map_and_slide_2_np
 #endif
@@ -1261,7 +1262,8 @@
         SYS_flock
         SYS_fsetxattr ;; <rdar://problem/56332491>
         SYS_msync
-        SYS_rename))
+        SYS_rename
+        SYS_renameat))
 
 (define (syscall-unix-downlevels-blocked-in-lockdown-mode)
     (syscall-number

--- a/Source/WebKit/WebProcess/com.apple.WebProcess.x86.sb.in
+++ b/Source/WebKit/WebProcess/com.apple.WebProcess.x86.sb.in
@@ -1201,6 +1201,7 @@
         SYS_kqueue
         SYS_mkdirat
         SYS_open_dprotected_np
+        SYS_openat_dprotected_np
         SYS_setrlimit
         SYS_shared_region_map_and_slide_2_np
 #endif
@@ -1225,7 +1226,8 @@
         SYS_flock
         SYS_fsetxattr ;; <rdar://problem/56332491>
         SYS_msync
-        SYS_rename))
+        SYS_rename
+        SYS_renameat))
 
 (define (syscall-unix-downlevels-blocked-in-lockdown-mode)
     (syscall-number


### PR DESCRIPTION
#### 3e277d994fe5fa7482b96d1dd87e0e7643803d42
<pre>
[Sandboxing] Update sandbox profiles to allow the `*at` counterparts to some syscalls
<a href="https://bugs.webkit.org/show_bug.cgi?id=319647">https://bugs.webkit.org/show_bug.cgi?id=319647</a>
<a href="https://rdar.apple.com/181861452">rdar://181861452</a>

Reviewed by Sihui Liu.

Whereever we allow:
```
`SYS_rename`
`SYS_open_dprotected_np`
`SYS_open`
```

We need to also allow:
```
`SYS_renameat`
`SYS_openat_dprotected_np`
`SYS_openat`
```

This is to unblock an underlying framework.

* Source/WebKit/GPUProcess/mac/com.apple.WebKit.GPUProcess.sb.in:
* Source/WebKit/NetworkProcess/mac/com.apple.WebKit.NetworkProcess.sb.in:
* Source/WebKit/Shared/Sandbox/iOS/gpu-defines.sb:
* Source/WebKit/Shared/Sandbox/iOS/networking-defines.sb:
* Source/WebKit/Shared/Sandbox/iOS/webcontent-defines.sb:
* Source/WebKit/WebProcess/com.apple.WebProcess.sb.in:
* Source/WebKit/WebProcess/com.apple.WebProcess.x86.sb.in:

Canonical link: <a href="https://commits.webkit.org/317594@main">https://commits.webkit.org/317594@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a37ec1a224df6d0d3126b0cc1df6da3b1b27bc48

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175162 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49094 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42875 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184747 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/133069 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0902a120-8101-4f31-a0b7-c69f90a53601) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50386 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48777 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136337 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96169 "4 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8a050ea5-7cf5-4d48-aa7a-56c0baed4a4c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178119 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39775 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157130 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116816 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6c2abdec-f19d-45b0-bc4a-cc8749bdafef) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38416 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36799 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Skipping applying patch since patch_id isn't provided; Checked out pull request; run-api-tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33220 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148839 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36623 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187167 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/40779 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41002 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145284 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48761 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145140 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39238 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49441 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33244 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115276 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39996 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/121618 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47947 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11596 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47350 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47580 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47407 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->