### PR TITLE
Add a touch-action double-tap-to-zoom policy predicate

### DIFF
--- a/Source/WebCore/platform/TouchAction.h
+++ b/Source/WebCore/platform/TouchAction.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <wtf/OptionSet.h>
 #include <wtf/text/TextStream.h>
 
 namespace WebCore {
@@ -37,6 +38,12 @@ enum class TouchAction : uint8_t {
     PanY         = 1 << 4,
     PinchZoom    = 1 << 5,
 };
+
+// https://www.w3.org/TR/pointerevents/#dfn-touch-action-values
+inline bool touchActionAllowsDoubleTapToZoom(OptionSet<TouchAction> touchActions)
+{
+    return !touchActions.containsAny({ TouchAction::None, TouchAction::Manipulation });
+}
 
 WEBCORE_EXPORT TextStream& operator<<(TextStream&, TouchAction);
 

--- a/Source/WebKit/UIProcess/ios/WKTouchActionGestureRecognizer.mm
+++ b/Source/WebKit/UIProcess/ios/WKTouchActionGestureRecognizer.mm
@@ -115,7 +115,7 @@
             if (mayPinchToZoom && !iterator->value.containsAny({ WebCore::TouchAction::PinchZoom, WebCore::TouchAction::Manipulation }))
                 return YES;
             // Double-tap-to-zoom is disallowed if "none" or "manipulation" is specified.
-            if (mayDoubleTapToZoom && iterator->value.containsAny({ WebCore::TouchAction::None, WebCore::TouchAction::Manipulation }))
+            if (mayDoubleTapToZoom && !WebCore::touchActionAllowsDoubleTapToZoom(iterator->value))
                 return YES;
         }
     }


### PR DESCRIPTION
#### 1448205ae3fa7c6ff3d6bb6379288cd230c8cd72
<pre>
Add a touch-action double-tap-to-zoom policy predicate
<a href="https://bugs.webkit.org/show_bug.cgi?id=319730">https://bugs.webkit.org/show_bug.cgi?id=319730</a>
<a href="https://rdar.apple.com/182562045">rdar://182562045</a>

Reviewed by Richard Robinson.

The CSS `touch-action` rule that double-tap-to-zoom-like gestures are
disabled by both `none` and `manipulation` can be shared by multiple
readers.

In this patch, we make it a single inline predicate, and we adopt it in
WKTouchActionGestureRecognizer. More callers will follow.

* Source/WebCore/platform/TouchAction.h:
(WebCore::touchActionAllowsDoubleTapToZoom):
* Source/WebKit/UIProcess/ios/WKTouchActionGestureRecognizer.mm:
(-[WKTouchActionGestureRecognizer canPreventGestureRecognizer:]):

Canonical link: <a href="https://commits.webkit.org/317451@main">https://commits.webkit.org/317451@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/baa076ab47a496a684bdd5b55bc2eb4f974716f9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175383 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49315 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43096 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184969 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/137509 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6d5f1a0c-2dc3-4691-a3b3-7e7568bbec34) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/177247 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50607 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48998 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136539 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/137509 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1de492fc-4113-478c-96c2-b1f2627c1876) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178340 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39956 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/157296 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117017 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fe542a12-ce7a-4606-aadc-5b0fb34bfff9) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/38598 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/36982 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/149020 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36789 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33444 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/41002 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/41186 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187394 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48982 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145504 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49662 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/33411 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145345 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26655 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40161 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/121855 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115550 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48168 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11762 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47571 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47801 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47628 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->