### PR TITLE
[TestWebKitAPI] Add Production build configuration

### DIFF
--- a/.submitproject-tools
+++ b/.submitproject-tools
@@ -5,5 +5,6 @@
     includedSubdirectoryPatterns = Tools/ImageDiff
     includedSubdirectoryPatterns = Tools/MiniBrowser
     includedSubdirectoryPatterns = Tools/TestRunnerShared
+    includedSubdirectoryPatterns = Tools/TestWebKitAPI
     includedSubdirectoryPatterns = Tools/WebKitTestRunner
     excludedSubdirectoryPatterns = Tools/WebKitTestRunner/gtk

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -180,11 +180,6 @@
 			);
 			script = (
 				"\"${SCRIPT_INPUT_FILE_0}\"",
-				"",
-				"",
-				"",
-				"",
-				"",
 			);
 		};
 /* End PBXBuildRule section */
@@ -2700,6 +2695,143 @@
 			};
 			name = Release;
 		};
+		441828632F97C67700CEC637 /* Production configuration for PBXProject "TestWebKitAPI" */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReferenceAnchor = 07C907E72F820957003A09D8 /* Configurations */;
+			baseConfigurationReferenceRelativePath = Base.xcconfig;
+			buildSettings = {
+			};
+			name = Production;
+		};
+		441828642F97C67700CEC637 /* Production configuration for PBXAggregateTarget "All" */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Production;
+		};
+		441828652F97C67700CEC637 /* Production configuration for PBXAggregateTarget "Derived Sources" */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Production;
+		};
+		441828662F97C67700CEC637 /* Production configuration for PBXAggregateTarget "Generate Unified Sources" */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Production;
+		};
+		441828672F97C67700CEC637 /* Production configuration for PBXNativeTarget "TestWebKitAPILibrary" */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReferenceAnchor = 07C907E72F820957003A09D8 /* Configurations */;
+			baseConfigurationReferenceRelativePath = TestWebKitAPILibrary.xcconfig;
+			buildSettings = {
+			};
+			name = Production;
+		};
+		441828682F97C67700CEC637 /* Production configuration for PBXNativeTarget "TestWTFLibrary" */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReferenceAnchor = 07C907E72F820957003A09D8 /* Configurations */;
+			baseConfigurationReferenceRelativePath = TestWTFLibrary.xcconfig;
+			buildSettings = {
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Tests/WTF/darwin",
+				);
+			};
+			name = Production;
+		};
+		441828692F97C67700CEC637 /* Production configuration for PBXNativeTarget "TestIPC" */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReferenceAnchor = 07C907E72F820957003A09D8 /* Configurations */;
+			baseConfigurationReferenceRelativePath = TestIPC.xcconfig;
+			buildSettings = {
+			};
+			name = Production;
+		};
+		4418286A2F97C67700CEC637 /* Production configuration for PBXNativeTarget "TestWebKitAPI" */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReferenceAnchor = 07C907E72F820957003A09D8 /* Configurations */;
+			baseConfigurationReferenceRelativePath = TestWebKitAPI.xcconfig;
+			buildSettings = {
+			};
+			name = Production;
+		};
+		4418286B2F97C67700CEC637 /* Production configuration for PBXNativeTarget "TestWebKitAPIApp" */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReferenceAnchor = 07C907E72F820957003A09D8 /* Configurations */;
+			baseConfigurationReferenceRelativePath = TestWebKitAPIApp.xcconfig;
+			buildSettings = {
+			};
+			name = Production;
+		};
+		4418286C2F97C67700CEC637 /* Production configuration for PBXNativeTarget "TestWebKitAPIBundle" */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReferenceAnchor = 07C907E72F820957003A09D8 /* Configurations */;
+			baseConfigurationReferenceRelativePath = TestWebKitAPIBundle.xcconfig;
+			buildSettings = {
+			};
+			name = Production;
+		};
+		4418286D2F97C67700CEC637 /* Production configuration for PBXNativeTarget "TestWebKitAPIResources" */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReferenceAnchor = 07C907E72F820957003A09D8 /* Configurations */;
+			baseConfigurationReferenceRelativePath = TestWebKitAPIResources.xcconfig;
+			buildSettings = {
+			};
+			name = Production;
+		};
+		4418286E2F97C67700CEC637 /* Production configuration for PBXNativeTarget "TestWGSL" */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReferenceAnchor = 07C907E72F820957003A09D8 /* Configurations */;
+			baseConfigurationReferenceRelativePath = TestWGSL.xcconfig;
+			buildSettings = {
+			};
+			name = Production;
+		};
+		4418286F2F97C67700CEC637 /* Production configuration for PBXNativeTarget "TestWTF" */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReferenceAnchor = 07C907E72F820957003A09D8 /* Configurations */;
+			baseConfigurationReferenceRelativePath = TestWTF.xcconfig;
+			buildSettings = {
+			};
+			name = Production;
+		};
+		441828702F97C67700CEC637 /* Production configuration for PBXNativeTarget "InjectedBundleTestWebKitAPI" */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReferenceAnchor = 07C907E72F820957003A09D8 /* Configurations */;
+			baseConfigurationReferenceRelativePath = InjectedBundle.xcconfig;
+			buildSettings = {
+			};
+			name = Production;
+		};
+		441828712F97C67700CEC637 /* Production configuration for PBXNativeTarget "WebProcessPlugIn" */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReferenceAnchor = 07C907E72F820957003A09D8 /* Configurations */;
+			baseConfigurationReferenceRelativePath = WebProcessPlugIn.xcconfig;
+			buildSettings = {
+			};
+			name = Production;
+		};
+		441828722F97C67700CEC637 /* Production configuration for PBXAggregateTarget "Apply Configuration to XCFileLists" */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Production;
+		};
+		44F8AAC9300AF10C00FF922E /* Production configuration for PBXAggregateTarget "Testing.framework Overlays" */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				PRODUCT_NAME = "Testing.framework Overlays";
+			};
+			name = Production;
+		};
 		537CF84422EFD64100C6EBB3 /* Debug configuration for PBXAggregateTarget "Apply Configuration to XCFileLists" */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -2904,136 +3036,153 @@
 			buildConfigurations = (
 				0723A74A2F80357300CB96E7 /* Debug configuration for PBXAggregateTarget "Derived Sources" */,
 				0723A74B2F80357300CB96E7 /* Release configuration for PBXAggregateTarget "Derived Sources" */,
+				441828652F97C67700CEC637 /* Production configuration for PBXAggregateTarget "Derived Sources" */,
 			);
-			defaultConfigurationName = Release;
+			defaultConfigurationName = Production;
 		};
 		07A11A5702F9C0FE00000002 /* Build configuration list for PBXAggregateTarget "Testing.framework Overlays" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				07A11A5702F9C0FE00000003 /* Debug configuration for PBXAggregateTarget "Testing.framework Overlays" */,
 				07A11A5702F9C0FE00000004 /* Release configuration for PBXAggregateTarget "Testing.framework Overlays" */,
+				44F8AAC9300AF10C00FF922E /* Production configuration for PBXAggregateTarget "Testing.framework Overlays" */,
 			);
-			defaultConfigurationName = Release;
+			defaultConfigurationName = Production;
 		};
 		1DEB927408733DD40010E9CD /* Build configuration list for PBXNativeTarget "TestWebKitAPI" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				1DEB927508733DD40010E9CD /* Debug configuration for PBXNativeTarget "TestWebKitAPI" */,
 				1DEB927608733DD40010E9CD /* Release configuration for PBXNativeTarget "TestWebKitAPI" */,
+				4418286A2F97C67700CEC637 /* Production configuration for PBXNativeTarget "TestWebKitAPI" */,
 			);
-			defaultConfigurationName = Release;
+			defaultConfigurationName = Production;
 		};
 		1DEB927808733DD40010E9CD /* Build configuration list for PBXProject "TestWebKitAPI" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				1DEB927908733DD40010E9CD /* Debug configuration for PBXProject "TestWebKitAPI" */,
 				1DEB927A08733DD40010E9CD /* Release configuration for PBXProject "TestWebKitAPI" */,
+				441828632F97C67700CEC637 /* Production configuration for PBXProject "TestWebKitAPI" */,
 			);
-			defaultConfigurationName = Release;
+			defaultConfigurationName = Production;
 		};
 		3A15785028D1505B00142DB1 /* Build configuration list for PBXNativeTarget "TestWGSL" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				3A15785128D1505B00142DB1 /* Debug configuration for PBXNativeTarget "TestWGSL" */,
 				3A15785228D1505B00142DB1 /* Release configuration for PBXNativeTarget "TestWGSL" */,
+				4418286E2F97C67700CEC637 /* Production configuration for PBXNativeTarget "TestWGSL" */,
 			);
-			defaultConfigurationName = Release;
+			defaultConfigurationName = Production;
 		};
 		537CF84622EFD64100C6EBB3 /* Build configuration list for PBXAggregateTarget "Apply Configuration to XCFileLists" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				537CF84422EFD64100C6EBB3 /* Debug configuration for PBXAggregateTarget "Apply Configuration to XCFileLists" */,
 				537CF84522EFD64100C6EBB3 /* Release configuration for PBXAggregateTarget "Apply Configuration to XCFileLists" */,
+				441828722F97C67700CEC637 /* Production configuration for PBXAggregateTarget "Apply Configuration to XCFileLists" */,
 			);
-			defaultConfigurationName = Release;
+			defaultConfigurationName = Production;
 		};
 		5C9D921922D7DA02008E9266 /* Build configuration list for PBXAggregateTarget "Generate Unified Sources" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				5C9D921A22D7DA02008E9266 /* Debug configuration for PBXAggregateTarget "Generate Unified Sources" */,
 				5C9D921B22D7DA02008E9266 /* Release configuration for PBXAggregateTarget "Generate Unified Sources" */,
+				441828662F97C67700CEC637 /* Production configuration for PBXAggregateTarget "Generate Unified Sources" */,
 			);
-			defaultConfigurationName = Release;
+			defaultConfigurationName = Production;
 		};
 		7B9FC57B28A26137007570E7 /* Build configuration list for PBXNativeTarget "TestIPC" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				7B9FC57C28A26137007570E7 /* Debug configuration for PBXNativeTarget "TestIPC" */,
 				7B9FC57D28A26137007570E7 /* Release configuration for PBXNativeTarget "TestIPC" */,
+				441828692F97C67700CEC637 /* Production configuration for PBXNativeTarget "TestIPC" */,
 			);
-			defaultConfigurationName = Release;
+			defaultConfigurationName = Production;
 		};
 		7C83DF651D0A590C00FEBCF3 /* Build configuration list for PBXNativeTarget "TestWTFLibrary" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				7C83DF661D0A590C00FEBCF3 /* Debug configuration for PBXNativeTarget "TestWTFLibrary" */,
 				7C83DF671D0A590C00FEBCF3 /* Release configuration for PBXNativeTarget "TestWTFLibrary" */,
+				441828682F97C67700CEC637 /* Production configuration for PBXNativeTarget "TestWTFLibrary" */,
 			);
-			defaultConfigurationName = Release;
+			defaultConfigurationName = Production;
 		};
 		7C83E0201D0A5AE400FEBCF3 /* Build configuration list for PBXNativeTarget "TestWTF" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				7C83E0211D0A5AE400FEBCF3 /* Debug configuration for PBXNativeTarget "TestWTF" */,
 				7C83E0221D0A5AE400FEBCF3 /* Release configuration for PBXNativeTarget "TestWTF" */,
+				4418286F2F97C67700CEC637 /* Production configuration for PBXNativeTarget "TestWTF" */,
 			);
-			defaultConfigurationName = Release;
+			defaultConfigurationName = Production;
 		};
 		7C83E02C1D0A5E1000FEBCF3 /* Build configuration list for PBXAggregateTarget "All" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				7C83E02D1D0A5E1000FEBCF3 /* Debug configuration for PBXAggregateTarget "All" */,
 				7C83E02E1D0A5E1000FEBCF3 /* Release configuration for PBXAggregateTarget "All" */,
+				441828642F97C67700CEC637 /* Production configuration for PBXAggregateTarget "All" */,
 			);
-			defaultConfigurationName = Release;
+			defaultConfigurationName = Production;
 		};
 		7CCE7EA11A41144E00447C4C /* Build configuration list for PBXNativeTarget "TestWebKitAPILibrary" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				7CCE7E9D1A41144E00447C4C /* Debug configuration for PBXNativeTarget "TestWebKitAPILibrary" */,
 				7CCE7E9E1A41144E00447C4C /* Release configuration for PBXNativeTarget "TestWebKitAPILibrary" */,
+				441828672F97C67700CEC637 /* Production configuration for PBXNativeTarget "TestWebKitAPILibrary" */,
 			);
-			defaultConfigurationName = Release;
+			defaultConfigurationName = Production;
 		};
 		A13EBB4C1B87339E00097110 /* Build configuration list for PBXNativeTarget "WebProcessPlugIn" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				A13EBB4D1B87339E00097110 /* Debug configuration for PBXNativeTarget "WebProcessPlugIn" */,
 				A13EBB4E1B87339E00097110 /* Release configuration for PBXNativeTarget "WebProcessPlugIn" */,
+				441828712F97C67700CEC637 /* Production configuration for PBXNativeTarget "WebProcessPlugIn" */,
 			);
-			defaultConfigurationName = Release;
+			defaultConfigurationName = Production;
 		};
 		A17C46472C98E3440023F3C7 /* Build configuration list for PBXNativeTarget "TestWebKitAPIResources" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				A17C46482C98E3440023F3C7 /* Debug configuration for PBXNativeTarget "TestWebKitAPIResources" */,
 				A17C46492C98E3440023F3C7 /* Release configuration for PBXNativeTarget "TestWebKitAPIResources" */,
+				4418286D2F97C67700CEC637 /* Production configuration for PBXNativeTarget "TestWebKitAPIResources" */,
 			);
-			defaultConfigurationName = Release;
+			defaultConfigurationName = Production;
 		};
 		A17C58212C9AA132009DD0B5 /* Build configuration list for PBXNativeTarget "TestWebKitAPIApp" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				A17C58182C9AA132009DD0B5 /* Debug configuration for PBXNativeTarget "TestWebKitAPIApp" */,
 				A17C58192C9AA132009DD0B5 /* Release configuration for PBXNativeTarget "TestWebKitAPIApp" */,
+				4418286B2F97C67700CEC637 /* Production configuration for PBXNativeTarget "TestWebKitAPIApp" */,
 			);
-			defaultConfigurationName = Release;
+			defaultConfigurationName = Production;
 		};
 		A17C583D2C9B3EAE009DD0B5 /* Build configuration list for PBXNativeTarget "TestWebKitAPIBundle" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				A17C58342C9B3EAE009DD0B5 /* Debug configuration for PBXNativeTarget "TestWebKitAPIBundle" */,
 				A17C58352C9B3EAE009DD0B5 /* Release configuration for PBXNativeTarget "TestWebKitAPIBundle" */,
+				4418286C2F97C67700CEC637 /* Production configuration for PBXNativeTarget "TestWebKitAPIBundle" */,
 			);
-			defaultConfigurationName = Release;
+			defaultConfigurationName = Production;
 		};
 		BC575986126E74AF006F0F12 /* Build configuration list for PBXNativeTarget "InjectedBundleTestWebKitAPI" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				BC575984126E74AF006F0F12 /* Debug configuration for PBXNativeTarget "InjectedBundleTestWebKitAPI" */,
 				BC575985126E74AF006F0F12 /* Release configuration for PBXNativeTarget "InjectedBundleTestWebKitAPI" */,
+				441828702F97C67700CEC637 /* Production configuration for PBXNativeTarget "InjectedBundleTestWebKitAPI" */,
 			);
-			defaultConfigurationName = Release;
+			defaultConfigurationName = Production;
 		};
 /* End XCConfigurationList section */
 	};


### PR DESCRIPTION
#### e0ee95bcafc0c470dfce6db7cfd8ce708c6e9e5e
<pre>
[TestWebKitAPI] Add Production build configuration
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=319723">https://bugs.webkit.org/show_bug.cgi?id=319723</a>&gt;
&lt;<a href="https://rdar.apple.com/182557522">rdar://182557522</a>&gt;

Reviewed by Alex Christensen.

Add a Production build configuration to the TestWebKitAPI Xcode
project, matching WebKitTestRunner, gtest, and gmock.

Set Production as the default configuration so Production builds use it
instead of Release.  This avoids loading `DebugRelease.xcconfig`, which
includes `ccache.xcconfig` (a file absent from the Production sandbox),
and resolves `WTF_BUILD_SCRIPTS_DIR` to the SDK path rather than the
empty `BUILT_PRODUCTS_DIR` engineering path.

Also remove the stray empty strings that Xcode accumulated in the
install-extensions `PBXBuildRule` script array in the same project
file.

No new tests since this change is not directly testable.

* .submitproject-tools:
- Add TestWebKitAPI sources for tools submissions.
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
- Add Production build configurations.

Canonical link: <a href="https://commits.webkit.org/317469@main">https://commits.webkit.org/317469@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/de6ccd7d6dee2b4eb20c22d79f8f076b712a40e6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175380 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49312 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43093 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184966 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/137506 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2e46b985-3e52-4c11-beae-c27b2bb02156) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/177244 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50604 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48995 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136534 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/137506 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ec805c6d-631d-4613-8956-c28e1cd4ff06) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178337 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39953 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157291 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117012 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/43bb444a-22ea-4e3d-9711-a1445c22c491) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38595 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36978 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149017 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36784 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33441 "Built successfully") | | 
| | | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41182 "Found 1 new test failure: http/tests/workers/service/service-worker-download-task-uaf.https.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187391 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48979 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145499 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49659 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33406 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145340 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26666 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40154 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115546 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48165 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11757 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47568 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47798 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47625 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->