### PR TITLE
[YARR] surrogateTagMask should be 0xfc00/0xfc00 instead of 0xdc00/0xdc00

### DIFF
--- a/JSTests/stress/regexp-unicode-surrogate-mask.js
+++ b/JSTests/stress/regexp-unicode-surrogate-mask.js
@@ -1,0 +1,60 @@
+// Regression test for the YARR JIT surrogate mask. Surrogates occupy U+D800..U+DFFF
+// and must be isolated with the mask 0xFC00 (bits 15..10). The JIT used 0xDC00, which
+// drops bit 13, so ordinary BMP code units in U+F800..U+FFFF were misclassified as
+// surrogates and two of them were fused into a single code point. All of these are
+// plain BMP scalars, so each string below is two code points, never one.
+
+function shouldBe(actual, expected, msg) {
+    if (actual !== expected)
+        throw new Error(`FAIL: ${msg}: expected ${expected}, got ${actual}`);
+}
+
+let loop = typeof testLoopCount !== "undefined" ? testLoopCount : 200;
+let cc = String.fromCharCode;
+
+// [firstUnit, secondUnit, codePoints]: only a genuine pair (lead 0xD800..0xDBFF followed
+// by trail 0xDC00..0xDFFF) is a single code point. The "fake" variants set bit 13 and are
+// two ordinary BMP code points.
+let cases = [
+    [0xd800, 0xdc00, 1], // genuine surrogate pair -> one code point
+    [0xdbff, 0xdfff, 1], // genuine pair, top of range
+    [0xf800, 0xfc00, 2], // fake lead + fake trail (both bit 13 set)
+    [0xd800, 0xfc00, 2], // real lead + fake trail
+    [0xf800, 0xdc00, 2], // fake lead + real trail
+    [0xfbff, 0xffff, 2], // fake pair, top of range
+    [0x0041, 0x0042, 2], // plain BMP control
+];
+
+for (let i = 0; i < loop; i++) {
+    for (let [a, b, cps] of cases) {
+        let s = cc(a, b);
+        let tag = `[${a.toString(16)},${b.toString(16)}]`;
+
+        // Spread is the correct code-point segmentation reference.
+        shouldBe([...s].length, cps, `codepoints ${tag}`);
+
+        // In /u mode a dot matches exactly one code point.
+        shouldBe(/^.$/u.test(s), cps === 1, `single dot ${tag}`);
+        shouldBe(/^..$/u.test(s), cps === 2, `double dot ${tag}`);
+
+        // Greedy variable-width class match (forward advance uses the same mask).
+        let fwd = new RegExp("([^X]*)Z", "u").exec(s + "Z");
+        shouldBe(fwd !== null, true, `greedy match ${tag}`);
+        shouldBe(fwd[1], s, `greedy capture ${tag}`);
+
+        // Greedy variable-width class backtracking: the class eats everything, then must
+        // give back exactly one code point so the trailing literal (the second code unit)
+        // can match. This only works if the last matched code point is one unit wide, i.e.
+        // the two units were not fused into a bogus pair.
+        if (cps === 2) {
+            let re = new RegExp("([^X]*)" + cc(b), "u");
+            let m = re.exec(s);
+            shouldBe(m !== null, true, `backtrack match ${tag}`);
+            shouldBe(m[1], cc(a), `backtrack capture ${tag}`);
+        }
+    }
+
+    // Genuine pairs must still be treated as one code point after the fix.
+    shouldBe(/^.$/u.test("\u{10000}"), true, "astral single dot");
+    shouldBe(/^.$/u.test("\u{10ffff}"), true, "astral max single dot");
+}

--- a/Source/JavaScriptCore/yarr/YarrJIT.cpp
+++ b/Source/JavaScriptCore/yarr/YarrJIT.cpp
@@ -455,7 +455,7 @@ public:
 };
 WTF_MAKE_TZONE_ALLOCATED_IMPL(MaskedAlternativeInfo);
 
-static constexpr MacroAssembler::TrustedImm32 surrogateTagMask = MacroAssembler::TrustedImm32(0xdc00dc00);
+static constexpr MacroAssembler::TrustedImm32 surrogateTagMask = MacroAssembler::TrustedImm32(0xfc00fc00);
 static constexpr MacroAssembler::TrustedImm32 surrogatePairTags = MacroAssembler::TrustedImm32(0xdc00d800);
 
 #if ENABLE(YARR_JIT_UNICODE_EXPRESSIONS)
@@ -542,7 +542,7 @@ void tryReadUnicodeCharSlowImpl(CCallHelpers& jit)
     // regs.input contains the pointer of the beginning of the string.
     // regs.endOfStringAddress contains the address one past the end of the string.
     // For architectures that put the surrogate masks and tags in registers,
-    // regs.surrogateTagMask contains 0xdc00dc00 and regs.surrogatePairTags contains 0xdc00d800.
+    // regs.surrogateTagMask contains 0xfc00fc00 and regs.surrogatePairTags contains 0xdc00d800.
     // When the YARR_JIT_UNICODE_CAN_INCREMENT_INDEX_FOR_NON_BMP optimization is enabled and used,
     // regs.firstCharacterAdditionalReadSize is used to advance 2 characters when we read a non-BMP codepoint.
     // regs.unicodeAndSubpatternIdTemp is used as a temporary.


### PR DESCRIPTION
#### 28426f73148a87823f5a1ffa0b2ef1bd9f658d2b
<pre>
[YARR] surrogateTagMask should be 0xfc00/0xfc00 instead of 0xdc00/0xdc00
<a href="https://bugs.webkit.org/show_bug.cgi?id=319651">https://bugs.webkit.org/show_bug.cgi?id=319651</a>
<a href="https://rdar.apple.com/182474262">rdar://182474262</a>

Reviewed by Yijia Huang.

We are checking the surrogates like this.

    jit.load32(Address(...), resultReg);
    jit.and32AndSetFlags(surrogateTagMask, resultReg, temp);
    isBMP.append(jit.branch(Zero));
    slowCases.append(jit.branch32(NotEqual, temp, surrogatePairTags));

Previously, the surrogateTagMask was 0xdc00/0xdc00. Then 0xf800 etc. can
pass the above filter and incorrectly recognized as a surrogate. This
patch fixes it by making surrogateTagMask 0xfc00/0xfc00 so we can correctly
filter out surrogates.

Test: JSTests/stress/regexp-unicode-surrogate-mask.js

* JSTests/stress/regexp-unicode-surrogate-mask.js: Added.
(shouldBe):
(i.cps.of.cases.a.toString):
* Source/JavaScriptCore/yarr/YarrJIT.cpp:
(JSC::Yarr::tryReadUnicodeCharSlowImpl):

Canonical link: <a href="https://commits.webkit.org/317399@main">https://commits.webkit.org/317399@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7c9f88a8c8b191b54a8ed2936467ec0e328fa7f4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175167 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49099 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42880 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184752 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/133074 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7ef956ad-ad4c-4088-bf0d-45ce03aeacb4) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50391 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48782 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136341 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96173 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178124 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39784 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/157129 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116820 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38425 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/36803 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33225 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/5638 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148848 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36622 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187173 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/36428 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/40786 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/41006 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145290 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48766 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145146 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49446 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/33243 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115281 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26633 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40000 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/121623 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/212258 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47952 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11595 "") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/55390 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47355 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47585 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47412 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->