### PR TITLE
[JSC] Use ApproximateTime for deadline in Opportunistic Task Scheduler and Incremental Sweeper

### DIFF
--- a/Source/JavaScriptCore/heap/IncrementalSweeper.cpp
+++ b/Source/JavaScriptCore/heap/IncrementalSweeper.cpp
@@ -49,7 +49,7 @@ IncrementalSweeper::IncrementalSweeper(JSC::Heap* heap)
 {
 }
 
-void IncrementalSweeper::doWorkUntil(VM& vm, MonotonicTime deadline)
+void IncrementalSweeper::doWorkUntil(VM& vm, ApproximateTime deadline)
 {
     if (!m_currentDirectory)
         m_currentDirectory = vm.heap.objectSpace().firstDirectory();
@@ -65,10 +65,10 @@ void IncrementalSweeper::doWork(VM& vm)
         scheduleTimer();
         return;
     }
-    doSweep(vm, MonotonicTime::now() + sweepTimeSlice, SweepTrigger::Timer);
+    doSweep(vm, ApproximateTime::now() + sweepTimeSlice, SweepTrigger::Timer);
 }
 
-void IncrementalSweeper::doSweep(VM& vm, MonotonicTime deadline, SweepTrigger trigger)
+void IncrementalSweeper::doSweep(VM& vm, ApproximateTime deadline, SweepTrigger trigger)
 {
     std::optional<TraceScope> traceScope;
     if (Options::useTracePoints()) [[unlikely]]
@@ -77,7 +77,7 @@ void IncrementalSweeper::doSweep(VM& vm, MonotonicTime deadline, SweepTrigger tr
     vm.heap.clearConcurrentRetainedDataIfPossible();
 
     while (sweepNextBlock(vm, trigger)) {
-        if (MonotonicTime::now() < deadline)
+        if (ApproximateTime::now() < deadline)
             continue;
 
         if (trigger == SweepTrigger::Timer)

--- a/Source/JavaScriptCore/heap/IncrementalSweeper.h
+++ b/Source/JavaScriptCore/heap/IncrementalSweeper.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <JavaScriptCore/JSRunLoopTimer.h>
+#include <wtf/ApproximateTime.h>
 
 namespace JSC {
 
@@ -39,14 +40,14 @@ public:
 
     JS_EXPORT_PRIVATE void startSweeping(Heap&);
 
-    void doWorkUntil(VM&, MonotonicTime deadline);
+    void doWorkUntil(VM&, ApproximateTime deadline);
     void doWork(VM&) final;
     void stopSweeping();
 
 private:
     enum class SweepTrigger : bool { Timer, OpportunisticTask };
     bool sweepNextBlock(VM&, SweepTrigger);
-    void doSweep(VM&, MonotonicTime startTime, SweepTrigger);
+    void doSweep(VM&, ApproximateTime deadline, SweepTrigger);
     void scheduleTimer();
     
     BlockDirectory* m_currentDirectory;

--- a/Source/JavaScriptCore/runtime/VM.cpp
+++ b/Source/JavaScriptCore/runtime/VM.cpp
@@ -1974,7 +1974,7 @@ void VM::removeDebugger(Debugger& debugger)
     m_debuggers.remove(&debugger);
 }
 
-void VM::performOpportunisticallyScheduledTasks(MonotonicTime deadline, OptionSet<SchedulerOptions> options)
+void VM::performOpportunisticallyScheduledTasks(ApproximateTime deadline, OptionSet<SchedulerOptions> options)
 {
     constexpr bool verbose = false;
 

--- a/Source/JavaScriptCore/runtime/VM.h
+++ b/Source/JavaScriptCore/runtime/VM.h
@@ -51,6 +51,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 #include <JavaScriptCore/VMThreadContext.h>
 #include <JavaScriptCore/WeakGCMap.h>
 #include <JavaScriptCore/WriteBarrier.h>
+#include <wtf/ApproximateTime.h>
 #include <wtf/BumpPointerAllocator.h>
 #include <wtf/CheckedArithmetic.h>
 #include <wtf/Compiler.h>
@@ -373,7 +374,7 @@ public:
     enum class SchedulerOptions : uint8_t {
         HasImminentlyScheduledWork = 1 << 0,
     };
-    JS_EXPORT_PRIVATE void performOpportunisticallyScheduledTasks(MonotonicTime deadline, OptionSet<SchedulerOptions>);
+    JS_EXPORT_PRIVATE void performOpportunisticallyScheduledTasks(ApproximateTime deadline, OptionSet<SchedulerOptions>);
 
     Structure* cellButterflyStructure(IndexingType indexingType) { return rawImmutableButterflyStructure(indexingType).get(); }
 

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -5367,7 +5367,8 @@ void Page::performOpportunisticallyScheduledTasks(MonotonicTime deadline)
     OptionSet<JSC::VM::SchedulerOptions> options;
     if (m_opportunisticTaskScheduler->hasImminentlyScheduledWork())
         options.add(JSC::VM::SchedulerOptions::HasImminentlyScheduledWork);
-    commonVM().performOpportunisticallyScheduledTasks(deadline, options);
+
+    commonVM().performOpportunisticallyScheduledTasks(deadline.approximate<ApproximateTime>(), options);
 
     deleteRemovedNodesAndDetachedRenderers();
 }


### PR DESCRIPTION
#### e1d43e57f4b1f721602480ec3bf2379e69ade3d0
<pre>
[JSC] Use ApproximateTime for deadline in Opportunistic Task Scheduler and Incremental Sweeper
<a href="https://bugs.webkit.org/show_bug.cgi?id=319662">https://bugs.webkit.org/show_bug.cgi?id=319662</a>
<a href="https://rdar.apple.com/182496956">rdar://182496956</a>

Reviewed by Yijia Huang.

Now UnbarrieredMonotonicTime is used in ApproximateTime if possible, so
using ApproximateTime for deadline representation in Opportunistic Task
Scheduler and Incremental Sweeper as it does not have precision issues.
When it is not available, it is either (1) still precision is fine or
(2) MonotonicTime is used.

* Source/JavaScriptCore/heap/IncrementalSweeper.cpp:
(JSC::IncrementalSweeper::doWorkUntil):
(JSC::IncrementalSweeper::doWork):
(JSC::IncrementalSweeper::doSweep):
* Source/JavaScriptCore/heap/IncrementalSweeper.h:
* Source/JavaScriptCore/runtime/VM.cpp:
(JSC::VM::performOpportunisticallyScheduledTasks):
* Source/JavaScriptCore/runtime/VM.h:
* Source/WebCore/page/Page.cpp:
(WebCore::Page::performOpportunisticallyScheduledTasks):

Canonical link: <a href="https://commits.webkit.org/317524@main">https://commits.webkit.org/317524@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4f878b484af56ed360bb51249fa25aad97c0875b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175484 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49416 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43197 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185070 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/137630 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ebdc7597-f951-4012-a945-b9153364bf74) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/177348 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50708 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49099 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136635 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/137630 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/75cf4124-9152-44b4-b644-5c4a36a6a951) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178441 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40048 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157388 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117113 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ecb7eed9-7efe-402f-a895-f43c06dff017) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38690 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37076 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/5897 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149112 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36881 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33545 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/36745 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41103 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41279 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187495 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49083 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145599 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49763 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33505 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145437 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26677 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40254 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/121956 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115701 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48269 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11857 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47672 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47902 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47729 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->