### PR TITLE
Create FlowMode to allow using WritingMode APIs with e.g. flex-flow

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -2217,6 +2217,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/FileStreamClient.h
     platform/FixedContainerEdges.h
     platform/FloatConversion.h
+    platform/FlowMode.h
     platform/FrameRateMonitor.h
     platform/GraphicsClient.h
     platform/HostWindow.h

--- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
+++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
@@ -554,6 +554,7 @@
 		142B97CA13138943008BEF4B /* TextControlInnerElements.h in Headers */ = {isa = PBXBuildFile; fileRef = 142B97C813138943008BEF4B /* TextControlInnerElements.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		1432E8470C51493800B1500F /* GarbageCollectionController.h in Headers */ = {isa = PBXBuildFile; fileRef = 1432E8460C51493800B1500F /* GarbageCollectionController.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		14476AA815DC4BB100305DB2 /* WritingMode.h in Headers */ = {isa = PBXBuildFile; fileRef = 14476AA715DC4BB100305DB2 /* WritingMode.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		DBAAA5A17A33454D339D8E56 /* FlowMode.h in Headers */ = {isa = PBXBuildFile; fileRef = BBF58114651D5C792A7CFBD4 /* FlowMode.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		1449E24C107D4A8400B5793F /* JSCallbackData.h in Headers */ = {isa = PBXBuildFile; fileRef = 1449E24A107D4A8400B5793F /* JSCallbackData.h */; };
 		1477E7770BF4134A00152872 /* BackForwardCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 1477E7750BF4134A00152872 /* BackForwardCache.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		14947FFE12F80CD200A0F631 /* TreeScopeOrderedMap.h in Headers */ = {isa = PBXBuildFile; fileRef = 14947FFC12F80CD200A0F631 /* TreeScopeOrderedMap.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -8742,6 +8743,7 @@
 		1432E8460C51493800B1500F /* GarbageCollectionController.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; path = GarbageCollectionController.h; sourceTree = "<group>"; };
 		1432E8480C51493F00B1500F /* GarbageCollectionController.cpp */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.cpp.cpp; path = GarbageCollectionController.cpp; sourceTree = "<group>"; };
 		14476AA715DC4BB100305DB2 /* WritingMode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WritingMode.h; sourceTree = "<group>"; };
+		BBF58114651D5C792A7CFBD4 /* FlowMode.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FlowMode.h; sourceTree = "<group>"; };
 		1449E24A107D4A8400B5793F /* JSCallbackData.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSCallbackData.h; sourceTree = "<group>"; };
 		1449E286107D4DB400B5793F /* JSCallbackData.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = JSCallbackData.cpp; sourceTree = "<group>"; };
 		1477E7740BF4134A00152872 /* BackForwardCache.cpp */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.cpp.cpp; path = BackForwardCache.cpp; sourceTree = "<group>"; };
@@ -39554,6 +39556,7 @@
 				F4CC0F1D2DD80F3800A1E2BB /* FixedContainerEdges.cpp */,
 				F44CD9F42D29DBB600276C79 /* FixedContainerEdges.h */,
 				BC073BA90C399B1F000F5979 /* FloatConversion.h */,
+				BBF58114651D5C792A7CFBD4 /* FlowMode.h */,
 				4190F3A1249D152700531C57 /* FrameRateMonitor.cpp */,
 				4190F3A3249D152800531C57 /* FrameRateMonitor.h */,
 				A7D8E64928C80F2A0019F92F /* GraphicsClient.h */,
@@ -45520,6 +45523,7 @@
 				7BF22C0B2D43D10100F94FCE /* FloatSegment.h in Headers */,
 				B275356D0B053814002CE64F /* FloatSize.h in Headers */,
 				58CD35CB18EB4C3900B9F3AC /* FloatSizeHash.h in Headers */,
+				DBAAA5A17A33454D339D8E56 /* FlowMode.h in Headers */,
 				14993BE60B2F2B1C0050497F /* FocusController.h in Headers */,
 				334B59922E86ACA40067471D /* FocusControllerTypes.h in Headers */,
 				062287840B4DB322000C34DF /* FocusDirection.h in Headers */,

--- a/Source/WebCore/platform/BoxSides.h
+++ b/Source/WebCore/platform/BoxSides.h
@@ -51,6 +51,11 @@ enum class BoxAxis : uint8_t {
     HighestEnumValue = Vertical
 };
 
+enum class AxisDirection : bool {
+    Normal = 0,
+    Reverse = 1,
+};
+
 constexpr BoxAxis mapAxisLogicalToPhysical(const WritingMode, const LogicalBoxAxis);
 constexpr LogicalBoxAxis mapAxisPhysicalToLogical(const WritingMode, const BoxAxis);
 constexpr LogicalBoxAxis oppositeAxis(LogicalBoxAxis axis) { return axis == LogicalBoxAxis::Inline ? LogicalBoxAxis::Block : LogicalBoxAxis::Inline; }

--- a/Source/WebCore/platform/FlowMode.h
+++ b/Source/WebCore/platform/FlowMode.h
@@ -1,0 +1,226 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <WebCore/BoxSides.h>
+#include <WebCore/WritingMode.h>
+
+namespace WebCore {
+
+struct FlowReversal {
+    AxisDirection main { AxisDirection::Normal };
+    AxisDirection cross { AxisDirection::Normal };
+
+    constexpr FlowReversal() = default;
+    constexpr FlowReversal(AxisDirection mainDirection, AxisDirection crossDirection)
+        : main(mainDirection), cross(crossDirection)
+        { }
+
+    constexpr bool isMainReversed() const { return main == AxisDirection::Reverse; }
+    constexpr bool isCrossReversed() const { return cross == AxisDirection::Reverse; }
+};
+
+/**
+ * FlowMode represents the primary and secondary flow directions of a layout.
+ * Main is the primary placement axis (like inline); cross is the secondary placement axis (like block).
+ *
+ * FlowMode allows efficient querying of information about the layout flow, and
+ * can also be cast to a WritingMode object for use in APIs like marginStart().
+ *
+ * (It is not, however, an efficient representation for data-packing.)
+ */
+
+class FlowMode final {
+public:
+
+    FlowMode(WritingMode);
+    enum class ConversionStyle { FlowRelative, LineRelative };
+    FlowMode(WritingMode, ConversionStyle);
+    FlowMode(WritingMode, BoxAxis mainAxis, FlowReversal = { });
+    FlowMode(WritingMode, LogicalBoxAxis mainAxis, FlowReversal = { });
+
+    // Axis identification.
+    constexpr bool isMainHorizontal() const;
+    constexpr bool isMainInline(WritingMode) const;
+
+    // Compare to self writing mode.
+    constexpr bool isMainInline() const;
+    constexpr bool isMainReverse() const;
+    constexpr bool isCrossReverse() const;
+
+    // (Mis)Matching. Pass FlowMode if you want, it'll cast over.
+    constexpr bool matches(WritingMode) const;
+    constexpr bool isOrthogonal(WritingMode) const;
+    constexpr bool isMainOpposing(WritingMode) const;
+    constexpr bool isCrossOpposing(WritingMode) const;
+    constexpr bool isMainMatchingAny(WritingMode) const;
+    constexpr bool isCrossMatchingAny(WritingMode) const;
+
+    // Physical flow directions.
+    constexpr bool isMainTopToBottom() const;
+    constexpr bool isMainLeftToRight() const;
+    constexpr bool isCrossTopToBottom() const;
+    constexpr bool isCrossLeftToRight() const;
+    // Main OR cross direction is top-to-bottom.
+    constexpr bool isAnyTopToBottom() const;
+    // Main OR cross direction is left-to-right.
+    constexpr bool isAnyLeftToRight() const;
+
+    // Coordinate flow queries.
+    constexpr bool isMainFlipped() const; // Main direction is RTL or BTT.
+    constexpr bool isCrossFlipped() const; // Cross direction is RTL or BTT.
+    constexpr bool isInlineFlipped() const; // Inline axis direction is RTL or BTT.
+    constexpr bool isBlockFlipped() const; // Block axis direction is RTL or BTT.
+
+    // Directions as enums. Prefer booleans if doing boolean checks.
+    constexpr FlowDirection mainDirection() const;
+    constexpr FlowDirection crossDirection() const;
+
+    // Axes as enums. Prefer booleans if doing boolean checks.
+    constexpr BoxAxis mainAxis() const;
+    constexpr BoxAxis crossAxis() const;
+
+    constexpr operator WritingMode() const { return static_cast<WritingMode::Data>(m_mode.m_bits & ~WritingMode::kFlowModeMask); }
+    friend bool operator==(FlowMode, FlowMode) = default;
+
+private:
+    // Represents FlowMode as a horizontal- or vertical- WritingMode,
+    // letting us re-use logic and cast efficiently.
+    WritingMode m_mode;
+};
+
+/** Implementation Below **********************************************/
+
+inline FlowMode::FlowMode(WritingMode writingMode)
+    : m_mode(writingMode)
+{
+    // Standardize to sideways- representation of inline flow.
+    if (writingMode.isVertical())
+        m_mode.m_bits |= WritingMode::kIsVerticalType;
+    if (writingMode.computedWritingMode() == StyleWritingMode::SidewaysLr) {
+        if (writingMode.isBidiRTL())
+            m_mode.m_bits &= ~WritingMode::kIsBidiRTL;
+        else
+            m_mode.m_bits |= WritingMode::kIsBidiRTL;
+    }
+
+    // Only keep the bits we need.
+    m_mode.m_bits &= WritingMode::kIsVerticalText | WritingMode::kIsFlippedBlock | WritingMode::kIsVerticalType | WritingMode::kIsBidiRTL;
+}
+
+inline FlowMode::FlowMode(WritingMode writingMode, ConversionStyle conversion)
+    : FlowMode(writingMode)
+{
+    if (conversion == ConversionStyle::LineRelative && writingMode.isLineInverted())
+        m_mode.m_bits &= ~WritingMode::kIsFlippedBlock | (m_mode.m_bits ^ WritingMode::kIsFlippedBlock);
+}
+
+inline FlowMode::FlowMode(WritingMode writingMode, BoxAxis mainAxis, FlowReversal reversal)
+    : FlowMode(writingMode, mapAxisPhysicalToLogical(writingMode, mainAxis), reversal)
+{ }
+
+inline FlowMode::FlowMode(WritingMode writingMode, LogicalBoxAxis mainAxis, FlowReversal reversal)
+{
+    if ((mainAxis == LogicalBoxAxis::Inline) == writingMode.isVertical())
+        m_mode.m_bits |= WritingMode::kIsVerticalText | WritingMode::kIsVerticalType;
+
+    if (mainAxis == LogicalBoxAxis::Inline) {
+        if (writingMode.isInlineFlipped() != reversal.isMainReversed())
+            m_mode.m_bits |= WritingMode::kIsBidiRTL;
+        if (writingMode.isBlockFlipped() != reversal.isCrossReversed())
+            m_mode.m_bits |= WritingMode::kIsFlippedBlock;
+    } else {
+        m_mode.m_bits |= WritingMode::kIsMainBlock;
+        if (writingMode.isBlockFlipped() != reversal.isMainReversed())
+            m_mode.m_bits |= WritingMode::kIsBidiRTL;
+        if (writingMode.isInlineFlipped() != reversal.isCrossReversed())
+            m_mode.m_bits |= WritingMode::kIsFlippedBlock;
+    }
+
+    if (reversal.isMainReversed())
+        m_mode.m_bits |= WritingMode::kIsMainReverse;
+    if (reversal.isCrossReversed())
+        m_mode.m_bits |= WritingMode::kIsCrossReverse;
+}
+
+constexpr bool FlowMode::isMainHorizontal() const { return m_mode.isHorizontal(); }
+constexpr bool FlowMode::isMainInline(WritingMode mode) const { return !m_mode.isOrthogonal(mode); }
+
+constexpr bool FlowMode::isMainInline() const { return !(m_mode.m_bits & WritingMode::kIsMainBlock); }
+constexpr bool FlowMode::isMainReverse() const { return m_mode.m_bits & WritingMode::kIsMainReverse; }
+constexpr bool FlowMode::isCrossReverse() const { return m_mode.m_bits & WritingMode::kIsCrossReverse; }
+
+constexpr bool FlowMode::matches(WritingMode mode) const { return m_mode.inlineDirection() == mode.inlineDirection() && m_mode.blockDirection() == mode.blockDirection(); }
+constexpr bool FlowMode::isOrthogonal(WritingMode mode) const { return m_mode.isOrthogonal(mode); }
+constexpr bool FlowMode::isMainOpposing(WritingMode mode) const { return m_mode.isInlineOpposing(mode); }
+constexpr bool FlowMode::isCrossOpposing(WritingMode mode) const { return m_mode.isBlockOpposing(mode); }
+constexpr bool FlowMode::isMainMatchingAny(WritingMode mode) const { return m_mode.isInlineMatchingAny(mode); }
+constexpr bool FlowMode::isCrossMatchingAny(WritingMode mode) const { return m_mode.isBlockMatchingAny(mode); }
+
+constexpr bool FlowMode::isMainTopToBottom() const { return m_mode.isInlineTopToBottom(); }
+constexpr bool FlowMode::isMainLeftToRight() const { return m_mode.isInlineLeftToRight(); }
+constexpr bool FlowMode::isCrossTopToBottom() const { return m_mode.isBlockTopToBottom(); }
+constexpr bool FlowMode::isCrossLeftToRight() const { return m_mode.isBlockLeftToRight(); }
+constexpr bool FlowMode::isAnyTopToBottom() const { return m_mode.isAnyTopToBottom(); }
+constexpr bool FlowMode::isAnyLeftToRight() const { return m_mode.isAnyLeftToRight(); }
+
+constexpr bool FlowMode::isMainFlipped() const { return m_mode.isInlineFlipped(); }
+constexpr bool FlowMode::isCrossFlipped() const { return m_mode.isBlockFlipped(); }
+constexpr bool FlowMode::isInlineFlipped() const { return isMainInline() ? m_mode.isInlineFlipped() : m_mode.isBlockFlipped(); }
+constexpr bool FlowMode::isBlockFlipped() const { return isMainInline() ? m_mode.isBlockFlipped() : m_mode.isInlineFlipped(); }
+
+constexpr FlowDirection FlowMode::mainDirection() const { return m_mode.inlineDirection(); }
+constexpr FlowDirection FlowMode::crossDirection() const { return m_mode.blockDirection(); }
+
+constexpr BoxAxis FlowMode::mainAxis() const { return m_mode.inlineAxis(); }
+constexpr BoxAxis FlowMode::crossAxis() const { return m_mode.blockAxis(); }
+
+/** Logging ***********************************************************/
+
+inline TextStream& operator<<(TextStream& ts, AxisDirection direction)
+{
+    switch (direction) {
+    case AxisDirection::Normal: ts << "normal"_s; break;
+    case AxisDirection::Reverse: ts << "reverse"_s; break;
+    }
+    return ts;
+}
+
+inline TextStream& operator<<(TextStream& stream, FlowMode flowMode)
+{
+    stream << "(main=" << flowMode.mainDirection()
+        << ", cross=" << flowMode.crossDirection()
+        << ", mainReversal=" << (flowMode.isMainReverse() ? AxisDirection::Reverse : AxisDirection::Normal)
+        << ", crossReversal=" << (flowMode.isCrossReverse() ? AxisDirection::Reverse : AxisDirection::Normal) << ")";
+    return stream;
+}
+
+} // namespace WebCore

--- a/Source/WebCore/platform/text/WritingMode.h
+++ b/Source/WebCore/platform/text/WritingMode.h
@@ -58,6 +58,7 @@ enum class TextOrientation : uint8_t;
 enum class FlowDirection : uint8_t;
 enum class BoxAxis : uint8_t;
 enum class LogicalBoxAxis : uint8_t;
+class FlowMode;
 
 class WritingMode final {
 public:
@@ -140,9 +141,10 @@ public:
 
 private:
     Data m_bits { 0 };
+    friend FlowMode;
 
-public: // Private except StyleWritingMode and FlowDirection are friends
-    enum Bits {
+public: // Private except StyleWritingMode, FlowDirection, and FlowMode are friends
+    enum Bits : Data {
         kIsVerticalText  = 1 << 0, // Vertical writing modes.
         kIsFlippedBlock  = 1 << 1, // RL or BT block flow directions.
         kIsVerticalType  = 1 << 2, // Vertical typographic mode.
@@ -154,6 +156,11 @@ public: // Private except StyleWritingMode and FlowDirection are friends
         kWritingModeMask = kBlockFlowMask  | kIsVerticalType,
         kOrientationMask = kIsSidewaysType | kIsUprightType, // Both is an error.
         kOrientationShift = 4,
+
+        kIsMainBlock     = 1 << 5, // Alternate use in FlowMode.
+        kIsMainReverse   = 1 << 6, // Reserved for FlowMode.
+        kIsCrossReverse  = 1 << 7, // Reserved for FlowMode.
+        kFlowModeMask    = kIsMainBlock | kIsMainReverse | kIsCrossReverse,
     };
 };
 

--- a/Source/WebCore/rendering/style/RenderStyleConstants.h
+++ b/Source/WebCore/rendering/style/RenderStyleConstants.h
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include <WebCore/BoxSides.h>
 #include <initializer_list>
 #include <limits>
 #include <optional>
@@ -404,6 +405,9 @@ enum class FlexWrap : uint8_t {
     Wrap,
     Reverse
 };
+
+inline AxisDirection toAxisDirection(FlexDirection direction) { return static_cast<AxisDirection>(direction == FlexDirection::RowReverse || direction == FlexDirection::ColumnReverse); }
+inline AxisDirection toAxisDirection(FlexWrap wrap) { return static_cast<AxisDirection>(wrap == FlexWrap::Reverse); }
 
 enum class ItemPosition : uint8_t {
     Legacy,

--- a/Source/WebCore/style/computed/StyleComputedStyle+GettersInlines.h
+++ b/Source/WebCore/style/computed/StyleComputedStyle+GettersInlines.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <WebCore/FlowMode.h>
 #include <WebCore/StyleComputedStyle.h>
 
 #define COMPUTED_STYLE_PROPERTIES_GETTERS_INLINES_INCLUDE_TRAP 1
@@ -409,6 +410,17 @@ inline bool ComputedStyle::isRowFlexDirection() const
     return flexDirection() == FlexDirection::Row || flexDirection() == FlexDirection::RowReverse;
 }
 
+inline bool ComputedStyle::isReverseFlexDirection() const
+{
+    return flexDirection() == FlexDirection::RowReverse || flexDirection() == FlexDirection::ColumnReverse;
+}
+
+inline FlowMode ComputedStyle::flexFlowMode() const
+{
+    return { writingMode(), isRowFlexDirection() ? LogicalBoxAxis::Inline : LogicalBoxAxis::Block,
+        { toAxisDirection(flexDirection()), toAxisDirection(flexWrap()) } };
+}
+
 inline bool ComputedStyle::isFixedTableLayout() const
 {
     return tableLayout() == TableLayoutType::Fixed
@@ -421,11 +433,6 @@ inline bool ComputedStyle::isFixedTableLayout() const
 inline bool ComputedStyle::isOverflowVisible() const
 {
     return overflowX() == Overflow::Visible || overflowY() == Overflow::Visible;
-}
-
-inline bool ComputedStyle::isReverseFlexDirection() const
-{
-    return flexDirection() == FlexDirection::RowReverse || flexDirection() == FlexDirection::ColumnReverse;
 }
 
 inline bool ComputedStyle::isSkippedRootOrSkippedContent() const

--- a/Source/WebCore/style/computed/StyleComputedStyle.h
+++ b/Source/WebCore/style/computed/StyleComputedStyle.h
@@ -213,11 +213,13 @@ public:
     // MARK: - Other predicates
 
     inline bool isColumnFlexDirection() const;
+    inline bool isRowFlexDirection() const;
+    inline bool isReverseFlexDirection() const;
+    inline FlowMode flexFlowMode() const; // This is not trivial so cache it.
+
     inline bool isFixedTableLayout() const;
     inline bool isInterCharacterRubyPosition() const;
     inline bool isOverflowVisible() const;
-    inline bool isReverseFlexDirection() const;
-    inline bool isRowFlexDirection() const;
     inline bool isSkippedRootOrSkippedContent() const;
 
     bool isListItemType() const;

--- a/Tools/TestWebKitAPI/CMakeLists.txt
+++ b/Tools/TestWebKitAPI/CMakeLists.txt
@@ -230,6 +230,7 @@ if (ENABLE_WEBCORE)
         Tests/WebCore/FloatRectTests.cpp
         Tests/WebCore/FloatSegmentTest.cpp
         Tests/WebCore/FloatSizeTests.cpp
+        Tests/WebCore/FlowModeTests.cpp
         Tests/WebCore/GridPosition.cpp
         Tests/WebCore/HTMLParserIdioms.cpp
         Tests/WebCore/HTTPParsers.cpp

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -744,6 +744,7 @@
 				WebCore/FloatRectTests.cpp,
 				WebCore/FloatSegmentTest.cpp,
 				WebCore/FloatSizeTests.cpp,
+				WebCore/FlowModeTests.cpp,
 				WebCore/FontCascade.cpp,
 				WebCore/FontShadowTests.cpp,
 				WebCore/GridPosition.cpp,

--- a/Tools/TestWebKitAPI/Tests/WebCore/FlowModeTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/FlowModeTests.cpp
@@ -1,0 +1,202 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#include <WebCore/FlowMode.h>
+
+using namespace WebCore;
+
+namespace TestWebKitAPI {
+
+constexpr std::array<WritingMode, 28> writingModes = {
+    WritingMode { StyleWritingMode::HorizontalTb, TextDirection::LTR, TextOrientation::Mixed  },
+    WritingMode { StyleWritingMode::HorizontalTb, TextDirection::LTR, TextOrientation::Mixed  },
+    WritingMode { StyleWritingMode::HorizontalBt, TextDirection::RTL, TextOrientation::Mixed  },
+    WritingMode { StyleWritingMode::HorizontalBt, TextDirection::RTL, TextOrientation::Mixed  },
+
+    WritingMode { StyleWritingMode::VerticalRl, TextDirection::LTR, TextOrientation::Mixed    },
+    WritingMode { StyleWritingMode::VerticalRl, TextDirection::LTR, TextOrientation::Upright  },
+    WritingMode { StyleWritingMode::VerticalRl, TextDirection::LTR, TextOrientation::Sideways },
+    WritingMode { StyleWritingMode::VerticalRl, TextDirection::RTL, TextOrientation::Mixed    },
+    WritingMode { StyleWritingMode::VerticalRl, TextDirection::RTL, TextOrientation::Upright  },
+    WritingMode { StyleWritingMode::VerticalRl, TextDirection::RTL, TextOrientation::Sideways },
+
+    WritingMode { StyleWritingMode::VerticalLr, TextDirection::LTR, TextOrientation::Mixed    },
+    WritingMode { StyleWritingMode::VerticalLr, TextDirection::LTR, TextOrientation::Upright  },
+    WritingMode { StyleWritingMode::VerticalLr, TextDirection::LTR, TextOrientation::Sideways },
+    WritingMode { StyleWritingMode::VerticalLr, TextDirection::RTL, TextOrientation::Mixed    },
+    WritingMode { StyleWritingMode::VerticalLr, TextDirection::RTL, TextOrientation::Upright  },
+    WritingMode { StyleWritingMode::VerticalLr, TextDirection::RTL, TextOrientation::Sideways },
+
+    WritingMode { StyleWritingMode::SidewaysRl, TextDirection::LTR, TextOrientation::Mixed    },
+    WritingMode { StyleWritingMode::SidewaysRl, TextDirection::LTR, TextOrientation::Upright  },
+    WritingMode { StyleWritingMode::SidewaysRl, TextDirection::LTR, TextOrientation::Sideways },
+    WritingMode { StyleWritingMode::SidewaysRl, TextDirection::RTL, TextOrientation::Mixed    },
+    WritingMode { StyleWritingMode::SidewaysRl, TextDirection::RTL, TextOrientation::Upright  },
+    WritingMode { StyleWritingMode::SidewaysRl, TextDirection::RTL, TextOrientation::Sideways },
+
+    WritingMode { StyleWritingMode::SidewaysLr, TextDirection::LTR, TextOrientation::Mixed    },
+    WritingMode { StyleWritingMode::SidewaysLr, TextDirection::LTR, TextOrientation::Upright  },
+    WritingMode { StyleWritingMode::SidewaysLr, TextDirection::LTR, TextOrientation::Sideways },
+    WritingMode { StyleWritingMode::SidewaysLr, TextDirection::RTL, TextOrientation::Mixed    },
+    WritingMode { StyleWritingMode::SidewaysLr, TextDirection::RTL, TextOrientation::Upright  },
+    WritingMode { StyleWritingMode::SidewaysLr, TextDirection::RTL, TextOrientation::Sideways }
+};
+
+constexpr std::array<BoxAxis, 2> boxAxes = {
+    BoxAxis::Horizontal,
+    BoxAxis::Vertical
+};
+
+constexpr std::array<LogicalBoxAxis, 2> logicalBoxAxes = {
+    LogicalBoxAxis::Inline,
+    LogicalBoxAxis::Block
+};
+
+constexpr std::array<FlowReversal, 4> flowReversals = {
+    FlowReversal { AxisDirection::Normal, AxisDirection::Normal },
+    FlowReversal { AxisDirection::Normal, AxisDirection::Reverse },
+    FlowReversal { AxisDirection::Reverse, AxisDirection::Normal },
+    FlowReversal { AxisDirection::Reverse, AxisDirection::Reverse },
+};
+
+inline std::string writingModeString(WritingMode writingMode)
+{
+    TextStream stream;
+    stream << writingMode;
+    return stream.release().utf8().toStdString();
+}
+
+inline std::string flowModeString(FlowMode flowMode)
+{
+    TextStream stream;
+    stream << flowMode;
+    return stream.release().utf8().toStdString();
+}
+
+inline std::string flowReversalString(FlowReversal reversal)
+{
+    TextStream stream;
+    stream << "(main=" << reversal.main << ", cross=" << reversal.cross << ")";
+    return stream.release().utf8().toStdString();
+}
+
+// Tests all combinations of WritingMode, mainAxis, and FlowReversal
+// using the FlowMode(WritingMode, BoxAxis, FlowReversal) constructor
+// to ensure they map to an appropriate WritingMode.
+TEST(FlowMode, BoxAxisConstructor)
+{
+    for (auto writingMode : writingModes) {
+        for (auto mainAxis : boxAxes) {
+            bool mainIsAligned = (mainAxis == BoxAxis::Horizontal) == writingMode.isHorizontal();
+            for (auto reversal : flowReversals) {
+                auto flowMode = FlowMode(writingMode, mainAxis, reversal);
+                auto description = [&] {
+                    return " with writingMode=" + writingModeString(writingMode) + ", mainAxis=" + (mainAxis == BoxAxis::Horizontal ? "Horizontal" : "Vertical") + ", reversal=" + flowReversalString(reversal);
+                };
+
+                bool isRTL = mainIsAligned
+                    ? (writingMode.isInlineFlipped() != reversal.isMainReversed())
+                    : (writingMode.isBlockFlipped() != reversal.isMainReversed());
+                bool isFlippedBlock = mainIsAligned
+                    ? (writingMode.isBlockFlipped() != reversal.isCrossReversed())
+                    : (writingMode.isInlineFlipped() != reversal.isCrossReversed());
+
+                auto expectedStyleWritingMode = mainAxis == BoxAxis::Horizontal
+                    ? (isFlippedBlock ? StyleWritingMode::HorizontalBt : StyleWritingMode::HorizontalTb)
+                    : (isFlippedBlock ? StyleWritingMode::VerticalRl : StyleWritingMode::VerticalLr);
+                auto expectedWritingMode = WritingMode { expectedStyleWritingMode, isRTL ? TextDirection::RTL : TextDirection::LTR, TextOrientation::Mixed };
+
+                EXPECT_EQ(flowMode.mainDirection(), FlowMode(expectedWritingMode).mainDirection())
+                    << description()
+                    << " for " << flowModeString(flowMode)
+                    << ", " << writingModeString(expectedWritingMode);
+                EXPECT_EQ(flowMode.crossDirection(), FlowMode(expectedWritingMode).crossDirection())
+                    << description()
+                    << " for " << flowModeString(flowMode)
+                    << ", " << writingModeString(expectedWritingMode);
+                EXPECT_EQ(static_cast<WritingMode>(flowMode).inlineDirection(), expectedWritingMode.inlineDirection())
+                    << description()
+                    << " for " << flowModeString(flowMode)
+                    << ", " << writingModeString(expectedWritingMode);
+                EXPECT_EQ(static_cast<WritingMode>(flowMode).blockDirection(), expectedWritingMode.blockDirection())
+                    << description()
+                    << " for " << flowModeString(flowMode)
+                    << ", " << writingModeString(expectedWritingMode);
+            }
+        }
+    }
+}
+
+// Verifies that the FlowMode(WritingMode, LogicalBoxAxis, FlowReversal) constructor
+// produces the same FlowMode as the equivalent BoxAxis construction.
+TEST(FlowMode, LogicalBoxAxisConstructor)
+{
+    for (auto writingMode : writingModes) {
+        for (auto logicalAxis : logicalBoxAxes) {
+            auto physicalAxis = mapAxisLogicalToPhysical(writingMode, logicalAxis);
+            for (auto reversal : flowReversals) {
+                auto flowModeFromLogical = FlowMode(writingMode, logicalAxis, reversal);
+                auto flowModeFromPhysical = FlowMode(writingMode, physicalAxis, reversal);
+                EXPECT_EQ(flowModeFromLogical, flowModeFromPhysical)
+                    << " for " << writingModeString(writingMode)
+                    << " " << (logicalAxis == LogicalBoxAxis::Inline ? "Inline" : "Block")
+                    << " " << flowReversalString(reversal)
+                    << " -> " << flowModeString(flowModeFromLogical)
+                    << ", " << flowModeString(flowModeFromPhysical);
+            }
+        }
+    }
+}
+
+// Verifies that the FlowMode(WritingMode, ConversionStyle) constructor produces
+// effectively the same FlowMode as the equivalent LogicalBoxAxis construction.
+TEST(FlowMode, ConversionStyleConstructor)
+{
+    for (auto writingMode : writingModes) {
+        auto flowRelative = FlowMode(writingMode, FlowMode::ConversionStyle::FlowRelative);
+        auto flowRelativeExpected = FlowMode(writingMode, LogicalBoxAxis::Inline, FlowReversal { AxisDirection::Normal, AxisDirection::Normal });
+        EXPECT_EQ(static_cast<WritingMode>(flowRelative), static_cast<WritingMode>(flowRelativeExpected))
+            << " for " << writingModeString(writingMode)
+            << " flowRelative " << flowModeString(flowRelative)
+            << " expected=" << flowModeString(flowRelativeExpected);
+
+        auto lineRelative = FlowMode(writingMode, FlowMode::ConversionStyle::LineRelative);
+        auto crossReversal = writingMode.isLineInverted() ? AxisDirection::Reverse : AxisDirection::Normal;
+        auto lineRelativeExpected = FlowMode(writingMode, LogicalBoxAxis::Inline, FlowReversal { AxisDirection::Normal, crossReversal });
+        EXPECT_EQ(static_cast<WritingMode>(flowRelative), static_cast<WritingMode>(flowRelativeExpected))
+            << " for " << writingModeString(writingMode)
+            << " lineRelative " << flowModeString(lineRelative)
+            << " expected=" << flowModeString(lineRelativeExpected);
+    }
+}
+
+}


### PR DESCRIPTION
#### ff9b65a73dacb1403fb444ab7e5ec60631db81cf
<pre>
Create FlowMode to allow using WritingMode APIs with e.g. flex-flow
<a href="https://bugs.webkit.org/show_bug.cgi?id=319521">https://bugs.webkit.org/show_bug.cgi?id=319521</a>
<a href="https://rdar.apple.com/182338907">rdar://182338907</a>

Reviewed by Alan Baradlay.

We have a lot of APIs that take WritingMode in order to map coordinates;
for example the marginStart()/marginBefore() getters.

However layout does not always follow the primary inline/block directions.
For example, flex-flow can reverse these directions or transpose them.
And inline layout is oriented to the line&apos;s over/under sides, which might
not match the block-start/inline-start sides.

Rather than requiring these cases to create their own mapping tools, this
patch creates a FlowMode object that mimics WritingMode, and can be used
similarly: it can be queried in ways similar to WritingMode, and can also
be cast into a WritingMode for use in existing APIs that accept WritingMode.

Test: Tools/TestWebKitAPI/Tests/WebCore/FlowModeTests.cpp

* Source/WebCore/Headers.cmake:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/BoxSides.h:
* Source/WebCore/platform/FlowMode.h: Added.
(WebCore::FlowReversal::FlowReversal):
(WebCore::FlowReversal::isMainReversed const):
(WebCore::FlowReversal::isCrossReversed const):
(WebCore::FlowMode::FlowMode):
(WebCore::FlowMode::isMainHorizontal const):
(WebCore::FlowMode::isMainInline const):
(WebCore::FlowMode::isMainReverse const):
(WebCore::FlowMode::isCrossReverse const):
(WebCore::FlowMode::matches const):
(WebCore::FlowMode::isOrthogonal const):
(WebCore::FlowMode::isMainOpposing const):
(WebCore::FlowMode::isCrossOpposing const):
(WebCore::FlowMode::isMainMatchingAny const):
(WebCore::FlowMode::isCrossMatchingAny const):
(WebCore::FlowMode::isMainTopToBottom const):
(WebCore::FlowMode::isMainLeftToRight const):
(WebCore::FlowMode::isCrossTopToBottom const):
(WebCore::FlowMode::isCrossLeftToRight const):
(WebCore::FlowMode::isAnyTopToBottom const):
(WebCore::FlowMode::isAnyLeftToRight const):
(WebCore::FlowMode::isMainFlipped const):
(WebCore::FlowMode::isCrossFlipped const):
(WebCore::FlowMode::isInlineFlipped const):
(WebCore::FlowMode::isBlockFlipped const):
(WebCore::FlowMode::mainDirection const):
(WebCore::FlowMode::crossDirection const):
(WebCore::FlowMode::mainAxis const):
(WebCore::FlowMode::crossAxis const):
(WebCore::operator&lt;&lt;):
* Source/WebCore/platform/text/WritingMode.h:
* Source/WebCore/rendering/style/RenderStyleConstants.h:
(WebCore::toAxisDirection):
* Source/WebCore/style/computed/StyleComputedStyle+GettersInlines.h:
(WebCore::Style::ComputedStyle::isReverseFlexDirection const):
(WebCore::Style::ComputedStyle::flexFlowMode const):
* Source/WebCore/style/computed/StyleComputedStyle.h:
* Tools/TestWebKitAPI/CMakeLists.txt:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebCore/FlowModeTests.cpp: Added.
(TestWebKitAPI::writingModeString):
(TestWebKitAPI::flowModeString):
(TestWebKitAPI::flowReversalString):
(TestWebKitAPI::TEST(FlowMode, BoxAxisConstructor)):
(TestWebKitAPI::TEST(FlowMode, LogicalBoxAxisConstructor)):
(TestWebKitAPI::TEST(FlowMode, ConversionStyleConstructor)):

Canonical link: <a href="https://commits.webkit.org/317539@main">https://commits.webkit.org/317539@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ad7750c83de1596313c357be346afbdf923a98ec

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175525 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49457 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43238 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185111 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/137672 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2b085e62-5197-42a3-affe-98bd907f3c38) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/177389 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50749 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49140 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136671 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/137672 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b6d0e1fc-a8c4-4898-bef3-b71d1a2ec915) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178482 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40087 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157427 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117149 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/368f1fad-8750-41af-b2f6-7a9b72847645) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38729 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37115 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149151 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36920 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33586 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41144 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41318 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187536 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49124 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145639 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39194 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49804 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33544 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145476 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40293 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/121997 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115760 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48311 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11896 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47713 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47943 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47770 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->