### PR TITLE
Reloading a local file after a WebContent process crash can fail with kCFURLErrorCannotOpenFile (-3001)

### DIFF
--- a/Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "NetworkResourceLoadParameters.h"
 
+#include "Logging.h"
 #include "NetworkProcessConnection.h"
 #include "WebProcess.h"
 #include <WebCore/SecurityOriginData.h>
@@ -36,19 +37,27 @@ using namespace WebCore;
 
 void NetworkResourceLoadParameters::createSandboxExtensionHandlesIfNecessary()
 {
-    if (request.url().protocolIsFile()) {
-        String path = request.url().fileSystemPath();
+    if (!request.url().protocolIsFile())
+        return;
+
+    String path = request.url().fileSystemPath();
+    // Log the file-load sandbox extension mint outcome at release level for diagnosis when it fails.
 #if HAVE(AUDIT_TOKEN)
-        if (auto networkProcessAuditToken = WebProcess::singleton().ensureNetworkProcessConnection().networkProcessAuditToken()) {
-            if (auto handle = SandboxExtension::createHandleForReadByAuditToken(path, *networkProcessAuditToken))
-                resourceSandboxExtension = WTF::move(*handle);
-        } else
-#endif
-        {
-            if (auto handle = SandboxExtension::createHandle(path, SandboxExtension::Type::ReadOnly))
-                resourceSandboxExtension = WTF::move(*handle);
-        }
+    if (auto networkProcessAuditToken = WebProcess::singleton().ensureNetworkProcessConnection().networkProcessAuditToken()) {
+        auto handle = SandboxExtension::createHandleForReadByAuditToken(path, *networkProcessAuditToken);
+        if (handle)
+            resourceSandboxExtension = WTF::move(*handle);
+        else
+            RELEASE_LOG_ERROR(Sandbox, "NetworkResourceLoadParameters::createSandboxExtensionHandlesIfNecessary: file load, createHandleForReadByAuditToken(networkProcess) failed for '%" PRIVATE_LOG_STRING "'", path.utf8().data());
+        return;
     }
+    RELEASE_LOG_ERROR(Sandbox, "NetworkResourceLoadParameters::createSandboxExtensionHandlesIfNecessary: file load, network process audit token unavailable; falling back to non-targeted read handle for '%" PRIVATE_LOG_STRING "'", path.utf8().data());
+#endif
+    auto handle = SandboxExtension::createHandle(path, SandboxExtension::Type::ReadOnly);
+    if (handle)
+        resourceSandboxExtension = WTF::move(*handle);
+    else
+        RELEASE_LOG_ERROR(Sandbox, "NetworkResourceLoadParameters::createSandboxExtensionHandlesIfNecessary: file load, createHandle(ReadOnly) failed for '%" PRIVATE_LOG_STRING "'", path.utf8().data());
 }
 
 RefPtr<SecurityOrigin> NetworkResourceLoadParameters::parentOrigin() const

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
@@ -414,6 +414,10 @@ bool NetworkResourceLoader::isLocalFileLoadAllowed(const URL& url)
 
 void NetworkResourceLoader::startNetworkLoad(ResourceRequest&& request, FirstLoad load)
 {
+    if (request.url().protocolIsFile() && !m_parameters.resourceSandboxExtension) {
+        // Record when a file-load sandbox extension failed to reach the Networking process.
+        LOADER_RELEASE_LOG_ERROR("startNetworkLoad: local file load, resourceSandboxExtension not provided");
+    }
 #if ENABLE(BLOCKING_OF_LOCAL_FILE_LOADS_WITHOUT_SANDBOX_EXTENSION)
         if (request.url().protocolIsFile() && !isLocalFileLoadAllowed(request.url())) {
             LOADER_RELEASE_LOG("startNetworkLoad: stop local file load because a sandbox extension is not provided");

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -1776,7 +1776,14 @@ RefPtr<API::Navigation> WebPageProxy::launchProcessForReload()
     auto publicSuffix = WebCore::PublicSuffixStore::singleton().publicSuffix(URL(currentItem->url()));
 
     // We allow stale content when reloading a WebProcess that's been killed or crashed.
-    send(Messages::WebPage::GoToBackForwardItem({ navigation->navigationID(), copyFrameStateForBackForwardNavigation(protect(currentItem->mainFrameItem())), FrameLoadType::IndexedBackForward, ShouldTreatAsContinuingLoad::No, std::nullopt, m_lastNavigationWasAppInitiated, ShouldRestoreFromBackForwardCache::Unspecified, std::nullopt, publicSuffix, { }, WebCore::ProcessSwapDisposition::None }));
+    GoToBackForwardItemParameters parameters { navigation->navigationID(), copyFrameStateForBackForwardNavigation(protect(currentItem->mainFrameItem())), FrameLoadType::IndexedBackForward, ShouldTreatAsContinuingLoad::No, std::nullopt, m_lastNavigationWasAppInitiated, ShouldRestoreFromBackForwardCache::Unspecified, std::nullopt, publicSuffix, { }, WebCore::ProcessSwapDisposition::None };
+
+    // The relaunched process is still launching; for a file:// item defer the load so the sandbox
+    // extension is re-issued after launch, as the other load paths do.
+    if (protect(m_legacyMainFrameProcess)->isLaunching() && URL { currentItem->url() }.protocolIsFile())
+        send(Messages::WebPage::GoToBackForwardItemWaitingForProcessLaunch(WTF::move(parameters), identifier()));
+    else
+        send(Messages::WebPage::GoToBackForwardItem(WTF::move(parameters)));
 
     Ref legacyMainFrameProcess = m_legacyMainFrameProcess;
     legacyMainFrameProcess->startResponsivenessTimer();

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKPage/cocoa/FetchLocalFile.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKPage/cocoa/FetchLocalFile.mm
@@ -25,6 +25,7 @@
 
 #import "config.h"
 
+#import "Helpers/cocoa/TestNavigationDelegate.h"
 #import "PlatformUtilities.h"
 #import "TestWKWebView.h"
 #import <WebKit/WKPreferencesPrivate.h>
@@ -249,3 +250,56 @@ TEST(WebKit, FetchCookieFile)
 
     FileSystem::deleteFile(fetchFilePath);
 }
+
+// Reloading a local file after a WebContent process crash must re-issue the sandbox extension to the
+// relaunched process, or the load fails with -3001.
+#if ENABLE(BLOCKING_OF_LOCAL_FILE_LOADS_WITHOUT_SANDBOX_EXTENSION) && !PLATFORM(IOS_SIMULATOR)
+TEST(WebKit, ReloadLocalFileAfterWebContentProcessTermination)
+{
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
+
+    RetainPtr navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
+    [webView setNavigationDelegate:navigationDelegate.get()];
+
+    __block bool navigationDone = false;
+    __block bool navigationSucceeded = false;
+    __block RetainPtr<NSError> provisionalNavigationError;
+    [navigationDelegate setDidFinishNavigation:^(WKWebView *, WKNavigation *) {
+        navigationSucceeded = true;
+        navigationDone = true;
+    }];
+    [navigationDelegate setDidFailProvisionalNavigation:^(WKWebView *, WKNavigation *, NSError *error) {
+        provisionalNavigationError = error;
+        navigationDone = true;
+    }];
+    [navigationDelegate setWebContentProcessDidTerminate:^(WKWebView *crashedWebView, _WKProcessTerminationReason) {
+        // Reload the local file after the crash. This exercises WebPageProxy::launchProcessForReload().
+        [crashedWebView reload];
+    }];
+
+    auto [filePath, fileHandle] = FileSystem::openTemporaryFile("ReloadLocalFileAfterCrash"_s, ".html"_s);
+    fileHandle.write("<body>local file loaded</body>"_s.span8());
+    fileHandle = { };
+    RetainPtr nsFileURL = URL::fileURLWithFileSystemPath(filePath).createNSURL();
+
+    // Initial load of the local file succeeds and grants read access.
+    [webView loadFileURL:nsFileURL.get() allowingReadAccessToURL:[nsFileURL URLByDeletingLastPathComponent]];
+    TestWebKitAPI::Util::run(&navigationDone);
+    EXPECT_TRUE(navigationSucceeded);
+
+    // Crash the WebContent process; the terminate handler reloads. The reload must succeed rather
+    // than fail with -3001 once the sandbox extension is re-issued to the relaunched process.
+    navigationDone = false;
+    navigationSucceeded = false;
+    provisionalNavigationError = nil;
+    [webView _killWebContentProcess];
+    TestWebKitAPI::Util::run(&navigationDone);
+
+    EXPECT_TRUE(navigationSucceeded);
+    if (!navigationSucceeded)
+        EXPECT_NE([provisionalNavigationError code], NSURLErrorCannotOpenFile);
+
+    FileSystem::deleteFile(filePath);
+}
+#endif // ENABLE(BLOCKING_OF_LOCAL_FILE_LOADS_WITHOUT_SANDBOX_EXTENSION) && !PLATFORM(IOS_SIMULATOR)


### PR DESCRIPTION
#### 22d9c3a6e99c50eeb774cc1583e9654788ca18a3
<pre>
Reloading a local file after a WebContent process crash can fail with kCFURLErrorCannotOpenFile (-3001)
<a href="https://bugs.webkit.org/show_bug.cgi?id=319695">https://bugs.webkit.org/show_bug.cgi?id=319695</a>
<a href="https://rdar.apple.com/164578060">rdar://164578060</a>

Reviewed by Per Arne Vollan.

Loading a top-level file:// resource requires a sandbox extension to be handed down to the Networking
process, which performs the file read. WebPageProxy::maybeInitializeSandboxExtensionHandle() cannot
issue that extension while the target WebContent process is still launching (it has no audit token
yet), so it returns std::nullopt and the load is expected to be deferred until the process finishes
launching, at which point the extension is re-issued (WebProcessProxy::shouldSendPendingMessage).

loadFile(), loadRequestWithNavigationShared(), and ProvisionalPageProxy all implement this deferral:
for a file:// URL on a launching process they send the *WaitingForProcessLaunch variant of the load
message. WebPageProxy::launchProcessForReload() -- the path taken to reload the current back/forward
item after the WebContent process is killed or crashes -- did not. It relaunched the process and
immediately sent WebPage::GoToBackForwardItem with an empty sandbox extension handle. For a file://
item the relaunched WebContent therefore had no file access, could not create a sandbox extension for
the Networking process, and the main-resource read failed with EPERM -- surfaced to the client as
NSURLErrorDomain -3001 (kCFURLErrorCannotOpenFile) and an error page.

This is intermittent in the field because it requires the file load to coincide with a WebContent
process launch/relaunch; it reproduces reliably by killing the WebContent process and reloading a
local file (e.g. a Mail attachment or a file in ~/Downloads or ~/Documents). Granting the browser
Full Disk Access masks it because TCC then bypasses the extension chain entirely.

Fix launchProcessForReload() to defer the reload for a file:// item on a still-launching process by
sending GoToBackForwardItemWaitingForProcessLaunch, matching the other load paths, so the sandbox
extension is re-issued once the process has finished launching.

Also add release-level error logging along the file-load sandbox-extension path -- when the
extension fails to be minted in the Networking process (createSandboxExtensionHandlesIfNecessary)
or fails to reach the loader (startNetworkLoad) -- so this class of failure can be diagnosed from
a field log without a debug build.

* Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.cpp:
(WebKit::NetworkResourceLoadParameters::createSandboxExtensionHandlesIfNecessary):
* Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp:
(WebKit::NetworkResourceLoader::startNetworkLoad):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::launchProcessForReload):
* Tools/TestWebKitAPI/Tests/WebKit/WKPage/cocoa/FetchLocalFile.mm:
(TEST(WebKit, ReloadLocalFileAfterWebContentProcessTermination)):

Canonical link: <a href="https://commits.webkit.org/318090@main">https://commits.webkit.org/318090@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/63bad30fda095e30ab7dd02320ab468679e0cbd0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177096 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51033 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44828 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186699 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140332 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178959 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52326 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50719 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137987 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140332 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180052 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41497 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158759 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118455 "Passed tests") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/176419 "Build is in progress. Recent messages:") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40153 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38519 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150563 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38258 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35167 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42808 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42737 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189125 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50700 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147070 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39563 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51383 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34882 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146861 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41604 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123597 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/117884 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49888 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13238 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49287 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49524 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49348 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->