### PR TITLE
Wrong ended event fired on HLS live stream when dealing with playbackRate

### DIFF
--- a/LayoutTests/http/tests/media/hls/hls-live-playbackrate-no-ended-expected.txt
+++ b/LayoutTests/http/tests/media/hls/hls-live-playbackrate-no-ended-expected.txt
@@ -1,0 +1,26 @@
+
+RUN(video.src = "../resources/hls/bip-bop-live.m3u8")
+EVENT(canplay)
+EXPECTED (video.duration == 'Infinity') OK
+
+Phase 1: pause, change playbackRate, resume into the live edge.
+RUN(video.play())
+EVENT(playing)
+RUN(video.pause())
+EVENT(pause)
+RUN(video.playbackRate = 2)
+RUN(video.currentTime = video.seekable.end(0) - 0.5)
+EVENT(seeked)
+RUN(video.play())
+EVENT(waiting)
+EXPECTED (video.ended == 'false') OK
+EXPECTED (video.duration == 'Infinity') OK
+
+Phase 2: play forward into the live edge.
+RUN(video.currentTime = video.seekable.end(0) - 1)
+EVENT(seeked)
+RUN(video.play())
+EXPECTED (video.ended == 'false') OK
+EXPECTED (video.duration == 'Infinity') OK
+END OF TEST
+

--- a/LayoutTests/http/tests/media/hls/hls-live-playbackrate-no-ended.html
+++ b/LayoutTests/http/tests/media/hls/hls-live-playbackrate-no-ended.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>hls-live-playbackrate-no-ended</title>
+    <script src=../../media-resources/video-test.js></script>
+    <script>
+    // A live (infinite-duration) HLS stream must not fire 'ended' when playback
+    // reaches the live edge after the playbackRate has been changed. Reaching the
+    // live edge should stall the element (fire 'waiting'); it must never end the
+    // stream or demote the infinite duration to a finite value. Both invariants
+    // are enforced across every phase below.
+    window.addEventListener('load', async event => {
+        findMediaElement();
+
+        failTestIn(30000);
+
+        waitForEventAndFail('ended');
+        video.addEventListener('durationchange', () => {
+            if (video.duration !== Infinity)
+                failTest(`duration demoted to finite value ${video.duration}`);
+        });
+
+        run('video.src = "../resources/hls/bip-bop-live.m3u8"');
+        await waitFor(video, 'canplay');
+
+        // A live stream reports an infinite duration.
+        testExpected('video.duration', Infinity, '==');
+
+        // Phase 1: pause, change the rate, then resume and run into the live edge.
+        consoleWrite('');
+        consoleWrite('Phase 1: pause, change playbackRate, resume into the live edge.');
+        run('video.play()');
+        await waitFor(video, 'playing');
+        run('video.pause()');
+        await waitFor(video, 'pause');
+        run('video.playbackRate = 2');
+        run('video.currentTime = video.seekable.end(0) - 0.5');
+        await waitFor(video, 'seeked');
+        run('video.play()');
+        await waitFor(video, 'waiting');
+        testExpected('video.ended', false, '==');
+        testExpected('video.duration', Infinity, '==');
+
+        // Phase 2: without pausing, play forward through the final samples into the
+        // live edge. Unlike phase 1's seek-and-stall, this drives AVFoundation to
+        // report end-of-media, which is the trigger for the spurious 'ended'. Once the
+        // stream correctly stays live there is no distinct event to await, so dwell
+        // briefly and confirm no 'ended' fired and the duration was not demoted.
+        consoleWrite('');
+        consoleWrite('Phase 2: play forward into the live edge.');
+        run('video.currentTime = video.seekable.end(0) - 1');
+        await waitFor(video, 'seeked');
+        run('video.play()');
+        await sleepFor(3000);
+        testExpected('video.ended', false, '==');
+        testExpected('video.duration', Infinity, '==');
+
+        endTest();
+    });
+    </script>
+</head>
+<body>
+    <video id="video" controls muted></video>
+</body>
+</html>

--- a/Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.cpp
+++ b/Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.cpp
@@ -722,8 +722,11 @@ void MediaPlayerPrivateAVFoundation::didEnd(double now)
 {
     // Hang onto the current time and use it as duration from now on since we are definitely at
     // the end of the movie. Do this because the initial duration is sometimes an estimate.
-    ALWAYS_LOG(LOGIDENTIFIER, "currentTime: ", now, ", seeking: ", m_seeking);
-    if (now > 0 && !m_seeking) {
+    // Never do this for a live stream: its duration is unbounded (positive infinity), and
+    // demoting it to a finite value here would make endedPlayback() treat reaching the live
+    // edge as the end of the media and fire a spurious 'ended' event.
+    ALWAYS_LOG(LOGIDENTIFIER, "currentTime: ", now, ", seeking: ", m_seeking, ", isLiveStream: ", isLiveStream());
+    if (now > 0 && !m_seeking && !isLiveStream()) {
         ALWAYS_LOG(LOGIDENTIFIER, "Updating cached duration to ", now);
         m_cachedDuration = MediaTime::createWithDouble(now);
     }


### PR DESCRIPTION
#### c782c456f8ed7fcd7132b1a111e705324be386c8
<pre>
Wrong ended event fired on HLS live stream when dealing with playbackRate
<a href="https://bugs.webkit.org/show_bug.cgi?id=245519">https://bugs.webkit.org/show_bug.cgi?id=245519</a>
<a href="https://rdar.apple.com/100556746">rdar://100556746</a>

Reviewed by Jean-Yves Avenard.

A live HLS stream reports an unbounded duration (positive infinity), which is
how WebKit recognizes it as live. When such a stream is played forward into the
live edge, AVFoundation posts AVPlayerItemDidPlayToEndTimeNotification, which
routes into MediaPlayerPrivateAVFoundation::didEnd(). That method caches the
current time as the media&apos;s duration to correct estimated durations. For a live
stream this demotes the duration from positive infinity to a finite value, so
the next HTMLMediaElement::handlePlaybackPositionChanged() sees currentTime at
the (now finite) duration and fires a spurious pause and ended, even though the
stream has not finished. Changing playbackRate makes this easy to hit because
playback reaches the live edge sooner.

Skip caching the duration in didEnd() when the resource is a live stream, so its
unbounded duration is preserved and endedPlayback() does not treat reaching the
live edge as the end of the media. Also log isLiveStream() in didEnd() to make
this state visible for future diagnosis.

Test: http/tests/media/hls/hls-live-playbackrate-no-ended.html

* LayoutTests/http/tests/media/hls/hls-live-playbackrate-no-ended-expected.txt: Added.
* LayoutTests/http/tests/media/hls/hls-live-playbackrate-no-ended.html: Added.
* Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.cpp:
(WebCore::MediaPlayerPrivateAVFoundation::didEnd):

Canonical link: <a href="https://commits.webkit.org/317626@main">https://commits.webkit.org/317626@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c91910c1ace79900f96b7006599cee7b4ac485ca

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175835 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49768 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43552 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185428 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/138025 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/51a862a5-73ae-458b-8a06-f8230031bbc2) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/177698 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51060 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49450 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136921 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/138025 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bb77d046-9685-4065-a679-358cdccb1149) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178791 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40382 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157696 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117400 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/865329b7-f559-4f0f-8a00-e44863a74c5c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39024 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37403 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149443 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37188 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33898 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41466 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41609 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187849 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49435 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/157247 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145914 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39257 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50115 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/33812 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145754 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40548 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122311 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/116151 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48622 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12168 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48024 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48256 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48081 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->