### PR TITLE
[JSC] Put slow path of emitWriteBarrier in m_slowPaths

### DIFF
--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
@@ -1058,37 +1058,35 @@ Value BBQJIT::exception(const ControlData& control)
 
 void BBQJIT::emitWriteBarrier(GPRReg cellGPR)
 {
-    GPRReg vmGPR;
-    GPRReg cellStateGPR;
-    {
-        ScratchScope<2, 0> scratches(*this);
-        vmGPR = scratches.gpr(0);
-        cellStateGPR = scratches.gpr(1);
-    }
-
-    // We must flush everything first. Jumping over flush (emitCCall) is wrong since paths need to get merged.
-    flushRegisters();
+    ScratchScope<2, 0> scratches(*this, Location::fromGPR(cellGPR));
+    GPRReg vmGPR = scratches.gpr(0);
+    GPRReg cellStateGPR = scratches.gpr(1);
+    ASSERT(vmGPR != cellGPR);
+    ASSERT(cellStateGPR != cellGPR);
 
     m_jit.loadPtr(Address(GPRInfo::wasmContextInstancePointer, JSWebAssemblyInstance::offsetOfVM()), vmGPR);
     m_jit.load8(Address(cellGPR, JSCell::cellStateOffset()), cellStateGPR);
-    auto noFenceCheck = m_jit.branch32(RelationalCondition::Above, cellStateGPR, Address(vmGPR, VM::offsetOfHeapBarrierThreshold()));
 
-    // Fence check path
-    auto toSlowPath = m_jit.branchTest8(ResultCondition::Zero, Address(vmGPR, VM::offsetOfHeapMutatorShouldBeFenced()));
+    JumpList slowPath;
+    slowPath.append(m_jit.branch32(RelationalCondition::BelowOrEqual, cellStateGPR, Address(vmGPR, VM::offsetOfHeapBarrierThreshold())));
 
-    // Fence path
-    m_jit.memoryFence();
-    Jump belowBlackThreshold = m_jit.branch8(RelationalCondition::Above, Address(cellGPR, JSCell::cellStateOffset()), TrustedImm32(blackThreshold));
+    // FIXME: We should only spill the register bindings when actually taking the call.
+    MacroAssembler::Label done = m_jit.label();
+    m_slowPaths.append({ origin(), WTF::move(slowPath), done, copyBindings(), [cellGPR](BBQJIT&, CCallHelpers& jit) {
+        jit.move(cellGPR, GPRInfo::argumentGPR0);
+        jit.loadPtr(Address(GPRInfo::wasmContextInstancePointer, JSWebAssemblyInstance::offsetOfVM()), wasmScratchGPR);
 
-    // Slow path
-    toSlowPath.link(&m_jit);
-    m_jit.prepareWasmCallOperation(GPRInfo::wasmContextInstancePointer);
-    m_jit.setupArguments<decltype(operationWasmWriteBarrierSlowPath)>(cellGPR, vmGPR);
-    m_jit.callOperation<OperationPtrTag>(operationWasmWriteBarrierSlowPath);
+        auto toSlowPath = jit.branchTest8(ResultCondition::Zero, Address(wasmScratchGPR, VM::offsetOfHeapMutatorShouldBeFenced()));
+        jit.memoryFence();
+        auto belowBlackThreshold = jit.branch8(RelationalCondition::Above, Address(GPRInfo::argumentGPR0, JSCell::cellStateOffset()), TrustedImm32(blackThreshold));
 
-    // Continuation
-    noFenceCheck.link(&m_jit);
-    belowBlackThreshold.link(&m_jit);
+        toSlowPath.link(&jit);
+        jit.prepareWasmCallOperation(GPRInfo::wasmContextInstancePointer);
+        jit.setupArguments<decltype(operationWasmWriteBarrierSlowPath)>(GPRInfo::argumentGPR0, wasmScratchGPR);
+        jit.callOperation<OperationPtrTag>(operationWasmWriteBarrierSlowPath);
+
+        belowBlackThreshold.link(&jit);
+    } });
 }
 
 void BBQJIT::emitMutatorFence()


### PR DESCRIPTION
#### 03d11dcd3986d5218cf235dd40f6088ca222ec4c
<pre>
[JSC] Put slow path of emitWriteBarrier in m_slowPaths
<a href="https://bugs.webkit.org/show_bug.cgi?id=319688">https://bugs.webkit.org/show_bug.cgi?id=319688</a>
<a href="https://rdar.apple.com/182533142">rdar://182533142</a>

Reviewed by Keith Miller.

Let&apos;s place the slow path of emitWriteBarrier in m_slowPaths to make the
main path tight and clean.

* Source/JavaScriptCore/wasm/WasmBBQJIT.cpp:
(JSC::Wasm::BBQJITImpl::BBQJIT::emitWriteBarrier):

Canonical link: <a href="https://commits.webkit.org/317448@main">https://commits.webkit.org/317448@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/23aee38226cb21aa5ce2d83590fbb2fdbd620839

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175389 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49321 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/43102 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184975 "Failed to checkout and rebase branch from PR 69665") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/137515 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50613 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49004 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/184975 "Failed to checkout and rebase branch from PR 69665") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/137515 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178346 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/39960 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/157300 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/184975 "Failed to checkout and rebase branch from PR 69665") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/38602 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/36987 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/5/builds/184975 "Failed to checkout and rebase branch from PR 69665") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/218/builds/5809 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/149024 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/36793 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33450 "Failed to checkout and rebase branch from PR 69665") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/36650 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/41008 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/41191 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187400 "Failed to checkout and rebase branch from PR 69665") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48988 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/156856 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/187400 "Failed to checkout and rebase branch from PR 69665") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49668 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/33415 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/187400 "Failed to checkout and rebase branch from PR 69665") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26653 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/40166 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/121861 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115558 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48174 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/11766 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47577 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47807 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47634 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->