### PR TITLE
Adjust pixel tolerance in various WPTs

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -3024,6 +3024,7 @@ imported/w3c/web-platform-tests/css/css-masking/mask-image/mask-clip-5.html [ Im
 imported/w3c/web-platform-tests/css/css-masking/mask-image/mask-clip-6.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-masking/mask-image/mask-clip-7.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-masking/mask-image/mask-composite-2d.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/css/css-masking/mask-image/mask-image-cors-001.sub.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-masking/mask-image/mask-image-svg-gradient-zoomed.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-masking/mask-image/mask-mode-e.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-masking/mask-image/mask-mode-to-mask-type-svg.html [ ImageOnlyFailure ]
@@ -3086,19 +3087,9 @@ imported/w3c/web-platform-tests/css/css-masking/mask-image/mask-size-percent-per
 # A support file for a test
 imported/w3c/web-platform-tests/css/css-masking/clip-path/svg-clipPath.svg [ Skip ]
 
-# Require pixel tolerance adjustment then a re-export
-imported/w3c/web-platform-tests/css/css-masking/clip-path/animations/clip-path-transition-allow-discrete-shape.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-borderBox-1c.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-paddingBox-1c.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-strokeBox-1a.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-viewBox-1c.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-masking/mask-image/mask-image-cors-001.sub.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-masking/mask-image/mask-image-inline-sliced-1.html [ ImageOnlyFailure ]
-
 # Requires scoped view transitions
 webkit.org/b/319445 imported/w3c/web-platform-tests/css/css-masking/clip-path/animations/clip-path-animation-view-transition-mixed-change.html [ Skip ]
 
-# Imported w3c tests require fuzzy image comparison
 webkit.org/b/149828 imported/w3c/web-platform-tests/density-size-correction/density-corrected-image-svg-aspect-ratio.html [ ImageOnlyFailure ]
 webkit.org/b/149828 imported/w3c/web-platform-tests/density-size-correction/density-corrected-size-bg.html [ ImageOnlyFailure ]
 webkit.org/b/149828 imported/w3c/web-platform-tests/css/css-will-change/will-change-transform-zero-size-child-overflow-visible.html [ Pass ImageOnlyFailure ]
@@ -7975,10 +7966,6 @@ webkit.org/b/293973 [ Debug ] http/tests/ipc/gpu-load-error-empty-user-info-crss
 
 webkit.org/b/297505 ipc/LocalSampleBufferDisplayLayer-LogIdentifier-data-race-uaf.html [ Skip ]
 
-# Fix upstream in WPT by increasing pixel tolerance
-imported/w3c/web-platform-tests/svg/shapes/rect-03.svg [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/svg/shapes/reftests/pathlength-003.svg [ ImageOnlyFailure ]
-
 imported/w3c/web-platform-tests/css/css-pseudo/first-line-line-height-003.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-pseudo/relative-box-order-of-pseudo-elements.html [ ImageOnlyFailure ]
 
@@ -8023,7 +8010,7 @@ imported/w3c/web-platform-tests/css/css-break/table/repeated-section/text-in-nes
 imported/w3c/web-platform-tests/css/css-break/text-indent-and-wide-float.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-break/transform-025.html [ ImageOnlyFailure ]
 
-# Need to add tolerance for local in separate since failure is 0.01% and these tests pass on WPT itself.
+# Small but real rendering differences.
 imported/w3c/web-platform-tests/svg/painting/reftests/text-shadow-01.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/svg/painting/reftests/text-shadow-02.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/svg/painting/reftests/text-shadow-03.html [ ImageOnlyFailure ]
@@ -8232,11 +8219,6 @@ imported/w3c/web-platform-tests/css/css-shapes/shape-outside/supported-shapes/sh
 imported/w3c/web-platform-tests/css/css-shapes/shape-outside/supported-shapes/shape/shape-outside-shape-001.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-shapes/shape-outside/supported-shapes/shape/shape-outside-shape-002.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-shapes/shape-outside/supported-shapes/shape/shape-outside-shape-003.html [ ImageOnlyFailure ]
-
-# These need some pixel tolerance then a re-export
-imported/w3c/web-platform-tests/css/css-shapes/shape-outside/shape-image/gradients/shape-outside-linear-gradient-001.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-shapes/shape-outside/shape-image/gradients/shape-outside-linear-gradient-002.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-shapes/shape-outside/shape-image/gradients/shape-outside-linear-gradient-003.html [ ImageOnlyFailure ]
 
 webkit.org/b/317017 imported/w3c/web-platform-tests/largest-contentful-paint/multiple-redirects-TAO.html [ Pass Failure ]
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip-path/animations/clip-path-transition-allow-discrete-shape.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip-path/animations/clip-path-transition-allow-discrete-shape.html
@@ -2,7 +2,7 @@
 <html class="reftest-wait">
 <link rel="help" href="https://drafts.csswg.org/css-shapes-1/#basic-shape-interpolation">
 <link rel="match" href="clip-path-transition-ref.html">
-<meta name="fuzzy" content="maxDifference=0-32;totalPixels=0-32">
+<meta name="fuzzy" content="maxDifference=0-92;totalPixels=0-340">
 <style>
   .container {
     width: 100px;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-borderBox-1c.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-borderBox-1c.html
@@ -7,7 +7,7 @@
     <link rel="author" title="Mozilla" href="https://www.mozilla.org">
     <link rel="help" href="https://www.w3.org/TR/css-masking-1/#the-clip-path">
     <link rel="match" href="clip-path-geometryBox-1-ref.html">
-    <meta name="fuzzy" content="maxDifference=0-65; totalPixels=0-750">
+    <meta name="fuzzy" content="maxDifference=0-102; totalPixels=0-750">
     <meta name="assert" content="Test checks whether clip-path border-box works correctly or not. This test is for clip-path applied to an SVG  SVG element.">
     <style>
       svg {

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-paddingBox-1c.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-paddingBox-1c.html
@@ -7,7 +7,7 @@
     <link rel="author" title="Mozilla" href="https://www.mozilla.org">
     <link rel="help" href="https://www.w3.org/TR/css-masking-1/#the-clip-path">
     <link rel="match" href="clip-path-geometryBox-1-ref.html">
-    <meta name="fuzzy" content="maxDifference=0-52; totalPixels=0-376">
+    <meta name="fuzzy" content="maxDifference=0-68; totalPixels=0-376">
     <meta name="assert" content="Test checks whether clip-path padding-box works correctly or not. This test is for clip-path applied to an SVG  SVG element.">
     <style>
       svg {

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-strokeBox-1a.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-strokeBox-1a.html
@@ -7,7 +7,7 @@
     <link rel="author" title="Mozilla" href="https://www.mozilla.org">
     <link rel="help" href="https://www.w3.org/TR/css-masking-1/#the-clip-path">
     <link rel="match" href="clip-path-geometryBox-1-ref.html">
-    <meta name="fuzzy" content="maxDifference=0-65; totalPixels=0-750">
+    <meta name="fuzzy" content="maxDifference=0-102; totalPixels=0-750">
     <meta name="assert" content="Test checks whether clip-path stroke-box works correctly or not. This test is for clip-path applied to an SVG  SVG element.">
     <style>
       svg {

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-viewBox-1c.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-viewBox-1c.html
@@ -7,7 +7,7 @@
     <link rel="author" title="Mozilla" href="https://www.mozilla.org">
     <link rel="help" href="https://www.w3.org/TR/css-masking-1/#the-clip-path">
     <link rel="match" href="clip-path-geometryBox-1-ref.html">
-    <meta name="fuzzy" content="maxDifference=0-65; totalPixels=0-750">
+    <meta name="fuzzy" content="maxDifference=0-102; totalPixels=0-750">
     <meta name="assert" content="Test checks whether clip-path view-box works correctly or not. This test is for clip-path applied to an SVG  SVG element.">
     <style>
       svg {

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/mask-image/mask-image-inline-sliced-1.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/mask-image/mask-image-inline-sliced-1.html
@@ -5,6 +5,7 @@
 <link rel="help" href="https://www.w3.org/TR/css-break-3/#break-decoration">
 <link rel="help" href="https://drafts.fxtf.org/css-masking/#the-mask-image">
 <link rel="match" href="reference/mask-image-inline-sliced-1-ref.html">
+<meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-1450">
 <style>
   .mask-image {
     font: 100px/1 Ahem;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-shapes/shape-outside/shape-image/gradients/shape-outside-linear-gradient-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-shapes/shape-outside/shape-image/gradients/shape-outside-linear-gradient-001.html
@@ -9,7 +9,7 @@
     <meta name="flags" content="ahem"/>
     <meta name="assert" content="This test verifies that shape-outside respects a
                                 simple linear gradient."/>
-    <meta name="fuzzy" content="maxDifference=0-2; totalPixels=0-9600"/>
+    <meta name="fuzzy" content="maxDifference=0-2; totalPixels=0-9650"/>
     <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
     <style type="text/css">
         .container {

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-shapes/shape-outside/shape-image/gradients/shape-outside-linear-gradient-002.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-shapes/shape-outside/shape-image/gradients/shape-outside-linear-gradient-002.html
@@ -9,7 +9,7 @@
     <meta name="flags" content="ahem"/>
     <meta name="assert" content="This test verifies that shape-outside respects a
                                 simple linear gradient on a right float."/>
-    <meta name="fuzzy" content="maxDifference=0-2; totalPixels=0-9600"/>
+    <meta name="fuzzy" content="maxDifference=0-2; totalPixels=0-9650"/>
     <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
     <style type="text/css">
         .container {

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-shapes/shape-outside/shape-image/gradients/shape-outside-linear-gradient-003.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-shapes/shape-outside/shape-image/gradients/shape-outside-linear-gradient-003.html
@@ -11,7 +11,7 @@
     <meta name="assert" content="This test verifies that shape-outside respects a
                                 simple linear gradient on a right float with
                                 shape-margin applied."/>
-    <meta name="fuzzy" content="maxDifference=0-2; totalPixels=0-9600"/>
+    <meta name="fuzzy" content="maxDifference=0-2; totalPixels=0-9650"/>
     <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
     <style type="text/css">
         .container {

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/shapes/reftests/pathlength-003.svg
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/shapes/reftests/pathlength-003.svg
@@ -11,7 +11,7 @@
     <html:link rel="help"
           href="https://www.w3.org/TR/SVG2/shapes.html#CircleElement"/>
     <html:link rel="match"  href="pathlength-003-ref.svg" />
-    <html:meta name="fuzzy" content="0-61;0-4900"/>
+    <html:meta name="fuzzy" content="0-125;0-7315"/>
   </g>
 
   <style id="test-font" type="text/css">


### PR DESCRIPTION
#### 1164339199c9bab6c47898813324875bd3d3fbdc
<pre>
Adjust pixel tolerance in various WPTs
<a href="https://bugs.webkit.org/show_bug.cgi?id=319648">https://bugs.webkit.org/show_bug.cgi?id=319648</a>
<a href="https://rdar.apple.com/182472161">rdar://182472161</a>

Reviewed by Cameron McCormack.

When we import WPTs we often have to mark tests as `ImageOnlyFailure` when they just need pixel tolerance
adjustment. If we modify the tests at import time, re-exporting is harder. Then we forget about them.

So go back and fix pixel tolerance for a set of tests.

Some SVG tests which TestExpectations suggests only needed tolerance adjustment seem to have actual
rendering issues, so remove the comments.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-paddingBox-1c.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-masking/mask-image/mask-image-inline-sliced-1.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-shapes/shape-outside/shape-image/gradients/shape-outside-linear-gradient-001.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-shapes/shape-outside/shape-image/gradients/shape-outside-linear-gradient-002.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-shapes/shape-outside/shape-image/gradients/shape-outside-linear-gradient-003.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip-path/animations/clip-path-transition-allow-discrete-shape.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-borderBox-1c.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-strokeBox-1a.html:
* LayoutTests/imported/w3c/web-platform-tests/svg/shapes/reftests/pathlength-003.svg:
* LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-viewBox-1c.html:

Canonical link: <a href="https://commits.webkit.org/317470@main">https://commits.webkit.org/317470@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6e560d83ea66322b8a543638b4dfb582cd872ecc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175353 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49285 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43066 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184939 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/137474 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50577 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48968 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136510 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/137474 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178310 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39926 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157263 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116988 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38567 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36952 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148990 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36756 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33414 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41156 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187363 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48952 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/156819 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145475 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39149 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49632 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33378 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145316 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40129 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115512 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48138 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11729 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47541 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47771 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47598 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->