### PR TITLE
[JSC][Temporal] Fix Japanese, ROC, and Buddhist calendar fields

### DIFF
--- a/JSTests/stress/temporal-calendar-icu-bridge-non-iso.js
+++ b/JSTests/stress/temporal-calendar-icu-bridge-non-iso.js
@@ -31,6 +31,109 @@ function shouldRoundTripDuration(start, end, largestUnit, expected, label) {
     shouldBe(end.add(reverse).equals(start), true, `${label} reverse inverse`);
 }
 
+function shouldHaveCalendarDateFields(date, year, era, eraYear, month, day, label) {
+    shouldBe(date.year, year, `${label} year`);
+    shouldBe(date.era, era, `${label} era`);
+    shouldBe(date.eraYear, eraYear, `${label} eraYear`);
+    shouldBe(date.month, month, `${label} month`);
+    shouldBe(date.monthCode, `M${String(month).padStart(2, "0")}`, `${label} monthCode`);
+    shouldBe(date.day, day, `${label} day`);
+}
+
+// Japanese `year` is always the proleptic-Gregorian ISO year. Era fields remain calendar-native.
+for (const [isoDate, era, eraYear] of [
+    ["-271821-04-19", "bce", 271822],
+    ["-000001-01-01", "bce", 2],
+    ["0000-01-01", "bce", 1],
+    ["0001-01-01", "ce", 1],
+    ["1000-01-01", "ce", 1000],
+    ["1500-02-28", "ce", 1500],
+    ["1868-10-22", "ce", 1868],
+    ["1872-12-31", "ce", 1872],
+    ["1873-01-01", "meiji", 6],
+    ["1912-07-29", "meiji", 45],
+    ["1912-07-30", "taisho", 1],
+    ["1926-12-24", "taisho", 15],
+    ["1926-12-25", "showa", 1],
+    ["1989-01-07", "showa", 64],
+    ["1989-01-08", "heisei", 1],
+    ["2019-04-30", "heisei", 31],
+    ["2019-05-01", "reiwa", 1],
+    ["+275760-09-13", "reiwa", 273742],
+]) {
+    const iso = Temporal.PlainDate.from(isoDate);
+    const date = iso.withCalendar("japanese");
+    shouldHaveCalendarDateFields(date, iso.year, era, eraYear, iso.month, iso.day, `japanese ${isoDate}`);
+
+    const roundTrip = Temporal.PlainDate.from({
+        calendar: "japanese",
+        year: date.year,
+        era: date.era,
+        eraYear: date.eraYear,
+        monthCode: date.monthCode,
+        day: date.day,
+    });
+    shouldBe(roundTrip.withCalendar("iso8601").toString(), isoDate, `japanese ${isoDate} field round-trip`);
+}
+
+for (const [fields, isoDate, era, eraYear] of [
+    [{ year: -1, era: "bce", eraYear: 2, month: 1, day: 1 }, "-000001-01-01", "bce", 2],
+    [{ year: 1000, era: "ce", eraYear: 1000, month: 1, day: 1 }, "1000-01-01", "ce", 1000],
+    [{ year: 1873, era: "meiji", eraYear: 6, month: 1, day: 1 }, "1873-01-01", "meiji", 6],
+    [{ year: 2019, era: "reiwa", eraYear: 1, month: 5, day: 1 }, "2019-05-01", "reiwa", 1],
+]) {
+    const date = Temporal.PlainDate.from({ calendar: "japanese", ...fields }, { overflow: "reject" });
+    shouldBe(date.withCalendar("iso8601").toString(), isoDate, `japanese ${isoDate} from fields`);
+    shouldHaveCalendarDateFields(date, fields.year, era, eraYear, fields.month, fields.day, `japanese ${isoDate} from fields`);
+
+    const updated = date.with({ day: 2 }, { overflow: "reject" });
+    shouldHaveCalendarDateFields(updated, fields.year, era, eraYear, fields.month, 2, `japanese ${isoDate} with`);
+}
+
+// A Japanese year-only property bag uses the same ISO year exposed by the getter.
+for (const [year, month, day, era, eraYear] of [
+    [1000, 2, 28, "ce", 1000],
+    [1872, 12, 31, "ce", 1872],
+    [1873, 1, 1, "meiji", 6],
+]) {
+    const date = Temporal.PlainDate.from({ calendar: "japanese", year, month, day }, { overflow: "reject" });
+    shouldBe(date.withCalendar("iso8601").toString(), `${String(year).padStart(4, "0")}-${String(month).padStart(2, "0")}-${String(day).padStart(2, "0")}`, `japanese year-only ${year} ISO date`);
+    shouldHaveCalendarDateFields(date, year, era, eraYear, month, day, `japanese year-only ${year}`);
+}
+
+const japaneseYearMonth = Temporal.PlainYearMonth.from({ calendar: "japanese", year: 1000, month: 2 }, { overflow: "reject" });
+shouldBe(japaneseYearMonth.toString({ calendarName: "never" }), "1000-02-01", "japanese year-only PlainYearMonth ISO date");
+shouldBe(japaneseYearMonth.year, 1000, "japanese year-only PlainYearMonth year");
+shouldBe(japaneseYearMonth.month, 2, "japanese year-only PlainYearMonth month");
+shouldBe(japaneseYearMonth.monthCode, "M02", "japanese year-only PlainYearMonth monthCode");
+
+// Named Meiji era input uses proleptic Gregorian arithmetic before the 1873 cutover.
+const negativeMeiji = Temporal.PlainDate.from({ calendar: "japanese", year: 1500, era: "meiji", eraYear: -367, month: 12, day: 31 }, { overflow: "reject" });
+shouldBe(negativeMeiji.withCalendar("iso8601").toString(), "1500-12-31", "negative Meiji eraYear ISO date");
+shouldBe(negativeMeiji.with({ era: "meiji", eraYear: -367, day: 30 }, { overflow: "reject" }).withCalendar("iso8601").toString(), "1500-12-30", "negative Meiji eraYear with");
+shouldBe(Temporal.PlainDate.from({ calendar: "japanese", year: negativeMeiji.year, era: negativeMeiji.era, eraYear: negativeMeiji.eraYear, monthCode: negativeMeiji.monthCode, day: negativeMeiji.day }).withCalendar("iso8601").toString(), "1500-12-31", "negative Meiji eraYear round-trip");
+shouldThrow(() => Temporal.PlainDate.from({ calendar: "japanese", year: 1501, era: "meiji", eraYear: -367, month: 12, day: 31 }), RangeError, "inconsistent negative Meiji year");
+shouldBe(Temporal.PlainDate.from({ calendar: "japanese", era: "meiji", eraYear: -367, month: 2, day: 29 }).withCalendar("iso8601").toString(), "1500-02-28", "negative Meiji Gregorian February constrain");
+shouldThrow(() => Temporal.PlainDate.from({ calendar: "japanese", era: "meiji", eraYear: -367, month: 2, day: 29 }, { overflow: "reject" }), RangeError, "negative Meiji Gregorian February reject");
+shouldBe(Temporal.PlainDate.from({ calendar: "japanese", era: "meiji", eraYear: 0, month: 1, day: 1 }).withCalendar("iso8601").toString(), "1867-01-01", "Meiji eraYear zero");
+
+for (const [era, month, day, isoDate, outputEra, outputEraYear] of [["meiji", 9, 8, "1868-09-08", "ce", 1868], ["taisho", 7, 30, "1912-07-30", "taisho", 1], ["showa", 12, 25, "1926-12-25", "showa", 1], ["heisei", 1, 8, "1989-01-08", "heisei", 1], ["reiwa", 5, 1, "2019-05-01", "reiwa", 1]]) {
+    const date = Temporal.PlainDate.from({ calendar: "japanese", era, eraYear: 1, month, day }, { overflow: "reject" });
+    shouldBe(date.withCalendar("iso8601").toString(), isoDate, `${era} transition ISO date`);
+    shouldHaveCalendarDateFields(date, Number(isoDate.slice(0, 4)), outputEra, outputEraYear, month, day, `${era} transition`);
+}
+
+shouldThrow(() => Temporal.PlainDate.from({ calendar: "japanese", year: 999, era: "ce", eraYear: 1000, month: 1, day: 1 }), RangeError, "inconsistent Japanese CE year");
+shouldThrow(() => Temporal.PlainDate.from({ calendar: "japanese", year: 2018, era: "reiwa", eraYear: 1, month: 5, day: 1 }), RangeError, "inconsistent Japanese Reiwa year");
+
+for (const [type, date] of [
+    ["PlainDateTime", Temporal.PlainDateTime.from("1000-01-01T12:00").withCalendar("japanese")],
+    ["ZonedDateTime", Temporal.ZonedDateTime.from("1000-01-01T12:00Z[UTC]").withCalendar("japanese")],
+]) {
+    shouldHaveCalendarDateFields(date, 1000, "ce", 1000, 1, 1, `japanese ${type}`);
+    shouldHaveCalendarDateFields(date.with({ day: 2 }), 1000, "ce", 1000, 1, 2, `japanese ${type} with`);
+}
+
 // Buddhist: `year` is BE (Gregorian + 543). BE 2567 = Gregorian 2024.
 {
     const pd = Temporal.PlainDate.from({year:2567, month:1, day:1, calendar:"buddhist"});
@@ -48,6 +151,115 @@ function shouldRoundTripDuration(start, end, largestUnit, expected, label) {
     const pd = Temporal.PlainDate.from({era:"be", eraYear:2567, month:1, day:1, calendar:"buddhist"});
     shouldBe(pd.year, 2567, "buddhist era:be eraYear:2567 -> year");
     shouldBe(pd.toString(), "2024-01-01[u-ca=buddhist]", "buddhist era -> ISO");
+}
+
+function shouldHaveISODate(date, expectedYear, expectedMonth, expectedDay, label) {
+    const isoDate = date.withCalendar("iso8601");
+    shouldBe(isoDate.year, expectedYear, `${label} ISO year`);
+    shouldBe(isoDate.month, expectedMonth, `${label} ISO month`);
+    shouldBe(isoDate.day, expectedDay, `${label} ISO day`);
+}
+
+function shouldRoundTripGregorianDate(date, createFromFields, expectedYear, expectedEra, expectedEraYear, expectedMonth, label) {
+    shouldHaveCalendarDateFields(date, expectedYear, expectedEra, expectedEraYear, expectedMonth, 1, label);
+
+    const result = date.with({ day: 2 });
+    shouldHaveISODate(result, 1500, expectedMonth, 2, `${label} after with`);
+    shouldHaveCalendarDateFields(result, expectedYear, expectedEra, expectedEraYear, expectedMonth, 2, `${label} after with`);
+
+    const roundTrip = createFromFields({
+        year: date.year,
+        era: date.era,
+        eraYear: date.eraYear,
+        monthCode: date.monthCode,
+        day: date.day,
+        calendar: date.calendarId,
+    });
+    shouldHaveISODate(roundTrip, 1500, expectedMonth, 1, `${label} field round-trip`);
+    shouldHaveCalendarDateFields(roundTrip, expectedYear, expectedEra, expectedEraYear, expectedMonth, 1, `${label} field round-trip`);
+}
+
+// ROC and Buddhist use proleptic Gregorian date fields before 1582.
+for (const calendar of ["roc", "buddhist"]) {
+    const expectedYear = calendar === "roc" ? -411 : 2043;
+    const expectedEra = calendar === "roc" ? "broc" : "be";
+    const expectedEraYear = calendar === "roc" ? 412 : 2043;
+    for (const month of [1, 2]) {
+        const isoMonth = `0${month}`;
+        const dates = [
+            ["PlainDate", Temporal.PlainDate.from(`1500-${isoMonth}-01`).withCalendar(calendar), fields => Temporal.PlainDate.from(fields)],
+            ["PlainDateTime", Temporal.PlainDateTime.from(`1500-${isoMonth}-01T12:00`).withCalendar(calendar), fields => Temporal.PlainDateTime.from({ ...fields, hour: 12 })],
+            ["ZonedDateTime", Temporal.ZonedDateTime.from(`1500-${isoMonth}-01T12:00Z[UTC]`).withCalendar(calendar), fields => Temporal.ZonedDateTime.from({ ...fields, hour: 12, timeZone: "UTC" })],
+        ];
+        for (const [type, date, createFromFields] of dates) {
+            const label = `${calendar} ${type} 1500-${isoMonth}`;
+            shouldRoundTripGregorianDate(date, createFromFields, expectedYear, expectedEra, expectedEraYear, month, label);
+        }
+    }
+}
+
+// ROC year 0 is the year before ROC year 1.
+for (const [isoDate, year, era, eraYear] of [
+    ["1911-12-31", 0, "broc", 1],
+    ["1912-01-01", 1, "roc", 1],
+]) {
+    const date = Temporal.PlainDate.from(isoDate).withCalendar("roc");
+    shouldBe(date.year, year, `${isoDate} ROC year`);
+    shouldBe(date.era, era, `${isoDate} ROC era`);
+    shouldBe(date.eraYear, eraYear, `${isoDate} ROC eraYear`);
+    const roundTrip = Temporal.PlainDate.from({ year, era, eraYear, monthCode: date.monthCode, day: date.day, calendar: "roc" });
+    shouldBe(roundTrip.withCalendar("iso8601").toString(), isoDate, `${isoDate} ROC round-trip`);
+}
+
+// Buddhist has one era and its arithmetic year may be non-positive.
+for (const [year, isoDate] of [
+    [-1, "-000544-01-01"],
+    [0, "-000543-01-01"],
+    [1, "-000542-01-01"],
+]) {
+    const date = Temporal.PlainDate.from({ year, era: "be", eraYear: year, monthCode: "M01", day: 1, calendar: "buddhist" });
+    shouldBe(date.withCalendar("iso8601").toString(), isoDate, `Buddhist year ${year} ISO date`);
+    shouldBe(date.year, year, `Buddhist year ${year}`);
+    shouldBe(date.era, "be", `Buddhist year ${year} era`);
+    shouldBe(date.eraYear, year, `Buddhist year ${year} eraYear`);
+}
+
+shouldThrow(() => Temporal.PlainDate.from({ year: 0, era: "roc", eraYear: 1, monthCode: "M01", day: 1, calendar: "roc" }), RangeError, "inconsistent ROC year and eraYear");
+shouldThrow(() => Temporal.PlainDate.from({ year: 0, era: "be", eraYear: 1, monthCode: "M01", day: 1, calendar: "buddhist" }), RangeError, "inconsistent Buddhist year and eraYear");
+
+for (const [calendar, fields] of [["japanese", { era: "meiji", eraYear: -367 }], ["roc", { year: -411 }], ["buddhist", { year: 2043 }]]) {
+    const constrained = Temporal.PlainMonthDay.from({ calendar, ...fields, month: 2, day: 29 });
+    shouldBe(constrained.toString(), `1972-02-28[u-ca=${calendar}]`, `${calendar} historical PlainMonthDay constrain and reference year`);
+    shouldThrow(() => Temporal.PlainMonthDay.from({ calendar, ...fields, month: 2, day: 29 }, { overflow: "reject" }), RangeError, `${calendar} historical PlainMonthDay reject`);
+    shouldBe(Temporal.PlainMonthDay.from({ calendar, monthCode: "M02", day: 29 }).toString(), `1972-02-29[u-ca=${calendar}]`, `${calendar} PlainMonthDay leap reference year`);
+}
+for (const [calendar, fields] of [["roc", { era: "roc", eraYear: 2147483647 }], ["roc", { era: "broc", eraYear: -2147483648 }], ["buddhist", { era: "be", eraYear: 2147483647 }], ["buddhist", { era: "be", eraYear: -2147483648 }]]) {
+    shouldThrow(() => Temporal.ZonedDateTime.from(`2000-01-01T00:00[UTC][u-ca=${calendar}]`).with(fields), RangeError, `${calendar} ZonedDateTime.with checked year offset`);
+}
+
+for (const [calendar, year] of [["roc", -411], ["buddhist", 2043]]) {
+    const constrainedDay = Temporal.PlainDate.from({ year, month: 2, day: 29, calendar }, { overflow: "constrain" });
+    shouldBe(constrainedDay.withCalendar("iso8601").toString(), "1500-02-28", `${calendar} day constrain`);
+    shouldThrow(() => Temporal.PlainDate.from({ year, month: 2, day: 29, calendar }, { overflow: "reject" }), RangeError, `${calendar} day reject`);
+
+    const constrainedMonth = Temporal.PlainDate.from({ year, month: 13, day: 1, calendar }, { overflow: "constrain" });
+    shouldBe(constrainedMonth.withCalendar("iso8601").toString(), "1500-12-01", `${calendar} month constrain`);
+    shouldThrow(() => Temporal.PlainDate.from({ year, month: 13, day: 1, calendar }, { overflow: "reject" }), RangeError, `${calendar} month reject`);
+}
+
+// The exact Temporal PlainDate limits support stable calendar-field round-trips.
+for (const [isoDate, calendar, year, era, eraYear] of [
+    ["-271821-04-19", "roc", -273732, "broc", 273733],
+    ["-271821-04-19", "buddhist", -271278, "be", -271278],
+    ["+275760-09-13", "roc", 273849, "roc", 273849],
+    ["+275760-09-13", "buddhist", 276303, "be", 276303],
+]) {
+    const date = Temporal.PlainDate.from(isoDate).withCalendar(calendar);
+    shouldBe(date.year, year, `${calendar} ${isoDate} year`);
+    shouldBe(date.era, era, `${calendar} ${isoDate} era`);
+    shouldBe(date.eraYear, eraYear, `${calendar} ${isoDate} eraYear`);
+    const roundTrip = Temporal.PlainDate.from({ year, era, eraYear, monthCode: date.monthCode, day: date.day, calendar });
+    shouldBe(roundTrip.withCalendar("iso8601").toString(), isoDate, `${calendar} ${isoDate} round-trip`);
 }
 
 // Coptic `am` era: AM 1740 M01 D01 = ISO 2023-09-12.

--- a/JSTests/stress/temporal-japanese-ce-bce-era-validation.js
+++ b/JSTests/stress/temporal-japanese-ce-bce-era-validation.js
@@ -29,10 +29,10 @@ function shouldThrow(func, errorType) {
     shouldBe(r.toString(), "2000-12-01[u-ca=japanese]");
 }
 {
-    // ISO year 0 (bce 1); assert via toString since the year getter goes
-    // through ICU and is subject to Julian/Gregorian switch quirks near year 0.
+    // ISO year 0 (bce 1); the Japanese year getter is always the ISO year.
     const r = Temporal.PlainDate.from({ calendar: "japanese", era: "bce", eraYear: 1, month: 255, day: 40 });
     shouldBe(r.toString(), "0000-12-31[u-ca=japanese]");
+    shouldBe(r.year, 0);
     shouldBe(r.month, 12);
     shouldBe(r.day, 31);
 }

--- a/Source/JavaScriptCore/runtime/temporal/core/CalendarICUBridge.cpp
+++ b/Source/JavaScriptCore/runtime/temporal/core/CalendarICUBridge.cpp
@@ -63,7 +63,7 @@ static CString buildICULocale(StringView calendarId)
 }
 
 // buildCalendarTemplate — internal: opens ICU UCalendar for the given CalendarID, set to UTC.
-// NOTE: For Gregory/ISO/Japanese/Buddhist/Roc: sets Gregorian change date to -infinity for proleptic Gregorian arithmetic.
+// NOTE: For Gregory/ISO: sets Gregorian change date to -infinity for proleptic Gregorian arithmetic.
 static std::unique_ptr<UCalendar, ICUDeleter<ucal_close>> buildCalendarTemplate(const AbstractLocker&, CalendarID calendarId)
 {
     auto str = calendarIDToString(calendarId);
@@ -76,8 +76,8 @@ static std::unique_ptr<UCalendar, ICUDeleter<ucal_close>> buildCalendarTemplate(
     // use proleptic Gregorian for all valid dates (effectively -infinity for our purposes).
     // ucal_setGregorianChange is only supported on the base Gregorian calendar; ICU returns
     // U_UNSUPPORTED_ERROR for derived calendars (Japanese, Buddhist, ROC). Those derived
-    // calendars already use proleptic-Gregorian arithmetic in the years Temporal cares about,
-    // so calling ucal_setGregorianChange would be a no-op and we skip it.
+    // calendars cannot be configured this way, so Gregorian-arithmetic accessors route through
+    // the base Gregorian calendar below.
     if (calendarId == gregoryCalendarID() || calendarIsISO(calendarId)) {
         const double prolepticGregorianChangeMs = -8.64e15; // ExactTime::minValue / nsPerMillisecond
         ucal_setGregorianChange(cal.get(), prolepticGregorianChangeMs, &status);
@@ -96,14 +96,37 @@ public:
 WTF_MAKE_TZONE_ALLOCATED_IMPL(CalendarCacheEntry);
 
 // Japanese/ROC/Buddhist derive from Gregorian and reject ucal_setGregorianChange
-// (U_UNSUPPORTED_ERROR), so year-length / month-length / leap-year accessors
-// route through gregory to get proleptic Gregorian. Era-facing paths keep the
-// derived calendar so era labels remain correct.
+// (U_UNSUPPORTED_ERROR), so Gregorian-arithmetic accessors route through gregory
+// to get proleptic Gregorian. Calendar-native year and era fields are handled
+// separately.
 static CalendarID gregorianArithmeticCalendarFor(CalendarID calendarId)
 {
     if (calendarId == japaneseCalendarID() || calendarId == rocCalendarID() || calendarId == buddhistCalendarID())
         return gregoryCalendarID();
     return calendarId;
+}
+
+static constexpr int32_t rocCalendarYearOffset = 1911;
+static constexpr int32_t buddhistCalendarYearOffset = 543;
+
+struct GregorianArithmeticYearFields {
+    int32_t year;
+    ASCIILiteral era;
+    int32_t eraYear;
+};
+
+static GregorianArithmeticYearFields gregorianArithmeticYearFieldsFor(CalendarID calendarId, int32_t isoYear)
+{
+    ASSERT(calendarId == rocCalendarID() || calendarId == buddhistCalendarID());
+    if (calendarId == buddhistCalendarID()) {
+        int32_t year = isoYear + buddhistCalendarYearOffset;
+        return { year, "be"_s, year };
+    }
+
+    int32_t year = isoYear - rocCalendarYearOffset;
+    if (year > 0)
+        return { year, "roc"_s, year };
+    return { year, "broc"_s, 1 - year };
 }
 
 struct CalendarLRUCachePolicy {
@@ -435,9 +458,21 @@ static std::optional<int32_t> mapTemporalEraToICUEra(CalendarID calendarId, Stri
     return std::nullopt;
 }
 
-// isoToCalendarFields — no single temporal_rs equivalent; aggregates Calendar::year/month/month_code/day/era into one ICU pass.
+// isoToCalendarFields — no single temporal_rs equivalent; aggregates Calendar::year/month/month_code/day/era.
 TemporalResult<CalendarFields> isoToCalendarFields(CalendarID calendarId, const ISO8601::PlainDate& isoDate)
 {
+    if (calendarId == rocCalendarID() || calendarId == buddhistCalendarID()) {
+        auto yearFields = gregorianArithmeticYearFieldsFor(calendarId, isoDate.year());
+        CalendarFields fields;
+        fields.year = yearFields.year;
+        fields.era = String(yearFields.era);
+        fields.eraYear = yearFields.eraYear;
+        fields.month = isoDate.month();
+        fields.day = isoDate.day();
+        fields.monthCode = ISO8601::monthCode(isoDate.month());
+        return fields;
+    }
+
     struct RawFields {
         int32_t extendedYear { 0 };
         int32_t ucalEra { 0 };
@@ -456,7 +491,6 @@ TemporalResult<CalendarFields> isoToCalendarFields(CalendarID calendarId, const 
 
         UErrorCode status = U_ZERO_ERROR;
         RawFields raw;
-        // NOTE: ROC UCAL_EXTENDED_YEAR may return Gregorian year on some ICU versions; handled below.
         raw.extendedYear = ucal_get(cal, UCAL_EXTENDED_YEAR, &status);
         if (U_FAILURE(status)) [[unlikely]]
             return makeUnexpected(rangeError(icuReadCalendarFailed));
@@ -485,13 +519,20 @@ TemporalResult<CalendarFields> isoToCalendarFields(CalendarID calendarId, const 
 
     CalendarFields fields;
     fields.year = raw.extendedYear;
-    if (calendarId == rocCalendarID())
-        fields.year = !raw.ucalEra ? -(raw.ucalYear - 1) : raw.ucalYear;
-    else if (calendarId == ethioaaCalendarID())
+    if (calendarId == ethioaaCalendarID())
         fields.year = raw.ucalYear;
     fields.month = *raw.ordinalMonth;
     fields.day = static_cast<uint8_t>(raw.day);
     fields.monthCode = WTF::move(*raw.monthCode);
+
+    if (calendarId == japaneseCalendarID()) {
+        fields.year = isoDate.year();
+        if (isoDate.year() < japaneseCalendarGregorianTransitionYear) {
+            fields.month = isoDate.month();
+            fields.day = isoDate.day();
+            fields.monthCode = ISO8601::monthCode(isoDate.month());
+        }
+    }
 
     // isLeapMonth is re-derived from the month code (avoids needing UCAL_IS_LEAP_MONTH in raw)
     fields.isLeapMonth = fields.monthCode.endsWith("L"_s);
@@ -522,25 +563,20 @@ TemporalResult<CalendarFields> isoToCalendarFields(CalendarID calendarId, const 
 TemporalResult<int32_t> calendarYear(CalendarID calendarId, const ISO8601::PlainDate& isoDate)
 {
     // 1. Return the extended year of isoDate in calendarId.
+    // NOTE: The Japanese extended year is always the ISO year.
+    if (calendarId == japaneseCalendarID())
+        return isoDate.year();
+    if (calendarId == rocCalendarID() || calendarId == buddhistCalendarID())
+        return gregorianArithmeticYearFieldsFor(calendarId, isoDate.year()).year;
     return withCalendar(calendarId, [&](UCalendar* cal) -> TemporalResult<int32_t> {
         if (!cal) [[unlikely]]
             return makeUnexpected(rangeError(icuOpenCalendarFailed));
         if (!setCalendarToISODate(cal, isoDate)) [[unlikely]]
             return makeUnexpected(rangeError(icuSetCalendarFailed));
         UErrorCode status = U_ZERO_ERROR;
-        // NOTE: ROC UCAL_EXTENDED_YEAR may return Gregorian year on some ICU versions; compute from era+year.
-        if (calendarId == rocCalendarID()) {
-            int32_t era = ucal_get(cal, UCAL_ERA, &status);
-            if (U_FAILURE(status)) [[unlikely]]
-                return makeUnexpected(rangeError(icuReadCalendarFailed));
-            int32_t eraYear = ucal_get(cal, UCAL_YEAR, &status);
-            if (U_FAILURE(status)) [[unlikely]]
-                return makeUnexpected(rangeError(icuReadCalendarFailed));
-            return !era ? -(eraYear - 1) : eraYear;
-        }
-        // Use UCAL_YEAR for these calendars' native arithmetic year. Older ICU versions expose an
-        // Amete Mihret-relative UCAL_EXTENDED_YEAR for Ethioaa; newer versions may make the fields equal.
-        if (calendarId == buddhistCalendarID() || calendarId == ethioaaCalendarID()) {
+        // Older ICU versions expose an Amete Mihret-relative UCAL_EXTENDED_YEAR for Ethioaa;
+        // newer versions may make UCAL_YEAR and UCAL_EXTENDED_YEAR equal.
+        if (calendarId == ethioaaCalendarID()) {
             int32_t eraYear = ucal_get(cal, UCAL_YEAR, &status);
             if (U_FAILURE(status)) [[unlikely]]
                 return makeUnexpected(rangeError(icuReadCalendarFailed));
@@ -565,7 +601,7 @@ TemporalResult<uint8_t> calendarMonth(CalendarID calendarId, const ISO8601::Plai
     // NOTE: Japanese pre-1873 "ce"/"bce" eras use ISO month directly to bypass ICU Julian conversion.
     if (calendarId == japaneseCalendarID() && isoDate.year() < japaneseCalendarGregorianTransitionYear)
         return isoDate.month();
-    return withCalendar(calendarId, [&](UCalendar* cal) -> TemporalResult<uint8_t> {
+    return withCalendar(gregorianArithmeticCalendarFor(calendarId), [&](UCalendar* cal) -> TemporalResult<uint8_t> {
         if (!cal) [[unlikely]]
             return makeUnexpected(rangeError(icuOpenCalendarFailed));
         if (!setCalendarToISODate(cal, isoDate)) [[unlikely]]
@@ -589,7 +625,7 @@ TemporalResult<String> calendarMonthCode(CalendarID calendarId, const ISO8601::P
     // NOTE: Japanese pre-1873 "ce"/"bce" eras use ISO month code directly to bypass ICU Julian conversion.
     if (calendarId == japaneseCalendarID() && isoDate.year() < japaneseCalendarGregorianTransitionYear)
         return ISO8601::monthCode(isoDate.month());
-    return withCalendar(calendarId, [&](UCalendar* cal) -> TemporalResult<String> {
+    return withCalendar(gregorianArithmeticCalendarFor(calendarId), [&](UCalendar* cal) -> TemporalResult<String> {
         if (!cal) [[unlikely]]
             return makeUnexpected(rangeError(icuOpenCalendarFailed));
         if (!setCalendarToISODate(cal, isoDate)) [[unlikely]]
@@ -613,7 +649,7 @@ TemporalResult<uint8_t> calendarDay(CalendarID calendarId, const ISO8601::PlainD
     // NOTE: Japanese pre-1873 "ce"/"bce" eras return ISO day directly to bypass ICU Julian conversion.
     if (calendarId == japaneseCalendarID() && isoDate.year() < japaneseCalendarGregorianTransitionYear)
         return isoDate.day();
-    return withCalendar(calendarId, [&](UCalendar* cal) -> TemporalResult<uint8_t> {
+    return withCalendar(gregorianArithmeticCalendarFor(calendarId), [&](UCalendar* cal) -> TemporalResult<uint8_t> {
         if (!cal) [[unlikely]]
             return makeUnexpected(rangeError(icuOpenCalendarFailed));
         if (!setCalendarToISODate(cal, isoDate)) [[unlikely]]
@@ -652,6 +688,8 @@ TemporalResult<std::optional<String>> calendarEra(CalendarID calendarId, const I
     // 1. If calendarId has no eras, return undefined.
     if (!calendarHasEras(calendarId))
         return std::optional<String>(std::nullopt);
+    if (calendarId == rocCalendarID() || calendarId == buddhistCalendarID())
+        return std::optional<String>(String(gregorianArithmeticYearFieldsFor(calendarId, isoDate.year()).era));
     // 2. Return the era string for isoDate in calendarId (e.g. "ce", "bce", "reiwa").
     // NOTE: Japanese dates before 1873 use "ce"/"bce" per spec, not ICU era names.
     if (calendarId == japaneseCalendarID() && isoDate.year() < japaneseCalendarGregorianTransitionYear)
@@ -685,6 +723,8 @@ TemporalResult<std::optional<int32_t>> calendarEraYear(CalendarID calendarId, co
     // 1. If calendarId has no eras, return undefined.
     if (!calendarHasEras(calendarId))
         return std::optional<int32_t>(std::nullopt);
+    if (calendarId == rocCalendarID() || calendarId == buddhistCalendarID())
+        return std::optional<int32_t>(gregorianArithmeticYearFieldsFor(calendarId, isoDate.year()).eraYear);
     // 2. Return the era year (year within the current era) of isoDate in calendarId.
     // NOTE: Japanese "ce"/"bce" fallback: eraYear is the Gregorian year.
     if (calendarId == japaneseCalendarID() && isoDate.year() < japaneseCalendarGregorianTransitionYear)
@@ -1848,41 +1888,67 @@ TemporalResult<ISO8601::PlainDate> calendarDateFromFields(CalendarID calendarId,
     bool tookEraPath = false;
     if (era && eraYear) {
         tookEraPath = true;
-        // Japanese "ce"/"bce": eraYear IS the Gregorian year. Use ISO date path.
-        if (calendarId == japaneseCalendarID() && (*era == "ce"_s || *era == "bce"_s)) {
-            // For Japanese "ce"/"bce" eras, the year IS the ISO year — bypass ICU to avoid
-            // Julian/Gregorian calendar switch issues for pre-1582 dates. Apply overflow.
+        if (calendarId == japaneseCalendarID()) {
+            // Named-era arithmetic year is era start year + eraYear - 1.
             CheckedInt32 checkedISOYear = *eraYear;
             if (*era == "bce"_s)
                 checkedISOYear = 1 - checkedISOYear;
+            else if (*era != "ce"_s) {
+                const JapaneseEra* japaneseEra = nullptr;
+                for (auto& candidate : japaneseEras) {
+                    if (*era == StringView(candidate.name)) {
+                        japaneseEra = &candidate;
+                        break;
+                    }
+                }
+                if (!japaneseEra) [[unlikely]]
+                    return makeUnexpected(rangeError("era is not valid for this calendar"_s));
+                checkedISOYear += japaneseEra->startYear;
+                checkedISOYear -= 1;
+            }
             if (checkedISOYear.hasOverflowed() || !ISO8601::isYearWithinLimits(checkedISOYear.value())) [[unlikely]]
                 return makeUnexpected(rangeError("Resolved calendar date is outside representable range"_s));
             int32_t isoYear = checkedISOYear.value();
-            // year.has_value() means user-provided; check for consistency (NonISOResolveFields step).
             if (year && *year != isoYear) [[unlikely]]
                 return makeUnexpected(rangeError("year is inconsistent with era and eraYear"_s));
-            uint8_t resolvedMonth = month;
-            if (month > 12) {
-                if (overflow == TemporalOverflow::Reject) [[unlikely]]
-                    return makeUnexpected(rangeError("month is out of range for this calendar"_s));
-                resolvedMonth = 12;
-            }
-            uint8_t resolvedDay = day;
-            uint8_t daysInMo = ISO8601::daysInMonth(isoYear, resolvedMonth);
-            if (day > daysInMo) {
-                if (overflow == TemporalOverflow::Reject) [[unlikely]]
-                    return makeUnexpected(rangeError("Day is out of range for the given month"_s));
-                resolvedDay = daysInMo;
-            }
-            return ISO8601::PlainDate(isoYear, resolvedMonth, resolvedDay);
+            return calendarDateFromFields(gregoryCalendarID(), isoYear, month, day, std::nullopt, std::nullopt, monthCode, overflow);
         }
     }
+
+    // A Japanese extended year is an ISO year. Resolve year-only input through the
+    // proleptic-Gregorian calendar so getters can be fed back through from() or with().
+    if (calendarId == japaneseCalendarID() && !tookEraPath)
+        return calendarDateFromFields(gregorianArithmeticCalendarFor(calendarId), year, month, day, std::nullopt, std::nullopt, monthCode, overflow);
 
     std::optional<int32_t> icuEraCode;
     if (tookEraPath && era) {
         icuEraCode = mapTemporalEraToICUEra(calendarId, *era);
         if (!icuEraCode) [[unlikely]]
             return makeUnexpected(rangeError("era is not valid for this calendar"_s));
+    }
+
+    if (calendarId == rocCalendarID() || calendarId == buddhistCalendarID()) {
+        CheckedInt32 checkedCalendarYear = year.value_or(0);
+        if (tookEraPath) {
+            checkedCalendarYear = *eraYear;
+            if (calendarId == rocCalendarID() && !*icuEraCode) {
+                checkedCalendarYear = 1;
+                checkedCalendarYear -= *eraYear;
+            }
+            if (checkedCalendarYear.hasOverflowed()) [[unlikely]]
+                return makeUnexpected(rangeError("Resolved calendar date is outside representable range"_s));
+            if (year && *year != checkedCalendarYear.value()) [[unlikely]]
+                return makeUnexpected(rangeError("year is inconsistent with era and eraYear"_s));
+        }
+
+        CheckedInt32 checkedISOYear = checkedCalendarYear;
+        if (calendarId == rocCalendarID())
+            checkedISOYear += rocCalendarYearOffset;
+        else
+            checkedISOYear -= buddhistCalendarYearOffset;
+        if (checkedISOYear.hasOverflowed() || !ISO8601::isYearWithinLimits(checkedISOYear.value())) [[unlikely]]
+            return makeUnexpected(rangeError("Resolved calendar date is outside representable range"_s));
+        return calendarDateFromFields(gregoryCalendarID(), checkedISOYear.value(), month, day, std::nullopt, std::nullopt, monthCode, overflow);
     }
 
     return withCalendar(calendarId, [&](UCalendar* cal) -> TemporalResult<ISO8601::PlainDate> {
@@ -1892,23 +1958,13 @@ TemporalResult<ISO8601::PlainDate> calendarDateFromFields(CalendarID calendarId,
         UErrorCode status = U_ZERO_ERROR;
 
         if (tookEraPath) {
-            // era && eraYear, not Japanese "ce"/"bce".
+            // Gregorian-derived calendars returned through arithmetic paths above.
             if (!icuEraCode) [[unlikely]]
                 return makeUnexpected(rangeError("era is not valid for this calendar"_s));
             ucal_set(cal, UCAL_ERA, *icuEraCode);
             ucal_set(cal, UCAL_YEAR, *eraYear);
-        } else if (calendarId == rocCalendarID()) {
-            // ROC: convert temporal year to era+eraYear for ICU.
-            int32_t y = year.value_or(0);
-            if (y <= 0) {
-                ucal_set(cal, UCAL_ERA, 0); // broc
-                ucal_set(cal, UCAL_YEAR, 1 - y);
-            } else {
-                ucal_set(cal, UCAL_ERA, 1); // roc
-                ucal_set(cal, UCAL_YEAR, y);
-            }
-        } else if (calendarId == buddhistCalendarID() || calendarId == ethioaaCalendarID()) {
-            // These one-era calendars use calendar-native UCAL_YEAR for arithmetic.
+        } else if (calendarId == ethioaaCalendarID()) {
+            // Ethioaa uses calendar-native UCAL_YEAR for arithmetic.
             ucal_set(cal, UCAL_ERA, 0);
             ucal_set(cal, UCAL_YEAR, year.value_or(0));
         } else


### PR DESCRIPTION
#### 8ccbe522e1f14bc3356a6124fa05b7e53a5f723c
<pre>
[JSC][Temporal] Fix Japanese, ROC, and Buddhist calendar fields

<a href="https://bugs.webkit.org/show_bug.cgi?id=319663">https://bugs.webkit.org/show_bug.cgi?id=319663</a>

Reviewed by Yusuke Suzuki.

ICU derived Gregorian calendars retain a Julian-to-Gregorian cutover that cannot be disabled. Use an unconditional ISO year for Japanese dates, keep pre-1873 aggregate fields proleptic Gregorian, and construct year-only and named-era property bags with Gregorian arithmetic. Named eras derive the arithmetic ISO year from checked era metadata while retaining canonical era and eraYear output at modern transitions.

Route ROC and Buddhist Gregorian-arithmetic fields through deterministic ISO date fields and checked fixed-year offsets so getters, property bags, with(), overflow handling, PlainMonthDay reference dates, and boundary round trips agree across historical dates.

Test: JSTests/stress/temporal-calendar-icu-bridge-non-iso.js

* JSTests/stress/temporal-calendar-icu-bridge-non-iso.js:
  - Cover Japanese ISO-year and named-era construction, historical Gregorian overflow, modern transitions, PlainMonthDay reference dates, and ROC/Buddhist checked-offset boundaries.
* JSTests/stress/temporal-japanese-ce-bce-era-validation.js:
  - Update the year-zero assertion for unconditional Japanese ISO-year behavior.
* Source/JavaScriptCore/runtime/temporal/core/CalendarICUBridge.cpp:
  - Use coherent proleptic-Gregorian field and construction paths for Japanese, ROC, and Buddhist calendars.

Canonical link: <a href="https://commits.webkit.org/317678@main">https://commits.webkit.org/317678@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b8cb85164c0cf5a631213f197d44814eea3773ad

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175935 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49868 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43652 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185528 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/138145 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51160 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49550 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137006 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/138145 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178891 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40472 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157788 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117485 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39114 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37494 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/6297 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149533 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37280 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33998 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/37199 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41568 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/41700 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187950 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49535 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146007 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50215 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/33905 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145846 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26741 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40636 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122411 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/116288 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48722 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12261 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48124 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48356 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48181 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->