### PR TITLE
[JSC][Wasm] Support WebAssembly.Exception options.traceStack

### DIFF
--- a/JSTests/wasm/stress/exception-trace-stack.js
+++ b/JSTests/wasm/stress/exception-trace-stack.js
@@ -1,0 +1,39 @@
+//@ requireOptions("--useExecutableAllocationFuzz=false")
+import * as assert from "../assert.js";
+
+const tag = new WebAssembly.Tag({ parameters: ["i32"] });
+
+function testDefaultHasNoStack() {
+    const e = new WebAssembly.Exception(tag, [0]);
+    assert.eq(e.stack, undefined);
+}
+
+function testTraceStackFalse() {
+    const e = new WebAssembly.Exception(tag, [0], { traceStack: false });
+    assert.eq(e.stack, undefined);
+}
+
+function testTraceStackTrue() {
+    function makeException() {
+        return new WebAssembly.Exception(tag, [0], { traceStack: true });
+    }
+    const e = makeException();
+    assert.eq(typeof e.stack, "string");
+    assert.truthy(e.stack.length > 0, "stack should be non-empty");
+    assert.truthy(e.stack.includes("makeException") || e.stack.includes("testTraceStackTrue"),
+        `stack should include a JS frame, got:\n${e.stack}`);
+    // IDL: stack is a prototype getter, not an own data property.
+    assert.eq(Object.hasOwn(e, "stack"), false);
+    const desc = Object.getOwnPropertyDescriptor(WebAssembly.Exception.prototype, "stack");
+    assert.eq(typeof desc.get, "function");
+}
+
+function testConstructorLength() {
+    assert.eq(WebAssembly.Exception.length, 2);
+}
+
+testDefaultHasNoStack();
+testTraceStackFalse();
+testTraceStackTrue();
+testConstructorLength();
+print("exception-trace-stack: ok");

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/exception/constructor.tentative.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/exception/constructor.tentative.any-expected.txt
@@ -1,6 +1,6 @@
 
 PASS name
-FAIL length assert_equals: WebAssembly.Exception length should be 2 expected 2 but got 1
+PASS length
 PASS No arguments
 PASS Calling
 PASS Invalid descriptor argument

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/exception/constructor.tentative.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/exception/constructor.tentative.any.worker-expected.txt
@@ -1,6 +1,6 @@
 
 PASS name
-FAIL length assert_equals: WebAssembly.Exception length should be 2 expected 2 but got 1
+PASS length
 PASS No arguments
 PASS Calling
 PASS Invalid descriptor argument

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/idlharness.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/idlharness.any-expected.txt
@@ -82,12 +82,12 @@ PASS Tag interface: existence and properties of interface prototype object
 PASS Tag interface: existence and properties of interface prototype object's "constructor" property
 PASS Tag interface: existence and properties of interface prototype object's @@unscopables property
 PASS Exception interface: existence and properties of interface object
-FAIL Exception interface object length assert_equals: wrong value for Exception.length expected 2 but got 1
+PASS Exception interface object length
 PASS Exception interface object name
 PASS Exception interface: existence and properties of interface prototype object
 PASS Exception interface: existence and properties of interface prototype object's "constructor" property
 PASS Exception interface: existence and properties of interface prototype object's @@unscopables property
 FAIL Exception interface: operation getArg(unsigned long) assert_equals: property has wrong .length expected 1 but got 2
 PASS Exception interface: operation is(Tag)
-FAIL Exception interface: attribute stack assert_true: The prototype object must have a property "stack" expected true got false
+PASS Exception interface: attribute stack
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/idlharness.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/idlharness.any.worker-expected.txt
@@ -82,12 +82,12 @@ PASS Tag interface: existence and properties of interface prototype object
 PASS Tag interface: existence and properties of interface prototype object's "constructor" property
 PASS Tag interface: existence and properties of interface prototype object's @@unscopables property
 PASS Exception interface: existence and properties of interface object
-FAIL Exception interface object length assert_equals: wrong value for Exception.length expected 2 but got 1
+PASS Exception interface object length
 PASS Exception interface object name
 PASS Exception interface: existence and properties of interface prototype object
 PASS Exception interface: existence and properties of interface prototype object's "constructor" property
 PASS Exception interface: existence and properties of interface prototype object's @@unscopables property
 FAIL Exception interface: operation getArg(unsigned long) assert_equals: property has wrong .length expected 1 but got 2
 PASS Exception interface: operation is(Tag)
-FAIL Exception interface: attribute stack assert_true: The prototype object must have a property "stack" expected true got false
+PASS Exception interface: attribute stack
 

--- a/Source/JavaScriptCore/builtins/BuiltinNames.cpp
+++ b/Source/JavaScriptCore/builtins/BuiltinNames.cpp
@@ -45,6 +45,7 @@ JSC_COMMON_PRIVATE_IDENTIFIERS_EACH_PROPERTY_NAME(INITIALIZE_BUILTIN_PRIVATE_NAM
 
 SymbolImpl::StaticSymbolImpl dollarVMPrivateName { "$vm", SymbolImpl::s_flagIsPrivate };
 SymbolImpl::StaticSymbolImpl polyProtoPrivateName { "PolyProto", SymbolImpl::s_flagIsPrivate };
+SymbolImpl::StaticSymbolImpl stackPrivateName { "stack", SymbolImpl::s_flagIsPrivate };
 
 } // namespace Symbols
 
@@ -79,6 +80,7 @@ BuiltinNames::BuiltinNames(VM& vm, CommonIdentifiers* commonIdentifiers)
     , m_dollarVMName(Identifier::fromString(vm, "$vm"_s))
     , m_dollarVMPrivateName(Identifier::fromUid(vm, &static_cast<SymbolImpl&>(Symbols::dollarVMPrivateName)))
     , m_polyProtoPrivateName(Identifier::fromUid(vm, &static_cast<SymbolImpl&>(Symbols::polyProtoPrivateName)))
+    , m_stackPrivateName(Identifier::fromUid(vm, &static_cast<SymbolImpl&>(Symbols::stackPrivateName)))
 {
     JSC_FOREACH_BUILTIN_FUNCTION_NAME(INITIALIZE_PUBLIC_TO_PRIVATE_ENTRY)
     JSC_COMMON_PRIVATE_IDENTIFIERS_EACH_PROPERTY_NAME(INITIALIZE_PUBLIC_TO_PRIVATE_ENTRY)

--- a/Source/JavaScriptCore/builtins/BuiltinNames.h
+++ b/Source/JavaScriptCore/builtins/BuiltinNames.h
@@ -238,6 +238,7 @@ JSC_COMMON_PRIVATE_IDENTIFIERS_EACH_PROPERTY_NAME(DECLARE_BUILTIN_PRIVATE_NAMES)
 
 extern JS_EXPORT_PRIVATE SymbolImpl::StaticSymbolImpl dollarVMPrivateName;
 extern JS_EXPORT_PRIVATE SymbolImpl::StaticSymbolImpl polyProtoPrivateName;
+extern JS_EXPORT_PRIVATE SymbolImpl::StaticSymbolImpl stackPrivateName;
 }
 
 class BuiltinNames {
@@ -269,6 +270,7 @@ public:
     const JSC::Identifier& dollarVMPublicName() const { return m_dollarVMName; }
     const JSC::Identifier& dollarVMPrivateName() const { return m_dollarVMPrivateName; }
     const JSC::Identifier& polyProtoName() const { return m_polyProtoPrivateName; }
+    const JSC::Identifier& stackPrivateName() const { return m_stackPrivateName; }
 
 private:
     void checkPublicToPrivateMapConsistency(UniquedStringImpl* privateName);
@@ -281,6 +283,7 @@ private:
     const JSC::Identifier m_dollarVMName;
     const JSC::Identifier m_dollarVMPrivateName;
     const JSC::Identifier m_polyProtoPrivateName;
+    const JSC::Identifier m_stackPrivateName;
     PrivateNameSet m_privateNameSet;
     WellKnownSymbolMap m_wellKnownSymbolsMap;
 };

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyExceptionConstructor.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyExceptionConstructor.cpp
@@ -28,6 +28,8 @@
 
 #if ENABLE(WEBASSEMBLY)
 
+#include "BuiltinNames.h"
+#include "Interpreter.h"
 #include "IteratorOperations.h"
 #include "JITOpaqueByproducts.h"
 #include "JSCInlines.h"
@@ -80,11 +82,28 @@ JSC_DEFINE_HOST_FUNCTION(constructJSWebAssemblyException, (JSGlobalObject* globa
         RETURN_IF_EXCEPTION(scope, { });
     }
 
+    bool traceStack = false;
+    JSValue optionsValue = callFrame->argument(2);
+    if (!optionsValue.isUndefined()) {
+        JSValue traceStackValue = optionsValue.get(globalObject, Identifier::fromString(vm, "traceStack"_s));
+        RETURN_IF_EXCEPTION(scope, { });
+        traceStack = traceStackValue.toBoolean(globalObject);
+        RETURN_IF_EXCEPTION(scope, { });
+    }
+
     JSObject* newTarget = asObject(callFrame->newTarget());
     Structure* structure = JSC_GET_DERIVED_STRUCTURE(vm, webAssemblyExceptionStructure, newTarget, callFrame->jsCallee());
     RETURN_IF_EXCEPTION(scope, { });
 
-    RELEASE_AND_RETURN(scope, JSValue::encode(JSWebAssemblyException::create(vm, structure, tag->tag(), WTF::move(payload))));
+    auto* exception = JSWebAssemblyException::create(vm, structure, tag->tag(), WTF::move(payload));
+    if (traceStack) {
+        Vector<StackFrame> stackTrace;
+        constexpr size_t framesToSkip = 1;
+        vm.interpreter.getStackTrace(exception, stackTrace, framesToSkip, globalObject->stackTraceLimit().value_or(0));
+        exception->putDirect(vm, vm.propertyNames->builtinNames().stackPrivateName(), jsString(vm, Interpreter::stackTraceAsString(vm, stackTrace)), static_cast<unsigned>(PropertyAttribute::DontEnum | PropertyAttribute::ReadOnly | PropertyAttribute::DontDelete));
+    }
+
+    return JSValue::encode(exception);
 }
 
 JSC_DEFINE_HOST_FUNCTION(callJSWebAssemblyException, (JSGlobalObject* globalObject, CallFrame*))
@@ -108,7 +127,7 @@ Structure* WebAssemblyExceptionConstructor::createStructure(VM& vm, JSGlobalObje
 
 void WebAssemblyExceptionConstructor::finishCreation(VM& vm, WebAssemblyExceptionPrototype* prototype)
 {
-    Base::finishCreation(vm, 1, "Exception"_s, PropertyAdditionMode::WithoutStructureTransition);
+    Base::finishCreation(vm, 2, "Exception"_s, PropertyAdditionMode::WithoutStructureTransition);
     putDirectWithoutTransition(vm, vm.propertyNames->prototype, prototype, PropertyAttribute::ReadOnly | PropertyAttribute::DontEnum | PropertyAttribute::DontDelete);
 }
 

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyExceptionPrototype.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyExceptionPrototype.cpp
@@ -29,6 +29,7 @@
 #if ENABLE(WEBASSEMBLY)
 
 #include "AuxiliaryBarrierInlines.h"
+#include "BuiltinNames.h"
 #include "JSCInlines.h"
 #include "JSWebAssemblyException.h"
 #include "JSWebAssemblyHelpers.h"
@@ -38,6 +39,7 @@
 namespace JSC {
 static JSC_DECLARE_HOST_FUNCTION(webAssemblyExceptionProtoFuncGetArg);
 static JSC_DECLARE_HOST_FUNCTION(webAssemblyExceptionProtoFuncIs);
+static JSC_DECLARE_CUSTOM_GETTER(webAssemblyExceptionProtoGetterStack);
 }
 
 #include "WebAssemblyExceptionPrototype.lut.h"
@@ -50,6 +52,7 @@ const ClassInfo WebAssemblyExceptionPrototype::s_info = { "WebAssembly.Exception
  @begin prototypeTableWebAssemblyException
  getArg   webAssemblyExceptionProtoFuncGetArg   Function 2
  is       webAssemblyExceptionProtoFuncIs       Function 1
+ stack    webAssemblyExceptionProtoGetterStack  ReadOnly|CustomAccessor
  @end
  */
 
@@ -140,6 +143,20 @@ JSC_DEFINE_HOST_FUNCTION(webAssemblyExceptionProtoFuncIs, (JSGlobalObject* globa
         return throwVMTypeError(globalObject, throwScope, "WebAssembly.Exception.is(): First argument must be a WebAssembly.Tag"_s);
 
     RELEASE_AND_RETURN(throwScope, JSValue::encode(jsBoolean(jsException->tag() == tag->tag())));
+}
+
+JSC_DEFINE_CUSTOM_GETTER(webAssemblyExceptionProtoGetterStack, (JSGlobalObject* globalObject, EncodedJSValue thisValue, PropertyName))
+{
+    VM& vm = globalObject->vm();
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
+
+    JSWebAssemblyException* jsException = getException(globalObject, JSValue::decode(thisValue));
+    RETURN_IF_EXCEPTION(throwScope, { });
+
+    JSValue stack = jsException->getDirect(vm, vm.propertyNames->builtinNames().stackPrivateName());
+    if (!stack)
+        return JSValue::encode(jsUndefined());
+    return JSValue::encode(stack);
 }
 
 } // namespace JSC


### PR DESCRIPTION
#### bf6512f84f7d9275332b8d119ab2b79a72ee8287
<pre>
[JSC][Wasm] Support WebAssembly.Exception options.traceStack
<a href="https://bugs.webkit.org/show_bug.cgi?id=319826">https://bugs.webkit.org/show_bug.cgi?id=319826</a>

Reviewed by Keith Miller.

Accept the optional ExceptionOptions argument on WebAssembly.Exception.
When traceStack is true, capture a stack and store it under a private
name; expose it via a prototype getter (IDL attribute). Default remains
no stack. Set the constructor length to 2 to match the IDL.

Keep Error on CommonIdentifiers::stack. Register stackPrivateName as a
private-only special case (like polyProto) so Exception storage does not
introduce a second public &quot;stack&quot; Identifier.

* Source/JavaScriptCore/wasm/js/WebAssemblyExceptionConstructor.cpp:
* Source/JavaScriptCore/wasm/js/WebAssemblyExceptionPrototype.cpp:
* Source/JavaScriptCore/builtins/BuiltinNames.h:
* Source/JavaScriptCore/builtins/BuiltinNames.cpp:
* JSTests/wasm/stress/exception-trace-stack.js: Added.
* LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/exception/constructor.tentative.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/exception/constructor.tentative.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/idlharness.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/idlharness.any.worker-expected.txt:

Canonical link: <a href="https://commits.webkit.org/318397@main">https://commits.webkit.org/318397@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4af022bb37b2b5dcc0160a594e7771479027d3c2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177248 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51186 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44980 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186851 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/140484 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52478 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50874 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138118 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96298 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180204 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41621 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158883 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118583 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40281 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38660 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/552 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/7383 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150690 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38381 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35319 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/38519 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42971 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42874 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189278 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50852 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147207 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51535 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35007 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146999 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27025 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41725 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123750 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/118082 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50040 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13359 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49439 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49678 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49500 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->