### PR TITLE
WebKit fails to build with latest swift compiler due to lack of SWIFT_RETURNS_UNRETAINED

### DIFF
--- a/Source/WTF/wtf/Ref.h
+++ b/Source/WTF/wtf/Ref.h
@@ -162,11 +162,11 @@ public:
     const T* ptrAllowingHashTableEmptyValue() const LIFETIME_BOUND { ASSERT(m_ptr || isHashTableEmptyValue()); return PtrTraits::unwrap(m_ptr); }
     T* ptrAllowingHashTableEmptyValue() LIFETIME_BOUND { ASSERT(m_ptr || isHashTableEmptyValue()); return PtrTraits::unwrap(m_ptr); }
 
-    T* operator->() const LIFETIME_BOUND { ASSERT(m_ptr); return PtrTraits::unwrap(m_ptr); }
-    T* ptr() const LIFETIME_BOUND RETURNS_NONNULL { ASSERT(m_ptr); return PtrTraits::unwrap(m_ptr); }
-    T* unsafePtr() const RETURNS_NONNULL { ASSERT(m_ptr); return PtrTraits::unwrap(m_ptr); } // FIXME: Replace with ptr() then remove.
-    T& get() const LIFETIME_BOUND { ASSERT(m_ptr); return *PtrTraits::unwrap(m_ptr); }
-    T& unsafeGet() const { ASSERT(m_ptr); return *PtrTraits::unwrap(m_ptr); } // FIXME: Replace with get() then remove.
+    SWIFT_RETURNS_UNRETAINED T* operator->() const LIFETIME_BOUND { ASSERT(m_ptr); return PtrTraits::unwrap(m_ptr); }
+    SWIFT_RETURNS_UNRETAINED T* ptr() const LIFETIME_BOUND RETURNS_NONNULL { ASSERT(m_ptr); return PtrTraits::unwrap(m_ptr); }
+    SWIFT_RETURNS_UNRETAINED T* unsafePtr() const RETURNS_NONNULL { ASSERT(m_ptr); return PtrTraits::unwrap(m_ptr); } // FIXME: Replace with ptr() then remove.
+    SWIFT_RETURNS_UNRETAINED T& get() const LIFETIME_BOUND { ASSERT(m_ptr); return *PtrTraits::unwrap(m_ptr); }
+    SWIFT_RETURNS_UNRETAINED T& unsafeGet() const { ASSERT(m_ptr); return *PtrTraits::unwrap(m_ptr); } // FIXME: Replace with get() then remove.
     operator T&() const LIFETIME_BOUND { ASSERT(m_ptr); return *PtrTraits::unwrap(m_ptr); }
     bool operator!() const { ASSERT(m_ptr); return !*m_ptr; }
 

--- a/Source/WebGPU/WebGPU/APIConversions.h
+++ b/Source/WebGPU/WebGPU/APIConversions.h
@@ -60,147 +60,147 @@ namespace WebGPU {
 
 // FIXME: It would be cool if we didn't have to list all these overloads, but instead could do something like bridge_cast() in WTF.
 
-inline Adapter& fromAPI(WGPUAdapter adapter)
+inline SWIFT_RETURNS_UNRETAINED Adapter& fromAPI(WGPUAdapter adapter)
 {
     return static_cast<Adapter&>(*adapter);
 }
 
-inline BindGroup& fromAPI(WGPUBindGroup bindGroup)
+inline SWIFT_RETURNS_UNRETAINED BindGroup& fromAPI(WGPUBindGroup bindGroup)
 {
     return static_cast<BindGroup&>(*bindGroup);
 }
 
-inline BindGroupLayout& fromAPI(WGPUBindGroupLayout bindGroupLayout)
+inline SWIFT_RETURNS_UNRETAINED BindGroupLayout& fromAPI(WGPUBindGroupLayout bindGroupLayout)
 {
     return static_cast<BindGroupLayout&>(*bindGroupLayout);
 }
 
-inline Buffer& fromAPI(WGPUBuffer buffer)
+inline SWIFT_RETURNS_UNRETAINED Buffer& fromAPI(WGPUBuffer buffer)
 {
     return static_cast<Buffer&>(*buffer);
 }
 
-inline CommandBuffer& fromAPI(WGPUCommandBuffer commandBuffer)
+inline SWIFT_RETURNS_UNRETAINED CommandBuffer& fromAPI(WGPUCommandBuffer commandBuffer)
 {
     return static_cast<CommandBuffer&>(*commandBuffer);
 }
 
-inline CommandEncoder& fromAPI(WGPUCommandEncoder commandEncoder)
+inline SWIFT_RETURNS_UNRETAINED CommandEncoder& fromAPI(WGPUCommandEncoder commandEncoder)
 {
     return static_cast<CommandEncoder&>(*commandEncoder);
 }
 
-inline ComputePassEncoder& fromAPI(WGPUComputePassEncoder computePassEncoder)
+inline SWIFT_RETURNS_UNRETAINED ComputePassEncoder& fromAPI(WGPUComputePassEncoder computePassEncoder)
 {
     return static_cast<ComputePassEncoder&>(*computePassEncoder);
 }
 
-inline ComputePipeline& fromAPI(WGPUComputePipeline computePipeline)
+inline SWIFT_RETURNS_UNRETAINED ComputePipeline& fromAPI(WGPUComputePipeline computePipeline)
 {
     return static_cast<ComputePipeline&>(*computePipeline);
 }
 
-inline Device& fromAPI(WGPUDevice device)
+inline SWIFT_RETURNS_UNRETAINED Device& fromAPI(WGPUDevice device)
 {
     return static_cast<Device&>(*device);
 }
 
-inline ExternalTexture& fromAPI(WGPUExternalTexture texture)
+inline SWIFT_RETURNS_UNRETAINED ExternalTexture& fromAPI(WGPUExternalTexture texture)
 {
     return static_cast<ExternalTexture&>(*texture);
 }
 
-inline Instance& fromAPI(WGPUInstance instance)
+inline SWIFT_RETURNS_UNRETAINED Instance& fromAPI(WGPUInstance instance)
 {
     return static_cast<Instance&>(*instance);
 }
 
-inline PipelineLayout& fromAPI(WGPUPipelineLayout pipelineLayout)
+inline SWIFT_RETURNS_UNRETAINED PipelineLayout& fromAPI(WGPUPipelineLayout pipelineLayout)
 {
     return static_cast<PipelineLayout&>(*pipelineLayout);
 }
 
-inline QuerySet& fromAPI(WGPUQuerySet querySet)
+inline SWIFT_RETURNS_UNRETAINED QuerySet& fromAPI(WGPUQuerySet querySet)
 {
     return static_cast<QuerySet&>(*querySet);
 }
 
-inline Queue& fromAPI(WGPUQueue queue)
+inline SWIFT_RETURNS_UNRETAINED Queue& fromAPI(WGPUQueue queue)
 {
     return static_cast<Queue&>(*queue);
 }
 
-inline RenderBundle& fromAPI(WGPURenderBundle renderBundle)
+inline SWIFT_RETURNS_UNRETAINED RenderBundle& fromAPI(WGPURenderBundle renderBundle)
 {
     return static_cast<RenderBundle&>(*renderBundle);
 }
 
-inline RenderBundleEncoder& fromAPI(WGPURenderBundleEncoder renderBundleEncoder)
+inline SWIFT_RETURNS_UNRETAINED RenderBundleEncoder& fromAPI(WGPURenderBundleEncoder renderBundleEncoder)
 {
     return static_cast<RenderBundleEncoder&>(*renderBundleEncoder);
 }
 
-inline RenderPassEncoder& fromAPI(WGPURenderPassEncoder renderPassEncoder)
+inline SWIFT_RETURNS_UNRETAINED RenderPassEncoder& fromAPI(WGPURenderPassEncoder renderPassEncoder)
 {
     return static_cast<RenderPassEncoder&>(*renderPassEncoder);
 }
 
-inline RenderPipeline& fromAPI(WGPURenderPipeline renderPipeline)
+inline SWIFT_RETURNS_UNRETAINED RenderPipeline& fromAPI(WGPURenderPipeline renderPipeline)
 {
     return static_cast<RenderPipeline&>(*renderPipeline);
 }
 
-inline Sampler& fromAPI(WGPUSampler sampler)
+inline SWIFT_RETURNS_UNRETAINED Sampler& fromAPI(WGPUSampler sampler)
 {
     return static_cast<Sampler&>(*sampler);
 }
 
-inline ShaderModule& fromAPI(WGPUShaderModule shaderModule)
+inline SWIFT_RETURNS_UNRETAINED ShaderModule& fromAPI(WGPUShaderModule shaderModule)
 {
     return static_cast<ShaderModule&>(*shaderModule);
 }
 
-inline PresentationContext& fromAPI(WGPUSurface surface)
+inline SWIFT_RETURNS_UNRETAINED PresentationContext& fromAPI(WGPUSurface surface)
 {
     return static_cast<PresentationContext&>(*surface);
 }
 
-inline PresentationContext& fromAPI(WGPUSwapChain swapChain)
+inline SWIFT_RETURNS_UNRETAINED PresentationContext& fromAPI(WGPUSwapChain swapChain)
 {
     return static_cast<PresentationContext&>(*swapChain);
 }
 
-inline Texture& fromAPI(WGPUTexture texture)
+inline SWIFT_RETURNS_UNRETAINED Texture& fromAPI(WGPUTexture texture)
 {
     return static_cast<Texture&>(*texture);
 }
 
-inline TextureView& fromAPI(WGPUTextureView textureView)
+inline SWIFT_RETURNS_UNRETAINED TextureView& fromAPI(WGPUTextureView textureView)
 {
     return static_cast<TextureView&>(*textureView);
 }
 
-inline XRBinding& fromAPI(WGPUXRBinding binding)
+inline SWIFT_RETURNS_UNRETAINED XRBinding& fromAPI(WGPUXRBinding binding)
 {
     return static_cast<XRBinding&>(*binding);
 }
 
-inline XRSubImage& fromAPI(WGPUXRSubImage subImage)
+inline SWIFT_RETURNS_UNRETAINED XRSubImage& fromAPI(WGPUXRSubImage subImage)
 {
     return static_cast<XRSubImage&>(*subImage);
 }
 
-inline XRProjectionLayer& fromAPI(WGPUXRProjectionLayer layer)
+inline SWIFT_RETURNS_UNRETAINED XRProjectionLayer& fromAPI(WGPUXRProjectionLayer layer)
 {
     return static_cast<XRProjectionLayer&>(*layer);
 }
 
-inline XRView& fromAPI(WGPUXRView view)
+inline SWIFT_RETURNS_UNRETAINED XRView& fromAPI(WGPUXRView view)
 {
     return static_cast<XRView&>(*view);
 }
 
-inline String fromAPI(const char* string)
+inline SWIFT_RETURNS_UNRETAINED String fromAPI(const char* string)
 {
     return String::fromUTF8(string);
 }

--- a/Source/WebKit/Shared/WebBackForwardListFrameItem.h
+++ b/Source/WebKit/Shared/WebBackForwardListFrameItem.h
@@ -41,7 +41,7 @@ public:
     static Ref<WebBackForwardListFrameItem> create(WebBackForwardListItem&, WebBackForwardListFrameItem* parentItem, Ref<FrameState>&&);
     ~WebBackForwardListFrameItem();
 
-    static WebBackForwardListFrameItem* NODELETE itemForID(WebCore::BackForwardItemIdentifier, WebCore::BackForwardFrameItemIdentifier);
+    static SWIFT_RETURNS_UNRETAINED WebBackForwardListFrameItem* NODELETE itemForID(WebCore::BackForwardItemIdentifier, WebCore::BackForwardFrameItemIdentifier);
 
     FrameState& frameState() const { return m_frameState; }
     void updateFrameStatePayload(Ref<FrameState>&&);
@@ -59,8 +59,8 @@ public:
 
     Ref<WebBackForwardListFrameItem> rootFrame();
     Ref<WebBackForwardListFrameItem> mainFrame();
-    WebBackForwardListFrameItem* NODELETE childItemForFrameID(WebCore::FrameIdentifier);
-    WebBackForwardListFrameItem* NODELETE childItemAtIndex(uint64_t);
+    SWIFT_RETURNS_UNRETAINED WebBackForwardListFrameItem* NODELETE childItemForFrameID(WebCore::FrameIdentifier);
+    SWIFT_RETURNS_UNRETAINED WebBackForwardListFrameItem* NODELETE childItemAtIndex(uint64_t);
     const Vector<Ref<WebBackForwardListFrameItem>>& children() const { return m_children; }
 
     WebBackForwardListItem* NODELETE backForwardListItem() const;

--- a/Source/WebKit/Shared/WebBackForwardListItem.h
+++ b/Source/WebKit/Shared/WebBackForwardListItem.h
@@ -95,8 +95,8 @@ public:
     WebBackForwardListFrameItem& NODELETE navigatedFrameItem() const;
 
     // rdar://168057355
-    WebBackForwardListFrameItem* WTF_NONNULL mainFrameItemPtrForSwift() const SWIFT_NAME(mainFrameItem()) { return &mainFrameItem(); }
-    WebBackForwardListFrameItem& NODELETE mainFrameItem() const SWIFT_NAME(__mainFrameItemUnsafe());
+    SWIFT_RETURNS_UNRETAINED WebBackForwardListFrameItem* WTF_NONNULL mainFrameItemPtrForSwift() const SWIFT_NAME(mainFrameItem()) { return &mainFrameItem(); }
+    SWIFT_RETURNS_UNRETAINED WebBackForwardListFrameItem& NODELETE mainFrameItem() const SWIFT_NAME(__mainFrameItemUnsafe());
 
     void NODELETE setWasRestoredFromSession();
 

--- a/Source/WebKit/UIProcess/WebBackForwardListSwiftUtilities.h
+++ b/Source/WebKit/UIProcess/WebBackForwardListSwiftUtilities.h
@@ -68,7 +68,7 @@ inline void setOptionalUInt32Value(std::optional<uint32_t>& optional, uint32_t v
 using WebBackForwardListItemFilter = WTF::RefCountable<WTF::Function<bool (WebKit::WebBackForwardListItem&)>>;
 
 // Workaround for rdar://168057355
-inline WebKit::FrameState* getFrameState(WebKit::WebBackForwardListFrameItem& item)
+inline SWIFT_RETURNS_UNRETAINED WebKit::FrameState* getFrameState(WebKit::WebBackForwardListFrameItem& item)
 {
     return &item.frameState();
 }

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1872,8 +1872,8 @@ public:
     WebProcessProxy& ensureRunningProcess();
     WebProcessProxy& siteIsolatedProcess() const { return m_legacyMainFrameProcess; }
     // rdar://168057355
-    WebProcessProxy* WTF_NONNULL legacyMainFrameProcessPtrForSwift() const SWIFT_NAME(legacyMainFrameProcess()) { return &legacyMainFrameProcess(); }
-    WebProcessProxy& legacyMainFrameProcess() const SWIFT_NAME(__legacyMainFrameProcessUnsafe()) { return m_legacyMainFrameProcess; }
+    SWIFT_RETURNS_UNRETAINED WebProcessProxy* WTF_NONNULL legacyMainFrameProcessPtrForSwift() const SWIFT_NAME(legacyMainFrameProcess()) { return &legacyMainFrameProcess(); }
+    SWIFT_RETURNS_UNRETAINED WebProcessProxy& legacyMainFrameProcess() const SWIFT_NAME(__legacyMainFrameProcessUnsafe()) { return m_legacyMainFrameProcess; }
 
     ProcessID NODELETE legacyMainFrameProcessID() const;
 
@@ -2914,8 +2914,8 @@ public:
     void didAdjustVisibilityWithSelectors(Vector<String>&&);
 
     // rdar://168057355
-    BrowsingContextGroup* WTF_NONNULL browsingContextGroupPtrForSwift() const SWIFT_NAME(browsingContextGroup()) { return &browsingContextGroup(); }
-    BrowsingContextGroup& browsingContextGroup() const SWIFT_NAME(__browsingContextGroupUnsafe()) { return m_browsingContextGroup; }
+    SWIFT_RETURNS_UNRETAINED BrowsingContextGroup* WTF_NONNULL browsingContextGroupPtrForSwift() const SWIFT_NAME(browsingContextGroup()) { return &browsingContextGroup(); }
+    SWIFT_RETURNS_UNRETAINED BrowsingContextGroup& browsingContextGroup() const SWIFT_NAME(__browsingContextGroupUnsafe()) { return m_browsingContextGroup; }
     std::optional<WebCore::FrameIdentifier> openerFrameIdentifier() const { return m_openerFrameIdentifier; }
 
     WebPageProxyTesting* NODELETE pageForTesting() const;


### PR DESCRIPTION
#### 99b2089b84d67ec51097897266c8495fb21ded4a
<pre>
WebKit fails to build with latest swift compiler due to lack of SWIFT_RETURNS_UNRETAINED
<a href="https://bugs.webkit.org/show_bug.cgi?id=319676">https://bugs.webkit.org/show_bug.cgi?id=319676</a>

Reviewed by NOBODY (OOPS!).

Added SWIFT_RETURNS_UNRETAINED to Ref getters and WebGPU::fromAPI so that it can be
built with the latest Swift compiler.

No new tests since there should be no behavioral changes.

* Source/WTF/wtf/Ref.h:
(WTF::Ref::unsafeGet const):
* Source/WebGPU/WebGPU/APIConversions.h:
(WebGPU::fromAPI):
* Source/WebKit/Shared/WebBackForwardListFrameItem.h:
* Source/WebKit/Shared/WebBackForwardListItem.h:
(WebKit::WebBackForwardListItem):
* Source/WebKit/UIProcess/WebBackForwardListSwiftUtilities.h:
(getFrameState):
* Source/WebKit/UIProcess/WebPageProxy.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/99b2089b84d67ec51097897266c8495fb21ded4a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175422 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49354 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43135 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185008 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/137558 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0fb6140f-3f4a-4300-9fae-48a0682808b3) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50646 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49037 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136572 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96197 "3 failures") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6dd43b95-6696-4130-a3a6-2384ea735d6c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178379 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39994 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157333 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117050 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c1084fcb-febe-4b95-b1e6-b7194e793428) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38636 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37020 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/5842 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149058 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36826 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33483 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/36683 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41041 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41224 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187433 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49021 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145537 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49701 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33448 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145378 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40199 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/121894 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115603 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48207 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11799 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47610 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47840 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47667 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->