### PR TITLE
Remove some `!__has_feature(modules)` in VisionKitCoreSPI.h that are no longer needed

### DIFF
--- a/Source/WebCore/PAL/pal/spi/cocoa/VisionKitCoreSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/VisionKitCoreSPI.h
@@ -43,8 +43,7 @@ DECLARE_SYSTEM_HEADER
 
 #if HAVE(VK_IMAGE_ANALYSIS)
 
-// FIXME: Remove the `__has_feature(modules)` condition when possible.
-#if USE(APPLE_INTERNAL_SDK) && !__has_feature(modules)
+#if USE(APPLE_INTERNAL_SDK)
 
 #if __has_include(<TextRecognition/CRRegion.h>)
 #import <TextRecognition/CRRegion.h>
@@ -229,7 +228,7 @@ NS_ASSUME_NONNULL_END
 
 #if ENABLE(IMAGE_ANALYSIS)
 
-#if __has_include(<VisionKitCore/VKCImageAnalysisTranslation.h>) && !__has_feature(modules)
+#if __has_include(<VisionKitCore/VKCImageAnalysisTranslation.h>)
 #import <VisionKitCore/VKCImageAnalysisTranslation.h>
 #elif defined(__OBJC__)
 
@@ -254,7 +253,7 @@ NS_ASSUME_NONNULL_END
 
 #endif
 
-#if __has_include(<VisionKitCore/VKCImageAnalysis.h>) && !__has_feature(modules)
+#if __has_include(<VisionKitCore/VKCImageAnalysis.h>)
 #import <VisionKitCore/VKCImageAnalysis.h>
 #elif defined(__OBJC__)
 
@@ -274,7 +273,7 @@ NS_ASSUME_NONNULL_END
 
 #endif
 
-#if __has_include(<VisionKitCore/VKImageClass_Private.h>) && !__has_feature(modules)
+#if __has_include(<VisionKitCore/VKImageClass_Private.h>)
 #import <VisionKitCore/VKImageClass_Private.h>
 #elif defined(__OBJC__)
 
@@ -293,7 +292,7 @@ NS_ASSUME_NONNULL_END
 
 #endif
 
-#if __has_include(<VisionKitCore/VKCRemoveBackgroundRequestHandler.h>) && !__has_feature(modules)
+#if __has_include(<VisionKitCore/VKCRemoveBackgroundRequestHandler.h>)
 #import <VisionKitCore/VKCRemoveBackgroundRequest.h>
 #import <VisionKitCore/VKCRemoveBackgroundRequestHandler.h>
 #import <VisionKitCore/VKCRemoveBackgroundResult.h>
@@ -325,7 +324,7 @@ NS_ASSUME_NONNULL_END
 
 #endif
 
-#if __has_include(<VisionKitCore/VKCImageAnalyzer.h>) && !__has_feature(modules)
+#if __has_include(<VisionKitCore/VKCImageAnalyzer.h>)
 #import <VisionKitCore/VKCImageAnalyzer.h>
 #import <VisionKitCore/VKCImageAnalyzerRequest.h>
 #elif defined(__OBJC__)
@@ -357,7 +356,7 @@ NS_ASSUME_NONNULL_END
 #endif
 
 #if PLATFORM(MAC)
-#if __has_include(<VisionKitCore/VKCImageAnalysisOverlayView.h>) && !__has_feature(modules)
+#if __has_include(<VisionKitCore/VKCImageAnalysisOverlayView.h>)
 #import <VisionKitCore/VKCImageAnalysisOverlayView.h>
 #elif defined(__OBJC__)
 
@@ -384,7 +383,7 @@ NS_ASSUME_NONNULL_END
 #endif // PLATFORM(MAC)
 
 #if PLATFORM(IOS) || PLATFORM(VISION) || PLATFORM(MACCATALYST)
-#if __has_include(<VisionKitCore/VKCImageAnalysisInteraction.h>) && !__has_feature(modules)
+#if __has_include(<VisionKitCore/VKCImageAnalysisInteraction.h>)
 #import <VisionKitCore/VKCImageAnalysisInteraction.h>
 #elif defined(__OBJC__)
 


### PR DESCRIPTION
#### 8fd6383f5ad80aba7d1526cb6559de1dcbe46e2c
<pre>
Remove some `!__has_feature(modules)` in VisionKitCoreSPI.h that are no longer needed
<a href="https://bugs.webkit.org/show_bug.cgi?id=319734">https://bugs.webkit.org/show_bug.cgi?id=319734</a>
<a href="https://rdar.apple.com/182573949">rdar://182573949</a>

Reviewed by NOBODY (OOPS!).

* Source/WebCore/PAL/pal/spi/cocoa/VisionKitCoreSPI.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8fd6383f5ad80aba7d1526cb6559de1dcbe46e2c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180949 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54894 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48692 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191163 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145272 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d47c7bef-71aa-446e-8777-3e6a206cdee8) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182811 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56192 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54610 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141176 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97873 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2b0053e8-1d03-418d-8484-7807359442bc) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183904 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44839 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161924 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121628 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bde1df78-0672-410a-9431-96dee6cd6f16) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43512 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41791 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153916 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41451 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2323 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47506 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46046 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193098 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54560 "Built successfully") | | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150561 "Found 1 new test failure: compositing/framesets/composited-frame-alignment.html (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55248 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38069 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150278 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44868 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127514 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122949 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53765 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16445 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53147 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53384 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53212 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->