### PR TITLE
[iOS] "touch-action: manipulation" does not prevent double-tap-to-zoom

### DIFF
--- a/LayoutTests/pointerevents/ios/touch-action-manipulation-double-tap-to-zoom-expected.txt
+++ b/LayoutTests/pointerevents/ios/touch-action-manipulation-double-tap-to-zoom-expected.txt
@@ -1,3 +1,3 @@
 
-PASS Testing that setting touch-action: manipulation on an element allows double tap to zoom.
+PASS Testing that setting touch-action: manipulation on an element prevents double tap to zoom.
 

--- a/LayoutTests/pointerevents/ios/touch-action-manipulation-double-tap-to-zoom.html
+++ b/LayoutTests/pointerevents/ios/touch-action-manipulation-double-tap-to-zoom.html
@@ -21,12 +21,12 @@ target_test({ width: "200px", height: "200px" }, (target, test) => {
     requestAnimationFrame(() => {
         const initialPageScaleFactor = window.internals.pageScaleFactor();
         ui.doubleTapToZoom({ x: 10, y: 10 }).then(() => {
-            assert_not_equals(window.internals.pageScaleFactor(), initialPageScaleFactor, "The page was scaled.");
+            assert_equals(window.internals.pageScaleFactor(), initialPageScaleFactor, "The page was not scaled.");
             test.done();
         });
     })
 
-}, "Testing that setting touch-action: manipulation on an element allows double tap to zoom.");
+}, "Testing that setting touch-action: manipulation on an element prevents double tap to zoom.");
 
 </script>
 </body>

--- a/Source/WebKit/UIProcess/ios/WKTouchActionGestureRecognizer.mm
+++ b/Source/WebKit/UIProcess/ios/WKTouchActionGestureRecognizer.mm
@@ -114,8 +114,8 @@
             // Pinch-to-zoom is only allowed if "pinch-zoom" or "manipulation" is specified.
             if (mayPinchToZoom && !iterator->value.containsAny({ WebCore::TouchAction::PinchZoom, WebCore::TouchAction::Manipulation }))
                 return YES;
-            // Double-tap-to-zoom is only disallowed if "none" is specified.
-            if (mayDoubleTapToZoom && iterator->value.contains(WebCore::TouchAction::None))
+            // Double-tap-to-zoom is disallowed if "none" or "manipulation" is specified.
+            if (mayDoubleTapToZoom && iterator->value.containsAny({ WebCore::TouchAction::None, WebCore::TouchAction::Manipulation }))
                 return YES;
         }
     }


### PR DESCRIPTION
#### 504edb5c563f9ad8d0436f60b5a608f0ec384f42
<pre>
[iOS] &quot;touch-action: manipulation&quot; does not prevent double-tap-to-zoom
<a href="https://bugs.webkit.org/show_bug.cgi?id=319664">https://bugs.webkit.org/show_bug.cgi?id=319664</a>
<a href="https://rdar.apple.com/182499287">rdar://182499287</a>

Reviewed by Antoine Quint.

Per the pointer events spec, &quot;touch-action: manipulation&quot; enables panning
and continuous zoom gestures but disables additional gestures such as
double-tap-to-zoom (DTTZ). On iOS, WKTouchActionGestureRecognizer only
prevented DTTZ when &quot;touch-action: none&quot; was specified, though. This
seems to be behavior explicitly added in 213469@main (with a test in
pointerevents/ios/touch-action-manipulation-double-tap-to-zoom.html).

In this patch, we prevent DTTZ recognizers when the touched element has
a touch-action: manipulation value.

There may be some web compatibility ramifications, but I&apos;m weighing that
against the spec (and, prior WebKit blogs!).

* LayoutTests/pointerevents/ios/touch-action-manipulation-double-tap-to-zoom-expected.txt:
* LayoutTests/pointerevents/ios/touch-action-manipulation-double-tap-to-zoom.html:
* Source/WebKit/UIProcess/ios/WKTouchActionGestureRecognizer.mm:
(-[WKTouchActionGestureRecognizer canPreventGestureRecognizer:]):

Canonical link: <a href="https://commits.webkit.org/317443@main">https://commits.webkit.org/317443@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1cf01db75239cbc1f8f1bbd65df1ca07ca1659d2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175344 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49276 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43057 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184930 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/137465 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/650a9d32-876c-4a2c-abdc-ab07c80528d9) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50568 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48959 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136506 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/137465 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/45c23a15-5b68-4967-a955-a59fd2b162f0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178301 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39917 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/157253 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116984 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a8f19620-0d90-4754-9f80-d60207e4b846) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/38558 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/36945 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/148981 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36746 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33405 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/40963 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/41149 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187354 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48943 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/156809 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145468 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49623 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/33368 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145309 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26652 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40122 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/121816 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115503 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48129 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11719 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47532 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47762 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47589 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->