### PR TITLE
[CSS Scroll Snap] Aligned snap targets are not selected in tree order

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/snap-after-relayout/multiple-aligned-targets/prefer-first-in-tree-order-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/snap-after-relayout/multiple-aligned-targets/prefer-first-in-tree-order-expected.txt
@@ -1,6 +1,6 @@
-Outer 1Outer placeholder Outer 2Outer 3Outer 4Outer 5
+Inner 5Inner 4Inner 3Inner 2Inner 1
 Inner Placeholder
-Inner 1Inner 2Inner 3Inner 4Inner 5
+Outer 5Outer 4Outer 3Outer 2Outer 1Outer placeholder
 
-FAIL first in tree-order is selected as snap target. assert_equals: scroller followed outertarget1 in y axis after layout change expected 250 but got 150
+PASS first in tree-order is selected as snap target.
 

--- a/Source/WebCore/page/scrolling/ScrollSnapOffsetsInfo.cpp
+++ b/Source/WebCore/page/scrolling/ScrollSnapOffsetsInfo.cpp
@@ -32,6 +32,7 @@
 #include "FloatQuad.h"
 #include "LayoutRect.h"
 #include "Logging.h"
+#include "Node.h"
 #include "RenderBox.h"
 #include "RenderElementInlines.h"
 #include "RenderObjectInlines.h"
@@ -376,7 +377,12 @@ void updateSnapOffsetsForScrollableArea(ScrollableArea& scrollableArea, const Re
     // https://drafts.csswg.org/css-scroll-snap-1/#re-snap: a focused element, then a fragment-targeted
     // element, then the first box in tree order. isFocused/isTarget accumulate across all areas
     // sharing the offset (not just the first one added).
-    auto addOrUpdateStopForSnapOffset = [](HashMap<LayoutUnit, SnapOffset<LayoutUnit>>& offsets, LayoutUnit newOffset, ScrollSnapStop stop, bool hasSnapAreaLargerThanViewport, bool isFocused, bool isTarget, NodeIdentifier snapTargetID, size_t snapAreaIndices)
+    //
+    // boxesWithScrollSnapPositions is a hash set with arbitrary iteration order, so snapAreaIndices
+    // isn't naturally in tree order like it would be if boxes were visited in tree order. Rather than
+    // sorting every snap box up front, insert each new index in tree order relative only to the other
+    // indices already tied at this exact offset (almost always zero or one of them).
+    auto addOrUpdateStopForSnapOffset = [](HashMap<LayoutUnit, SnapOffset<LayoutUnit>>& offsets, LayoutUnit newOffset, ScrollSnapStop stop, bool hasSnapAreaLargerThanViewport, bool isFocused, bool isTarget, NodeIdentifier snapTargetID, size_t snapAreaIndex, const Vector<CheckedRef<const RenderBox>>& snapBoxesByAreaIndex)
     {
         if (!offsets.isValidKey(newOffset))
             return;
@@ -400,13 +406,23 @@ void updateSnapOffsetsForScrollableArea(ScrollableArea& scrollableArea, const Re
         offset.isTarget |= isTarget;
 
         offset.hasSnapAreaLargerThanViewport |= hasSnapAreaLargerThanViewport;
-        offset.snapAreaIndices.append(snapAreaIndices);
+
+        Ref newElement = *snapBoxesByAreaIndex[snapAreaIndex]->element();
+        auto insertionPoint = std::ranges::find_if(offset.snapAreaIndices, [&](size_t existingIndex) {
+            Ref existingElement = *snapBoxesByAreaIndex[existingIndex]->element();
+            return is_lt(treeOrder<ComposedTree>(newElement, existingElement));
+        });
+        offset.snapAreaIndices.insert(insertionPoint - offset.snapAreaIndices.begin(), snapAreaIndex);
     };
 
     HashMap<LayoutUnit, SnapOffset<LayoutUnit>> verticalSnapOffsetsMap;
     HashMap<LayoutUnit, SnapOffset<LayoutUnit>> horizontalSnapOffsetsMap;
     Vector<LayoutRect> snapAreas;
     Vector<NodeIdentifier> snapAreasIDs;
+
+    // Parallel to snapAreas/snapAreasIDs, used only to compare tree order between areas that tie at
+    // the same snap offset (see addOrUpdateStopForSnapOffset above).
+    Vector<CheckedRef<const RenderBox>> snapBoxesByAreaIndex;
 
     auto maxScrollOffset = scrollableArea.maximumScrollOffset();
     maxScrollOffset.clampNegativeToZero();
@@ -435,7 +451,6 @@ void updateSnapOffsetsForScrollableArea(ScrollableArea& scrollableArea, const Re
     for (CheckedRef child : boxesWithScrollSnapPositions) {
         if (child->enclosingScrollableContainer() != &scrollingElementBox || !child->element())
             continue;
-
         // The bounds of the child element's snap area, where the top left of the scrolling container's border box is the origin.
         // The snap area is the bounding box of the child element's border box, after applying transformations.
         OptionSet<MapCoordinatesMode> options = { MapCoordinatesMode::UseTransforms, MapCoordinatesMode::IgnoreStickyOffsets };
@@ -484,16 +499,17 @@ void updateSnapOffsetsForScrollableArea(ScrollableArea& scrollableArea, const Re
         auto isTarget = child->element() ? child->element()->contains(targetElement) : false;
         auto identifier = protect(child->element())->nodeIdentifier();
         snapAreasIDs.append(identifier);
+        snapBoxesByAreaIndex.append(child);
 
         if (snapsHorizontally) {
             auto absoluteScrollXPosition = computeScrollSnapAlignOffset(scrollSnapArea.x(), scrollSnapArea.maxX(), xAlign, areaXAxisFlipped) - computeScrollSnapAlignOffset(scrollSnapPort.x(), scrollSnapPort.maxX(), xAlign, areaXAxisFlipped);
             auto absoluteScrollOffset = clampTo<int>(scrollableArea.scrollOffsetFromPosition({ roundToInt(absoluteScrollXPosition), 0 }).x(), 0, maxScrollOffset.x());
-            addOrUpdateStopForSnapOffset(horizontalSnapOffsetsMap, absoluteScrollOffset, stop, scrollSnapAreaAsOffsets.width() > scrollSnapPort.width(), isFocused, isTarget, identifier, snapAreas.size() - 1);
+            addOrUpdateStopForSnapOffset(horizontalSnapOffsetsMap, absoluteScrollOffset, stop, scrollSnapAreaAsOffsets.width() > scrollSnapPort.width(), isFocused, isTarget, identifier, snapAreas.size() - 1, snapBoxesByAreaIndex);
         }
         if (snapsVertically) {
             auto absoluteScrollYPosition = computeScrollSnapAlignOffset(scrollSnapArea.y(), scrollSnapArea.maxY(), yAlign, areaYAxisFlipped) - computeScrollSnapAlignOffset(scrollSnapPort.y(), scrollSnapPort.maxY(), yAlign, areaYAxisFlipped);
             auto absoluteScrollOffset = clampTo<int>(scrollableArea.scrollOffsetFromPosition({ 0, roundToInt(absoluteScrollYPosition) }).y(), 0, maxScrollOffset.y());
-            addOrUpdateStopForSnapOffset(verticalSnapOffsetsMap, absoluteScrollOffset, stop, scrollSnapAreaAsOffsets.height() > scrollSnapPort.height(), isFocused, isTarget, identifier, snapAreas.size() - 1);
+            addOrUpdateStopForSnapOffset(verticalSnapOffsetsMap, absoluteScrollOffset, stop, scrollSnapAreaAsOffsets.height() > scrollSnapPort.height(), isFocused, isTarget, identifier, snapAreas.size() - 1, snapBoxesByAreaIndex);
         }
 
         if (!snapAreas.isEmpty())


### PR DESCRIPTION
#### ab7cea82fa11083830493260bdccf58b5246ffa0
<pre>
[CSS Scroll Snap] Aligned snap targets are not selected in tree order
<a href="https://bugs.webkit.org/show_bug.cgi?id=319733">https://bugs.webkit.org/show_bug.cgi?id=319733</a>
<a href="https://rdar.apple.com/182571341">rdar://182571341</a>

Reviewed by Simon Fraser.

When multiple snap areas are aligned at the same offset, snap target
selection breaks the tie by &quot;first in tree order&quot;
(ScrollSnapAnimatorState::selectSnapTargetForAxis), which assumes
snapAreas/snapAreasIDs are built in tree order. But
updateSnapOffsetsForScrollableArea() iterates
RenderView::boxesWithScrollSnapPositions(), a hash set with arbitrary
iteration order, so the box chosen as &quot;first in tree order&quot; was
effectively random.

Rather than sorting every snap box in the scroller into tree order up
front, insert each snap area&apos;s index into its offset&apos;s snapAreaIndices
in tree order relative only to the other indices already tied at that
exact offset (almost always zero or one of them). This avoids an
O(n log n) sort of all snap boxes on every layout in exchange for a
handful of treeOrder() comparisons limited to actual aligned ties,
while still keeping the tree-order comparison itself on the main
thread, since ScrollSnapAnimatorState::selectSnapTargetForAxis (which
consumes the already-ordered snapAreaIndices) can run on the scrolling
thread, where live DOM access is unsafe.

* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/snap-after-relayout/multiple-aligned-targets/prefer-first-in-tree-order-expected.txt: Progressions
* Source/WebCore/page/scrolling/ScrollSnapOffsetsInfo.cpp:
(WebCore::updateSnapOffsetsForScrollableArea):

Canonical link: <a href="https://commits.webkit.org/317997@main">https://commits.webkit.org/317997@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/192687dd5a103dc1de89427b8dbbe09d49c3ae75

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176719 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50656 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44448 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186321 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/139955 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/365579ab-94f1-4abd-9541-fd79c41c3c45) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178582 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51949 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50342 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137660 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/139955 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7f6fc203-7072-4053-b55f-797479a72876) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179675 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41165 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158450 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118134 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ffdd02f3-fe0b-4953-a060-d2da118f4f11) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39820 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38189 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150232 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37948 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34789 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42399 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42405 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188745 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50323 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146726 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39507 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51006 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34569 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146531 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41295 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123212 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117352 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49511 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12927 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48910 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49146 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48971 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->