### PR TITLE
WIP

### DIFF
--- a/Source/WTF/wtf/PlatformEnable.h
+++ b/Source/WTF/wtf/PlatformEnable.h
@@ -313,6 +313,14 @@
 #define ENABLE_INSPECTOR_EXTENSIONS 0
 #endif
 
+// When enabled, the Web Inspector surfaces per-frame targets to the frontend, and routes the Page
+// and Network domains through the UIProcess "web-page" target, for every inspection -- not only
+// when Site Isolation is enabled. This decouples the inspector's frame-target architecture from
+// Site Isolation so inspection behaves the same regardless of that setting.
+#if !defined(ENABLE_INSPECTOR_FRAME_TARGETS)
+#define ENABLE_INSPECTOR_FRAME_TARGETS 0
+#endif
+
 #if !defined(ENABLE_INSPECTOR_TELEMETRY)
 #define ENABLE_INSPECTOR_TELEMETRY 0
 #endif

--- a/Source/WTF/wtf/PlatformEnableCocoa.h
+++ b/Source/WTF/wtf/PlatformEnableCocoa.h
@@ -440,6 +440,10 @@
 #define ENABLE_INSPECTOR_EXTENSIONS 1
 #endif
 
+#if !defined(ENABLE_INSPECTOR_FRAME_TARGETS)
+#define ENABLE_INSPECTOR_FRAME_TARGETS 1
+#endif
+
 // FIXME: Disabled pending rdar://122224142 (Per process network link conditioner SPI)
 #if !defined(ENABLE_INSPECTOR_NETWORK_THROTTLING)
 #define ENABLE_INSPECTOR_NETWORK_THROTTLING 0

--- a/Source/WebCore/inspector/FrameInspectorController.cpp
+++ b/Source/WebCore/inspector/FrameInspectorController.cpp
@@ -76,7 +76,7 @@ FrameInspectorController::FrameInspectorController(LocalFrame& frame, PageInspec
     , m_backendDispatcher(BackendDispatcher::create(m_frontendRouter.copyRef(), &parentPageController.backendDispatcher()))
     , m_executionStopwatch(Stopwatch::create())
 {
-    if (frame.settings().siteIsolationEnabled())
+    if (inspectorFrameTargetsEnabled(frame.settings()))
         createConsoleAgent();
 }
 
@@ -143,7 +143,7 @@ void FrameInspectorController::createLazyAgents()
     if (!frame)
         return;
 
-    if (!frame->settings().siteIsolationEnabled())
+    if (!inspectorFrameTargetsEnabled(frame->settings()))
         return;
 
     // Create debugger before agents that depend on it.

--- a/Source/WebCore/inspector/PageDebugger.cpp
+++ b/Source/WebCore/inspector/PageDebugger.cpp
@@ -69,9 +69,10 @@ void PageDebugger::attachDebugger()
 {
     JSC::Debugger::attachDebugger();
 
-    // Under site isolation, FrameDebugger handles per-frame debugging.
-    // Don't attach the PageDebugger to frames to avoid conflicts.
-    if (m_page->settings().siteIsolationEnabled())
+    // Under the frame-target architecture, per-frame debugging is handled by FrameDebugger, so this
+    // PageDebugger is not attached to any frame (it exists only so PageDebuggerAgent can register
+    // the Debugger domain).
+    if (inspectorFrameTargetsEnabled(m_page->settings()))
         return;
 
     protect(m_page)->setDebugger(this);

--- a/Source/WebCore/inspector/PageInspectorController.cpp
+++ b/Source/WebCore/inspector/PageInspectorController.cpp
@@ -201,6 +201,16 @@ void PageInspectorController::siteIsolationFirstEnabled()
     m_identifierRegistry = Inspector::BackendIdentifierRegistry::create();
 }
 
+bool inspectorFrameTargetsEnabled(const Settings& settings)
+{
+#if ENABLE(INSPECTOR_FRAME_TARGETS)
+    UNUSED_PARAM(settings);
+    return true;
+#else
+    return settings.siteIsolationEnabled();
+#endif
+}
+
 void PageInspectorController::inspectedPageDestroyed()
 {
     // Clean up resources and disconnect local and remote frontends.

--- a/Source/WebCore/inspector/PageInspectorController.h
+++ b/Source/WebCore/inspector/PageInspectorController.h
@@ -64,8 +64,15 @@ class LocalFrame;
 class Node;
 class Page;
 class PageDebugger;
+class Settings;
 class WebInjectedScriptManager;
 struct PageAgentContext;
+
+// Whether the Web Inspector uses its frame-target architecture -- per-frame targets, plus the Page
+// and Network domains served from the UIProcess "web-page" target -- for this page. True under Site
+// Isolation, and (when ENABLE(INSPECTOR_FRAME_TARGETS) is set) for every inspection, so inspection
+// behaves the same regardless of Site Isolation.
+WEBCORE_EXPORT bool inspectorFrameTargetsEnabled(const Settings&);
 
 class PageInspectorController final : public Inspector::InspectorEnvironment, public CanMakeCheckedPtr<PageInspectorController> {
     WTF_MAKE_NONCOPYABLE(PageInspectorController);

--- a/Source/WebCore/inspector/agents/page/PageNetworkAgent.cpp
+++ b/Source/WebCore/inspector/agents/page/PageNetworkAgent.cpp
@@ -63,10 +63,10 @@ PageNetworkAgent::~PageNetworkAgent() = default;
 
 Inspector::Protocol::ErrorStringOr<void> PageNetworkAgent::enable()
 {
-    // Under Site Isolation, ProxyingNetworkAgent in the UIProcess handles Network
-    // events for all processes. PageNetworkAgent should not be enabled to avoid
-    // duplicate events for same-process frames.
-    if (RefPtr page = m_inspectedPage.get(); page && page->settings().siteIsolationEnabled())
+    // Under the frame-target architecture, ProxyingNetworkAgent in the UIProcess handles Network
+    // events for all processes, so this in-process agent stays inert to avoid duplicate events for
+    // same-process frames.
+    if (RefPtr page = m_inspectedPage.get(); page && inspectorFrameTargetsEnabled(page->settings()))
         return { };
 
     return InspectorNetworkAgent::enable();

--- a/Source/WebCore/inspector/agents/page/PageWorkerAgent.cpp
+++ b/Source/WebCore/inspector/agents/page/PageWorkerAgent.cpp
@@ -27,6 +27,7 @@
 #include "PageWorkerAgent.h"
 
 #include "Page.h"
+#include "PageInspectorController.h"
 #include "Settings.h"
 #include "WorkerInspectorProxy.h"
 
@@ -46,10 +47,10 @@ PageWorkerAgent::~PageWorkerAgent() = default;
 
 void PageWorkerAgent::connectToAllWorkerInspectorProxies()
 {
-    // Under site isolation, every frame (including the main frame) has its own
-    // FrameInspectorController with a FrameWorkerAgent that handles workers for
-    // that frame. PageWorkerAgent does not need to connect to any workers.
-    if (m_page->settings().siteIsolationEnabled())
+    // Under the frame-target architecture, every frame (including the main frame) has its own
+    // FrameInspectorController with a FrameWorkerAgent that handles workers for that frame, so
+    // this page-level agent connects to none.
+    if (inspectorFrameTargetsEnabled(m_page->settings()))
         return;
 
     for (Ref proxy : WorkerInspectorProxy::proxiesForPage(*m_page->identifier()))

--- a/Source/WebKit/Modules/OSX.modulemap
+++ b/Source/WebKit/Modules/OSX.modulemap
@@ -2,9 +2,4 @@ framework module WebKit [system] {
   umbrella header "WebKit.h"
   module * { export * }
   export *
-
-  explicit module DOMProgressEvent {
-    header "DOMProgressEvent.h"
-    export *
-  }
 }

--- a/Source/WebKit/UIProcess/Inspector/Agents/ProxyingNetworkAgent.cpp
+++ b/Source/WebKit/UIProcess/Inspector/Agents/ProxyingNetworkAgent.cpp
@@ -36,6 +36,7 @@
 #include "ProxyingNetworkAgentMessages.h"
 #include "WebInspectorBackendMessages.h"
 #include "WebPageProxy.h"
+#include "WebPreferences.h"
 #include "WebProcessProxy.h"
 #include "WebsiteDataStore.h"
 #include <JavaScriptCore/InspectorProtocolObjects.h>
@@ -242,11 +243,8 @@ void ProxyingNetworkAgent::disableInstrumentationForProcess(WebKit::WebProcessPr
 
 CommandResult<void> ProxyingNetworkAgent::enable()
 {
-    // FIXME: <https://webkit.org/b/308890> Only needed under Site Isolation; without it,
-    // InspectorNetworkAgent in the single WebContent process handles network events.
     Ref inspectedPage = m_inspectedPage.get();
-    Ref prefs = inspectedPage->preferences();
-    if (!prefs->siteIsolationEnabled())
+    if (!inspectedPage->preferences().inspectorFrameTargetsEnabled())
         return { };
 
     m_enabled = true;

--- a/Source/WebKit/UIProcess/Inspector/Agents/ProxyingPageAgent.cpp
+++ b/Source/WebKit/UIProcess/Inspector/Agents/ProxyingPageAgent.cpp
@@ -31,6 +31,7 @@
 #include "WebFrameProxy.h"
 #include "WebInspectorBackendMessages.h"
 #include "WebPageProxy.h"
+#include "WebPreferences.h"
 #include "WebProcessProxy.h"
 #include <JavaScriptCore/InspectorProtocolObjects.h>
 #include <WebCore/InspectorIdentifierRegistry.h>
@@ -217,8 +218,7 @@ void ProxyingPageAgent::disableInstrumentationForProcess(WebProcessProxy& webPro
 CommandResult<void> ProxyingPageAgent::enable()
 {
     Ref<WebPageProxy> inspectedPage = m_inspectedPage.get();
-    Ref preferences = inspectedPage->preferences();
-    if (!preferences->siteIsolationEnabled())
+    if (!inspectedPage->preferences().inspectorFrameTargetsEnabled())
         return { };
 
     m_enabled = true;

--- a/Source/WebKit/UIProcess/Inspector/WebPageInspectorController.cpp
+++ b/Source/WebKit/UIProcess/Inspector/WebPageInspectorController.cpp
@@ -40,6 +40,7 @@
 #include "WebFrameProxy.h"
 #include "WebPageInspectorAgentBase.h"
 #include "WebPageProxy.h"
+#include "WebPreferences.h"
 #include "WebProcessProxy.h"
 #include "WebsiteDataStore.h"
 #include <JavaScriptCore/InspectorAgentBase.h>
@@ -514,7 +515,11 @@ void WebPageInspectorController::createLazyAgents()
     m_agents.append(makeUniqueRef<InspectorBrowserAgent>(webPageContext));
     m_agents.append(makeUniqueRef<InspectorStorageAgent>(webPageContext));
 
-    if (protect(protect(m_inspectedPage)->preferences())->siteIsolationEnabled()) {
+    // When frame targets are in use, the Page and Network domains are served from this UIProcess
+    // "web-page" target by these proxying agents (aggregating events across all WebContent
+    // processes), rather than from the per-page target's in-process InspectorPageAgent /
+    // InspectorNetworkAgent. See WebPreferences::inspectorFrameTargetsEnabled().
+    if (protect(protect(m_inspectedPage)->preferences())->inspectorFrameTargetsEnabled()) {
         // ProxyingNetworkAgent and ProxyingPageAgent are RefCounted (for IPC MessageReceiver)
         // so they can't be stored in AgentRegistry which expects UniqueRef ownership.
         // Their lifecycle (didCreateFrontendAndBackend / willDestroyFrontendAndBackend) is
@@ -541,7 +546,7 @@ void WebPageInspectorController::removeTarget(const String& targetId)
 
 bool WebPageInspectorController::shouldManageFrameTargets() const
 {
-    return protect(protect(m_inspectedPage)->preferences())->siteIsolationEnabled();
+    return protect(protect(m_inspectedPage)->preferences())->inspectorFrameTargetsEnabled();
 }
 
 bool WebPageInspectorController::isNetworkInstrumentationEnabled() const

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -6076,14 +6076,17 @@ void WebPageProxy::commitProvisionalPage(IPC::Connection& connection, FrameIdent
     RefPtr mainFrameInPreviousProcess = m_mainFrame;
     Ref preferences = m_preferences;
     std::optional<WebCore::FrameIdentifier> oldMainFrameID;
-    if (mainFrameInPreviousProcess && preferences->siteIsolationEnabled()) {
+    if (mainFrameInPreviousProcess) {
+        // The inspector's frame-target commit (WebPageInspectorController::didCommitProvisionalPage)
+        // needs the previous main frame's identifier whenever frame targets are surfaced, which is
+        // no longer tied to Site Isolation. Capture it regardless of that setting.
         oldMainFrameID = mainFrameInPreviousProcess->frameID();
 
         // Update the back/forward list so existing entries use the new main frame's FrameIdentifier.
         // This is needed for back/forward navigations that trigger a process swap, since no new
         // back/forward list item is added (unlike forward navigations where backForwardAddItemShared
-        // handles the update).
-        if (*oldMainFrameID != frameID)
+        // handles the update). Only Site Isolation reassigns the main frame's identifier on swap.
+        if (preferences->siteIsolationEnabled() && *oldMainFrameID != frameID)
             backForwardList().updateFrameIdentifier(*oldMainFrameID, frameID);
     }
 

--- a/Source/WebKit/UIProcess/WebPreferences.cpp
+++ b/Source/WebKit/UIProcess/WebPreferences.cpp
@@ -97,6 +97,15 @@ void WebPreferences::forceSiteIsolationAlwaysOnForTesting()
     WebKit::forceSiteIsolationAlwaysOnForTesting = true;
 }
 
+bool WebPreferences::inspectorFrameTargetsEnabled() const
+{
+#if ENABLE(INSPECTOR_FRAME_TARGETS)
+    return true;
+#else
+    return siteIsolationEnabled();
+#endif
+}
+
 const Vector<RefPtr<API::Object>>& WebPreferences::experimentalFeatures()
 {
     static auto experimentalFeatures = NeverDestroyed([]() {

--- a/Source/WebKit/UIProcess/WebPreferences.h
+++ b/Source/WebKit/UIProcess/WebPreferences.h
@@ -71,6 +71,12 @@ public:
     FOR_EACH_WEBKIT_PREFERENCE(DECLARE_PREFERENCE_GETTER_AND_SETTERS)
     FOR_EACH_WEBKIT_PREFERENCE_WITH_INSPECTOR_OVERRIDE(DECLARE_INSPECTOR_OVERRIDE_SETTERS)
 
+    // Whether the Web Inspector uses its frame-target architecture -- per-frame targets, plus the
+    // Page and Network domains served from this (UIProcess) "web-page" target -- for pages using
+    // these preferences. True when siteIsolationEnabled(), and (when ENABLE(INSPECTOR_FRAME_TARGETS)
+    // is set) for every inspection, so inspection behaves the same regardless of Site Isolation.
+    bool inspectorFrameTargetsEnabled() const;
+
     static const Vector<RefPtr<API::Object>>& features();
     static const Vector<RefPtr<API::Object>>& experimentalFeatures();
     static const Vector<RefPtr<API::Object>>& internalDebugFeatures();

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -959,7 +959,10 @@ WebPage::WebPage(PageIdentifier pageID, WebPageCreationParameters&& parameters)
         WebPreferences::forceSiteIsolationAlwaysOnForTesting();
 
     updatePreferences(parameters.store);
-    if (page->settings().siteIsolationEnabled()) {
+    // Switch the inspector to its frame-target architecture: a backend-coordinated identifier
+    // registry (so frame/loader IDs are process-qualified and match the events the UIProcess
+    // proxying agents synthesize) and a per-frame console agent. See inspectorFrameTargetsEnabled().
+    if (inspectorFrameTargetsEnabled(page->settings())) {
         page->inspectorController().siteIsolationFirstEnabled();
         if (RefPtr frame = page->localMainFrame())
             frame->inspectorController().siteIsolationFirstEnabled();


### PR DESCRIPTION
#### b621c6371d30814d78fa10d5c1df497de1fb0590
<pre>
WIP Experiment with using Frame Targets even with SI off
</pre>
----------------------------------------------------------------------
#### 3fad81a0d701b3a5e785541d7e1071799fb70f30
<pre>
WIP Unrelated local build patch
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b621c6371d30814d78fa10d5c1df497de1fb0590

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175360 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49292 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43073 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184946 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/137481 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/177224 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50584 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48975 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136517 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96191 "2 flakes 3 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e6303ebf-210c-472b-9a97-cf4e3ae4d8f6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178317 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39936 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157275 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116995 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38578 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36962 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/5784 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149000 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36768 "Exiting early after 60 failures. 76899 tests run. 60 failures") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33421 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/36621 "Built successfully and passed tests") | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/40979 "Found 2 new failures in UIProcess/Inspector/Agents/ProxyingNetworkAgent.cpp, UIProcess/Inspector/Agents/ProxyingPageAgent.cpp") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41166 "Found 60 new test failures: fast/forms/state-restore-to-non-edited-controls.html http/tests/inspector/network/beacon-type.html http/tests/inspector/network/copy-as-curl.html http/tests/inspector/network/copy-as-fetch.html http/tests/inspector/network/eventsource-type.html http/tests/inspector/network/fetch-network-data.html http/tests/inspector/network/fetch-response-body.html http/tests/inspector/network/getSerializedCertificate.html http/tests/inspector/network/har/har-page.html http/tests/inspector/network/intercept-request-fragment.html ... (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187371 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48959 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145486 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49639 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33390 "Found 60 new test failures: fast/canvas/webgl/context-attributes-alpha.html fast/canvas/webgl/copy-tex-image-and-sub-image-2d.html fast/canvas/webgl/tex-input-validation.html fast/canvas/webgl/webgl-clear-composited-notshowing.html fast/css-grid-layout/grid-simplified-layout-positioned.html fast/overflow/intrinsic-width-container-with-scrollable-descendant-vertical-lr.html http/tests/inspector/network/beacon-type.html http/tests/inspector/network/copy-as-curl.html http/tests/inspector/network/copy-as-fetch.html http/tests/inspector/network/eventsource-type.html ... (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145327 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40141 "Passed tests") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/121832 "Found 2 new failures in UIProcess/Inspector/Agents/ProxyingNetworkAgent.cpp, UIProcess/Inspector/Agents/ProxyingPageAgent.cpp") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115522 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48145 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11741 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47548 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47778 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47605 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->