### PR TITLE
[JSC] Wasm-backed resizable ArrayBuffers should throw for all invalid sizes

### DIFF
--- a/JSTests/wasm/js-api/memory-toResizableBuffer.js
+++ b/JSTests/wasm/js-api/memory-toResizableBuffer.js
@@ -67,6 +67,29 @@ function assertSharedGrowableBufferOfPageSize(pageCount, buffer, maxPageCount) {
     assertTrue(memory.buffer !== buffer);
 }
 
+// A resize whose page-aligned growth delta exceeds the maximum representable
+// PageCount must throw a catchable RangeError, not hit a release assertion.
+// https://bugs.webkit.org/show_bug.cgi?id=318524
+{
+    let memory = new WebAssembly.Memory({ initial: 1, maximum: 65536 });
+    let buffer = memory.toResizableBuffer();
+    assertIsolatedResizableBufferOfPageSize(1, buffer, 65536);
+
+    // Growth delta of 65537 pages is not representable as a PageCount.
+    assertThrows(() => buffer.resize(65538 * pageSize), RangeError, "");
+    // The buffer is unchanged and remains usable after the failed resize.
+    assertIsolatedResizableBufferOfPageSize(1, buffer, 65536);
+
+    // A representable delta that would still exceed the declared maximum must
+    // also throw catchably.
+    assertThrows(() => buffer.resize(65537 * pageSize), RangeError, "");
+    assertIsolatedResizableBufferOfPageSize(1, buffer, 65536);
+
+    // A legal resize still works after the failed attempts.
+    buffer.resize(2 * pageSize);
+    assertIsolatedResizableBufferOfPageSize(2, buffer, 65536);
+}
+
 // Now a similar sequence for a shared memory
 
 {

--- a/Source/JavaScriptCore/runtime/JSArrayBufferPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/JSArrayBufferPrototype.cpp
@@ -312,7 +312,7 @@ JSC_DEFINE_HOST_FUNCTION(arrayBufferProtoFuncResize, (JSGlobalObject* globalObje
             return throwVMRangeError(globalObject, scope, makeString("WebAssembly memory cannot be resized to new byte length "_s, newByteLength, " because it is not a multiple of "_s, PageCount::pageSize));
         size_t delta = newByteLength - oldByteLength;
         if (delta) {
-            auto result = jsMemory->memory().grow(vm, PageCount::fromBytes(delta));
+            auto result = jsMemory->memory().grow(vm, PageCount::fromBytesUnchecked(delta));
             if (!result)
                 return throwVMRangeError(globalObject, scope, makeString("ArrayBuffer resize failed with new byte length "_s, newByteLength));
         }

--- a/Source/JavaScriptCore/runtime/PageCount.h
+++ b/Source/JavaScriptCore/runtime/PageCount.h
@@ -74,10 +74,15 @@ public:
 
     static PageCount fromBytes(uint64_t bytes)
     {
+        PageCount count = fromBytesUnchecked(bytes);
+        RELEASE_ASSERT(count.isValid());
+        return count;
+    }
+
+    static PageCount fromBytesUnchecked(uint64_t bytes)
+    {
         RELEASE_ASSERT(bytes % pageSize == 0);
-        uint32_t numPages = bytes / pageSize;
-        RELEASE_ASSERT(PageCount::isValid(numPages));
-        return PageCount(numPages);
+        return PageCount(bytes / pageSize);
     }
 
     static PageCount fromBytesWithRoundUp(uint64_t bytes)


### PR DESCRIPTION
#### 575b7fa2016905586dc82337b53bd04065f094c5
<pre>
[JSC] Wasm-backed resizable ArrayBuffers should throw for all invalid sizes
<a href="https://bugs.webkit.org/show_bug.cgi?id=319705">https://bugs.webkit.org/show_bug.cgi?id=319705</a>
<a href="https://rdar.apple.com/181293951">rdar://181293951</a>

Reviewed by Mark Lam and Yusuke Suzuki.

Resizable ArrayBuffers that are backed by Wasm memories cannot grow beyond
65536 pages.  Currently, we RELEASE_ASSERT when exceeding that max. This PR
fixes it to throw a RangeError instead.

Test: JSTests/wasm/js-api/memory-toResizableBuffer.js:

* JSTests/wasm/js-api/memory-toResizableBuffer.js:
(assertTrue):
* Source/JavaScriptCore/runtime/JSArrayBufferPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/PageCount.h:
(JSC::PageCount::fromBytes):
(JSC::PageCount::fromBytesUnchecked):

Canonical link: <a href="https://commits.webkit.org/317540@main">https://commits.webkit.org/317540@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/774fdc214ed7933126f1f28016a309818508d044

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175349 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49281 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43062 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184935 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/137470 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50573 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48964 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136522 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/137470 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178306 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39927 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157266 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117000 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38569 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36950 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/5775 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148991 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36759 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33410 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/36610 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/40968 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41154 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187359 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48948 "Built successfully") | | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145476 "Found 1 new test failure: compositing/color-matching/image-color-matching.html (failure)") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39195 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49628 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33381 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/bfcache/abort.tentative.https.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145317 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40132 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/121821 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115508 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48134 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11732 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47537 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47767 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47594 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->