### PR TITLE
Don't tell users their API token is out of date on non-auth GitHub errors

### DIFF
--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/github.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/github.py
@@ -47,6 +47,8 @@ class Tracker(GenericTracker):
         r'\A<?api.github.{}/repos/{}/{}/issues/(?P<id>\d+)>?\Z',
     ]
     REFRESH_TOKEN_PROMPT = "Is your API token out of date? Run 'git-webkit setup' to refresh credentials\n"
+    SERVER_ERROR_PROMPT = 'This is likely a transient server-side error, trying again later may succeed\n'
+    RATE_LIMIT_PROMPT = 'The API rate limit has been exceeded, waiting before retrying may succeed\n'
     DEFAULT_COMPONENT_COLOR = 'FFFFFF'
     DEFAULT_VERSION_COLOR = 'EEEEEE'
     ACCEPT_HEADER = 'application/vnd.github.v3+json'
@@ -158,6 +160,20 @@ with 'repo' and 'workflow' access and appropriate 'Expiration' for your {host} u
             save_in_keyring=save_in_keyring,
         )
 
+    @classmethod
+    def api_error_hint(cls, response) -> str:
+        status_code = response.status_code
+        if status_code in (403, 429) and (
+            response.headers.get('x-ratelimit-remaining') == '0'
+            or response.headers.get('retry-after')
+        ):
+            return cls.RATE_LIMIT_PROMPT
+        if status_code in (401, 403):
+            return cls.REFRESH_TOKEN_PROMPT
+        if status_code // 100 == 5:
+            return cls.SERVER_ERROR_PROMPT
+        return ''
+
     def request(self, path=None, params=None, method='GET', headers=None, authenticated=None, paginate=True, json=None, error_message=None):
         headers = {key: value for key, value in headers.items()} if headers else dict()
         headers['Accept'] = headers.get('Accept', self.ACCEPT_HEADER)
@@ -190,7 +206,7 @@ with 'repo' and 'workflow' access and appropriate 'Expiration' for your {host} u
             if message:
                 sys.stderr.write('Message: {}\n'.format(message))
             if auth:
-                sys.stderr.write(self.REFRESH_TOKEN_PROMPT)
+                sys.stderr.write(self.api_error_hint(response))
             return None
         result = response.json()
 
@@ -219,7 +235,7 @@ with 'repo' and 'workflow' access and appropriate 'Expiration' for your {host} u
             message = response.json().get('message')
             if message:
                 sys.stderr.write('Message: {}\n'.format(message))
-            sys.stderr.write(self.REFRESH_TOKEN_PROMPT)
+            sys.stderr.write(self.api_error_hint(response))
             return None
 
         data = response.json()

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/github_unittest.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/github_unittest.py
@@ -53,6 +53,19 @@ class TestGitHub(unittest.TestCase):
         self.assertEqual(decoded.url, 'https://github.example.com/WebKit/WebKit')
         self.assertEqual(decoded.from_string('example.com/b/1234').id, 1234)
 
+    def test_api_error_hint(self):
+        def resp(status_code, headers=None):
+            return type('Response', (), dict(status_code=status_code, headers=headers or {}))
+
+        self.assertEqual(github.Tracker.api_error_hint(resp(401)), github.Tracker.REFRESH_TOKEN_PROMPT)
+        self.assertEqual(github.Tracker.api_error_hint(resp(403)), github.Tracker.REFRESH_TOKEN_PROMPT)
+        self.assertEqual(github.Tracker.api_error_hint(resp(403, {'x-ratelimit-remaining': '0'})), github.Tracker.RATE_LIMIT_PROMPT)
+        self.assertEqual(github.Tracker.api_error_hint(resp(429, {'retry-after': '60'})), github.Tracker.RATE_LIMIT_PROMPT)
+        self.assertEqual(github.Tracker.api_error_hint(resp(500)), github.Tracker.SERVER_ERROR_PROMPT)
+        self.assertEqual(github.Tracker.api_error_hint(resp(503)), github.Tracker.SERVER_ERROR_PROMPT)
+        self.assertEqual(github.Tracker.api_error_hint(resp(404)), '')
+        self.assertEqual(github.Tracker.api_error_hint(resp(422)), '')
+
     def test_users(self):
         with mocks.GitHub(self.URL.split('://')[1], users=mocks.USERS):
             tracker = github.Tracker(self.URL)

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/git_hub.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/git_hub.py
@@ -170,7 +170,7 @@ class GitHub(Scm):
             if response.status_code // 100 != 2:
                 sys.stderr.write("Request to '{}' returned status code '{}'\n".format(url, response.status_code))
                 sys.stderr.write(self.repository.tracker.parse_error(response.json()))
-                sys.stderr.write(Tracker.REFRESH_TOKEN_PROMPT)
+                sys.stderr.write(Tracker.api_error_hint(response))
                 return None
             result = self.PullRequest(response.json())
 
@@ -216,7 +216,7 @@ class GitHub(Scm):
             if response.status_code // 100 != 2:
                 sys.stderr.write("Request to '{}' returned status code '{}'\n".format(url, response.status_code))
                 sys.stderr.write(self.repository.tracker.parse_error(response.json()))
-                sys.stderr.write(Tracker.REFRESH_TOKEN_PROMPT)
+                sys.stderr.write(Tracker.api_error_hint(response))
                 return None
             data = response.json()
 
@@ -403,8 +403,7 @@ class GitHub(Scm):
             if response.status_code // 100 != 2:
                 sys.stderr.write("Request to '{}' returned status code '{}'\n".format(url, response.status_code))
                 sys.stderr.write(self.repository.tracker.parse_error(response.json()))
-                if response.status_code != 422:
-                    sys.stderr.write(Tracker.REFRESH_TOKEN_PROMPT)
+                sys.stderr.write(Tracker.api_error_hint(response))
                 return False
             return True
 
@@ -472,8 +471,7 @@ class GitHub(Scm):
             if response.status_code // 100 != 2:
                 sys.stderr.write("Request to '{}' returned status code '{}'\n".format(url, response.status_code))
                 sys.stderr.write(self.repository.tracker.parse_error(response.json()))
-                if response.status_code != 422:
-                    sys.stderr.write(Tracker.REFRESH_TOKEN_PROMPT)
+                sys.stderr.write(Tracker.api_error_hint(response))
                 return None
 
             me = self._contributor(self.repository.credentials(required=True)[0])
@@ -619,7 +617,7 @@ class GitHub(Scm):
             if message:
                 sys.stderr.write('Message: {}\n'.format(message))
             if auth:
-                sys.stderr.write(Tracker.REFRESH_TOKEN_PROMPT)
+                sys.stderr.write(Tracker.api_error_hint(response))
             return None
 
         if not is_json_response:
@@ -646,7 +644,7 @@ class GitHub(Scm):
             message = response.json().get('message')
             if message:
                 sys.stderr.write('Message: {}\n'.format(message))
-            sys.stderr.write(Tracker.REFRESH_TOKEN_PROMPT)
+            sys.stderr.write(Tracker.api_error_hint(response))
             return None
         return response.json()
 

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/checkout_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/checkout_unittest.py
@@ -78,7 +78,6 @@ class TestCheckout(testing.PathTestCase):
         self.assertEqual(
             "Request to 'https://api.github.example.com/repos/WebKit/WebKit/pulls/1' returned status code '404'\n"
             "Message: Not found\n"
-            "Is your API token out of date? Run 'git-webkit setup' to refresh credentials\n"
             "Failed to find 'PR-1' associated with this repository\n",
             captured.stderr.getvalue(),
         )


### PR DESCRIPTION
#### ef92b431a492aa839a089bbb1bffff6cf7b3337f
<pre>
Don&apos;t tell users their API token is out of date on non-auth GitHub errors
<a href="https://bugs.webkit.org/show_bug.cgi?id=319642">https://bugs.webkit.org/show_bug.cgi?id=319642</a>
<a href="https://rdar.apple.com/problem/182462879">rdar://problem/182462879</a>

Reviewed by Aakash Jain.

The GitHub remote and tracker printed the &quot;Is your API token out of date?&quot; refresh prompt
after any non-2xx response that carried authentication, such as a transient 5xx server error,
a 404 for a missing/non-existent request, or a 403/429 rate-limit response.

Create a new class that provides uses with a more accurate hint, surfacing rate-limiting,
transient server errors, or authentication issues depending on the response code.

* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/github.py:
(Tracker): Add SERVER_ERROR_PROMPT, RATE_LIMIT_PROMPT and the api_error_hint() classmethod.
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/github_unittest.py:
(TestGitHub.test_api_error_hint): Add new test.
(TestGitHub.test_api_error_hint.resp):
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/git_hub.py:
Route create/update/_make_comment/review/request/graphql through api_error_hint(), drop the
now-redundant 422 guards.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/checkout_unittest.py:
(TestCheckout.test_no_pr_github): A 404 for a missing PR no longer asserts the refresh prompt,
so update the test.

Canonical link: <a href="https://commits.webkit.org/317643@main">https://commits.webkit.org/317643@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/502a45c5e0d926b91fcb718a98a38e2edf911f65

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175253 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49185 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42966 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184838 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/133607 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c25789a0-1286-4845-9f34-199d1e82a0e8) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/177117 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50477 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48868 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136417 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/133607 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d11024ff-46c4-497d-850c-98481da978a6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178210 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39839 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157190 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116896 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/99fcf7c4-739f-44ee-9e12-aa041516a77c) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/174575 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38480 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36863 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33311 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148903 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36683 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187259 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41066 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145367 "Passed tests") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/174700 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48852 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145223 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49532 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33304 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115411 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26725 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40058 "Passed tests") | | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48038 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11656 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47441 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47671 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47498 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->