### PR TITLE
REGRESSION (290497@main): [iOS] Adjusting selection handles in Google search field causes page to autoscroll

### DIFF
--- a/LayoutTests/editing/selection/ios/autoscroll-does-not-scroll-main-frame-in-fixed-container-expected.txt
+++ b/LayoutTests/editing/selection/ios/autoscroll-does-not-scroll-main-frame-in-fixed-container-expected.txt
@@ -1,0 +1,12 @@
+
+Verifies that dragging a selection handle inside a text field that lives in a position: fixed container does not autoscroll the main frame. To run manually: scroll to the very bottom of the page, focus the text field pinned to the top, select a word, then drag a selection handle up to the top edge of the viewport and hold. The page should stay put.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS offsetBefore > 0 is true
+PASS verticalMovement <= 1 is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/editing/selection/ios/autoscroll-does-not-scroll-main-frame-in-fixed-container.html
+++ b/LayoutTests/editing/selection/ios/autoscroll-does-not-scroll-main-frame-in-fixed-container.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="../../../resources/js-test.js"></script>
+<script src="../../../resources/ui-helper.js"></script>
+<style>
+body, html {
+    margin: 0;
+}
+
+#bar {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    padding: 8px;
+    box-sizing: border-box;
+    background: silver;
+}
+
+#field {
+    font-size: 24px;
+    width: 90%;
+}
+
+#spacer {
+    height: 5000px;
+}
+</style>
+<script>
+jsTestIsAsync = true;
+
+addEventListener("load", async () => {
+    description(`Verifies that dragging a selection handle inside a text field that lives in a
+        position: fixed container does not autoscroll the main frame. To run manually: scroll to the
+        very bottom of the page, focus the text field pinned to the top, select a word, then drag a
+        selection handle up to the top edge of the viewport and hold. The page should stay put.`);
+
+    const field = document.getElementById("field");
+    await UIHelper.activateElement(field);
+
+    window.scrollBy(0, document.documentElement.scrollHeight);
+    await UIHelper.ensurePresentationUpdate();
+
+    field.select();
+    await UIHelper.waitForSelectionToAppear();
+
+    offsetBefore = pageYOffset;
+    shouldBeTrue("offsetBefore > 0");
+
+    const grabber = UIHelper.midPointOfRect(await UIHelper.getSelectionStartGrabberViewRect());
+    await UIHelper.sendEventStream(new UIHelper.EventStreamBuilder()
+        .begin(grabber.x, grabber.y)
+        .wait(0.25)
+        .move(grabber.x + 100, grabber.y, 0.75)
+        .end()
+        .wait(0.5)
+        .takeResult());
+
+    offsetAfter = pageYOffset;
+    verticalMovement = Math.abs(offsetAfter - offsetBefore);
+    shouldBeTrue("verticalMovement <= 1");
+    finishJSTest();
+});
+</script>
+</head>
+<body>
+    <div id="bar"><input inputmode="none" id="field" value="Hello world"></div>
+    <div id="spacer"></div>
+    <p id="description"></p>
+    <p id="console"></p>
+</body>
+</html>

--- a/Source/WebCore/page/AutoscrollController.cpp
+++ b/Source/WebCore/page/AutoscrollController.cpp
@@ -73,19 +73,35 @@ bool AutoscrollController::autoscrollInProgress() const
     return m_autoscrollType == AutoscrollType::Selection;
 }
 
-void AutoscrollController::startAutoscrollForSelection(RenderObject* renderer)
+bool AutoscrollController::startAutoscrollForSelection(RenderObject* renderer)
 {
     // We don't want to trigger the autoscroll or the panScroll if it's already active
     if (m_autoscrollTimer.isActive())
-        return;
+        return true;
+
     CheckedPtr scrollable = RenderBox::findAutoscrollable(renderer);
     if (!scrollable)
         scrollable = renderer->isRenderListBox() ? downcast<RenderListBox>(renderer) : nullptr;
+
     if (!scrollable)
-        return;
+        return false;
+
+    auto rendererIsInsideFixedPosition = [renderer] ALWAYS_INLINE_LAMBDA {
+        if (!renderer)
+            return false;
+
+        bool isInFixed = false;
+        renderer->localToAbsolute({ }, { }, &isInFixed);
+        return isInFixed;
+    };
+
+    if (is<RenderView>(*scrollable) && scrollable->frame().isMainFrame() && rendererIsInsideFixedPosition())
+        return false;
+
     m_autoscrollType = AutoscrollType::Selection;
     m_autoscrollRenderer = WeakPtr { *scrollable };
     startAutoscrollTimer();
+    return true;
 }
 
 void AutoscrollController::stopAutoscrollTimer(bool rendererIsBeingDestroyed)

--- a/Source/WebCore/page/AutoscrollController.h
+++ b/Source/WebCore/page/AutoscrollController.h
@@ -77,7 +77,7 @@ public:
     RenderBox* NODELETE autoscrollRenderer() const;
     bool NODELETE autoscrollInProgress() const;
     bool NODELETE panScrollInProgress() const;
-    void startAutoscrollForSelection(RenderObject*);
+    bool startAutoscrollForSelection(RenderObject*);
     void stopAutoscrollTimer(bool rendererIsBeingDestroyed = false);
     void updateAutoscrollRenderer();
     void updateDragAndDrop(Node* targetNode, const IntPoint& eventPosition, MonotonicTime eventTime);

--- a/Source/WebCore/page/EventHandler.h
+++ b/Source/WebCore/page/EventHandler.h
@@ -395,7 +395,7 @@ public:
 #endif
     
 #if PLATFORM(COCOA)
-    WEBCORE_EXPORT void startSelectionAutoscroll(RenderObject* renderer, const FloatPoint& positionInWindow);
+    WEBCORE_EXPORT bool startSelectionAutoscroll(RenderObject* renderer, const FloatPoint& positionInWindow);
     WEBCORE_EXPORT void cancelSelectionAutoscroll();
 #endif
 

--- a/Source/WebCore/page/cocoa/EventHandlerCocoa.mm
+++ b/Source/WebCore/page/cocoa/EventHandlerCocoa.mm
@@ -79,12 +79,12 @@ void EventHandler::dispatchSyntheticMouseMove(const PlatformMouseEvent& platform
 
 #endif // ENABLE(TWO_PHASE_CLICKS)
 
-void EventHandler::startSelectionAutoscroll(RenderObject* renderer, const FloatPoint& positionInWindow)
+bool EventHandler::startSelectionAutoscroll(RenderObject* renderer, const FloatPoint& positionInWindow)
 {
     Ref frame = m_frame.get();
     RefPtr frameView = frame->view();
     if (!frameView)
-        return;
+        return false;
 
     m_targetAutoscrollPositionInRootView = roundedIntPoint(positionInWindow);
 
@@ -95,8 +95,8 @@ void EventHandler::startSelectionAutoscroll(RenderObject* renderer, const FloatP
         m_initialAutoscrollPositionInUnscrolledRootView = m_targetAutoscrollPositionInUnscrolledRootView;
 #endif // PLATFORM(IOS_FAMILY)
 
-    m_isAutoscrolling = true;
-    m_autoscrollController->startAutoscrollForSelection(renderer);
+    m_isAutoscrolling = m_autoscrollController->startAutoscrollForSelection(renderer);
+    return m_isAutoscrolling;
 }
 
 void EventHandler::cancelSelectionAutoscroll()

--- a/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
@@ -2246,13 +2246,21 @@ void WebPageProxy::updateSelectionWithExtentPointAndBoundary(WebCore::IntPoint p
 
 void WebPageProxy::startAutoscrollAtPosition(const WebCore::FloatPoint& positionInWindow)
 {
-    m_isAutoscrolling = true;
-    protect(m_legacyMainFrameProcess)->send(Messages::WebPage::StartAutoscrollAtPosition(positionInWindow), webPageIDInMainFrameProcess());
+    if (m_autoscrollState == AutoscrollState::Inactive)
+        m_autoscrollState = AutoscrollState::Pending;
+
+    protect(m_legacyMainFrameProcess)->sendWithAsyncReply(Messages::WebPage::StartAutoscrollAtPosition(positionInWindow), [weakThis = WeakPtr { *this }](bool didStartAutoscrolling) {
+        RefPtr protectedThis = weakThis.get();
+        if (!protectedThis || protectedThis->m_autoscrollState == AutoscrollState::Inactive)
+            return;
+
+        protectedThis->m_autoscrollState = didStartAutoscrolling ? AutoscrollState::Active : AutoscrollState::Inactive;
+    }, webPageIDInMainFrameProcess());
 }
 
 void WebPageProxy::cancelAutoscroll()
 {
-    m_isAutoscrolling = false;
+    m_autoscrollState = AutoscrollState::Inactive;
     protect(m_legacyMainFrameProcess)->send(Messages::WebPage::CancelAutoscroll(), webPageIDInMainFrameProcess());
 }
 

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1331,7 +1331,7 @@ public:
 
     void startAutoscrollAtPosition(const WebCore::FloatPoint& positionInWindow);
     void cancelAutoscroll();
-    bool isAutoscrolling() const { return m_isAutoscrolling; }
+    bool isAutoscrolling() const { return m_autoscrollState == AutoscrollState::Active; }
 #endif
 
 #if ENABLE(DATA_DETECTION)
@@ -3858,7 +3858,8 @@ private:
 #endif
 
 #if PLATFORM(COCOA)
-    bool m_isAutoscrolling { false };
+    enum class AutoscrollState : uint8_t { Inactive, Pending, Active };
+    AutoscrollState m_autoscrollState { AutoscrollState::Inactive };
 #endif
 
     bool m_isTakingSnapshotsForApplicationSuspension { false };

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -2938,14 +2938,17 @@ RenderObject* WebPage::rendererForSelectionAutoscroll(LocalFrame& frame) const
     return range->start.container->renderer();
 }
 
-void WebPage::startAutoscrollAtPosition(const WebCore::FloatPoint& positionInWindow)
+void WebPage::startAutoscrollAtPosition(const WebCore::FloatPoint& positionInWindow, CompletionHandler<void(bool)>&& completionHandler)
 {
     RefPtr frame = m_page->focusController().focusedOrMainFrame();
     if (!frame)
-        return;
+        return completionHandler(false);
 
-    if (CheckedPtr renderer = rendererForSelectionAutoscroll(*frame))
-        frame->eventHandler().startSelectionAutoscroll(renderer.get(), positionInWindow);
+    CheckedPtr renderer = rendererForSelectionAutoscroll(*frame);
+    if (!renderer)
+        return completionHandler(false);
+
+    completionHandler(frame->eventHandler().startSelectionAutoscroll(renderer.get(), positionInWindow));
 }
 
 void WebPage::cancelAutoscroll()

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1242,7 +1242,7 @@ public:
 
 #if PLATFORM(COCOA)
     WebCore::RenderObject* rendererForSelectionAutoscroll(WebCore::LocalFrame&) const;
-    void startAutoscrollAtPosition(const WebCore::FloatPoint&);
+    void startAutoscrollAtPosition(const WebCore::FloatPoint&, CompletionHandler<void(bool)>&&);
     void cancelAutoscroll();
 #endif
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -163,7 +163,7 @@ messages -> WebPage WantsAsyncDispatchMessage {
 #endif
 
 #if PLATFORM(COCOA)
-    StartAutoscrollAtPosition(WebCore::FloatPoint positionInWindow)
+    StartAutoscrollAtPosition(WebCore::FloatPoint positionInWindow) -> (bool didStartAutoscrolling)
     CancelAutoscroll()
 #endif
 


### PR DESCRIPTION
#### 16a8a13f3916c670aebb3e3f4367f07234d25051
<pre>
REGRESSION (290497@main): [iOS] Adjusting selection handles in Google search field causes page to autoscroll
<a href="https://bugs.webkit.org/show_bug.cgi?id=319722">https://bugs.webkit.org/show_bug.cgi?id=319722</a>
<a href="https://rdar.apple.com/181954850">rdar://181954850</a>

Reviewed by Abrar Rahman Protyasha.

On Google search results on iPhone and iPad, the search field is fixed to the top of the page.
Selecting text in it and then dragging a selection handle causes the main frame to autoscroll on
its own because the fixed field stays in place while the page scrolls underneath it.

290497@main made selection autoscroll engage as soon as the drag point is close to the viewport
edge, dropping the earlier requirement that the drag first move toward the edge. A field fixed to
the top of the page is always inside the top edge band, so merely adjusting its selection now starts
a main-frame autoscroll.

Scrolling the main frame can never reveal more of a fixed-position container, so autoscrolling it
for such a selection serves no purpose. Rather than restore the drag-distance requirement (which
would undo the scrolling smoothness 290497@main added), don&apos;t start main-frame selection autoscroll
when the selection is anchored inside a fixed-position container; a scrollable subframe nested
within it may still autoscroll, since scrolling it can reveal more content.

AutoscrollController::startAutoscrollForSelection now reports whether it actually started
autoscrolling, and the UI process marks itself autoscrolling only once the web process confirms it
did.

Test: editing/selection/ios/autoscroll-does-not-scroll-main-frame-in-fixed-container.html

* LayoutTests/editing/selection/ios/autoscroll-does-not-scroll-main-frame-in-fixed-container-expected.txt: Added.
* LayoutTests/editing/selection/ios/autoscroll-does-not-scroll-main-frame-in-fixed-container.html: Added.
* Source/WebCore/page/AutoscrollController.cpp:
(WebCore::AutoscrollController::startAutoscrollForSelection):
* Source/WebCore/page/AutoscrollController.h:
* Source/WebCore/page/EventHandler.h:
* Source/WebCore/page/cocoa/EventHandlerCocoa.mm:
(WebCore::EventHandler::startSelectionAutoscroll):

Make this return whether or not autoscrolling started, and bubble that result back into the WebKit
client layer (as well as through the IPC reply to `StartAutoscrollAtPosition`). This returns `false`
in the case where the selection is inside a fixed-position renderer, and the mainframe is the
autoscrolled renderer.

* Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm:
(WebKit::WebPageProxy::startAutoscrollAtPosition):
(WebKit::WebPageProxy::cancelAutoscroll):
* Source/WebKit/UIProcess/WebPageProxy.h:

Turn `m_isAutoscrolling` into a tri-state enum, since the value is now set asynchronously. In the
case where we start and then immediately stop autoscrolling before the IPC reply for autoscroll
start is received, we won&apos;t end up permanently stuck in autoscrolling state.

* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::startAutoscrollAtPosition):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:

Canonical link: <a href="https://commits.webkit.org/317473@main">https://commits.webkit.org/317473@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d37246bbf68290f6e23a70937035a77ca01c5375

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175381 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49313 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43094 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184967 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/137507 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/49b67730-def0-4ffd-9e22-e9959ea7f547) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/177245 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50605 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48996 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136535 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/137507 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178338 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39952 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157293 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117013 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/27b695a5-1720-4d64-9a75-f4ee38828765) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38594 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36979 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149016 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36786 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33442 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41000 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41183 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187392 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48980 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/156849 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145500 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39150 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49660 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33408 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145341 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40159 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/121853 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115547 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48166 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11759 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47569 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47799 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47626 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->