### PR TITLE
[JSC][Wasm] Zero-extend memory32 data segment offsets

### DIFF
--- a/JSTests/wasm/stress/data-segment-offset-2gb.js
+++ b/JSTests/wasm/stress/data-segment-offset-2gb.js
@@ -1,0 +1,79 @@
+//@ skip if $memoryLimited or $addressBits <= 32
+//@ requireOptions("--useExecutableAllocationFuzz=false")
+import * as assert from "../assert.js";
+
+function encodeU32(n) {
+    const out = [];
+    while (true) {
+        let b = n & 0x7f;
+        n >>>= 7;
+        if (n)
+            out.push(b | 0x80);
+        else {
+            out.push(b);
+            break;
+        }
+    }
+    return out;
+}
+
+function encodeSleb32(v) {
+    let n = v | 0;
+    const out = [];
+    while (true) {
+        let b = n & 0x7f;
+        n >>= 7;
+        if ((n === 0 && (b & 0x40) === 0) || (n === -1 && (b & 0x40) !== 0)) {
+            out.push(b);
+            break;
+        }
+        out.push(b | 0x80);
+    }
+    return out;
+}
+
+function section(id, bodyArr) {
+    const body = bodyArr;
+    const len = encodeU32(body.length);
+    return [id, ...len, ...body];
+}
+
+// (module
+//   (memory 32769 32769)
+//   (data (i32.const 0x80000000) "\x2a\x00\x00\x00")
+//   (func (export "load") (result i32)
+//     i32.const 0x80000000
+//     i32.load))
+const pages = 32769; // 2GB + 1 page
+const cBase = encodeSleb32(0x80000000);
+
+const typeSec = section(1, [1, 0x60, 0, 1, 0x7f]);
+const funcSec = section(3, [1, 0]);
+const memSec = section(5, [1, 0x01, ...encodeU32(pages), ...encodeU32(pages)]);
+const exportSec = section(7, [1, 4, 0x6c, 0x6f, 0x61, 0x64, 0, 0]);
+const codeBody = [0, 0x41, ...cBase, 0x28, 0x02, 0x00, 0x0b];
+const codeSized = [...encodeU32(codeBody.length), ...codeBody];
+const codeSec = section(10, [1, ...codeSized]);
+// data: flag 0, i32.const 0x80000000 end, len 4, bytes
+const dataPayload = [
+    1, // 1 segment
+    0, // active mem 0
+    0x41, ...cBase, 0x0b,
+    4, 0x2a, 0x00, 0x00, 0x00,
+];
+const dataSec = section(11, dataPayload);
+
+const bytes = new Uint8Array([
+    0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
+    ...typeSec, ...funcSec, ...memSec, ...exportSec, ...codeSec, ...dataSec,
+]);
+
+let instance;
+try {
+    instance = new WebAssembly.Instance(new WebAssembly.Module(bytes));
+} catch (e) {
+    throw new Error(`instantiation failed (bug 314444 sign-extended data offset?): ${e}`);
+}
+
+assert.eq(instance.exports.load(), 42);
+print("data-segment-offset-2gb: ok");

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp
@@ -873,16 +873,23 @@ JSValue WebAssemblyModuleRecord::evaluate(JSGlobalObject* globalObject)
             uint8_t* memory = static_cast<uint8_t*>(wasmMemory.basePointer());
             uint64_t sizeInBytes = wasmMemory.size();
 
+            const bool isMemory64 = moduleInformation.memory(segment->memoryIndex()).isMemory64();
             uint64_t offset = 0;
-            if (segment->offsetIfActive()->isGlobalImport())
-                offset = static_cast<uint64_t>(m_instance->loadI32Global(segment->offsetIfActive()->globalImportIndex()));
-            else if (segment->offsetIfActive()->isConst())
-                offset = segment->offsetIfActive()->constValue();
-            else {
+            if (segment->offsetIfActive()->isGlobalImport()) {
+                if (isMemory64)
+                    offset = static_cast<uint64_t>(m_instance->loadI64Global(segment->offsetIfActive()->globalImportIndex()));
+                else
+                    offset = static_cast<uint32_t>(m_instance->loadI32Global(segment->offsetIfActive()->globalImportIndex()));
+            } else if (segment->offsetIfActive()->isConst()) {
+                if (isMemory64)
+                    offset = segment->offsetIfActive()->constValue();
+                else
+                    offset = static_cast<uint32_t>(segment->offsetIfActive()->constValue());
+            } else {
                 uint64_t result;
-                evaluateConstantExpression(globalObject, moduleInformation.constantExpressions[segment->offsetIfActive()->constantExpressionIndex()], moduleInformation, Wasm::Types::I32, result);
+                evaluateConstantExpression(globalObject, moduleInformation.constantExpressions[segment->offsetIfActive()->constantExpressionIndex()], moduleInformation, isMemory64 ? Wasm::Types::I64 : Wasm::Types::I32, result);
                 RETURN_IF_EXCEPTION(scope, void());
-                offset = result;
+                offset = isMemory64 ? result : static_cast<uint32_t>(result);
             }
 
             if (fn(memory, sizeInBytes, segment, offset) == IterationStatus::Done)


### PR DESCRIPTION
#### 7a71bbb85003c03c9da7c85fa194069bc8992095
<pre>
[JSC][Wasm] Zero-extend memory32 data segment offsets
<a href="https://bugs.webkit.org/show_bug.cgi?id=314444">https://bugs.webkit.org/show_bug.cgi?id=314444</a>

Reviewed by Yusuke Suzuki.

i32.const data offsets are stored in a uint64_t with C++ sign-extension, so
0x80000000 (e.g. Emscripten GLOBAL_BASE=2GB) became 0xffffffff80000000 and
failed active data segment initialization. Treat memory32 offsets as u32
(zero-extend from the i32 bit pattern). Memory64 keeps full i64 offsets and
uses i64 globals / const expressions.

* Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp:
* JSTests/wasm/stress/data-segment-offset-2gb.js: Added.

Canonical link: <a href="https://commits.webkit.org/317633@main">https://commits.webkit.org/317633@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/15bbc57a3e0ca688915101156de3256075f76c61

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175221 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49153 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42934 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184806 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/133319 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50445 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48836 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136391 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/133319 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178178 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39807 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157158 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116870 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38448 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36836 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33279 "Built successfully") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/5667 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148871 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36651 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187227 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/36482 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/40840 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41039 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145338 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48820 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145195 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49500 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33272 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/115373 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26719 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40030 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/121689 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/212312 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48006 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11624 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/55411 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47409 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47639 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47466 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->