### PR TITLE
[JSC] Use pass-by-value for `resultIndex` argument of `JS::fastFlatIntoBuffer()`

### DIFF
--- a/Source/JavaScriptCore/runtime/JSArray.cpp
+++ b/Source/JavaScriptCore/runtime/JSArray.cpp
@@ -2442,7 +2442,7 @@ static uint64_t calculateFlattenedLength(JSGlobalObject* globalObject, JSArray* 
 }
 
 template<typename T>
-static uint64_t fastFlatIntoBuffer(JSGlobalObject* globalObject, T* resultBuffer, uint64_t& resultIndex, JSArray* sourceArray, uint64_t sourceLength, uint64_t depth, uint64_t vectorLength)
+static uint64_t fastFlatIntoBuffer(JSGlobalObject* globalObject, T* resultBuffer, uint64_t startIndex, JSArray* sourceArray, uint64_t sourceLength, uint64_t depth, uint64_t vectorLength)
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
@@ -2454,6 +2454,7 @@ static uint64_t fastFlatIntoBuffer(JSGlobalObject* globalObject, T* resultBuffer
 
     IndexingType sourceType = sourceArray->indexingType();
 
+    uint64_t resultIndex = startIndex;
     switch (sourceType) {
     case ArrayWithInt32: {
         auto* sourceBuffer = sourceArray->butterfly()->contiguous().data();
@@ -2569,10 +2570,10 @@ JSArray* JSArray::fastFlat(JSGlobalObject* globalObject, uint64_t depth, uint64_
         uint64_t resultIndex = 0;
         if (indexingType == ArrayWithDouble) {
             auto* resultBuffer = butterfly->contiguousDouble().data();
-            resultIndex = fastFlatIntoBuffer(globalObject, resultBuffer, resultIndex, this, length, depth, vectorLength);
+            resultIndex = fastFlatIntoBuffer(globalObject, resultBuffer, 0, this, length, depth, vectorLength);
         } else {
             auto* resultBuffer = butterfly->contiguous().data();
-            resultIndex = fastFlatIntoBuffer(globalObject, resultBuffer, resultIndex, this, length, depth, vectorLength);
+            resultIndex = fastFlatIntoBuffer(globalObject, resultBuffer, 0, this, length, depth, vectorLength);
         }
         RETURN_IF_EXCEPTION(scope, nullptr);
         if (resultIndex == std::numeric_limits<uint64_t>::max())


### PR DESCRIPTION
#### 4b8e37abf2836c3dda3db728c5e2e82de59c7a49
<pre>
[JSC] Use pass-by-value for `resultIndex` argument of `JS::fastFlatIntoBuffer()`
<a href="https://bugs.webkit.org/show_bug.cgi?id=319673">https://bugs.webkit.org/show_bug.cgi?id=319673</a>

Reviewed by Sosuke Suzuki.

This change is related to only the fast path of `Array#flat()`.
`resultIndex` is 8-bytes (`uint64_t`). It&apos;s enough small size.

Interestingly, this change has a side-effect which is a micro benchmark
progression on macOS arm64 at least.

                                             TipOfTree                  Patched

array-prototype-flat-depth-1-string      124.7313+-15.7674    ?    126.7053+-14.0930       ? might be 1.0158x slower
array-prototype-flat-depth-1-double       85.8047+-8.6982     ?     88.9680+-4.1780        ? might be 1.0369x slower
array-prototype-flat-large-nested         45.0930+-2.4765     ^     27.1562+-1.0824        ^ definitely 1.6605x faster
array-prototype-flat-huge-arrays          10.5353+-1.8040           10.0453+-1.7224          might be 1.0488x faster
array-prototype-flat-small-arrays          3.4522+-0.1238            3.3026+-0.0755          might be 1.0453x faster
array-prototype-flat-depth-infinity      117.2919+-1.0095          117.0930+-0.6006
array-prototype-flat-depth-2              94.7117+-1.3260     ?     95.6852+-4.3372        ? might be 1.0103x slower
array-prototype-flat-depth-1-int32        85.2135+-4.3134     ?     88.4635+-2.5566        ? might be 1.0381x slower
array-prototype-flat-depth-3             105.7020+-7.5027          102.3541+-4.5175          might be 1.0327x faster
array-prototype-flat-sparse-array        152.1396+-3.2477     ?    161.3152+-11.0580       ? might be 1.0603x slower
array-prototype-flat-depth-1-mixed        93.9877+-4.2939     ?     94.3616+-4.7335        ?

&lt;geometric&gt;                               57.9736+-0.6088     ^     55.5547+-0.9141        ^ definitely 1.0435x faster

No new tests.
It wlll be covered by exist test cases.

Canonical link: <a href="https://commits.webkit.org/317700@main">https://commits.webkit.org/317700@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7f79271a07c017169bdcfe3eb9d5687d9069c51f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175987 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49920 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43704 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185581 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/138199 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51212 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49602 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137044 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/138199 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178943 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40513 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157821 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117523 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39156 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37534 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/6330 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149574 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37313 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34050 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/37251 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41622 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41740 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188002 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49587 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146050 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39305 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50267 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33938 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145888 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40670 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122463 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/116341 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48774 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12294 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48176 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48408 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48233 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->