### PR TITLE
[WKCI] filter-test-logs can cause that buildbot ends killing an in-progress step when the test runner produces output slowly

### DIFF
--- a/Tools/Scripts/filter-test-logs
+++ b/Tools/Scripts/filter-test-logs
@@ -23,6 +23,7 @@
 
 import os
 import argparse
+import datetime
 import sys
 import re
 import time
@@ -31,20 +32,21 @@ import time
 # by buildbot because "command timed out: XXX seconds without output running YYY"
 class KeepAliveStdoutProgress:
 
-    def __init__(self, interval_seconds=300, check_every_n_lines=100):
+    def __init__(self, interval_seconds=60):
         self.line_count = 0
         self.last_progress_time = time.time()
         self.interval_seconds = interval_seconds
-        self.check_every_n_lines = check_every_n_lines
+        self.last_count = 0
 
     def maybe_update_progress(self):
         self.line_count += 1
-        # Only check time every N lines to avoid expensive system calls
-        if self.line_count % self.check_every_n_lines == 0:
-            current_time = time.time()
-            if current_time - self.last_progress_time >= self.interval_seconds:
-                print(f'filter-test-logs progress: {self.line_count} lines processed', flush=True)
-                self.last_progress_time = current_time
+        current_time = time.time()
+        if current_time - self.last_progress_time >= self.interval_seconds:
+            delta = self.line_count - self.last_count
+            timestamp = datetime.datetime.now().astimezone().strftime("%Y-%m-%d|%H:%M:%S|%Z")
+            print(f"[{timestamp}] filter-test-logs progress: {self.line_count} lines processed ({delta} since last update)", flush=True)
+            self.last_progress_time = current_time
+            self.last_count = self.line_count
 
 
 def parser():


### PR DESCRIPTION
#### c35e39f7208608e335e85b3c121b938c6549307c
<pre>
[WKCI] filter-test-logs can cause that buildbot ends killing an in-progress step when the test runner produces output slowly
<a href="https://bugs.webkit.org/show_bug.cgi?id=319686">https://bugs.webkit.org/show_bug.cgi?id=319686</a>

Reviewed by Nikolas Zimmermann.

When a build step runs through filter-test-logs, buildbot only sees the
few lines the filter prints, since the full output goes to a log file.
To avoid buildbot killing the step for lack of output, filter-test-logs
prints a progress line from time to time. But the check to wether it
should print the summary por not ran only once every 100 lines.
With a command that prints slowly (for example one line every 15 seconds),
the check ran once every 1500 seconds which is above the standard 1200
buildbot timeout, so buildbot killed the step with &quot;command timed
out: XXX seconds without output&quot;.

This patch changes it to run the check if it should print the summary for
every line received. Calling time.time() is way cheaper than I thought at
303319@main
I have benchmarked this an the cost is well under 100 nanoseconds per call,
so doing it once per line adds only a few milliseconds to a standard layout
test run with ~150k lines.

The format to print the summary is also improved, now includes a timestamp
and how many lines arrived since the last update.
The frequency to print the summary is changed to once per minute instead of
once each 5 minutes, that should not be an issue for buildbot to handle, and
makes more interactive and helpful to look at the progress of a filtered
on-going build.

* Tools/Scripts/filter-test-logs:
(KeepAliveStdoutProgress):
(KeepAliveStdoutProgress.__init__):
(KeepAliveStdoutProgress.maybe_update_progress):

Canonical link: <a href="https://commits.webkit.org/317461@main">https://commits.webkit.org/317461@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/95eb1234d486ef9109ff26c226eac4e0c610275e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175307 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49239 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43020 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184893 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/137424 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/177171 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50531 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48922 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136468 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/137424 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178264 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39883 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157223 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116946 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38524 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36909 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/5732 "Build is in progress. Recent messages:") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148947 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36716 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33368 "Built successfully") | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41113 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187317 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48906 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145435 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49586 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33338 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145277 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26660 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40090 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115465 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48092 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11689 "") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47495 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47725 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47552 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->