### PR TITLE
[WPT] Wheel actions: Follow tick-based event dispatch logic rather than sending scroll events instantaneously

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7083,8 +7083,6 @@ webkit.org/b/261916 media/video-pause-while-seeking.html [ Pass Failure ]
 
 webkit.org/b/263434 imported/w3c/web-platform-tests/uievents/order-of-events/mouse-events/wheel-basic.html [ Skip ]
 
-webkit.org/b/261810 imported/w3c/web-platform-tests/css/css-scroll-snap/input/mouse-wheel.html [ Skip ]
-
 webkit.org/b/237552 imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/same-hash.html [ Pass Failure ]
 
 # scroll-animations timeouts

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/input/mouse-wheel-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/input/mouse-wheel-expected.txt
@@ -1,5 +1,3 @@
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT Wheel-scroll triggers snap to target position immediately. Test timed out
+PASS Wheel-scroll triggers snap to target position without intermediate pause.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/input/snap-area-overflow-boundary-viewport-covering-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/input/snap-area-overflow-boundary-viewport-covering-expected.txt
@@ -2,5 +2,5 @@ Header 1Footer 1
 Header 2Footer 2
 
 FAIL Keyboard scrolling with vertical snap-area overflow assert_equals: End boundary of snap-area is valid snap target expected 79 but got 489
-FAIL Mouse-wheel scrolling with vertical snap-area overflow assert_equals: End boundary of snap-area is valid snap target expected 100 but got 101
+FAIL Mouse-wheel scrolling with vertical snap-area overflow assert_equals: End boundary of snap-area is valid snap target expected 100 but got 0
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/snap-at-user-scroll-end-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/snap-at-user-scroll-end-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Tests that window should snap at user scroll end. assert_approx_equals: window.scrollX should be at snapped position. expected 408 +/- 0.5 but got 508
+PASS Tests that window should snap at user scroll end.
 

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -4496,6 +4496,7 @@ imported/w3c/web-platform-tests/css/css-color/system-color-hightlights-vs-getSel
 webkit.org/b/286131 imported/w3c/web-platform-tests/css/css-transforms/transform-box/cssbox-content-box-002.html [ Pass Crash ImageOnlyFailure ]
 
 imported/w3c/web-platform-tests/css/css-overscroll-behavior/overscroll-behavior.html [ Skip ]
+imported/w3c/web-platform-tests/css/css-scroll-snap/input/mouse-wheel.html [ Skip ]
 imported/w3c/web-platform-tests/css/css-scroll-snap/snap-at-user-scroll-end.html [ Skip ]
 imported/w3c/web-platform-tests/css/css-transforms/scroll-preserve-3d.html [ Skip ]
 imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive [ Skip ]

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -4825,6 +4825,7 @@ imported/w3c/web-platform-tests/css/css-scroll-snap/snap-at-user-scroll-end.html
 imported/w3c/web-platform-tests/css/css-transforms/scroll-preserve-3d.html [ Skip ]
 
 # These tests assume synthesized 'wheel' events.
+imported/w3c/web-platform-tests/css/css-scroll-snap/input/mouse-wheel.html [ Skip ]
 imported/w3c/web-platform-tests/css/css-scroll-snap/overscroll-snap.html [ Skip ]
 imported/w3c/web-platform-tests/css/css-scroll-snap/snap-after-relayout/multiple-aligned-targets/common-to-both-axes-supercedes-first-in-tree-order.html [ Skip ]
 imported/w3c/web-platform-tests/css/css-scroll-snap/snap-after-relayout/multiple-aligned-targets/prefer-common-to-both-axes.html [ Skip ]

--- a/LayoutTests/resources/testdriver-vendor.js
+++ b/LayoutTests/resources/testdriver-vendor.js
@@ -227,14 +227,13 @@ async function dispatchWheelActions(actions)
             await pause(action.duration);
             break;
         case "scroll":
-            // FIXME(261810): Follow tick-based event dispatch logic rather than sending scroll events instantaneously
             // https://w3c.github.io/webdriver/#dfn-perform-a-scroll
             let { x, y, origin, deltaX, deltaY, duration } = action;
             if ((x < 0) || (x > window.innerWidth) || (y < 0) || (y > window.innerHeight))
                 throw new Error('Move target out of bounds');
             if (duration === undefined)
                 duration = computeTickDuration(actions, "wheel");
-
+ 
             const originWindow = origin?.ownerDocument?.defaultView;
             if (originWindow && origin instanceof originWindow.Element) {
                 const bounds = origin.getBoundingClientRect();
@@ -242,26 +241,68 @@ async function dispatchWheelActions(actions)
                 x += bounds.left + (bounds.width / 2.0);
                 y += bounds.top + (bounds.height / 2.0);
             }
-            const scrollEvents = [
-                {
-                    type : "wheel",
-                    viewX : x,
-                    viewY : y,
-                    deltaX : 0,
-                    deltaY : -deltaY,
-                    phase : "began"
-                },
-                {
-                    type : "wheel",
-                    deltaX : -deltaX,
-                    deltaY : 0,
-                    phase : "changed"
-                },
-                {
-                    type : "wheel",
-                    momentumPhase : "ended"
+
+            const eventInterval = 1000. / 60.; // Matches the hardcoded interval in sendEventStream()
+            const eventCount = Math.ceil(duration / eventInterval);
+            const scrollEvents = [];
+
+            if (eventCount === 1 && deltaX && deltaY) {
+                // Special-case single-event cases; separate out the X and Y deltas into different events,
+                // to avoid the axis-locking code from zeroing out one of them.
+                scrollEvents.push({
+                        type : "wheel",
+                        viewX : x,
+                        viewY : y,
+                        deltaX : 0,
+                        deltaY : -deltaY,
+                        phase : "began"
+                    });
+                scrollEvents.push({
+                        type : "wheel",
+                        deltaX : -deltaX,
+                        deltaY : 0,
+                        phase : "changed"
+                    });
+            } else {
+                const perEventDeltaX = Math.floor(deltaX / eventCount);
+                const perEventDeltaY = Math.floor(deltaY / eventCount);
+
+                scrollEvents.push({
+                        type : "wheel",
+                        viewX : x,
+                        viewY : y,
+                        deltaX : -perEventDeltaX,
+                        deltaY : -perEventDeltaY,
+                        phase : "began"
+                    });
+
+                for (let i = 1; i < eventCount; ++i) {
+                    scrollEvents.push({
+                            type : "wheel",
+                            deltaX : -perEventDeltaX,
+                            deltaY : -perEventDeltaY,
+                            phase : "changed"
+                        });
                 }
-            ];
+
+                const remainingDeltaX = deltaX - (eventCount * perEventDeltaX);
+                const remainingDeltaY = deltaY - (eventCount * perEventDeltaY);
+
+                if (remainingDeltaX || remainingDeltaY) {
+                    scrollEvents.push({
+                            type : "wheel",
+                            deltaX : -remainingDeltaX,
+                            deltaY : -remainingDeltaY,
+                            phase : "changed"
+                        });
+                }
+            }
+
+            scrollEvents.push({
+                    type : "wheel",
+                    phase : "ended"
+                });
+
             eventSender.monitorWheelEvents();
             await ensurePresentationUpdate();
             const eventStreamAsString = JSON.stringify({ events: scrollEvents });


### PR DESCRIPTION
#### 3b1deb16fd46634de113e032ec4f07113ff84ed7
<pre>
[WPT] Wheel actions: Follow tick-based event dispatch logic rather than sending scroll events instantaneously
<a href="https://bugs.webkit.org/show_bug.cgi?id=261810">https://bugs.webkit.org/show_bug.cgi?id=261810</a>
<a href="https://rdar.apple.com/115772410">rdar://115772410</a>

Reviewed by Abrar Rahman Protyasha.

The wheel event dispatch code in `testdriver-vendor.js` just sent a single wheel event, instead of following [1].
But the existing code also had a bug, where the last event had `momentumPhase : &quot;ended&quot;` instead of
`phase : &quot;ended&quot;`: that&apos;s wrong here, because we haven&apos;t generated a momentum phase at all, and it prevented
end-of-scroll snapping from happening.

So synthesize a stream of events at 16ms intervals, dividing the delta as described in the spec.

Sending a single event with non-zero deltaX and deltaY broke `pointerevent_touch-action-mouse.html`,
because the wheel handling code does aggressive axis-locking (which zeros out the non-dominant axis),
which is why the old code sent two events in this case; we have to preserve this behavior. This
could also affect the multi-event code path in future.

This fixed `css-scroll-snap/input/mouse-wheel.html` and `snap-at-user-scroll-end.html`, and changed
the output of `snap-area-overflow-boundary-viewport-covering.html` which is broken for other reasons
(webkit.org/b/319715).

[1] <a href="https://w3c.github.io/webdriver/#dfn-perform-a-scroll">https://w3c.github.io/webdriver/#dfn-perform-a-scroll</a>

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/input/mouse-wheel-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/input/snap-area-overflow-boundary-viewport-covering-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/snap-at-user-scroll-end-expected.txt:
* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/resources/testdriver-vendor.js:

Canonical link: <a href="https://commits.webkit.org/317497@main">https://commits.webkit.org/317497@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6a624786da51d97b7611c4d4aaa5c5ca6d6bf94e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175445 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49377 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43158 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185031 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/137590 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/68d9d857-27e5-45f5-b91f-78c24261ae75) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50669 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49060 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136594 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/137590 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2ecced46-05d2-4272-9bc7-0415fc645d7c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178402 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40013 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157351 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117072 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/11a6e62f-23e0-48aa-8e3c-a0522e29b690) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38655 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37038 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149077 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36844 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33506 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41241 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187456 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49044 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/156907 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145559 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39165 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49724 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33467 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145399 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40223 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115636 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48230 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11818 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47633 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47863 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47690 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->