### PR TITLE
[Scroll snap] Respect scroll-snap-align for `scrollToAnchor()` and `scrollIntoView()`

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -5634,8 +5634,6 @@ imported/w3c/web-platform-tests/css/css-shapes/shape-outside/shape-image/shape-i
 js/throw-large-string-oom.html [ Skip ]
 
 # Newly imported scroll-snap tests that are failing
-imported/w3c/web-platform-tests/css/css-scroll-snap/scroll-target-align-001.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-scroll-snap/scroll-target-align-002.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-scroll-snap/snap-after-initial-layout/scroll-snap-writing-mode-000.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-scroll-snap/snap-after-style-change-respects-scroll-behavior.html [ Pass Failure ]
 webkit.org/b/218325 imported/w3c/web-platform-tests/css/css-scroll-snap/scroll-target-margin-001.html [ Pass ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/scroll-target-align-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/scroll-target-align-001.html
@@ -4,6 +4,7 @@
 <link rel='author' title='Elika J. Etemad' href='http://fantasai.inkedblade.net/contact'>
 <link rel='help' href='https://www.w3.org/TR/css-scroll-snap-1/#choosing'>
 <link rel='match' href='scroll-target-001-ref.html'>
+<meta name="fuzzy" content="maxDifference=0-110; totalPixels=0-20">
 <meta name="flags" content="may">
 <meta name='assert'
       content="Test passes if scroll snapping is honored

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/scroll-target-align-002.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/scroll-target-align-002.html
@@ -4,6 +4,7 @@
 <link rel='author' title='Elika J. Etemad' href='http://fantasai.inkedblade.net/contact'>
 <link rel='help' href='https://www.w3.org/TR/css-scroll-snap-1/#choosing'>
 <link rel='match' href='scroll-target-001-ref.html'>
+<meta name="fuzzy" content="maxDifference=0-110; totalPixels=0-20">
 <meta name="flags" content="may">
 <meta name='assert'
       content="Test passes if scroll snapping is honored

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -143,6 +143,7 @@
 #include "ScriptDisallowedScope.h"
 #include "ScrollIntoViewOptions.h"
 #include "ScrollLatchingController.h"
+#include "ScrollSnapOffsetsInfo.h"
 #include "ScrollToOptions.h"
 #include "SecurityPolicyViolationEvent.h"
 #include "SelectorQuery.h"
@@ -1258,8 +1259,9 @@ void Element::scrollIntoView(Variant<bool, ScrollIntoViewOptions>&& arg)
     auto options = WTF::switchOn(arg,
         [&](bool boolArg) -> ScrollIntoViewOptions {
             ScrollIntoViewOptions options;
-            if (!boolArg)
-                options.blockPosition = ScrollLogicalPosition::End;
+            // The legacy boolean argument explicitly requests top (true) or bottom (false) alignment,
+            // so treat the block axis as author-specified (not eligible for scroll-snap adjustment).
+            options.blockPosition = boolArg ? ScrollLogicalPosition::Start : ScrollLogicalPosition::End;
             return options;
         },
         [](ScrollIntoViewOptions options) -> ScrollIntoViewOptions {
@@ -1273,10 +1275,21 @@ void Element::scrollIntoView(Variant<bool, ScrollIntoViewOptions>&& arg)
     alignX.disableLegacyHorizontalVisibilityThreshold();
 
     bool isHorizontal = writingMode.isHorizontal();
+    auto physicalAlignX = isHorizontal ? alignX : alignY;
+    auto physicalAlignY = isHorizontal ? alignY : alignX;
+
+    // Honor the target's scroll-snap-align even when the scroll container has scroll-snap-type: none, but only
+    // for an axis whose alignment the author did not explicitly specify. https://drafts.csswg.org/cssom-view/#determine-the-scroll-into-view-position
+    bool blockSpecified = options.blockPosition.has_value();
+    bool inlineSpecified = options.inlinePosition.has_value();
+    bool adjustX = isHorizontal ? !inlineSpecified : !blockSpecified;
+    bool adjustY = isHorizontal ? !blockSpecified : !inlineSpecified;
+    adjustScrollAlignmentForScrollSnapAlign(*renderer, adjustX ? &physicalAlignX : nullptr, adjustY ? &physicalAlignY : nullptr);
+
     auto visibleOptions = ScrollRectToVisibleOptions {
         .revealMode = SelectionRevealMode::Reveal,
-        .alignX = isHorizontal ? alignX : alignY,
-        .alignY = isHorizontal ? alignY : alignX,
+        .alignX = physicalAlignX,
+        .alignY = physicalAlignY,
         .behavior = options.behavior,
         .skipScrollingTargetElement = SkipScrollingTargetElement::Yes
     };

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -4676,14 +4676,26 @@ void LocalFrameView::scrollToAnchor()
 
     LOG_WITH_STREAM(Scrolling, stream << " anchor node rect " << rect);
 
+    CheckedRef renderer = *anchorNode->renderer();
+
     // Scroll nested layers and frames to reveal the anchor.
     // Align to the top and to the closest side (this matches other browsers).
-    if (anchorNode->renderer()->writingMode().isHorizontal())
-        scrollRectToVisible(rect, *anchorNode->renderer(), insideFixed, { SelectionRevealMode::Reveal, ScrollAlignment::alignToEdgeIfNeeded, ScrollAlignment::alignTopAlways, ShouldAllowCrossOriginScrolling::No });
-    else if (anchorNode->renderer()->writingMode().blockDirection() == FlowDirection::RightToLeft)
-        scrollRectToVisible(rect, *anchorNode->renderer(), insideFixed, { SelectionRevealMode::Reveal, ScrollAlignment::alignRightAlways, ScrollAlignment::alignToEdgeIfNeeded, ShouldAllowCrossOriginScrolling::No });
-    else
-        scrollRectToVisible(rect, *anchorNode->renderer(), insideFixed, { SelectionRevealMode::Reveal, ScrollAlignment::alignLeftAlways, ScrollAlignment::alignToEdgeIfNeeded, ShouldAllowCrossOriginScrolling::No });
+    ScrollAlignment alignX;
+    ScrollAlignment alignY;
+    if (renderer->writingMode().isHorizontal()) {
+        alignX = ScrollAlignment::alignToEdgeIfNeeded;
+        alignY = ScrollAlignment::alignTopAlways;
+    } else if (renderer->writingMode().blockDirection() == FlowDirection::RightToLeft) {
+        alignX = ScrollAlignment::alignRightAlways;
+        alignY = ScrollAlignment::alignToEdgeIfNeeded;
+    } else {
+        alignX = ScrollAlignment::alignLeftAlways;
+        alignY = ScrollAlignment::alignToEdgeIfNeeded;
+    }
+
+    adjustScrollAlignmentForScrollSnapAlign(renderer, &alignX, &alignY);
+
+    scrollRectToVisible(rect, renderer, insideFixed, { SelectionRevealMode::Reveal, alignX, alignY, ShouldAllowCrossOriginScrolling::No });
 
     if (AXObjectCache* cache = protect(m_frame->document())->existingAXObjectCache())
         cache->handleScrolledToAnchor(*anchorNode);

--- a/Source/WebCore/page/ScrollIntoViewOptions.h
+++ b/Source/WebCore/page/ScrollIntoViewOptions.h
@@ -25,8 +25,11 @@
 namespace WebCore {
 
 struct ScrollIntoViewOptions : ScrollOptions {
-    ScrollLogicalPosition blockPosition { ScrollLogicalPosition::Start };
-    ScrollLogicalPosition inlinePosition { ScrollLogicalPosition::Nearest };
+    // These are std::optional so that we can tell whether the author explicitly requested an
+    // alignment for an axis. An unspecified axis defaults to "start" (block) / "nearest" (inline),
+    // and is eligible to be adjusted to honor the target's scroll-snap-align.
+    std::optional<ScrollLogicalPosition> blockPosition;
+    std::optional<ScrollLogicalPosition> inlinePosition;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/page/ScrollIntoViewOptions.idl
+++ b/Source/WebCore/page/ScrollIntoViewOptions.idl
@@ -19,8 +19,10 @@
 
 // https://drafts.csswg.org/cssom-view/#dictdef-scrollintoviewoptions
 dictionary ScrollIntoViewOptions : ScrollOptions {
-    [ImplementedAs=blockPosition] ScrollLogicalPosition block = "start";
-    [ImplementedAs=inlinePosition] ScrollLogicalPosition inline = "nearest";
+    // No default values so we can distinguish an author-specified alignment (which must be honored)
+    // from an unspecified one (which defaults to start/nearest and may be adjusted for scroll-snap-align).
+    [ImplementedAs=blockPosition] ScrollLogicalPosition block;
+    [ImplementedAs=inlinePosition] ScrollLogicalPosition inline;
     // FIXME: Add support for `container`.
     // ScrollIntoViewContainer container = "all";
 };

--- a/Source/WebCore/page/scrolling/ScrollSnapOffsetsInfo.cpp
+++ b/Source/WebCore/page/scrolling/ScrollSnapOffsetsInfo.cpp
@@ -36,6 +36,7 @@
 #include "RenderElementInlines.h"
 #include "RenderObjectInlines.h"
 #include "RenderView.h"
+#include "ScrollAlignment.h"
 #include "ScrollableArea.h"
 #include "StyleComputedStyle+GettersInlines.h"
 #include <ranges>
@@ -300,6 +301,43 @@ static LayoutUnit NODELETE computeScrollSnapAlignOffset(LayoutUnit minLocation, 
     }
 }
 
+// https://drafts.csswg.org/css-scroll-snap-1/#scroll-snap-align
+void adjustScrollAlignmentForScrollSnapAlign(const RenderElement& renderer, ScrollAlignment* alignX, ScrollAlignment* alignY)
+{
+    if (!alignX && !alignY)
+        return;
+
+    auto snapAlign = renderer.style().scrollSnapAlign();
+    if (snapAlign.isNone())
+        return;
+
+    auto writingMode = renderer.writingMode();
+    bool hasVerticalWritingMode = writingMode.isVertical();
+
+    auto alignmentForAxis = [](ScrollSnapAxisAlignType type, bool axisIsFlipped, const ScrollAlignment& startAlignment, const ScrollAlignment& endAlignment, const ScrollAlignment& fallback) -> ScrollAlignment {
+        switch (type) {
+        case ScrollSnapAxisAlignType::Start:
+            return axisIsFlipped ? endAlignment : startAlignment;
+        case ScrollSnapAxisAlignType::Center:
+            return ScrollAlignment::alignCenterAlways;
+        case ScrollSnapAxisAlignType::End:
+            return axisIsFlipped ? startAlignment : endAlignment;
+        case ScrollSnapAxisAlignType::None:
+            break;
+        }
+        return fallback;
+    };
+
+    // scroll-snap-align is specified as block / inline; resolve to physical axes and directions.
+    auto xAlignType = hasVerticalWritingMode ? snapAlign.blockAlign : snapAlign.inlineAlign;
+    auto yAlignType = hasVerticalWritingMode ? snapAlign.inlineAlign : snapAlign.blockAlign;
+
+    if (alignX)
+        *alignX = alignmentForAxis(xAlignType, !writingMode.isAnyLeftToRight(), ScrollAlignment::alignLeftAlways, ScrollAlignment::alignRightAlways, *alignX);
+    if (alignY)
+        *alignY = alignmentForAxis(yAlignType, !writingMode.isAnyTopToBottom(), ScrollAlignment::alignTopAlways, ScrollAlignment::alignBottomAlways, *alignY);
+}
+
 bool mayHaveScrollSnappedBoxes(const RenderBox& scrollingElementBox)
 {
     if (scrollingElementBox.style().scrollSnapType().isNone())
@@ -415,8 +453,8 @@ void updateSnapOffsetsForScrollableArea(ScrollableArea& scrollableArea, const Re
             areaYAxisFlipped = !child->writingMode().isAnyTopToBottom();
         }
 
-        ScrollSnapAxisAlignType xAlign = scrollerHasVerticalWritingMode ? alignment.blockAlign : alignment.inlineAlign;
-        ScrollSnapAxisAlignType yAlign = scrollerHasVerticalWritingMode ? alignment.inlineAlign : alignment.blockAlign;
+        auto xAlign = scrollerHasVerticalWritingMode ? alignment.blockAlign : alignment.inlineAlign;
+        auto yAlign = scrollerHasVerticalWritingMode ? alignment.inlineAlign : alignment.blockAlign;
         bool snapsHorizontally = hasHorizontalSnapOffsets && xAlign != ScrollSnapAxisAlignType::None;
         bool snapsVertically = hasVerticalSnapOffsets && yAlign != ScrollSnapAxisAlignType::None;
 

--- a/Source/WebCore/page/scrolling/ScrollSnapOffsetsInfo.h
+++ b/Source/WebCore/page/scrolling/ScrollSnapOffsetsInfo.h
@@ -36,9 +36,11 @@
 
 namespace WebCore {
 
-class ScrollableArea;
-class RenderBox;
 class Element;
+class RenderBox;
+class RenderElement;
+class ScrollableArea;
+struct ScrollAlignment;
 
 namespace Style {
 class ComputedStyle;
@@ -115,6 +117,10 @@ WEBCORE_EXPORT std::pair<LayoutUnit, std::optional<unsigned>> LayoutScrollSnapOf
 // the scrolling container's border box.
 bool NODELETE mayHaveScrollSnappedBoxes(const RenderBox& scrollingElementBox);
 void updateSnapOffsetsForScrollableArea(ScrollableArea&, const RenderBox& scrollingElementBox, const Style::ComputedStyle& scrollingElementStyle, LayoutRect viewportRectInBorderBoxCoordinates, WritingMode, Element* focusedElement, Element* targetElement);
+// Adjust the scroll-into-view alignment of each axis to honor the target's scroll-snap-align. Only axes
+// without an author-specified alignment (adjustX / adjustY) are adjusted, per the CSSOM View rule that an
+// explicitly requested scrollIntoView() alignment must be used as-is.
+void adjustScrollAlignmentForScrollSnapAlign(const RenderElement&, ScrollAlignment* alignX, ScrollAlignment* alignY);
 
 template <typename T> WTF::TextStream& operator<<(WTF::TextStream& ts, SnapOffset<T> offset)
 {


### PR DESCRIPTION
#### 231d6768da287cf5c43dab04722adaed9324d343
<pre>
[Scroll snap] Respect scroll-snap-align for `scrollToAnchor()` and `scrollIntoView()`
<a href="https://bugs.webkit.org/show_bug.cgi?id=319703">https://bugs.webkit.org/show_bug.cgi?id=319703</a>
<a href="https://rdar.apple.com/182544180">rdar://182544180</a>

Reviewed by Tim Nguyen.

`scroll-snap-align`[1] should impact scrolling to anchors, and scrollIntoView per spec.

Add `adjustScrollAlignmentForScrollSnapAlign()` which computes alignment, and call it
from `LocalFrameView::scrollToAnchor()` and `Element::scrollIntoView()`. In the latter
case, it should only override the chosen alignment if the `options` dict doesn&apos;t already
contain alignment data.

[1] <a href="https://drafts.csswg.org/css-scroll-snap-1/#scroll-snap-align">https://drafts.csswg.org/css-scroll-snap-1/#scroll-snap-align</a>
[2] <a href="https://drafts.csswg.org/css-scroll-snap-1/#choosing">https://drafts.csswg.org/css-scroll-snap-1/#choosing</a>

This fixes css/css-scroll-snap/scroll-target-align-001.html and css/css-scroll-snap/scroll-target-align-002.html

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/scroll-target-align-001.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/scroll-target-align-002.html:
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::scrollIntoView):
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::scrollToAnchor):
* Source/WebCore/page/ScrollIntoViewOptions.h:
(): Deleted.
* Source/WebCore/page/ScrollIntoViewOptions.idl:
* Source/WebCore/page/scrolling/ScrollSnapOffsetsInfo.cpp:
(WebCore::adjustScrollAlignmentForScrollSnapAlign):
(WebCore::updateSnapOffsetsForScrollableArea):
* Source/WebCore/page/scrolling/ScrollSnapOffsetsInfo.h:

Canonical link: <a href="https://commits.webkit.org/317495@main">https://commits.webkit.org/317495@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/34323fd8a24de90ea1c3f7bb04ce55a9ac879e6c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175447 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49379 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43160 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185033 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/137592 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/308fc61a-062b-4d24-919c-61d66d9e56b8) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/177311 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50671 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49062 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136599 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/137592 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/de15775c-b27e-450f-9101-9e9b23b010a5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178404 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40016 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157352 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117077 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a05f8f42-e14e-4ed4-bb25-974407dff0e9) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38658 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37041 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149080 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36845 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33508 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41066 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41244 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187458 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49046 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/156908 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145563 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39163 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49726 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33468 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145403 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40219 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/121919 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115639 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48232 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11819 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47635 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47865 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47692 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->