### PR TITLE
[EvaluationTimeZoom] Convert animation-range properties to use unzoomed lengths

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/animation-range-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/animation-range-expected.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.group {
+  border: solid black 1px;
+  padding: 20px;
+  margin: 10px;
+  width: max-content;
+}
+.spacer {
+  height: 1000px;
+}
+.scroller {
+  display: inline-block;
+  outline: 1px solid black;
+  margin: 0 10px;
+  padding: 0;
+  border: 0;
+  overflow-y: scroll;
+  width: 200px;
+  height: 200px;
+}
+
+.scroller-zoomed {
+  display: inline-block;
+  outline: 1px solid black;
+  margin: 0 10px;
+  padding: 0;
+  border: 0;
+  overflow-y: scroll;
+  width: 200px;
+  height: 200px;
+}
+
+.target {
+  position: fixed;
+  height: 100px;
+  width: 100px;
+  background-color: black;
+}
+.target-zoomed {
+  position: fixed;
+  height: 100px;
+  width: 100px;
+  background-color: black;
+}
+</style>
+</head>
+<body>
+<p>Each grouping below should have two matching boxes.</p>
+<div class="group">
+  <div class="scroller" id="scroller1">
+    <div class="target" id="target1"></div>
+    <div class="spacer"></div>
+  </div>
+
+  <div class="scroller" id="scroller2">
+    <div class="target" id="target2"></div>
+    <div class="spacer"></div>
+  </div>
+</div>
+
+<div class="group">
+  <div class="scroller-zoomed" id="scroller3">
+    <div class="target-zoomed" id="target3"></div>
+    <div class="spacer"></div>
+  </div>
+
+  <div class="scroller-zoomed" id="scroller4">
+    <div class="target-zoomed" id="target4"></div>
+    <div class="spacer"></div>
+  </div>
+</div>
+
+<script>
+  window.addEventListener('load', function() {
+    const target1 = document.getElementById('target1');
+    const target2 = document.getElementById('target2');
+    const target3 = document.getElementById('target3');
+    const target4 = document.getElementById('target4');
+
+    const scroller1 = document.getElementById('scroller1');
+    const scroller2 = document.getElementById('scroller2');
+    const scroller3 = document.getElementById('scroller3');
+    const scroller4 = document.getElementById('scroller4');
+
+    const maxScroll1 = scroller1.scrollHeight - scroller1.clientHeight;
+    scroller1.scrollTop = (maxScroll1 + 300) * 0.5;
+
+    const maxScroll2 = scroller2.scrollHeight - scroller2.clientHeight;
+    scroller2.scrollTop = (maxScroll2 + 300) * 0.5;
+
+    const maxScroll3 = scroller3.scrollHeight - scroller3.clientHeight;
+    scroller3.scrollTop = (maxScroll3 + 300) * 0.5;
+
+    const maxScroll4 = scroller4.scrollHeight - scroller4.clientHeight;
+    scroller4.scrollTop = (maxScroll4 + 300) * 0.5;
+  });
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/animation-range.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/animation-range.html
@@ -1,0 +1,155 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<head>
+<title>CSS Zoom applies to animation-range-start/animation-range-end</title>
+<link rel="author" title="Sam Weinig" href="mailto:sam@webkit.org">
+<link rel="help" href="https://drafts.csswg.org/css-viewport/">
+<link rel="match" href="reference/animation-range-ref.html">
+<script src="/web-animations/testcommon.js"></script>
+<script src="/common/reftest-wait.js"></script>
+<style>
+.group {
+  border: solid black 1px;
+  padding: 20px;
+  margin: 10px;
+  width: max-content;
+}
+.spacer {
+  height: 1000px;
+}
+.scroller {
+  display: inline-block;
+  outline: 1px solid black;
+  margin: 0 10px;
+  padding: 0;
+  border: 0;
+  overflow-y: scroll;
+  width: 200px;
+  height: 200px;
+  scroll-timeline: --t1;
+  animation-range: 200px 900px;
+}
+
+.scroller-zoomed {
+  display: inline-block;
+  outline: 1px solid black;
+  margin: 0 10px;
+  padding: 0;
+  border: 0;
+  overflow-y: scroll;
+  width: 200px;
+  height: 200px;
+  scroll-timeline: --t1;
+  animation-range: 100px 450px;
+}
+
+@keyframes grow {
+  to { width: 200px }
+}
+
+@keyframes grow-zoomed {
+  to { width: 100px }
+}
+
+.target {
+  position: fixed;
+  height: 100px;
+  width: 0px;
+  background-color: black;
+}
+.target-zoomed {
+  position: fixed;
+  height: 50px;
+  width: 0px;
+  background-color: black;
+}
+
+.anim-1 {
+  animation: auto grow linear;
+  animation-timeline: --t1;
+  animation-range: 200px 900px;
+}
+.anim-2 {
+  animation: auto grow linear;
+  animation-timeline: --t1;
+  animation-range: inherit;
+}
+.anim-3 {
+  animation: auto grow-zoomed linear;
+  animation-timeline: --t1;
+  animation-range: 100px 450px;
+}
+.anim-4 {
+  animation: auto grow-zoomed linear;
+  animation-timeline: --t1;
+  animation-range: inherit;
+}
+</style>
+</head>
+<body>
+<p>Each grouping below should have two matching boxes.</p>
+<div class="group">
+  <div class="scroller" id="scroller1">
+    <div class="target" id="target1" style="zoom: 1"></div>
+    <div class="spacer"></div>
+  </div>
+
+  <div class="scroller" id="scroller2">
+    <div class="target" id="target2" style="zoom: 1"></div>
+    <div class="spacer"></div>
+  </div>
+</div>
+
+<div class="group">
+  <div class="scroller-zoomed" id="scroller3">
+    <div class="target-zoomed" id="target3" style="zoom: 2"></div>
+    <div class="spacer"></div>
+  </div>
+
+  <div class="scroller-zoomed" id="scroller4">
+    <div class="target-zoomed" id="target4" style="zoom: 2"></div>
+    <div class="spacer"></div>
+  </div>
+</div>
+
+<script>
+  const target1 = document.getElementById('target1');
+  const target2 = document.getElementById('target2');
+  const target3 = document.getElementById('target3');
+  const target4 = document.getElementById('target4');
+
+  const scroller1 = document.getElementById('scroller1');
+  const scroller2 = document.getElementById('scroller2');
+  const scroller3 = document.getElementById('scroller3');
+  const scroller4 = document.getElementById('scroller4');
+
+  target1.classList.add("anim-1");
+  const animation1 = target1.getAnimations()[0];
+
+  target2.classList.add("anim-2");
+  const animation2 = target2.getAnimations()[0];
+
+  target3.classList.add("anim-3");
+  const animation3 = target3.getAnimations()[0];
+
+  target4.classList.add("anim-4");
+  const animation4 = target4.getAnimations()[0];
+
+  Promise.all([animation1.ready, animation2.ready, animation3.ready, animation4.ready]).then(() => {
+    const maxScroll1 = scroller1.scrollHeight - scroller1.clientHeight;
+    scroller1.scrollTop = (maxScroll1 + 300) * 0.5;
+
+    const maxScroll2 = scroller2.scrollHeight - scroller2.clientHeight;
+    scroller2.scrollTop = (maxScroll2 + 300) * 0.5;
+
+    const maxScroll3 = scroller3.scrollHeight - scroller3.clientHeight;
+    scroller3.scrollTop = (maxScroll3 + 300) * 0.5;
+
+    const maxScroll4 = scroller4.scrollHeight - scroller4.clientHeight;
+    scroller4.scrollTop = (maxScroll4 + 300) * 0.5;
+
+    waitForAnimationFrames(2).then(takeScreenshot);
+  });
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/animation-range-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/animation-range-ref.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.group {
+  border: solid black 1px;
+  padding: 20px;
+  margin: 10px;
+  width: max-content;
+}
+.spacer {
+  height: 1000px;
+}
+.scroller {
+  display: inline-block;
+  outline: 1px solid black;
+  margin: 0 10px;
+  padding: 0;
+  border: 0;
+  overflow-y: scroll;
+  width: 200px;
+  height: 200px;
+}
+
+.scroller-zoomed {
+  display: inline-block;
+  outline: 1px solid black;
+  margin: 0 10px;
+  padding: 0;
+  border: 0;
+  overflow-y: scroll;
+  width: 200px;
+  height: 200px;
+}
+
+.target {
+  position: fixed;
+  height: 100px;
+  width: 100px;
+  background-color: black;
+}
+.target-zoomed {
+  position: fixed;
+  height: 100px;
+  width: 100px;
+  background-color: black;
+}
+</style>
+</head>
+<body>
+<p>Each grouping below should have two matching boxes.</p>
+<div class="group">
+  <div class="scroller" id="scroller1">
+    <div class="target" id="target1"></div>
+    <div class="spacer"></div>
+  </div>
+
+  <div class="scroller" id="scroller2">
+    <div class="target" id="target2"></div>
+    <div class="spacer"></div>
+  </div>
+</div>
+
+<div class="group">
+  <div class="scroller-zoomed" id="scroller3">
+    <div class="target-zoomed" id="target3"></div>
+    <div class="spacer"></div>
+  </div>
+
+  <div class="scroller-zoomed" id="scroller4">
+    <div class="target-zoomed" id="target4"></div>
+    <div class="spacer"></div>
+  </div>
+</div>
+
+<script>
+  window.addEventListener('load', function() {
+    const target1 = document.getElementById('target1');
+    const target2 = document.getElementById('target2');
+    const target3 = document.getElementById('target3');
+    const target4 = document.getElementById('target4');
+
+    const scroller1 = document.getElementById('scroller1');
+    const scroller2 = document.getElementById('scroller2');
+    const scroller3 = document.getElementById('scroller3');
+    const scroller4 = document.getElementById('scroller4');
+
+    const maxScroll1 = scroller1.scrollHeight - scroller1.clientHeight;
+    scroller1.scrollTop = (maxScroll1 + 300) * 0.5;
+
+    const maxScroll2 = scroller2.scrollHeight - scroller2.clientHeight;
+    scroller2.scrollTop = (maxScroll2 + 300) * 0.5;
+
+    const maxScroll3 = scroller3.scrollHeight - scroller3.clientHeight;
+    scroller3.scrollTop = (maxScroll3 + 300) * 0.5;
+
+    const maxScroll4 = scroller4.scrollHeight - scroller4.clientHeight;
+    scroller4.scrollTop = (maxScroll4 + 300) * 0.5;
+  });
+</script>
+</body>
+</html>

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -893,6 +893,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     animation/KeyframeInterpolation.h
     animation/OptionalEffectTiming.h
     animation/PlaybackDirection.h
+    animation/ResolvableTimelineRange.h
     animation/ScrollAxis.h
     animation/ScrollTimeline.h
     animation/ScrollTimelineOptions.h

--- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
+++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
@@ -5571,6 +5571,7 @@
 		BCB16C240979C3BD00467741 /* CachedScript.h in Headers */ = {isa = PBXBuildFile; fileRef = BCB16C0B0979C3BD00467741 /* CachedScript.h */; };
 		BCB16C280979C3BD00467741 /* CachedXSLStyleSheet.h in Headers */ = {isa = PBXBuildFile; fileRef = BCB16C0F0979C3BD00467741 /* CachedXSLStyleSheet.h */; };
 		BCB16C2A0979C3BD00467741 /* CachedResourceLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = BCB16C110979C3BD00467741 /* CachedResourceLoader.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		BCB19186300A967C00A9A5C7 /* ResolvableTimelineRange.h in Headers */ = {isa = PBXBuildFile; fileRef = BCB19185300A93CD00A9A5C7 /* ResolvableTimelineRange.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BCB271F92CC16DD500265123 /* CSSPathValue.h in Headers */ = {isa = PBXBuildFile; fileRef = BCB271F82CC16DD500265123 /* CSSPathValue.h */; };
 		BCB271FB2CC174D400265123 /* StyleSVGPathData.h in Headers */ = {isa = PBXBuildFile; fileRef = BCB271F52CC16CF600265123 /* StyleSVGPathData.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BCB271FF2CC1E6CD00265123 /* CSSPrimitiveNumericTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = BCB271DA2CC0142C00265123 /* CSSPrimitiveNumericTypes.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -20243,6 +20244,7 @@
 		BCB16C0F0979C3BD00467741 /* CachedXSLStyleSheet.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; path = CachedXSLStyleSheet.h; sourceTree = "<group>"; };
 		BCB16C100979C3BD00467741 /* CachedResourceLoader.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CachedResourceLoader.cpp; sourceTree = "<group>"; };
 		BCB16C110979C3BD00467741 /* CachedResourceLoader.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; path = CachedResourceLoader.h; sourceTree = "<group>"; };
+		BCB19185300A93CD00A9A5C7 /* ResolvableTimelineRange.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ResolvableTimelineRange.h; sourceTree = "<group>"; };
 		BCB271952CBC466500265123 /* CSSPropertyParserConsumer+FlexDefinitions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "CSSPropertyParserConsumer+FlexDefinitions.h"; sourceTree = "<group>"; };
 		BCB271962CBC466F00265123 /* CSSPropertyParserConsumer+FrequencyDefinitions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "CSSPropertyParserConsumer+FrequencyDefinitions.h"; sourceTree = "<group>"; };
 		BCB2719F2CBD7D4C00265123 /* CSSGradient.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CSSGradient.h; sourceTree = "<group>"; };
@@ -31717,6 +31719,7 @@
 				7120733F216DFAF200C78329 /* OptionalEffectTiming.idl */,
 				712BE47E1FE8649D002031CC /* PlaybackDirection.h */,
 				712BE47F1FE8649E002031CC /* PlaybackDirection.idl */,
+				BCB19185300A93CD00A9A5C7 /* ResolvableTimelineRange.h */,
 				BCB0259A2C87DDD800ACC2B3 /* ScrollAxis.cpp */,
 				713516962AE6D29600718EBE /* ScrollAxis.h */,
 				713516952AE6D29600718EBE /* ScrollAxis.idl */,
@@ -48281,6 +48284,7 @@
 				58B2F9F72232D46100938D63 /* ResizeObserverEntry.h in Headers */,
 				0FD6A68A26EEC32B007B2231 /* ResizeObserverOptions.h in Headers */,
 				0FD6A68E26EEC5E9007B2231 /* ResizeObserverSize.h in Headers */,
+				BCB19186300A967C00A9A5C7 /* ResolvableTimelineRange.h in Headers */,
 				CD14C2432ECB999900F9C56D /* ResolvedCaptionDisplaySettingsOptions.h in Headers */,
 				CD14C2562ECC65D500F9C56D /* ResolvedCaptionDisplaySettingsOptionsWrapper.h in Headers */,
 				EE62BD9D2DE12C1B006C9A05 /* ResolvedScopedName.h in Headers */,

--- a/Source/WebCore/animation/AnimationEffect.cpp
+++ b/Source/WebCore/animation/AnimationEffect.cpp
@@ -422,7 +422,7 @@ void AnimationEffect::animationPlaybackRateDidChange()
     m_timingDidMutate = true;
 }
 
-void AnimationEffect::animationProgressBasedTimelineSourceDidChangeMetrics(const Style::SingleAnimationRange& animationAttachmentRange)
+void AnimationEffect::animationProgressBasedTimelineSourceDidChangeMetrics(const ResolvableTimelineRange& animationAttachmentRange)
 {
     if (!animationAttachmentRange.isDefault())
         m_timingDidMutate = true;

--- a/Source/WebCore/animation/AnimationEffect.h
+++ b/Source/WebCore/animation/AnimationEffect.h
@@ -44,10 +44,6 @@
 
 namespace WebCore {
 
-namespace Style {
-struct SingleAnimationRange;
-}
-
 class AnimationEffect : public RefCountedAndCanMakeWeakPtr<AnimationEffect> {
     WTF_MAKE_TZONE_ALLOCATED(AnimationEffect);
 public:
@@ -70,7 +66,7 @@ public:
     virtual void animationTimelineDidChange();
     virtual void animationDidFinish() { };
     virtual void animationPlaybackRateDidChange();
-    virtual void animationProgressBasedTimelineSourceDidChangeMetrics(const Style::SingleAnimationRange&);
+    virtual void animationProgressBasedTimelineSourceDidChangeMetrics(const ResolvableTimelineRange&);
     void NODELETE animationRangeDidChange();
 
     AnimationEffectTiming timing() const { return m_timing; }

--- a/Source/WebCore/animation/CSSAnimation.cpp
+++ b/Source/WebCore/animation/CSSAnimation.cpp
@@ -40,13 +40,13 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(CSSAnimation);
 
-Ref<CSSAnimation> CSSAnimation::create(const Styleable& owningElement, Style::Animation&& backingStyleAnimation, const Style::ComputedStyle* oldStyle, const Style::ComputedStyle& newStyle, const Style::ResolutionContext& resolutionContext)
+Ref<CSSAnimation> CSSAnimation::create(const Styleable& owningElement, Style::Animation&& backingStyleAnimation, Style::ZoomFactor backingStyleZoomForLength, const Style::ComputedStyle* oldStyle, const Style::ComputedStyle& newStyle, const Style::ResolutionContext& resolutionContext)
 {
     // CSSAnimation should only ever be created with non-"none" animation names.
     auto name = backingStyleAnimation.name().tryKeyframesName();
     RELEASE_ASSERT(name);
 
-    auto result = adoptRef(*new CSSAnimation(owningElement, WTF::move(*name), WTF::move(backingStyleAnimation)));
+    auto result = adoptRef(*new CSSAnimation(owningElement, WTF::move(*name), WTF::move(backingStyleAnimation), backingStyleZoomForLength));
     result->initialize(oldStyle, newStyle, resolutionContext);
 
     InspectorInstrumentation::didCreateWebAnimation(result.get());
@@ -54,16 +54,18 @@ Ref<CSSAnimation> CSSAnimation::create(const Styleable& owningElement, Style::An
     return result;
 }
 
-CSSAnimation::CSSAnimation(const Styleable& element, Style::ScopedName&& animationName, Style::Animation&& backingStyleAnimation)
+CSSAnimation::CSSAnimation(const Styleable& element, Style::ScopedName&& animationName, Style::Animation&& backingStyleAnimation, Style::ZoomFactor backingStyleZoomForLength)
     : StyleOriginatedAnimation(element)
     , m_animationName(WTF::move(animationName))
     , m_backingStyleAnimation(WTF::move(backingStyleAnimation))
+    , m_backingStyleZoomForLength(backingStyleZoomForLength)
 {
 }
 
-void CSSAnimation::setBackingStyleAnimation(const Style::Animation& backingStyleAnimation)
+void CSSAnimation::setBackingStyleAnimation(const Style::Animation& backingStyleAnimation, Style::ZoomFactor backingStyleZoomForLength)
 {
     m_backingStyleAnimation = backingStyleAnimation;
+    m_backingStyleZoomForLength = backingStyleZoomForLength;
     syncPropertiesWithBackingAnimation();
 }
 
@@ -155,9 +157,9 @@ void CSSAnimation::syncPropertiesWithBackingAnimation()
     }
 
     if (!m_overriddenProperties.contains(Property::RangeStart))
-        setRangeStart(Style::SingleAnimationRangeStart { animation.range().start });
+        setRangeStart(Style::SingleAnimationRangeStart { animation.range().start }, m_backingStyleZoomForLength);
     if (!m_overriddenProperties.contains(Property::RangeEnd))
-        setRangeEnd(Style::SingleAnimationRangeEnd { animation.range().end });
+        setRangeEnd(Style::SingleAnimationRangeEnd { animation.range().end }, m_backingStyleZoomForLength);
 
     effectTimingDidChange();
 

--- a/Source/WebCore/animation/CSSAnimation.h
+++ b/Source/WebCore/animation/CSSAnimation.h
@@ -42,7 +42,7 @@ class CSSAnimation final : public StyleOriginatedAnimation {
     WTF_MAKE_TZONE_ALLOCATED(CSSAnimation);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(CSSAnimation);
 public:
-    static Ref<CSSAnimation> create(const Styleable&, Style::Animation&&, const Style::ComputedStyle* oldStyle, const Style::ComputedStyle& newStyle, const Style::ResolutionContext&);
+    static Ref<CSSAnimation> create(const Styleable&, Style::Animation&&, Style::ZoomFactor, const Style::ComputedStyle* oldStyle, const Style::ComputedStyle& newStyle, const Style::ResolutionContext&);
     ~CSSAnimation() = default;
 
     const String& animationName() const LIFETIME_BOUND { return m_animationName.name; }
@@ -57,10 +57,12 @@ public:
     void syncStyleOriginatedTimeline();
 
     const Style::Animation& backingStyleAnimation() const LIFETIME_BOUND { return m_backingStyleAnimation; }
-    void setBackingStyleAnimation(const Style::Animation&);
+    Style::ZoomFactor backingStyleZoomForLength() const { return m_backingStyleZoomForLength; }
+
+    void setBackingStyleAnimation(const Style::Animation&, Style::ZoomFactor);
 
 private:
-    CSSAnimation(const Styleable&, Style::ScopedName&&, Style::Animation&&);
+    CSSAnimation(const Styleable&, Style::ScopedName&&, Style::Animation&&, Style::ZoomFactor);
 
     bool isCSSAnimation() const final { return true; }
 
@@ -99,6 +101,7 @@ private:
     OptionSet<Property> m_overriddenProperties;
     std::optional<AnimationPlayState> m_lastStyleOriginatedPlayState;
     Style::Animation m_backingStyleAnimation;
+    Style::ZoomFactor m_backingStyleZoomForLength;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -258,7 +258,7 @@ static double computedOffset(Style::SingleAnimationRangeName rangeName, Style::P
     if (!animation)
         return computedOffsetWithinNamedRange;
 
-    auto attachmentRange = Ref { *animation }->range();
+    auto attachmentRange = protect(animation)->range();
     if (attachmentRange.isDefault())
         return computedOffsetWithinNamedRange;
 
@@ -3354,7 +3354,7 @@ RefPtr<const ScrollTimeline> KeyframeEffect::activeScrollTimeline() const
     return nullptr;
 }
 
-void KeyframeEffect::animationProgressBasedTimelineSourceDidChangeMetrics(const Style::SingleAnimationRange& animationAttachmentRange)
+void KeyframeEffect::animationProgressBasedTimelineSourceDidChangeMetrics(const ResolvableTimelineRange& animationAttachmentRange)
 {
     AnimationEffect::animationProgressBasedTimelineSourceDidChangeMetrics(animationAttachmentRange);
     m_needsComputedKeyframeOffsetsUpdate = true;

--- a/Source/WebCore/animation/KeyframeEffect.h
+++ b/Source/WebCore/animation/KeyframeEffect.h
@@ -287,7 +287,7 @@ private:
     bool ticksContinuouslyWhileActive() const final;
     std::optional<double> progressUntilNextStep(double) const final;
     bool preventsAnimationReadiness() const final;
-    void animationProgressBasedTimelineSourceDidChangeMetrics(const Style::SingleAnimationRange&) final;
+    void animationProgressBasedTimelineSourceDidChangeMetrics(const ResolvableTimelineRange&) final;
 
     RefPtr<const ScrollTimeline> activeScrollTimeline() const;
     void updateComputedKeyframeOffsetsIfNeeded();

--- a/Source/WebCore/animation/ResolvableTimelineRange.h
+++ b/Source/WebCore/animation/ResolvableTimelineRange.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2026 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <WebCore/StyleSingleAnimationRange.h>
+#include <WebCore/StyleZoomPrimitives.h>
+
+namespace WebCore {
+
+struct ResolvableTimelineRange {
+    Style::SingleAnimationRangeStart start;
+    Style::SingleAnimationRangeEnd end;
+    Style::ZoomFactor startZoom;
+    Style::ZoomFactor endZoom;
+
+    bool isDefault() const { return start.isNormal() && end.isNormal(); }
+
+    bool operator==(const ResolvableTimelineRange&) const = default;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/animation/ScrollTimeline.cpp
+++ b/Source/WebCore/animation/ScrollTimeline.cpp
@@ -360,23 +360,29 @@ ScrollTimeline::Data ScrollTimeline::computeTimelineData(UseCachedCurrentTime us
     };
 }
 
-std::pair<WebAnimationTime, WebAnimationTime> ScrollTimeline::intervalForAttachmentRange(const Style::SingleAnimationRange& attachmentRange) const
+std::pair<WebAnimationTime, WebAnimationTime> ScrollTimeline::intervalForAttachmentRange(const ResolvableTimelineRange& resolvableTimelineRange) const
 {
     auto maxScrollOffset = m_cachedCurrentTimeData.maxScrollOffset;
     if (!maxScrollOffset)
         return { WebAnimationTime::fromPercentage(0), WebAnimationTime::fromPercentage(100) };
 
-    auto attachmentRangeOrDefault = attachmentRange.isDefault() ? defaultRange() : attachmentRange;
-
-    auto computedPercentageIfNecessary = [&](const auto& rangeOffset) {
-        if (auto percentage = rangeOffset.tryPercentage())
-            return percentage->value;
-        return Style::evaluate<float>(rangeOffset, maxScrollOffset, Style::ZoomNeeded { }) / maxScrollOffset * 100;
+    auto computedTime = [&](const auto& edge, auto zoom) {
+        if (auto percentage = edge.offset().tryPercentage())
+            return WebAnimationTime::fromPercentage(percentage->value);
+        return WebAnimationTime::fromPercentage(Style::evaluate<float>(edge.offset(), maxScrollOffset, zoom) / maxScrollOffset * 100);
     };
 
+    if (resolvableTimelineRange.isDefault()) {
+        auto range = defaultRange();
+        return {
+            computedTime(range.start, Style::ZoomFactor::none()),
+            computedTime(range.end, Style::ZoomFactor::none()),
+        };
+    }
+
     return {
-        WebAnimationTime::fromPercentage(computedPercentageIfNecessary(attachmentRangeOrDefault.start.offset())),
-        WebAnimationTime::fromPercentage(computedPercentageIfNecessary(attachmentRangeOrDefault.end.offset()))
+        computedTime(resolvableTimelineRange.start, resolvableTimelineRange.startZoom),
+        computedTime(resolvableTimelineRange.end, resolvableTimelineRange.endZoom),
     };
 }
 

--- a/Source/WebCore/animation/ScrollTimeline.h
+++ b/Source/WebCore/animation/ScrollTimeline.h
@@ -42,6 +42,7 @@ class AnimationTimelinesController;
 class Document;
 class Element;
 class ScrollableArea;
+struct ResolvableTimelineRange;
 
 namespace Style {
 class ComputedStyle;
@@ -81,7 +82,7 @@ public:
     void setTimelineScopeElement(const Element&);
     void clearTimelineScopeDeclaredElement() { m_timelineScopeElement = nullptr; }
 
-    virtual std::pair<WebAnimationTime, WebAnimationTime> intervalForAttachmentRange(const Style::SingleAnimationRange&) const;
+    virtual std::pair<WebAnimationTime, WebAnimationTime> intervalForAttachmentRange(const ResolvableTimelineRange&) const;
 
     void removeTimelineFromDocument(Element*);
 

--- a/Source/WebCore/animation/ViewTimeline.cpp
+++ b/Source/WebCore/animation/ViewTimeline.cpp
@@ -613,27 +613,27 @@ std::pair<double, double> ViewTimeline::offsetIntervalForTimelineRangeName(const
     return { computeOffset(0), computeOffset(1) };
 }
 
-std::pair<double, double> ViewTimeline::offsetIntervalForAttachmentRange(const Style::SingleAnimationRange& attachmentRange) const
+std::pair<double, double> ViewTimeline::offsetIntervalForAttachmentRange(const ResolvableTimelineRange& resolvableTimelineRange) const
 {
     auto data = computeTimelineData();
     auto timelineRange = data.rangeEnd - data.rangeStart;
     ASSERT(timelineRange);
 
-    auto offsetForSingleTimelineRange = [&](const auto& rangeToConvert) {
-        auto [conversionRangeStart, conversionRangeEnd] = intervalForTimelineRangeName(data, rangeToConvert.name());
+    auto offsetForSingleTimelineRange = [&](const auto& edge, auto zoom) {
+        auto [conversionRangeStart, conversionRangeEnd] = intervalForTimelineRangeName(data, edge.name());
         auto conversionRange = conversionRangeEnd - conversionRangeStart;
-        auto convertedValue = Style::evaluate<float>(rangeToConvert.offset(), conversionRange, Style::ZoomNeeded { });
+        auto convertedValue = Style::evaluate<float>(edge.offset(), conversionRange, zoom);
         auto position = conversionRangeStart + convertedValue;
         return (position - data.rangeStart) / timelineRange;
     };
 
     return {
-        offsetForSingleTimelineRange(attachmentRange.start),
-        offsetForSingleTimelineRange(attachmentRange.end)
+        offsetForSingleTimelineRange(resolvableTimelineRange.start, resolvableTimelineRange.startZoom),
+        offsetForSingleTimelineRange(resolvableTimelineRange.end, resolvableTimelineRange.endZoom)
     };
 }
 
-std::pair<WebAnimationTime, WebAnimationTime> ViewTimeline::intervalForAttachmentRange(const Style::SingleAnimationRange& attachmentRange) const
+std::pair<WebAnimationTime, WebAnimationTime> ViewTimeline::intervalForAttachmentRange(const ResolvableTimelineRange& resolvableTimelineRange) const
 {
     // https://drafts.csswg.org/scroll-animations-1/#view-timelines-ranges
     auto data = computeTimelineData();
@@ -641,17 +641,24 @@ std::pair<WebAnimationTime, WebAnimationTime> ViewTimeline::intervalForAttachmen
     if (!timelineRange)
         return { WebAnimationTime::fromPercentage(0), WebAnimationTime::fromPercentage(100) };
 
-    auto computeTime = [&](const auto& rangeToConvert) {
-        auto mappedOffset = mapOffsetToTimelineRange(data, rangeToConvert.name(), [&](const float& subjectRange) {
-            return Style::evaluate<float>(rangeToConvert.offset(), subjectRange, Style::ZoomNeeded { });
+    auto computeTime = [&](const auto& edge, auto zoom) {
+        auto mappedOffset = mapOffsetToTimelineRange(data, edge.name(), [&](const float& subjectRange) {
+            return Style::evaluate<float>(edge.offset(), subjectRange, zoom);
         });
         return WebAnimationTime::fromPercentage(mappedOffset * 100);
     };
 
-    auto attachmentRangeOrDefault = attachmentRange.isDefault() ? defaultRange() : attachmentRange;
+    if (resolvableTimelineRange.isDefault()) {
+        auto range = defaultRange();
+        return {
+            computeTime(range.start, Style::ZoomFactor::none()),
+            computeTime(range.end, Style::ZoomFactor::none()),
+        };
+    }
+
     return {
-        computeTime(attachmentRangeOrDefault.start),
-        computeTime(attachmentRangeOrDefault.end),
+        computeTime(resolvableTimelineRange.start, resolvableTimelineRange.startZoom),
+        computeTime(resolvableTimelineRange.end, resolvableTimelineRange.endZoom),
     };
 }
 

--- a/Source/WebCore/animation/ViewTimeline.h
+++ b/Source/WebCore/animation/ViewTimeline.h
@@ -95,8 +95,8 @@ public:
     RefPtr<Element> source() const override;
     Style::SingleAnimationRange defaultRange() const final;
 
-    std::pair<WebAnimationTime, WebAnimationTime> intervalForAttachmentRange(const Style::SingleAnimationRange&) const final;
-    std::pair<double, double> offsetIntervalForAttachmentRange(const Style::SingleAnimationRange&) const;
+    std::pair<WebAnimationTime, WebAnimationTime> intervalForAttachmentRange(const ResolvableTimelineRange&) const final;
+    std::pair<double, double> offsetIntervalForAttachmentRange(const ResolvableTimelineRange&) const;
     std::pair<double, double> offsetIntervalForTimelineRangeName(Style::SingleAnimationRangeName) const;
 
     bool matchesAnonymousViewFunctionForSubject(const Style::ViewFunction&, const Styleable&) const;

--- a/Source/WebCore/animation/WebAnimation.cpp
+++ b/Source/WebCore/animation/WebAnimation.cpp
@@ -117,7 +117,12 @@ WebAnimation::WebAnimation(Document& document)
     : ActiveDOMObject(document)
     , m_readyPromise(makeUniqueRef<ReadyPromise>(*this, &WebAnimation::readyPromiseResolve))
     , m_finishedPromise(makeUniqueRef<FinishedPromise>(*this, &WebAnimation::finishedPromiseResolve))
-    , m_timelineRange({ Style::SingleAnimationRangeStart { CSS::Keyword::Normal { } }, Style::SingleAnimationRangeEnd { CSS::Keyword::Normal { } } })
+    , m_timelineRange({
+        .start = Style::SingleAnimationRangeStart { CSS::Keyword::Normal { } },
+        .end = Style::SingleAnimationRangeEnd { CSS::Keyword::Normal { } },
+        .startZoom = Style::ZoomFactor::none(),
+        .endZoom = Style::ZoomFactor::none(),
+    })
 {
     instances().add(*this);
 }
@@ -2047,41 +2052,51 @@ void WebAnimation::setBindingsRangeEnd(TimelineRangeValue&& rangeEndValue)
         effect->animationRangeDidChange();
 }
 
-void WebAnimation::setRangeStart(Style::SingleAnimationRangeStart&& rangeStart)
+void WebAnimation::setRangeStart(Style::SingleAnimationRangeStart&& start, Style::ZoomFactor startZoom)
 {
-    if (m_timelineRange.start == rangeStart)
+    if (m_timelineRange.start == start && m_timelineRange.startZoom == startZoom)
         return;
 
-    m_timelineRange.start = WTF::move(rangeStart);
+    m_timelineRange.start = WTF::move(start);
+    m_timelineRange.startZoom = WTF::move(startZoom);
+
     if (auto* effect = this->effect())
         effect->animationRangeDidChange();
 }
 
-void WebAnimation::setRangeEnd(Style::SingleAnimationRangeEnd&& rangeEnd)
+void WebAnimation::setRangeEnd(Style::SingleAnimationRangeEnd&& end, Style::ZoomFactor endZoom)
 {
-    if (m_timelineRange.end == rangeEnd)
+    if (m_timelineRange.end == end && m_timelineRange.endZoom == endZoom)
         return;
 
-    m_timelineRange.end = WTF::move(rangeEnd);
+    m_timelineRange.end = WTF::move(end);
+    m_timelineRange.endZoom = WTF::move(endZoom);
+
     if (auto* effect = this->effect())
         effect->animationRangeDidChange();
 }
 
-const Style::SingleAnimationRange& WebAnimation::range()
+const ResolvableTimelineRange& WebAnimation::range()
 {
-    if (RefPtr keyframeEffect = this->keyframeEffect()) {
-        auto conversionData = CSSToLengthConversionData::tryCreateForNonStyleBuildingResolution(keyframeEffect->target());
+    if (m_specifiedRangeStart || m_specifiedRangeEnd) {
+        if (RefPtr keyframeEffect = this->keyframeEffect()) {
+            auto conversionData = CSSToLengthConversionData::tryCreateForNonStyleBuildingResolution(keyframeEffect->target());
 
-        auto computedEdge = [&]<typename To>(const CSSValue& specifiedEdge, To&& defaultValue) {
-            if (!conversionData)
-                return Style::deprecatedToStyleFromCSSValue<To>(specifiedEdge).value_or(defaultValue);
-            return Style::toStyleFromCSSValue<To>(*conversionData, specifiedEdge);
-        };
+            auto computedEdge = [&]<typename To>(const CSSValue& specifiedEdge, To&& defaultValue) {
+                if (!conversionData)
+                    return Style::deprecatedToStyleFromCSSValue<To>(specifiedEdge).value_or(defaultValue);
+                return Style::toStyleFromCSSValue<To>(*conversionData, specifiedEdge);
+            };
 
-        if (m_specifiedRangeStart)
-            m_timelineRange.start = computedEdge(protect(*m_specifiedRangeStart), Style::SingleAnimationRangeStart { CSS::Keyword::Normal { } });
-        if (m_specifiedRangeEnd)
-            m_timelineRange.end = computedEdge(protect(*m_specifiedRangeEnd), Style::SingleAnimationRangeEnd { CSS::Keyword::Normal { } });
+            if (m_specifiedRangeStart) {
+                m_timelineRange.start = computedEdge(protect(*m_specifiedRangeStart), Style::SingleAnimationRangeStart { CSS::Keyword::Normal { } });
+                m_timelineRange.startZoom = Style::ZoomFactor::none();
+            }
+            if (m_specifiedRangeEnd) {
+                m_timelineRange.end = computedEdge(protect(*m_specifiedRangeEnd), Style::SingleAnimationRangeEnd { CSS::Keyword::Normal { } });
+                m_timelineRange.endZoom = Style::ZoomFactor::none();
+            }
+        }
     }
 
     return m_timelineRange;

--- a/Source/WebCore/animation/WebAnimation.h
+++ b/Source/WebCore/animation/WebAnimation.h
@@ -34,7 +34,7 @@
 #include <WebCore/EventTargetInterfaces.h>
 #include <WebCore/ExceptionOr.h>
 #include <WebCore/IDLTypes.h>
-#include <WebCore/StyleSingleAnimationRange.h>
+#include <WebCore/ResolvableTimelineRange.h>
 #include <WebCore/Styleable.h>
 #include <WebCore/TimelineRangeValue.h>
 #include <WebCore/WebAnimationTypes.h>
@@ -150,13 +150,13 @@ public:
     virtual void setBindingsFrameRate(Variant<FramesPerSecond, AnimationFrameRatePreset>&&);
     std::optional<FramesPerSecond> frameRate() const { return m_effectiveFrameRate; }
 
-    TimelineRangeValue bindingsRangeStart() const { return m_timelineRange.start.toTimelineRangeValue(); }
-    TimelineRangeValue bindingsRangeEnd() const { return m_timelineRange.end.toTimelineRangeValue(); }
+    TimelineRangeValue bindingsRangeStart() const { return m_timelineRange.start.toTimelineRangeValue(m_timelineRange.startZoom); }
+    TimelineRangeValue bindingsRangeEnd() const { return m_timelineRange.end.toTimelineRangeValue(m_timelineRange.endZoom); }
     virtual void setBindingsRangeStart(TimelineRangeValue&&);
     virtual void setBindingsRangeEnd(TimelineRangeValue&&);
-    void setRangeStart(Style::SingleAnimationRangeStart&&);
-    void setRangeEnd(Style::SingleAnimationRangeEnd&&);
-    const Style::SingleAnimationRange& range() LIFETIME_BOUND;
+    void setRangeStart(Style::SingleAnimationRangeStart&&, Style::ZoomFactor);
+    void setRangeEnd(Style::SingleAnimationRangeEnd&&, Style::ZoomFactor);
+    const ResolvableTimelineRange& range() LIFETIME_BOUND;
 
     bool needsTick() const;
     virtual void tick();
@@ -272,7 +272,8 @@ private:
     TimeToRunPendingTask m_timeToRunPendingPauseTask { TimeToRunPendingTask::NotScheduled };
     ReplaceState m_replaceState { ReplaceState::Active };
     uint64_t m_globalPosition { 0 };
-    Style::SingleAnimationRange m_timelineRange;
+
+    ResolvableTimelineRange m_timelineRange;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/style/Styleable.cpp
+++ b/Source/WebCore/style/Styleable.cpp
@@ -438,7 +438,7 @@ void Styleable::updateCSSAnimations(const Style::ComputedStyle* currentStyle, co
                 if (previousAnimation->animationName() == currentAnimationName) {
                     // Timing properties or play state may have changed so we need to update the backing animation with
                     // the Animation found in the current style.
-                    previousAnimation->setBackingStyleAnimation(currentAnimation);
+                    previousAnimation->setBackingStyleAnimation(currentAnimation, newStyle.usedZoomForLength());
                     // Keyframes may have been cleared if the @keyframes rules was changed since
                     // the last style update, so we must ensure keyframes are picked up.
                     previousAnimation->updateKeyframesIfNeeded(currentStyle, newStyle, resolutionContext);
@@ -452,7 +452,7 @@ void Styleable::updateCSSAnimations(const Style::ComputedStyle* currentStyle, co
             }
 
             if (!foundMatchingAnimation && isInDisplayNoneTree == Style::IsInDisplayNoneTree::No) {
-                auto cssAnimation = CSSAnimation::create(*this, Style::Animation { currentAnimation }, currentStyle, newStyle, resolutionContext);
+                auto cssAnimation = CSSAnimation::create(*this, Style::Animation { currentAnimation }, newStyle.usedZoomForLength(), currentStyle, newStyle, resolutionContext);
                 newStyleOriginatedAnimations.append(cssAnimation.ptr());
                 newAnimations.add(WTF::move(cssAnimation));
             }

--- a/Source/WebCore/style/values/animations/StyleSingleAnimationRange.cpp
+++ b/Source/WebCore/style/values/animations/StyleSingleAnimationRange.cpp
@@ -35,33 +35,33 @@
 namespace WebCore {
 namespace Style {
 
-static RefPtr<CSSNumericValue> toCSSNumericValue(const LengthPercentage<>& offset)
+static RefPtr<CSSNumericValue> toCSSNumericValue(const SingleAnimationRangeEdgeOffset& offset, ZoomFactor zoom)
 {
     // FIXME: This will fail for calc().
     return offset.isPercentOrCalculated()
         ? CSSNumericFactory::percent(offset.tryPercentage()->value)
-        : CSSNumericFactory::px(offset.tryFixed()->resolveZoom(Style::ZoomNeeded { }));
+        : CSSNumericFactory::px(offset.tryFixed()->resolveZoom(zoom));
 }
 
-TimelineRangeValue SingleAnimationRangeStart::toTimelineRangeValue() const
+TimelineRangeValue SingleAnimationRangeStart::toTimelineRangeValue(ZoomFactor zoom) const
 {
     if (m_name == SingleAnimationRangeName::Normal)
         return convertSingleAnimationRangeNameToRangeString(m_name);
 
     return TimelineRangeOffset {
         convertSingleAnimationRangeNameToRangeString(m_name),
-        toCSSNumericValue(m_offset),
+        toCSSNumericValue(m_offset, zoom),
     };
 }
 
-TimelineRangeValue SingleAnimationRangeEnd::toTimelineRangeValue() const
+TimelineRangeValue SingleAnimationRangeEnd::toTimelineRangeValue(ZoomFactor zoom) const
 {
     if (m_name == SingleAnimationRangeName::Normal)
         return convertSingleAnimationRangeNameToRangeString(m_name);
 
     return TimelineRangeOffset {
         convertSingleAnimationRangeNameToRangeString(m_name),
-        toCSSNumericValue(m_offset),
+        toCSSNumericValue(m_offset, zoom),
     };
 }
 

--- a/Source/WebCore/style/values/animations/StyleSingleAnimationRange.h
+++ b/Source/WebCore/style/values/animations/StyleSingleAnimationRange.h
@@ -38,11 +38,13 @@ namespace Style {
 
 enum class SingleAnimationRangeType : bool { Start, End };
 
+using SingleAnimationRangeEdgeOffset = LengthPercentage<CSS::AllUnzoomed>;
+
 template<SingleAnimationRangeType type>
 struct SingleAnimationRangeEdge {
     using Base = SingleAnimationRangeEdge<type>;
     using Name = SingleAnimationRangeName;
-    using Offset = LengthPercentage<>;
+    using Offset = SingleAnimationRangeEdgeOffset;
 
     SingleAnimationRangeEdge(Offset&& offset)
         : SingleAnimationRangeEdge { Name::Omitted, WTF::move(offset) }
@@ -155,13 +157,13 @@ auto SingleAnimationRangeEdge<type>::defaultOffset() -> Offset
 struct SingleAnimationRangeStart : SingleAnimationRangeEdge<SingleAnimationRangeType::Start> {
     using Base::Base;
 
-    TimelineRangeValue toTimelineRangeValue() const;
+    TimelineRangeValue toTimelineRangeValue(ZoomFactor) const;
 };
 
 struct SingleAnimationRangeEnd : SingleAnimationRangeEdge<SingleAnimationRangeType::End> {
     using Base::Base;
 
-    TimelineRangeValue toTimelineRangeValue() const;
+    TimelineRangeValue toTimelineRangeValue(ZoomFactor) const;
 };
 
 struct SingleAnimationRange {

--- a/Source/WebCore/style/values/viewport/StyleZoomPrimitives.h
+++ b/Source/WebCore/style/values/viewport/StyleZoomPrimitives.h
@@ -44,6 +44,8 @@ struct ZoomFactor {
 
     // Special zoom factor to use when zoom has already been applied to a value.
     static constexpr ZoomFactor none() { return ZoomFactor { 1 }; }
+
+    constexpr bool operator==(const ZoomFactor&) const = default;
 };
 
 // Map from computed style values (which take zoom into account) to web-exposed values, which are zoom-independent.


### PR DESCRIPTION
#### f6b407dde7b750f4b1bae4db37a94b6caab491d9
<pre>
[EvaluationTimeZoom] Convert animation-range properties to use unzoomed lengths
<a href="https://bugs.webkit.org/show_bug.cgi?id=319682">https://bugs.webkit.org/show_bug.cgi?id=319682</a>

Reviewed by Darin Adler.

Converts the animation-range CSS properties to use unzoomed lengths.

New test added showing animation-range working properly with inherited + zoomed values.

Tests: imported/w3c/web-platform-tests/css/css-viewport/zoom/animation-range.html
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/animation-range-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/animation-range.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/animation-range-ref.html: Added.
* Source/WebCore/Headers.cmake:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/animation/AnimationEffect.cpp:
* Source/WebCore/animation/AnimationEffect.h:
* Source/WebCore/animation/CSSAnimation.cpp:
* Source/WebCore/animation/CSSAnimation.h:
* Source/WebCore/animation/KeyframeEffect.cpp:
* Source/WebCore/animation/KeyframeEffect.h:
* Source/WebCore/animation/ResolvableTimelineRange.h: Added.
* Source/WebCore/animation/ScrollTimeline.cpp:
* Source/WebCore/animation/ScrollTimeline.h:
* Source/WebCore/animation/ViewTimeline.cpp:
* Source/WebCore/animation/ViewTimeline.h:
* Source/WebCore/animation/WebAnimation.cpp:
* Source/WebCore/animation/WebAnimation.h:
* Source/WebCore/style/Styleable.cpp:
* Source/WebCore/style/values/animations/StyleSingleAnimationRange.cpp:
* Source/WebCore/style/values/animations/StyleSingleAnimationRange.h:
* Source/WebCore/style/values/viewport/StyleZoomPrimitives.h:

Canonical link: <a href="https://commits.webkit.org/317640@main">https://commits.webkit.org/317640@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fb2ae8ec072d7b669cafa282b03aa340236f512b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175876 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49809 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43593 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185469 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/138071 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/177739 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51101 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49491 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136958 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/138071 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178832 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40420 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157736 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117437 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39062 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37444 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149481 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37228 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33939 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41509 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/41650 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187890 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49476 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/157287 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145951 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39268 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50156 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/33852 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145792 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40587 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122352 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/116214 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48663 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12208 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48065 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48297 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48122 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->