### PR TITLE
[libpas] Add fragmentation and aliasing coverage to AllocationZeroingTest

### DIFF
--- a/Source/bmalloc/libpas/src/test/AllocationZeroingTests.cpp
+++ b/Source/bmalloc/libpas/src/test/AllocationZeroingTests.cpp
@@ -74,12 +74,28 @@ void dirtyBuffer(void* ptr, size_t size)
 }
 
 // Return the offset of the first non-zero byte, or size if every byte is zero.
+// Scans 8 bytes at a time (a word is non-zero iff some byte is), byte-scanning an
+// unaligned head and the sub-word tail.
 size_t firstNonZeroByte(const void* ptr, size_t size)
 {
     const uint8_t* bytes = static_cast<const uint8_t*>(ptr);
-    for (size_t offset = 0; offset < size; ++offset) {
-        if (bytes[offset])
-            return offset;
+    size_t i = 0;
+    while (i < size && (reinterpret_cast<uintptr_t>(bytes + i) & (sizeof(uint64_t) - 1))) {
+        if (bytes[i])
+            return i;
+        ++i;
+    }
+    for (; i + sizeof(uint64_t) <= size; i += sizeof(uint64_t)) {
+        if (*reinterpret_cast<const uint64_t*>(bytes + i)) {
+            for (size_t b = i; b < i + sizeof(uint64_t); ++b) {
+                if (bytes[b])
+                    return b;
+            }
+        }
+    }
+    for (; i < size; ++i) {
+        if (bytes[i])
+            return i;
     }
     return size;
 }
@@ -162,6 +178,19 @@ const char* faultOrderName(FaultOrder order)
     return "";
 }
 
+// In-place Fisher-Yates shuffle using the seeded test RNG: random order, but
+// reproducible across runs.
+template<typename T>
+void seededShuffle(std::vector<T>& values)
+{
+    for (size_t i = values.size(); i-- > 1;) {
+        size_t j = deterministicRandomNumber(static_cast<unsigned>(i + 1));
+        T swapTemp = values[i];
+        values[i] = values[j];
+        values[j] = swapTemp;
+    }
+}
+
 // The sequence of page indices to touch, in the requested first-fault order.
 std::vector<size_t> pageVisitationOrder(size_t numPages, FaultOrder order)
 {
@@ -177,14 +206,7 @@ std::vector<size_t> pageVisitationOrder(size_t numPages, FaultOrder order)
         std::reverse(pages.begin(), pages.end());
         break;
     case FaultOrder::Shuffled:
-        // Deterministic Fisher-Yates using the seeded test RNG, so the order is
-        // reproducible across runs.
-        for (size_t i = numPages; i-- > 1;) {
-            size_t j = deterministicRandomNumber(static_cast<unsigned>(i + 1));
-            size_t swapTemp = pages[i];
-            pages[i] = pages[j];
-            pages[j] = swapTemp;
-        }
+        seededShuffle(pages);
         break;
     }
     return pages;
@@ -513,6 +535,239 @@ void testLargeZeroingFaultOrder()
     runZeroingReuseFaultOrders({ vaZeroThreshold, multiMegabyteSize });
 }
 
+// A live buffer in the fragmentation pool, carrying the unique stamp written into
+// it. stamp() fills the whole buffer with a single non-zero byte keyed to stampId:
+// the high bit is always set (so it is never mistaken for zeroed memory) and the
+// low 7 bits are the id. Two live buffers whose ids differ mod 128 therefore hold
+// different bytes, so if one is handed the other's still-live memory the overwrite
+// differs from the expected byte at every overlapping position -- at any offset, so
+// a partial/shifted overlap is caught too. Stamp and verify run 8 bytes at a time.
+struct LiveBuffer {
+    void* ptr;
+    size_t size;
+    uint32_t stampId;
+
+    uint8_t stampByte() const
+    {
+        return static_cast<uint8_t>(0x80 | (stampId & 0x7f));
+    }
+
+    // The stamp byte broadcast to all 8 lanes, for word-at-a-time stamp/verify.
+    uint64_t stampWord() const
+    {
+        return static_cast<uint64_t>(stampByte()) * 0x0101010101010101ULL;
+    }
+
+    // Write the stamp across the whole buffer. The allocation base is at least
+    // 8-byte aligned, so full words are written aligned; the sub-word tail is
+    // written byte-wise.
+    void stamp()
+    {
+        uint8_t* bytes = static_cast<uint8_t*>(ptr);
+        uint64_t word = stampWord();
+        size_t i = 0;
+        for (; i + sizeof(uint64_t) <= size; i += sizeof(uint64_t))
+            *reinterpret_cast<uint64_t*>(bytes + i) = word;
+        for (; i < size; ++i)
+            bytes[i] = stampByte();
+    }
+
+    // Verify the buffer still holds its stamp, reporting the first mismatching
+    // offset on failure. A mismatch means another allocation was handed this
+    // still-live buffer's memory (overwriting the stamp, or re-zeroing it).
+    void verify(HeapVariant variant, const char* phase) const
+    {
+        const uint8_t* bytes = static_cast<const uint8_t*>(ptr);
+        uint64_t word = stampWord();
+        uint8_t expected = stampByte();
+        size_t i = 0;
+        for (; i + sizeof(uint64_t) <= size; i += sizeof(uint64_t)) {
+            if (*reinterpret_cast<const uint64_t*>(bytes + i) != word)
+                break;
+        }
+        for (; i < size; ++i) {
+            if (bytes[i] != expected) {
+                std::cout << "  stamp mismatch: variant=" << variantName(variant) << " phase=" << phase
+                          << " stampId=" << stampId << " size=" << size << " offset=" << i << " expected=0x"
+                          << std::hex << static_cast<unsigned>(expected) << " actual=0x"
+                          << static_cast<unsigned>(bytes[i]) << std::dec << "." << std::endl;
+                CHECK_EQUAL(bytes[i], expected);
+                return;
+            }
+        }
+    }
+};
+
+// One zeroing regime's size range. The pool takes one size per regime per round,
+// so every regime stays covered while the exact size within it is randomized --
+// varying fragmentation and catching any size-rounding bug. Ranges track the config
+// constants; the large-VA range is capped so the many-live pool, whose stamps are
+// verified byte-for-byte, stays bounded.
+struct FragmentationRegime {
+    size_t minSize;
+    size_t maxSize;
+};
+
+std::vector<FragmentationRegime> fragmentationRegimes()
+{
+    size_t smallSegMax = PAS_SMALL_PAGE_DEFAULT_SIZE / PAS_MIN_OBJECTS_PER_PAGE;
+    size_t mediumSegMax = PAS_MEDIUM_PAGE_DEFAULT_SIZE / PAS_MIN_OBJECTS_PER_PAGE;
+    size_t bitfitMax = PAS_MARGE_PAGE_DEFAULT_SIZE / PAS_MIN_OBJECTS_PER_PAGE;
+    return {
+        { bmallocMinAlign, smallSegMax }, // small-segregated (memset)
+        { smallSegMax + 1, mediumSegMax }, // medium-segregated (memset)
+        { mediumSegMax + 1, bitfitMax }, // medium/marge bitfit (memset)
+        { bitfitMax + 1, vaZeroThreshold - 1 }, // large heap, memset
+        { vaZeroThreshold, 2 * vaZeroThreshold }, // large heap, virtual-memory zeroing
+    };
+}
+
+// One pool allocation's randomized size and alignment entry point.
+struct AllocationSpec {
+    size_t size;
+    size_t alignment;
+    AlignmentApi api;
+};
+
+struct AlignmentChoice {
+    AlignmentApi api;
+    size_t alignment;
+};
+
+// A size in [minSize, maxSize], chosen with the seeded RNG.
+size_t randomSizeInRange(size_t minSize, size_t maxSize)
+{
+    if (maxSize <= minSize)
+        return minSize;
+    return minSize + deterministicRandomNumber(static_cast<unsigned>(maxSize - minSize + 1));
+}
+
+// Randomly pick an alignment entry point (seeded): the plain API at the natural
+// minimum, or the with-alignment API at one of the reuse sweep's quanta, so the
+// pool exercises both paths across a range of alignments.
+AlignmentChoice randomAlignmentChoice()
+{
+    static constexpr AlignmentChoice choices[] = {
+        { AlignmentApi::Plain, bmallocMinAlign },
+        { AlignmentApi::WithAlignment, 16 },
+        { AlignmentApi::WithAlignment, 512 },
+        { AlignmentApi::WithAlignment, 4096 },
+        { AlignmentApi::WithAlignment, 16384 },
+    };
+    unsigned count = static_cast<unsigned>(sizeof(choices) / sizeof(choices[0]));
+    return choices[deterministicRandomNumber(count)];
+}
+
+// A shuffled, stratified allocation plan: one spec per regime per round (so every
+// regime is covered poolRounds times) with a randomized size and alignment, then
+// shuffled so regimes and sizes interleave. A fresh call re-randomizes, so fill and
+// refill differ.
+std::vector<AllocationSpec> fragmentationPlan(size_t poolRounds)
+{
+    std::vector<FragmentationRegime> regimes = fragmentationRegimes();
+    std::vector<AllocationSpec> plan;
+    plan.reserve(regimes.size() * poolRounds);
+    for (size_t round = 0; round < poolRounds; ++round) {
+        for (const FragmentationRegime& regime : regimes) {
+            AlignmentChoice choice = randomAlignmentChoice();
+            plan.push_back({ randomSizeInRange(regime.minSize, regime.maxSize), choice.alignment, choice.api });
+        }
+    }
+    seededShuffle(plan);
+    return plan;
+}
+
+// Fragmentation + aliasing coverage over randomized, per-regime-stratified sizes
+// and alignments (phases detailed inline). Every allocation is zero-checked,
+// extending born-dirty coverage to fragmented and possibly-decommitted backing;
+// each live buffer's unique stamp is re-verified after every phase, catching a
+// double-handout -- an allocation returned an address still owned by a live buffer.
+// Single-threaded; the chaos tests cover the concurrent case.
+void fragmentationReuse(HeapVariant variant, Reuse reuse)
+{
+    constexpr size_t poolRounds = 12;
+
+    std::vector<LiveBuffer> live;
+    uint32_t nextStampId = 1;
+
+    auto allocateStamped = [&](const AllocationSpec& spec, const char* phase) {
+        void* ptr = allocateZeroed(variant, spec.api, spec.size, spec.alignment);
+        if (!ptr)
+            reportParameters(variant, spec.api, spec.size, spec.alignment, phase);
+        CHECK(ptr);
+        checkIsZeroed(ptr, spec.size, variant, spec.api, spec.alignment, phase);
+        if (spec.api == AlignmentApi::WithAlignment)
+            checkIsAligned(ptr, spec.size, variant, spec.api, spec.alignment, phase);
+        LiveBuffer buffer { ptr, spec.size, nextStampId };
+        buffer.stamp();
+        live.push_back(buffer);
+        ++nextStampId;
+    };
+
+    auto verifyAllStamps = [&](const char* phase) {
+        for (const LiveBuffer& buffer : live)
+            buffer.verify(variant, phase);
+    };
+
+    // Fill the pool from a shuffled, stratified plan.
+    for (const AllocationSpec& spec : fragmentationPlan(poolRounds))
+        allocateStamped(spec, "fill");
+    verifyAllStamps("after-fill");
+
+    // Free a seeded-random subset so live and freed regions interleave irregularly;
+    // WithScavenge decommits them before the refill. Survivors' stamps must stay
+    // untouched.
+    std::vector<LiveBuffer> survivors;
+    for (const LiveBuffer& buffer : live) {
+        if (deterministicRandomNumber(2))
+            survivors.push_back(buffer);
+        else
+            deallocateVariant(variant, buffer.ptr);
+    }
+    live = survivors;
+    if (reuse == Reuse::WithScavenge)
+        pas_scavenger_run_synchronously_now();
+    verifyAllStamps("after-scattered-free");
+
+    // Refill from a fresh plan so the irregularly fragmented free regions must be
+    // split and coalesced to serve the new sizes, not just reused in the order freed.
+    for (const AllocationSpec& spec : fragmentationPlan(poolRounds))
+        allocateStamped(spec, "refill");
+    verifyAllStamps("after-refill");
+
+    // Teardown: a final stamp check as each buffer is freed.
+    for (const LiveBuffer& buffer : live) {
+        buffer.verify(variant, "teardown");
+        deallocateVariant(variant, buffer.ptr);
+    }
+}
+
+// Run across both heap variants, scavenger suspended so freed regions decommit
+// only at the forced scavenge (WithScavenge), not at an unpredictable background
+// point.
+void runFragmentationReuse(Reuse reuse)
+{
+    pas_scavenger_suspend();
+
+    static constexpr HeapVariant variants[] = { HeapVariant::Untagged, HeapVariant::Tagged };
+    for (HeapVariant variant : variants)
+        fragmentationReuse(variant, reuse);
+}
+
+// Fragmentation + aliasing with immediate free-list reuse (no scavenge between
+// free and refill).
+void testFragmentationReuse()
+{
+    runFragmentationReuse(Reuse::WithoutScavenge);
+}
+
+// Same, but forcing a synchronous scavenge after the scattered frees so the
+// refills recommit and re-zero decommitted, fragmented backing.
+void testFragmentationReuseWithScavenge()
+{
+    runFragmentationReuse(Reuse::WithScavenge);
+}
+
 } // anonymous namespace
 
 #endif // PAS_ENABLE_BMALLOC
@@ -530,5 +785,7 @@ void addAllocationZeroingTests()
     ADD_TEST(testZeroingReuseWithScavengeLargeVirtualMemorySizes());
     ADD_TEST(testSmallZeroingPageBatching());
     ADD_TEST(testLargeZeroingFaultOrder());
+    ADD_TEST(testFragmentationReuse());
+    ADD_TEST(testFragmentationReuseWithScavenge());
 #endif // PAS_ENABLE_BMALLOC
 }


### PR DESCRIPTION
#### ac2f235d63c0dead89627c283358301e2ac5939b
<pre>
[libpas] Add fragmentation and aliasing coverage to AllocationZeroingTest
<a href="https://bugs.webkit.org/show_bug.cgi?id=319697">https://bugs.webkit.org/show_bug.cgi?id=319697</a>
<a href="https://rdar.apple.com/182541235">rdar://182541235</a>

Reviewed by Yusuke Suzuki.

The existing zeroing tests reuse one buffer at a time, leaving two gaps:
born-dirty memory that only surfaces once the large heap has split and
coalesced fragmented free regions, and double-handout -- the allocator
returning an address still owned by a live allocation.

Add a single-threaded case that keeps many mixed-size, mixed-alignment
buffers live under a fragmented heap, checking both: every allocation is
verified zero, and a per-buffer stamp catches any overlap with a live
buffer. The multi-threaded case will be covered by a later chaos test.

* Source/bmalloc/libpas/src/test/AllocationZeroingTests.cpp:
(addAllocationZeroingTests):

Canonical link: <a href="https://commits.webkit.org/317418@main">https://commits.webkit.org/317418@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/94324809792e6c22aaba924e15a358d2c770a911

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175304 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49236 "Built successfully") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43017 "Failed to checkout and rebase branch from PR 69671") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184890 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/137420 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50528 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48919 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/136465 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/137420 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178261 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/39881 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/168/builds/43017 "Failed to checkout and rebase branch from PR 69671") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116943 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/38522 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/36906 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| [❌ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/168/builds/43017 "Failed to checkout and rebase branch from PR 69671") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/148945 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/168/builds/43017 "Failed to checkout and rebase branch from PR 69671") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33365 "Built successfully") | | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/36565 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/41110 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187314 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48903 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/168/builds/43017 "Failed to checkout and rebase branch from PR 69671") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/145432 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/49583 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/168/builds/43017 "Failed to checkout and rebase branch from PR 69671") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/145274 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26643 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/49583 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115462 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48089 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/168/builds/43017 "Failed to checkout and rebase branch from PR 69671") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/47492 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47722 "Build is in progress. Recent messages:") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/47549 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->