### PR TITLE
Replace start and stop markers in ExecutionHandlerIdleStopTest.cpp

### DIFF
--- a/Source/JavaScriptCore/wasm/debugger/tests/ExecutionHandlerIdleStopTest.cpp
+++ b/Source/JavaScriptCore/wasm/debugger/tests/ExecutionHandlerIdleStopTest.cpp
@@ -215,7 +215,7 @@ static void testOrderingVMEnterInterruptContinue()
     unsigned successCount = 0;
 
     for (unsigned i = 0; i < STRESS_TEST_ITERATIONS; ++i) {
-        VLOG("[Test1][Iter ", i, "] start >>>>>>>>>>>>>>>>>>>>>>> ");
+        VLOG("[Test1][Iter ", i, "] start >>=>>=>>=>>=>>=>>=>>=>> ");
 
         // Signal VM to execute (becomes active)
         runVM = true;
@@ -235,7 +235,7 @@ static void testOrderingVMEnterInterruptContinue()
         CHECK(isRunning(), "Should be running after resume");
 
         successCount++;
-        VLOG("[Test1][Iter ", i, "] end <<<<<<<<<<<<<<<<<<<<<<<<< ");
+        VLOG("[Test1][Iter ", i, "] end <<=<<=<<=<<=<<=<<=<<=<<=< ");
     }
 
     TEST_LOG("PASS: ", successCount, "/", STRESS_TEST_ITERATIONS, " iterations succeeded");
@@ -277,7 +277,7 @@ static void testOrderingInterruptVMEnterContinue()
     unsigned successCount = 0;
 
     for (unsigned i = 0; i < STRESS_TEST_ITERATIONS; ++i) {
-        VLOG("[Test2][Iter ", i, "] start >>>>>>>>>>>>>>>>>>>>>>> ");
+        VLOG("[Test2][Iter ", i, "] start >>=>>=>>=>>=>>=>>=>>=>> ");
 
         // Interrupt FIRST (VM idle, not executing)
         // RunLoop dispatch will handle callback delivery
@@ -300,7 +300,7 @@ static void testOrderingInterruptVMEnterContinue()
         CHECK(isRunning(), "Should be running after resume");
 
         successCount++;
-        VLOG("[Test2][Iter ", i, "] end <<<<<<<<<<<<<<<<<<<<<<<<< ");
+        VLOG("[Test2][Iter ", i, "] end <<=<<=<<=<<=<<=<<=<<=<<=< ");
     }
 
     TEST_LOG("PASS: ", successCount, "/", STRESS_TEST_ITERATIONS, " iterations succeeded");
@@ -342,7 +342,7 @@ static void testOrderingInterruptContinueVMEnter()
     unsigned successCount = 0;
 
     for (unsigned i = 0; i < STRESS_TEST_ITERATIONS; ++i) {
-        VLOG("[Test3][Iter ", i, "] start >>>>>>>>>>>>>>>>>>>>>>> ");
+        VLOG("[Test3][Iter ", i, "] start >>=>>=>>=>>=>>=>>=>>=>> ");
 
         // Interrupt FIRST (VM should be idle)
         executionHandler->interrupt();
@@ -369,7 +369,7 @@ static void testOrderingInterruptContinueVMEnter()
         CHECK(info.numberOfVMs >= 1, "VM should be running");
 
         successCount++;
-        VLOG("[Test3][Iter ", i, "] end <<<<<<<<<<<<<<<<<<<<<<<<< ");
+        VLOG("[Test3][Iter ", i, "] end <<=<<=<<=<<=<<=<<=<<=<<=< ");
     }
 
     TEST_LOG("PASS: ", successCount, "/", STRESS_TEST_ITERATIONS, " iterations succeeded");
@@ -411,7 +411,7 @@ static void testIdleVMInterruptResumeLoops()
     unsigned successCount = 0;
 
     for (unsigned i = 0; i < STRESS_TEST_ITERATIONS; ++i) {
-        VLOG("[Test4][Iter ", i, "] start >>>>>>>>>>>>>>>>>>>>>>> ");
+        VLOG("[Test4][Iter ", i, "] start >>=>>=>>=>>=>>=>>=>>=>> ");
 
         // Interrupt while VM is idle - ONLY RunLoop dispatch can handle this
         executionHandler->interrupt();
@@ -431,7 +431,7 @@ static void testIdleVMInterruptResumeLoops()
         // This ensures we're testing pure RunLoop dispatch without any trap checking
 
         successCount++;
-        VLOG("[Test4][Iter ", i, "] end <<<<<<<<<<<<<<<<<<<<<<<<< ");
+        VLOG("[Test4][Iter ", i, "] end <<=<<=<<=<<=<<=<<=<<=<<=< ");
     }
 
     TEST_LOG("PASS: ", successCount, "/", STRESS_TEST_ITERATIONS, " iterations succeeded");
@@ -561,7 +561,7 @@ static void testIdleVMWithActiveVM()
     unsigned successCount = 0;
 
     for (unsigned i = 0; i < STRESS_TEST_ITERATIONS; ++i) {
-        VLOG("[Test5][Iter ", i, "] start >>>>>>>>>>>>>>>>>>>>>>> ");
+        VLOG("[Test5][Iter ", i, "] start >>=>>=>>=>>=>>=>>=>>=>> ");
 
         executionHandler->interrupt();
         CHECK(isStopped(), "Should be stopped after interrupt");
@@ -575,7 +575,7 @@ static void testIdleVMWithActiveVM()
         CHECK(isRunning(), "Should be running after resume");
 
         successCount++;
-        VLOG("[Test5][Iter ", i, "] end <<<<<<<<<<<<<<<<<<<<<<<<< ");
+        VLOG("[Test5][Iter ", i, "] end <<=<<=<<=<<=<<=<<=<<=<<=< ");
     }
 
     TEST_LOG("PASS: ", successCount, "/", STRESS_TEST_ITERATIONS, " iterations succeeded");


### PR DESCRIPTION
#### fcd9a87c22d4f285d0f4cafc8bf3096a65b7d26d
<pre>
Replace start and stop markers in ExecutionHandlerIdleStopTest.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=319690">https://bugs.webkit.org/show_bug.cgi?id=319690</a>
<a href="https://rdar.apple.com/182535047">rdar://182535047</a>

Reviewed by Yijia Huang.

When I search for git conflict markers &quot;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&quot; and &quot;&gt;&gt;&gt;&gt;&gt;&gt;&gt;&quot; these always show up.
Add some = characters to make the search for merge conflicts not show these test markers.

* Source/JavaScriptCore/wasm/debugger/tests/ExecutionHandlerIdleStopTest.cpp:
(ExecutionHandlerIdleStopTest::testOrderingVMEnterInterruptContinue):
(ExecutionHandlerIdleStopTest::testOrderingInterruptVMEnterContinue):
(ExecutionHandlerIdleStopTest::testOrderingInterruptContinueVMEnter):
(ExecutionHandlerIdleStopTest::testIdleVMInterruptResumeLoops):
(ExecutionHandlerIdleStopTest::testIdleVMWithActiveVM):

Canonical link: <a href="https://commits.webkit.org/317423@main">https://commits.webkit.org/317423@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cbd7d46a0807cc4c447c25f6b09d084fbb998cda

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175283 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49215 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42996 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184868 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/136431 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/40f2959c-da0c-44b6-a97e-89a28d7f902a) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50507 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48898 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136444 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/136431 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e465093a-a087-41cd-aab3-4a3278b728e1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178240 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39860 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/157208 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116922 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7e3e0c58-e069-4e64-ad01-ced558afb7d8) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/38501 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/36886 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/218/builds/5717 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/148924 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36701 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33344 "Built successfully") | | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/36544 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/40902 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/41090 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187293 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48882 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145408 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49562 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/33323 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145252 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26644 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40075 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/121755 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115441 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48068 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11674 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47471 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47701 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47528 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->