### PR TITLE
[JSC] Introduce MicrotaskCallCache for async generator driver path

### DIFF
--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -80,6 +80,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 #include "LLIntEntrypoint.h"
 #include "LLIntThunks.h"
 #include "MaxFrameExtentForSlowPathCall.h"
+#include "MicrotaskCall.h"
 #include "ProbeContext.h"
 #include "RegExpObject.h"
 #include "ScopedArguments.h"
@@ -8917,7 +8918,7 @@ void SpeculativeJIT::compileEnqueueAsyncGeneratorDriver(Node* node)
     GPRReg driverGPR = driver.gpr();
 
     flushRegisters();
-    callOperation(operationEnqueueAsyncGeneratorDriver, LinkableConstant::globalObject(*this, node), iteratorGPR, driverGPR);
+    callOperation(operationEnqueueAsyncGeneratorDriver, LinkableConstant::globalObject(*this, node), iteratorGPR, driverGPR, TrustedImmPtr(&vm().syncResumeCallCache()));
 
     noResult(node);
 }

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -105,6 +105,7 @@
 #include "JSWrapForValidIterator.h"
 #include "LLIntThunks.h"
 #include "MegamorphicCache.h"
+#include "MicrotaskCall.h"
 #include "OperandsInlines.h"
 #include "PCToCodeOriginMap.h"
 #include "ProbeContext.h"
@@ -19802,7 +19803,7 @@ IGNORE_CLANG_WARNINGS_END
     {
         JSGlobalObject* globalObject = m_graph.globalObjectFor(m_origin.semantic);
         vmCall(Void, operationEnqueueAsyncGeneratorDriver, weakPointer(globalObject),
-            lowCell(m_node->child1()), lowCell(m_node->child2()));
+            lowCell(m_node->child1()), lowCell(m_node->child2()), m_out.constIntPtr(&vm().syncResumeCallCache()));
     }
 
     void compileStringReplace()

--- a/Source/JavaScriptCore/heap/Heap.cpp
+++ b/Source/JavaScriptCore/heap/Heap.cpp
@@ -830,6 +830,8 @@ void Heap::finalizeUnconditionalFinalizers()
     if (m_webAssemblyInstanceSpace)
         finalizeMarkedUnconditionalFinalizers<JSWebAssemblyInstance>(*m_webAssemblyInstanceSpace, collectionScope);
 #endif
+
+    vm().finalizeUnconditionally();
 }
 
 void Heap::willStartIterating()

--- a/Source/JavaScriptCore/interpreter/MicrotaskCall.cpp
+++ b/Source/JavaScriptCore/interpreter/MicrotaskCall.cpp
@@ -27,11 +27,14 @@
 #include "MicrotaskCall.h"
 
 #include "CodeBlock.h"
+#include "HeapInlines.h"
 #include "Interpreter.h"
 #include "JSFunctionInlines.h"
 #include "ThrowScope.h"
 
 namespace JSC {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(MicrotaskCallCache);
 
 void MicrotaskCall::initialize(VM& vm, JSFunction* function)
 {
@@ -68,6 +71,18 @@ void MicrotaskCall::unlinkOrUpgradeImpl(VM&, CodeBlock* oldCodeBlock, CodeBlock*
         return;
     }
     m_addressForCall = nullptr;
+}
+
+void MicrotaskCall::visitWeak(VM& vm)
+{
+    if ((m_functionExecutable && !vm.heap.isMarked(m_functionExecutable)) || (m_codeBlock && !vm.heap.isMarked(m_codeBlock))) {
+        if (isOnList())
+            remove();
+        m_addressForCall = nullptr;
+        m_codeBlock = nullptr;
+        m_functionExecutable = nullptr;
+        m_numParameters = 0;
+    }
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/interpreter/MicrotaskCall.h
+++ b/Source/JavaScriptCore/interpreter/MicrotaskCall.h
@@ -31,6 +31,7 @@
 #include <JavaScriptCore/JSFunction.h>
 #include <wtf/ForbidHeapAllocation.h>
 #include <wtf/MathExtras.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC {
 
@@ -67,6 +68,8 @@ public:
     void unlinkOrUpgradeImpl(VM&, CodeBlock* oldCodeBlock, CodeBlock* newCodeBlock);
     void relink(VM&, JSFunction*);
 
+    void visitWeak(VM&);
+
 private:
     CodeBlock* m_codeBlock { nullptr };
     FunctionExecutable* m_functionExecutable { nullptr };
@@ -77,7 +80,7 @@ private:
 
 class MicrotaskCallCache final {
     WTF_MAKE_NONCOPYABLE(MicrotaskCallCache);
-    WTF_FORBID_HEAP_ALLOCATION;
+    WTF_MAKE_TZONE_ALLOCATED(MicrotaskCallCache);
 public:
     static constexpr unsigned cacheSize = 8;
     static_assert(hasOneBitSet(cacheSize));
@@ -104,6 +107,12 @@ public:
         auto* result = &m_entries[m_nextEntryIndex];
         m_nextEntryIndex = (m_nextEntryIndex + 1) & (cacheSize - 1);
         return result;
+    }
+
+    void finalizeUnconditionally(VM& vm)
+    {
+        for (auto& entry : m_entries)
+            entry.visitWeak(vm);
     }
 
 private:

--- a/Source/JavaScriptCore/jit/JITCall.cpp
+++ b/Source/JavaScriptCore/jit/JITCall.cpp
@@ -622,7 +622,7 @@ void JIT::emit_op_async_iterator_next(const JSInstruction* instruction)
     emitGetVirtualRegisterPayload(bytecode.m_iterator, iteratorGPR);
     emitGetVirtualRegisterPayload(bytecode.m_driver, driverGPR);
     loadGlobalObject(globalObjectGPR);
-    callOperation(operationAsyncIteratorNextWithDriver, globalObjectGPR, iteratorGPR, driverGPR);
+    callOperation(operationAsyncIteratorNextWithDriver, globalObjectGPR, iteratorGPR, driverGPR, TrustedImmPtr(&vm().syncResumeCallCache()));
     emitPutVirtualRegister(bytecode.m_dst, returnValueJSR);
     Jump doneCase = jump();
 

--- a/Source/JavaScriptCore/jit/JITOperations.cpp
+++ b/Source/JavaScriptCore/jit/JITOperations.cpp
@@ -2905,25 +2905,25 @@ JSC_DEFINE_JIT_OPERATION(operationSetFunctionName, void, (JSGlobalObject* global
     OPERATION_RETURN(scope);
 }
 
-JSC_DEFINE_JIT_OPERATION(operationEnqueueAsyncGeneratorDriver, void, (JSGlobalObject* globalObject, JSAsyncGenerator* iterator, JSObject* driver))
+JSC_DEFINE_JIT_OPERATION(operationEnqueueAsyncGeneratorDriver, void, (JSGlobalObject* globalObject, JSAsyncGenerator* iterator, JSObject* driver, MicrotaskCallCache* microtaskCallCache))
 {
     VM& vm = globalObject->vm();
     CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
     JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    enqueueAsyncGeneratorDriver(globalObject, iterator, driver);
+    enqueueAsyncGeneratorDriver(globalObject, iterator, driver, microtaskCallCache);
     OPERATION_RETURN(scope);
 }
 
-JSC_DEFINE_JIT_OPERATION(operationAsyncIteratorNextWithDriver, EncodedJSValue, (JSGlobalObject* globalObject, JSObject* iterator, JSObject* driver))
+JSC_DEFINE_JIT_OPERATION(operationAsyncIteratorNextWithDriver, EncodedJSValue, (JSGlobalObject* globalObject, JSObject* iterator, JSObject* driver, MicrotaskCallCache* microtaskCallCache))
 {
     VM& vm = globalObject->vm();
     CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
     JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    OPERATION_RETURN(scope, JSValue::encode(asyncIteratorNextWithDriver(globalObject, iterator, driver)));
+    OPERATION_RETURN(scope, JSValue::encode(asyncIteratorNextWithDriver(globalObject, iterator, driver, microtaskCallCache)));
 }
 
 JSC_DEFINE_JIT_OPERATION(operationNewObject, JSCell*, (VM* vmPointer, Structure* structure))

--- a/Source/JavaScriptCore/jit/JITOperations.h
+++ b/Source/JavaScriptCore/jit/JITOperations.h
@@ -64,6 +64,7 @@ class JSRemoteFunction;
 class JSScope;
 class JSString;
 class JSValue;
+class MicrotaskCallCache;
 class RegExp;
 class RegExpObject;
 class Register;
@@ -357,8 +358,8 @@ JSC_DECLARE_JIT_OPERATION(operationNewAsyncFunctionWithInvalidatedReallocationWa
 JSC_DECLARE_JIT_OPERATION(operationNewAsyncGeneratorFunction, EncodedJSValue, (JSGlobalObject*, JSScope*, JSCell*));
 JSC_DECLARE_JIT_OPERATION(operationNewAsyncGeneratorFunctionWithInvalidatedReallocationWatchpoint, EncodedJSValue, (JSGlobalObject*, JSScope*, JSCell*));
 JSC_DECLARE_JIT_OPERATION(operationSetFunctionName, void, (JSGlobalObject*, JSCell*, EncodedJSValue));
-JSC_DECLARE_JIT_OPERATION(operationEnqueueAsyncGeneratorDriver, void, (JSGlobalObject*, JSAsyncGenerator*, JSObject*));
-JSC_DECLARE_JIT_OPERATION(operationAsyncIteratorNextWithDriver, EncodedJSValue, (JSGlobalObject*, JSObject*, JSObject*));
+JSC_DECLARE_JIT_OPERATION(operationEnqueueAsyncGeneratorDriver, void, (JSGlobalObject*, JSAsyncGenerator*, JSObject*, MicrotaskCallCache*));
+JSC_DECLARE_JIT_OPERATION(operationAsyncIteratorNextWithDriver, EncodedJSValue, (JSGlobalObject*, JSObject*, JSObject*, MicrotaskCallCache*));
 JSC_DECLARE_JIT_OPERATION(operationNewObject, JSCell*, (VM*, Structure*));
 JSC_DECLARE_JIT_OPERATION(operationNewPromise, JSCell*, (VM*, Structure*));
 JSC_DECLARE_JIT_OPERATION(operationNewGenerator, JSCell*, (VM*, Structure*));

--- a/Source/JavaScriptCore/llint/LLIntSlowPaths.cpp
+++ b/Source/JavaScriptCore/llint/LLIntSlowPaths.cpp
@@ -2025,7 +2025,7 @@ LLINT_SLOW_PATH_DECL(slow_path_async_iterator_next_with_driver)
     metadata.m_iterationMetadata.seenModes = metadata.m_iterationMetadata.seenModes | IterationMode::FastAsyncGenerator;
     JSObject* iterator = asObject(getNonConstantOperand(callFrame, bytecode.m_iterator).asCell());
     auto* driver = asObject(getNonConstantOperand(callFrame, bytecode.m_driver).asCell());
-    JSValue result = asyncIteratorNextWithDriver(globalObject, iterator, driver);
+    JSValue result = asyncIteratorNextWithDriver(globalObject, iterator, driver, &vm.syncResumeCallCache());
     LLINT_RETURN(result);
 }
 

--- a/Source/JavaScriptCore/runtime/AsyncGeneratorPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/AsyncGeneratorPrototype.cpp
@@ -33,6 +33,7 @@
 #include "JSGenerator.h"
 #include "JSMicrotask.h"
 #include "JSPromise.h"
+#include "MicrotaskCall.h"
 
 namespace JSC {
 
@@ -55,7 +56,7 @@ const ClassInfo AsyncGeneratorPrototype::s_info = { "AsyncGenerator"_s, &Base::s
 */
 
 // https://tc39.es/ecma262/#sec-asyncgenerator-prototype-next
-JSValue asyncGeneratorNext(JSGlobalObject* globalObject, JSAsyncGenerator* generator, JSValue argument)
+JSValue asyncGeneratorNext(JSGlobalObject* globalObject, JSAsyncGenerator* generator, JSValue argument, MicrotaskCallCache* microtaskCallCache)
 {
     VM& vm = globalObject->vm();
     auto* promise = JSPromise::create(vm, globalObject->promiseStructure());
@@ -78,7 +79,7 @@ JSValue asyncGeneratorNext(JSGlobalObject* globalObject, JSAsyncGenerator* gener
     // 9. If state is either suspended-start or suspended-yield, then
     if (state == static_cast<int32_t>(JSAsyncGenerator::AsyncGeneratorState::Init) || JSAsyncGenerator::isSuspendedYieldState(state)) {
         // 9.a. Perform AsyncGeneratorResume(gen, completion).
-        asyncGeneratorResume(globalObject, generator);
+        asyncGeneratorResume(globalObject, generator, microtaskCallCache);
     } else {
         // 10. Else,
         // 10.a. Assert: state is either executing or draining-queue.
@@ -102,7 +103,7 @@ JSC_DEFINE_HOST_FUNCTION(asyncGeneratorPrototypeNext, (JSGlobalObject* globalObj
         return JSValue::encode(promise);
     }
 
-    return JSValue::encode(asyncGeneratorNext(globalObject, generator, callFrame->argument(0)));
+    return JSValue::encode(asyncGeneratorNext(globalObject, generator, callFrame->argument(0), &vm.syncResumeCallCache()));
 }
 
 // https://tc39.es/ecma262/#sec-asyncgenerator-prototype-return
@@ -134,7 +135,7 @@ JSC_DEFINE_HOST_FUNCTION(asyncGeneratorPrototypeReturn, (JSGlobalObject* globalO
     } else if (JSAsyncGenerator::isSuspendedYieldState(state)) {
         // 9. Else if state is suspended-yield, then
         // 9.a. Perform AsyncGeneratorResume(gen, completion).
-        asyncGeneratorResume(globalObject, generator);
+        asyncGeneratorResume(globalObject, generator, &vm.syncResumeCallCache());
     } else {
         // 10. Else,
         // 10.a. Assert: state is either executing or draining-queue.
@@ -185,7 +186,7 @@ JSC_DEFINE_HOST_FUNCTION(asyncGeneratorPrototypeThrow, (JSGlobalObject* globalOb
     // 10. If state is suspended-yield, then
     // 10.a. Perform AsyncGeneratorResume(gen, completion).
     if (JSAsyncGenerator::isSuspendedYieldState(state))
-        asyncGeneratorResume(globalObject, generator);
+        asyncGeneratorResume(globalObject, generator, &vm.syncResumeCallCache());
     else {
         // 11. Else,
         // 11.a. Assert: state is either executing or draining-queue.

--- a/Source/JavaScriptCore/runtime/JSAsyncGenerator.h
+++ b/Source/JavaScriptCore/runtime/JSAsyncGenerator.h
@@ -209,6 +209,6 @@ private:
     void finishCreation(VM&);
 };
 
-JSValue asyncGeneratorNext(JSGlobalObject*, JSAsyncGenerator*, JSValue argument);
+JSValue asyncGeneratorNext(JSGlobalObject*, JSAsyncGenerator*, JSValue argument, MicrotaskCallCache*);
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/JSMicrotask.cpp
+++ b/Source/JavaScriptCore/runtime/JSMicrotask.cpp
@@ -608,7 +608,7 @@ void asyncGeneratorResume(JSGlobalObject* globalObject, JSAsyncGenerator* genera
     asyncGeneratorUnwrapYieldResumption(globalObject, generator, generator->resumeValue(), generator->resumeMode(), microtaskCallCache);
 }
 
-void enqueueAsyncGeneratorDriver(JSGlobalObject* globalObject, JSAsyncGenerator* iterator, JSObject* driver)
+void enqueueAsyncGeneratorDriver(JSGlobalObject* globalObject, JSAsyncGenerator* iterator, JSObject* driver, MicrotaskCallCache* microtaskCallCache)
 {
     VM& vm = globalObject->vm();
 
@@ -624,18 +624,18 @@ void enqueueAsyncGeneratorDriver(JSGlobalObject* globalObject, JSAsyncGenerator*
 
     // https://tc39.es/ecma262/#sec-asyncgeneratorenqueue step 6: a non-busy generator resumes immediately.
     if (state == static_cast<int32_t>(JSAsyncGenerator::AsyncGeneratorState::Init) || JSAsyncGenerator::isSuspendedYieldState(state))
-        asyncGeneratorResume(globalObject, iterator);
+        asyncGeneratorResume(globalObject, iterator, microtaskCallCache);
 }
 
-JSValue asyncIteratorNextWithDriver(JSGlobalObject* globalObject, JSObject* iterator, JSObject* driver)
+JSValue asyncIteratorNextWithDriver(JSGlobalObject* globalObject, JSObject* iterator, JSObject* driver, MicrotaskCallCache* microtaskCallCache)
 {
     VM& vm = globalObject->vm();
     auto* generator = uncheckedDowncast<JSAsyncGenerator>(iterator);
 
     if (globalObject->promiseSpeciesWatchpointSet().state() != IsWatched) [[unlikely]]
-        return asyncGeneratorNext(globalObject, generator, jsUndefined());
+        return asyncGeneratorNext(globalObject, generator, jsUndefined(), microtaskCallCache);
 
-    enqueueAsyncGeneratorDriver(globalObject, generator, driver);
+    enqueueAsyncGeneratorDriver(globalObject, generator, driver, microtaskCallCache);
     return vm.fastAsyncGeneratorSentinel();
 }
 

--- a/Source/JavaScriptCore/runtime/JSMicrotask.h
+++ b/Source/JavaScriptCore/runtime/JSMicrotask.h
@@ -38,12 +38,12 @@ void runInternalMicrotask(JSGlobalObject*, VM&, InternalMicrotask, uint8_t, std:
 
 // https://tc39.es/ecma262/#sec-asyncgeneratorresume and #sec-asyncgeneratorawaitreturn — used by the C++
 // %AsyncGeneratorPrototype%.return / .throw host functions to drive a non-busy generator.
-void asyncGeneratorResume(JSGlobalObject*, JSAsyncGenerator*, MicrotaskCallCache* = nullptr);
+void asyncGeneratorResume(JSGlobalObject*, JSAsyncGenerator*, MicrotaskCallCache*);
 void asyncGeneratorAwaitReturn(JSGlobalObject*, JSAsyncGenerator*);
 
-void enqueueAsyncGeneratorDriver(JSGlobalObject*, JSAsyncGenerator* iterator, JSObject* driver);
+void enqueueAsyncGeneratorDriver(JSGlobalObject*, JSAsyncGenerator* iterator, JSObject* driver, MicrotaskCallCache*);
 
-JSValue asyncIteratorNextWithDriver(JSGlobalObject*, JSObject* iterator, JSObject* driver);
+JSValue asyncIteratorNextWithDriver(JSGlobalObject*, JSObject* iterator, JSObject* driver, MicrotaskCallCache*);
 
 JSC_DECLARE_HOST_FUNCTION(asyncFunctionDrive);
 

--- a/Source/JavaScriptCore/runtime/VM.cpp
+++ b/Source/JavaScriptCore/runtime/VM.cpp
@@ -95,6 +95,7 @@
 #include "LLIntExceptions.h"
 #include "MarkedBlockInlines.h"
 #include "MegamorphicCache.h"
+#include "MicrotaskCall.h"
 #include "MicrotaskQueueInlines.h"
 #include "MinimumReservedZoneSize.h"
 #include "ModuleGraphLoadingStateInlines.h"
@@ -270,6 +271,7 @@ VM::VM(VMType vmType, HeapType heapType, WTF::RunLoop* runLoop, bool* success)
 #endif
     , m_regExpCache(makeUnique<RegExpCache>())
     , m_compactVariableMap(adoptRef(*new CompactTDZEnvironmentMap))
+    , m_syncResumeCallCache(makeUniqueRef<MicrotaskCallCache>())
     , m_codeCache(makeUnique<CodeCache>())
     , m_intlCache(makeUnique<IntlCache>())
     , m_builtinExecutables(makeUnique<BuiltinExecutables>(*this))
@@ -1845,6 +1847,11 @@ void VM::beginMarking()
     m_microtaskQueues.forEach([&](MicrotaskQueue* microtaskQueue) {
         microtaskQueue->beginMarking();
     });
+}
+
+void VM::finalizeUnconditionally()
+{
+    m_syncResumeCallCache->finalizeUnconditionally(*this);
 }
 
 template<typename Visitor>

--- a/Source/JavaScriptCore/runtime/VM.h
+++ b/Source/JavaScriptCore/runtime/VM.h
@@ -131,6 +131,7 @@ class JSPropertyNameEnumerator;
 class JITSizeStatistics;
 class JITThunks;
 class MegamorphicCache;
+class MicrotaskCallCache;
 class MicrotaskQueue;
 class NativeExecutable;
 class Debugger;
@@ -930,6 +931,9 @@ public:
     ALWAYS_INLINE MegamorphicCache* megamorphicCache() { return m_megamorphicCache.getIfExists(); }
     MegamorphicCache& ensureMegamorphicCache() { return m_megamorphicCache.get(*this); }
 
+    const UniqueRef<MicrotaskCallCache> m_syncResumeCallCache;
+    MicrotaskCallCache& syncResumeCallCache() { return m_syncResumeCallCache.get(); }
+
     enum class StructureChainIntegrityEvent : uint8_t {
         Add,
         Remove,
@@ -1102,6 +1106,7 @@ public:
 #endif
 
     void beginMarking();
+    void finalizeUnconditionally();
     DECLARE_VISIT_AGGREGATE;
 
     void NODELETE addDebugger(Debugger&);


### PR DESCRIPTION
#### bafc1f2d7f1e8c6c2eb2ebc395c8f94af5f35c33
<pre>
[JSC] Introduce MicrotaskCallCache for async generator driver path
<a href="https://bugs.webkit.org/show_bug.cgi?id=319650">https://bugs.webkit.org/show_bug.cgi?id=319650</a>
<a href="https://rdar.apple.com/182472828">rdar://182472828</a>

Reviewed by Sosuke Suzuki.

Let&apos;s have per-VM MicrotaskCallCache for async generator driver path.
Since MicrotaskCallCache is no longer on the stack, we need to finalize
the MicrotaskCall when GC happens. When it is used on-stack, we do not
need it since everything is alive via conservative scanning. But now
VM&apos;s one is not so we should purge invalid entries.

* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileCompareStrictEq):
* Source/JavaScriptCore/heap/Heap.cpp:
(JSC::Heap::finalizeUnconditionalFinalizers):
* Source/JavaScriptCore/interpreter/MicrotaskCall.cpp:
(JSC::MicrotaskCall::visitWeak):
* Source/JavaScriptCore/interpreter/MicrotaskCall.h:
* Source/JavaScriptCore/jit/JITCall.cpp:
(JSC::JIT::emit_op_async_iterator_next):
* Source/JavaScriptCore/jit/JITOperations.cpp:
(JSC::JSC_DEFINE_JIT_OPERATION):
* Source/JavaScriptCore/jit/JITOperations.h:
* Source/JavaScriptCore/llint/LLIntSlowPaths.cpp:
(JSC::LLInt::LLINT_SLOW_PATH_DECL):
* Source/JavaScriptCore/runtime/AsyncGeneratorPrototype.cpp:
(JSC::asyncGeneratorNext):
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/JSAsyncGenerator.h:
* Source/JavaScriptCore/runtime/JSMicrotask.cpp:
(JSC::enqueueAsyncGeneratorDriver):
(JSC::asyncIteratorNextWithDriver):
* Source/JavaScriptCore/runtime/JSMicrotask.h:
* Source/JavaScriptCore/runtime/VM.cpp:
(JSC::VM::VM):
(JSC::VM::finalizeUnconditionally):
* Source/JavaScriptCore/runtime/VM.h:
(JSC::VM::syncResumeCallCache):

Canonical link: <a href="https://commits.webkit.org/317384@main">https://commits.webkit.org/317384@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d800e9e637ddc1c5eef054507b5813a683648214

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175168 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49100 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42881 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184753 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/133075 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7fbd5c82-9a09-40fb-beef-5505eabd771e) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50392 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48783 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136349 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96174 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3432a76e-6872-43da-9656-90edc309718c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178125 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39783 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/157141 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116828 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2d0b7f44-479c-42a0-8a0e-1d97e7077c89) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/38424 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/36809 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33226 "Built successfully") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/218/builds/5650 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/148847 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36634 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187174 "Built successfully") | | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/36429 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/40787 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/41012 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145291 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48767 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145147 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49447 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/33255 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115282 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26626 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40005 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/121624 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/212259 "Build is in progress. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; Compiled JSC") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47953 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11607 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/55391 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47356 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47586 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47413 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->