### PR TITLE
REGRESSION (317433@main): Build failure: AVOutputDeviceTypeCustomProtocol is only available on macOS 27.0 or newer

### DIFF
--- a/Source/WebCore/platform/graphics/avfoundation/MediaPlaybackTargetCocoa.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/MediaPlaybackTargetCocoa.mm
@@ -81,8 +81,10 @@ bool MediaPlaybackTargetCocoa::hasActiveRoute() const
 bool MediaPlaybackTargetCocoa::supportsCustomProtocolVideoPlayback() const
 {
     for (AVOutputDevice *outputDevice in [m_outputContext outputDevices]) {
+ALLOW_NEW_API_WITHOUT_GUARDS_BEGIN
         if (outputDevice.deviceType == AVOutputDeviceTypeCustomProtocol && outputDevice.deviceFeatures & AVOutputDeviceFeatureVideo)
             return true;
+ALLOW_NEW_API_WITHOUT_GUARDS_END
     }
 
     return false;


### PR DESCRIPTION
#### d8474d43be34f4568b8cfc5ce3895ff20ac8e1fe
<pre>
REGRESSION (317433@main): Build failure: AVOutputDeviceTypeCustomProtocol is only available on macOS 27.0 or newer
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=319732">https://bugs.webkit.org/show_bug.cgi?id=319732</a>&gt;
&lt;<a href="https://rdar.apple.com/182570316">rdar://182570316</a>&gt;

Unreviewed build fix.

Fix the `-Wunguarded-availability-new` error introduced by 317433@main.
The AVRouting SDK annotates the `AVOutputDeviceType` enumerator
`AVOutputDeviceTypeCustomProtocol` as `SPI_AVAILABLE(macos(27.0),
ios(27.0), tvos(27.0), watchos(27.0), visionos(27.0))`, so referencing
it in `supportsCustomProtocolVideoPlayback()` fails to build for
deployment targets earlier than 27.0.

Suppress the availability warning rather than adding a runtime
`@available` guard.  The enumerator is a compile-time constant and
`-[AVOutputDevice deviceType]` has been available since macOS 10.12, so
no runtime API is absent on older systems.  On those systems, no output
device reports the custom-protocol type, so the loop already returns
false.

No new tests since this change is not directly testable.

* Source/WebCore/platform/graphics/avfoundation/MediaPlaybackTargetCocoa.mm:
(WebCore::MediaPlaybackTargetCocoa::supportsCustomProtocolVideoPlayback const):

Canonical link: <a href="https://commits.webkit.org/317450@main">https://commits.webkit.org/317450@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/853bfdecfcb67193a8ad860ea89b88f10c01e136

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175390 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49322 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/43103 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184976 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/137516 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1a68a852-f0a8-4233-aef5-3c16218fb9c5) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/177254 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50614 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49005 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/136543 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/137516 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5178ae25-5e24-4ccc-8084-133bd7f643b8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178347 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39962 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/157301 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117021 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6b70d7bc-8682-4db9-a61f-ddbcf47be57a) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/38604 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/36988 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/149026 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/36794 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33451 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/41009 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/41192 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187401 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48989 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/156857 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/145508 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49669 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/33416 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145349 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26654 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/40167 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/121862 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115559 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48175 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/11767 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47578 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47808 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47635 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->