### PR TITLE
Enable alpha.webkit.UncheckedLambdaCapturesChecker when it's available

### DIFF
--- a/Tools/Scripts/build-and-analyze
+++ b/Tools/Scripts/build-and-analyze
@@ -36,6 +36,7 @@ WEBKIT_CHECKERS = [
     'alpha.webkit.NoUnretainedMemberChecker',
     'alpha.webkit.RetainPtrCtorAdoptChecker',
     'alpha.webkit.UncheckedCallArgsChecker',
+    'alpha.webkit.UncheckedLambdaCapturesChecker',
     'alpha.webkit.UncheckedLocalVarsChecker',
     'alpha.webkit.UncountedCallArgsChecker',
     'alpha.webkit.UncountedLocalVarsChecker',
@@ -108,6 +109,13 @@ def make_analyzer_flags(output_dir, args):
 
     if args.only_smart_pointers:
         additional_checkers.extend(WEBKIT_CHECKERS)
+
+    # FIXME: Remove this code once we've fully migrated to 2026-07-17 merge.
+    if args.toolchains:
+        result = subprocess.run(['xcrun', 'clang', '-cc1', '-analyzer-checker-help-alpha'], env={'TOOLCHAINS': args.toolchains}, capture_output=True, encoding='ascii')
+        # Remove checker if not available in the specified toolchain.
+        if 'alpha.webkit.UncheckedLambdaCapturesChecker' not in result.stdout:
+            additional_checkers.remove('alpha.webkit.UncheckedLambdaCapturesChecker')
 
     if additional_checkers:
         analyzer_flags.extend(args_for_additional_checkers(additional_checkers))


### PR DESCRIPTION
#### 48d77f21514cd3507785be686d50be8220e59d08
<pre>
Enable alpha.webkit.UncheckedLambdaCapturesChecker when it&apos;s available
<a href="https://bugs.webkit.org/show_bug.cgi?id=319681">https://bugs.webkit.org/show_bug.cgi?id=319681</a>

Reviewed by David Kilzer.

Enable alpha.webkit.UncheckedLambdaCapturesChecker when it&apos;s available
to prepare for the next rollout of safer C++ static analyzers.

* Tools/Scripts/build-and-analyze:
(make_analyzer_flags):

Canonical link: <a href="https://commits.webkit.org/317458@main">https://commits.webkit.org/317458@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bad6f3bc557a03bcff7fb42ba5efae77691dc1f9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175298 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49230 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43011 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184884 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/137412 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/177162 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50522 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48913 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136459 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/137412 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178255 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39874 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157216 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116937 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38515 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36900 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148938 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36709 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33359 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/40917 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41104 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187308 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48897 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145422 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49577 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33331 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145265 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26658 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40084 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/121770 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115456 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48083 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11682 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47486 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47716 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47543 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->