### PR TITLE
AX: AXTextMarkerForIndex and AXIndexForTextMarker don't round-trip in the isolated tree

### DIFF
--- a/LayoutTests/accessibility/mac/index-for-zero-offset-text-marker-expected.txt
+++ b/LayoutTests/accessibility/mac/index-for-zero-offset-text-marker-expected.txt
@@ -1,6 +1,6 @@
-This test ensures we can get the index of a zero offset text marker without crashing.
+This test ensures we can get the index of a zero offset text marker without crashing, and that the index is consistent with the string length up to that marker.
 
-PASS: axElement.indexForTextMarker(startMarker) === 39
+PASS: index === prefixLength
 
 PASS successfullyParsed is true
 

--- a/LayoutTests/accessibility/mac/index-for-zero-offset-text-marker.html
+++ b/LayoutTests/accessibility/mac/index-for-zero-offset-text-marker.html
@@ -12,14 +12,26 @@ This is static text<br>with a line break.
 <p>This is text in a p tag with no line break</p>
 
 <script>
-let output = "This test ensures we can get the index of a zero offset text marker without crashing.\n\n";
+let output = "This test ensures we can get the index of a zero offset text marker without crashing, and that the index is consistent with the string length up to that marker.\n\n";
 
 if (window.accessibilityController) {
+    var webArea = accessibilityController.rootElement.childAtIndex(0);
     var axElement = accessibilityController.accessibleElementById("p");
     const range = axElement.textMarkerRangeForElement(axElement);
     var startMarker = axElement.startTextMarkerForTextMarkerRange(range);
 
-    output += expect("axElement.indexForTextMarker(startMarker)", "39");
+    // The index of a marker must equal the number of characters before it — i.e. the length of
+    // the string from the document start up to the marker. Asserting this invariant (rather than a
+    // hard-coded number) keeps the test correct regardless of how block boundaries are counted,
+    // which differs between the isolated tree and the main thread (e.g. a paragraph boundary that
+    // emits one newline vs. two).
+    var fullRange = webArea.textMarkerRangeForElement(webArea);
+    var documentStart = webArea.startTextMarkerForTextMarkerRange(fullRange);
+    var prefixRange = webArea.textMarkerRangeForMarkers(documentStart, startMarker);
+    var index = webArea.indexForTextMarker(startMarker);
+    var prefixLength = webArea.stringForTextMarkerRange(prefixRange).length;
+
+    output += expect("index", "prefixLength");
     debug(output);
 }
 </script>

--- a/LayoutTests/accessibility/mac/text-marker-index-round-trip-expected.txt
+++ b/LayoutTests/accessibility/mac/text-marker-index-round-trip-expected.txt
@@ -1,0 +1,10 @@
+Verifies that AXIndexForTextMarker and AXTextMarkerForIndex round-trip without accumulating error across paragraphs and hard line breaks.
+
+PASS: worstRoundTripDrift was equal or approximately equal to 0.
+PASS: worstLengthDifference was equal or approximately equal to 0.
+PASS: uncheckedCharacters was equal or approximately equal to 0.
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/mac/text-marker-index-round-trip-list-expected.txt
+++ b/LayoutTests/accessibility/mac/text-marker-index-round-trip-list-expected.txt
@@ -1,0 +1,10 @@
+Verifies round-trip does not accumulate error across lists following block content.
+
+PASS: worstRoundTripDrift was equal or approximately equal to 0.
+PASS: worstLengthDifference was equal or approximately equal to 0.
+PASS: uncheckedCharacters was equal or approximately equal to 0.
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/mac/text-marker-index-round-trip-list.html
+++ b/LayoutTests/accessibility/mac/text-marker-index-round-trip-list.html
@@ -1,0 +1,57 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<script src="../../resources/js-test.js"></script>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/ax-text-marker-helper.js"></script>
+</head>
+<body>
+
+<div id="container" role="group">
+<p>Group 0</p><ul style='list-style:none'><li>Apple 0</li><li>Berry 0</li></ul>
+<p>Group 1</p><ul style='list-style:none'><li>Apple 1</li><li>Berry 1</li></ul>
+<p>Group 2</p><ul style='list-style:none'><li>Apple 2</li><li>Berry 2</li></ul>
+<p>Group 3</p><ul style='list-style:none'><li>Apple 3</li><li>Berry 3</li></ul>
+<p>Group 4</p><ul style='list-style:none'><li>Apple 4</li><li>Berry 4</li></ul>
+<p>Group 5</p><ul style='list-style:none'><li>Apple 5</li><li>Berry 5</li></ul>
+<p>Group 6</p><ul style='list-style:none'><li>Apple 6</li><li>Berry 6</li></ul>
+<p>Group 7</p><ul style='list-style:none'><li>Apple 7</li><li>Berry 7</li></ul>
+<p>Group 8</p><ul style='list-style:none'><li>Apple 8</li><li>Berry 8</li></ul>
+<p>Group 9</p><ul style='list-style:none'><li>Apple 9</li><li>Berry 9</li></ul>
+</div>
+
+<script>
+var output = "Verifies round-trip does not accumulate error across lists following block content.\n\n";
+window.jsTestIsAsync = true;
+
+async function runTest() {
+    if (window.accessibilityController) {
+        await waitForFrameGeometryReady();
+        var container = await waitForElementById("container");
+
+        // The critical property (VoiceOver relies on it) is that converting a marker to an index and
+        // back does not ACCUMULATE error. Bounded, non-accumulating quirks are acceptable (snapping
+        // at newlines, or a +/-1 at a table cell boundary), so the pattern is repeated many times and
+        // we assert only that the worst round-trip drift -- and the worst index-vs-string-length
+        // difference -- stays within a small tolerance that does not grow with the number of
+        // repetitions. A regression that reintroduces per-element drift accumulates past the tolerance.
+        var result = checkRoundTripAllTextMarkerIndicesWithinContainer(container);
+        worstRoundTripDrift = result.worstRoundTripDrift;
+        worstLengthDifference = result.worstLengthDifference;
+        // Guard against a collapsed/degenerate index space passing vacuously: every character of the
+        // container's text must have been covered by the index walk, so none go unchecked.
+        uncheckedCharacters = result.containerTextLength - result.indicesChecked;
+        output += expectNumber("worstRoundTripDrift", 0, 2);
+        output += expectNumber("worstLengthDifference", 0, 2);
+        output += expectNumber("uncheckedCharacters", 0, 2);
+
+        // Hide the fixture so the dumped result is just the assertions, not the test markup.
+        document.getElementById("container").hidden = true;
+        debug(output);
+    }
+    finishJSTest();
+}
+runTest();
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/mac/text-marker-index-round-trip-nested-blocks-expected.txt
+++ b/LayoutTests/accessibility/mac/text-marker-index-round-trip-nested-blocks-expected.txt
@@ -1,0 +1,10 @@
+Verifies round-trip does not accumulate error across nested block wrappers (a block whose only child is another block).
+
+PASS: worstRoundTripDrift was equal or approximately equal to 0.
+PASS: worstLengthDifference was equal or approximately equal to 0.
+PASS: uncheckedCharacters was equal or approximately equal to 0.
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/mac/text-marker-index-round-trip-nested-blocks.html
+++ b/LayoutTests/accessibility/mac/text-marker-index-round-trip-nested-blocks.html
@@ -1,0 +1,57 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<script src="../../resources/js-test.js"></script>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/ax-text-marker-helper.js"></script>
+</head>
+<body>
+
+<div id="container" role="group">
+<div>Section 0</div><div><div>Nested block 0</div></div>
+<div>Section 1</div><div><div>Nested block 1</div></div>
+<div>Section 2</div><div><div>Nested block 2</div></div>
+<div>Section 3</div><div><div>Nested block 3</div></div>
+<div>Section 4</div><div><div>Nested block 4</div></div>
+<div>Section 5</div><div><div>Nested block 5</div></div>
+<div>Section 6</div><div><div>Nested block 6</div></div>
+<div>Section 7</div><div><div>Nested block 7</div></div>
+<div>Section 8</div><div><div>Nested block 8</div></div>
+<div>Section 9</div><div><div>Nested block 9</div></div>
+</div>
+
+<script>
+var output = "Verifies round-trip does not accumulate error across nested block wrappers (a block whose only child is another block).\n\n";
+window.jsTestIsAsync = true;
+
+async function runTest() {
+    if (window.accessibilityController) {
+        await waitForFrameGeometryReady();
+        var container = await waitForElementById("container");
+
+        // The critical property (VoiceOver relies on it) is that converting a marker to an index and
+        // back does not ACCUMULATE error. Bounded, non-accumulating quirks are acceptable (snapping
+        // at newlines, or a +/-1 at a table cell boundary), so the pattern is repeated many times and
+        // we assert only that the worst round-trip drift -- and the worst index-vs-string-length
+        // difference -- stays within a small tolerance that does not grow with the number of
+        // repetitions. A regression that reintroduces per-element drift accumulates past the tolerance.
+        var result = checkRoundTripAllTextMarkerIndicesWithinContainer(container);
+        worstRoundTripDrift = result.worstRoundTripDrift;
+        worstLengthDifference = result.worstLengthDifference;
+        // Guard against a collapsed/degenerate index space passing vacuously: every character of the
+        // container's text must have been covered by the index walk, so none go unchecked.
+        uncheckedCharacters = result.containerTextLength - result.indicesChecked;
+        output += expectNumber("worstRoundTripDrift", 0, 2);
+        output += expectNumber("worstLengthDifference", 0, 2);
+        output += expectNumber("uncheckedCharacters", 0, 2);
+
+        // Hide the fixture so the dumped result is just the assertions, not the test markup.
+        document.getElementById("container").hidden = true;
+        debug(output);
+    }
+    finishJSTest();
+}
+runTest();
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/mac/text-marker-index-round-trip-table-expected.txt
+++ b/LayoutTests/accessibility/mac/text-marker-index-round-trip-table-expected.txt
@@ -1,0 +1,10 @@
+Verifies round-trip does not accumulate error across tables following block content.
+
+PASS: worstRoundTripDrift was equal or approximately equal to 0.
+PASS: worstLengthDifference was equal or approximately equal to 0.
+PASS: uncheckedCharacters was equal or approximately equal to 0.
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/mac/text-marker-index-round-trip-table.html
+++ b/LayoutTests/accessibility/mac/text-marker-index-round-trip-table.html
@@ -1,0 +1,57 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<script src="../../resources/js-test.js"></script>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/ax-text-marker-helper.js"></script>
+</head>
+<body>
+
+<div id="container" role="group">
+<p>Caption 0</p><table><tr><td>a0</td><td>b0</td></tr><tr><td>c0</td><td>d0</td></tr></table>
+<p>Caption 1</p><table><tr><td>a1</td><td>b1</td></tr><tr><td>c1</td><td>d1</td></tr></table>
+<p>Caption 2</p><table><tr><td>a2</td><td>b2</td></tr><tr><td>c2</td><td>d2</td></tr></table>
+<p>Caption 3</p><table><tr><td>a3</td><td>b3</td></tr><tr><td>c3</td><td>d3</td></tr></table>
+<p>Caption 4</p><table><tr><td>a4</td><td>b4</td></tr><tr><td>c4</td><td>d4</td></tr></table>
+<p>Caption 5</p><table><tr><td>a5</td><td>b5</td></tr><tr><td>c5</td><td>d5</td></tr></table>
+<p>Caption 6</p><table><tr><td>a6</td><td>b6</td></tr><tr><td>c6</td><td>d6</td></tr></table>
+<p>Caption 7</p><table><tr><td>a7</td><td>b7</td></tr><tr><td>c7</td><td>d7</td></tr></table>
+<p>Caption 8</p><table><tr><td>a8</td><td>b8</td></tr><tr><td>c8</td><td>d8</td></tr></table>
+<p>Caption 9</p><table><tr><td>a9</td><td>b9</td></tr><tr><td>c9</td><td>d9</td></tr></table>
+</div>
+
+<script>
+var output = "Verifies round-trip does not accumulate error across tables following block content.\n\n";
+window.jsTestIsAsync = true;
+
+async function runTest() {
+    if (window.accessibilityController) {
+        await waitForFrameGeometryReady();
+        var container = await waitForElementById("container");
+
+        // The critical property (VoiceOver relies on it) is that converting a marker to an index and
+        // back does not ACCUMULATE error. Bounded, non-accumulating quirks are acceptable (snapping
+        // at newlines, or a +/-1 at a table cell boundary), so the pattern is repeated many times and
+        // we assert only that the worst round-trip drift -- and the worst index-vs-string-length
+        // difference -- stays within a small tolerance that does not grow with the number of
+        // repetitions. A regression that reintroduces per-element drift accumulates past the tolerance.
+        var result = checkRoundTripAllTextMarkerIndicesWithinContainer(container);
+        worstRoundTripDrift = result.worstRoundTripDrift;
+        worstLengthDifference = result.worstLengthDifference;
+        // Guard against a collapsed/degenerate index space passing vacuously: every character of the
+        // container's text must have been covered by the index walk, so none go unchecked.
+        uncheckedCharacters = result.containerTextLength - result.indicesChecked;
+        output += expectNumber("worstRoundTripDrift", 0, 2);
+        output += expectNumber("worstLengthDifference", 0, 2);
+        output += expectNumber("uncheckedCharacters", 0, 2);
+
+        // Hide the fixture so the dumped result is just the assertions, not the test markup.
+        document.getElementById("container").hidden = true;
+        debug(output);
+    }
+    finishJSTest();
+}
+runTest();
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/mac/text-marker-index-round-trip.html
+++ b/LayoutTests/accessibility/mac/text-marker-index-round-trip.html
@@ -1,0 +1,51 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<script src="../../resources/js-test.js"></script>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/ax-text-marker-helper.js"></script>
+</head>
+<body>
+
+<div id="container" role="group">
+<p>Para One</p>
+<p>One<br>Two<br>Three</p>
+<p>Para Two</p>
+<p>Four<br>Five<br>Six</p>
+</div>
+
+<script>
+var output = "Verifies that AXIndexForTextMarker and AXTextMarkerForIndex round-trip without accumulating error across paragraphs and hard line breaks.\n\n";
+window.jsTestIsAsync = true;
+
+async function runTest() {
+    if (window.accessibilityController) {
+        await waitForFrameGeometryReady();
+        var container = await waitForElementById("container");
+
+        // The critical property (VoiceOver relies on it) is that converting a marker to an index and
+        // back does not ACCUMULATE error. Bounded, non-accumulating quirks are acceptable (snapping
+        // at newlines, or a +/-1 at a table cell boundary), so the pattern is repeated many times and
+        // we assert only that the worst round-trip drift -- and the worst index-vs-string-length
+        // difference -- stays within a small tolerance that does not grow with the number of
+        // repetitions. A regression that reintroduces per-element drift accumulates past the tolerance.
+        var result = checkRoundTripAllTextMarkerIndicesWithinContainer(container);
+        worstRoundTripDrift = result.worstRoundTripDrift;
+        worstLengthDifference = result.worstLengthDifference;
+        // Guard against a collapsed/degenerate index space passing vacuously: every character of the
+        // container's text must have been covered by the index walk, so none go unchecked.
+        uncheckedCharacters = result.containerTextLength - result.indicesChecked;
+        output += expectNumber("worstRoundTripDrift", 0, 2);
+        output += expectNumber("worstLengthDifference", 0, 2);
+        output += expectNumber("uncheckedCharacters", 0, 2);
+
+        // Hide the fixture so the dumped result is just the assertions, not the test markup.
+        document.getElementById("container").hidden = true;
+        debug(output);
+    }
+    finishJSTest();
+}
+runTest();
+</script>
+</body>
+</html>

--- a/LayoutTests/resources/ax-text-marker-helper.js
+++ b/LayoutTests/resources/ax-text-marker-helper.js
@@ -1,0 +1,42 @@
+// Helpers for testing AXTextMarkers
+
+// Walks every document text-marker index spanned by `container` and measures how far the two
+// invariants deviate:
+//   * round-trip:      indexForTextMarker(textMarkerForIndex(i)) should equal i.
+//   * string-length:   the string from the container start to textMarkerForIndex(i) should be
+//                      (i - containerStartIndex) characters long.
+// Returns the worst (maximum absolute) deviation of each as { worstRoundTripDrift, worstLengthDifference },
+// plus indicesChecked (how many index positions were walked) and containerTextLength (the container's
+// text length, measured independently). Callers should assert indicesChecked matches containerTextLength
+// so a collapsed/degenerate index space can't pass vacuously by making the walk iterate zero times.
+//
+// Callers should scope this to a container (rather than the web area) so that DOM injected by
+// js-test.js — its description and console elements, added at the top of the body — is not part of
+// the tree under test. AXIndexForTextMarker / AXTextMarkerForIndex are document-relative, so this
+// walks the range of document indices the container spans and offsets lengths by the container's start.
+//
+// Bounded, non-accumulating deviations are expected (e.g. snapping at a newline or a table cell
+// boundary); the bug these guard against is drift that accumulates down the page, so callers should
+// assert the returned values stay within a small tolerance that does not grow with content length.
+function checkRoundTripAllTextMarkerIndicesWithinContainer(container) {
+    var containerRange = container.textMarkerRangeForElement(container);
+    var startMarker = container.startTextMarkerForTextMarkerRange(containerRange);
+    var endMarker = container.endTextMarkerForTextMarkerRange(containerRange);
+    var baseIndex = container.indexForTextMarker(startMarker);
+    var lastIndex = container.indexForTextMarker(endMarker);
+
+    var worstRoundTripDrift = 0;
+    var worstLengthDifference = 0;
+    for (var index = baseIndex; index <= lastIndex; index++) {
+        var marker = container.textMarkerForIndex(index);
+        worstRoundTripDrift = Math.max(worstRoundTripDrift, Math.abs(container.indexForTextMarker(marker) - index));
+        var prefixLength = container.stringForTextMarkerRange(container.textMarkerRangeForMarkers(startMarker, marker)).length;
+        worstLengthDifference = Math.max(worstLengthDifference, Math.abs(prefixLength - (index - baseIndex)));
+    }
+    return {
+        worstRoundTripDrift: worstRoundTripDrift,
+        worstLengthDifference: worstLengthDifference,
+        indicesChecked: lastIndex - baseIndex,
+        containerTextLength: container.stringForTextMarkerRange(containerRange).length,
+    };
+}

--- a/Source/WebCore/accessibility/AXTextMarker.cpp
+++ b/Source/WebCore/accessibility/AXTextMarker.cpp
@@ -898,90 +898,171 @@ bool AXTextMarker::atLineBoundaryForDirection(AXDirection direction, const AXTex
     return direction == AXDirection::Previous ? !offsetInLine : runs->runLength(runIndex) == offsetInLine;
 }
 
+// --- Shared text-length walk backing AXIndexForTextMarker (offsetFromRoot) and
+// --- AXTextMarkerForIndex (nextMarkerFromOffset).
+//
+// These two attributes must be inverses: VoiceOver converts a text marker to a
+// document-relative index and back, and any drift (especially drift that accumulates
+// down the page) is a serious bug. To guarantee they invert each other, both are driven
+// by ONE traversal — forEachRunObjectForward — that visits text-run objects in document
+// order via findObjectWithRuns and counts characters the same way AXTextMarkerRange::toString
+// emits them: each run contributes its length, and crossing a block boundary contributes a
+// newline (TextEmissionBehavior::Newline => 1, DoubleNewline => 2) unless the previously
+// emitted character was already a newline. Image alt text is intentionally NOT counted, so
+// the index space is independent of it (this is the one place we deliberately diverge from
+// toString).
+
+static bool runEndsWithNewline(const AXIsolatedObject& object)
+{
+    const auto* runs = object.textRuns();
+    return runs && runs->toStringView().endsWith('\n');
+}
+
+// Mirrors the newline emission in AXTextMarkerRange::toString's emitAuxiliaryText (minus alt text).
+static unsigned emittedNewlineLength(const AXCoreObject& object, bool lastEmittedWasNewline)
+{
+    if (lastEmittedWasNewline)
+        return 0;
+    switch (object.textEmissionBehavior()) {
+    case TextEmissionBehavior::Newline:
+        return 1;
+    case TextEmissionBehavior::DoubleNewline:
+        return 2;
+    case TextEmissionBehavior::None:
+    case TextEmissionBehavior::Tab:
+        return 0;
+    }
+    return 0;
+}
+
+// Visits each text-run object reachable forward from `start`'s object (inclusive), in document
+// order, invoking visit(object, precedingNewlines) where precedingNewlines is the number of
+// newline characters emitted immediately before that object's text. Return false from `visit`
+// to stop. The newline accounting matches AXTextMarkerRange::toString (excluding alt text).
+template<typename Visitor>
+static void forEachRunObjectForward(const AXTextMarker& start, std::optional<AXID> stopAtID, Visitor&& visit)
+{
+    RefPtr current = start.isolatedObject();
+    const auto* runs = current ? current->textRuns() : nullptr;
+    if (!runs || !runs->size())
+        return;
+
+    if (!visit(*current, 0u))
+        return;
+    bool lastEmittedWasNewline = runEndsWithNewline(*current);
+
+    for (unsigned iterations = 0; ; ++iterations) {
+        if (iterations >= maxDescendantTraversalIterations) [[unlikely]] {
+            // Failsafe: never spin forever on a malformed (e.g. cyclic) tree.
+            AX_ASSERT_NOT_REACHED();
+            break;
+        }
+
+        unsigned precedingNewlines = 0;
+        auto exitObject = [&] (AXIsolatedObject& exited) {
+            if (unsigned emitted = emittedNewlineLength(exited, lastEmittedWasNewline)) {
+                precedingNewlines += emitted;
+                lastEmittedWasNewline = true;
+            }
+        };
+        RefPtr next = findObjectWithRuns(*current, AXDirection::Next, stopAtID, exitObject);
+        if (!next || next == current)
+            break;
+        if (!visit(*next, precedingNewlines))
+            return;
+        lastEmittedWasNewline = runEndsWithNewline(*next);
+        current = WTF::move(next);
+    }
+}
+
 unsigned AXTextMarker::offsetFromRoot() const
 {
     AX_ASSERT(!isMainThread());
 
     if (!isValid())
         return 0;
+    auto target = toTextRunMarker();
+    if (!target.isValid())
+        return 0;
+
     RefPtr tree = std::get<RefPtr<AXIsolatedTree>>(axTreeForID(treeID()));
-    if (RefPtr root = tree ? tree->rootNode() : nullptr) {
-        AXTextMarker rootMarker { root->treeID(), root->objectID(), 0 };
-        unsigned offset = 0;
-        auto current = rootMarker;
+    RefPtr root = tree ? tree->rootNode() : nullptr;
+    if (!root)
+        return 0;
+    auto start = AXTextMarker { root->treeID(), root->objectID(), 0 }.toTextRunMarker();
+    if (!start.isValid())
+        return 0;
 
-        bool needsNewlineOffset = false;
-        auto applyNewlineOffset = [&] () {
-            if (needsNewlineOffset && offset) {
-                // Only represent a newline if we have started counting
-                // actual, non-whitespace text (i.e. offset is > 0).
-                offset++;
-            }
-            needsNewlineOffset = false;
-        };
-
-        while (current.isValid() && !hasSameObjectAndOffset(current)) {
-            applyNewlineOffset();
-            auto previous = current;
-            // If an object has text runs, and we are not at the very last position in those runs, use findMarker to navigate within them.
-            // Otherwise, we want to explore all objects.
-            RefPtr currentObject = current.isolatedObject();
-            const auto* runs = currentObject->textRuns();
-            if (runs && current.offset() < runs->totalLength()) {
-                current = previous.findMarker(AXDirection::Next, CoalesceObjectBreaks::No, IgnoreBRs::No);
-                // While searching, we want to explore all positions (hence, we don't coalesce newlines or skip line breaks above)
-                // But, don't increment if the previous and current have the same visual position.
-                if (!previous.equivalentTextPosition(current))
-                    offset++;
-            } else {
-                if (currentObject->emitsNewline()) {
-                    // If the next text we come across is on a new line, we need to increment the offset, since the
-                    // previous + current text marker won't share an equivalent visual text position.
-                    needsNewlineOffset = true;
-                }
-                RefPtr nextObject = currentObject->nextInPreOrder();
-                current = nextObject ? AXTextMarker { *nextObject, 0 } : AXTextMarker();
-            }
-
-            if (previous == current) [[unlikely]] {
-                // Advancement returned its input. Would loop forever.
-                AX_ASSERT_NOT_REACHED();
-                break;
-            }
+    // `start` is the document's first text position, so its offset within its run is 0. The walk
+    // therefore counts each object's full run length, with no per-object base to subtract (which
+    // also means there is no unsigned subtraction here to underflow).
+    TEXT_MARKER_ASSERT(!start.offset());
+    auto targetID = target.objectID();
+    unsigned offset = 0;
+    bool found = false;
+    forEachRunObjectForward(start, std::nullopt, [&] (AXIsolatedObject& object, unsigned precedingNewlines) {
+        offset += precedingNewlines;
+        if (object.objectID() == targetID) {
+            offset += target.offset();
+            found = true;
+            return false;
         }
-        applyNewlineOffset();
+        offset += object.textRuns()->totalLength();
+        return true;
+    });
 
-        // If this assert fails, it means we couldn't navigate from root to `this`, which should never happen.
-        TEXT_MARKER_ASSERT_DOUBLE(hasSameObjectAndOffset(current), (*this), current);
-        return offset;
-    }
-    return 0;
+    // If this assert fails, it means we couldn't navigate from root to `this`, which should never happen.
+    TEXT_MARKER_ASSERT_DOUBLE(found, (*this), target);
+    return offset;
 }
 
-AXTextMarker AXTextMarker::nextMarkerFromOffset(unsigned offset, ForceSingleOffsetMovement forceSingleOffsetMovement, std::optional<AXID> stopAtID) const
+// The ForceSingleOffsetMovement argument is intentionally ignored: this walk always advances by
+// UTF-16 code units (offsets into the run text), which is what the old ForceSingleOffsetMovement::Yes
+// path did. That keeps the index space consistent with offsetFromRoot (AXIndexForTextMarker) and with
+// stringForTextMarkerRange, all of which count UTF-16 code units, so the round-trip and index/length
+// invariants hold for non-ASCII text too. The trade-off is that an index landing inside a grapheme
+// cluster (e.g. between the halves of a surrogate pair) yields a marker inside that cluster.
+// FIXME: Consider snapping the returned marker to a grapheme-cluster boundary (a bounded,
+// non-accumulating snap, like the newline-gap case below).
+AXTextMarker AXTextMarker::nextMarkerFromOffset(unsigned offset, ForceSingleOffsetMovement, std::optional<AXID> stopAtID) const
 {
     AX_ASSERT(!isMainThread());
 
     if (!isValid())
         return { };
-    if (!isInTextRun())
-        return toTextRunMarker(stopAtID).nextMarkerFromOffset(offset, forceSingleOffsetMovement, stopAtID);
+    auto start = toTextRunMarker(stopAtID);
+    if (!start.isValid())
+        return { };
 
-    auto marker = *this;
-    while (offset) {
-        auto newMarker = marker.findMarker(AXDirection::Next, CoalesceObjectBreaks::No, IgnoreBRs::No, stopAtID, forceSingleOffsetMovement);
-        if (!newMarker)
-            break;
-        if (newMarker == marker) [[unlikely]] {
-            // findMarker returned its input. Would loop until offset reaches 0,
-            // returning a wildly wrong marker.
-            AX_ASSERT_NOT_REACHED();
-            break;
+    // Walk the same traversal offsetFromRoot counts, consuming `offset` characters. Because both
+    // functions share forEachRunObjectForward with identical newline accounting, the marker this
+    // returns satisfies offsetFromRoot(result) == offset for every position that has a distinct
+    // text-run marker — i.e. the round-trip is exact for real markers. Positions that fall inside an
+    // emitted (virtual) newline gap have no marker of their own, so they snap back to the end of the
+    // preceding run; this is a bounded, non-accumulating snap (acceptable per VoiceOver's needs).
+    unsigned remaining = offset;
+    auto result = start;
+    forEachRunObjectForward(start, stopAtID, [&] (AXIsolatedObject& object, unsigned precedingNewlines) {
+        if (remaining < precedingNewlines) {
+            // Target lands within an emitted newline gap; keep `result` at the previous run's end.
+            return false;
         }
-        marker = WTF::move(newMarker);
-        --offset;
-    }
-    return marker;
+        remaining -= precedingNewlines; // Safe: guarded by the check above.
+
+        unsigned totalLength = object.textRuns()->totalLength();
+        // Only the first object can start partway through its run (when `this` was mid-run). Clamp so
+        // `totalLength - base` can never underflow even if a stale marker's offset is out of bounds.
+        unsigned base = object.objectID() == start.objectID() ? std::min(start.offset(), totalLength) : 0;
+        unsigned available = totalLength - base;
+        if (remaining <= available) {
+            result = AXTextMarker { object, base + remaining };
+            return false;
+        }
+        remaining -= available; // Safe: guarded by the check above.
+        result = AXTextMarker { object, totalLength };
+        return true;
+    });
+    return result;
 }
 
 AXTextMarker AXTextMarker::findLastBefore(std::optional<AXID> stopAtID) const


### PR DESCRIPTION
#### 6371c7a9813368cba21d606cb2a3209d064144c1
<pre>
AX: AXTextMarkerForIndex and AXIndexForTextMarker don&apos;t round-trip in the isolated tree
<a href="https://bugs.webkit.org/show_bug.cgi?id=319672">https://bugs.webkit.org/show_bug.cgi?id=319672</a>
<a href="https://rdar.apple.com/182515917">rdar://182515917</a>

Reviewed by Tyler Wilcock and Andres Gonzalez.

AXIndexForTextMarker and AXTextMarkerForIndex are documented inverses
-- VoiceOver converts a text marker to a document-relative index and
back -- but in the isolated-tree text path the two directions were
implemented by separate traversals that counted positions differently:

- AXTextMarkerRange::toString (the string) walks findObjectWithRuns and emits a newline
  &quot;don&apos;t repeat a newline&quot; rule).
- offsetFromRoot (AXIndexForTextMarker) walked nextInPreOrder and counted newlines with
  an emitsNewline() bool that added at most 1, never accounting for DoubleNewline.
- nextMarkerFromOffset (AXTextMarkerForIndex) walked findMarker and counted every step.

Because these three disagree, converting a marker to an index and back
drifted, and the drift accumulated with each list, table, nested block
wrapper, &lt;br&gt;, and paragraph break, so selecting content further down
a page (e.g. Wikipedia) was increasingly wrong.

Make offsetFromRoot and nextMarkerFromOffset inverses by construction
by driving both from a single shared forward walk
(forEachRunObjectForward) that mirrors AXTextMarkerRange:: toString&apos;s
iteration and newline emission. The index of a marker is defined as
the number of characters before it in that walk; nextMarkerFromOffset
walks the same way until it has consumed that many characters. Image
alt text is intentionally excluded, so the index space is independent
of it. The round-trip is now exact for every real (run-position)
marker -- which is what VoiceOver round-trips -- while positions
inside an emitted newline gap, which have no marker of their own, snap
to an adjacent boundary (bounded and non-accumulating).

Tests: accessibility/mac/text-marker-index-round-trip-list.html
       accessibility/mac/text-marker-index-round-trip-nested-blocks.html
       accessibility/mac/text-marker-index-round-trip-table.html
       accessibility/mac/text-marker-index-round-trip.html

* LayoutTests/accessibility/mac/index-for-zero-offset-text-marker-expected.txt:
* LayoutTests/accessibility/mac/index-for-zero-offset-text-marker.html:
* LayoutTests/accessibility/mac/text-marker-index-round-trip-expected.txt: Added.
* LayoutTests/accessibility/mac/text-marker-index-round-trip-list-expected.txt: Added.
* LayoutTests/accessibility/mac/text-marker-index-round-trip-list.html: Added.
* LayoutTests/accessibility/mac/text-marker-index-round-trip-nested-blocks-expected.txt: Added.
* LayoutTests/accessibility/mac/text-marker-index-round-trip-nested-blocks.html: Added.
* LayoutTests/accessibility/mac/text-marker-index-round-trip-table-expected.txt: Added.
* LayoutTests/accessibility/mac/text-marker-index-round-trip-table.html: Added.
* LayoutTests/accessibility/mac/text-marker-index-round-trip.html: Added.
* LayoutTests/resources/ax-text-marker-helper.js: Added.
(checkRoundTripAllTextMarkerIndicesWithinContainer):
* Source/WebCore/accessibility/AXTextMarker.cpp:
(WebCore::runEndsWithNewline):
(WebCore::emittedNewlineLength):
(WebCore::forEachRunObjectForward):
(WebCore::AXTextMarker::offsetFromRoot const):
(WebCore::AXTextMarker::nextMarkerFromOffset const):

Canonical link: <a href="https://commits.webkit.org/317545@main">https://commits.webkit.org/317545@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fbdc7d92074e84196c99522bd1c493d9ee722cfc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175341 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49273 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43054 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184927 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/137462 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/177205 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50565 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48956 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136501 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/137462 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178298 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39924 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157255 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116979 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38565 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36940 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148988 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36748 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33402 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/40960 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41144 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187351 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48940 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/156811 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145467 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39202 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49620 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33370 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145308 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40118 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/121813 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115500 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48126 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11721 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47529 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47759 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47586 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->