### PR TITLE
[libpas] Add compact-heap coverage to AllocationZeroingTests

### DIFF
--- a/Source/bmalloc/libpas/src/test/AllocationZeroingTests.cpp
+++ b/Source/bmalloc/libpas/src/test/AllocationZeroingTests.cpp
@@ -100,11 +100,11 @@ size_t firstNonZeroByte(const void* ptr, size_t size)
     return size;
 }
 
-// The two axes varied below, in addition to size and alignment. Untagged vs
-// tagged selects the two families of zeroed entry points. Plain vs
-// with-alignment selects entry points that take different internal paths even
-// when the requested alignment is the natural minimum.
-enum class HeapVariant { Untagged, Tagged };
+// The two axes varied below, besides size and alignment. HeapVariant selects the
+// zeroed entry point; Compact routes to the separate compact primitive
+// heap and is untagged-only, as the tagged API takes no allocation mode. Plain vs
+// with-alignment takes a different internal path even at the minimum alignment.
+enum class HeapVariant { Untagged, Compact, Tagged };
 enum class AlignmentApi { Plain, WithAlignment };
 
 // Whether reuse goes straight through (WithoutScavenge) or forces a synchronous
@@ -115,7 +115,16 @@ enum class Reuse { WithoutScavenge, WithScavenge };
 
 const char* variantName(HeapVariant variant)
 {
-    return variant == HeapVariant::Tagged ? "tagged" : "untagged";
+    switch (variant) {
+    case HeapVariant::Untagged:
+        return "untagged";
+    case HeapVariant::Compact:
+        return "compact";
+    case HeapVariant::Tagged:
+        return "tagged";
+    }
+    CHECK(!"Invalid variant");
+    return "";
 }
 
 const char* alignmentApiName(AlignmentApi api)
@@ -130,6 +139,10 @@ void* allocateZeroed(HeapVariant variant, AlignmentApi api, size_t size, size_t 
         if (api == AlignmentApi::WithAlignment)
             return bmalloc_try_allocate_zeroed_with_alignment(size, alignment, pas_non_compact_allocation_mode);
         return bmalloc_try_allocate_zeroed(size, pas_non_compact_allocation_mode);
+    case HeapVariant::Compact:
+        if (api == AlignmentApi::WithAlignment)
+            return bmalloc_try_allocate_zeroed_with_alignment(size, alignment, pas_always_compact_allocation_mode);
+        return bmalloc_try_allocate_zeroed(size, pas_always_compact_allocation_mode);
     case HeapVariant::Tagged:
         if (api == AlignmentApi::WithAlignment)
             return tagged_bmalloc_try_allocate_zeroed_with_alignment(size, alignment);
@@ -312,7 +325,7 @@ void runZeroingReuse(const std::vector<size_t>& sizes, Reuse reuse = Reuse::With
 {
     pas_scavenger_suspend();
 
-    static constexpr HeapVariant variants[] = { HeapVariant::Untagged, HeapVariant::Tagged };
+    static constexpr HeapVariant variants[] = { HeapVariant::Untagged, HeapVariant::Compact, HeapVariant::Tagged };
     static constexpr size_t alignments[] = { 16, 512, 4096, 16384 };
 
     for (HeapVariant variant : variants) {
@@ -514,7 +527,7 @@ void testSmallZeroingPageBatching()
         bmallocMinAlign,
         PAS_SMALL_PAGE_DEFAULT_SIZE / PAS_MIN_OBJECTS_PER_PAGE,
     };
-    static constexpr HeapVariant variants[] = { HeapVariant::Untagged, HeapVariant::Tagged };
+    static constexpr HeapVariant variants[] = { HeapVariant::Untagged, HeapVariant::Compact, HeapVariant::Tagged };
     for (HeapVariant variant : variants) {
         for (size_t size : sizes)
             smallPageBatching(variant, size);
@@ -749,7 +762,7 @@ void runFragmentationReuse(Reuse reuse)
 {
     pas_scavenger_suspend();
 
-    static constexpr HeapVariant variants[] = { HeapVariant::Untagged, HeapVariant::Tagged };
+    static constexpr HeapVariant variants[] = { HeapVariant::Untagged, HeapVariant::Compact, HeapVariant::Tagged };
     for (HeapVariant variant : variants)
         fragmentationReuse(variant, reuse);
 }


### PR DESCRIPTION
#### b93c112f86d1abbe2cef8abed63c8124b10419c5
<pre>
[libpas] Add compact-heap coverage to AllocationZeroingTests
<a href="https://bugs.webkit.org/show_bug.cgi?id=319699">https://bugs.webkit.org/show_bug.cgi?id=319699</a>
<a href="https://rdar.apple.com/182542964">rdar://182542964</a>

Reviewed by Yusuke Suzuki.

The tests so far only allocate through the non-compact primitive heap (the
pas_non_compact_allocation_mode path fastMalloc uses). fastCompactZeroedMalloc&apos;s
always_compact mode routes to a separate compact primitive heap -- its own
regions and reuse/decommit bookkeeping -- which nothing here exercised.

Add Compact as a third HeapVariant so the reuse, page-batching, and
fragmentation sweeps also run against the compact heap. Compact is
untagged-only: the tagged API takes no allocation mode.

* Source/bmalloc/libpas/src/test/AllocationZeroingTests.cpp:

Canonical link: <a href="https://commits.webkit.org/317424@main">https://commits.webkit.org/317424@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f568ad665af9a7def512aeef51e650b08dc9292c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175317 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49249 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43030 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184903 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/137434 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e58b162a-b914-4375-8b5a-2535dcd649b0) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50541 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48932 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/136480 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/137434 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e3684d6f-773c-45dc-918a-11dc085a310f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178274 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/39890 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/157232 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116958 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f69dafc8-9ff5-4afb-b0f5-38363ab63fc5) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/38531 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/36917 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/218/builds/5741 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/148954 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36725 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33378 "Built successfully") | | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/36578 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/41121 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187327 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48916 "Built successfully") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/145444 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49596 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/33347 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145286 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26645 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40098 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115475 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48102 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/11698 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/47505 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47735 "Built successfully") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/47562 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->