### PR TITLE
[WKCI] filter-test-logs crashes on output that is not valid UTF-8, and loses the tail of the log when the step is killed

### DIFF
--- a/Tools/Scripts/filter-test-logs
+++ b/Tools/Scripts/filter-test-logs
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 # Copyright (C) 2024 Apple Inc. All rights reserved.
+# Copyright (C) 2026 Igalia S.L. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -53,7 +54,7 @@ def parser():
     parser = argparse.ArgumentParser(description='filter test output')
     parser.add_argument(
         'filter_type',
-        choices=['jsc', 'layout', 'scan-build', 'webdriver', 'test262', 'minibrowser', 'swift', 'api'],
+        choices=sorted(FILTERS.keys()),
         help='Choose which test logs to filter'
     )
     parser.add_argument(
@@ -65,159 +66,67 @@ def parser():
     return parser.parse_args()
 
 
-def filter_jsc_tests(log_file_name):
+FILTERS = {
+    'jsc': {
+        'start_printing': lambda line: line.startswith('** The following JSC') or line.startswith('Results'),
+    },
+    'layout': {
+        'start_printing': lambda line: line.startswith('=> Results') or 'Exiting early' in line or 'leaks found' in line,
+    },
+    'scan-build': {
+        # A success or failure is always preceeded by **
+        'start_printing': lambda line: line.startswith('**'),
+        'always_print': lambda line: line.startswith('=====') or ': error:' in line,
+    },
+    'webdriver': {
+        'start_printing': lambda line: 'tests ran as expected' in line,
+    },
+    'test262': {
+        'start_printing': lambda line: 'TESTS SUMMARY---' in line,
+        'always_print': lambda line: line.startswith('! NEW FAIL'),
+    },
+    'minibrowser': {
+        'start_printing': lambda line: 'Bundle passed tests on all this' in line,
+    },
+    'swift': {
+        'start_printing': lambda line: line.startswith('ERROR:') or line.startswith('FAILURE:') or '--- Build Script Analyzer ---' in line,
+        'always_print': lambda line: 'error:' in line.lower(),
+    },
+    'api': {
+        'start_printing': lambda line: re.match(r'.*Ran \d+ tests of \d+', line),
+    },
+}
+
+
+def filter_logs(filter_type, log_file_name):
+    config = FILTERS[filter_type]
+    start_printing = config['start_printing']
+    always_print = config.get('always_print', lambda line: False)
     log_file = os.path.abspath(f'{log_file_name}')
     keep_alive_stdout = KeepAliveStdoutProgress()
-    with open(log_file, 'w') as f:
+
+    with open(log_file, 'w', buffering=1, errors='backslashreplace') as f:
         print_all_lines = False
         for line in sys.stdin:
             f.write(line)
             if print_all_lines:
                 print(line, end='')
-            elif line.startswith('** The following JSC') or line.startswith('Results'):
+            elif start_printing(line):
                 print_all_lines = True
                 print(line, end='')
-            else:
-                keep_alive_stdout.maybe_update_progress()
-
-
-def filter_layout_tests(log_file_name):
-    log_file = os.path.abspath(f'{log_file_name}')
-    keep_alive_stdout = KeepAliveStdoutProgress()
-    with open(log_file, 'w') as f:
-        print_all_lines = False
-        for line in sys.stdin:
-            match = re.search(r'[\uD800-\uDFFF]', line)
-            if not match:
-                f.write(line)
-            if print_all_lines:
-                print(line, end='')
-            elif line.startswith('=> Results') or 'Exiting early' in line or 'leaks found' in line:
-                print_all_lines = True
-                print(line, end='')
-            else:
-                keep_alive_stdout.maybe_update_progress()
-
-
-def filter_scan_build(log_file_name):
-    log_file = os.path.abspath(f'{log_file_name}')
-    keep_alive_stdout = KeepAliveStdoutProgress()
-    with open(log_file, 'w') as f:
-        print_all_lines = False
-        for line in sys.stdin:
-            f.write(line)
-            if line.startswith('=====') or print_all_lines:
-                print(line, end='')
-            # A success or failure is always preceeded by **
-            elif line.startswith('**'):
-                print_all_lines = True
-                print(line, end='')
-            elif ': error:' in line:
-                print(line, end='')
-            else:
-                keep_alive_stdout.maybe_update_progress()
-
-
-def filter_webdriver_tests(log_file_name):
-    log_file = os.path.abspath(f'{log_file_name}')
-    keep_alive_stdout = KeepAliveStdoutProgress()
-    with open(log_file, 'w') as f:
-        print_all_lines = False
-        for line in sys.stdin:
-            f.write(line)
-            if print_all_lines:
-                print(line, end='')
-            elif 'tests ran as expected' in line:
-                print_all_lines = True
-                print(line, end='')
-            else:
-                keep_alive_stdout.maybe_update_progress()
-
-
-def filter_test262(log_file_name):
-    log_file = os.path.abspath(f'{log_file_name}')
-    keep_alive_stdout = KeepAliveStdoutProgress()
-    with open(log_file, 'w') as f:
-        print_all_lines = False
-        for line in sys.stdin:
-            f.write(line)
-            if print_all_lines or line.startswith('! NEW FAIL'):
-                print(line, end='')
-            elif 'TESTS SUMMARY---' in line:
-                print_all_lines = True
-                print(line, end='')
-            else:
-                keep_alive_stdout.maybe_update_progress()
-
-
-def filter_minibrowser_tests(log_file_name):
-    log_file = os.path.abspath(f'{log_file_name}')
-    keep_alive_stdout = KeepAliveStdoutProgress()
-    with open(log_file, 'w') as f:
-        print_all_lines = False
-        for line in sys.stdin:
-            f.write(line)
-            if print_all_lines:
-                print(line, end='')
-            elif 'Bundle passed tests on all this' in line:
-                print_all_lines = True
-                print(line, end='')
-            else:
-                keep_alive_stdout.maybe_update_progress()
-
-
-def filter_swift(log_file_name):
-    log_file = os.path.abspath(f'{log_file_name}')
-    keep_alive_stdout = KeepAliveStdoutProgress()
-    with open(log_file, 'w') as f:
-        print_all_lines = False
-        for line in sys.stdin:
-            f.write(line)
-            if print_all_lines:
-                print(line, end='')
-            elif line.startswith('ERROR:') or line.startswith('FAILURE:') or '--- Build Script Analyzer ---' in line:
-                print_all_lines = True
-                print(line, end='')
-            elif 'error:' in line.lower():
-                print(line, end='')
-            else:
-                keep_alive_stdout.maybe_update_progress()
-
-
-def filter_api_tests(log_file_name):
-    log_file = os.path.abspath(f'{log_file_name}')
-    keep_alive_stdout = KeepAliveStdoutProgress()
-    with open(log_file, 'w') as f:
-        print_all_lines = False
-        for line in sys.stdin:
-            f.write(line)
-            if print_all_lines:
-                print(line, end='')
-            elif re.match(r'.*Ran \d+ tests of \d+', line):
-                print_all_lines = True
+            elif always_print(line):
                 print(line, end='')
             else:
                 keep_alive_stdout.maybe_update_progress()
 
 
 def main():
+    # stdin 'surrogateescape': never crash reading malformed bytes, keep them as placeholders (0xff -> \udcff).
+    # stdout and the log file use 'backslashreplace': print them as visible escapes instead of crashing.
+    sys.stdin.reconfigure(errors='surrogateescape')
+    sys.stdout.reconfigure(errors='backslashreplace')
     args = parser()
-    if args.filter_type == 'jsc':
-        filter_jsc_tests(args.output)
-    elif args.filter_type == 'layout':
-        filter_layout_tests(args.output)
-    elif args.filter_type == 'scan-build':
-        filter_scan_build(args.output)
-    elif args.filter_type == 'webdriver':
-        filter_webdriver_tests(args.output)
-    elif args.filter_type == 'test262':
-        filter_test262(args.output)
-    elif args.filter_type == 'minibrowser':
-        filter_minibrowser_tests(args.output)
-    elif args.filter_type == 'swift':
-        filter_swift(args.output)
-    elif args.filter_type == 'api':
-        filter_api_tests(args.output)
+    filter_logs(args.filter_type, args.output)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
#### f98b3f2b9488e5917929305e79d87c820311792e
<pre>
[WKCI] filter-test-logs crashes on output that is not valid UTF-8, and loses the tail of the log when the step is killed
<a href="https://bugs.webkit.org/show_bug.cgi?id=319698">https://bugs.webkit.org/show_bug.cgi?id=319698</a>

Reviewed by Alexey Proskuryakov.

This patch introduces the following three improvements:
 - Never crash on text that is not valid UTF-8. Test output can contain
garbage bytes from a crashing process, or lone unicode surrogates from WPT
tests that use intentionally malformed text. The problematic characters
are kept and written as visible escapes (for example \udcff) instead
of crashing or being dropped. This replaces the workaround from
300617@main, which only covered the layout filter and silently dropped
the problematic lines from the log.
 - Open the log file line-buffered. If buildbot kills the step, the log
uploaded to S3 is now complete up to the last line received, instead
of losing whatever was sitting in the write buffer. The cost was
measured on Linux and Mac and it is negligible (well below 1 second
for a 30-minute layout test run producing 150k lines).
 - Remove the duplicated code in the filter functions. The eight
functions were almost identical, differing only in which lines switch
the filter to print-everything mode and which lines are always
printed. They are replaced by a single function plus a table (FILTERS)
describing each filter with those two conditions. Adding a new filter
is now a couple of lines in the table.

* Tools/Scripts/filter-test-logs:
(parser):
(filter_logs):
(main):
(filter_jsc_tests): Deleted.
(filter_layout_tests): Deleted.
(filter_scan_build): Deleted.
(filter_webdriver_tests): Deleted.
(filter_test262): Deleted.
(filter_minibrowser_tests): Deleted.
(filter_swift): Deleted.
(filter_api_tests): Deleted.

Canonical link: <a href="https://commits.webkit.org/317900@main">https://commits.webkit.org/317900@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/25e2fc24ce1103dc6ead48f9a045d1a70431101e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175311 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49243 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43024 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184897 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/137428 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/177175 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50535 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48926 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136474 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/137428 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178268 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39899 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157226 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116952 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38540 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36910 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148963 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36719 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33372 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41114 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187321 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48910 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145437 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49590 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33341 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145279 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26815 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40093 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115469 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48096 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11692 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47499 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47729 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47556 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->