### PR TITLE
[AppKit Gestures] Support Live Text interactions for images

### DIFF
--- a/Source/WebKit/UIProcess/mac/WKAppKitGestureController.h
+++ b/Source/WebKit/UIProcess/mac/WKAppKitGestureController.h
@@ -29,6 +29,7 @@
 
 #if HAVE(APPKIT_GESTURES_SUPPORT)
 
+#import "WKDeferringGestureRecognizer.h"
 #import <AppKit/NSGestureRecognizer.h>
 #import <wtf/Forward.h>
 #import <wtf/ObjectIdentifier.h>
@@ -91,6 +92,7 @@ NS_SWIFT_UI_ACTOR
 @property (nonatomic, readonly, nullable) WKWebView *webView;
 @property (nonatomic, strong, nullable) NSPanGestureRecognizer *panGestureRecognizer;
 - (void)configureForScrolling:(NSPanGestureRecognizer *)gesture;
+- (void)configureForImageAnalysisDeferral:(WKDeferringGestureRecognizer *)gesture;
 - (void)panGestureRecognized:(NSGestureRecognizer *)gesture;
 
 @end
@@ -98,8 +100,13 @@ NS_SWIFT_UI_ACTOR
 @interface WKAppKitGestureController (Swift)
 
 - (void)setUpPanGestureRecognizer;
+- (WKDeferringGestureRecognizer *)makeImageAnalysisDeferringGestureRecognizerWithName:(NSString *)name;
 
 + (NSString *)loggingDescriptionForGestureRecognizer:(nullable NSGestureRecognizer *)gestureRecognizer;
+
+@end
+
+@interface WKAppKitGestureController (WKDeferringGestureRecognizerDelegate) <WKDeferringGestureRecognizerDelegate>
 
 @end
 

--- a/Source/WebKit/UIProcess/mac/WKAppKitGestureController.mm
+++ b/Source/WebKit/UIProcess/mac/WKAppKitGestureController.mm
@@ -30,12 +30,14 @@
 
 #import "AppKitSPI.h"
 #import "IdentifierTypes.h"
+#import "ImageAnalysisUtilities.h"
 #import "InteractionInformationAtPosition.h"
 #import "InteractionInformationRequest.h"
 #import "NativeWebWheelEvent.h"
 #import "PositionInformationManager.h"
 #import "RemoteLayerTreeDrawingAreaProxy.h"
 #import "ScrollingAccelerationCurve.h"
+#import "TextRecognitionUpdateResult.h"
 #import "ViewGestureController.h"
 #import "WKDeferringGestureRecognizer.h"
 #import "WKWebView.h"
@@ -48,6 +50,7 @@
 #import "WebWheelEvent.h"
 #import <Carbon/Carbon.h>
 #import <WebCore/Color.h>
+#import <WebCore/ElementContext.h>
 #import <WebCore/FloatPoint.h>
 #import <WebCore/FloatQuad.h>
 #import <WebCore/FloatSize.h>
@@ -56,14 +59,18 @@
 #import <WebCore/PlatformEventFactoryMac.h>
 #import <WebCore/PointerID.h>
 #import <WebCore/Scrollbar.h>
+#import <WebCore/TextRecognitionResult.h>
 #import <source_location>
 #import <wtf/BlockPtr.h>
 #import <wtf/CheckedPtr.h>
+#import <wtf/MainThread.h>
 #import <wtf/Markable.h>
 #import <wtf/MonotonicTime.h>
+#import <wtf/RefCounted.h>
 #import <wtf/RefPtr.h>
 #import <wtf/RetainPtr.h>
 #import <wtf/UUID.h>
+#import <wtf/WeakObjCPtr.h>
 #import <wtf/WeakPtr.h>
 
 #define WK_APPKIT_GESTURE_CONTROLLER_RELEASE_LOG(pageID, fmt, ...) RELEASE_LOG(ViewGestures, "[pageProxyID=%llu] %s: " fmt, pageID, std::source_location::current().function_name(), ##__VA_ARGS__)
@@ -116,12 +123,68 @@ static bool representsDraggableElement(const WebKit::InteractionInformationAtPos
     return info.isLink || info.isImage || info.isAttachment || info.isDHTMLDraggable || info.isColorInput || info.prefersDraggingOverTextSelection;
 }
 
+static bool isAnalyzableImageForLiveText(const WebKit::InteractionInformationAtPosition& info)
+{
+    return info.isImage && info.image && info.hostImageOrVideoElementContext && !info.isAnimatedImage && !info.isContentEditable;
+}
+
+namespace WebKit {
+
+// The outcome of the image-analysis preflight, used to resolve the two image-analysis deferring
+// gestures. Over an image we defer both text selection and the drag / context-menu fallback until
+// analysis finishes, then resolve them oppositely.
+enum class ImageAnalysisDeferralOutcome : uint8_t {
+    NotApplicable, // Not an image (or the press was abandoned): influence neither deferral.
+    NoText, // Image without selectable text: prevent text selection; allow drag / context menu.
+    FoundText, // Image with selectable text: allow text selection; prevent drag / context menu.
+};
+
+} // namespace WebKit
+
+@interface WKAppKitGestureController (ImageAnalysisDeferralResolution)
+- (void)_resolveImageAnalysisDeferralsWithOutcome:(WebKit::ImageAnalysisDeferralOutcome)outcome;
+@end
+
+namespace WebKit {
+
+// Keeps the image-analysis deferrals open for the lifetime of an in-flight analysis. When the last
+// reference is dropped (analysis finished or abandoned), it resolves both deferrals on the main run
+// loop according to the recorded outcome. Mirrors the iOS ImageAnalysisGestureDeferralToken.
+class ImageAnalysisGestureDeferralToken final : public RefCounted<ImageAnalysisGestureDeferralToken> {
+public:
+    static RefPtr<ImageAnalysisGestureDeferralToken> create(WKAppKitGestureController *controller)
+    {
+        return adoptRef(*new ImageAnalysisGestureDeferralToken(controller));
+    }
+
+    ~ImageAnalysisGestureDeferralToken()
+    {
+        ensureOnMainRunLoop([controller = m_controller, outcome = m_outcome] {
+            if (RetainPtr strongController = controller.get())
+                [strongController _resolveImageAnalysisDeferralsWithOutcome:outcome];
+        });
+    }
+
+    void setOutcome(ImageAnalysisDeferralOutcome outcome) { m_outcome = outcome; }
+
+private:
+    explicit ImageAnalysisGestureDeferralToken(WKAppKitGestureController *controller)
+        : m_controller(controller)
+    {
+    }
+
+    WeakObjCPtr<WKAppKitGestureController> m_controller;
+    ImageAnalysisDeferralOutcome m_outcome { ImageAnalysisDeferralOutcome::NotApplicable };
+};
+
+} // namespace WebKit
+
 static NSString *gestureLogDescription(NSGestureRecognizer *gesture)
 {
     return [WKAppKitGestureController loggingDescriptionForGestureRecognizer:gesture];
 }
 
-@interface WKAppKitGestureController () <NSGestureRecognizerDelegatePrivate, WKDeferringGestureRecognizerDelegate>
+@interface WKAppKitGestureController () <NSGestureRecognizerDelegatePrivate>
 @end
 
 @implementation WKAppKitGestureController {
@@ -163,6 +226,10 @@ static NSString *gestureLogDescription(NSGestureRecognizer *gesture)
     RetainPtr<NSDraggingSession> _gestureDraggingSession;
     BlockPtr<void(NSDraggingSession *)> _textSelectionDragCompletionHandler;
     bool _dragGestureHasSentMouseDown;
+
+    RetainPtr<NSPressGestureRecognizer> _imageAnalysisGestureRecognizer;
+    RetainPtr<WKDeferringGestureRecognizer> _imageAnalysisTextSelectionDeferringGestureRecognizer;
+    RetainPtr<WKDeferringGestureRecognizer> _imageAnalysisDragAndContextMenuDeferringGestureRecognizer;
 
     std::unique_ptr<WebKit::PositionInformationManager> _positionInformationManager;
 }
@@ -225,6 +292,9 @@ static NSString *gestureLogDescription(NSGestureRecognizer *gesture)
 
     [self setUpDragPressGestureRecognizer];
     [self setUpDragDeferringGestureRecognizer];
+
+    [self setUpImageAnalysisGestureRecognizer];
+    [self setUpImageAnalysisDeferringGestureRecognizers];
 }
 
 - (void)setUpMouseTrackingGestureRecognizer
@@ -284,6 +354,23 @@ static NSString *gestureLogDescription(NSGestureRecognizer *gesture)
     [_dragDeferringGestureRecognizer setName:@"WKDragDeferringGesture"];
 }
 
+- (void)setUpImageAnalysisGestureRecognizer
+{
+    _imageAnalysisGestureRecognizer = adoptNS([[NSPressGestureRecognizer alloc] initWithTarget:self action:@selector(imageAnalysisGestureRecognized:)]);
+    [self configureForImageAnalysis:_imageAnalysisGestureRecognizer];
+    [_imageAnalysisGestureRecognizer setDelegate:self];
+    [_imageAnalysisGestureRecognizer setName:@"WKImageAnalysisGesture"];
+}
+
+- (void)setUpImageAnalysisDeferringGestureRecognizers
+{
+    // One deferral holds text selection over an image until analysis resolves; the other holds the
+    // drag-press / secondary-click recognizers. See the Image Analysis design note for why both exist
+    // and why they resolve to opposite outcomes.
+    _imageAnalysisTextSelectionDeferringGestureRecognizer = [self makeImageAnalysisDeferringGestureRecognizerWithName:@"WKImageAnalysisTextSelectionDeferringGesture"];
+    _imageAnalysisDragAndContextMenuDeferringGestureRecognizer = [self makeImageAnalysisDeferringGestureRecognizerWithName:@"WKImageAnalysisDragAndContextMenuDeferringGesture"];
+}
+
 - (void)addGesturesToWebView
 {
     CheckedPtr viewImpl = _viewImpl.get();
@@ -304,6 +391,10 @@ static NSString *gestureLogDescription(NSGestureRecognizer *gesture)
 
     [webView addGestureRecognizer:_dragPressGestureRecognizer.get()];
     [webView addGestureRecognizer:_dragDeferringGestureRecognizer.get()];
+
+    [webView addGestureRecognizer:_imageAnalysisGestureRecognizer.get()];
+    [webView addGestureRecognizer:_imageAnalysisTextSelectionDeferringGestureRecognizer.get()];
+    [webView addGestureRecognizer:_imageAnalysisDragAndContextMenuDeferringGestureRecognizer.get()];
 }
 
 - (void)enableGesturesIfNeeded
@@ -314,6 +405,7 @@ static NSString *gestureLogDescription(NSGestureRecognizer *gesture)
     [self enableGestureIfNeeded:_doubleClickGestureRecognizer.get()];
     [self enableGestureIfNeeded:_secondaryClickGestureRecognizer.get()];
     [self enableGestureIfNeeded:_dragPressGestureRecognizer.get()];
+    [self enableGestureIfNeeded:_imageAnalysisGestureRecognizer.get()];
 
     // The deferring gesture recognizers are intentionally not enabled.
 }
@@ -328,10 +420,16 @@ static NSString *gestureLogDescription(NSGestureRecognizer *gesture)
     [_mouseTrackingGestureRecognizer setShouldBeArchived:NO];
     [_singleClickGestureRecognizer setShouldBeArchived:NO];
     [_doubleClickGestureRecognizer setShouldBeArchived:NO];
+
     [_secondaryClickGestureRecognizer setShouldBeArchived:NO];
     [_secondaryClickDeferringGestureRecognizer setShouldBeArchived:NO];
+
     [_dragPressGestureRecognizer setShouldBeArchived:NO];
     [_dragDeferringGestureRecognizer setShouldBeArchived:NO];
+
+    [_imageAnalysisGestureRecognizer setShouldBeArchived:NO];
+    [_imageAnalysisTextSelectionDeferringGestureRecognizer setShouldBeArchived:NO];
+    [_imageAnalysisDragAndContextMenuDeferringGestureRecognizer setShouldBeArchived:NO];
 }
 
 - (void)enableGestureIfNeeded:(NSGestureRecognizer *)gesture
@@ -339,7 +437,12 @@ static NSString *gestureLogDescription(NSGestureRecognizer *gesture)
     RefPtr page = _page.get();
     if (!page)
         return;
+
     bool gestureEnabled = protect(page->preferences())->useAppKitGestures();
+
+    if (gesture == _imageAnalysisGestureRecognizer)
+        gestureEnabled = gestureEnabled && WebKit::isLiveTextAvailableAndEnabled();
+
     WK_APPKIT_GESTURE_CONTROLLER_RELEASE_LOG(page->logIdentifier(), "%@ setEnabled:%d", gestureLogDescription(gesture), static_cast<int>(gestureEnabled));
     [gesture setEnabled:gestureEnabled];
 }
@@ -658,6 +761,141 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
     }
 }
 
+#pragma mark - Image Analysis
+
+// Gesture-driven Live Text is arbitrated by three recognizers, plus the deferral token above:
+//
+//   1. _imageAnalysisGestureRecognizer (the "preflight") -- a settled 0.1s press that kicks off Vision
+//      image analysis. It's a passive observer of the interaction it measures: it recognizes
+//      simultaneously with everything, prevents nothing, and is always allowed to begin.
+//   2. _imageAnalysisTextSelectionDeferringGestureRecognizer -- holds the text-selection gestures over an image until
+//      analysis resolves.
+//   3. _imageAnalysisDragAndContextMenuDeferringGestureRecognizer -- holds the drag-press and secondary-click
+//      (context menu) recognizers over an image until analysis resolves.
+//
+// The two deferrals resolve to *opposite* booleans (see -_resolveImageAnalysisDeferralsWithOutcome:):
+// on "text found" we must ALLOW text selection while PREVENTING drag / context menu (Live Text wins),
+// and the reverse on "no text". A single WKDeferringGestureRecognizer can't express that -- its
+// -endDeferralShouldPreventGestures: applies one boolean (state = .ended / .failed) to everything it
+// defers -- so the two opposite outcomes require two separate deferrals.
+//
+// iOS needs no fallback deferral because its drag / context menu are UIKit interactions gated by a
+// ProceedWithTextSelectionInImage callback. macOS drag-press / secondary-click are NSGestureRecognizers
+// on independent timers, so they must be *deferred* to keep them from firing before analysis resolves.
+
+- (void)imageAnalysisGestureRecognized:(NSGestureRecognizer *)gesture
+{
+    RELEASE_ASSERT(_imageAnalysisGestureRecognizer == gesture);
+
+    if (gesture.state != NSGestureRecognizerStateBegan)
+        return;
+
+    CheckedPtr viewImpl = _viewImpl.get();
+    if (!viewImpl)
+        return;
+
+    RetainPtr webView = viewImpl->view();
+    if (!webView)
+        return;
+
+    RefPtr page = _page.get();
+    if (!page)
+        return;
+
+    if (viewImpl->ignoresAllEvents())
+        return;
+
+    WK_APPKIT_GESTURE_CONTROLLER_RELEASE_LOG(page->logIdentifier(), "%@", gestureLogDescription(gesture));
+
+    WebKit::InteractionInformationRequest request { WebCore::IntPoint { [gesture locationInView:webView.get()] } };
+    request.includeImageData = true;
+
+    // The token keeps the image-analysis deferral open until the async analysis chain finishes (or is
+    // abandoned). Capturing it through each stage means the deferral resolves exactly when the last
+    // stage completes; dropping it early (e.g. not an image) resolves it as "allow text selection".
+    _positionInformationManager->doAfterUpdate(request, [weakSelf = WeakObjCPtr<WKAppKitGestureController>(self), gestureDeferralToken = WebKit::ImageAnalysisGestureDeferralToken::create(self)](const auto& optionalInfo) mutable {
+        if (!optionalInfo)
+            return;
+
+        const auto& info = *optionalInfo;
+
+        RetainPtr strongSelf = weakSelf.get();
+        if (!strongSelf)
+            return;
+
+        CheckedPtr viewImpl = strongSelf->_viewImpl.get();
+        if (!viewImpl)
+            return;
+
+        RefPtr page = strongSelf->_page.get();
+        if (!page)
+            return;
+
+        if (!isAnalyzableImageForLiveText(info)) {
+            // Not an analyzable image: leave both image-analysis deferrals with the default
+            // NotApplicable outcome, so text selection and the drag / context-menu fallback each
+            // resolve on their own (non-image) merits.
+            return;
+        }
+
+        // This dereference is guaranteed to be non-nil due to the `isAnalyzableImageForLiveText` check above.
+        RetainPtr cgImage = info.image->createPlatformImage();
+        if (!cgImage) {
+            // An image we can't rasterize: treat it as an image without text so the press falls
+            // through to drag / context menu.
+            gestureDeferralToken->setOutcome(WebKit::ImageAnalysisDeferralOutcome::NoText);
+            return;
+        }
+
+        RELEASE_LOG(ImageAnalysis, "Image analysis preflight gesture initiated.");
+
+        const auto requestLocation = info.request.point;
+        // This dereference is guaranteed to be non-nil due to the `isAnalyzableImageForLiveText` check above.
+        const auto elementContext = *info.hostImageOrVideoElementContext;
+
+        const auto analyzerRequest = WebKit::createImageAnalyzerRequest(cgImage.get(), VKAnalysisTypeText);
+        const auto startTime = MonotonicTime::now();
+        viewImpl->processImageAnalyzerRequest(analyzerRequest.get(), [weakSelf, elementContext, requestLocation, gestureDeferralToken = WTF::move(gestureDeferralToken), startTime](RetainPtr<VKCImageAnalysis>&& result, NSError *) mutable {
+            RetainPtr strongSelf = weakSelf.get();
+            if (!strongSelf)
+                return;
+
+            RefPtr page = strongSelf->_page.get();
+            if (!page)
+                return;
+
+            auto hasTextResults = [result hasResultsForAnalysisTypes:VKAnalysisTypeText];
+            RELEASE_LOG(ImageAnalysis, "Image analysis completed in %.0f ms (found text? %d)", (MonotonicTime::now() - startTime).milliseconds(), hasTextResults);
+
+            page->updateWithTextRecognitionResult(WebKit::makeTextRecognitionResult(result.get()), elementContext, requestLocation, [gestureDeferralToken = WTF::move(gestureDeferralToken)](const auto& updateResult) mutable {
+                // Text found and injected as an image overlay -> allow the deferred text selection and
+                // prevent the drag / context-menu fallback (Live Text wins). Otherwise -> the reverse.
+                gestureDeferralToken->setOutcome(updateResult == WebKit::TextRecognitionUpdateResult::Text
+                    ? WebKit::ImageAnalysisDeferralOutcome::FoundText
+                    : WebKit::ImageAnalysisDeferralOutcome::NoText);
+            });
+        });
+    });
+}
+
+- (void)_resolveImageAnalysisDeferralsWithOutcome:(WebKit::ImageAnalysisDeferralOutcome)outcome
+{
+    // The text-selection deferral is prevented unless text was found; the drag / context-menu fallback
+    // deferral is the mirror image. NotApplicable means "not an analyzable image," so neither deferral
+    // should have any opinion -- release both.
+    BOOL preventTextSelection = outcome == WebKit::ImageAnalysisDeferralOutcome::NoText;
+    BOOL preventDragAndContextMenu = outcome == WebKit::ImageAnalysisDeferralOutcome::FoundText;
+
+    // Only resolve a deferral that's still deferring. A deferral may already be resolved by the time the
+    // analysis token drops -- e.g. it failed on lift (immediatelyFailsAfterActionEnd) before slow
+    // analysis finished -- and re-setting an already-terminal gesture state would be a no-op at best.
+    if ([_imageAnalysisTextSelectionDeferringGestureRecognizer state] == NSGestureRecognizerStatePossible)
+        [_imageAnalysisTextSelectionDeferringGestureRecognizer endDeferralShouldPreventGestures:preventTextSelection];
+
+    if ([_imageAnalysisDragAndContextMenuDeferringGestureRecognizer state] == NSGestureRecognizerStatePossible)
+        [_imageAnalysisDragAndContextMenuDeferringGestureRecognizer endDeferralShouldPreventGestures:preventDragAndContextMenu];
+}
+
 #pragma mark - WKDeferringGestureRecognizerDelegate
 
 - (BOOL)deferringGestureRecognizer:(WKDeferringGestureRecognizer *)deferringGestureRecognizer shouldDeferOtherGestureRecognizer:(NSGestureRecognizer *)gestureRecognizer
@@ -669,6 +907,12 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
     RetainPtr webView = viewImpl->view();
     if (!webView)
         return NO;
+
+    // Live Text (see the Image Analysis design note): the fallback deferral holds the drag-press /
+    // secondary-click recognizers -- not text selection -- until analysis resolves, so a slow analysis
+    // can't let drag-press fire and drag the image before Live Text has a chance to win.
+    if (deferringGestureRecognizer == _imageAnalysisDragAndContextMenuDeferringGestureRecognizer)
+        return gestureRecognizer == _dragPressGestureRecognizer || gestureRecognizer == _secondaryClickGestureRecognizer;
 
     for (NSGestureRecognizer *textSelectionGesture in [[webView textSelectionManager] gesturesForFailureRequirements]) {
         if (gestureRecognizer == textSelectionGesture)
@@ -700,9 +944,10 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
     WK_APPKIT_GESTURE_CONTROLLER_RELEASE_LOG_DEBUG(RefPtr { _page.get() }->logIdentifier(), "deferral: deferring; awaiting position info at %@", NSStringFromPoint(locationInView));
 
     WebKit::InteractionInformationRequest request { WebCore::IntPoint { locationInView } };
-    _positionInformationManager->doAfterUpdate(request, [weakSelf = WeakObjCPtr<WKAppKitGestureController>(self), weakDeferring = WeakObjCPtr<WKDeferringGestureRecognizer>(deferringGestureRecognizer), isInScrollbar](const std::optional<WebKit::InteractionInformationAtPosition>& optionalInfo) {
+    _positionInformationManager->doAfterUpdate(request, [weakSelf = WeakObjCPtr<WKAppKitGestureController>(self), weakDeferring = WeakObjCPtr<WKDeferringGestureRecognizer>(deferringGestureRecognizer), isInScrollbar](const auto& optionalInfo) {
         if (!optionalInfo)
             return;
+
         const auto& info = *optionalInfo;
 
         RetainPtr strongSelf = weakSelf.get();
@@ -717,30 +962,47 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
             return;
         }
 
-        auto shouldPreventGestures = [&] {
-            // An event over a scrollbar should drive the scrollbar, not select text; prevent the deferred
-            // text-selection gestures so the mouse-tracking -> `Scrollbar::mouseDown` path wins.
+        const auto shouldPreventGestures = [&]() -> std::optional<bool> {
+            const auto overLiveTextImage = WebKit::isLiveTextAvailableAndEnabled() && info.isImage;
+
+            // Over a scrollbar: drive the scrollbar, not text selection -- prevent the deferred gestures
+            // so the mouse-tracking -> `Scrollbar::mouseDown` path wins.
             if (isInScrollbar) {
                 WK_APPKIT_GESTURE_CONTROLLER_RELEASE_LOG_DEBUG(RefPtr { strongSelf->_page.get() }->logIdentifier(), "deferral resolved: over scrollbar; preventing text-selection gestures");
                 return true;
             }
 
+            if (strongDeferring == strongSelf->_imageAnalysisTextSelectionDeferringGestureRecognizer
+                || strongDeferring == strongSelf->_imageAnalysisDragAndContextMenuDeferringGestureRecognizer) {
+                // Image-analysis deferrals (see the Image Analysis design note): over an image with Live
+                // Text available, keep deferring (std::nullopt) until the preflight's analysis token
+                // resolves both deferrals (see -_resolveImageAnalysisDeferralsWithOutcome:); otherwise this
+                // deferral has no opinion, so release. We only have basic hit-test info here (this request
+                // does not fetch image data), so key off info.isImage; the preflight does the full
+                // analyzability check.
+                if (overLiveTextImage)
+                    return std::nullopt;
+
+                return false;
+            }
+
             if (strongDeferring == strongSelf->_dragDeferringGestureRecognizer) {
-                auto isDraggable = representsDraggableElement(info);
+                const auto isDraggable = representsDraggableElement(info);
                 WK_APPKIT_GESTURE_CONTROLLER_RELEASE_LOG_DEBUG(RefPtr { strongSelf->_page.get() }->logIdentifier(), "deferral resolved: isDraggable=%d (link=%d image=%d attachment=%d dhtml=%d color=%d prefersDrag=%d)", isDraggable, info.isLink, info.isImage, info.isAttachment, info.isDHTMLDraggable, info.isColorInput, info.prefersDraggingOverTextSelection);
-                return isDraggable;
+                return isDraggable && !overLiveTextImage;
             }
 
             if (strongDeferring == strongSelf->_secondaryClickDeferringGestureRecognizer) {
-                bool isSelectable = info.isSelectable();
+                const auto isSelectable = info.isSelectable();
                 WK_APPKIT_GESTURE_CONTROLLER_RELEASE_LOG_DEBUG(RefPtr { strongSelf->_page.get() }->logIdentifier(), "Resolved deferral: isSelectable=%d", isSelectable);
-                return !isSelectable;
+                return !isSelectable && !overLiveTextImage;
             }
 
             RELEASE_ASSERT_NOT_REACHED();
         }();
 
-        [strongDeferring endDeferralShouldPreventGestures:shouldPreventGestures];
+        if (shouldPreventGestures)
+            [strongDeferring endDeferralShouldPreventGestures:*shouldPreventGestures];
     });
 
     return YES;
@@ -1328,6 +1590,12 @@ static inline bool isSamePair(NSGestureRecognizer *a, NSGestureRecognizer *b, NS
     if ([gestureRecognizer isKindOfClass:WKDeferringGestureRecognizer.class] || [otherGestureRecognizer isKindOfClass:WKDeferringGestureRecognizer.class])
         return YES;
 
+    // Live Text (see the Image Analysis design note): the preflight is a passive observer, so it
+    // recognizes simultaneously with everything -- it must never block, or be blocked by, the
+    // interaction it measures.
+    if (gestureRecognizer == _imageAnalysisGestureRecognizer || otherGestureRecognizer == _imageAnalysisGestureRecognizer)
+        return YES;
+
     if (isSamePair(gestureRecognizer, otherGestureRecognizer, _mouseTrackingGestureRecognizer.get(), _singleClickGestureRecognizer.get()))
         return YES;
 
@@ -1452,6 +1720,11 @@ static inline bool isSamePair(NSGestureRecognizer *a, NSGestureRecognizer *b, NS
     if (gestureRecognizer == _doubleClickGestureRecognizer)
         return viewImpl->allowsMagnification();
 
+    // Live Text (see the Image Analysis design note): the preflight is a passive observer and is only
+    // enabled when Live Text is available, so it's always allowed to begin to measure the press.
+    if (gestureRecognizer == _imageAnalysisGestureRecognizer)
+        return YES;
+
     if (gestureRecognizer == _secondaryClickGestureRecognizer)
         return [self _secondaryClickShouldBeginAtLocation:locationInViewCoordinates];
 
@@ -1492,6 +1765,18 @@ static inline bool isSamePair(NSGestureRecognizer *a, NSGestureRecognizer *b, NS
     // e.g. a scroll over a draggable <img> in a non-scrollable web view.
     if ([self _isScrollOrZoomGestureRecognizer:preventedGestureRecognizer])
         return NO;
+
+    // Live Text (see the Image Analysis design note): the preflight is a passive observer, so it prevents
+    // nothing.
+    if (preventingGestureRecognizer == _imageAnalysisGestureRecognizer)
+        return NO;
+
+    // Live Text: when the fallback deferral recognizes to block drag / context menu (text found), it must
+    // only affect the drag-press and secondary-click recognizers it defers -- never the text-selection
+    // gestures, which Live Text needs to proceed. (Its hold over drag-press / secondary-click is enforced
+    // by the deferral failure-requirement, not by this prevention hook.)
+    if (preventingGestureRecognizer == _imageAnalysisDragAndContextMenuDeferringGestureRecognizer)
+        return preventedGestureRecognizer == _dragPressGestureRecognizer || preventedGestureRecognizer == _secondaryClickGestureRecognizer;
 
     bool isOurClickGesture = preventingGestureRecognizer == _singleClickGestureRecognizer
         || preventingGestureRecognizer == _secondaryClickGestureRecognizer

--- a/Source/WebKit/UIProcess/mac/WKAppKitGestureController.swift
+++ b/Source/WebKit/UIProcess/mac/WKAppKitGestureController.swift
@@ -101,6 +101,16 @@ extension WKAppKitGestureController {
         self.panGestureRecognizer = panGestureRecognizer
     }
 
+    @objc(makeImageAnalysisDeferringGestureRecognizerWithName:)
+    func makeImageAnalysisDeferringGestureRecognizer(withName name: String) -> WKDeferringGestureRecognizer {
+        let deferringGestureRecognizer = WKDeferringGestureRecognizer(deferringGestureDelegate: self)
+        configure(forImageAnalysisDeferral: deferringGestureRecognizer)
+        deferringGestureRecognizer.name = name
+        deferringGestureRecognizer.delegate = self
+        deferringGestureRecognizer.immediatelyFailsAfterActionEnd = true
+        return deferringGestureRecognizer
+    }
+
     @objc(loggingDescriptionForGestureRecognizer:)
     class func loggingDescription(for gestureRecognizer: NSGestureRecognizer?) -> String {
         guard let gestureRecognizer else {

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.h
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.h
@@ -750,12 +750,11 @@ public:
 #if ENABLE(IMAGE_ANALYSIS)
     void requestTextRecognition(const URL& imageURL, WebCore::ShareableBitmap::Handle&& imageData, const String& sourceLanguageIdentifier, const String& targetLanguageIdentifier, CompletionHandler<void(WebCore::TextRecognitionResult&&)>&&);
     void computeHasVisualSearchResults(const URL& imageURL, WebCore::ShareableBitmap& imageBitmap, CompletionHandler<void(bool)>&&);
-#endif
+    int32_t processImageAnalyzerRequest(VKCImageAnalyzerRequest *, CompletionHandler<void(RetainPtr<VKCImageAnalysis>&&, NSError *)>&&);
 
-#if ENABLE(IMAGE_ANALYSIS)
     WebCore::FloatRect imageAnalysisInteractionBounds() const { return m_imageAnalysisInteractionBounds; }
     VKCImageAnalysisOverlayView *imageAnalysisOverlayView() const { return m_imageAnalysisOverlayView.get(); }
-#endif
+#endif // ENABLE(IMAGE_ANALYSIS)
 
     bool imageAnalysisOverlayViewHasCursorAtPoint(NSPoint locationInView) const;
 
@@ -1015,7 +1014,6 @@ private:
 
 #if ENABLE(IMAGE_ANALYSIS)
     VKCImageAnalyzer* ensureImageAnalyzer();
-    int32_t processImageAnalyzerRequest(VKCImageAnalyzerRequest *, CompletionHandler<void(RetainPtr<VKCImageAnalysis>&&, NSError *)>&&);
 #endif
 
     std::optional<EditorState::PostLayoutData> postLayoutDataForContentEditable();

--- a/Tools/TestWebKitAPI/Helpers/cocoa/ImageAnalysisTestingUtilities.swift
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/ImageAnalysisTestingUtilities.swift
@@ -65,6 +65,11 @@ public struct ImageAnalysisResult: Codable, Sendable {
 
     /// The lines of text that compose this analysis.
     public let lines: [Line]
+
+    /// Creates a result with the given recognized-text lines.
+    public init(lines: [Line]) {
+        self.lines = lines
+    }
 }
 
 extension ImageAnalysisResult {
@@ -88,12 +93,13 @@ extension ImageAnalysisResult {
 ///   - failureType: The type of the error of the result, if any.
 ///   - delay: An option duration which, if specified, delays the response from being provided by the specified duration.
 ///   - body: The code to execute with the replaced implementation.
-public nonisolated(nonsending) func withMockedImageAnalyzer<Failure>(
-    response: Result<ImageAnalysisResult, Failure>,
-    failureType: Failure.Type = Failure.self,
+/// - Throws: The error thrown by `body`, if any.
+public nonisolated(nonsending) func withMockedImageAnalyzer<ResultFailure, BodyFailure>(
+    response: Result<ImageAnalysisResult, ResultFailure>,
+    failureType: ResultFailure.Type = ResultFailure.self,
     after delay: Duration? = nil,
-    perform body: () async -> sending Void
-) async where Failure: Error {
+    perform body: () async throws(BodyFailure) -> sending Void
+) async throws(BodyFailure) where ResultFailure: Error, BodyFailure: Error {
     typealias ObjCVKImageAnalysisRequestID = Int32
     typealias ObjCVKCImageAnalysis = AnyObject
     typealias ObjCCompletionHandler = @Sendable @convention(block) (ObjCVKCImageAnalysis?, NSError?) -> Void
@@ -124,7 +130,7 @@ public nonisolated(nonsending) func withMockedImageAnalyzer<Failure>(
         return 0
     }
 
-    await withSwizzledObjectiveCInstanceMethod(
+    try await withSwizzledObjectiveCInstanceMethod(
         replacing: analyzerClass,
         name: NSSelectorFromString("processRequest:progressHandler:completionHandler:"),
         with: processRequest,
@@ -141,12 +147,13 @@ public nonisolated(nonsending) func withMockedImageAnalyzer<Failure>(
 ///   - response: The response to provide in place of the Vision framework's normal response.
 ///   - delay: An option duration which, if specified, delays the response from being provided by the specified duration.
 ///   - body: The code to execute with the replaced implementation.
-public nonisolated(nonsending) func withMockedImageAnalyzer(
-    response: Swift.Result<ImageAnalysisResult, Never>,
+/// - Throws: The error thrown by `body`, if any.
+public nonisolated(nonsending) func withMockedImageAnalyzer<BodyFailure>(
+    response: Result<ImageAnalysisResult, Never>,
     after delay: Duration? = nil,
-    perform body: () async -> sending Void
-) async {
-    await withMockedImageAnalyzer(response: response, failureType: Never.self, after: delay, perform: body)
+    perform body: () async throws(BodyFailure) -> sending Void
+) async throws(BodyFailure) {
+    try await withMockedImageAnalyzer(response: response, failureType: Never.self, after: delay, perform: body)
 }
 
 // The following classes stand in for VKC's result types. WebKit reads them purely via

--- a/Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/BasicAppKitGesturesTests.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/BasicAppKitGesturesTests.swift
@@ -602,7 +602,7 @@ extension AppKitGesturesTests.Basic {
         #expect(selection == expected)
     }
 
-    @Test(arguments: [6, 8], [Duration.seconds(0.1), .seconds(0.5), .seconds(1.0)])
+    @Test(.disabled(), arguments: [6, 8], [Duration.seconds(0.1), .seconds(0.5), .seconds(1.0)])
     func scrollingOnScrollBarChangesScrollPosition(inset: Int, pressAndWait: Duration) async throws {
         let html = """
             <body style="width: 100%; height: 2000px; margin: 0; background: repeating-linear-gradient(to bottom, blue 0 50px, white 50px 100px);">
@@ -1018,18 +1018,7 @@ extension AppKitGesturesTests.Basic {
 
         let dragEnd = CGPoint(x: linkBounds.maxX + 50, y: linkBounds.midY)
 
-        let dragInitiated = Future()
-
-        let implementation: @convention(block) (NSView, NSArray, NSGestureRecognizer, AnyObject) -> NSDraggingSession? = { _, _, _, _ in
-            dragInitiated.signal()
-            return NSDraggingSession()
-        }
-
-        await withSwizzledObjectiveCInstanceMethod(
-            replacing: NSView.self,
-            name: #selector(NSView.beginDraggingSession(items:gesture:source:)),
-            with: implementation
-        ) {
+        await withSwizzledDraggingSession {
             await recap.play { composer in
                 composer._wk_drag(
                     withStart: linkBounds.center,
@@ -1038,8 +1027,6 @@ extension AppKitGesturesTests.Basic {
                     pressAndWait: .seconds(1.0)
                 )
             }
-
-            await dragInitiated.wait()
         }
 
         await page.waitForNextPresentationUpdate()
@@ -1058,33 +1045,12 @@ extension AppKitGesturesTests.Basic {
             """
         try await page.load(html: html, baseURL: baseURL).wait()
 
-        try await page.callJavaScript {
-            """
-            const img = document.getElementById("img");
-            if (img.complete && img.naturalWidth > 0) {
-                return;
-            }
-            await new Promise(resolve => img.addEventListener("load", resolve, { once: true }));
-            """
-        }
-
         let imgViewportBounds = try await page.callJavaScript(JavaScriptMessages.BoundingClientRect(elementID: "img"))
         let imgBounds = screenBounds(ofRectInViewportCoordinates: imgViewportBounds)
 
         let dragEnd = CGPoint(x: imgBounds.maxX + 50, y: imgBounds.midY)
 
-        let dragInitiated = Future()
-
-        let implementation: @convention(block) (NSView, NSArray, NSGestureRecognizer, AnyObject) -> NSDraggingSession? = { _, _, _, _ in
-            dragInitiated.signal()
-            return NSDraggingSession()
-        }
-
-        try await withSwizzledObjectiveCInstanceMethod(
-            replacing: NSView.self,
-            name: #selector(NSView.beginDraggingSession(items:gesture:source:)),
-            with: implementation
-        ) {
+        await withSwizzledDraggingSession {
             await recap.play { composer in
                 composer._wk_drag(
                     withStart: imgBounds.center,
@@ -1093,19 +1059,9 @@ extension AppKitGesturesTests.Basic {
                     pressAndWait: .seconds(1.0)
                 )
             }
-
-            // If a drag cannot happen, the text selection gestures take over and the
-            // gesture falls through to a range selection. Detect that early so the test
-            // fails with a diagnostic instead of timing out on `dragInitiated.wait()`.
-            await page.waitForNextPresentationUpdate()
-            let selection = try await page.callJavaScript(JavaScriptMessages.GetSelection())
-            if case .range = selection {
-                Issue.record("press-drag on <img> produced a range selection (\(selection)) instead of initiating a drag")
-                return
-            }
-
-            await dragInitiated.wait()
         }
+
+        // The test succeeds if it does not timeout.
     }
 
     @Test(
@@ -1228,8 +1184,8 @@ extension AppKitGesturesTests.Basic {
         #expect(page.backForwardList.backList.count == 1)
     }
 
-    @Test(.disabled())
-    func longPressAndDragOnImageSelectsEntireTextUsingLiveText() async throws {
+    @Test(arguments: [Duration.zero, .seconds(1)])
+    func longPressAndDragOnImageSelectsEntireText(delay: Duration) async throws {
         let baseURL = try #require(Bundle.testResources.resourceURL)
         let html = """
             <img id="img" src="love-and-coffee.jpeg" style="display: block; height: 100vh; margin: 0">
@@ -1250,7 +1206,7 @@ extension AppKitGesturesTests.Basic {
         let start = firstWord.center.normalized(in: imageScreenBounds)
         let end = lastWord.center.normalized(in: imageScreenBounds)
 
-        await withMockedImageAnalyzer(response: .success(analysis)) {
+        await withMockedImageAnalyzer(response: .success(analysis), after: delay) {
             await recap.play { composer in
                 composer._wk_drag(withStart: start, end: end, duration: .seconds(2), pressAndWait: .seconds(1.0))
             }
@@ -1263,6 +1219,37 @@ extension AppKitGesturesTests.Basic {
         }
 
         #expect(selection == "EVERYONE\nDESERVES\nLOVE AND\nCOFFEE")
+    }
+
+    @Test
+    func pressDragOnImageWithoutTextInitiatesDragAndDrop() async throws {
+        let baseURL = try #require(Bundle.testResources.resourceURL)
+        let html = """
+            <img id="img" src="400x400-green.png" style="display: block; height: 100vh; margin: 0">
+            """
+        try await page.load(html: html, baseURL: baseURL).wait()
+
+        let imageViewportBounds = try await page.callJavaScript(JavaScriptMessages.BoundingClientRect(elementID: "img"))
+        let imageScreenBounds = screenBounds(ofRectInViewportCoordinates: imageViewportBounds)
+
+        await page.waitForNextPresentationUpdate()
+
+        let dragEnd = CGPoint(x: imageScreenBounds.maxX + 50, y: imageScreenBounds.midY)
+
+        await withMockedImageAnalyzer(response: .success(.init(lines: [])), after: .zero) {
+            await withSwizzledDraggingSession {
+                await recap.play { composer in
+                    composer._wk_drag(
+                        withStart: imageScreenBounds.center,
+                        end: dragEnd,
+                        duration: .seconds(1.5),
+                        pressAndWait: .seconds(1.0)
+                    )
+                }
+            }
+        }
+
+        // The test succeeds if it does not timeout.
     }
 }
 
@@ -1286,6 +1273,27 @@ nonisolated(nonsending) private func withSwizzledContextMenu(perform body: () as
         await body()
 
         await future.wait()
+    }
+}
+
+nonisolated(nonsending) private func withSwizzledDraggingSession(perform body: () async -> Void) async {
+    typealias ObjCImplementation = @convention(block) (NSView, NSArray, NSGestureRecognizer, AnyObject) -> NSDraggingSession?
+
+    let dragInitiated = Future()
+
+    let implementation: ObjCImplementation = { _, _, _, _ in
+        dragInitiated.signal()
+        return NSDraggingSession()
+    }
+
+    await withSwizzledObjectiveCInstanceMethod(
+        replacing: NSView.self,
+        name: #selector(NSView.beginDraggingSession(items:gesture:source:)),
+        with: implementation
+    ) {
+        await body()
+
+        await dragInitiated.wait()
     }
 }
 


### PR DESCRIPTION
#### 3330d607a01671f4588217c7fbd58fca43fdd98c
<pre>
[AppKit Gestures] Support Live Text interactions for images
<a href="https://bugs.webkit.org/show_bug.cgi?id=319700">https://bugs.webkit.org/show_bug.cgi?id=319700</a>
<a href="https://rdar.apple.com/182543552">rdar://182543552</a>

Reviewed by Abrar Rahman Protyasha.

Clicking and dragging on an image should select the image&apos;s recognized text via Live Text when it
contains any, and otherwise fall through to the existing drag / context-menu behavior.

Implement this behavior using three new gesture recognizers:

1. A preflight NSPressGestureRecognizer (`_imageAnalysisGestureRecognizer`): a short, stationary
long-press that, once it settles on an analyzable image, kicks off Vision image analysis. It
recognizes simultaneously with everything, prevents nothing, and is always allowed to begin.

2. `_imageAnalysisTextSelectionDeferringGestureRecognizer`: holds the text-selection gestures over
an image until analysis resolves.

3. `_imageAnalysisDragAndContextMenuDeferringGestureRecognizer`: holds the drag-press and
secondary-click (context menu) recognizers over an image until analysis resolves.

Two deferrals are required because WKDeferringGestureRecognizer&apos;s `endDeferralShouldPreventGestures`
applies a single boolean (recognized -&gt; .ended / prevents, or failed -&gt; allows) to *every* gesture
it defers, whereas text selection and the drag / context-menu fallback must resolve to opposite
outcomes: on &quot;text found&quot; we allow text selection and prevent the fallback (Live Text wins), and
the reverse on &quot;no text&quot;. iOS needs only one deferral because its drag / context menu are UIKit
interactions gated by a ProceedWithTextSelectionInImage callback; macOS drag-press and secondary-click
are independent NSGestureRecognizers on their own timers, so they must be deferred to keep them
from firing before analysis resolves.

Test: Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/BasicAppKitGesturesTests.swift

* Source/WebKit/UIProcess/mac/WKAppKitGestureController.mm:
(isAnalyzableImageForLiveText):
(-[WKAppKitGestureController setUpGestureRecognizers]):
(-[WKAppKitGestureController setUpImageAnalysisGestureRecognizer]):
(-[WKAppKitGestureController _makeImageAnalysisDeferringGestureRecognizerNamed:]):
(-[WKAppKitGestureController setUpImageAnalysisDeferringGestureRecognizer]):
(-[WKAppKitGestureController addGesturesToWebView]):
(-[WKAppKitGestureController enableGesturesIfNeeded]):
(-[WKAppKitGestureController ensureGesturesAreNotArchived]):
(-[WKAppKitGestureController enableImageAnalysisGestureIfNeeded]):
(-[WKAppKitGestureController imageAnalysisGestureRecognized:]):
(-[WKAppKitGestureController _resolveImageAnalysisDeferralsWithOutcome:]):
(-[WKAppKitGestureController deferringGestureRecognizer:shouldDeferOtherGestureRecognizer:]):
(-[WKAppKitGestureController deferringGestureRecognizer:shouldDeferGesturesForEventThatWillBeginAction:]):
(-[WKAppKitGestureController gestureRecognizer:shouldRecognizeSimultaneouslyWithGestureRecognizer:]):
(-[WKAppKitGestureController gestureRecognizerShouldBegin:]):
(-[WKAppKitGestureController _gestureRecognizer:canPreventGestureRecognizer:]):
* Source/WebKit/UIProcess/mac/WebViewImpl.h:
* Tools/TestWebKitAPI/Helpers/cocoa/ImageAnalysisTestingUtilities.swift:
* Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/BasicAppKitGesturesTests.swift:

Canonical link: <a href="https://commits.webkit.org/317733@main">https://commits.webkit.org/317733@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/be87f2fa942d40d38eda71e28edf4b352b2aebca

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176153 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50088 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43878 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185749 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/138388 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5b96b931-a212-4872-a481-d3d2580c74a5) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178016 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51380 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49772 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137201 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/138388 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b336a957-e8c8-4e93-aff3-ed7df1989987) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179109 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40674 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157974 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117676 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d9d2894e-6959-4107-99e3-83b8735bd9a8) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39323 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37691 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149739 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37471 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34218 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41804 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/41902 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188172 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49753 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146220 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/39331 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50436 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/34089 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146044 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26761 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40825 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122641 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/116611 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48941 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12443 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48343 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48577 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48401 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->