### PR TITLE
Implement the active custom element constructor map

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/createElement-reentrant-construction.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/createElement-reentrant-construction.window-expected.txt
@@ -1,0 +1,4 @@
+
+PASS Re-entrant createElement() of the same element before super()
+PASS Re-entrant createElement() of the same element after super()
+

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/createElement-reentrant-construction.window.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/createElement-reentrant-construction.window.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/createElement-reentrant-construction.window.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/createElement-reentrant-construction.window.js
@@ -1,0 +1,53 @@
+// create an element does not push onto the construction stack; the constructor
+// creates the element. So a re-entrant createElement() for the same element
+// yields two independent elements rather than hitting an "already constructed"
+// marker.
+
+// A failed construction is reported rather than rethrown by create an element.
+setup({allow_uncaught_exception: true});
+
+test(() => {
+  let nested;
+  let needsReentry = true;
+  class Reentrant extends HTMLElement {
+    constructor() {
+      if (needsReentry) {
+        needsReentry = false;
+        nested = document.createElement('reentrant-before-super');
+      }
+      super();
+    }
+  }
+  customElements.define('reentrant-before-super', Reentrant);
+
+  const outer = document.createElement('reentrant-before-super');
+
+  assert_true(nested instanceof Reentrant, 'the re-entrant createElement() constructs an element');
+  assert_equals(nested.localName, 'reentrant-before-super');
+  assert_true(outer instanceof Reentrant, 'the outer createElement() constructs an element');
+  assert_equals(outer.localName, 'reentrant-before-super');
+  assert_not_equals(outer, nested, 'the two createElement() calls construct distinct elements');
+}, 'Re-entrant createElement() of the same element before super()');
+
+test(() => {
+  let nested;
+  let needsReentry = true;
+  class Reentrant extends HTMLElement {
+    constructor() {
+      super();
+      if (needsReentry) {
+        needsReentry = false;
+        nested = document.createElement('reentrant-after-super');
+      }
+    }
+  }
+  customElements.define('reentrant-after-super', Reentrant);
+
+  const outer = document.createElement('reentrant-after-super');
+
+  assert_true(nested instanceof Reentrant, 'the re-entrant createElement() constructs an element');
+  assert_equals(nested.localName, 'reentrant-after-super');
+  assert_true(outer instanceof Reentrant, 'the outer createElement() constructs an element');
+  assert_equals(outer.localName, 'reentrant-after-super');
+  assert_not_equals(outer, nested, 'the two createElement() calls construct distinct elements');
+}, 'Re-entrant createElement() of the same element after super()');

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/constructor-direct-call-fallback-registry.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/constructor-direct-call-fallback-registry.window-expected.txt
@@ -1,0 +1,4 @@
+
+PASS Direct construction of a global-only element after super() during a scoped upgrade
+PASS Direct construction of a global-only element before super() during a scoped upgrade
+

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/constructor-direct-call-fallback-registry.window.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/constructor-direct-call-fallback-registry.window.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/constructor-direct-call-fallback-registry.window.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/constructor-direct-call-fallback-registry.window.js
@@ -1,0 +1,75 @@
+// https://html.spec.whatwg.org/multipage/custom-elements.html#html-element-constructors
+// https://dom.spec.whatwg.org/#concept-create-element
+
+function createShadowForTest(t, customElementRegistry) {
+  const host = document.createElement('div');
+  const shadow = host.attachShadow({mode: 'open', customElementRegistry});
+  document.body.appendChild(host);
+  t.add_cleanup(() => host.remove());
+  return shadow;
+}
+
+// GlobalOnly is only defined in the global registry, so `new GlobalOnly()` must
+// resolve against it even during a scoped upgrade.
+class GlobalOnly extends HTMLElement {}
+window.customElements.define('global-only-element', GlobalOnly);
+
+test(t => {
+  let nestedElement;
+  let nestedError;
+  class ScopedElement extends HTMLElement {
+    constructor() {
+      super();
+      try {
+        nestedElement = new GlobalOnly();
+      } catch (e) {
+        nestedError = e;
+      }
+    }
+  }
+
+  const registry = new CustomElementRegistry();
+  registry.define('scoped-element-1', ScopedElement);
+
+  const shadow = createShadowForTest(t, registry);
+  shadow.innerHTML = '<scoped-element-1></scoped-element-1>';
+
+  const shadowElement = shadow.firstChild;
+  assert_true(shadowElement instanceof ScopedElement);
+  assert_equals(shadowElement.localName, 'scoped-element-1');
+
+  assert_equals(nestedError, undefined,
+      'new GlobalOnly() should not throw during a scoped upgrade');
+  assert_true(nestedElement instanceof GlobalOnly);
+  assert_equals(nestedElement.localName, 'global-only-element');
+}, 'Direct construction of a global-only element after super() during a scoped upgrade');
+
+test(t => {
+  let nestedElement;
+  let nestedError;
+  class ScopedElement extends HTMLElement {
+    constructor() {
+      try {
+        nestedElement = new GlobalOnly();
+      } catch (e) {
+        nestedError = e;
+      }
+      super();
+    }
+  }
+
+  const registry = new CustomElementRegistry();
+  registry.define('scoped-element-2', ScopedElement);
+
+  const shadow = createShadowForTest(t, registry);
+  shadow.innerHTML = '<scoped-element-2></scoped-element-2>';
+
+  const shadowElement = shadow.firstChild;
+  assert_true(shadowElement instanceof ScopedElement);
+  assert_equals(shadowElement.localName, 'scoped-element-2');
+
+  assert_equals(nestedError, undefined,
+      'new GlobalOnly() should not throw during a scoped upgrade');
+  assert_true(nestedElement instanceof GlobalOnly);
+  assert_equals(nestedElement.localName, 'global-only-element');
+}, 'Direct construction of a global-only element before super() during a scoped upgrade');

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/constructor-reentry-createElement.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/constructor-reentry-createElement.window-expected.txt
@@ -1,0 +1,6 @@
+
+PASS Re-entry via createElement with a different registry after super()
+PASS Re-entry via createElement with a different registry before super()
+PASS Direct construction of a global-only element after super() during a scoped createElement construction
+PASS Direct construction of a global-only element before super() during a scoped createElement construction
+

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/constructor-reentry-createElement.window.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/constructor-reentry-createElement.window.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/constructor-reentry-createElement.window.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/constructor-reentry-createElement.window.js
@@ -1,0 +1,119 @@
+// Exercises the active custom element constructor map through the DOM
+// "create an element" path rather than the HTML "upgrade an element" path.
+// https://github.com/whatwg/html/issues/12691
+
+// create an element reports constructor exceptions rather than rethrowing them.
+setup({allow_uncaught_exception: true});
+
+test(() => {
+  let nestedElement;
+  let needsReentry = true;
+  class Reentry extends HTMLElement {
+    constructor() {
+      super();
+      if (needsReentry) {
+        needsReentry = false;
+        nestedElement = document.createElement('global-reentry');
+      }
+    }
+  }
+  window.customElements.define('global-reentry', Reentry);
+
+  const registry = new CustomElementRegistry();
+  registry.define('scoped-reentry', Reentry);
+
+  const element = document.createElement('scoped-reentry', {customElementRegistry: registry});
+
+  assert_true(element instanceof Reentry);
+  assert_equals(element.localName, 'scoped-reentry');
+  assert_true(nestedElement instanceof Reentry);
+  assert_equals(nestedElement.localName, 'global-reentry');
+}, 'Re-entry via createElement with a different registry after super()');
+
+// The re-entrant construction overwrites the map entry for the shared
+// constructor and must restore it, or the outer super() falls back to the wrong
+// registry.
+test(() => {
+  let nestedElement;
+  let needsReentry = true;
+  class Reentry extends HTMLElement {
+    constructor() {
+      if (needsReentry) {
+        needsReentry = false;
+        nestedElement = document.createElement('global-reentry-before');
+      }
+      super();
+    }
+  }
+  window.customElements.define('global-reentry-before', Reentry);
+
+  const registry = new CustomElementRegistry();
+  registry.define('scoped-reentry-before', Reentry);
+
+  const element = document.createElement('scoped-reentry-before', {customElementRegistry: registry});
+
+  assert_true(element instanceof Reentry);
+  assert_equals(element.localName, 'scoped-reentry-before');
+  assert_true(nestedElement instanceof Reentry);
+  assert_equals(nestedElement.localName, 'global-reentry-before');
+  assert_not_equals(element, nestedElement);
+}, 'Re-entry via createElement with a different registry before super()');
+
+// GlobalOnly is a different constructor, so it has its own construction stack
+// and resolves against the global registry.
+class GlobalOnly extends HTMLElement {}
+window.customElements.define('global-only-element', GlobalOnly);
+
+test(() => {
+  let nestedElement;
+  let nestedError;
+  class ScopedElement extends HTMLElement {
+    constructor() {
+      super();
+      try {
+        nestedElement = new GlobalOnly();
+      } catch (e) {
+        nestedError = e;
+      }
+    }
+  }
+
+  const registry = new CustomElementRegistry();
+  registry.define('scoped-element-after', ScopedElement);
+
+  const element = document.createElement('scoped-element-after', {customElementRegistry: registry});
+
+  assert_true(element instanceof ScopedElement);
+  assert_equals(element.localName, 'scoped-element-after');
+  assert_equals(nestedError, undefined,
+      'new GlobalOnly() should not throw during a scoped createElement construction');
+  assert_true(nestedElement instanceof GlobalOnly);
+  assert_equals(nestedElement.localName, 'global-only-element');
+}, 'Direct construction of a global-only element after super() during a scoped createElement construction');
+
+test(() => {
+  let nestedElement;
+  let nestedError;
+  class ScopedElement extends HTMLElement {
+    constructor() {
+      try {
+        nestedElement = new GlobalOnly();
+      } catch (e) {
+        nestedError = e;
+      }
+      super();
+    }
+  }
+
+  const registry = new CustomElementRegistry();
+  registry.define('scoped-element-before', ScopedElement);
+
+  const element = document.createElement('scoped-element-before', {customElementRegistry: registry});
+
+  assert_true(element instanceof ScopedElement);
+  assert_equals(element.localName, 'scoped-element-before');
+  assert_equals(nestedError, undefined,
+      'new GlobalOnly() should not throw during a scoped createElement construction');
+  assert_true(nestedElement instanceof GlobalOnly);
+  assert_equals(nestedElement.localName, 'global-only-element');
+}, 'Direct construction of a global-only element before super() during a scoped createElement construction');

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/w3c-import.log
@@ -30,6 +30,8 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/ShadowRoot-innerHTML.html
 /LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/WEB_FEATURES.yml
 /LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/adoption.window.js
+/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/constructor-direct-call-fallback-registry.window.js
+/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/constructor-reentry-createElement.window.js
 /LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/constructor-reentry-with-different-definition.html
 /LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/define-customized-builtins.html
 /LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/define.html

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/w3c-import.log
@@ -35,6 +35,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/custom-elements/connected-callbacks-html-fragment-parsing.html
 /LayoutTests/imported/w3c/web-platform-tests/custom-elements/connected-callbacks-template.html
 /LayoutTests/imported/w3c/web-platform-tests/custom-elements/connected-callbacks.html
+/LayoutTests/imported/w3c/web-platform-tests/custom-elements/createElement-reentrant-construction.window.js
 /LayoutTests/imported/w3c/web-platform-tests/custom-elements/cross-realm-callback-report-exception.html
 /LayoutTests/imported/w3c/web-platform-tests/custom-elements/custom-element-reaction-queue.html
 /LayoutTests/imported/w3c/web-platform-tests/custom-elements/customized-built-in-constructor-exceptions.html

--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -22,7 +22,6 @@ accessibility/AccessibilitySVGObject.cpp
 bindings/js/JSAbortSignalCustom.cpp
 bindings/js/JSCSSRuleListCustom.cpp
 bindings/js/JSCSSStyleDeclarationCustom.cpp
-bindings/js/JSCustomElementInterface.cpp
 bindings/js/JSHTMLElementCustom.cpp
 bindings/js/JSIDBCursorCustom.cpp
 bindings/js/JSIDBRequestCustom.cpp

--- a/Source/WebCore/bindings/js/JSCustomElementInterface.cpp
+++ b/Source/WebCore/bindings/js/JSCustomElementInterface.cpp
@@ -130,10 +130,14 @@ RefPtr<Element> JSCustomElementInterface::tryToConstructCustomElement(Document& 
     ASSERT(lexicalGlobalObject);
     if (!lexicalGlobalObject)
         return nullptr;
-    auto* oldRegistry = contextDocument->activeCustomElementRegistry();
-    contextDocument->setActiveCustomElementRegistry(&registry);
-    auto element = constructCustomElementSynchronously(document, vm, *lexicalGlobalObject, m_constructor.get(), localName, parserConstructElementWithEmptyStack);
-    contextDocument->setActiveCustomElementRegistry(oldRegistry);
+    auto* constructor = m_constructor.get();
+    RefPtr previousRegistry = contextDocument->activeCustomElementConstructorRegistry(constructor);
+    contextDocument->addToActiveCustomElementConstructorMap(constructor, registry);
+    RefPtr element = constructCustomElementSynchronously(document, vm, *lexicalGlobalObject, constructor, localName, parserConstructElementWithEmptyStack);
+    if (previousRegistry)
+        contextDocument->addToActiveCustomElementConstructorMap(constructor, *previousRegistry);
+    else
+        contextDocument->removeFromActiveCustomElementConstructorMap(constructor);
     EXCEPTION_ASSERT(!!scope.exception() == !element);
     if (!element) {
         auto* exception = scope.exception();
@@ -255,16 +259,20 @@ void JSCustomElementInterface::upgradeElement(Element& element)
     if (m_isFormAssociated)
         downcast<HTMLMaybeFormAssociatedCustomElement>(element).willUpgradeFormAssociated();
 
-    auto* oldRegistry = document->activeCustomElementRegistry();
-    document->setActiveCustomElementRegistry(registry.get());
+    auto* constructor = m_constructor.get();
+    RefPtr previousRegistry = document->activeCustomElementConstructorRegistry(constructor);
+    document->addToActiveCustomElementConstructorMap(constructor, *registry);
 
     MarkedArgumentBuffer args;
     ASSERT(!args.hasOverflowed());
     JSExecState::instrumentFunction(context.get(), constructData);
-    JSValue returnedElement = construct(lexicalGlobalObject, m_constructor.get(), constructData, args);
+    JSValue returnedElement = construct(lexicalGlobalObject, constructor, constructData, args);
     InspectorInstrumentation::didCallFunction(context.get());
 
-    document->setActiveCustomElementRegistry(oldRegistry);
+    if (previousRegistry)
+        document->addToActiveCustomElementConstructorMap(constructor, *previousRegistry);
+    else
+        document->removeFromActiveCustomElementConstructorMap(constructor);
 
     m_constructionStack.removeLast();
 

--- a/Source/WebCore/bindings/js/JSHTMLElementCustom.cpp
+++ b/Source/WebCore/bindings/js/JSHTMLElementCustom.cpp
@@ -72,7 +72,7 @@ EncodedJSValue constructJSHTMLElement(JSGlobalObject* lexicalGlobalObject, CallF
 
     Ref document = downcast<Document>(*context);
 
-    RefPtr registry = document->activeCustomElementRegistry();
+    RefPtr registry = document->activeCustomElementConstructorRegistry(newTarget);
     if (!registry) {
         RefPtr window = document->window();
         if (!window)

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -1943,9 +1943,19 @@ CustomElementNameValidationStatus Document::validateCustomElementName(const Atom
     return CustomElementNameValidationStatus::Valid;
 }
 
-void Document::setActiveCustomElementRegistry(CustomElementRegistry* registry)
+CustomElementRegistry* Document::activeCustomElementConstructorRegistry(JSC::JSObject* constructor)
 {
-    m_activeCustomElementRegistry = registry;
+    return m_activeCustomElementConstructorMap.get(reinterpret_cast<uintptr_t>(constructor));
+}
+
+void Document::addToActiveCustomElementConstructorMap(JSC::JSObject* constructor, CustomElementRegistry& registry)
+{
+    m_activeCustomElementConstructorMap.set(reinterpret_cast<uintptr_t>(constructor), registry);
+}
+
+void Document::removeFromActiveCustomElementConstructorMap(JSC::JSObject* constructor)
+{
+    m_activeCustomElementConstructorMap.remove(reinterpret_cast<uintptr_t>(constructor));
 }
 
 ExceptionOr<Ref<Element>> Document::createElementNS(const AtomString& namespaceURI, const AtomString& qualifiedName, Variant<String, ElementCreationOptions>&& argument)

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -83,6 +83,7 @@
 namespace JSC {
 class CallFrame;
 class InputCursor;
+class JSObject;
 }
 
 namespace WTF {
@@ -590,8 +591,9 @@ public:
     RefPtr<CustomElementRegistry> customElementRegistryForBindings();
     CustomElementRegistry* NODELETE effectiveGlobalCustomElementRegistry();
     static CustomElementNameValidationStatus validateCustomElementName(const AtomString&);
-    void setActiveCustomElementRegistry(CustomElementRegistry*);
-    CustomElementRegistry* activeCustomElementRegistry() { return m_activeCustomElementRegistry.get(); }
+    CustomElementRegistry* activeCustomElementConstructorRegistry(JSC::JSObject* constructor);
+    void addToActiveCustomElementConstructorMap(JSC::JSObject* constructor, CustomElementRegistry&);
+    void removeFromActiveCustomElementConstructorMap(JSC::JSObject* constructor);
 
     WEBCORE_EXPORT RefPtr<Range> caretRangeFromPoint(int x, int y, HitTestSource = HitTestSource::Script);
     std::optional<BoundaryPoint> caretPositionFromPoint(const LayoutPoint& clientPoint, HitTestSource);
@@ -2571,7 +2573,7 @@ private:
 
     WeakListHashSet<ShadowRoot, WeakPtrImplWithEventTargetData> m_inDocumentShadowRoots;
 
-    RefPtr<CustomElementRegistry> m_activeCustomElementRegistry;
+    HashMap<uintptr_t, RefPtr<CustomElementRegistry>> m_activeCustomElementConstructorMap;
 
 #if ENABLE(WIRELESS_PLAYBACK_TARGET)
     using TargetIdToClientMap = HashMap<PlaybackTargetClientContextIdentifier, WeakPtr<MediaPlaybackTargetClient>>;


### PR DESCRIPTION
#### 48915d8239475d1ebbcf5936f6b25dccf24659b3
<pre>
Implement the active custom element constructor map
<a href="https://bugs.webkit.org/show_bug.cgi?id=319658">https://bugs.webkit.org/show_bug.cgi?id=319658</a>

Reviewed by Ryosuke Niwa.

Keith Cirkel pointed out that the constructor map as defined did not
quite work and also that WebKit did not implement it.

This aligns WebKit with the proposed changes to DOM and HTML and also
adds some additional test coverage for the gaps:

- <a href="https://github.com/whatwg/dom/pull/1494">https://github.com/whatwg/dom/pull/1494</a>
- <a href="https://github.com/whatwg/html/pull/12696">https://github.com/whatwg/html/pull/12696</a>

Tests: imported/w3c/web-platform-tests/custom-elements/createElement-reentrant-construction.window.html
       imported/w3c/web-platform-tests/custom-elements/registries/constructor-direct-call-fallback-registry.window.html
       imported/w3c/web-platform-tests/custom-elements/registries/constructor-reentry-createElement.window.html

Canonical link: <a href="https://commits.webkit.org/317462@main">https://commits.webkit.org/317462@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/72ac26bcb0fb991afcd81f8e6245af4488c1c704

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175406 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49338 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43119 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184992 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/137532 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2c94bc57-160e-43db-a18b-88065952c10b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/177270 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50630 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49021 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136558 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/137532 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8cfad813-e3e0-4b57-a1ff-5b307b3bb7fd) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178363 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39978 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157317 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117036 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0f53ad10-c2b2-4093-bf5f-ab21eddf3741) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38620 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37003 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149042 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36810 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33467 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41025 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/41207 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187417 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49005 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/156873 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145523 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49685 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/33432 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145364 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26664 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40183 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/121878 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115581 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48191 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11783 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47594 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47824 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47651 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->