### PR TITLE
REGRESSION(316854@main): [macOS Debug] ASSERTION FAILED: !m_waitingForMessage in imported/w3c/web-platform-tests/html/cross-origin-opener-policy/resource-popup.https.html

### DIFF
--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2439,5 +2439,3 @@ media/media-source/media-managedmse-webvtt-track.html [ Pass Timeout ]
 webkit.org/b/319121 [ Release ] imported/w3c/web-platform-tests/css/filter-effects/backdrop-filter-corner-shape-change.html [ Pass ImageOnlyFailure ]
 
 webkit.org/b/319606 [ Debug ] http/tests/ipc/createnewpage-file-body-sandbox-extension.html [ Failure ]
-
-webkit.org/b/319273 [ Debug ] imported/w3c/web-platform-tests/html/cross-origin-opener-policy/resource-popup.https.html [ Crash ]

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
@@ -369,6 +369,9 @@ public:
 
     void flushNetworkProcessIPC(CompletionHandler<void()>&&);
 
+    bool isWaitingForCertificateInfo() const { return m_isWaitingForCertificateInfo; }
+    void setIsWaitingForCertificateInfo(bool waiting) { m_isWaitingForCertificateInfo = waiting; }
+
 private:
     explicit NetworkProcessProxy();
 
@@ -503,6 +506,7 @@ private:
     RetainPtr<id> m_backgroundObserver;
     RetainPtr<id> m_foregroundObserver;
 #endif
+    bool m_isWaitingForCertificateInfo { false };
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebFrameProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFrameProxy.cpp
@@ -1241,10 +1241,18 @@ void WebFrameProxy::waitForCertificateInfoFromNetworkProcess(const String& hostA
     RefPtr connection = networkProcess->connection();
     if (!connection)
         return;
+
+    // waitForAndDispatchImmediately dispatches messages besides the one being waited for.
+    // If another Messages::WebPageProxy::DidCommitLoadForFrame is received, we can get Error::MultipleWaitingClients.
+    // To prevent this, only be in one waitForAndDispatchImmediately call at a time per connection for this.
+    // If the next frame commit is also missing certificate info after this, then it will wait too.
+    if (networkProcess->isWaitingForCertificateInfo())
+        return;
+    networkProcess->setIsWaitingForCertificateInfo(true);
     if (connection->waitForAndDispatchImmediately<Messages::WebFrameProxyFromNetworkProcess::ReceivedMainResourceResponseWithCertificateInfo>(frameID(), 0_s) != IPC::Error::NoError) {
         RELEASE_LOG_ERROR(Network, "Unexpectedly missing certificate info from IPC");
-        return;
     }
+    networkProcess->setIsWaitingForCertificateInfo(false);
 }
 
 void WebFrameProxy::commitCertificateInfo(const URL& url)
@@ -1261,7 +1269,7 @@ void WebFrameProxy::commitCertificateInfo(const URL& url)
             waitForCertificateInfoFromNetworkProcess(hostAndPort);
             certificateInfo = m_hostAndPortToCertificateInfo.get(hostAndPort);
             if (certificateInfo.isEmpty())
-            RELEASE_LOG_ERROR(Network, "Unexpectedly missing certificate info");
+                RELEASE_LOG_ERROR(Network, "Unexpectedly missing certificate info");
         }
     }
 


### PR DESCRIPTION
#### 5e99592ba2f7c5f8c8b88d05f888a08b7e21a762
<pre>
REGRESSION(316854@main): [macOS Debug] ASSERTION FAILED: !m_waitingForMessage in imported/w3c/web-platform-tests/html/cross-origin-opener-policy/resource-popup.https.html
<a href="https://bugs.webkit.org/show_bug.cgi?id=319273">https://bugs.webkit.org/show_bug.cgi?id=319273</a>
<a href="https://rdar.apple.com/182115695">rdar://182115695</a>

Reviewed by Chris Dumez.

317090@main wasn&apos;t quite enough.  We also need to prevent multiple calls to WebFrameProxy::waitForCertificateInfoFromNetworkProcess
in case multiple frames are committing in fast succession.

* LayoutTests/platform/mac-wk2/TestExpectations:
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.h:
* Source/WebKit/UIProcess/WebFrameProxy.cpp:
(WebKit::WebFrameProxy::waitForCertificateInfoFromNetworkProcess):
(WebKit::WebFrameProxy::commitCertificateInfo):

Canonical link: <a href="https://commits.webkit.org/317375@main">https://commits.webkit.org/317375@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8a5b469755616cabe62a57ba42994106ce49bd80

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/38/builds/175182 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/49114 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/42895 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184767 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/133089 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/50406 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/48797 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136357 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/133089 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/178139 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/50406 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/42895 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116836 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/50406 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/48797 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33240 "Built successfully") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/42895 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/50406 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/42895 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187188 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/40801 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/48797 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145303 "Passed tests") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/174582 "Build is in progress. Recent messages:") | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/48781 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/42895 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145160 "Passed tests") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/49461 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/42895 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115308 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26619 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/49461 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/121640 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/47967 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/42895 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/47370 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/47600 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/47427 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->