### PR TITLE
[css-conditional-5] Fix serialization of @container condition

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/at-container-serialization-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/at-container-serialization-expected.txt
@@ -16,6 +16,6 @@ PASS @container conditionText serialization: (100px>WIDTH>10px)
 PASS @container conditionText serialization: (  100px >= width >= 10px  )
 PASS @container conditionText serialization: (calc(1em + 1px) >= width >= max(10em, 10px))
 FAIL @container conditionText serialization: (width),(height) ,--foo ,--bar assert_equals: expected 1 but got 0
-FAIL @container conditionText serialization:   --NAMe    assert_equals: expected "--NAMe" but got "--NAMe "
+PASS @container conditionText serialization:   --NAMe
 PASS @container conditionText serialization: NAMe   (inline-sizE  < 1300px )
 

--- a/Source/WebCore/css/query/ContainerQuery.cpp
+++ b/Source/WebCore/css/query/ContainerQuery.cpp
@@ -100,12 +100,18 @@ void collectCustomPropertyNames(const MQ::Feature& feature, HashSet<AtomString>&
 void serialize(StringBuilder& builder, const ContainerQuery& query)
 {
     auto name = query.name;
-    if (!name.isEmpty()) {
-        serializeIdentifier(builder, name);
-        builder.append(' ');
-    }
+    // No-op if empty.
+    serializeIdentifier(builder, name);
 
-    serialize(builder, query.condition);
+    StringBuilder conditionString;
+    serialize(conditionString, query.condition);
+
+    // If the name and condition are both non-empty, put a space in-between to separate them.
+    if (!name.isEmpty() && !conditionString.isEmpty())
+        builder.append(' ');
+
+    // No-op if empty.
+    builder.append(conditionString);
 }
 
 }


### PR DESCRIPTION
#### 8f1b55f545af549e7795a88e31b94ed62404c242
<pre>
[css-conditional-5] Fix serialization of @container condition
<a href="https://rdar.apple.com/182530213">rdar://182530213</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=319683">https://bugs.webkit.org/show_bug.cgi?id=319683</a>

Reviewed by Tim Nguyen.

The condition in a @container at-rule includes at least one of: container
name, and container query. When serializing the at-rule for cssText, if
both are present, there should be a space in between. But the current
code always insert a space after the name, even if the query is empty.
Fix it to only emit a space if both are present.

Test: imported/w3c/web-platform-tests/css/css-conditional/container-queries/at-container-serialization.html

* LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/at-container-serialization-expected.txt:
* Source/WebCore/css/query/ContainerQuery.cpp:
(WebCore::CQ::serialize):

Canonical link: <a href="https://commits.webkit.org/317635@main">https://commits.webkit.org/317635@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b4caf5c10800a94f9a9e496ea673dfc8dc2c969c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175810 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49743 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43527 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185403 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/137993 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/177673 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51035 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49425 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136899 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/137993 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f60e72d2-ea15-4c94-a4fc-09a0c8ca935f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178766 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40356 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157673 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117378 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/55d18ab6-8b8e-41ef-a5b9-c2dbd55853b2) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38998 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37380 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149417 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37165 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33873 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41439 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41586 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187824 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49410 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145893 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39264 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50090 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33789 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145734 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40524 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122286 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/116114 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48597 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12145 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47999 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48231 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48056 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->