### PR TITLE
[JSC] Run WPT Wasm tests in run-jsc-stress-tests' wasm.yaml

### DIFF
--- a/JSTests/wasm.yaml
+++ b/JSTests/wasm.yaml
@@ -78,3 +78,13 @@
 - path: ../PerformanceTests/JetStream2/wasm-cli.js
   cmd: runWebAssemblyJetStream2 unless parseRunCommands
 
+# Imported WPT WebAssembly tests, these are diffed against their committed -expected.txt baselines.
+# recursive: true so proposal subdirectories (core/js/gc, core/js/simd, jsapi/*, ...) are picked
+# up automatically as WPT adds them. .tentative.js tests are skipped inside run-jsc-stress-tests.
+- path: ../LayoutTests/imported/w3c/web-platform-tests/wasm/core/js
+  cmd: runWebAssemblyWPTCore unless parseRunCommands
+  recursive: true
+- path: ../LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi
+  cmd: runWebAssemblyWPTJSAPI unless parseRunCommands
+  recursive: true
+

--- a/JSTests/wasm/wpt/wpt-harness-mid.js
+++ b/JSTests/wasm/wpt/wpt-harness-mid.js
@@ -1,0 +1,13 @@
+// Loaded after resources/testharness.js and the WPT harness helpers, immediately before the test
+// file, when running the imported WPT WebAssembly tests in the `jsc` shell under
+// run-jsc-stress-tests.
+//
+// A browser takes an event-loop turn between the harness <script> and the test <script>; the jsc
+// shell load()s every file synchronously with no turn in between. The WAST core harness
+// (core/js/harness/async_index.js) installs its `spectest` import registry Proxy in a deferred
+// microtask (reinitializeRegistry -> chain.then), so without a turn here that Proxy is not yet in
+// place when a test body runs.
+//
+// explicit_done keeps testharness from finalizing the run while we drain.
+setup({ output: false, explicit_timeout: true, explicit_done: true });
+drainMicrotasks();

--- a/JSTests/wasm/wpt/wpt-harness-post.js
+++ b/JSTests/wasm/wpt/wpt-harness-post.js
@@ -1,0 +1,67 @@
+// Result reporter for running the imported WPT WebAssembly tests in the `jsc` shell under
+// run-jsc-stress-tests. Loaded last of the pre/mid/post harness shims (see wpt-harness-pre.js for
+// the load order), after the test file.
+//
+// In a browser these results are emitted by resources/testharnessreport.js into the DOM and
+// dumped as text; that path needs testRunner/document, which the shell lacks. This reproduces
+// the same text so stdout can be diffed against the committed -expected.txt baselines.
+//
+// wpt-harness-mid.js has already called setup({ explicit_done: true }), so the harness will not
+// finalize until done() is called below. Registering the completion callback first guarantees it
+// is in place for the results; done() then releases the wait, and completion fires once the
+// promise/timer chain drains via deferredWorkTimer->runRunLoop() before exit.
+
+// Title passed by the runner as a trailing `-- <title>` argument (the test's file name). The
+// browser names an unnamed block-body test after the page title; the shell's ShellTestEnvironment
+// hardcodes "Untitled"/"Untitled N" instead (that environment object is a closure local, so it
+// cannot be patched from here). Remapping the "Untitled" prefix to the title reproduces the
+// committed baseline. Single-line arrow tests derive their name from the function source in both
+// environments, so they are unaffected.
+const WPT_TITLE = (globalThis.arguments && globalThis.arguments.length) ? globalThis.arguments[0] : null;
+
+function titledName(name) {
+    if (WPT_TITLE && /^Untitled( \d+)?$/.test(name))
+        return name.replace(/^Untitled/, () => WPT_TITLE);
+    return name;
+}
+
+function convertResult(status) {
+    if (status == 0) return "PASS";
+    if (status == 1) return "FAIL";
+    if (status == 2) return "TIMEOUT";
+    return "NOTRUN";
+}
+
+function sanitize(text) {
+    if (!text)
+        return "";
+    return text.replace(/\0/g, "\\0").replace(/\r/g, "\\r");
+}
+
+add_completion_callback(function (tests, harness_status) {
+    let out = "\n";
+    if (harness_status.status != 0)
+        out += "Harness Error (" + convertResult(harness_status.status) + "), message = " +
+               harness_status.message + "\n\n";
+
+    for (const test of tests) {
+        let message = sanitize(test.message);
+        // Match the browser baseline: drop the stack from failed subtests so the text is
+        // stable across environments (testharnessreport.js does the same unless dumpStack).
+        if (test.status == 1 && !test.dumpStack) {
+            const stackIndex = message.indexOf("(stack:");
+            if (stackIndex > 0)
+                message = message.substr(0, stackIndex);
+        }
+        // Append the message only when present; the committed baselines have no trailing
+        // space after the name for passing subtests, and diff does not ignore trailing spaces.
+        out += convertResult(test.status) + " " + titledName(sanitize(test.name)) + (message ? " " + message : "") + "\n";
+    }
+
+    print(out); // print() appends the final newline, reproducing the trailing blank line.
+});
+
+// Release the explicit_done wait that wpt-harness-mid.js set; completion (and the callback above)
+// fires once the test's promise/timer chain drains.
+done();
+

--- a/JSTests/wasm/wpt/wpt-harness-pre.js
+++ b/JSTests/wasm/wpt/wpt-harness-pre.js
@@ -1,0 +1,16 @@
+// Bootstrap for running the imported WPT WebAssembly tests in the `jsc` shell under
+// run-jsc-stress-tests. It is the first of three harness shims loaded around each test:
+// wpt-harness-pre.js (this file) before resources/testharness.js (the imported WPT copy,
+// LayoutTests/imported/w3c/web-platform-tests/resources/testharness.js — the version the browser
+// loads for these tests, not LayoutTests/resources/testharness.js); wpt-harness-mid.js just before
+// the test file (it drains microtasks so the WAST harness's deferred import registry is installed,
+// and marks the run explicit_done); and wpt-harness-post.js after the test (it emits the results
+// and calls done()).
+//
+// The jsc shell has no `self` (testharness.js invokes its IIFE as `})(self)`) and leaves
+// `console` undefined, so both must be supplied here, before testharness.js loads. `console` is a
+// no-op: the browser's testharnessreport.js does not dump console output into the test text, and
+// the WAST harness binds the wasm `spectest.print` imports to `console.log` — suppressing it keeps
+// that output out of stdout so it matches the committed -expected.txt baselines.
+globalThis.self = globalThis;
+globalThis.console = { log() {}, error() {}, warn() {}, info() {}, debug() {} };

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/align.wast.js-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/align.wast.js-expected.txt
@@ -331,14 +331,14 @@ PASS #329 Test that WebAssembly compilation fails (align.wast:891)
 PASS #330 Test that WebAssembly compilation fails (align.wast:910)
 PASS #331 Test that WebAssembly compilation fails (align.wast:929)
 PASS #332 Test that WebAssembly compilation fails (align.wast:948)
-FAIL #333 Test that WebAssembly compilation fails (align.wast:967) assert_true: module@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:163:24
-assert_invalid@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:192:9
-align_wast_js@http://web-platform.test:8800/wasm/core/js/align.wast.js:562:17
-global code@http://web-platform.test:8800/wasm/core/js/align.wast.js:573:3 expected true got false
-FAIL #334 Test that WebAssembly compilation fails (align.wast:986) assert_true: module@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:163:24
-assert_invalid@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:192:9
-align_wast_js@http://web-platform.test:8800/wasm/core/js/align.wast.js:565:17
-global code@http://web-platform.test:8800/wasm/core/js/align.wast.js:573:3 expected true got false
+FAIL #333 Test that WebAssembly compilation fails (align.wast:967) assert_true: module@async_index.js:175:29
+assert_invalid@async_index.js:204:9
+align_wast_js@align.wast.js:562:17
+global code@align.wast.js:573:3 expected true got false
+FAIL #334 Test that WebAssembly compilation fails (align.wast:986) assert_true: module@async_index.js:175:29
+assert_invalid@async_index.js:204:9
+align_wast_js@align.wast.js:565:17
+global code@align.wast.js:573:3 expected true got false
 PASS #335 Test that WebAssembly compilation fails (align.wast:1004)
 PASS #336 Test that WebAssembly compilation fails (align.wast:1016)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/bulk-memory/table_init.wast.js-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/bulk-memory/table_init.wast.js-expected.txt
@@ -940,7 +940,7 @@ PASS #938 Test that WebAssembly compilation succeeds (table_init.wast:2248)
 PASS #939 Test that WebAssembly instantiation succeeds (table_init.wast:2248)
 PASS #940 Test that WebAssembly compilation succeeds (table_init.wast:2272)
 PASS #941 Test that WebAssembly instantiation succeeds (table_init.wast:2272)
-FAIL #942 Test that a WebAssembly code returns a specific result (table_init.wast:2286) assert_equals: assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_init_wast_js@http://web-platform.test:8800/wasm/core/js/bulk-memory/table_init.wast.js:2500:14
-global code@http://web-platform.test:8800/wasm/core/js/bulk-memory/table_init.wast.js:2502:3 expected 1 but got 0
+FAIL #942 Test that a WebAssembly code returns a specific result (table_init.wast:2286) assert_equals: assert_return@async_index.js:324:29
+table_init_wast_js@table_init.wast.js:2500:14
+global code@table_init.wast.js:2502:3 expected 1 but got 0
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/call_ref.wast.js-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/call_ref.wast.js-expected.txt
@@ -44,14 +44,14 @@ PASS #42 Test that a WebAssembly code traps (call_ref.wast:149)
 PASS #43 Test that WebAssembly compilation succeeds (call_ref.wast:151)
 PASS #44 Test that WebAssembly instantiation succeeds (call_ref.wast:151)
 PASS #45 Test that a WebAssembly code traps (call_ref.wast:165)
-FAIL #46 Test that WebAssembly compilation fails (call_ref.wast:167) assert_true: module@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:163:24
-assert_invalid@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:192:9
-call_ref_wast_js@http://web-platform.test:8800/wasm/core/js/call_ref.wast.js:109:15
-global code@http://web-platform.test:8800/wasm/core/js/call_ref.wast.js:120:3 expected true got false
-FAIL #47 Test that WebAssembly compilation fails (call_ref.wast:183) assert_true: module@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:163:24
-assert_invalid@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:192:9
-call_ref_wast_js@http://web-platform.test:8800/wasm/core/js/call_ref.wast.js:112:15
-global code@http://web-platform.test:8800/wasm/core/js/call_ref.wast.js:120:3 expected true got false
+FAIL #46 Test that WebAssembly compilation fails (call_ref.wast:167) assert_true: module@async_index.js:175:29
+assert_invalid@async_index.js:204:9
+call_ref_wast_js@call_ref.wast.js:109:15
+global code@call_ref.wast.js:120:3 expected true got false
+FAIL #47 Test that WebAssembly compilation fails (call_ref.wast:183) assert_true: module@async_index.js:175:29
+assert_invalid@async_index.js:204:9
+call_ref_wast_js@call_ref.wast.js:112:15
+global code@call_ref.wast.js:120:3 expected true got false
 PASS #48 Test that WebAssembly compilation fails (call_ref.wast:200)
 PASS #49 Test that WebAssembly compilation fails (call_ref.wast:210)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/gc/array_init_elem.wast.js-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/gc/array_init_elem.wast.js-expected.txt
@@ -42,12 +42,12 @@ PASS #40 Test that a WebAssembly code returns a specific result (array_init_elem
 PASS #41 Test that a WebAssembly code returns a specific result (array_init_elem.wast:154)
 PASS #42 Test that a WebAssembly code returns a specific result (array_init_elem.wast:155)
 PASS #43 Test that a WebAssembly code returns a specific result (array_init_elem.wast:156)
-FAIL #44 Test that a WebAssembly code returns a specific result (array_init_elem.wast:157) assert_equals: assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-array_init_elem_wast_js@http://web-platform.test:8800/wasm/core/js/gc/array_init_elem.wast.js:109:14
-global code@http://web-platform.test:8800/wasm/core/js/gc/array_init_elem.wast.js:120:3 expected 1 but got 0
+FAIL #44 Test that a WebAssembly code returns a specific result (array_init_elem.wast:157) assert_equals: assert_return@async_index.js:324:29
+array_init_elem_wast_js@array_init_elem.wast.js:109:14
+global code@array_init_elem.wast.js:120:3 expected 1 but got 0
 PASS #45 Test that WebAssembly compilation succeeds (array_init_elem.wast:160)
 PASS #46 Test that WebAssembly instantiation succeeds (array_init_elem.wast:160)
-FAIL #47 Test that a WebAssembly code returns a specific result (array_init_elem.wast:178) assert_equals: assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-array_init_elem_wast_js@http://web-platform.test:8800/wasm/core/js/gc/array_init_elem.wast.js:118:14
-global code@http://web-platform.test:8800/wasm/core/js/gc/array_init_elem.wast.js:120:3 expected 1 but got 0
+FAIL #47 Test that a WebAssembly code returns a specific result (array_init_elem.wast:178) assert_equals: assert_return@async_index.js:324:29
+array_init_elem_wast_js@array_init_elem.wast.js:118:14
+global code@array_init_elem.wast.js:120:3 expected 1 but got 0
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/gc/array_new_elem.wast.js-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/gc/array_new_elem.wast.js-expected.txt
@@ -34,7 +34,7 @@ PASS #32 Test that WebAssembly instantiation succeeds (array_new_elem.wast:77)
 PASS #33 Test that a WebAssembly code returns a specific result (array_new_elem.wast:103)
 PASS #34 Test that WebAssembly compilation succeeds (array_new_elem.wast:106)
 PASS #35 Test that WebAssembly instantiation succeeds (array_new_elem.wast:106)
-FAIL #36 Test that a WebAssembly code returns a specific result (array_new_elem.wast:121) assert_equals: assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-array_new_elem_wast_js@http://web-platform.test:8800/wasm/core/js/gc/array_new_elem.wast.js:88:14
-global code@http://web-platform.test:8800/wasm/core/js/gc/array_new_elem.wast.js:90:3 expected 1 but got 0
+FAIL #36 Test that a WebAssembly code returns a specific result (array_new_elem.wast:121) assert_equals: assert_return@async_index.js:324:29
+array_new_elem_wast_js@array_new_elem.wast.js:88:14
+global code@array_new_elem.wast.js:90:3 expected 1 but got 0
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/js/harness/async_index.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/js/harness/async_index.js
@@ -153,6 +153,18 @@ function binary(bytes) {
   return buffer;
 }
 
+// Captures the current call site as a stack string for use in assertion descriptions. Each
+// frame's path is reduced to its basename so the text is identical whether the tests are served
+// over HTTP (the WPT server bakes its scheme/host/port into stack URLs) or loaded from local
+// files by a command-line shell (which embeds environment-specific paths). This function's own
+// frame is elided so the location points at the caller.
+function callerLocation() {
+  let lines = new Error().stack.toString().split("\n");
+  // V8 prefixes the stack with an "Error" line; JavaScriptCore and SpiderMonkey start with frames.
+  let firstFrame = /@|^\s*at\s/.test(lines[0]) ? 0 : 1;
+  return lines.slice(firstFrame + 1).join("\n").replace(/[^\s@(]*\//g, "");
+}
+
 /**
  * Returns a compiled module, or throws if there was an error at compilation.
  */
@@ -160,7 +172,7 @@ function module(bytes, source, valid = true) {
   const test = `${ valid ? "Test that WebAssembly compilation succeeds" :
                 "Test that WebAssembly compilation fails"} (${source})`;
 
-  const loc = new Error().stack.toString().replace("Error", "");
+  const loc = callerLocation();
   let buffer = binary(bytes);
   let validated = WebAssembly.validate(buffer);
 
@@ -204,7 +216,7 @@ function instance(module, imports, valid = true) {
   let test = valid
     ? "Test that WebAssembly instantiation succeeds"
     : "Test that WebAssembly instantiation fails";
-  const loc = new Error().stack.toString().replace("Error", "");
+  const loc = callerLocation();
   chain = Promise.all([module, imports, chain])
     .then(values => {
       let imports = values[1] ? values[1] : registry;
@@ -245,7 +257,7 @@ function call(instance, name, args) {
 
 function run(action, source) {
   const test = `Run a WebAssembly test without special assertions (${source})`;
-  const loc = new Error().stack.toString().replace("Error", "");
+  const loc = callerLocation();
   chain = Promise.all([chain, action()])
     .then(
       _ => {
@@ -266,7 +278,7 @@ function run(action, source) {
 
 function assert_trap(action, source) {
   const test = `Test that a WebAssembly code traps (${source})`;
-  const loc = new Error().stack.toString().replace("Error", "");
+  const loc = callerLocation();
   chain = Promise.all([chain, action()])
     .then(
       result => {
@@ -289,7 +301,7 @@ function assert_trap(action, source) {
 
 function assert_exception(action, source) {
   const test = `Test that a WebAssembly code throws an exception (${source})`;
-  const loc = new Error().stack.toString().replace("Error", "");
+  const loc = callerLocation();
   chain = Promise.all([chain, action()])
     .then(
       result => {
@@ -309,7 +321,7 @@ function assert_exception(action, source) {
 
 function assert_return(action, source, ...expected) {
   const test = `Test that a WebAssembly code returns a specific result (${source})`;
-  const loc = new Error().stack.toString().replace("Error", "");
+  const loc = callerLocation();
   chain = Promise.all([action(), chain])
     .then(
       values => {
@@ -384,7 +396,7 @@ try {
 
 function assert_exhaustion(action) {
   const test = "Test that a WebAssembly code exhausts the stack space";
-  const loc = new Error().stack.toString().replace("Error", "");
+  const loc = callerLocation();
   chain = Promise.all([action(), chain])
     .then(
       _ => {
@@ -407,7 +419,7 @@ function assert_exhaustion(action) {
 
 function assert_unlinkable(bytes) {
   const test = "Test that a WebAssembly module is unlinkable";
-  const loc = new Error().stack.toString().replace("Error", "");
+  const loc = callerLocation();
   instance(bytes, registry, EXPECT_INVALID)
     .then(
       result => {
@@ -430,7 +442,7 @@ function assert_unlinkable(bytes) {
 
 function assert_uninstantiable(bytes) {
   const test = "Test that a WebAssembly module is uninstantiable";
-  const loc = new Error().stack.toString().replace("Error", "");
+  const loc = callerLocation();
   instance(bytes, registry, EXPECT_INVALID)
     .then(
       result => {
@@ -454,7 +466,7 @@ function assert_uninstantiable(bytes) {
 function register(name, instance) {
   const test =
     "Test that the exports of a WebAssembly module can be registered";
-  const loc = new Error().stack.toString().replace("Error", "");
+  const loc = callerLocation();
   let stack = new Error();
   chain = Promise.all([instance, chain])
     .then(
@@ -473,7 +485,7 @@ function register(name, instance) {
 
 function get(instance, name) {
   const test = "Test that an export of a WebAssembly instance can be acquired";
-  const loc = new Error().stack.toString().replace("Error", "");
+  const loc = callerLocation();
   chain = Promise.all([instance, chain]).then(
     values => {
       let v = values[0].exports[name];

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/call_indirect64.wast.js-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/call_indirect64.wast.js-expected.txt
@@ -3,10 +3,10 @@ PASS #1 Reinitialize the default imports
 FAIL #2 Test that WebAssembly compilation succeeds (call_indirect64.wast:3) assert_equals: expected false but got true
 PASS #3 Reinitialize the default imports
 FAIL #4 Test that WebAssembly compilation succeeds (call_indirect64.wast:3) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 76: Element init_expr must produce an i32 at {loc} expected true got false
-FAIL #5 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-call_indirect64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/call_indirect64.wast.js:7:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/call_indirect64.wast.js:12:3 expected true got false
-FAIL #6 Test that a WebAssembly code returns a specific result (call_indirect64.wast:26) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-call_indirect64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/call_indirect64.wast.js:10:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/call_indirect64.wast.js:12:3 expected true got false
+FAIL #5 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@async_index.js:219:29
+call_indirect64_wast_js@call_indirect64.wast.js:7:18
+global code@call_indirect64.wast.js:12:3 expected true got false
+FAIL #6 Test that a WebAssembly code returns a specific result (call_indirect64.wast:26) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+call_indirect64_wast_js@call_indirect64.wast.js:10:14
+global code@call_indirect64.wast.js:12:3 expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/memory64-imports.wast.js-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/memory64-imports.wast.js-expected.txt
@@ -136,37 +136,37 @@ PASS #134 Test that WebAssembly compilation succeeds (memory64-imports.wast:49)
 PASS #135 Test that WebAssembly instantiation fails (memory64-imports.wast:49)
 PASS #136 Test that a WebAssembly module is unlinkable
 PASS #137 Test that WebAssembly compilation succeeds (memory64-imports.wast:53)
-FAIL #138 Test that WebAssembly instantiation fails (memory64-imports.wast:53) assert_true: instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-assert_unlinkable@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:411:11
-memory64_imports_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:211:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:447:3 expected true got false
-FAIL #139 Test that a WebAssembly module is unlinkable assert_true: expected link error, observed [object WebAssembly.Instance] assert_unlinkable@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:410:24
-memory64_imports_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:211:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:447:3 expected true got false
+FAIL #138 Test that WebAssembly instantiation fails (memory64-imports.wast:53) assert_true: instance@async_index.js:219:29
+assert_unlinkable@async_index.js:423:11
+memory64_imports_wast_js@memory64-imports.wast.js:211:18
+global code@memory64-imports.wast.js:447:3 expected true got false
+FAIL #139 Test that a WebAssembly module is unlinkable assert_true: expected link error, observed [object WebAssembly.Instance] assert_unlinkable@async_index.js:422:29
+memory64_imports_wast_js@memory64-imports.wast.js:211:18
+global code@memory64-imports.wast.js:447:3 expected true got false
 PASS #140 Test that WebAssembly compilation succeeds (memory64-imports.wast:57)
-FAIL #141 Test that WebAssembly instantiation fails (memory64-imports.wast:57) assert_true: instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-assert_unlinkable@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:411:11
-memory64_imports_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:217:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:447:3 expected true got false
-FAIL #142 Test that a WebAssembly module is unlinkable assert_true: expected link error, observed [object WebAssembly.Instance] assert_unlinkable@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:410:24
-memory64_imports_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:217:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:447:3 expected true got false
+FAIL #141 Test that WebAssembly instantiation fails (memory64-imports.wast:57) assert_true: instance@async_index.js:219:29
+assert_unlinkable@async_index.js:423:11
+memory64_imports_wast_js@memory64-imports.wast.js:217:18
+global code@memory64-imports.wast.js:447:3 expected true got false
+FAIL #142 Test that a WebAssembly module is unlinkable assert_true: expected link error, observed [object WebAssembly.Instance] assert_unlinkable@async_index.js:422:29
+memory64_imports_wast_js@memory64-imports.wast.js:217:18
+global code@memory64-imports.wast.js:447:3 expected true got false
 PASS #143 Test that WebAssembly compilation succeeds (memory64-imports.wast:61)
-FAIL #144 Test that WebAssembly instantiation fails (memory64-imports.wast:61) assert_true: instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-assert_unlinkable@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:411:11
-memory64_imports_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:223:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:447:3 expected true got false
-FAIL #145 Test that a WebAssembly module is unlinkable assert_true: expected link error, observed [object WebAssembly.Instance] assert_unlinkable@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:410:24
-memory64_imports_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:223:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:447:3 expected true got false
+FAIL #144 Test that WebAssembly instantiation fails (memory64-imports.wast:61) assert_true: instance@async_index.js:219:29
+assert_unlinkable@async_index.js:423:11
+memory64_imports_wast_js@memory64-imports.wast.js:223:18
+global code@memory64-imports.wast.js:447:3 expected true got false
+FAIL #145 Test that a WebAssembly module is unlinkable assert_true: expected link error, observed [object WebAssembly.Instance] assert_unlinkable@async_index.js:422:29
+memory64_imports_wast_js@memory64-imports.wast.js:223:18
+global code@memory64-imports.wast.js:447:3 expected true got false
 PASS #146 Test that WebAssembly compilation succeeds (memory64-imports.wast:65)
-FAIL #147 Test that WebAssembly instantiation fails (memory64-imports.wast:65) assert_true: instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-assert_unlinkable@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:411:11
-memory64_imports_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:229:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:447:3 expected true got false
-FAIL #148 Test that a WebAssembly module is unlinkable assert_true: expected link error, observed [object WebAssembly.Instance] assert_unlinkable@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:410:24
-memory64_imports_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:229:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:447:3 expected true got false
+FAIL #147 Test that WebAssembly instantiation fails (memory64-imports.wast:65) assert_true: instance@async_index.js:219:29
+assert_unlinkable@async_index.js:423:11
+memory64_imports_wast_js@memory64-imports.wast.js:229:18
+global code@memory64-imports.wast.js:447:3 expected true got false
+FAIL #148 Test that a WebAssembly module is unlinkable assert_true: expected link error, observed [object WebAssembly.Instance] assert_unlinkable@async_index.js:422:29
+memory64_imports_wast_js@memory64-imports.wast.js:229:18
+global code@memory64-imports.wast.js:447:3 expected true got false
 PASS #149 Test that WebAssembly compilation succeeds (memory64-imports.wast:68)
 PASS #150 Test that WebAssembly instantiation succeeds (memory64-imports.wast:68)
 PASS #151 Test that WebAssembly compilation succeeds (memory64-imports.wast:69)

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/memory64.wast.js-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/memory64.wast.js-expected.txt
@@ -36,9 +36,9 @@ PASS #34 Test that WebAssembly compilation succeeds (memory64.wast:7)
 PASS #35 Test that WebAssembly instantiation succeeds (memory64.wast:7)
 FAIL #36 Test that WebAssembly compilation succeeds (memory64.wast:8) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 23: Memory's initial page count of 281474976710656 is invalid at {loc} expected true got false
 FAIL #37 Test that WebAssembly compilation succeeds (memory64.wast:9) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 24: Memory's maximum page count of 281474976710656 is invalid at {loc} expected true got false
-FAIL #38 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:34:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:237:3 expected true got false
+FAIL #38 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@async_index.js:219:29
+memory64_wast_js@memory64.wast.js:34:18
+global code@memory64.wast.js:237:3 expected true got false
 PASS #39 Test that WebAssembly compilation succeeds (memory64.wast:11)
 PASS #40 Test that WebAssembly instantiation succeeds (memory64.wast:11)
 PASS #41 Test that a WebAssembly code returns a specific result (memory64.wast:12)

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table_copy64.wast.js-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table_copy64.wast.js-expected.txt
@@ -1190,159 +1190,159 @@ PASS #1188 Test that a WebAssembly code traps (table_copy64.wast:1667)
 PASS #1189 Test that a WebAssembly code traps (table_copy64.wast:1668)
 PASS #1190 Test that a WebAssembly code traps (table_copy64.wast:1669)
 FAIL #1191 Test that WebAssembly compilation succeeds (table_copy64.wast:1671) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 80: Element init_expr must produce an i32 at {loc} expected true got false
-FAIL #1192 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-table_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:3418:19
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:5343:3 expected true got false
-FAIL #1193 Test that a WebAssembly code traps (table_copy64.wast:1694) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-table_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:3421:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:5343:3 expected true got false
+FAIL #1192 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@async_index.js:219:29
+table_copy64_wast_js@table_copy64.wast.js:3418:19
+global code@table_copy64.wast.js:5343:3 expected true got false
+FAIL #1193 Test that a WebAssembly code traps (table_copy64.wast:1694) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
+table_copy64_wast_js@table_copy64.wast.js:3421:12
+global code@table_copy64.wast.js:5343:3 expected true got false
 FAIL #1194 Test that WebAssembly compilation succeeds (table_copy64.wast:1696) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 80: Element init_expr must produce an i32 at {loc} expected true got false
-FAIL #1195 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-table_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:3427:19
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:5343:3 expected true got false
-FAIL #1196 Test that a WebAssembly code traps (table_copy64.wast:1719) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-table_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:3430:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:5343:3 expected true got false
+FAIL #1195 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@async_index.js:219:29
+table_copy64_wast_js@table_copy64.wast.js:3427:19
+global code@table_copy64.wast.js:5343:3 expected true got false
+FAIL #1196 Test that a WebAssembly code traps (table_copy64.wast:1719) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
+table_copy64_wast_js@table_copy64.wast.js:3430:12
+global code@table_copy64.wast.js:5343:3 expected true got false
 FAIL #1197 Test that WebAssembly compilation succeeds (table_copy64.wast:1721) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 80: Element init_expr must produce an i32 at {loc} expected true got false
-FAIL #1198 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-table_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:3436:19
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:5343:3 expected true got false
-FAIL #1199 Test that a WebAssembly code traps (table_copy64.wast:1744) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-table_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:3439:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:5343:3 expected true got false
+FAIL #1198 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@async_index.js:219:29
+table_copy64_wast_js@table_copy64.wast.js:3436:19
+global code@table_copy64.wast.js:5343:3 expected true got false
+FAIL #1199 Test that a WebAssembly code traps (table_copy64.wast:1744) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
+table_copy64_wast_js@table_copy64.wast.js:3439:12
+global code@table_copy64.wast.js:5343:3 expected true got false
 FAIL #1200 Test that WebAssembly compilation succeeds (table_copy64.wast:1746) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 80: Element init_expr must produce an i32 at {loc} expected true got false
-FAIL #1201 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-table_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:3445:19
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:5343:3 expected true got false
-FAIL #1202 Test that a WebAssembly code traps (table_copy64.wast:1769) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-table_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:3448:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:5343:3 expected true got false
+FAIL #1201 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@async_index.js:219:29
+table_copy64_wast_js@table_copy64.wast.js:3445:19
+global code@table_copy64.wast.js:5343:3 expected true got false
+FAIL #1202 Test that a WebAssembly code traps (table_copy64.wast:1769) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
+table_copy64_wast_js@table_copy64.wast.js:3448:12
+global code@table_copy64.wast.js:5343:3 expected true got false
 FAIL #1203 Test that WebAssembly compilation succeeds (table_copy64.wast:1771) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 80: Element init_expr must produce an i32 at {loc} expected true got false
-FAIL #1204 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-table_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:3454:19
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:5343:3 expected true got false
-FAIL #1205 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-table_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:3457:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:5343:3 expected true got false
+FAIL #1204 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@async_index.js:219:29
+table_copy64_wast_js@table_copy64.wast.js:3454:19
+global code@table_copy64.wast.js:5343:3 expected true got false
+FAIL #1205 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@async_index.js:260:29
+table_copy64_wast_js@table_copy64.wast.js:3457:4
+global code@table_copy64.wast.js:5343:3 expected true got false
 FAIL #1206 Test that WebAssembly compilation succeeds (table_copy64.wast:1796) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 80: Element init_expr must produce an i32 at {loc} expected true got false
-FAIL #1207 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-table_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:3463:19
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:5343:3 expected true got false
-FAIL #1208 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-table_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:3466:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:5343:3 expected true got false
+FAIL #1207 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@async_index.js:219:29
+table_copy64_wast_js@table_copy64.wast.js:3463:19
+global code@table_copy64.wast.js:5343:3 expected true got false
+FAIL #1208 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@async_index.js:260:29
+table_copy64_wast_js@table_copy64.wast.js:3466:4
+global code@table_copy64.wast.js:5343:3 expected true got false
 FAIL #1209 Test that WebAssembly compilation succeeds (table_copy64.wast:1821) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 80: Element init_expr must produce an i32 at {loc} expected true got false
-FAIL #1210 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-table_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:3472:19
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:5343:3 expected true got false
-FAIL #1211 Test that a WebAssembly code traps (table_copy64.wast:1844) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-table_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:3475:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:5343:3 expected true got false
+FAIL #1210 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@async_index.js:219:29
+table_copy64_wast_js@table_copy64.wast.js:3472:19
+global code@table_copy64.wast.js:5343:3 expected true got false
+FAIL #1211 Test that a WebAssembly code traps (table_copy64.wast:1844) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
+table_copy64_wast_js@table_copy64.wast.js:3475:12
+global code@table_copy64.wast.js:5343:3 expected true got false
 FAIL #1212 Test that WebAssembly compilation succeeds (table_copy64.wast:1846) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 80: Element init_expr must produce an i32 at {loc} expected true got false
-FAIL #1213 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-table_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:3481:19
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:5343:3 expected true got false
-FAIL #1214 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-table_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:3484:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:5343:3 expected true got false
+FAIL #1213 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@async_index.js:219:29
+table_copy64_wast_js@table_copy64.wast.js:3481:19
+global code@table_copy64.wast.js:5343:3 expected true got false
+FAIL #1214 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@async_index.js:260:29
+table_copy64_wast_js@table_copy64.wast.js:3484:4
+global code@table_copy64.wast.js:5343:3 expected true got false
 FAIL #1215 Test that WebAssembly compilation succeeds (table_copy64.wast:1871) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 80: Element init_expr must produce an i32 at {loc} expected true got false
-FAIL #1216 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-table_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:3490:19
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:5343:3 expected true got false
-FAIL #1217 Test that a WebAssembly code traps (table_copy64.wast:1894) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-table_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:3493:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:5343:3 expected true got false
+FAIL #1216 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@async_index.js:219:29
+table_copy64_wast_js@table_copy64.wast.js:3490:19
+global code@table_copy64.wast.js:5343:3 expected true got false
+FAIL #1217 Test that a WebAssembly code traps (table_copy64.wast:1894) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
+table_copy64_wast_js@table_copy64.wast.js:3493:12
+global code@table_copy64.wast.js:5343:3 expected true got false
 FAIL #1218 Test that WebAssembly compilation succeeds (table_copy64.wast:1896) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 80: Element init_expr must produce an i32 at {loc} expected true got false
-FAIL #1219 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-table_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:3499:19
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:5343:3 expected true got false
-FAIL #1220 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-table_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:3502:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:5343:3 expected true got false
+FAIL #1219 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@async_index.js:219:29
+table_copy64_wast_js@table_copy64.wast.js:3499:19
+global code@table_copy64.wast.js:5343:3 expected true got false
+FAIL #1220 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@async_index.js:260:29
+table_copy64_wast_js@table_copy64.wast.js:3502:4
+global code@table_copy64.wast.js:5343:3 expected true got false
 FAIL #1221 Test that WebAssembly compilation succeeds (table_copy64.wast:1921) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 80: Element init_expr must produce an i32 at {loc} expected true got false
-FAIL #1222 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-table_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:3508:19
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:5343:3 expected true got false
-FAIL #1223 Test that a WebAssembly code traps (table_copy64.wast:1944) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-table_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:3511:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:5343:3 expected true got false
+FAIL #1222 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@async_index.js:219:29
+table_copy64_wast_js@table_copy64.wast.js:3508:19
+global code@table_copy64.wast.js:5343:3 expected true got false
+FAIL #1223 Test that a WebAssembly code traps (table_copy64.wast:1944) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
+table_copy64_wast_js@table_copy64.wast.js:3511:12
+global code@table_copy64.wast.js:5343:3 expected true got false
 FAIL #1224 Test that WebAssembly compilation succeeds (table_copy64.wast:1946) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 80: Element init_expr must produce an i32 at {loc} expected true got false
-FAIL #1225 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-table_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:3517:19
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:5343:3 expected true got false
-FAIL #1226 Test that a WebAssembly code traps (table_copy64.wast:1969) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-table_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:3520:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:5343:3 expected true got false
+FAIL #1225 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@async_index.js:219:29
+table_copy64_wast_js@table_copy64.wast.js:3517:19
+global code@table_copy64.wast.js:5343:3 expected true got false
+FAIL #1226 Test that a WebAssembly code traps (table_copy64.wast:1969) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
+table_copy64_wast_js@table_copy64.wast.js:3520:12
+global code@table_copy64.wast.js:5343:3 expected true got false
 FAIL #1227 Test that WebAssembly compilation succeeds (table_copy64.wast:1971) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 80: Element init_expr must produce an i32 at {loc} expected true got false
-FAIL #1228 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-table_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:3526:19
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:5343:3 expected true got false
-FAIL #1229 Test that a WebAssembly code traps (table_copy64.wast:1994) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-table_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:3529:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:5343:3 expected true got false
+FAIL #1228 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@async_index.js:219:29
+table_copy64_wast_js@table_copy64.wast.js:3526:19
+global code@table_copy64.wast.js:5343:3 expected true got false
+FAIL #1229 Test that a WebAssembly code traps (table_copy64.wast:1994) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
+table_copy64_wast_js@table_copy64.wast.js:3529:12
+global code@table_copy64.wast.js:5343:3 expected true got false
 FAIL #1230 Test that WebAssembly compilation succeeds (table_copy64.wast:1996) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 80: Element init_expr must produce an i32 at {loc} expected true got false
-FAIL #1231 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-table_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:3535:19
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:5343:3 expected true got false
-FAIL #1232 Test that a WebAssembly code traps (table_copy64.wast:2019) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-table_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:3538:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:5343:3 expected true got false
+FAIL #1231 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@async_index.js:219:29
+table_copy64_wast_js@table_copy64.wast.js:3535:19
+global code@table_copy64.wast.js:5343:3 expected true got false
+FAIL #1232 Test that a WebAssembly code traps (table_copy64.wast:2019) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
+table_copy64_wast_js@table_copy64.wast.js:3538:12
+global code@table_copy64.wast.js:5343:3 expected true got false
 FAIL #1233 Test that WebAssembly compilation succeeds (table_copy64.wast:2021) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 80: Element init_expr must produce an i32 at {loc} expected true got false
-FAIL #1234 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-table_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:3544:19
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:5343:3 expected true got false
-FAIL #1235 Test that a WebAssembly code traps (table_copy64.wast:2044) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-table_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:3547:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:5343:3 expected true got false
+FAIL #1234 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@async_index.js:219:29
+table_copy64_wast_js@table_copy64.wast.js:3544:19
+global code@table_copy64.wast.js:5343:3 expected true got false
+FAIL #1235 Test that a WebAssembly code traps (table_copy64.wast:2044) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
+table_copy64_wast_js@table_copy64.wast.js:3547:12
+global code@table_copy64.wast.js:5343:3 expected true got false
 FAIL #1236 Test that WebAssembly compilation succeeds (table_copy64.wast:2046) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 80: Element init_expr must produce an i32 at {loc} expected true got false
-FAIL #1237 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-table_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:3553:19
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:5343:3 expected true got false
-FAIL #1238 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-table_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:3556:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:5343:3 expected true got false
+FAIL #1237 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@async_index.js:219:29
+table_copy64_wast_js@table_copy64.wast.js:3553:19
+global code@table_copy64.wast.js:5343:3 expected true got false
+FAIL #1238 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@async_index.js:260:29
+table_copy64_wast_js@table_copy64.wast.js:3556:4
+global code@table_copy64.wast.js:5343:3 expected true got false
 FAIL #1239 Test that WebAssembly compilation succeeds (table_copy64.wast:2071) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 80: Element init_expr must produce an i32 at {loc} expected true got false
-FAIL #1240 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-table_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:3562:19
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:5343:3 expected true got false
-FAIL #1241 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-table_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:3565:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:5343:3 expected true got false
+FAIL #1240 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@async_index.js:219:29
+table_copy64_wast_js@table_copy64.wast.js:3562:19
+global code@table_copy64.wast.js:5343:3 expected true got false
+FAIL #1241 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@async_index.js:260:29
+table_copy64_wast_js@table_copy64.wast.js:3565:4
+global code@table_copy64.wast.js:5343:3 expected true got false
 FAIL #1242 Test that WebAssembly compilation succeeds (table_copy64.wast:2096) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 80: Element init_expr must produce an i32 at {loc} expected true got false
-FAIL #1243 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-table_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:3571:19
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:5343:3 expected true got false
-FAIL #1244 Test that a WebAssembly code traps (table_copy64.wast:2119) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-table_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:3574:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:5343:3 expected true got false
+FAIL #1243 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@async_index.js:219:29
+table_copy64_wast_js@table_copy64.wast.js:3571:19
+global code@table_copy64.wast.js:5343:3 expected true got false
+FAIL #1244 Test that a WebAssembly code traps (table_copy64.wast:2119) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
+table_copy64_wast_js@table_copy64.wast.js:3574:12
+global code@table_copy64.wast.js:5343:3 expected true got false
 FAIL #1245 Test that WebAssembly compilation succeeds (table_copy64.wast:2121) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 80: Element init_expr must produce an i32 at {loc} expected true got false
-FAIL #1246 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-table_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:3580:19
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:5343:3 expected true got false
-FAIL #1247 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-table_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:3583:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:5343:3 expected true got false
+FAIL #1246 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@async_index.js:219:29
+table_copy64_wast_js@table_copy64.wast.js:3580:19
+global code@table_copy64.wast.js:5343:3 expected true got false
+FAIL #1247 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@async_index.js:260:29
+table_copy64_wast_js@table_copy64.wast.js:3583:4
+global code@table_copy64.wast.js:5343:3 expected true got false
 FAIL #1248 Test that WebAssembly compilation succeeds (table_copy64.wast:2146) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 80: Element init_expr must produce an i32 at {loc} expected true got false
-FAIL #1249 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-table_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:3589:19
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:5343:3 expected true got false
-FAIL #1250 Test that a WebAssembly code traps (table_copy64.wast:2169) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-table_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:3592:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:5343:3 expected true got false
+FAIL #1249 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@async_index.js:219:29
+table_copy64_wast_js@table_copy64.wast.js:3589:19
+global code@table_copy64.wast.js:5343:3 expected true got false
+FAIL #1250 Test that a WebAssembly code traps (table_copy64.wast:2169) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
+table_copy64_wast_js@table_copy64.wast.js:3592:12
+global code@table_copy64.wast.js:5343:3 expected true got false
 FAIL #1251 Test that WebAssembly compilation succeeds (table_copy64.wast:2171) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 80: Element init_expr must produce an i32 at {loc} expected true got false
-FAIL #1252 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-table_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:3598:19
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:5343:3 expected true got false
-FAIL #1253 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-table_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:3601:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:5343:3 expected true got false
+FAIL #1252 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@async_index.js:219:29
+table_copy64_wast_js@table_copy64.wast.js:3598:19
+global code@table_copy64.wast.js:5343:3 expected true got false
+FAIL #1253 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@async_index.js:260:29
+table_copy64_wast_js@table_copy64.wast.js:3601:4
+global code@table_copy64.wast.js:5343:3 expected true got false
 FAIL #1254 Test that WebAssembly compilation succeeds (table_copy64.wast:2196) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 80: Element init_expr must produce an i32 at {loc} expected true got false
-FAIL #1255 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-table_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:3607:19
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:5343:3 expected true got false
-FAIL #1256 Test that a WebAssembly code traps (table_copy64.wast:2219) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-table_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:3610:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:5343:3 expected true got false
+FAIL #1255 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@async_index.js:219:29
+table_copy64_wast_js@table_copy64.wast.js:3607:19
+global code@table_copy64.wast.js:5343:3 expected true got false
+FAIL #1256 Test that a WebAssembly code traps (table_copy64.wast:2219) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
+table_copy64_wast_js@table_copy64.wast.js:3610:12
+global code@table_copy64.wast.js:5343:3 expected true got false
 PASS #1257 Test that WebAssembly compilation succeeds (table_copy64.wast:2221)
 PASS #1258 Test that WebAssembly instantiation succeeds (table_copy64.wast:2221)
 PASS #1259 Test that a WebAssembly code traps (table_copy64.wast:2247)

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table_copy_mixed.wast.js-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table_copy_mixed.wast.js-expected.txt
@@ -6,13 +6,13 @@ FAIL #4 Test that WebAssembly compilation fails (table_copy_mixed.wast:30) asser
 PASS #5 Test that WebAssembly compilation fails (table_copy_mixed.wast:40)
 PASS #6 Reinitialize the default imports
 FAIL #7 Test that WebAssembly compilation succeeds (table_copy_mixed.wast:2) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't validate: table.copy dst_offset to type I64 expected I32, in function at index 1 at {loc} expected true got false
-FAIL #8 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-table_copy_mixed_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_copy_mixed.wast.js:7:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_copy_mixed.wast.js:18:3 expected true got false
+FAIL #8 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@async_index.js:219:29
+table_copy_mixed_wast_js@table_copy_mixed.wast.js:7:18
+global code@table_copy_mixed.wast.js:18:3 expected true got false
 PASS #9 Test that WebAssembly compilation fails (table_copy_mixed.wast:20)
-FAIL #10 Test that WebAssembly compilation fails (table_copy_mixed.wast:30) assert_true: module@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:163:24
-assert_invalid@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:192:9
-table_copy_mixed_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_copy_mixed.wast.js:13:15
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_copy_mixed.wast.js:18:3 expected true got false
+FAIL #10 Test that WebAssembly compilation fails (table_copy_mixed.wast:30) assert_true: module@async_index.js:175:29
+assert_invalid@async_index.js:204:9
+table_copy_mixed_wast_js@table_copy_mixed.wast.js:13:15
+global code@table_copy_mixed.wast.js:18:3 expected true got false
 PASS #11 Test that WebAssembly compilation fails (table_copy_mixed.wast:40)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table_fill64.wast.js-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table_fill64.wast.js-expected.txt
@@ -12,219 +12,219 @@ PASS #10 Test that WebAssembly compilation fails (table_fill64.wast:203)
 PASS #11 Test that WebAssembly compilation fails (table_fill64.wast:214)
 PASS #12 Reinitialize the default imports
 FAIL #13 Test that WebAssembly compilation succeeds (table_fill64.wast:1) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't validate: table.fill expects an i32 offset value, got I64, in function at index 3 at {loc} expected true got false
-FAIL #14 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-table_fill64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:7:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:246:3 expected true got false
-FAIL #15 Test that a WebAssembly code returns a specific result (table_fill64.wast:27) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_fill64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:10:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:246:3 expected true got false
-FAIL #16 Test that a WebAssembly code returns a specific result (table_fill64.wast:28) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_fill64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:13:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:246:3 expected true got false
-FAIL #17 Test that a WebAssembly code returns a specific result (table_fill64.wast:29) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_fill64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:16:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:246:3 expected true got false
-FAIL #18 Test that a WebAssembly code returns a specific result (table_fill64.wast:30) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_fill64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:19:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:246:3 expected true got false
-FAIL #19 Test that a WebAssembly code returns a specific result (table_fill64.wast:31) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_fill64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:22:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:246:3 expected true got false
-FAIL #20 Test that a WebAssembly code returns a specific result (table_fill64.wast:33) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_fill64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:25:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:246:3 expected true got false
-FAIL #21 Test that a WebAssembly code returns a specific result (table_fill64.wast:34) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_fill64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:28:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:246:3 expected true got false
-FAIL #22 Test that a WebAssembly code returns a specific result (table_fill64.wast:35) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_fill64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:31:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:246:3 expected true got false
-FAIL #23 Test that a WebAssembly code returns a specific result (table_fill64.wast:36) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_fill64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:34:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:246:3 expected true got false
-FAIL #24 Test that a WebAssembly code returns a specific result (table_fill64.wast:37) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_fill64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:37:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:246:3 expected true got false
-FAIL #25 Test that a WebAssembly code returns a specific result (table_fill64.wast:38) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_fill64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:40:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:246:3 expected true got false
-FAIL #26 Test that a WebAssembly code returns a specific result (table_fill64.wast:40) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_fill64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:43:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:246:3 expected true got false
-FAIL #27 Test that a WebAssembly code returns a specific result (table_fill64.wast:41) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_fill64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:46:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:246:3 expected true got false
-FAIL #28 Test that a WebAssembly code returns a specific result (table_fill64.wast:42) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_fill64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:49:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:246:3 expected true got false
-FAIL #29 Test that a WebAssembly code returns a specific result (table_fill64.wast:43) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_fill64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:52:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:246:3 expected true got false
-FAIL #30 Test that a WebAssembly code returns a specific result (table_fill64.wast:44) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_fill64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:55:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:246:3 expected true got false
-FAIL #31 Test that a WebAssembly code returns a specific result (table_fill64.wast:46) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_fill64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:58:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:246:3 expected true got false
-FAIL #32 Test that a WebAssembly code returns a specific result (table_fill64.wast:47) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_fill64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:61:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:246:3 expected true got false
-FAIL #33 Test that a WebAssembly code returns a specific result (table_fill64.wast:48) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_fill64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:64:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:246:3 expected true got false
-FAIL #34 Test that a WebAssembly code returns a specific result (table_fill64.wast:49) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_fill64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:67:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:246:3 expected true got false
-FAIL #35 Test that a WebAssembly code returns a specific result (table_fill64.wast:51) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_fill64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:70:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:246:3 expected true got false
-FAIL #36 Test that a WebAssembly code returns a specific result (table_fill64.wast:52) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_fill64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:73:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:246:3 expected true got false
-FAIL #37 Test that a WebAssembly code returns a specific result (table_fill64.wast:53) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_fill64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:76:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:246:3 expected true got false
-FAIL #38 Test that a WebAssembly code returns a specific result (table_fill64.wast:54) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_fill64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:79:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:246:3 expected true got false
-FAIL #39 Test that a WebAssembly code returns a specific result (table_fill64.wast:56) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_fill64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:82:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:246:3 expected true got false
-FAIL #40 Test that a WebAssembly code returns a specific result (table_fill64.wast:57) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_fill64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:85:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:246:3 expected true got false
-FAIL #41 Test that a WebAssembly code returns a specific result (table_fill64.wast:58) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_fill64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:88:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:246:3 expected true got false
-FAIL #42 Test that a WebAssembly code returns a specific result (table_fill64.wast:60) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_fill64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:91:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:246:3 expected true got false
-FAIL #43 Test that a WebAssembly code returns a specific result (table_fill64.wast:61) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_fill64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:94:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:246:3 expected true got false
-FAIL #44 Test that a WebAssembly code traps (table_fill64.wast:63) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-table_fill64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:97:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:246:3 expected true got false
-FAIL #45 Test that a WebAssembly code returns a specific result (table_fill64.wast:67) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_fill64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:100:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:246:3 expected true got false
-FAIL #46 Test that a WebAssembly code returns a specific result (table_fill64.wast:68) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_fill64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:103:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:246:3 expected true got false
-FAIL #47 Test that a WebAssembly code returns a specific result (table_fill64.wast:69) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_fill64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:106:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:246:3 expected true got false
-FAIL #48 Test that a WebAssembly code traps (table_fill64.wast:71) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-table_fill64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:109:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:246:3 expected true got false
-FAIL #49 Test that a WebAssembly code traps (table_fill64.wast:76) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-table_fill64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:112:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:246:3 expected true got false
-FAIL #50 Test that a WebAssembly code returns a specific result (table_fill64.wast:83) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_fill64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:115:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:246:3 expected true got false
-FAIL #51 Test that a WebAssembly code returns a specific result (table_fill64.wast:84) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_fill64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:118:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:246:3 expected true got false
-FAIL #52 Test that a WebAssembly code returns a specific result (table_fill64.wast:85) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_fill64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:121:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:246:3 expected true got false
-FAIL #53 Test that a WebAssembly code returns a specific result (table_fill64.wast:86) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_fill64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:124:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:246:3 expected true got false
-FAIL #54 Test that a WebAssembly code returns a specific result (table_fill64.wast:87) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_fill64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:127:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:246:3 expected true got false
-FAIL #55 Test that a WebAssembly code returns a specific result (table_fill64.wast:89) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_fill64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:130:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:246:3 expected true got false
-FAIL #56 Test that a WebAssembly code returns a specific result (table_fill64.wast:90) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_fill64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:133:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:246:3 expected true got false
-FAIL #57 Test that a WebAssembly code returns a specific result (table_fill64.wast:91) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_fill64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:136:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:246:3 expected true got false
-FAIL #58 Test that a WebAssembly code returns a specific result (table_fill64.wast:92) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_fill64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:139:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:246:3 expected true got false
-FAIL #59 Test that a WebAssembly code returns a specific result (table_fill64.wast:93) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_fill64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:142:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:246:3 expected true got false
-FAIL #60 Test that a WebAssembly code returns a specific result (table_fill64.wast:94) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_fill64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:145:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:246:3 expected true got false
-FAIL #61 Test that a WebAssembly code returns a specific result (table_fill64.wast:96) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_fill64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:148:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:246:3 expected true got false
-FAIL #62 Test that a WebAssembly code returns a specific result (table_fill64.wast:97) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_fill64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:151:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:246:3 expected true got false
-FAIL #63 Test that a WebAssembly code returns a specific result (table_fill64.wast:98) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_fill64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:154:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:246:3 expected true got false
-FAIL #64 Test that a WebAssembly code returns a specific result (table_fill64.wast:99) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_fill64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:157:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:246:3 expected true got false
-FAIL #65 Test that a WebAssembly code returns a specific result (table_fill64.wast:100) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_fill64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:160:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:246:3 expected true got false
-FAIL #66 Test that a WebAssembly code returns a specific result (table_fill64.wast:102) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_fill64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:163:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:246:3 expected true got false
-FAIL #67 Test that a WebAssembly code returns a specific result (table_fill64.wast:103) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_fill64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:166:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:246:3 expected true got false
-FAIL #68 Test that a WebAssembly code returns a specific result (table_fill64.wast:104) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_fill64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:169:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:246:3 expected true got false
-FAIL #69 Test that a WebAssembly code returns a specific result (table_fill64.wast:105) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_fill64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:172:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:246:3 expected true got false
-FAIL #70 Test that a WebAssembly code returns a specific result (table_fill64.wast:107) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_fill64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:175:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:246:3 expected true got false
-FAIL #71 Test that a WebAssembly code returns a specific result (table_fill64.wast:108) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_fill64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:178:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:246:3 expected true got false
-FAIL #72 Test that a WebAssembly code returns a specific result (table_fill64.wast:109) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_fill64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:181:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:246:3 expected true got false
-FAIL #73 Test that a WebAssembly code returns a specific result (table_fill64.wast:110) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_fill64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:184:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:246:3 expected true got false
-FAIL #74 Test that a WebAssembly code returns a specific result (table_fill64.wast:112) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_fill64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:187:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:246:3 expected true got false
-FAIL #75 Test that a WebAssembly code returns a specific result (table_fill64.wast:113) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_fill64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:190:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:246:3 expected true got false
-FAIL #76 Test that a WebAssembly code returns a specific result (table_fill64.wast:114) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_fill64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:193:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:246:3 expected true got false
-FAIL #77 Test that a WebAssembly code returns a specific result (table_fill64.wast:116) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_fill64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:196:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:246:3 expected true got false
-FAIL #78 Test that a WebAssembly code returns a specific result (table_fill64.wast:117) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_fill64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:199:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:246:3 expected true got false
-FAIL #79 Test that a WebAssembly code traps (table_fill64.wast:119) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-table_fill64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:202:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:246:3 expected true got false
-FAIL #80 Test that a WebAssembly code returns a specific result (table_fill64.wast:123) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_fill64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:205:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:246:3 expected true got false
-FAIL #81 Test that a WebAssembly code returns a specific result (table_fill64.wast:124) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_fill64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:208:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:246:3 expected true got false
-FAIL #82 Test that a WebAssembly code returns a specific result (table_fill64.wast:125) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_fill64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:211:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:246:3 expected true got false
-FAIL #83 Test that a WebAssembly code traps (table_fill64.wast:127) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-table_fill64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:214:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:246:3 expected true got false
-FAIL #84 Test that a WebAssembly code traps (table_fill64.wast:132) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-table_fill64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:217:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:246:3 expected true got false
+FAIL #14 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@async_index.js:219:29
+table_fill64_wast_js@table_fill64.wast.js:7:18
+global code@table_fill64.wast.js:246:3 expected true got false
+FAIL #15 Test that a WebAssembly code returns a specific result (table_fill64.wast:27) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_fill64_wast_js@table_fill64.wast.js:10:14
+global code@table_fill64.wast.js:246:3 expected true got false
+FAIL #16 Test that a WebAssembly code returns a specific result (table_fill64.wast:28) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_fill64_wast_js@table_fill64.wast.js:13:14
+global code@table_fill64.wast.js:246:3 expected true got false
+FAIL #17 Test that a WebAssembly code returns a specific result (table_fill64.wast:29) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_fill64_wast_js@table_fill64.wast.js:16:14
+global code@table_fill64.wast.js:246:3 expected true got false
+FAIL #18 Test that a WebAssembly code returns a specific result (table_fill64.wast:30) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_fill64_wast_js@table_fill64.wast.js:19:14
+global code@table_fill64.wast.js:246:3 expected true got false
+FAIL #19 Test that a WebAssembly code returns a specific result (table_fill64.wast:31) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_fill64_wast_js@table_fill64.wast.js:22:14
+global code@table_fill64.wast.js:246:3 expected true got false
+FAIL #20 Test that a WebAssembly code returns a specific result (table_fill64.wast:33) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_fill64_wast_js@table_fill64.wast.js:25:14
+global code@table_fill64.wast.js:246:3 expected true got false
+FAIL #21 Test that a WebAssembly code returns a specific result (table_fill64.wast:34) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_fill64_wast_js@table_fill64.wast.js:28:14
+global code@table_fill64.wast.js:246:3 expected true got false
+FAIL #22 Test that a WebAssembly code returns a specific result (table_fill64.wast:35) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_fill64_wast_js@table_fill64.wast.js:31:14
+global code@table_fill64.wast.js:246:3 expected true got false
+FAIL #23 Test that a WebAssembly code returns a specific result (table_fill64.wast:36) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_fill64_wast_js@table_fill64.wast.js:34:14
+global code@table_fill64.wast.js:246:3 expected true got false
+FAIL #24 Test that a WebAssembly code returns a specific result (table_fill64.wast:37) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_fill64_wast_js@table_fill64.wast.js:37:14
+global code@table_fill64.wast.js:246:3 expected true got false
+FAIL #25 Test that a WebAssembly code returns a specific result (table_fill64.wast:38) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_fill64_wast_js@table_fill64.wast.js:40:14
+global code@table_fill64.wast.js:246:3 expected true got false
+FAIL #26 Test that a WebAssembly code returns a specific result (table_fill64.wast:40) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_fill64_wast_js@table_fill64.wast.js:43:14
+global code@table_fill64.wast.js:246:3 expected true got false
+FAIL #27 Test that a WebAssembly code returns a specific result (table_fill64.wast:41) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_fill64_wast_js@table_fill64.wast.js:46:14
+global code@table_fill64.wast.js:246:3 expected true got false
+FAIL #28 Test that a WebAssembly code returns a specific result (table_fill64.wast:42) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_fill64_wast_js@table_fill64.wast.js:49:14
+global code@table_fill64.wast.js:246:3 expected true got false
+FAIL #29 Test that a WebAssembly code returns a specific result (table_fill64.wast:43) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_fill64_wast_js@table_fill64.wast.js:52:14
+global code@table_fill64.wast.js:246:3 expected true got false
+FAIL #30 Test that a WebAssembly code returns a specific result (table_fill64.wast:44) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_fill64_wast_js@table_fill64.wast.js:55:14
+global code@table_fill64.wast.js:246:3 expected true got false
+FAIL #31 Test that a WebAssembly code returns a specific result (table_fill64.wast:46) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_fill64_wast_js@table_fill64.wast.js:58:14
+global code@table_fill64.wast.js:246:3 expected true got false
+FAIL #32 Test that a WebAssembly code returns a specific result (table_fill64.wast:47) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_fill64_wast_js@table_fill64.wast.js:61:14
+global code@table_fill64.wast.js:246:3 expected true got false
+FAIL #33 Test that a WebAssembly code returns a specific result (table_fill64.wast:48) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_fill64_wast_js@table_fill64.wast.js:64:14
+global code@table_fill64.wast.js:246:3 expected true got false
+FAIL #34 Test that a WebAssembly code returns a specific result (table_fill64.wast:49) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_fill64_wast_js@table_fill64.wast.js:67:14
+global code@table_fill64.wast.js:246:3 expected true got false
+FAIL #35 Test that a WebAssembly code returns a specific result (table_fill64.wast:51) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_fill64_wast_js@table_fill64.wast.js:70:14
+global code@table_fill64.wast.js:246:3 expected true got false
+FAIL #36 Test that a WebAssembly code returns a specific result (table_fill64.wast:52) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_fill64_wast_js@table_fill64.wast.js:73:14
+global code@table_fill64.wast.js:246:3 expected true got false
+FAIL #37 Test that a WebAssembly code returns a specific result (table_fill64.wast:53) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_fill64_wast_js@table_fill64.wast.js:76:14
+global code@table_fill64.wast.js:246:3 expected true got false
+FAIL #38 Test that a WebAssembly code returns a specific result (table_fill64.wast:54) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_fill64_wast_js@table_fill64.wast.js:79:14
+global code@table_fill64.wast.js:246:3 expected true got false
+FAIL #39 Test that a WebAssembly code returns a specific result (table_fill64.wast:56) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_fill64_wast_js@table_fill64.wast.js:82:14
+global code@table_fill64.wast.js:246:3 expected true got false
+FAIL #40 Test that a WebAssembly code returns a specific result (table_fill64.wast:57) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_fill64_wast_js@table_fill64.wast.js:85:14
+global code@table_fill64.wast.js:246:3 expected true got false
+FAIL #41 Test that a WebAssembly code returns a specific result (table_fill64.wast:58) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_fill64_wast_js@table_fill64.wast.js:88:14
+global code@table_fill64.wast.js:246:3 expected true got false
+FAIL #42 Test that a WebAssembly code returns a specific result (table_fill64.wast:60) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_fill64_wast_js@table_fill64.wast.js:91:14
+global code@table_fill64.wast.js:246:3 expected true got false
+FAIL #43 Test that a WebAssembly code returns a specific result (table_fill64.wast:61) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_fill64_wast_js@table_fill64.wast.js:94:14
+global code@table_fill64.wast.js:246:3 expected true got false
+FAIL #44 Test that a WebAssembly code traps (table_fill64.wast:63) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
+table_fill64_wast_js@table_fill64.wast.js:97:12
+global code@table_fill64.wast.js:246:3 expected true got false
+FAIL #45 Test that a WebAssembly code returns a specific result (table_fill64.wast:67) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_fill64_wast_js@table_fill64.wast.js:100:14
+global code@table_fill64.wast.js:246:3 expected true got false
+FAIL #46 Test that a WebAssembly code returns a specific result (table_fill64.wast:68) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_fill64_wast_js@table_fill64.wast.js:103:14
+global code@table_fill64.wast.js:246:3 expected true got false
+FAIL #47 Test that a WebAssembly code returns a specific result (table_fill64.wast:69) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_fill64_wast_js@table_fill64.wast.js:106:14
+global code@table_fill64.wast.js:246:3 expected true got false
+FAIL #48 Test that a WebAssembly code traps (table_fill64.wast:71) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
+table_fill64_wast_js@table_fill64.wast.js:109:12
+global code@table_fill64.wast.js:246:3 expected true got false
+FAIL #49 Test that a WebAssembly code traps (table_fill64.wast:76) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
+table_fill64_wast_js@table_fill64.wast.js:112:12
+global code@table_fill64.wast.js:246:3 expected true got false
+FAIL #50 Test that a WebAssembly code returns a specific result (table_fill64.wast:83) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_fill64_wast_js@table_fill64.wast.js:115:14
+global code@table_fill64.wast.js:246:3 expected true got false
+FAIL #51 Test that a WebAssembly code returns a specific result (table_fill64.wast:84) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_fill64_wast_js@table_fill64.wast.js:118:14
+global code@table_fill64.wast.js:246:3 expected true got false
+FAIL #52 Test that a WebAssembly code returns a specific result (table_fill64.wast:85) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_fill64_wast_js@table_fill64.wast.js:121:14
+global code@table_fill64.wast.js:246:3 expected true got false
+FAIL #53 Test that a WebAssembly code returns a specific result (table_fill64.wast:86) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_fill64_wast_js@table_fill64.wast.js:124:14
+global code@table_fill64.wast.js:246:3 expected true got false
+FAIL #54 Test that a WebAssembly code returns a specific result (table_fill64.wast:87) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_fill64_wast_js@table_fill64.wast.js:127:14
+global code@table_fill64.wast.js:246:3 expected true got false
+FAIL #55 Test that a WebAssembly code returns a specific result (table_fill64.wast:89) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_fill64_wast_js@table_fill64.wast.js:130:14
+global code@table_fill64.wast.js:246:3 expected true got false
+FAIL #56 Test that a WebAssembly code returns a specific result (table_fill64.wast:90) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_fill64_wast_js@table_fill64.wast.js:133:14
+global code@table_fill64.wast.js:246:3 expected true got false
+FAIL #57 Test that a WebAssembly code returns a specific result (table_fill64.wast:91) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_fill64_wast_js@table_fill64.wast.js:136:14
+global code@table_fill64.wast.js:246:3 expected true got false
+FAIL #58 Test that a WebAssembly code returns a specific result (table_fill64.wast:92) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_fill64_wast_js@table_fill64.wast.js:139:14
+global code@table_fill64.wast.js:246:3 expected true got false
+FAIL #59 Test that a WebAssembly code returns a specific result (table_fill64.wast:93) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_fill64_wast_js@table_fill64.wast.js:142:14
+global code@table_fill64.wast.js:246:3 expected true got false
+FAIL #60 Test that a WebAssembly code returns a specific result (table_fill64.wast:94) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_fill64_wast_js@table_fill64.wast.js:145:14
+global code@table_fill64.wast.js:246:3 expected true got false
+FAIL #61 Test that a WebAssembly code returns a specific result (table_fill64.wast:96) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_fill64_wast_js@table_fill64.wast.js:148:14
+global code@table_fill64.wast.js:246:3 expected true got false
+FAIL #62 Test that a WebAssembly code returns a specific result (table_fill64.wast:97) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_fill64_wast_js@table_fill64.wast.js:151:14
+global code@table_fill64.wast.js:246:3 expected true got false
+FAIL #63 Test that a WebAssembly code returns a specific result (table_fill64.wast:98) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_fill64_wast_js@table_fill64.wast.js:154:14
+global code@table_fill64.wast.js:246:3 expected true got false
+FAIL #64 Test that a WebAssembly code returns a specific result (table_fill64.wast:99) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_fill64_wast_js@table_fill64.wast.js:157:14
+global code@table_fill64.wast.js:246:3 expected true got false
+FAIL #65 Test that a WebAssembly code returns a specific result (table_fill64.wast:100) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_fill64_wast_js@table_fill64.wast.js:160:14
+global code@table_fill64.wast.js:246:3 expected true got false
+FAIL #66 Test that a WebAssembly code returns a specific result (table_fill64.wast:102) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_fill64_wast_js@table_fill64.wast.js:163:14
+global code@table_fill64.wast.js:246:3 expected true got false
+FAIL #67 Test that a WebAssembly code returns a specific result (table_fill64.wast:103) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_fill64_wast_js@table_fill64.wast.js:166:14
+global code@table_fill64.wast.js:246:3 expected true got false
+FAIL #68 Test that a WebAssembly code returns a specific result (table_fill64.wast:104) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_fill64_wast_js@table_fill64.wast.js:169:14
+global code@table_fill64.wast.js:246:3 expected true got false
+FAIL #69 Test that a WebAssembly code returns a specific result (table_fill64.wast:105) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_fill64_wast_js@table_fill64.wast.js:172:14
+global code@table_fill64.wast.js:246:3 expected true got false
+FAIL #70 Test that a WebAssembly code returns a specific result (table_fill64.wast:107) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_fill64_wast_js@table_fill64.wast.js:175:14
+global code@table_fill64.wast.js:246:3 expected true got false
+FAIL #71 Test that a WebAssembly code returns a specific result (table_fill64.wast:108) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_fill64_wast_js@table_fill64.wast.js:178:14
+global code@table_fill64.wast.js:246:3 expected true got false
+FAIL #72 Test that a WebAssembly code returns a specific result (table_fill64.wast:109) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_fill64_wast_js@table_fill64.wast.js:181:14
+global code@table_fill64.wast.js:246:3 expected true got false
+FAIL #73 Test that a WebAssembly code returns a specific result (table_fill64.wast:110) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_fill64_wast_js@table_fill64.wast.js:184:14
+global code@table_fill64.wast.js:246:3 expected true got false
+FAIL #74 Test that a WebAssembly code returns a specific result (table_fill64.wast:112) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_fill64_wast_js@table_fill64.wast.js:187:14
+global code@table_fill64.wast.js:246:3 expected true got false
+FAIL #75 Test that a WebAssembly code returns a specific result (table_fill64.wast:113) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_fill64_wast_js@table_fill64.wast.js:190:14
+global code@table_fill64.wast.js:246:3 expected true got false
+FAIL #76 Test that a WebAssembly code returns a specific result (table_fill64.wast:114) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_fill64_wast_js@table_fill64.wast.js:193:14
+global code@table_fill64.wast.js:246:3 expected true got false
+FAIL #77 Test that a WebAssembly code returns a specific result (table_fill64.wast:116) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_fill64_wast_js@table_fill64.wast.js:196:14
+global code@table_fill64.wast.js:246:3 expected true got false
+FAIL #78 Test that a WebAssembly code returns a specific result (table_fill64.wast:117) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_fill64_wast_js@table_fill64.wast.js:199:14
+global code@table_fill64.wast.js:246:3 expected true got false
+FAIL #79 Test that a WebAssembly code traps (table_fill64.wast:119) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
+table_fill64_wast_js@table_fill64.wast.js:202:12
+global code@table_fill64.wast.js:246:3 expected true got false
+FAIL #80 Test that a WebAssembly code returns a specific result (table_fill64.wast:123) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_fill64_wast_js@table_fill64.wast.js:205:14
+global code@table_fill64.wast.js:246:3 expected true got false
+FAIL #81 Test that a WebAssembly code returns a specific result (table_fill64.wast:124) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_fill64_wast_js@table_fill64.wast.js:208:14
+global code@table_fill64.wast.js:246:3 expected true got false
+FAIL #82 Test that a WebAssembly code returns a specific result (table_fill64.wast:125) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_fill64_wast_js@table_fill64.wast.js:211:14
+global code@table_fill64.wast.js:246:3 expected true got false
+FAIL #83 Test that a WebAssembly code traps (table_fill64.wast:127) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
+table_fill64_wast_js@table_fill64.wast.js:214:12
+global code@table_fill64.wast.js:246:3 expected true got false
+FAIL #84 Test that a WebAssembly code traps (table_fill64.wast:132) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
+table_fill64_wast_js@table_fill64.wast.js:217:12
+global code@table_fill64.wast.js:246:3 expected true got false
 PASS #85 Test that WebAssembly compilation fails (table_fill64.wast:139)
 PASS #86 Test that WebAssembly compilation fails (table_fill64.wast:148)
 PASS #87 Test that WebAssembly compilation fails (table_fill64.wast:157)

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table_get64.wast.js-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table_get64.wast.js-expected.txt
@@ -3,37 +3,37 @@ PASS #1 Reinitialize the default imports
 FAIL #2 Test that WebAssembly compilation succeeds (table_get64.wast:1) assert_equals: expected false but got true
 PASS #3 Reinitialize the default imports
 FAIL #4 Test that WebAssembly compilation succeeds (table_get64.wast:1) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 136: Element init_expr must produce an i32 at {loc} expected true got false
-FAIL #5 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-table_get64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_get64.wast.js:7:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_get64.wast.js:39:3 expected true got false
-FAIL #6 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-table_get64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_get64.wast.js:10:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_get64.wast.js:39:3 expected true got false
-FAIL #7 Test that a WebAssembly code returns a specific result (table_get64.wast:26) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_get64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_get64.wast.js:13:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_get64.wast.js:39:3 expected true got false
-FAIL #8 Test that a WebAssembly code returns a specific result (table_get64.wast:27) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_get64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_get64.wast.js:16:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_get64.wast.js:39:3 expected true got false
-FAIL #9 Test that a WebAssembly code returns a specific result (table_get64.wast:29) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_get64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_get64.wast.js:19:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_get64.wast.js:39:3 expected true got false
-FAIL #10 Test that a WebAssembly code returns a specific result (table_get64.wast:30) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_get64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_get64.wast.js:22:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_get64.wast.js:39:3 expected true got false
-FAIL #11 Test that a WebAssembly code returns a specific result (table_get64.wast:31) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_get64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_get64.wast.js:25:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_get64.wast.js:39:3 expected true got false
-FAIL #12 Test that a WebAssembly code traps (table_get64.wast:33) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-table_get64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_get64.wast.js:28:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_get64.wast.js:39:3 expected true got false
-FAIL #13 Test that a WebAssembly code traps (table_get64.wast:34) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-table_get64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_get64.wast.js:31:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_get64.wast.js:39:3 expected true got false
-FAIL #14 Test that a WebAssembly code traps (table_get64.wast:35) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-table_get64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_get64.wast.js:34:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_get64.wast.js:39:3 expected true got false
-FAIL #15 Test that a WebAssembly code traps (table_get64.wast:36) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-table_get64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_get64.wast.js:37:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_get64.wast.js:39:3 expected true got false
+FAIL #5 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@async_index.js:219:29
+table_get64_wast_js@table_get64.wast.js:7:18
+global code@table_get64.wast.js:39:3 expected true got false
+FAIL #6 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@async_index.js:260:29
+table_get64_wast_js@table_get64.wast.js:10:4
+global code@table_get64.wast.js:39:3 expected true got false
+FAIL #7 Test that a WebAssembly code returns a specific result (table_get64.wast:26) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_get64_wast_js@table_get64.wast.js:13:14
+global code@table_get64.wast.js:39:3 expected true got false
+FAIL #8 Test that a WebAssembly code returns a specific result (table_get64.wast:27) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_get64_wast_js@table_get64.wast.js:16:14
+global code@table_get64.wast.js:39:3 expected true got false
+FAIL #9 Test that a WebAssembly code returns a specific result (table_get64.wast:29) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_get64_wast_js@table_get64.wast.js:19:14
+global code@table_get64.wast.js:39:3 expected true got false
+FAIL #10 Test that a WebAssembly code returns a specific result (table_get64.wast:30) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_get64_wast_js@table_get64.wast.js:22:14
+global code@table_get64.wast.js:39:3 expected true got false
+FAIL #11 Test that a WebAssembly code returns a specific result (table_get64.wast:31) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_get64_wast_js@table_get64.wast.js:25:14
+global code@table_get64.wast.js:39:3 expected true got false
+FAIL #12 Test that a WebAssembly code traps (table_get64.wast:33) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
+table_get64_wast_js@table_get64.wast.js:28:12
+global code@table_get64.wast.js:39:3 expected true got false
+FAIL #13 Test that a WebAssembly code traps (table_get64.wast:34) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
+table_get64_wast_js@table_get64.wast.js:31:12
+global code@table_get64.wast.js:39:3 expected true got false
+FAIL #14 Test that a WebAssembly code traps (table_get64.wast:35) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
+table_get64_wast_js@table_get64.wast.js:34:12
+global code@table_get64.wast.js:39:3 expected true got false
+FAIL #15 Test that a WebAssembly code traps (table_get64.wast:36) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
+table_get64_wast_js@table_get64.wast.js:37:12
+global code@table_get64.wast.js:39:3 expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table_grow64.wast.js-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table_grow64.wast.js-expected.txt
@@ -3,70 +3,70 @@ PASS #1 Reinitialize the default imports
 FAIL #2 Test that WebAssembly compilation succeeds (table_grow64.wast:1) assert_equals: expected false but got true
 PASS #3 Reinitialize the default imports
 FAIL #4 Test that WebAssembly compilation succeeds (table_grow64.wast:1) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't validate: table.get index to type I64 expected I32, in function at index 0 at {loc} expected true got false
-FAIL #5 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-table_grow64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_grow64.wast.js:7:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_grow64.wast.js:72:3 expected true got false
-FAIL #6 Test that a WebAssembly code returns a specific result (table_grow64.wast:12) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_grow64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_grow64.wast.js:10:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_grow64.wast.js:72:3 expected true got false
-FAIL #7 Test that a WebAssembly code traps (table_grow64.wast:13) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-table_grow64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_grow64.wast.js:13:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_grow64.wast.js:72:3 expected true got false
-FAIL #8 Test that a WebAssembly code traps (table_grow64.wast:14) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-table_grow64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_grow64.wast.js:16:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_grow64.wast.js:72:3 expected true got false
-FAIL #9 Test that a WebAssembly code returns a specific result (table_grow64.wast:16) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_grow64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_grow64.wast.js:19:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_grow64.wast.js:72:3 expected true got false
-FAIL #10 Test that a WebAssembly code returns a specific result (table_grow64.wast:17) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_grow64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_grow64.wast.js:22:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_grow64.wast.js:72:3 expected true got false
-FAIL #11 Test that a WebAssembly code returns a specific result (table_grow64.wast:18) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_grow64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_grow64.wast.js:25:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_grow64.wast.js:72:3 expected true got false
-FAIL #12 Test that a WebAssembly code returns a specific result (table_grow64.wast:19) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_grow64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_grow64.wast.js:28:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_grow64.wast.js:72:3 expected true got false
-FAIL #13 Test that a WebAssembly code returns a specific result (table_grow64.wast:20) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_grow64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_grow64.wast.js:31:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_grow64.wast.js:72:3 expected true got false
-FAIL #14 Test that a WebAssembly code traps (table_grow64.wast:21) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-table_grow64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_grow64.wast.js:34:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_grow64.wast.js:72:3 expected true got false
-FAIL #15 Test that a WebAssembly code traps (table_grow64.wast:22) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-table_grow64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_grow64.wast.js:37:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_grow64.wast.js:72:3 expected true got false
-FAIL #16 Test that a WebAssembly code returns a specific result (table_grow64.wast:24) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_grow64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_grow64.wast.js:40:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_grow64.wast.js:72:3 expected true got false
-FAIL #17 Test that a WebAssembly code returns a specific result (table_grow64.wast:25) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_grow64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_grow64.wast.js:43:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_grow64.wast.js:72:3 expected true got false
-FAIL #18 Test that a WebAssembly code returns a specific result (table_grow64.wast:26) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_grow64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_grow64.wast.js:46:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_grow64.wast.js:72:3 expected true got false
-FAIL #19 Test that a WebAssembly code returns a specific result (table_grow64.wast:27) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_grow64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_grow64.wast.js:49:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_grow64.wast.js:72:3 expected true got false
-FAIL #20 Test that a WebAssembly code returns a specific result (table_grow64.wast:28) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_grow64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_grow64.wast.js:52:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_grow64.wast.js:72:3 expected true got false
-FAIL #21 Test that a WebAssembly code returns a specific result (table_grow64.wast:29) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_grow64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_grow64.wast.js:55:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_grow64.wast.js:72:3 expected true got false
-FAIL #22 Test that a WebAssembly code returns a specific result (table_grow64.wast:30) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_grow64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_grow64.wast.js:58:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_grow64.wast.js:72:3 expected true got false
-FAIL #23 Test that a WebAssembly code returns a specific result (table_grow64.wast:31) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_grow64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_grow64.wast.js:61:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_grow64.wast.js:72:3 expected true got false
-FAIL #24 Test that a WebAssembly code returns a specific result (table_grow64.wast:32) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_grow64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_grow64.wast.js:64:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_grow64.wast.js:72:3 expected true got false
-FAIL #25 Test that a WebAssembly code traps (table_grow64.wast:33) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-table_grow64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_grow64.wast.js:67:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_grow64.wast.js:72:3 expected true got false
-FAIL #26 Test that a WebAssembly code traps (table_grow64.wast:34) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-table_grow64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_grow64.wast.js:70:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_grow64.wast.js:72:3 expected true got false
+FAIL #5 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@async_index.js:219:29
+table_grow64_wast_js@table_grow64.wast.js:7:18
+global code@table_grow64.wast.js:72:3 expected true got false
+FAIL #6 Test that a WebAssembly code returns a specific result (table_grow64.wast:12) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_grow64_wast_js@table_grow64.wast.js:10:14
+global code@table_grow64.wast.js:72:3 expected true got false
+FAIL #7 Test that a WebAssembly code traps (table_grow64.wast:13) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
+table_grow64_wast_js@table_grow64.wast.js:13:12
+global code@table_grow64.wast.js:72:3 expected true got false
+FAIL #8 Test that a WebAssembly code traps (table_grow64.wast:14) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
+table_grow64_wast_js@table_grow64.wast.js:16:12
+global code@table_grow64.wast.js:72:3 expected true got false
+FAIL #9 Test that a WebAssembly code returns a specific result (table_grow64.wast:16) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_grow64_wast_js@table_grow64.wast.js:19:14
+global code@table_grow64.wast.js:72:3 expected true got false
+FAIL #10 Test that a WebAssembly code returns a specific result (table_grow64.wast:17) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_grow64_wast_js@table_grow64.wast.js:22:14
+global code@table_grow64.wast.js:72:3 expected true got false
+FAIL #11 Test that a WebAssembly code returns a specific result (table_grow64.wast:18) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_grow64_wast_js@table_grow64.wast.js:25:14
+global code@table_grow64.wast.js:72:3 expected true got false
+FAIL #12 Test that a WebAssembly code returns a specific result (table_grow64.wast:19) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_grow64_wast_js@table_grow64.wast.js:28:14
+global code@table_grow64.wast.js:72:3 expected true got false
+FAIL #13 Test that a WebAssembly code returns a specific result (table_grow64.wast:20) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_grow64_wast_js@table_grow64.wast.js:31:14
+global code@table_grow64.wast.js:72:3 expected true got false
+FAIL #14 Test that a WebAssembly code traps (table_grow64.wast:21) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
+table_grow64_wast_js@table_grow64.wast.js:34:12
+global code@table_grow64.wast.js:72:3 expected true got false
+FAIL #15 Test that a WebAssembly code traps (table_grow64.wast:22) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
+table_grow64_wast_js@table_grow64.wast.js:37:12
+global code@table_grow64.wast.js:72:3 expected true got false
+FAIL #16 Test that a WebAssembly code returns a specific result (table_grow64.wast:24) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_grow64_wast_js@table_grow64.wast.js:40:14
+global code@table_grow64.wast.js:72:3 expected true got false
+FAIL #17 Test that a WebAssembly code returns a specific result (table_grow64.wast:25) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_grow64_wast_js@table_grow64.wast.js:43:14
+global code@table_grow64.wast.js:72:3 expected true got false
+FAIL #18 Test that a WebAssembly code returns a specific result (table_grow64.wast:26) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_grow64_wast_js@table_grow64.wast.js:46:14
+global code@table_grow64.wast.js:72:3 expected true got false
+FAIL #19 Test that a WebAssembly code returns a specific result (table_grow64.wast:27) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_grow64_wast_js@table_grow64.wast.js:49:14
+global code@table_grow64.wast.js:72:3 expected true got false
+FAIL #20 Test that a WebAssembly code returns a specific result (table_grow64.wast:28) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_grow64_wast_js@table_grow64.wast.js:52:14
+global code@table_grow64.wast.js:72:3 expected true got false
+FAIL #21 Test that a WebAssembly code returns a specific result (table_grow64.wast:29) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_grow64_wast_js@table_grow64.wast.js:55:14
+global code@table_grow64.wast.js:72:3 expected true got false
+FAIL #22 Test that a WebAssembly code returns a specific result (table_grow64.wast:30) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_grow64_wast_js@table_grow64.wast.js:58:14
+global code@table_grow64.wast.js:72:3 expected true got false
+FAIL #23 Test that a WebAssembly code returns a specific result (table_grow64.wast:31) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_grow64_wast_js@table_grow64.wast.js:61:14
+global code@table_grow64.wast.js:72:3 expected true got false
+FAIL #24 Test that a WebAssembly code returns a specific result (table_grow64.wast:32) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_grow64_wast_js@table_grow64.wast.js:64:14
+global code@table_grow64.wast.js:72:3 expected true got false
+FAIL #25 Test that a WebAssembly code traps (table_grow64.wast:33) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
+table_grow64_wast_js@table_grow64.wast.js:67:12
+global code@table_grow64.wast.js:72:3 expected true got false
+FAIL #26 Test that a WebAssembly code traps (table_grow64.wast:34) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
+table_grow64_wast_js@table_grow64.wast.js:70:12
+global code@table_grow64.wast.js:72:3 expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table_init64.wast.js-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table_init64.wast.js-expected.txt
@@ -313,296 +313,296 @@ PASS #311 Test that a WebAssembly code traps (table_init64.wast:381)
 PASS #312 Test that a WebAssembly code traps (table_init64.wast:382)
 PASS #313 Test that a WebAssembly code traps (table_init64.wast:383)
 FAIL #314 Test that WebAssembly compilation succeeds (table_init64.wast:385) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 141: Element init_expr must produce an i32 at {loc} expected true got false
-FAIL #315 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-table_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:610:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:2799:3 expected true got false
-FAIL #316 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-table_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:613:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:2799:3 expected true got false
-FAIL #317 Test that a WebAssembly code traps (table_init64.wast:413) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-table_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:616:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:2799:3 expected true got false
-FAIL #318 Test that a WebAssembly code traps (table_init64.wast:414) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-table_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:619:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:2799:3 expected true got false
-FAIL #319 Test that a WebAssembly code returns a specific result (table_init64.wast:415) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:622:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:2799:3 expected true got false
-FAIL #320 Test that a WebAssembly code returns a specific result (table_init64.wast:416) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:625:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:2799:3 expected true got false
-FAIL #321 Test that a WebAssembly code returns a specific result (table_init64.wast:417) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:628:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:2799:3 expected true got false
-FAIL #322 Test that a WebAssembly code returns a specific result (table_init64.wast:418) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:631:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:2799:3 expected true got false
-FAIL #323 Test that a WebAssembly code traps (table_init64.wast:419) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-table_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:634:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:2799:3 expected true got false
-FAIL #324 Test that a WebAssembly code returns a specific result (table_init64.wast:420) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:637:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:2799:3 expected true got false
-FAIL #325 Test that a WebAssembly code returns a specific result (table_init64.wast:421) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:640:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:2799:3 expected true got false
-FAIL #326 Test that a WebAssembly code returns a specific result (table_init64.wast:422) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:643:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:2799:3 expected true got false
-FAIL #327 Test that a WebAssembly code returns a specific result (table_init64.wast:423) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:646:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:2799:3 expected true got false
-FAIL #328 Test that a WebAssembly code traps (table_init64.wast:424) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-table_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:649:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:2799:3 expected true got false
-FAIL #329 Test that a WebAssembly code returns a specific result (table_init64.wast:425) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:652:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:2799:3 expected true got false
-FAIL #330 Test that a WebAssembly code returns a specific result (table_init64.wast:426) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:655:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:2799:3 expected true got false
-FAIL #331 Test that a WebAssembly code returns a specific result (table_init64.wast:427) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:658:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:2799:3 expected true got false
-FAIL #332 Test that a WebAssembly code returns a specific result (table_init64.wast:428) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:661:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:2799:3 expected true got false
-FAIL #333 Test that a WebAssembly code returns a specific result (table_init64.wast:429) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:664:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:2799:3 expected true got false
-FAIL #334 Test that a WebAssembly code traps (table_init64.wast:430) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-table_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:667:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:2799:3 expected true got false
-FAIL #335 Test that a WebAssembly code traps (table_init64.wast:431) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-table_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:670:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:2799:3 expected true got false
-FAIL #336 Test that a WebAssembly code traps (table_init64.wast:432) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-table_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:673:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:2799:3 expected true got false
-FAIL #337 Test that a WebAssembly code traps (table_init64.wast:433) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-table_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:676:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:2799:3 expected true got false
-FAIL #338 Test that a WebAssembly code traps (table_init64.wast:434) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-table_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:679:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:2799:3 expected true got false
-FAIL #339 Test that a WebAssembly code traps (table_init64.wast:435) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-table_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:682:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:2799:3 expected true got false
-FAIL #340 Test that a WebAssembly code traps (table_init64.wast:436) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-table_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:685:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:2799:3 expected true got false
-FAIL #341 Test that a WebAssembly code traps (table_init64.wast:437) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-table_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:688:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:2799:3 expected true got false
-FAIL #342 Test that a WebAssembly code traps (table_init64.wast:438) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-table_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:691:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:2799:3 expected true got false
-FAIL #343 Test that a WebAssembly code traps (table_init64.wast:439) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-table_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:694:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:2799:3 expected true got false
-FAIL #344 Test that a WebAssembly code traps (table_init64.wast:440) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-table_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:697:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:2799:3 expected true got false
-FAIL #345 Test that a WebAssembly code traps (table_init64.wast:441) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-table_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:700:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:2799:3 expected true got false
-FAIL #346 Test that a WebAssembly code traps (table_init64.wast:442) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-table_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:703:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:2799:3 expected true got false
+FAIL #315 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@async_index.js:219:29
+table_init64_wast_js@table_init64.wast.js:610:18
+global code@table_init64.wast.js:2799:3 expected true got false
+FAIL #316 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@async_index.js:260:29
+table_init64_wast_js@table_init64.wast.js:613:4
+global code@table_init64.wast.js:2799:3 expected true got false
+FAIL #317 Test that a WebAssembly code traps (table_init64.wast:413) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
+table_init64_wast_js@table_init64.wast.js:616:12
+global code@table_init64.wast.js:2799:3 expected true got false
+FAIL #318 Test that a WebAssembly code traps (table_init64.wast:414) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
+table_init64_wast_js@table_init64.wast.js:619:12
+global code@table_init64.wast.js:2799:3 expected true got false
+FAIL #319 Test that a WebAssembly code returns a specific result (table_init64.wast:415) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_init64_wast_js@table_init64.wast.js:622:14
+global code@table_init64.wast.js:2799:3 expected true got false
+FAIL #320 Test that a WebAssembly code returns a specific result (table_init64.wast:416) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_init64_wast_js@table_init64.wast.js:625:14
+global code@table_init64.wast.js:2799:3 expected true got false
+FAIL #321 Test that a WebAssembly code returns a specific result (table_init64.wast:417) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_init64_wast_js@table_init64.wast.js:628:14
+global code@table_init64.wast.js:2799:3 expected true got false
+FAIL #322 Test that a WebAssembly code returns a specific result (table_init64.wast:418) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_init64_wast_js@table_init64.wast.js:631:14
+global code@table_init64.wast.js:2799:3 expected true got false
+FAIL #323 Test that a WebAssembly code traps (table_init64.wast:419) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
+table_init64_wast_js@table_init64.wast.js:634:12
+global code@table_init64.wast.js:2799:3 expected true got false
+FAIL #324 Test that a WebAssembly code returns a specific result (table_init64.wast:420) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_init64_wast_js@table_init64.wast.js:637:14
+global code@table_init64.wast.js:2799:3 expected true got false
+FAIL #325 Test that a WebAssembly code returns a specific result (table_init64.wast:421) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_init64_wast_js@table_init64.wast.js:640:14
+global code@table_init64.wast.js:2799:3 expected true got false
+FAIL #326 Test that a WebAssembly code returns a specific result (table_init64.wast:422) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_init64_wast_js@table_init64.wast.js:643:14
+global code@table_init64.wast.js:2799:3 expected true got false
+FAIL #327 Test that a WebAssembly code returns a specific result (table_init64.wast:423) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_init64_wast_js@table_init64.wast.js:646:14
+global code@table_init64.wast.js:2799:3 expected true got false
+FAIL #328 Test that a WebAssembly code traps (table_init64.wast:424) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
+table_init64_wast_js@table_init64.wast.js:649:12
+global code@table_init64.wast.js:2799:3 expected true got false
+FAIL #329 Test that a WebAssembly code returns a specific result (table_init64.wast:425) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_init64_wast_js@table_init64.wast.js:652:14
+global code@table_init64.wast.js:2799:3 expected true got false
+FAIL #330 Test that a WebAssembly code returns a specific result (table_init64.wast:426) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_init64_wast_js@table_init64.wast.js:655:14
+global code@table_init64.wast.js:2799:3 expected true got false
+FAIL #331 Test that a WebAssembly code returns a specific result (table_init64.wast:427) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_init64_wast_js@table_init64.wast.js:658:14
+global code@table_init64.wast.js:2799:3 expected true got false
+FAIL #332 Test that a WebAssembly code returns a specific result (table_init64.wast:428) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_init64_wast_js@table_init64.wast.js:661:14
+global code@table_init64.wast.js:2799:3 expected true got false
+FAIL #333 Test that a WebAssembly code returns a specific result (table_init64.wast:429) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_init64_wast_js@table_init64.wast.js:664:14
+global code@table_init64.wast.js:2799:3 expected true got false
+FAIL #334 Test that a WebAssembly code traps (table_init64.wast:430) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
+table_init64_wast_js@table_init64.wast.js:667:12
+global code@table_init64.wast.js:2799:3 expected true got false
+FAIL #335 Test that a WebAssembly code traps (table_init64.wast:431) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
+table_init64_wast_js@table_init64.wast.js:670:12
+global code@table_init64.wast.js:2799:3 expected true got false
+FAIL #336 Test that a WebAssembly code traps (table_init64.wast:432) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
+table_init64_wast_js@table_init64.wast.js:673:12
+global code@table_init64.wast.js:2799:3 expected true got false
+FAIL #337 Test that a WebAssembly code traps (table_init64.wast:433) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
+table_init64_wast_js@table_init64.wast.js:676:12
+global code@table_init64.wast.js:2799:3 expected true got false
+FAIL #338 Test that a WebAssembly code traps (table_init64.wast:434) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
+table_init64_wast_js@table_init64.wast.js:679:12
+global code@table_init64.wast.js:2799:3 expected true got false
+FAIL #339 Test that a WebAssembly code traps (table_init64.wast:435) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
+table_init64_wast_js@table_init64.wast.js:682:12
+global code@table_init64.wast.js:2799:3 expected true got false
+FAIL #340 Test that a WebAssembly code traps (table_init64.wast:436) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
+table_init64_wast_js@table_init64.wast.js:685:12
+global code@table_init64.wast.js:2799:3 expected true got false
+FAIL #341 Test that a WebAssembly code traps (table_init64.wast:437) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
+table_init64_wast_js@table_init64.wast.js:688:12
+global code@table_init64.wast.js:2799:3 expected true got false
+FAIL #342 Test that a WebAssembly code traps (table_init64.wast:438) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
+table_init64_wast_js@table_init64.wast.js:691:12
+global code@table_init64.wast.js:2799:3 expected true got false
+FAIL #343 Test that a WebAssembly code traps (table_init64.wast:439) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
+table_init64_wast_js@table_init64.wast.js:694:12
+global code@table_init64.wast.js:2799:3 expected true got false
+FAIL #344 Test that a WebAssembly code traps (table_init64.wast:440) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
+table_init64_wast_js@table_init64.wast.js:697:12
+global code@table_init64.wast.js:2799:3 expected true got false
+FAIL #345 Test that a WebAssembly code traps (table_init64.wast:441) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
+table_init64_wast_js@table_init64.wast.js:700:12
+global code@table_init64.wast.js:2799:3 expected true got false
+FAIL #346 Test that a WebAssembly code traps (table_init64.wast:442) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
+table_init64_wast_js@table_init64.wast.js:703:12
+global code@table_init64.wast.js:2799:3 expected true got false
 FAIL #347 Test that WebAssembly compilation succeeds (table_init64.wast:444) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 141: Element init_expr must produce an i32 at {loc} expected true got false
-FAIL #348 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-table_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:709:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:2799:3 expected true got false
-FAIL #349 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-table_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:712:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:2799:3 expected true got false
-FAIL #350 Test that a WebAssembly code traps (table_init64.wast:472) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-table_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:715:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:2799:3 expected true got false
-FAIL #351 Test that a WebAssembly code traps (table_init64.wast:473) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-table_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:718:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:2799:3 expected true got false
-FAIL #352 Test that a WebAssembly code returns a specific result (table_init64.wast:474) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:721:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:2799:3 expected true got false
-FAIL #353 Test that a WebAssembly code returns a specific result (table_init64.wast:475) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:724:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:2799:3 expected true got false
-FAIL #354 Test that a WebAssembly code returns a specific result (table_init64.wast:476) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:727:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:2799:3 expected true got false
-FAIL #355 Test that a WebAssembly code returns a specific result (table_init64.wast:477) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:730:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:2799:3 expected true got false
-FAIL #356 Test that a WebAssembly code traps (table_init64.wast:478) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-table_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:733:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:2799:3 expected true got false
-FAIL #357 Test that a WebAssembly code traps (table_init64.wast:479) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-table_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:736:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:2799:3 expected true got false
-FAIL #358 Test that a WebAssembly code traps (table_init64.wast:480) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-table_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:739:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:2799:3 expected true got false
-FAIL #359 Test that a WebAssembly code traps (table_init64.wast:481) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-table_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:742:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:2799:3 expected true got false
-FAIL #360 Test that a WebAssembly code traps (table_init64.wast:482) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-table_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:745:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:2799:3 expected true got false
-FAIL #361 Test that a WebAssembly code traps (table_init64.wast:483) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-table_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:748:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:2799:3 expected true got false
-FAIL #362 Test that a WebAssembly code returns a specific result (table_init64.wast:484) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:751:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:2799:3 expected true got false
-FAIL #363 Test that a WebAssembly code returns a specific result (table_init64.wast:485) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:754:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:2799:3 expected true got false
-FAIL #364 Test that a WebAssembly code returns a specific result (table_init64.wast:486) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:757:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:2799:3 expected true got false
-FAIL #365 Test that a WebAssembly code returns a specific result (table_init64.wast:487) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:760:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:2799:3 expected true got false
-FAIL #366 Test that a WebAssembly code returns a specific result (table_init64.wast:488) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:763:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:2799:3 expected true got false
-FAIL #367 Test that a WebAssembly code returns a specific result (table_init64.wast:489) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:766:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:2799:3 expected true got false
-FAIL #368 Test that a WebAssembly code traps (table_init64.wast:490) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-table_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:769:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:2799:3 expected true got false
-FAIL #369 Test that a WebAssembly code traps (table_init64.wast:491) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-table_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:772:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:2799:3 expected true got false
-FAIL #370 Test that a WebAssembly code traps (table_init64.wast:492) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-table_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:775:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:2799:3 expected true got false
-FAIL #371 Test that a WebAssembly code traps (table_init64.wast:493) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-table_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:778:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:2799:3 expected true got false
-FAIL #372 Test that a WebAssembly code traps (table_init64.wast:494) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-table_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:781:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:2799:3 expected true got false
-FAIL #373 Test that a WebAssembly code traps (table_init64.wast:495) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-table_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:784:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:2799:3 expected true got false
-FAIL #374 Test that a WebAssembly code traps (table_init64.wast:496) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-table_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:787:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:2799:3 expected true got false
-FAIL #375 Test that a WebAssembly code traps (table_init64.wast:497) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-table_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:790:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:2799:3 expected true got false
-FAIL #376 Test that a WebAssembly code traps (table_init64.wast:498) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-table_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:793:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:2799:3 expected true got false
-FAIL #377 Test that a WebAssembly code traps (table_init64.wast:499) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-table_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:796:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:2799:3 expected true got false
-FAIL #378 Test that a WebAssembly code traps (table_init64.wast:500) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-table_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:799:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:2799:3 expected true got false
-FAIL #379 Test that a WebAssembly code traps (table_init64.wast:501) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-table_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:802:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:2799:3 expected true got false
+FAIL #348 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@async_index.js:219:29
+table_init64_wast_js@table_init64.wast.js:709:18
+global code@table_init64.wast.js:2799:3 expected true got false
+FAIL #349 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@async_index.js:260:29
+table_init64_wast_js@table_init64.wast.js:712:4
+global code@table_init64.wast.js:2799:3 expected true got false
+FAIL #350 Test that a WebAssembly code traps (table_init64.wast:472) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
+table_init64_wast_js@table_init64.wast.js:715:12
+global code@table_init64.wast.js:2799:3 expected true got false
+FAIL #351 Test that a WebAssembly code traps (table_init64.wast:473) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
+table_init64_wast_js@table_init64.wast.js:718:12
+global code@table_init64.wast.js:2799:3 expected true got false
+FAIL #352 Test that a WebAssembly code returns a specific result (table_init64.wast:474) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_init64_wast_js@table_init64.wast.js:721:14
+global code@table_init64.wast.js:2799:3 expected true got false
+FAIL #353 Test that a WebAssembly code returns a specific result (table_init64.wast:475) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_init64_wast_js@table_init64.wast.js:724:14
+global code@table_init64.wast.js:2799:3 expected true got false
+FAIL #354 Test that a WebAssembly code returns a specific result (table_init64.wast:476) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_init64_wast_js@table_init64.wast.js:727:14
+global code@table_init64.wast.js:2799:3 expected true got false
+FAIL #355 Test that a WebAssembly code returns a specific result (table_init64.wast:477) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_init64_wast_js@table_init64.wast.js:730:14
+global code@table_init64.wast.js:2799:3 expected true got false
+FAIL #356 Test that a WebAssembly code traps (table_init64.wast:478) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
+table_init64_wast_js@table_init64.wast.js:733:12
+global code@table_init64.wast.js:2799:3 expected true got false
+FAIL #357 Test that a WebAssembly code traps (table_init64.wast:479) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
+table_init64_wast_js@table_init64.wast.js:736:12
+global code@table_init64.wast.js:2799:3 expected true got false
+FAIL #358 Test that a WebAssembly code traps (table_init64.wast:480) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
+table_init64_wast_js@table_init64.wast.js:739:12
+global code@table_init64.wast.js:2799:3 expected true got false
+FAIL #359 Test that a WebAssembly code traps (table_init64.wast:481) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
+table_init64_wast_js@table_init64.wast.js:742:12
+global code@table_init64.wast.js:2799:3 expected true got false
+FAIL #360 Test that a WebAssembly code traps (table_init64.wast:482) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
+table_init64_wast_js@table_init64.wast.js:745:12
+global code@table_init64.wast.js:2799:3 expected true got false
+FAIL #361 Test that a WebAssembly code traps (table_init64.wast:483) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
+table_init64_wast_js@table_init64.wast.js:748:12
+global code@table_init64.wast.js:2799:3 expected true got false
+FAIL #362 Test that a WebAssembly code returns a specific result (table_init64.wast:484) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_init64_wast_js@table_init64.wast.js:751:14
+global code@table_init64.wast.js:2799:3 expected true got false
+FAIL #363 Test that a WebAssembly code returns a specific result (table_init64.wast:485) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_init64_wast_js@table_init64.wast.js:754:14
+global code@table_init64.wast.js:2799:3 expected true got false
+FAIL #364 Test that a WebAssembly code returns a specific result (table_init64.wast:486) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_init64_wast_js@table_init64.wast.js:757:14
+global code@table_init64.wast.js:2799:3 expected true got false
+FAIL #365 Test that a WebAssembly code returns a specific result (table_init64.wast:487) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_init64_wast_js@table_init64.wast.js:760:14
+global code@table_init64.wast.js:2799:3 expected true got false
+FAIL #366 Test that a WebAssembly code returns a specific result (table_init64.wast:488) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_init64_wast_js@table_init64.wast.js:763:14
+global code@table_init64.wast.js:2799:3 expected true got false
+FAIL #367 Test that a WebAssembly code returns a specific result (table_init64.wast:489) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_init64_wast_js@table_init64.wast.js:766:14
+global code@table_init64.wast.js:2799:3 expected true got false
+FAIL #368 Test that a WebAssembly code traps (table_init64.wast:490) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
+table_init64_wast_js@table_init64.wast.js:769:12
+global code@table_init64.wast.js:2799:3 expected true got false
+FAIL #369 Test that a WebAssembly code traps (table_init64.wast:491) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
+table_init64_wast_js@table_init64.wast.js:772:12
+global code@table_init64.wast.js:2799:3 expected true got false
+FAIL #370 Test that a WebAssembly code traps (table_init64.wast:492) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
+table_init64_wast_js@table_init64.wast.js:775:12
+global code@table_init64.wast.js:2799:3 expected true got false
+FAIL #371 Test that a WebAssembly code traps (table_init64.wast:493) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
+table_init64_wast_js@table_init64.wast.js:778:12
+global code@table_init64.wast.js:2799:3 expected true got false
+FAIL #372 Test that a WebAssembly code traps (table_init64.wast:494) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
+table_init64_wast_js@table_init64.wast.js:781:12
+global code@table_init64.wast.js:2799:3 expected true got false
+FAIL #373 Test that a WebAssembly code traps (table_init64.wast:495) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
+table_init64_wast_js@table_init64.wast.js:784:12
+global code@table_init64.wast.js:2799:3 expected true got false
+FAIL #374 Test that a WebAssembly code traps (table_init64.wast:496) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
+table_init64_wast_js@table_init64.wast.js:787:12
+global code@table_init64.wast.js:2799:3 expected true got false
+FAIL #375 Test that a WebAssembly code traps (table_init64.wast:497) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
+table_init64_wast_js@table_init64.wast.js:790:12
+global code@table_init64.wast.js:2799:3 expected true got false
+FAIL #376 Test that a WebAssembly code traps (table_init64.wast:498) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
+table_init64_wast_js@table_init64.wast.js:793:12
+global code@table_init64.wast.js:2799:3 expected true got false
+FAIL #377 Test that a WebAssembly code traps (table_init64.wast:499) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
+table_init64_wast_js@table_init64.wast.js:796:12
+global code@table_init64.wast.js:2799:3 expected true got false
+FAIL #378 Test that a WebAssembly code traps (table_init64.wast:500) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
+table_init64_wast_js@table_init64.wast.js:799:12
+global code@table_init64.wast.js:2799:3 expected true got false
+FAIL #379 Test that a WebAssembly code traps (table_init64.wast:501) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
+table_init64_wast_js@table_init64.wast.js:802:12
+global code@table_init64.wast.js:2799:3 expected true got false
 FAIL #380 Test that WebAssembly compilation succeeds (table_init64.wast:503) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 141: Element init_expr must produce an i32 at {loc} expected true got false
-FAIL #381 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-table_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:808:19
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:2799:3 expected true got false
-FAIL #382 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-table_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:811:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:2799:3 expected true got false
-FAIL #383 Test that a WebAssembly code traps (table_init64.wast:539) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-table_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:814:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:2799:3 expected true got false
-FAIL #384 Test that a WebAssembly code traps (table_init64.wast:540) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-table_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:817:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:2799:3 expected true got false
-FAIL #385 Test that a WebAssembly code returns a specific result (table_init64.wast:541) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:820:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:2799:3 expected true got false
-FAIL #386 Test that a WebAssembly code returns a specific result (table_init64.wast:542) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:823:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:2799:3 expected true got false
-FAIL #387 Test that a WebAssembly code returns a specific result (table_init64.wast:543) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:826:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:2799:3 expected true got false
-FAIL #388 Test that a WebAssembly code returns a specific result (table_init64.wast:544) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:829:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:2799:3 expected true got false
-FAIL #389 Test that a WebAssembly code traps (table_init64.wast:545) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-table_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:832:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:2799:3 expected true got false
-FAIL #390 Test that a WebAssembly code returns a specific result (table_init64.wast:546) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:835:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:2799:3 expected true got false
-FAIL #391 Test that a WebAssembly code returns a specific result (table_init64.wast:547) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:838:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:2799:3 expected true got false
-FAIL #392 Test that a WebAssembly code returns a specific result (table_init64.wast:548) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:841:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:2799:3 expected true got false
-FAIL #393 Test that a WebAssembly code returns a specific result (table_init64.wast:549) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:844:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:2799:3 expected true got false
-FAIL #394 Test that a WebAssembly code traps (table_init64.wast:550) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-table_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:847:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:2799:3 expected true got false
-FAIL #395 Test that a WebAssembly code returns a specific result (table_init64.wast:551) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:850:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:2799:3 expected true got false
-FAIL #396 Test that a WebAssembly code traps (table_init64.wast:552) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-table_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:853:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:2799:3 expected true got false
-FAIL #397 Test that a WebAssembly code returns a specific result (table_init64.wast:553) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:856:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:2799:3 expected true got false
-FAIL #398 Test that a WebAssembly code returns a specific result (table_init64.wast:554) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:859:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:2799:3 expected true got false
-FAIL #399 Test that a WebAssembly code returns a specific result (table_init64.wast:555) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:862:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:2799:3 expected true got false
-FAIL #400 Test that a WebAssembly code returns a specific result (table_init64.wast:556) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:865:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:2799:3 expected true got false
-FAIL #401 Test that a WebAssembly code traps (table_init64.wast:557) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-table_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:868:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:2799:3 expected true got false
-FAIL #402 Test that a WebAssembly code returns a specific result (table_init64.wast:558) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:871:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:2799:3 expected true got false
-FAIL #403 Test that a WebAssembly code traps (table_init64.wast:559) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-table_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:874:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:2799:3 expected true got false
-FAIL #404 Test that a WebAssembly code returns a specific result (table_init64.wast:560) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:877:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:2799:3 expected true got false
-FAIL #405 Test that a WebAssembly code traps (table_init64.wast:561) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-table_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:880:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:2799:3 expected true got false
-FAIL #406 Test that a WebAssembly code returns a specific result (table_init64.wast:562) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:883:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:2799:3 expected true got false
-FAIL #407 Test that a WebAssembly code returns a specific result (table_init64.wast:563) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:886:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:2799:3 expected true got false
-FAIL #408 Test that a WebAssembly code traps (table_init64.wast:564) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-table_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:889:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:2799:3 expected true got false
-FAIL #409 Test that a WebAssembly code traps (table_init64.wast:565) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-table_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:892:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:2799:3 expected true got false
-FAIL #410 Test that a WebAssembly code traps (table_init64.wast:566) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-table_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:895:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:2799:3 expected true got false
-FAIL #411 Test that a WebAssembly code traps (table_init64.wast:567) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-table_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:898:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:2799:3 expected true got false
-FAIL #412 Test that a WebAssembly code traps (table_init64.wast:568) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-table_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:901:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:2799:3 expected true got false
+FAIL #381 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@async_index.js:219:29
+table_init64_wast_js@table_init64.wast.js:808:19
+global code@table_init64.wast.js:2799:3 expected true got false
+FAIL #382 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@async_index.js:260:29
+table_init64_wast_js@table_init64.wast.js:811:4
+global code@table_init64.wast.js:2799:3 expected true got false
+FAIL #383 Test that a WebAssembly code traps (table_init64.wast:539) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
+table_init64_wast_js@table_init64.wast.js:814:12
+global code@table_init64.wast.js:2799:3 expected true got false
+FAIL #384 Test that a WebAssembly code traps (table_init64.wast:540) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
+table_init64_wast_js@table_init64.wast.js:817:12
+global code@table_init64.wast.js:2799:3 expected true got false
+FAIL #385 Test that a WebAssembly code returns a specific result (table_init64.wast:541) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_init64_wast_js@table_init64.wast.js:820:14
+global code@table_init64.wast.js:2799:3 expected true got false
+FAIL #386 Test that a WebAssembly code returns a specific result (table_init64.wast:542) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_init64_wast_js@table_init64.wast.js:823:14
+global code@table_init64.wast.js:2799:3 expected true got false
+FAIL #387 Test that a WebAssembly code returns a specific result (table_init64.wast:543) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_init64_wast_js@table_init64.wast.js:826:14
+global code@table_init64.wast.js:2799:3 expected true got false
+FAIL #388 Test that a WebAssembly code returns a specific result (table_init64.wast:544) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_init64_wast_js@table_init64.wast.js:829:14
+global code@table_init64.wast.js:2799:3 expected true got false
+FAIL #389 Test that a WebAssembly code traps (table_init64.wast:545) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
+table_init64_wast_js@table_init64.wast.js:832:12
+global code@table_init64.wast.js:2799:3 expected true got false
+FAIL #390 Test that a WebAssembly code returns a specific result (table_init64.wast:546) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_init64_wast_js@table_init64.wast.js:835:14
+global code@table_init64.wast.js:2799:3 expected true got false
+FAIL #391 Test that a WebAssembly code returns a specific result (table_init64.wast:547) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_init64_wast_js@table_init64.wast.js:838:14
+global code@table_init64.wast.js:2799:3 expected true got false
+FAIL #392 Test that a WebAssembly code returns a specific result (table_init64.wast:548) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_init64_wast_js@table_init64.wast.js:841:14
+global code@table_init64.wast.js:2799:3 expected true got false
+FAIL #393 Test that a WebAssembly code returns a specific result (table_init64.wast:549) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_init64_wast_js@table_init64.wast.js:844:14
+global code@table_init64.wast.js:2799:3 expected true got false
+FAIL #394 Test that a WebAssembly code traps (table_init64.wast:550) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
+table_init64_wast_js@table_init64.wast.js:847:12
+global code@table_init64.wast.js:2799:3 expected true got false
+FAIL #395 Test that a WebAssembly code returns a specific result (table_init64.wast:551) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_init64_wast_js@table_init64.wast.js:850:14
+global code@table_init64.wast.js:2799:3 expected true got false
+FAIL #396 Test that a WebAssembly code traps (table_init64.wast:552) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
+table_init64_wast_js@table_init64.wast.js:853:12
+global code@table_init64.wast.js:2799:3 expected true got false
+FAIL #397 Test that a WebAssembly code returns a specific result (table_init64.wast:553) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_init64_wast_js@table_init64.wast.js:856:14
+global code@table_init64.wast.js:2799:3 expected true got false
+FAIL #398 Test that a WebAssembly code returns a specific result (table_init64.wast:554) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_init64_wast_js@table_init64.wast.js:859:14
+global code@table_init64.wast.js:2799:3 expected true got false
+FAIL #399 Test that a WebAssembly code returns a specific result (table_init64.wast:555) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_init64_wast_js@table_init64.wast.js:862:14
+global code@table_init64.wast.js:2799:3 expected true got false
+FAIL #400 Test that a WebAssembly code returns a specific result (table_init64.wast:556) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_init64_wast_js@table_init64.wast.js:865:14
+global code@table_init64.wast.js:2799:3 expected true got false
+FAIL #401 Test that a WebAssembly code traps (table_init64.wast:557) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
+table_init64_wast_js@table_init64.wast.js:868:12
+global code@table_init64.wast.js:2799:3 expected true got false
+FAIL #402 Test that a WebAssembly code returns a specific result (table_init64.wast:558) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_init64_wast_js@table_init64.wast.js:871:14
+global code@table_init64.wast.js:2799:3 expected true got false
+FAIL #403 Test that a WebAssembly code traps (table_init64.wast:559) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
+table_init64_wast_js@table_init64.wast.js:874:12
+global code@table_init64.wast.js:2799:3 expected true got false
+FAIL #404 Test that a WebAssembly code returns a specific result (table_init64.wast:560) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_init64_wast_js@table_init64.wast.js:877:14
+global code@table_init64.wast.js:2799:3 expected true got false
+FAIL #405 Test that a WebAssembly code traps (table_init64.wast:561) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
+table_init64_wast_js@table_init64.wast.js:880:12
+global code@table_init64.wast.js:2799:3 expected true got false
+FAIL #406 Test that a WebAssembly code returns a specific result (table_init64.wast:562) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_init64_wast_js@table_init64.wast.js:883:14
+global code@table_init64.wast.js:2799:3 expected true got false
+FAIL #407 Test that a WebAssembly code returns a specific result (table_init64.wast:563) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_init64_wast_js@table_init64.wast.js:886:14
+global code@table_init64.wast.js:2799:3 expected true got false
+FAIL #408 Test that a WebAssembly code traps (table_init64.wast:564) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
+table_init64_wast_js@table_init64.wast.js:889:12
+global code@table_init64.wast.js:2799:3 expected true got false
+FAIL #409 Test that a WebAssembly code traps (table_init64.wast:565) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
+table_init64_wast_js@table_init64.wast.js:892:12
+global code@table_init64.wast.js:2799:3 expected true got false
+FAIL #410 Test that a WebAssembly code traps (table_init64.wast:566) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
+table_init64_wast_js@table_init64.wast.js:895:12
+global code@table_init64.wast.js:2799:3 expected true got false
+FAIL #411 Test that a WebAssembly code traps (table_init64.wast:567) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
+table_init64_wast_js@table_init64.wast.js:898:12
+global code@table_init64.wast.js:2799:3 expected true got false
+FAIL #412 Test that a WebAssembly code traps (table_init64.wast:568) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
+table_init64_wast_js@table_init64.wast.js:901:12
+global code@table_init64.wast.js:2799:3 expected true got false
 PASS #413 Test that WebAssembly compilation fails (table_init64.wast:569)
 PASS #414 Test that WebAssembly compilation fails (table_init64.wast:575)
 PASS #415 Test that WebAssembly compilation fails (table_init64.wast:581)
@@ -1233,10 +1233,10 @@ PASS #1039 Test that a WebAssembly code traps (table_init64.wast:2431)
 PASS #1040 Test that WebAssembly compilation succeeds (table_init64.wast:2433)
 PASS #1041 Test that WebAssembly instantiation succeeds (table_init64.wast:2433)
 FAIL #1042 Test that WebAssembly compilation succeeds (table_init64.wast:2457) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't validate: table.init dst_offset to type I64 expected I32, in function at index 0 at {loc} expected true got false
-FAIL #1043 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-table_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:2794:19
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:2799:3 expected true got false
-FAIL #1044 Test that a WebAssembly code returns a specific result (table_init64.wast:2471) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:2797:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:2799:3 expected true got false
+FAIL #1043 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@async_index.js:219:29
+table_init64_wast_js@table_init64.wast.js:2794:19
+global code@table_init64.wast.js:2799:3 expected true got false
+FAIL #1044 Test that a WebAssembly code returns a specific result (table_init64.wast:2471) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_init64_wast_js@table_init64.wast.js:2797:14
+global code@table_init64.wast.js:2799:3 expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table_set64.wast.js-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table_set64.wast.js-expected.txt
@@ -3,61 +3,61 @@ PASS #1 Reinitialize the default imports
 FAIL #2 Test that WebAssembly compilation succeeds (table_set64.wast:1) assert_equals: expected false but got true
 PASS #3 Reinitialize the default imports
 FAIL #4 Test that WebAssembly compilation succeeds (table_set64.wast:1) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 191: Element init_expr must produce an i32 at {loc} expected true got false
-FAIL #5 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-table_set64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_set64.wast.js:7:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_set64.wast.js:63:3 expected true got false
-FAIL #6 Test that a WebAssembly code returns a specific result (table_set64.wast:29) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_set64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_set64.wast.js:10:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_set64.wast.js:63:3 expected true got false
-FAIL #7 Test that a WebAssembly code returns a specific result (table_set64.wast:30) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_set64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_set64.wast.js:13:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_set64.wast.js:63:3 expected true got false
-FAIL #8 Test that a WebAssembly code returns a specific result (table_set64.wast:31) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_set64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_set64.wast.js:16:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_set64.wast.js:63:3 expected true got false
-FAIL #9 Test that a WebAssembly code returns a specific result (table_set64.wast:32) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_set64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_set64.wast.js:19:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_set64.wast.js:63:3 expected true got false
-FAIL #10 Test that a WebAssembly code returns a specific result (table_set64.wast:33) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_set64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_set64.wast.js:22:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_set64.wast.js:63:3 expected true got false
-FAIL #11 Test that a WebAssembly code returns a specific result (table_set64.wast:35) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_set64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_set64.wast.js:25:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_set64.wast.js:63:3 expected true got false
-FAIL #12 Test that a WebAssembly code returns a specific result (table_set64.wast:36) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_set64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_set64.wast.js:28:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_set64.wast.js:63:3 expected true got false
-FAIL #13 Test that a WebAssembly code returns a specific result (table_set64.wast:37) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_set64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_set64.wast.js:31:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_set64.wast.js:63:3 expected true got false
-FAIL #14 Test that a WebAssembly code returns a specific result (table_set64.wast:38) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_set64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_set64.wast.js:34:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_set64.wast.js:63:3 expected true got false
-FAIL #15 Test that a WebAssembly code returns a specific result (table_set64.wast:39) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_set64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_set64.wast.js:37:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_set64.wast.js:63:3 expected true got false
-FAIL #16 Test that a WebAssembly code traps (table_set64.wast:41) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-table_set64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_set64.wast.js:40:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_set64.wast.js:63:3 expected true got false
-FAIL #17 Test that a WebAssembly code traps (table_set64.wast:42) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-table_set64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_set64.wast.js:43:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_set64.wast.js:63:3 expected true got false
-FAIL #18 Test that a WebAssembly code traps (table_set64.wast:43) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-table_set64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_set64.wast.js:46:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_set64.wast.js:63:3 expected true got false
-FAIL #19 Test that a WebAssembly code traps (table_set64.wast:44) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-table_set64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_set64.wast.js:49:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_set64.wast.js:63:3 expected true got false
-FAIL #20 Test that a WebAssembly code traps (table_set64.wast:46) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-table_set64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_set64.wast.js:52:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_set64.wast.js:63:3 expected true got false
-FAIL #21 Test that a WebAssembly code traps (table_set64.wast:47) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-table_set64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_set64.wast.js:55:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_set64.wast.js:63:3 expected true got false
-FAIL #22 Test that a WebAssembly code traps (table_set64.wast:48) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-table_set64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_set64.wast.js:58:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_set64.wast.js:63:3 expected true got false
-FAIL #23 Test that a WebAssembly code traps (table_set64.wast:49) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-table_set64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_set64.wast.js:61:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_set64.wast.js:63:3 expected true got false
+FAIL #5 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@async_index.js:219:29
+table_set64_wast_js@table_set64.wast.js:7:18
+global code@table_set64.wast.js:63:3 expected true got false
+FAIL #6 Test that a WebAssembly code returns a specific result (table_set64.wast:29) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_set64_wast_js@table_set64.wast.js:10:14
+global code@table_set64.wast.js:63:3 expected true got false
+FAIL #7 Test that a WebAssembly code returns a specific result (table_set64.wast:30) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_set64_wast_js@table_set64.wast.js:13:14
+global code@table_set64.wast.js:63:3 expected true got false
+FAIL #8 Test that a WebAssembly code returns a specific result (table_set64.wast:31) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_set64_wast_js@table_set64.wast.js:16:14
+global code@table_set64.wast.js:63:3 expected true got false
+FAIL #9 Test that a WebAssembly code returns a specific result (table_set64.wast:32) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_set64_wast_js@table_set64.wast.js:19:14
+global code@table_set64.wast.js:63:3 expected true got false
+FAIL #10 Test that a WebAssembly code returns a specific result (table_set64.wast:33) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_set64_wast_js@table_set64.wast.js:22:14
+global code@table_set64.wast.js:63:3 expected true got false
+FAIL #11 Test that a WebAssembly code returns a specific result (table_set64.wast:35) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_set64_wast_js@table_set64.wast.js:25:14
+global code@table_set64.wast.js:63:3 expected true got false
+FAIL #12 Test that a WebAssembly code returns a specific result (table_set64.wast:36) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_set64_wast_js@table_set64.wast.js:28:14
+global code@table_set64.wast.js:63:3 expected true got false
+FAIL #13 Test that a WebAssembly code returns a specific result (table_set64.wast:37) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_set64_wast_js@table_set64.wast.js:31:14
+global code@table_set64.wast.js:63:3 expected true got false
+FAIL #14 Test that a WebAssembly code returns a specific result (table_set64.wast:38) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_set64_wast_js@table_set64.wast.js:34:14
+global code@table_set64.wast.js:63:3 expected true got false
+FAIL #15 Test that a WebAssembly code returns a specific result (table_set64.wast:39) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_set64_wast_js@table_set64.wast.js:37:14
+global code@table_set64.wast.js:63:3 expected true got false
+FAIL #16 Test that a WebAssembly code traps (table_set64.wast:41) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
+table_set64_wast_js@table_set64.wast.js:40:12
+global code@table_set64.wast.js:63:3 expected true got false
+FAIL #17 Test that a WebAssembly code traps (table_set64.wast:42) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
+table_set64_wast_js@table_set64.wast.js:43:12
+global code@table_set64.wast.js:63:3 expected true got false
+FAIL #18 Test that a WebAssembly code traps (table_set64.wast:43) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
+table_set64_wast_js@table_set64.wast.js:46:12
+global code@table_set64.wast.js:63:3 expected true got false
+FAIL #19 Test that a WebAssembly code traps (table_set64.wast:44) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
+table_set64_wast_js@table_set64.wast.js:49:12
+global code@table_set64.wast.js:63:3 expected true got false
+FAIL #20 Test that a WebAssembly code traps (table_set64.wast:46) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
+table_set64_wast_js@table_set64.wast.js:52:12
+global code@table_set64.wast.js:63:3 expected true got false
+FAIL #21 Test that a WebAssembly code traps (table_set64.wast:47) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
+table_set64_wast_js@table_set64.wast.js:55:12
+global code@table_set64.wast.js:63:3 expected true got false
+FAIL #22 Test that a WebAssembly code traps (table_set64.wast:48) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
+table_set64_wast_js@table_set64.wast.js:58:12
+global code@table_set64.wast.js:63:3 expected true got false
+FAIL #23 Test that a WebAssembly code traps (table_set64.wast:49) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
+table_set64_wast_js@table_set64.wast.js:61:12
+global code@table_set64.wast.js:63:3 expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table_size64.wast.js-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table_size64.wast.js-expected.txt
@@ -3,115 +3,115 @@ PASS #1 Reinitialize the default imports
 FAIL #2 Test that WebAssembly compilation succeeds (table_size64.wast:1) assert_equals: expected false but got true
 PASS #3 Reinitialize the default imports
 FAIL #4 Test that WebAssembly compilation succeeds (table_size64.wast:1) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't validate: control flow returns with unexpected type. I32 is not a I64, in function at index 0 at {loc} expected true got false
-FAIL #5 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-table_size64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_size64.wast.js:7:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_size64.wast.js:117:3 expected true got false
-FAIL #6 Test that a WebAssembly code returns a specific result (table_size64.wast:26) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_size64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_size64.wast.js:10:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_size64.wast.js:117:3 expected true got false
-FAIL #7 Test that a WebAssembly code returns a specific result (table_size64.wast:27) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_size64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_size64.wast.js:13:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_size64.wast.js:117:3 expected true got false
-FAIL #8 Test that a WebAssembly code returns a specific result (table_size64.wast:28) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_size64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_size64.wast.js:16:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_size64.wast.js:117:3 expected true got false
-FAIL #9 Test that a WebAssembly code returns a specific result (table_size64.wast:29) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_size64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_size64.wast.js:19:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_size64.wast.js:117:3 expected true got false
-FAIL #10 Test that a WebAssembly code returns a specific result (table_size64.wast:30) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_size64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_size64.wast.js:22:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_size64.wast.js:117:3 expected true got false
-FAIL #11 Test that a WebAssembly code returns a specific result (table_size64.wast:31) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_size64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_size64.wast.js:25:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_size64.wast.js:117:3 expected true got false
-FAIL #12 Test that a WebAssembly code returns a specific result (table_size64.wast:32) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_size64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_size64.wast.js:28:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_size64.wast.js:117:3 expected true got false
-FAIL #13 Test that a WebAssembly code returns a specific result (table_size64.wast:34) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_size64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_size64.wast.js:31:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_size64.wast.js:117:3 expected true got false
-FAIL #14 Test that a WebAssembly code returns a specific result (table_size64.wast:35) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_size64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_size64.wast.js:34:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_size64.wast.js:117:3 expected true got false
-FAIL #15 Test that a WebAssembly code returns a specific result (table_size64.wast:36) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_size64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_size64.wast.js:37:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_size64.wast.js:117:3 expected true got false
-FAIL #16 Test that a WebAssembly code returns a specific result (table_size64.wast:37) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_size64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_size64.wast.js:40:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_size64.wast.js:117:3 expected true got false
-FAIL #17 Test that a WebAssembly code returns a specific result (table_size64.wast:38) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_size64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_size64.wast.js:43:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_size64.wast.js:117:3 expected true got false
-FAIL #18 Test that a WebAssembly code returns a specific result (table_size64.wast:39) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_size64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_size64.wast.js:46:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_size64.wast.js:117:3 expected true got false
-FAIL #19 Test that a WebAssembly code returns a specific result (table_size64.wast:40) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_size64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_size64.wast.js:49:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_size64.wast.js:117:3 expected true got false
-FAIL #20 Test that a WebAssembly code returns a specific result (table_size64.wast:42) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_size64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_size64.wast.js:52:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_size64.wast.js:117:3 expected true got false
-FAIL #21 Test that a WebAssembly code returns a specific result (table_size64.wast:43) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_size64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_size64.wast.js:55:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_size64.wast.js:117:3 expected true got false
-FAIL #22 Test that a WebAssembly code returns a specific result (table_size64.wast:44) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_size64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_size64.wast.js:58:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_size64.wast.js:117:3 expected true got false
-FAIL #23 Test that a WebAssembly code returns a specific result (table_size64.wast:45) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_size64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_size64.wast.js:61:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_size64.wast.js:117:3 expected true got false
-FAIL #24 Test that a WebAssembly code returns a specific result (table_size64.wast:46) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_size64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_size64.wast.js:64:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_size64.wast.js:117:3 expected true got false
-FAIL #25 Test that a WebAssembly code returns a specific result (table_size64.wast:47) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_size64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_size64.wast.js:67:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_size64.wast.js:117:3 expected true got false
-FAIL #26 Test that a WebAssembly code returns a specific result (table_size64.wast:48) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_size64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_size64.wast.js:70:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_size64.wast.js:117:3 expected true got false
-FAIL #27 Test that a WebAssembly code returns a specific result (table_size64.wast:49) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_size64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_size64.wast.js:73:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_size64.wast.js:117:3 expected true got false
-FAIL #28 Test that a WebAssembly code returns a specific result (table_size64.wast:50) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_size64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_size64.wast.js:76:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_size64.wast.js:117:3 expected true got false
-FAIL #29 Test that a WebAssembly code returns a specific result (table_size64.wast:51) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_size64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_size64.wast.js:79:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_size64.wast.js:117:3 expected true got false
-FAIL #30 Test that a WebAssembly code returns a specific result (table_size64.wast:52) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_size64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_size64.wast.js:82:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_size64.wast.js:117:3 expected true got false
-FAIL #31 Test that a WebAssembly code returns a specific result (table_size64.wast:54) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_size64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_size64.wast.js:85:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_size64.wast.js:117:3 expected true got false
-FAIL #32 Test that a WebAssembly code returns a specific result (table_size64.wast:55) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_size64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_size64.wast.js:88:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_size64.wast.js:117:3 expected true got false
-FAIL #33 Test that a WebAssembly code returns a specific result (table_size64.wast:56) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_size64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_size64.wast.js:91:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_size64.wast.js:117:3 expected true got false
-FAIL #34 Test that a WebAssembly code returns a specific result (table_size64.wast:57) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_size64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_size64.wast.js:94:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_size64.wast.js:117:3 expected true got false
-FAIL #35 Test that a WebAssembly code returns a specific result (table_size64.wast:58) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_size64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_size64.wast.js:97:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_size64.wast.js:117:3 expected true got false
-FAIL #36 Test that a WebAssembly code returns a specific result (table_size64.wast:59) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_size64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_size64.wast.js:100:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_size64.wast.js:117:3 expected true got false
-FAIL #37 Test that a WebAssembly code returns a specific result (table_size64.wast:60) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_size64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_size64.wast.js:103:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_size64.wast.js:117:3 expected true got false
-FAIL #38 Test that a WebAssembly code returns a specific result (table_size64.wast:61) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_size64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_size64.wast.js:106:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_size64.wast.js:117:3 expected true got false
-FAIL #39 Test that a WebAssembly code returns a specific result (table_size64.wast:62) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_size64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_size64.wast.js:109:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_size64.wast.js:117:3 expected true got false
-FAIL #40 Test that a WebAssembly code returns a specific result (table_size64.wast:63) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_size64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_size64.wast.js:112:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_size64.wast.js:117:3 expected true got false
-FAIL #41 Test that a WebAssembly code returns a specific result (table_size64.wast:64) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-table_size64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_size64.wast.js:115:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table_size64.wast.js:117:3 expected true got false
+FAIL #5 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@async_index.js:219:29
+table_size64_wast_js@table_size64.wast.js:7:18
+global code@table_size64.wast.js:117:3 expected true got false
+FAIL #6 Test that a WebAssembly code returns a specific result (table_size64.wast:26) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_size64_wast_js@table_size64.wast.js:10:14
+global code@table_size64.wast.js:117:3 expected true got false
+FAIL #7 Test that a WebAssembly code returns a specific result (table_size64.wast:27) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_size64_wast_js@table_size64.wast.js:13:14
+global code@table_size64.wast.js:117:3 expected true got false
+FAIL #8 Test that a WebAssembly code returns a specific result (table_size64.wast:28) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_size64_wast_js@table_size64.wast.js:16:14
+global code@table_size64.wast.js:117:3 expected true got false
+FAIL #9 Test that a WebAssembly code returns a specific result (table_size64.wast:29) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_size64_wast_js@table_size64.wast.js:19:14
+global code@table_size64.wast.js:117:3 expected true got false
+FAIL #10 Test that a WebAssembly code returns a specific result (table_size64.wast:30) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_size64_wast_js@table_size64.wast.js:22:14
+global code@table_size64.wast.js:117:3 expected true got false
+FAIL #11 Test that a WebAssembly code returns a specific result (table_size64.wast:31) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_size64_wast_js@table_size64.wast.js:25:14
+global code@table_size64.wast.js:117:3 expected true got false
+FAIL #12 Test that a WebAssembly code returns a specific result (table_size64.wast:32) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_size64_wast_js@table_size64.wast.js:28:14
+global code@table_size64.wast.js:117:3 expected true got false
+FAIL #13 Test that a WebAssembly code returns a specific result (table_size64.wast:34) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_size64_wast_js@table_size64.wast.js:31:14
+global code@table_size64.wast.js:117:3 expected true got false
+FAIL #14 Test that a WebAssembly code returns a specific result (table_size64.wast:35) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_size64_wast_js@table_size64.wast.js:34:14
+global code@table_size64.wast.js:117:3 expected true got false
+FAIL #15 Test that a WebAssembly code returns a specific result (table_size64.wast:36) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_size64_wast_js@table_size64.wast.js:37:14
+global code@table_size64.wast.js:117:3 expected true got false
+FAIL #16 Test that a WebAssembly code returns a specific result (table_size64.wast:37) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_size64_wast_js@table_size64.wast.js:40:14
+global code@table_size64.wast.js:117:3 expected true got false
+FAIL #17 Test that a WebAssembly code returns a specific result (table_size64.wast:38) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_size64_wast_js@table_size64.wast.js:43:14
+global code@table_size64.wast.js:117:3 expected true got false
+FAIL #18 Test that a WebAssembly code returns a specific result (table_size64.wast:39) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_size64_wast_js@table_size64.wast.js:46:14
+global code@table_size64.wast.js:117:3 expected true got false
+FAIL #19 Test that a WebAssembly code returns a specific result (table_size64.wast:40) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_size64_wast_js@table_size64.wast.js:49:14
+global code@table_size64.wast.js:117:3 expected true got false
+FAIL #20 Test that a WebAssembly code returns a specific result (table_size64.wast:42) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_size64_wast_js@table_size64.wast.js:52:14
+global code@table_size64.wast.js:117:3 expected true got false
+FAIL #21 Test that a WebAssembly code returns a specific result (table_size64.wast:43) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_size64_wast_js@table_size64.wast.js:55:14
+global code@table_size64.wast.js:117:3 expected true got false
+FAIL #22 Test that a WebAssembly code returns a specific result (table_size64.wast:44) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_size64_wast_js@table_size64.wast.js:58:14
+global code@table_size64.wast.js:117:3 expected true got false
+FAIL #23 Test that a WebAssembly code returns a specific result (table_size64.wast:45) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_size64_wast_js@table_size64.wast.js:61:14
+global code@table_size64.wast.js:117:3 expected true got false
+FAIL #24 Test that a WebAssembly code returns a specific result (table_size64.wast:46) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_size64_wast_js@table_size64.wast.js:64:14
+global code@table_size64.wast.js:117:3 expected true got false
+FAIL #25 Test that a WebAssembly code returns a specific result (table_size64.wast:47) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_size64_wast_js@table_size64.wast.js:67:14
+global code@table_size64.wast.js:117:3 expected true got false
+FAIL #26 Test that a WebAssembly code returns a specific result (table_size64.wast:48) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_size64_wast_js@table_size64.wast.js:70:14
+global code@table_size64.wast.js:117:3 expected true got false
+FAIL #27 Test that a WebAssembly code returns a specific result (table_size64.wast:49) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_size64_wast_js@table_size64.wast.js:73:14
+global code@table_size64.wast.js:117:3 expected true got false
+FAIL #28 Test that a WebAssembly code returns a specific result (table_size64.wast:50) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_size64_wast_js@table_size64.wast.js:76:14
+global code@table_size64.wast.js:117:3 expected true got false
+FAIL #29 Test that a WebAssembly code returns a specific result (table_size64.wast:51) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_size64_wast_js@table_size64.wast.js:79:14
+global code@table_size64.wast.js:117:3 expected true got false
+FAIL #30 Test that a WebAssembly code returns a specific result (table_size64.wast:52) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_size64_wast_js@table_size64.wast.js:82:14
+global code@table_size64.wast.js:117:3 expected true got false
+FAIL #31 Test that a WebAssembly code returns a specific result (table_size64.wast:54) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_size64_wast_js@table_size64.wast.js:85:14
+global code@table_size64.wast.js:117:3 expected true got false
+FAIL #32 Test that a WebAssembly code returns a specific result (table_size64.wast:55) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_size64_wast_js@table_size64.wast.js:88:14
+global code@table_size64.wast.js:117:3 expected true got false
+FAIL #33 Test that a WebAssembly code returns a specific result (table_size64.wast:56) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_size64_wast_js@table_size64.wast.js:91:14
+global code@table_size64.wast.js:117:3 expected true got false
+FAIL #34 Test that a WebAssembly code returns a specific result (table_size64.wast:57) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_size64_wast_js@table_size64.wast.js:94:14
+global code@table_size64.wast.js:117:3 expected true got false
+FAIL #35 Test that a WebAssembly code returns a specific result (table_size64.wast:58) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_size64_wast_js@table_size64.wast.js:97:14
+global code@table_size64.wast.js:117:3 expected true got false
+FAIL #36 Test that a WebAssembly code returns a specific result (table_size64.wast:59) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_size64_wast_js@table_size64.wast.js:100:14
+global code@table_size64.wast.js:117:3 expected true got false
+FAIL #37 Test that a WebAssembly code returns a specific result (table_size64.wast:60) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_size64_wast_js@table_size64.wast.js:103:14
+global code@table_size64.wast.js:117:3 expected true got false
+FAIL #38 Test that a WebAssembly code returns a specific result (table_size64.wast:61) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_size64_wast_js@table_size64.wast.js:106:14
+global code@table_size64.wast.js:117:3 expected true got false
+FAIL #39 Test that a WebAssembly code returns a specific result (table_size64.wast:62) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_size64_wast_js@table_size64.wast.js:109:14
+global code@table_size64.wast.js:117:3 expected true got false
+FAIL #40 Test that a WebAssembly code returns a specific result (table_size64.wast:63) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_size64_wast_js@table_size64.wast.js:112:14
+global code@table_size64.wast.js:117:3 expected true got false
+FAIL #41 Test that a WebAssembly code returns a specific result (table_size64.wast:64) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
+table_size64_wast_js@table_size64.wast.js:115:14
+global code@table_size64.wast.js:117:3 expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/return_call_indirect.wast.js-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/return_call_indirect.wast.js-expected.txt
@@ -118,10 +118,10 @@ PASS #116 Test that WebAssembly compilation fails (return_call_indirect.wast:389
 PASS #117 Test that WebAssembly compilation fails (return_call_indirect.wast:399)
 PASS #118 Test that WebAssembly compilation fails (return_call_indirect.wast:411)
 PASS #119 Test that WebAssembly compilation fails (return_call_indirect.wast:426)
-FAIL #120 Test that WebAssembly compilation fails (return_call_indirect.wast:434) assert_true: module@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:163:24
-assert_invalid@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:192:9
-return_call_indirect_wast_js@http://web-platform.test:8800/wasm/core/js/return_call_indirect.wast.js:193:15
-global code@http://web-platform.test:8800/wasm/core/js/return_call_indirect.wast.js:249:3 expected true got false
+FAIL #120 Test that WebAssembly compilation fails (return_call_indirect.wast:434) assert_true: module@async_index.js:175:29
+assert_invalid@async_index.js:204:9
+return_call_indirect_wast_js@return_call_indirect.wast.js:193:15
+global code@return_call_indirect.wast.js:249:3 expected true got false
 PASS #121 Test that WebAssembly compilation fails (return_call_indirect.wast:442)
 PASS #122 Test that WebAssembly compilation fails (return_call_indirect.wast:451)
 PASS #123 Test that WebAssembly compilation fails (return_call_indirect.wast:459)

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/return_call_ref.wast.js-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/return_call_ref.wast.js-expected.txt
@@ -86,14 +86,14 @@ PASS #84 Test that a WebAssembly code traps (return_call_ref.wast:319)
 PASS #85 Test that WebAssembly compilation succeeds (return_call_ref.wast:321)
 PASS #86 Test that WebAssembly instantiation succeeds (return_call_ref.wast:321)
 PASS #87 Test that a WebAssembly code traps (return_call_ref.wast:334)
-FAIL #88 Test that WebAssembly compilation fails (return_call_ref.wast:336) assert_true: module@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:163:24
-assert_invalid@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:192:9
-return_call_ref_wast_js@http://web-platform.test:8800/wasm/core/js/return_call_ref.wast.js:157:15
-global code@http://web-platform.test:8800/wasm/core/js/return_call_ref.wast.js:171:3 expected true got false
-FAIL #89 Test that WebAssembly compilation fails (return_call_ref.wast:352) assert_true: module@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:163:24
-assert_invalid@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:192:9
-return_call_ref_wast_js@http://web-platform.test:8800/wasm/core/js/return_call_ref.wast.js:160:15
-global code@http://web-platform.test:8800/wasm/core/js/return_call_ref.wast.js:171:3 expected true got false
+FAIL #88 Test that WebAssembly compilation fails (return_call_ref.wast:336) assert_true: module@async_index.js:175:29
+assert_invalid@async_index.js:204:9
+return_call_ref_wast_js@return_call_ref.wast.js:157:15
+global code@return_call_ref.wast.js:171:3 expected true got false
+FAIL #89 Test that WebAssembly compilation fails (return_call_ref.wast:352) assert_true: module@async_index.js:175:29
+assert_invalid@async_index.js:204:9
+return_call_ref_wast_js@return_call_ref.wast.js:160:15
+global code@return_call_ref.wast.js:171:3 expected true got false
 PASS #90 Test that WebAssembly compilation fails (return_call_ref.wast:368)
 PASS #91 Test that WebAssembly compilation fails (return_call_ref.wast:378)
 PASS #92 Test that WebAssembly compilation fails (return_call_ref.wast:388)

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/unreached-invalid.wast.js-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/unreached-invalid.wast.js-expected.txt
@@ -126,178 +126,178 @@ PASS #124 Test that WebAssembly compilation fails (unreached-invalid.wast:3)
 PASS #125 Test that WebAssembly compilation fails (unreached-invalid.wast:7)
 PASS #126 Test that WebAssembly compilation fails (unreached-invalid.wast:11)
 PASS #127 Test that WebAssembly compilation fails (unreached-invalid.wast:15)
-FAIL #128 Test that WebAssembly compilation fails (unreached-invalid.wast:20) assert_true: module@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:163:24
-assert_invalid@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:192:9
-unreached_invalid_wast_js@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:16:15
-global code@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:366:3 expected true got false
-FAIL #129 Test that WebAssembly compilation fails (unreached-invalid.wast:26) assert_true: module@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:163:24
-assert_invalid@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:192:9
-unreached_invalid_wast_js@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:19:15
-global code@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:366:3 expected true got false
-FAIL #130 Test that WebAssembly compilation fails (unreached-invalid.wast:32) assert_true: module@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:163:24
-assert_invalid@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:192:9
-unreached_invalid_wast_js@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:22:15
-global code@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:366:3 expected true got false
-FAIL #131 Test that WebAssembly compilation fails (unreached-invalid.wast:41) assert_true: module@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:163:24
-assert_invalid@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:192:9
-unreached_invalid_wast_js@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:25:15
-global code@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:366:3 expected true got false
-FAIL #132 Test that WebAssembly compilation fails (unreached-invalid.wast:45) assert_true: module@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:163:24
-assert_invalid@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:192:9
-unreached_invalid_wast_js@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:28:15
-global code@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:366:3 expected true got false
-FAIL #133 Test that WebAssembly compilation fails (unreached-invalid.wast:49) assert_true: module@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:163:24
-assert_invalid@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:192:9
-unreached_invalid_wast_js@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:31:15
-global code@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:366:3 expected true got false
-FAIL #134 Test that WebAssembly compilation fails (unreached-invalid.wast:55) assert_true: module@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:163:24
-assert_invalid@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:192:9
-unreached_invalid_wast_js@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:34:15
-global code@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:366:3 expected true got false
-FAIL #135 Test that WebAssembly compilation fails (unreached-invalid.wast:59) assert_true: module@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:163:24
-assert_invalid@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:192:9
-unreached_invalid_wast_js@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:37:15
-global code@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:366:3 expected true got false
-FAIL #136 Test that WebAssembly compilation fails (unreached-invalid.wast:63) assert_true: module@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:163:24
-assert_invalid@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:192:9
-unreached_invalid_wast_js@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:40:15
-global code@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:366:3 expected true got false
-FAIL #137 Test that WebAssembly compilation fails (unreached-invalid.wast:70) assert_true: module@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:163:24
-assert_invalid@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:192:9
-unreached_invalid_wast_js@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:43:15
-global code@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:366:3 expected true got false
-FAIL #138 Test that WebAssembly compilation fails (unreached-invalid.wast:76) assert_true: module@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:163:24
-assert_invalid@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:192:9
-unreached_invalid_wast_js@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:46:15
-global code@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:366:3 expected true got false
-FAIL #139 Test that WebAssembly compilation fails (unreached-invalid.wast:82) assert_true: module@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:163:24
-assert_invalid@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:192:9
-unreached_invalid_wast_js@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:49:15
-global code@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:366:3 expected true got false
-FAIL #140 Test that WebAssembly compilation fails (unreached-invalid.wast:88) assert_true: module@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:163:24
-assert_invalid@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:192:9
-unreached_invalid_wast_js@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:52:15
-global code@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:366:3 expected true got false
-FAIL #141 Test that WebAssembly compilation fails (unreached-invalid.wast:94) assert_true: module@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:163:24
-assert_invalid@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:192:9
-unreached_invalid_wast_js@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:55:15
-global code@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:366:3 expected true got false
-FAIL #142 Test that WebAssembly compilation fails (unreached-invalid.wast:100) assert_true: module@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:163:24
-assert_invalid@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:192:9
-unreached_invalid_wast_js@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:58:15
-global code@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:366:3 expected true got false
-FAIL #143 Test that WebAssembly compilation fails (unreached-invalid.wast:106) assert_true: module@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:163:24
-assert_invalid@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:192:9
-unreached_invalid_wast_js@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:61:15
-global code@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:366:3 expected true got false
-FAIL #144 Test that WebAssembly compilation fails (unreached-invalid.wast:112) assert_true: module@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:163:24
-assert_invalid@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:192:9
-unreached_invalid_wast_js@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:64:15
-global code@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:366:3 expected true got false
-FAIL #145 Test that WebAssembly compilation fails (unreached-invalid.wast:118) assert_true: module@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:163:24
-assert_invalid@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:192:9
-unreached_invalid_wast_js@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:67:15
-global code@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:366:3 expected true got false
-FAIL #146 Test that WebAssembly compilation fails (unreached-invalid.wast:124) assert_true: module@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:163:24
-assert_invalid@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:192:9
-unreached_invalid_wast_js@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:70:15
-global code@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:366:3 expected true got false
-FAIL #147 Test that WebAssembly compilation fails (unreached-invalid.wast:131) assert_true: module@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:163:24
-assert_invalid@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:192:9
-unreached_invalid_wast_js@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:73:15
-global code@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:366:3 expected true got false
-FAIL #148 Test that WebAssembly compilation fails (unreached-invalid.wast:137) assert_true: module@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:163:24
-assert_invalid@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:192:9
-unreached_invalid_wast_js@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:76:15
-global code@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:366:3 expected true got false
-FAIL #149 Test that WebAssembly compilation fails (unreached-invalid.wast:143) assert_true: module@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:163:24
-assert_invalid@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:192:9
-unreached_invalid_wast_js@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:79:15
-global code@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:366:3 expected true got false
-FAIL #150 Test that WebAssembly compilation fails (unreached-invalid.wast:149) assert_true: module@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:163:24
-assert_invalid@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:192:9
-unreached_invalid_wast_js@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:82:15
-global code@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:366:3 expected true got false
-FAIL #151 Test that WebAssembly compilation fails (unreached-invalid.wast:155) assert_true: module@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:163:24
-assert_invalid@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:192:9
-unreached_invalid_wast_js@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:85:15
-global code@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:366:3 expected true got false
-FAIL #152 Test that WebAssembly compilation fails (unreached-invalid.wast:161) assert_true: module@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:163:24
-assert_invalid@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:192:9
-unreached_invalid_wast_js@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:88:15
-global code@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:366:3 expected true got false
-FAIL #153 Test that WebAssembly compilation fails (unreached-invalid.wast:167) assert_true: module@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:163:24
-assert_invalid@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:192:9
-unreached_invalid_wast_js@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:91:15
-global code@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:366:3 expected true got false
-FAIL #154 Test that WebAssembly compilation fails (unreached-invalid.wast:173) assert_true: module@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:163:24
-assert_invalid@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:192:9
-unreached_invalid_wast_js@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:94:15
-global code@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:366:3 expected true got false
-FAIL #155 Test that WebAssembly compilation fails (unreached-invalid.wast:179) assert_true: module@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:163:24
-assert_invalid@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:192:9
-unreached_invalid_wast_js@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:97:15
-global code@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:366:3 expected true got false
-FAIL #156 Test that WebAssembly compilation fails (unreached-invalid.wast:185) assert_true: module@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:163:24
-assert_invalid@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:192:9
-unreached_invalid_wast_js@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:100:15
-global code@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:366:3 expected true got false
-FAIL #157 Test that WebAssembly compilation fails (unreached-invalid.wast:192) assert_true: module@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:163:24
-assert_invalid@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:192:9
-unreached_invalid_wast_js@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:103:15
-global code@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:366:3 expected true got false
-FAIL #158 Test that WebAssembly compilation fails (unreached-invalid.wast:198) assert_true: module@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:163:24
-assert_invalid@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:192:9
-unreached_invalid_wast_js@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:106:15
-global code@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:366:3 expected true got false
-FAIL #159 Test that WebAssembly compilation fails (unreached-invalid.wast:204) assert_true: module@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:163:24
-assert_invalid@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:192:9
-unreached_invalid_wast_js@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:109:15
-global code@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:366:3 expected true got false
-FAIL #160 Test that WebAssembly compilation fails (unreached-invalid.wast:210) assert_true: module@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:163:24
-assert_invalid@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:192:9
-unreached_invalid_wast_js@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:112:15
-global code@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:366:3 expected true got false
-FAIL #161 Test that WebAssembly compilation fails (unreached-invalid.wast:216) assert_true: module@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:163:24
-assert_invalid@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:192:9
-unreached_invalid_wast_js@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:115:15
-global code@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:366:3 expected true got false
-FAIL #162 Test that WebAssembly compilation fails (unreached-invalid.wast:222) assert_true: module@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:163:24
-assert_invalid@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:192:9
-unreached_invalid_wast_js@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:118:15
-global code@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:366:3 expected true got false
-FAIL #163 Test that WebAssembly compilation fails (unreached-invalid.wast:228) assert_true: module@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:163:24
-assert_invalid@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:192:9
-unreached_invalid_wast_js@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:121:15
-global code@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:366:3 expected true got false
-FAIL #164 Test that WebAssembly compilation fails (unreached-invalid.wast:234) assert_true: module@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:163:24
-assert_invalid@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:192:9
-unreached_invalid_wast_js@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:124:15
-global code@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:366:3 expected true got false
-FAIL #165 Test that WebAssembly compilation fails (unreached-invalid.wast:240) assert_true: module@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:163:24
-assert_invalid@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:192:9
-unreached_invalid_wast_js@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:127:15
-global code@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:366:3 expected true got false
-FAIL #166 Test that WebAssembly compilation fails (unreached-invalid.wast:246) assert_true: module@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:163:24
-assert_invalid@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:192:9
-unreached_invalid_wast_js@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:130:15
-global code@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:366:3 expected true got false
-FAIL #167 Test that WebAssembly compilation fails (unreached-invalid.wast:252) assert_true: module@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:163:24
-assert_invalid@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:192:9
-unreached_invalid_wast_js@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:133:15
-global code@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:366:3 expected true got false
-FAIL #168 Test that WebAssembly compilation fails (unreached-invalid.wast:258) assert_true: module@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:163:24
-assert_invalid@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:192:9
-unreached_invalid_wast_js@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:136:15
-global code@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:366:3 expected true got false
-FAIL #169 Test that WebAssembly compilation fails (unreached-invalid.wast:264) assert_true: module@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:163:24
-assert_invalid@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:192:9
-unreached_invalid_wast_js@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:139:15
-global code@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:366:3 expected true got false
-FAIL #170 Test that WebAssembly compilation fails (unreached-invalid.wast:270) assert_true: module@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:163:24
-assert_invalid@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:192:9
-unreached_invalid_wast_js@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:142:15
-global code@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:366:3 expected true got false
+FAIL #128 Test that WebAssembly compilation fails (unreached-invalid.wast:20) assert_true: module@async_index.js:175:29
+assert_invalid@async_index.js:204:9
+unreached_invalid_wast_js@unreached-invalid.wast.js:16:15
+global code@unreached-invalid.wast.js:366:3 expected true got false
+FAIL #129 Test that WebAssembly compilation fails (unreached-invalid.wast:26) assert_true: module@async_index.js:175:29
+assert_invalid@async_index.js:204:9
+unreached_invalid_wast_js@unreached-invalid.wast.js:19:15
+global code@unreached-invalid.wast.js:366:3 expected true got false
+FAIL #130 Test that WebAssembly compilation fails (unreached-invalid.wast:32) assert_true: module@async_index.js:175:29
+assert_invalid@async_index.js:204:9
+unreached_invalid_wast_js@unreached-invalid.wast.js:22:15
+global code@unreached-invalid.wast.js:366:3 expected true got false
+FAIL #131 Test that WebAssembly compilation fails (unreached-invalid.wast:41) assert_true: module@async_index.js:175:29
+assert_invalid@async_index.js:204:9
+unreached_invalid_wast_js@unreached-invalid.wast.js:25:15
+global code@unreached-invalid.wast.js:366:3 expected true got false
+FAIL #132 Test that WebAssembly compilation fails (unreached-invalid.wast:45) assert_true: module@async_index.js:175:29
+assert_invalid@async_index.js:204:9
+unreached_invalid_wast_js@unreached-invalid.wast.js:28:15
+global code@unreached-invalid.wast.js:366:3 expected true got false
+FAIL #133 Test that WebAssembly compilation fails (unreached-invalid.wast:49) assert_true: module@async_index.js:175:29
+assert_invalid@async_index.js:204:9
+unreached_invalid_wast_js@unreached-invalid.wast.js:31:15
+global code@unreached-invalid.wast.js:366:3 expected true got false
+FAIL #134 Test that WebAssembly compilation fails (unreached-invalid.wast:55) assert_true: module@async_index.js:175:29
+assert_invalid@async_index.js:204:9
+unreached_invalid_wast_js@unreached-invalid.wast.js:34:15
+global code@unreached-invalid.wast.js:366:3 expected true got false
+FAIL #135 Test that WebAssembly compilation fails (unreached-invalid.wast:59) assert_true: module@async_index.js:175:29
+assert_invalid@async_index.js:204:9
+unreached_invalid_wast_js@unreached-invalid.wast.js:37:15
+global code@unreached-invalid.wast.js:366:3 expected true got false
+FAIL #136 Test that WebAssembly compilation fails (unreached-invalid.wast:63) assert_true: module@async_index.js:175:29
+assert_invalid@async_index.js:204:9
+unreached_invalid_wast_js@unreached-invalid.wast.js:40:15
+global code@unreached-invalid.wast.js:366:3 expected true got false
+FAIL #137 Test that WebAssembly compilation fails (unreached-invalid.wast:70) assert_true: module@async_index.js:175:29
+assert_invalid@async_index.js:204:9
+unreached_invalid_wast_js@unreached-invalid.wast.js:43:15
+global code@unreached-invalid.wast.js:366:3 expected true got false
+FAIL #138 Test that WebAssembly compilation fails (unreached-invalid.wast:76) assert_true: module@async_index.js:175:29
+assert_invalid@async_index.js:204:9
+unreached_invalid_wast_js@unreached-invalid.wast.js:46:15
+global code@unreached-invalid.wast.js:366:3 expected true got false
+FAIL #139 Test that WebAssembly compilation fails (unreached-invalid.wast:82) assert_true: module@async_index.js:175:29
+assert_invalid@async_index.js:204:9
+unreached_invalid_wast_js@unreached-invalid.wast.js:49:15
+global code@unreached-invalid.wast.js:366:3 expected true got false
+FAIL #140 Test that WebAssembly compilation fails (unreached-invalid.wast:88) assert_true: module@async_index.js:175:29
+assert_invalid@async_index.js:204:9
+unreached_invalid_wast_js@unreached-invalid.wast.js:52:15
+global code@unreached-invalid.wast.js:366:3 expected true got false
+FAIL #141 Test that WebAssembly compilation fails (unreached-invalid.wast:94) assert_true: module@async_index.js:175:29
+assert_invalid@async_index.js:204:9
+unreached_invalid_wast_js@unreached-invalid.wast.js:55:15
+global code@unreached-invalid.wast.js:366:3 expected true got false
+FAIL #142 Test that WebAssembly compilation fails (unreached-invalid.wast:100) assert_true: module@async_index.js:175:29
+assert_invalid@async_index.js:204:9
+unreached_invalid_wast_js@unreached-invalid.wast.js:58:15
+global code@unreached-invalid.wast.js:366:3 expected true got false
+FAIL #143 Test that WebAssembly compilation fails (unreached-invalid.wast:106) assert_true: module@async_index.js:175:29
+assert_invalid@async_index.js:204:9
+unreached_invalid_wast_js@unreached-invalid.wast.js:61:15
+global code@unreached-invalid.wast.js:366:3 expected true got false
+FAIL #144 Test that WebAssembly compilation fails (unreached-invalid.wast:112) assert_true: module@async_index.js:175:29
+assert_invalid@async_index.js:204:9
+unreached_invalid_wast_js@unreached-invalid.wast.js:64:15
+global code@unreached-invalid.wast.js:366:3 expected true got false
+FAIL #145 Test that WebAssembly compilation fails (unreached-invalid.wast:118) assert_true: module@async_index.js:175:29
+assert_invalid@async_index.js:204:9
+unreached_invalid_wast_js@unreached-invalid.wast.js:67:15
+global code@unreached-invalid.wast.js:366:3 expected true got false
+FAIL #146 Test that WebAssembly compilation fails (unreached-invalid.wast:124) assert_true: module@async_index.js:175:29
+assert_invalid@async_index.js:204:9
+unreached_invalid_wast_js@unreached-invalid.wast.js:70:15
+global code@unreached-invalid.wast.js:366:3 expected true got false
+FAIL #147 Test that WebAssembly compilation fails (unreached-invalid.wast:131) assert_true: module@async_index.js:175:29
+assert_invalid@async_index.js:204:9
+unreached_invalid_wast_js@unreached-invalid.wast.js:73:15
+global code@unreached-invalid.wast.js:366:3 expected true got false
+FAIL #148 Test that WebAssembly compilation fails (unreached-invalid.wast:137) assert_true: module@async_index.js:175:29
+assert_invalid@async_index.js:204:9
+unreached_invalid_wast_js@unreached-invalid.wast.js:76:15
+global code@unreached-invalid.wast.js:366:3 expected true got false
+FAIL #149 Test that WebAssembly compilation fails (unreached-invalid.wast:143) assert_true: module@async_index.js:175:29
+assert_invalid@async_index.js:204:9
+unreached_invalid_wast_js@unreached-invalid.wast.js:79:15
+global code@unreached-invalid.wast.js:366:3 expected true got false
+FAIL #150 Test that WebAssembly compilation fails (unreached-invalid.wast:149) assert_true: module@async_index.js:175:29
+assert_invalid@async_index.js:204:9
+unreached_invalid_wast_js@unreached-invalid.wast.js:82:15
+global code@unreached-invalid.wast.js:366:3 expected true got false
+FAIL #151 Test that WebAssembly compilation fails (unreached-invalid.wast:155) assert_true: module@async_index.js:175:29
+assert_invalid@async_index.js:204:9
+unreached_invalid_wast_js@unreached-invalid.wast.js:85:15
+global code@unreached-invalid.wast.js:366:3 expected true got false
+FAIL #152 Test that WebAssembly compilation fails (unreached-invalid.wast:161) assert_true: module@async_index.js:175:29
+assert_invalid@async_index.js:204:9
+unreached_invalid_wast_js@unreached-invalid.wast.js:88:15
+global code@unreached-invalid.wast.js:366:3 expected true got false
+FAIL #153 Test that WebAssembly compilation fails (unreached-invalid.wast:167) assert_true: module@async_index.js:175:29
+assert_invalid@async_index.js:204:9
+unreached_invalid_wast_js@unreached-invalid.wast.js:91:15
+global code@unreached-invalid.wast.js:366:3 expected true got false
+FAIL #154 Test that WebAssembly compilation fails (unreached-invalid.wast:173) assert_true: module@async_index.js:175:29
+assert_invalid@async_index.js:204:9
+unreached_invalid_wast_js@unreached-invalid.wast.js:94:15
+global code@unreached-invalid.wast.js:366:3 expected true got false
+FAIL #155 Test that WebAssembly compilation fails (unreached-invalid.wast:179) assert_true: module@async_index.js:175:29
+assert_invalid@async_index.js:204:9
+unreached_invalid_wast_js@unreached-invalid.wast.js:97:15
+global code@unreached-invalid.wast.js:366:3 expected true got false
+FAIL #156 Test that WebAssembly compilation fails (unreached-invalid.wast:185) assert_true: module@async_index.js:175:29
+assert_invalid@async_index.js:204:9
+unreached_invalid_wast_js@unreached-invalid.wast.js:100:15
+global code@unreached-invalid.wast.js:366:3 expected true got false
+FAIL #157 Test that WebAssembly compilation fails (unreached-invalid.wast:192) assert_true: module@async_index.js:175:29
+assert_invalid@async_index.js:204:9
+unreached_invalid_wast_js@unreached-invalid.wast.js:103:15
+global code@unreached-invalid.wast.js:366:3 expected true got false
+FAIL #158 Test that WebAssembly compilation fails (unreached-invalid.wast:198) assert_true: module@async_index.js:175:29
+assert_invalid@async_index.js:204:9
+unreached_invalid_wast_js@unreached-invalid.wast.js:106:15
+global code@unreached-invalid.wast.js:366:3 expected true got false
+FAIL #159 Test that WebAssembly compilation fails (unreached-invalid.wast:204) assert_true: module@async_index.js:175:29
+assert_invalid@async_index.js:204:9
+unreached_invalid_wast_js@unreached-invalid.wast.js:109:15
+global code@unreached-invalid.wast.js:366:3 expected true got false
+FAIL #160 Test that WebAssembly compilation fails (unreached-invalid.wast:210) assert_true: module@async_index.js:175:29
+assert_invalid@async_index.js:204:9
+unreached_invalid_wast_js@unreached-invalid.wast.js:112:15
+global code@unreached-invalid.wast.js:366:3 expected true got false
+FAIL #161 Test that WebAssembly compilation fails (unreached-invalid.wast:216) assert_true: module@async_index.js:175:29
+assert_invalid@async_index.js:204:9
+unreached_invalid_wast_js@unreached-invalid.wast.js:115:15
+global code@unreached-invalid.wast.js:366:3 expected true got false
+FAIL #162 Test that WebAssembly compilation fails (unreached-invalid.wast:222) assert_true: module@async_index.js:175:29
+assert_invalid@async_index.js:204:9
+unreached_invalid_wast_js@unreached-invalid.wast.js:118:15
+global code@unreached-invalid.wast.js:366:3 expected true got false
+FAIL #163 Test that WebAssembly compilation fails (unreached-invalid.wast:228) assert_true: module@async_index.js:175:29
+assert_invalid@async_index.js:204:9
+unreached_invalid_wast_js@unreached-invalid.wast.js:121:15
+global code@unreached-invalid.wast.js:366:3 expected true got false
+FAIL #164 Test that WebAssembly compilation fails (unreached-invalid.wast:234) assert_true: module@async_index.js:175:29
+assert_invalid@async_index.js:204:9
+unreached_invalid_wast_js@unreached-invalid.wast.js:124:15
+global code@unreached-invalid.wast.js:366:3 expected true got false
+FAIL #165 Test that WebAssembly compilation fails (unreached-invalid.wast:240) assert_true: module@async_index.js:175:29
+assert_invalid@async_index.js:204:9
+unreached_invalid_wast_js@unreached-invalid.wast.js:127:15
+global code@unreached-invalid.wast.js:366:3 expected true got false
+FAIL #166 Test that WebAssembly compilation fails (unreached-invalid.wast:246) assert_true: module@async_index.js:175:29
+assert_invalid@async_index.js:204:9
+unreached_invalid_wast_js@unreached-invalid.wast.js:130:15
+global code@unreached-invalid.wast.js:366:3 expected true got false
+FAIL #167 Test that WebAssembly compilation fails (unreached-invalid.wast:252) assert_true: module@async_index.js:175:29
+assert_invalid@async_index.js:204:9
+unreached_invalid_wast_js@unreached-invalid.wast.js:133:15
+global code@unreached-invalid.wast.js:366:3 expected true got false
+FAIL #168 Test that WebAssembly compilation fails (unreached-invalid.wast:258) assert_true: module@async_index.js:175:29
+assert_invalid@async_index.js:204:9
+unreached_invalid_wast_js@unreached-invalid.wast.js:136:15
+global code@unreached-invalid.wast.js:366:3 expected true got false
+FAIL #169 Test that WebAssembly compilation fails (unreached-invalid.wast:264) assert_true: module@async_index.js:175:29
+assert_invalid@async_index.js:204:9
+unreached_invalid_wast_js@unreached-invalid.wast.js:139:15
+global code@unreached-invalid.wast.js:366:3 expected true got false
+FAIL #170 Test that WebAssembly compilation fails (unreached-invalid.wast:270) assert_true: module@async_index.js:175:29
+assert_invalid@async_index.js:204:9
+unreached_invalid_wast_js@unreached-invalid.wast.js:142:15
+global code@unreached-invalid.wast.js:366:3 expected true got false
 PASS #171 Test that WebAssembly compilation fails (unreached-invalid.wast:276)
 PASS #172 Test that WebAssembly compilation fails (unreached-invalid.wast:283)
 PASS #173 Test that WebAssembly compilation fails (unreached-invalid.wast:289)
@@ -329,39 +329,39 @@ PASS #198 Test that WebAssembly compilation fails (unreached-invalid.wast:444)
 PASS #199 Test that WebAssembly compilation fails (unreached-invalid.wast:450)
 PASS #200 Test that WebAssembly compilation fails (unreached-invalid.wast:456)
 PASS #201 Test that WebAssembly compilation fails (unreached-invalid.wast:462)
-FAIL #202 Test that WebAssembly compilation fails (unreached-invalid.wast:469) assert_true: module@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:163:24
-assert_invalid@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:192:9
-unreached_invalid_wast_js@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:238:15
-global code@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:366:3 expected true got false
-FAIL #203 Test that WebAssembly compilation fails (unreached-invalid.wast:476) assert_true: module@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:163:24
-assert_invalid@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:192:9
-unreached_invalid_wast_js@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:241:15
-global code@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:366:3 expected true got false
-FAIL #204 Test that WebAssembly compilation fails (unreached-invalid.wast:483) assert_true: module@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:163:24
-assert_invalid@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:192:9
-unreached_invalid_wast_js@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:244:15
-global code@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:366:3 expected true got false
+FAIL #202 Test that WebAssembly compilation fails (unreached-invalid.wast:469) assert_true: module@async_index.js:175:29
+assert_invalid@async_index.js:204:9
+unreached_invalid_wast_js@unreached-invalid.wast.js:238:15
+global code@unreached-invalid.wast.js:366:3 expected true got false
+FAIL #203 Test that WebAssembly compilation fails (unreached-invalid.wast:476) assert_true: module@async_index.js:175:29
+assert_invalid@async_index.js:204:9
+unreached_invalid_wast_js@unreached-invalid.wast.js:241:15
+global code@unreached-invalid.wast.js:366:3 expected true got false
+FAIL #204 Test that WebAssembly compilation fails (unreached-invalid.wast:483) assert_true: module@async_index.js:175:29
+assert_invalid@async_index.js:204:9
+unreached_invalid_wast_js@unreached-invalid.wast.js:244:15
+global code@unreached-invalid.wast.js:366:3 expected true got false
 PASS #205 Test that WebAssembly compilation fails (unreached-invalid.wast:489)
-FAIL #206 Test that WebAssembly compilation fails (unreached-invalid.wast:497) assert_true: module@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:163:24
-assert_invalid@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:192:9
-unreached_invalid_wast_js@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:250:15
-global code@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:366:3 expected true got false
-FAIL #207 Test that WebAssembly compilation fails (unreached-invalid.wast:506) assert_true: module@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:163:24
-assert_invalid@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:192:9
-unreached_invalid_wast_js@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:253:15
-global code@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:366:3 expected true got false
-FAIL #208 Test that WebAssembly compilation fails (unreached-invalid.wast:514) assert_true: module@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:163:24
-assert_invalid@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:192:9
-unreached_invalid_wast_js@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:256:15
-global code@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:366:3 expected true got false
-FAIL #209 Test that WebAssembly compilation fails (unreached-invalid.wast:520) assert_true: module@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:163:24
-assert_invalid@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:192:9
-unreached_invalid_wast_js@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:259:15
-global code@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:366:3 expected true got false
-FAIL #210 Test that WebAssembly compilation fails (unreached-invalid.wast:526) assert_true: module@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:163:24
-assert_invalid@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:192:9
-unreached_invalid_wast_js@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:262:15
-global code@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:366:3 expected true got false
+FAIL #206 Test that WebAssembly compilation fails (unreached-invalid.wast:497) assert_true: module@async_index.js:175:29
+assert_invalid@async_index.js:204:9
+unreached_invalid_wast_js@unreached-invalid.wast.js:250:15
+global code@unreached-invalid.wast.js:366:3 expected true got false
+FAIL #207 Test that WebAssembly compilation fails (unreached-invalid.wast:506) assert_true: module@async_index.js:175:29
+assert_invalid@async_index.js:204:9
+unreached_invalid_wast_js@unreached-invalid.wast.js:253:15
+global code@unreached-invalid.wast.js:366:3 expected true got false
+FAIL #208 Test that WebAssembly compilation fails (unreached-invalid.wast:514) assert_true: module@async_index.js:175:29
+assert_invalid@async_index.js:204:9
+unreached_invalid_wast_js@unreached-invalid.wast.js:256:15
+global code@unreached-invalid.wast.js:366:3 expected true got false
+FAIL #209 Test that WebAssembly compilation fails (unreached-invalid.wast:520) assert_true: module@async_index.js:175:29
+assert_invalid@async_index.js:204:9
+unreached_invalid_wast_js@unreached-invalid.wast.js:259:15
+global code@unreached-invalid.wast.js:366:3 expected true got false
+FAIL #210 Test that WebAssembly compilation fails (unreached-invalid.wast:526) assert_true: module@async_index.js:175:29
+assert_invalid@async_index.js:204:9
+unreached_invalid_wast_js@unreached-invalid.wast.js:262:15
+global code@unreached-invalid.wast.js:366:3 expected true got false
 PASS #211 Test that WebAssembly compilation fails (unreached-invalid.wast:539)
 PASS #212 Test that WebAssembly compilation fails (unreached-invalid.wast:545)
 PASS #213 Test that WebAssembly compilation fails (unreached-invalid.wast:551)
@@ -382,57 +382,57 @@ PASS #227 Test that WebAssembly compilation fails (unreached-invalid.wast:642)
 PASS #228 Test that WebAssembly compilation fails (unreached-invalid.wast:648)
 PASS #229 Test that WebAssembly compilation fails (unreached-invalid.wast:655)
 PASS #230 Test that WebAssembly compilation fails (unreached-invalid.wast:661)
-FAIL #231 Test that WebAssembly compilation fails (unreached-invalid.wast:668) assert_true: module@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:163:24
-assert_invalid@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:192:9
-unreached_invalid_wast_js@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:325:15
-global code@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:366:3 expected true got false
-FAIL #232 Test that WebAssembly compilation fails (unreached-invalid.wast:675) assert_true: module@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:163:24
-assert_invalid@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:192:9
-unreached_invalid_wast_js@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:328:15
-global code@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:366:3 expected true got false
-FAIL #233 Test that WebAssembly compilation fails (unreached-invalid.wast:686) assert_true: module@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:163:24
-assert_invalid@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:192:9
-unreached_invalid_wast_js@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:331:15
-global code@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:366:3 expected true got false
-FAIL #234 Test that WebAssembly compilation fails (unreached-invalid.wast:697) assert_true: module@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:163:24
-assert_invalid@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:192:9
-unreached_invalid_wast_js@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:334:15
-global code@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:366:3 expected true got false
-FAIL #235 Test that WebAssembly compilation fails (unreached-invalid.wast:709) assert_true: module@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:163:24
-assert_invalid@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:192:9
-unreached_invalid_wast_js@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:337:15
-global code@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:366:3 expected true got false
-FAIL #236 Test that WebAssembly compilation fails (unreached-invalid.wast:714) assert_true: module@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:163:24
-assert_invalid@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:192:9
-unreached_invalid_wast_js@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:340:15
-global code@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:366:3 expected true got false
-FAIL #237 Test that WebAssembly compilation fails (unreached-invalid.wast:720) assert_true: module@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:163:24
-assert_invalid@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:192:9
-unreached_invalid_wast_js@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:343:15
-global code@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:366:3 expected true got false
-FAIL #238 Test that WebAssembly compilation fails (unreached-invalid.wast:725) assert_true: module@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:163:24
-assert_invalid@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:192:9
-unreached_invalid_wast_js@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:346:15
-global code@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:366:3 expected true got false
-FAIL #239 Test that WebAssembly compilation fails (unreached-invalid.wast:730) assert_true: module@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:163:24
-assert_invalid@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:192:9
-unreached_invalid_wast_js@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:349:15
-global code@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:366:3 expected true got false
-FAIL #240 Test that WebAssembly compilation fails (unreached-invalid.wast:736) assert_true: module@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:163:24
-assert_invalid@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:192:9
-unreached_invalid_wast_js@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:352:15
-global code@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:366:3 expected true got false
-FAIL #241 Test that WebAssembly compilation fails (unreached-invalid.wast:743) assert_true: module@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:163:24
-assert_invalid@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:192:9
-unreached_invalid_wast_js@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:355:15
-global code@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:366:3 expected true got false
+FAIL #231 Test that WebAssembly compilation fails (unreached-invalid.wast:668) assert_true: module@async_index.js:175:29
+assert_invalid@async_index.js:204:9
+unreached_invalid_wast_js@unreached-invalid.wast.js:325:15
+global code@unreached-invalid.wast.js:366:3 expected true got false
+FAIL #232 Test that WebAssembly compilation fails (unreached-invalid.wast:675) assert_true: module@async_index.js:175:29
+assert_invalid@async_index.js:204:9
+unreached_invalid_wast_js@unreached-invalid.wast.js:328:15
+global code@unreached-invalid.wast.js:366:3 expected true got false
+FAIL #233 Test that WebAssembly compilation fails (unreached-invalid.wast:686) assert_true: module@async_index.js:175:29
+assert_invalid@async_index.js:204:9
+unreached_invalid_wast_js@unreached-invalid.wast.js:331:15
+global code@unreached-invalid.wast.js:366:3 expected true got false
+FAIL #234 Test that WebAssembly compilation fails (unreached-invalid.wast:697) assert_true: module@async_index.js:175:29
+assert_invalid@async_index.js:204:9
+unreached_invalid_wast_js@unreached-invalid.wast.js:334:15
+global code@unreached-invalid.wast.js:366:3 expected true got false
+FAIL #235 Test that WebAssembly compilation fails (unreached-invalid.wast:709) assert_true: module@async_index.js:175:29
+assert_invalid@async_index.js:204:9
+unreached_invalid_wast_js@unreached-invalid.wast.js:337:15
+global code@unreached-invalid.wast.js:366:3 expected true got false
+FAIL #236 Test that WebAssembly compilation fails (unreached-invalid.wast:714) assert_true: module@async_index.js:175:29
+assert_invalid@async_index.js:204:9
+unreached_invalid_wast_js@unreached-invalid.wast.js:340:15
+global code@unreached-invalid.wast.js:366:3 expected true got false
+FAIL #237 Test that WebAssembly compilation fails (unreached-invalid.wast:720) assert_true: module@async_index.js:175:29
+assert_invalid@async_index.js:204:9
+unreached_invalid_wast_js@unreached-invalid.wast.js:343:15
+global code@unreached-invalid.wast.js:366:3 expected true got false
+FAIL #238 Test that WebAssembly compilation fails (unreached-invalid.wast:725) assert_true: module@async_index.js:175:29
+assert_invalid@async_index.js:204:9
+unreached_invalid_wast_js@unreached-invalid.wast.js:346:15
+global code@unreached-invalid.wast.js:366:3 expected true got false
+FAIL #239 Test that WebAssembly compilation fails (unreached-invalid.wast:730) assert_true: module@async_index.js:175:29
+assert_invalid@async_index.js:204:9
+unreached_invalid_wast_js@unreached-invalid.wast.js:349:15
+global code@unreached-invalid.wast.js:366:3 expected true got false
+FAIL #240 Test that WebAssembly compilation fails (unreached-invalid.wast:736) assert_true: module@async_index.js:175:29
+assert_invalid@async_index.js:204:9
+unreached_invalid_wast_js@unreached-invalid.wast.js:352:15
+global code@unreached-invalid.wast.js:366:3 expected true got false
+FAIL #241 Test that WebAssembly compilation fails (unreached-invalid.wast:743) assert_true: module@async_index.js:175:29
+assert_invalid@async_index.js:204:9
+unreached_invalid_wast_js@unreached-invalid.wast.js:355:15
+global code@unreached-invalid.wast.js:366:3 expected true got false
 PASS #242 Test that WebAssembly compilation fails (unreached-invalid.wast:748)
-FAIL #243 Test that WebAssembly compilation fails (unreached-invalid.wast:763) assert_true: module@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:163:24
-assert_invalid@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:192:9
-unreached_invalid_wast_js@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:361:15
-global code@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:366:3 expected true got false
-FAIL #244 Test that WebAssembly compilation fails (unreached-invalid.wast:773) assert_true: module@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:163:24
-assert_invalid@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:192:9
-unreached_invalid_wast_js@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:364:15
-global code@http://web-platform.test:8800/wasm/core/js/unreached-invalid.wast.js:366:3 expected true got false
+FAIL #243 Test that WebAssembly compilation fails (unreached-invalid.wast:763) assert_true: module@async_index.js:175:29
+assert_invalid@async_index.js:204:9
+unreached_invalid_wast_js@unreached-invalid.wast.js:361:15
+global code@unreached-invalid.wast.js:366:3 expected true got false
+FAIL #244 Test that WebAssembly compilation fails (unreached-invalid.wast:773) assert_true: module@async_index.js:175:29
+assert_invalid@async_index.js:204:9
+unreached_invalid_wast_js@unreached-invalid.wast.js:364:15
+global code@unreached-invalid.wast.js:366:3 expected true got false
 

--- a/Source/JavaScriptCore/Scripts/PreferencesTemplates/JSCWebPreferenceOptions.h.erb
+++ b/Source/JavaScriptCore/Scripts/PreferencesTemplates/JSCWebPreferenceOptions.h.erb
@@ -45,3 +45,12 @@
 -%>
     v(Bool, <%= pref.jscOptionName %>, <%= jscDefault %>, Normal, <%= jscDescription %>) \
 <% end %>
+
+// The subset of the above whose feature status is "experimental" (developer/testable/preview/
+// stable)
+#define FOR_EACH_JSC_EXPERIMENTAL_WEB_PREFERENCE_OPTION(v) \
+<% @jscOptions.each do |pref| -%>
+<% if pref.experimental? -%>
+    v(<%= pref.jscOptionName %>) \
+<% end -%>
+<% end %>

--- a/Source/JavaScriptCore/jsc.cpp
+++ b/Source/JavaScriptCore/jsc.cpp
@@ -611,6 +611,10 @@ private:
 
     void finishCreation(VM& vm, const Vector<String>& arguments)
     {
+        // This shouldn't actually throw in practice, it's a test object. That said, it creates
+        // arrays and such that can generally throw.
+        auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
+
         auto& filter = ensurePropertyFilter();
 
         auto addFunction = [&] (VM& vm, ASCIILiteral name, NativeFunction function, unsigned arguments, unsigned attributes = static_cast<unsigned>(PropertyAttribute::DontEnum)) {
@@ -774,8 +778,11 @@ private:
 
         if (!arguments.isEmpty()) {
             JSArray* array = constructEmptyArray(this, nullptr);
-            for (size_t i = 0; i < arguments.size(); ++i)
+            scope.assertNoException();
+            for (size_t i = 0; i < arguments.size(); ++i) {
                 array->putDirectIndex(this, i, jsString(vm, arguments[i]));
+                scope.assertNoException();
+            }
             putDirect(vm, Identifier::fromString(vm, "arguments"_s), array, DontEnum);
         }
 
@@ -4057,6 +4064,7 @@ static void runInteractive(GlobalObject* globalObject)
     fprintf(stderr, "  --footprint                Dump memory footprint after done executing\n");
     fprintf(stderr, "  --options                  Dumps all JSC VM options and exits\n");
     fprintf(stderr, "  --dumpOptions              Dumps all non-default JSC VM options before continuing\n");
+    fprintf(stderr, "  --enable-all-experimental-features  Enables all JSC feature-flag options (off-by-default in-development features)\n");
     fprintf(stderr, "  --<jsc VM option>=<value>  Sets the specified JSC VM option\n");
 #if USE(LIBPAS)
     fprintf(stderr, "  --crash-vm=<value>         Crash VM on startup due to PGM failure. Options PGMOOBLowerGuardPage, PGMOOBUpperGuardPage, or PGMUAF (For Testing Purposes).\n");
@@ -4261,6 +4269,13 @@ void CommandLine::parseArguments(int argc, char** argv, int start)
         }
         if (!strcmp(arg, "--disableOptionsFreezingForTesting")) {
             JSC::Config::disableFreezingForTesting();
+            continue;
+        }
+        if (!strcmp(arg, "--enable-all-experimental-features")) {
+#define JSC_ENABLE_EXPERIMENTAL_WEB_PREFERENCE_OPTION(name_) \
+            Options::name_() = true;
+            FOR_EACH_JSC_EXPERIMENTAL_WEB_PREFERENCE_OPTION(JSC_ENABLE_EXPERIMENTAL_WEB_PREFERENCE_OPTION)
+#undef JSC_ENABLE_EXPERIMENTAL_WEB_PREFERENCE_OPTION
             continue;
         }
 

--- a/Tools/Scripts/run-jsc-stress-tests
+++ b/Tools/Scripts/run-jsc-stress-tests
@@ -2098,6 +2098,142 @@ def runWebAssemblyLowExecutableMemory(*optionalTestSpecificOptions)
     run("default-wasm", "--useConcurrentGC=0" , "--useConcurrentJIT=0", "--jitMemoryReservationSize=80000", "--useBaselineJIT=0", "--useDFGJIT=0", "--useFTLJIT=0", "-m")
 end
 
+# Support for running the imported WPT WebAssembly tests
+# (LayoutTests/imported/w3c/web-platform-tests/wasm) in the jsc shell. Results are diffed against
+# the committed -expected.txt baselines.
+WPT_PATH = LAYOUTTESTS_PATH + "imported/w3c/web-platform-tests"
+
+# The wasm JIT-configuration matrix, mirroring runWebAssemblySpecTestBase. Returns [kind, options].
+def wasmWPTConfigs(*extraOptions)
+    configs = [["default-wasm", FTL_OPTIONS + extraOptions]]
+    if $mode != :quick
+        configs << ["wasm-no-cjit", FTL_OPTIONS + NO_CJIT_OPTIONS + extraOptions]
+        configs << ["wasm-eager-jettison", ["--forceCodeBlockToJettisonDueToOldAge=true", "--useRandomizingExecutableIslandAllocation=true", "--verifyGC=true"] + FTL_OPTIONS + extraOptions]
+        configs << ["wasm-collect-continuously", ["--collectContinuously=true", "--verifyGC=true"] + FTL_OPTIONS + extraOptions] if shouldCollectContinuously?
+        configs << ["wasm-bbq", ["--useWasmIPInt=false"] + FTL_OPTIONS + extraOptions]
+        configs << ["wasm-bbq-no-consts", ["--useWasmIPInt=false", "--disableBBQConsts=true"] + FTL_OPTIONS + extraOptions]
+        configs << ["wasm-omg", ["--useWasmIPInt=true", "--useBBQJIT=true", "--thresholdForBBQOptimizeAfterWarmUp=0", "--thresholdForBBQOptimizeSoon=0", "--thresholdForOMGOptimizeAfterWarmUp=0", "--thresholdForOMGOptimizeSoon=0"] + FTL_OPTIONS + extraOptions] if $isOMGPlatform
+        configs << ["wasm-simd", ["--useWasmSIMD=1", "--forceAllFunctionsToUseSIMD=1"] + FTL_OPTIONS + extraOptions] if $isFTLPlatform
+    end
+    configs
+end
+
+# Leading `// META: ...` comment lines of a WPT test (parsing stops at the first non-comment line).
+def wptMetaLines(path)
+    lines = []
+    File.open(path) { | inp |
+        inp.each_line { | line |
+            break unless line =~ /^\s*\/\//
+            lines << line
+        }
+    }
+    lines
+end
+
+def wptIsJSShell?(path)
+    line = wptMetaLines(path).find { | l | l =~ /\/\/\s*META:\s*global=/ }
+    !line.nil? && line.include?("jsshell")
+end
+
+def wptMetaScripts(path)
+    wptMetaLines(path).map { | l | l =~ /\/\/\s*META:\s*script=(\S+)/ ? $1 : nil }.compact
+end
+
+# Title WPT gives the generated page: the test's file name (basename, no subdirectory) without the
+# .any/.window/.worker.js suffix. The shell names an unnamed block-body test "Untitled";
+# wpt-harness-post.js remaps that to this.
+def wptTitle(benchmark)
+    File.basename(benchmark.to_s).sub(/\.js$/, '').sub(/\.(any|window|worker)$/, '')
+end
+
+# Copies a file (given as a path relative to sourceDir) into the collection root in the bundle
+# ($benchmarkDirectory), so it can be referenced by that same relative path from the run's working
+# directory. Recursive collections keep $benchmarkDirectory at the collection root and carry the
+# subdirectory in $benchmark, so harness files copied here are shared by every test in the tree.
+def wptCopyBeside(relativeName, sourceDir)
+    prepareExtraRelativeFilesWithBaseDirectory([relativeName], $benchmarkDirectory, sourceDir)
+end
+
+# Maps each `// META: script=` dependency to a load path relative to the run's working directory
+# (the collection root). prepareCollection copies the whole collection tree into the bundle, so a
+# dependency within it is already present: a /-absolute (/wasm/...) dep resolves to its
+# collection-relative path, a relative dep to the benchmark's own directory. A /-absolute dep
+# pointing outside the collection would not be in the bundle, so raise rather than reference a
+# missing file (no jsshell test does this today).
+def wptPrepareScripts(scripts)
+    collectionPrefix = $extraFilesBaseDir.relative_path_from(WPT_PATH.realpath)
+    scripts.map { | s |
+        if s.start_with?("/")
+            rel = Pathname.new(s.sub(%r{^/}, '')).relative_path_from(collectionPrefix)
+            raise "WPT script dependency #{s} is outside the #{collectionPrefix} collection" if rel.to_s.start_with?("..")
+            rel.to_s
+        else
+            ($benchmark.dirname + s).to_s
+        end
+    }
+end
+
+def runWebAssemblyWPT(expectedFile, harnessBeforeBenchmark, *extraOptions)
+    FileUtils.mkdir_p((Pathname.new($collectionName) + $benchmark.dirname).to_s)
+
+    # Copy the harness into the collection root so these references resolve from the run directory.
+    # Use the imported WPT copy of testharness.js (not LayoutTests/resources/testharness.js): it is
+    # the version the browser loads for these imported tests and thus the one that generated the
+    # committed baselines.
+    wptCopyBeside("resources/testharness.js", WPT_PATH)
+    wptCopyBeside("wpt-harness-pre.js", WASMTESTS_PATH + "wpt")
+    wptCopyBeside("wpt-harness-mid.js", WASMTESTS_PATH + "wpt")
+    wptCopyBeside("wpt-harness-post.js", WASMTESTS_PATH + "wpt")
+
+    before = ["wpt-harness-pre.js", "resources/testharness.js"] + harnessBeforeBenchmark + ["wpt-harness-mid.js"]
+    after = ["wpt-harness-post.js", "--", wptTitle($benchmark)]
+
+    # Enable the in-development JSC features the same way WebKitTestRunner does for the browser
+    # layout-test run, so these tests exercise the same feature set (and match the baselines the
+    # browser generated) rather than only the shipped defaults.
+    wasmWPTConfigs(*extraOptions).each { | kind, options |
+        args = vmCommand + BASE_OPTIONS + ["--enable-all-experimental-features"] + options + $testSpecificRequiredOptions +
+            before + [$benchmark.to_s] + after
+        addRunCommand(kind, args, noisyOutputHandler, diffErrorHandler(expectedFile))
+    }
+end
+
+def runWebAssemblyWPTJSAPI(*extraOptions)
+    return unless $isWasmPlatform
+    raise unless $benchmark.to_s =~ /\.js$/
+    testName = $~.pre_match
+    return unless wptIsJSShell?($benchmarkDirectory + $benchmark)
+    return if $benchmark.to_s =~ /\.tentative\./
+
+    # The -expected.txt baseline sits next to the test and is already in the bundle via cp_r.
+    # jsshell-only tests (global=jsshell, no window/worker) are never run in the browser and so
+    # have no committed baseline to diff against; skip them.
+    expectedFile = ($benchmarkDirectory + "#{testName}-expected.txt").to_s
+    return unless File.exist?(expectedFile)
+
+    scripts = wptPrepareScripts(wptMetaScripts($benchmarkDirectory + $benchmark))
+    runWebAssemblyWPT(expectedFile, scripts, *extraOptions)
+end
+
+def runWebAssemblyWPTCore(*extraOptions)
+    return unless $isWasmPlatform
+    raise unless $benchmark.to_s =~ /\.js$/
+
+    # Core baselines live in the parallel core/<proposal>/ tree: the test's path with the "js/"
+    # segment dropped (core/js[/<proposal>]/foo.wast.js -> core[/<proposal>]/foo.wast.js-expected.txt).
+    # $benchmark carries the proposal subdirectory, and $extraFilesBaseDir is the collection source
+    # (.../core/js) whose dirname (.../core) is that parallel tree's root; joining them yields the
+    # baseline. Copy it into the bundle at the same relative path so the diff path matches.
+    baselineSource = $extraFilesBaseDir.dirname + "#{$benchmark}-expected.txt"
+    return unless File.exist?(baselineSource.to_s)
+    wptCopyBeside("#{$benchmark}-expected.txt", $extraFilesBaseDir.dirname)
+    expectedFile = ($benchmarkDirectory + "#{$benchmark}-expected.txt").to_s
+
+    # harness/async_index.js is inside the collection, so prepareCollection already copied it into
+    # the bundle; reference it directly.
+    runWebAssemblyWPT(expectedFile, ["harness/async_index.js"], *extraOptions)
+end
+
 def runChakra(mode, exception, baselineFile, extraFiles)
     raise unless $benchmark.to_s =~ /\.js$/
     failsWithException = exception != "NoException"
@@ -2415,6 +2551,17 @@ def allJSFiles(path)
     end
 end
 
+# Like allJSFiles, but descends into subdirectories. Used by collections whose yaml entry sets
+# "recursive: true" (e.g. the imported WPT wasm tests, whose proposal subdirectories would
+# otherwise each need their own entry). Sorted for deterministic test ordering.
+def allJSFilesRecursive(path)
+    if path.file?
+        [path]
+    else
+        Dir.glob((path + "**" + "*.{js,mjs}").to_s).sort.map { | f | Pathname.new(f) }.select { | f | f.file? }
+    end
+end
+
 def uniqueifyName(names, name)
     result = name.to_s
     toAdd = 1
@@ -2526,12 +2673,22 @@ def handleCollectionFile(collection)
             end
             pathsToSearch.each {
                 | pathToSearch |
-                allJSFiles(pathToSearch).each {
+                jsFiles = entry["recursive"] ? allJSFilesRecursive(pathToSearch) : allJSFiles(pathToSearch)
+                jsFiles.each {
                     | path |
 
                     next if not $isWasmPlatform and isWasmTest(path)
-                    $benchmark = path.basename
-                    $benchmarkDirectory = path.dirname
+                    if entry["recursive"]
+                        # Preserve the subdirectory path in the benchmark identity so nested tests
+                        # sharing a basename (e.g. core/js/memory_grow and core/js/multi-memory/
+                        # memory_grow) do not collide in their output files, and the bundle layout
+                        # mirrors the source tree. $benchmarkDirectory stays at the collection root.
+                        $benchmark = path.relative_path_from(pathToSearch)
+                        $benchmarkDirectory = pathToSearch
+                    else
+                        $benchmark = path.basename
+                        $benchmarkDirectory = path.dirname
+                    end
                     $skipModes = Set.new
                     $runCommandOptions = {}
                     $testSpecificRequiredOptions = []


### PR DESCRIPTION
#### bdf5f869dc927e99bacd206f46558a505ebbd5a1
<pre>
[JSC] Run WPT Wasm tests in run-jsc-stress-tests&apos; wasm.yaml
<a href="https://bugs.webkit.org/show_bug.cgi?id=319669">https://bugs.webkit.org/show_bug.cgi?id=319669</a>
<a href="https://rdar.apple.com/182513824">rdar://182513824</a>

Reviewed by Yusuke Suzuki.

Run the imported Web Platform Tests WebAssembly suite
(LayoutTests/imported/w3c/web-platform-tests/wasm/{core/js,jsapi}) directly in the jsc
command-line shell, diffing stdout against the committed -expected.txt baselines. This
exercises the tests across the full wasm JIT-configuration matrix (BBQ/OMG/no-CJIT/eager/
SIMD/...) that the browser layout-test run does not cover.

Three harness shims bracket each test to reproduce the browser testharness reporting path
in a shell that has no DOM or event loop:
- wpt-harness-pre.js supplies self and a no-op console before testharness.js loads.
- wpt-harness-mid.js drains microtasks (so the WAST harness&apos;s deferred import registry
Proxy is installed before the test body reads it) and marks the run explicit_done.
- wpt-harness-post.js registers a completion callback that prints the PASS/FAIL text in
the committed baseline format, then calls done().

run-jsc-stress-tests gains recursive collection support (one yaml entry per suite root
instead of per proposal directory) and a data-returning wasm JIT-config matrix shared by
the new runners.

async_index.js reduces the assertion-location stack in each assert description to
basenames so the text is identical whether the tests are served over HTTP by the WPT
server or loaded from local files by a shell; the core baselines are regenerated to match.

jsc gains --enable-all-experimental-features, generated from the JSC web-preference
feature flags via FOR_EACH_JSC_EXPERIMENTAL_WEB_PREFERENCE_OPTION, mirroring
WebKitTestRunner&apos;s --enable-all-experimental-features. run-jsc-stress-tests passes
it when running WPT tests. In a future change we can apply it to other test drivers.

Canonical link: <a href="https://commits.webkit.org/317464@main">https://commits.webkit.org/317464@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8d476a4b961a0ade537c155fd95e567806a26e26

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175254 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49186 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42967 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184839 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/133609 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/de772afb-4990-49f6-a3b5-45186d8859f0) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/177118 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50478 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48869 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136418 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/133609 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c3971ada-5353-4b54-96da-efca2e29e315) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178211 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39843 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157191 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116897 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c6a576c6-343f-456b-883d-8b6c2d3f1450) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38484 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36865 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33312 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/5700 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148907 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36684 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187260 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/36515 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/40873 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41069 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145370 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48853 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145226 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49533 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33305 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115412 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26665 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40063 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/121726 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/212345 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48039 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11657 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/55424 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47442 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47672 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47499 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->