### PR TITLE
[cleanup] Split the flex container logical-height update into a row content set and a shared finalize

### DIFF
--- a/Source/WebCore/rendering/RenderFlexLayout.cpp
+++ b/Source/WebCore/rendering/RenderFlexLayout.cpp
@@ -88,15 +88,13 @@ FlexLayout::Result FlexLayout::performFlexLayout(FlexLayoutItems& flexItems, Rel
 
     // Record each line's cross-axis offset, growing the container's cross size to fit the lines (row flow).
     // Column flow's logical height is its main size, set later while placing the items, so accumulate here for row.
-    std::optional<LayoutUnit> contentLogicalHeightForRowFlow;
-    if (!m_constraints.isColumnFlow)
-        contentLogicalHeightForRowFlow = m_flexBox.logicalHeight();
+    auto contentLogicalHeightForRowFlow = m_flexBox.logicalHeight();
     auto flexLinesCrossPositionList = Vector<LayoutUnit>(flexLines.ranges.size());
     auto crossAxisOffset = m_constraints.flowAwareBorderBlock.first + m_constraints.flowAwarePaddingBlock.first;
     for (size_t lineIndex = 0; lineIndex < flexLines.ranges.size(); ++lineIndex) {
         InspectorInstrumentation::flexibleBoxRendererWrappedToNextLine(m_flexBox, flexLines.ranges[lineIndex].end());
         if (!m_constraints.isColumnFlow)
-            contentLogicalHeightForRowFlow = std::max(*contentLogicalHeightForRowFlow, crossAxisOffset + m_constraints.flowAwareBorderBlock.second + m_constraints.flowAwarePaddingBlock.second + flexLinesCrossSizeList[lineIndex] + flexLayoutUtils().crossAxisScrollbarExtent());
+            contentLogicalHeightForRowFlow = std::max(contentLogicalHeightForRowFlow, crossAxisOffset + m_constraints.flowAwareBorderBlock.second + m_constraints.flowAwarePaddingBlock.second + flexLinesCrossSizeList[lineIndex] + flexLayoutUtils().crossAxisScrollbarExtent());
         flexLinesCrossPositionList[lineIndex] = crossAxisOffset;
         crossAxisOffset += flexLinesCrossSizeList[lineIndex];
     }
@@ -109,10 +107,14 @@ FlexLayout::Result FlexLayout::performFlexLayout(FlexLayoutItems& flexItems, Rel
         positionList = handleMainAxisAlignment(flexLines, flexItems, flexItemsMainSizeList, flexLinesCrossPositionList);
         setFlexItemCountsForFirstAndLastLine(flexLines);
 
-        // 9.6. (#15) Determine the flex container's used cross size: hand the accumulated content extent to the
-        // container so it resolves its own logical height (specified vs content, min/max, box-sizing).
-        auto interLineGapTotal = !m_constraints.isColumnFlow && flexLines.ranges.size() > 1 ? flexLayoutUtils().computeGap(FlexLayoutUtils::GapType::BetweenLines) * (flexLines.ranges.size() - 1) : 0_lu;
-        m_flexBox.updateLogicalHeightForFlexContent(contentLogicalHeightForRowFlow, m_constraints.minimumHeightForLineIfEmpty, interLineGapTotal);
+        // 9.6. (#15) Determine the flex container's used cross size. Row flow's is the content extent accumulated
+        // from the lines plus the gaps between them; column flow's height was already set while placing the items.
+        // Either way the container then resolves its own logical height (specified vs content, min/max, box-sizing).
+        if (!m_constraints.isColumnFlow) {
+            auto totalGapBetweenLines = flexLines.ranges.size() > 1 ? flexLayoutUtils().computeGap(FlexLayoutUtils::GapType::BetweenLines) * (flexLines.ranges.size() - 1) : 0_lu;
+            m_flexBox.setLogicalHeightForRowFlexContent(contentLogicalHeightForRowFlow + totalGapBetweenLines);
+        }
+        m_flexBox.finalizeFlexContainerLogicalHeight(m_constraints.minimumHeightForLineIfEmpty);
 
         // Multi-line column flex only knows its main size now, so re-resolve the flexible lengths of any lines that were left short.
         distributeMainAxisFreeSpaceForMultilineColumnIfNeeded(flexLines, flexItems, flexBaseAndHypotheticalMainSizeList.span(), flexItemsMainSizeList, positionList, flexLinesCrossPositionList);

--- a/Source/WebCore/rendering/RenderFlexibleBox.cpp
+++ b/Source/WebCore/rendering/RenderFlexibleBox.cpp
@@ -1131,16 +1131,19 @@ LayoutUnit RenderFlexibleBox::mainAxisAvailableSpace()
     return logicalHeight == LayoutUnit::max() ? logicalHeight : std::max(0_lu, logicalHeight - (borderAndPaddingLogicalHeight() + scrollbarLogicalHeight()));
 }
 
-void RenderFlexibleBox::updateLogicalHeightForFlexContent(std::optional<LayoutUnit> contentLogicalHeightForRowFlow, std::optional<LayoutUnit> minimumHeightForLineIfEmpty, LayoutUnit interLineGapTotal)
+void RenderFlexibleBox::setLogicalHeightForRowFlexContent(LayoutUnit contentLogicalHeight)
 {
-    // Row flow's cross size is the content extent FlexLayout accumulated from the lines; column flow's logical
-    // height is its main size, already set while placing the items, so this is provided only for row flow.
-    if (contentLogicalHeightForRowFlow)
-        setLogicalHeight(*contentLogicalHeightForRowFlow);
+    // Row flow's cross size is the content extent FlexLayout accumulated from the lines, including the gaps
+    // between them. (Column flow's logical height is its main size, already set while placing the items.)
+    setLogicalHeight(contentLogicalHeight);
+}
+
+void RenderFlexibleBox::finalizeFlexContainerLogicalHeight(std::optional<LayoutUnit> minimumHeightForLineIfEmpty)
+{
+    // Reserve a line's worth of height if the container has a line even while empty, then resolve the final
+    // logical height against the container's own specified/min/max height and box-sizing.
     if (minimumHeightForLineIfEmpty && borderBoxHeight() < *minimumHeightForLineIfEmpty)
         setLogicalHeight(*minimumHeightForLineIfEmpty);
-    if (interLineGapTotal)
-        setLogicalHeight(logicalHeight() + interLineGapTotal);
     updateLogicalHeight();
 }
 

--- a/Source/WebCore/rendering/RenderFlexibleBox.h
+++ b/Source/WebCore/rendering/RenderFlexibleBox.h
@@ -165,7 +165,8 @@ private:
     FlexLayoutItems collectFlexItems(RelayoutChildren);
     FlexLayoutConstraints flexLayoutConstraints();
     LayoutUnit mainAxisAvailableSpace();
-    void updateLogicalHeightForFlexContent(std::optional<LayoutUnit> contentLogicalHeightForRowFlow, std::optional<LayoutUnit> minimumHeightForLineIfEmpty, LayoutUnit interLineGapTotal);
+    void setLogicalHeightForRowFlexContent(LayoutUnit contentLogicalHeight);
+    void finalizeFlexContainerLogicalHeight(std::optional<LayoutUnit> minimumHeightForLineIfEmpty);
     void prepareFlexItemForPositionedLayout(RenderBox& flexItem);
     void adjustLogicalHeightForLineIfEmpty();
     std::optional<LayoutUnit> minimumHeightForLineIfEmpty() const;


### PR DESCRIPTION
#### 6ea4c074cc709652e0bcb5a4e48f93024e836d0a
<pre>
[cleanup] Split the flex container logical-height update into a row content set and a shared finalize
<a href="https://bugs.webkit.org/show_bug.cgi?id=318629">https://bugs.webkit.org/show_bug.cgi?id=318629</a>
&lt;<a href="https://rdar.apple.com/problem/182049629">rdar://problem/182049629</a>&gt;

Reviewed by Antti Koivisto.

updateLogicalHeightForFlexContent bundled work that only row flow needs (set the container height to the
accumulated line content extent, then add the inter-line gaps) with work both flows need (reserve a
line&apos;s height if empty, then resolve the final height via updateLogicalHeight). Column flow passed a
nullopt content height and a zero gap through it just to reach that shared tail.

Split it into setLogicalHeightForRowFlexContent, which the caller invokes only for row flow, and
finalizeFlexContainerLogicalHeight, which both flows call. The row content height now carries the
inter-line gaps folded in, so the shared finalize is a clean tail and column flow no longer passes
through the row-shaped path.

This reorders one thing for row flow: the empty-line floor now sees the content plus the inter-line gaps
rather than the content alone, so max(content, floor) + gaps becomes max(content + gaps, floor). The two
differ only when the accumulated content is shorter than a single line, which also requires the
empty-line floor to apply, i.e. an editable root or a form control (button, select, input) flex
container that additionally wraps to multiple lines with a row-gap. That combination does not occur in
practice, but it is not strictly a no-op, so it is called out here rather than claimed as
behavior-preserving. Column flow is unchanged.

* Source/WebCore/rendering/RenderFlexLayout.cpp:
* Source/WebCore/rendering/RenderFlexibleBox.cpp:
* Source/WebCore/rendering/RenderFlexibleBox.h:
</pre>