### PR TITLE
[css-color-4] [css-ui-4] AccentColor system color should use accent-color if set

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-ui/accent-color-accentcolor-is-parent-accent-color-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-ui/accent-color-accentcolor-is-parent-accent-color-expected.txt
@@ -1,0 +1,6 @@
+
+PASS accent-color: AccentColor when parent has no accent-color set should result in the system default accent color
+PASS accent-color: AccentColor when parent has accent-color: auto should result in the system default accent color
+PASS accent-color: AccentColor when parent has accent-color: currentColor should result in the parent's current color
+PASS accent-color: AccentColor when parent has accent-color set to a resolved color should result in the parent's accent-color
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-ui/accent-color-accentcolor-is-parent-accent-color.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-ui/accent-color-accentcolor-is-parent-accent-color.html
@@ -1,0 +1,90 @@
+<!DOCTYPE html>
+
+<title>accent-color: AccentColor is the accent color of the parent element</title>
+<link rel="author" title="Kiet Ho" href="mailto:kiet.ho@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-ui-4/#widget-accent">
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<style>
+  #default-accent-color {
+    fill: AccentColor;
+    background-color: AccentColorText;
+  }
+
+  #accentcolortext-expected {
+    accent-color: #261200;
+    background-color: AccentColorText;
+  }
+
+  #parent-no-accent-color { }
+  #parent-accent-color-auto { accent-color: auto; }
+  #parent-accent-color-currentcolor { color: #261200; accent-color: currentColor; }
+  #parent-accent-color-fixed { accent-color: #261200; }
+
+  .target {
+    /* accent color of the parent */
+    accent-color: AccentColor;
+
+    /* accent color of this element, which is the accent color of the parent */
+    fill: AccentColor;
+
+    /* accent color text of this element, based on the accent color of the parent */
+    background-color: AccentColorText;
+  }
+</style>
+
+<div id="default-accent-color"></div>
+<div id="accentcolortext-expected"></div>
+
+<div id="parent-no-accent-color">
+  <div class="target" id="t1"></div>
+</div>
+
+<div id="parent-accent-color-auto">
+  <div class="target" id="t2"></div>
+</div>
+
+<div id="parent-accent-color-currentcolor">
+  <div class="target" id="t3"></div>
+</div>
+
+<div id="parent-accent-color-fixed">
+  <div class="target" id="t4"></div>
+</div>
+
+<script>
+  const defaultAccentColor = getComputedStyle(document.getElementById("default-accent-color")).fill;
+  const defaultAccentColorText = getComputedStyle(document.getElementById("default-accent-color")).backgroundColor;
+
+  test(() => {
+    const style = getComputedStyle(t1);
+    assert_equals(style.accentColor, defaultAccentColor);
+    assert_equals(style.fill, defaultAccentColor);
+    assert_equals(style.backgroundColor, defaultAccentColorText);
+  }, "accent-color: AccentColor when parent has no accent-color set should result in the system default accent color");
+
+  test(() => {
+    const style = getComputedStyle(t2);
+    assert_equals(style.accentColor, defaultAccentColor);
+    assert_equals(style.fill, defaultAccentColor);
+    assert_equals(style.backgroundColor, defaultAccentColorText);
+  }, "accent-color: AccentColor when parent has accent-color: auto should result in the system default accent color");
+
+  const accentColorTextExpected = getComputedStyle(document.getElementById("accentcolortext-expected")).backgroundColor;
+
+  test(() => {
+    const style = getComputedStyle(t3);
+    assert_equals(style.accentColor, "rgb(38, 18, 0)");
+    assert_equals(style.fill, "rgb(38, 18, 0)");
+    assert_equals(style.backgroundColor, accentColorTextExpected);
+  }, "accent-color: AccentColor when parent has accent-color: currentColor should result in the parent's current color");
+
+  test(() => {
+    const style = getComputedStyle(t4);
+    assert_equals(style.accentColor, "rgb(38, 18, 0)");
+    assert_equals(style.fill, "rgb(38, 18, 0)");
+    assert_equals(style.backgroundColor, accentColorTextExpected);
+  }, "accent-color: AccentColor when parent has accent-color set to a resolved color should result in the parent's accent-color");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-ui/accent-color-accentcolortext-is-parent-accentcolortext-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-ui/accent-color-accentcolortext-is-parent-accentcolortext-expected.txt
@@ -1,0 +1,6 @@
+
+PASS accent-color: AccentColorText when parent has no accent-color set should result in the system default AccentColorText
+PASS accent-color: AccentColorText when parent has accent-color: auto should result in the system default AccentColorText
+PASS accent-color: AccentColor when parent has accent-color: currentColor should result in the parent's current color
+PASS accent-color: AccentColor when parent has accent-color set to a resolved color should result in the parent's accent-color
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-ui/accent-color-accentcolortext-is-parent-accentcolortext.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-ui/accent-color-accentcolortext-is-parent-accentcolortext.html
@@ -1,0 +1,104 @@
+<!DOCTYPE html>
+
+<title>accent-color: AccentColorText is the AccentColorText of the parent element</title>
+<link rel="author" title="Kiet Ho" href="mailto:kiet.ho@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-ui-4/#widget-accent">
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<style>
+  #default-accentcolortext {
+    fill: AccentColorText;
+  }
+
+  #accentcolortext-of-default-accentcolortext {
+    /* Default AccentColorText is probably #000000 (black) */
+    accent-color: #000000;
+    background-color: AccentColorText;
+  }
+
+  #expected-accentcolortext {
+    accent-color: #261200;
+    fill: AccentColorText;
+  }
+
+  #accentcolortext-of-expected-accentcolortext {
+    /* #261200 is black-ish so AccentColorText should be all white */
+    accent-color: #ffffff;
+    background-color: AccentColorText;
+  }
+
+  #parent-no-accent-color { }
+  #parent-accent-color-auto { accent-color: auto; }
+  #parent-accent-color-currentcolor { color: #261200; accent-color: currentColor; }
+  #parent-accent-color-fixed { accent-color: #261200; }
+
+  .target {
+    /* AccentColorText of the parent */
+    accent-color: AccentColorText;
+
+    /* accent color of this element, which is the accent color of the parent */
+    fill: AccentColor;
+
+    /* accent color text of this element, based on the accent color of the parent */
+    background-color: AccentColorText;
+  }
+</style>
+
+<div id="default-accentcolortext"></div>
+<div id="accentcolortext-of-default-accentcolortext"></div>
+<div id="expected-accentcolortext"></div>
+<div id="accentcolortext-of-expected-accentcolortext"></div>
+
+<div id="parent-no-accent-color">
+  <div class="target" id="t1"></div>
+</div>
+
+<div id="parent-accent-color-auto">
+  <div class="target" id="t2"></div>
+</div>
+
+<div id="parent-accent-color-currentcolor">
+  <div class="target" id="t3"></div>
+</div>
+
+<div id="parent-accent-color-fixed">
+  <div class="target" id="t4"></div>
+</div>
+
+<script>
+  const defaultAccentColorText = getComputedStyle(document.getElementById("default-accentcolortext")).fill;
+  const accentColorTextOfDefaultAccentColorText = getComputedStyle(document.getElementById("accentcolortext-of-default-accentcolortext")).backgroundColor;
+
+  test(() => {
+    const style = getComputedStyle(t1);
+    assert_equals(style.accentColor, defaultAccentColorText);
+    assert_equals(style.fill, defaultAccentColorText);
+    assert_equals(style.backgroundColor, accentColorTextOfDefaultAccentColorText);
+  }, "accent-color: AccentColorText when parent has no accent-color set should result in the system default AccentColorText");
+
+  test(() => {
+    const style = getComputedStyle(t2);
+    assert_equals(style.accentColor, defaultAccentColorText);
+    assert_equals(style.fill, defaultAccentColorText);
+    assert_equals(style.backgroundColor, accentColorTextOfDefaultAccentColorText);
+  }, "accent-color: AccentColorText when parent has accent-color: auto should result in the system default AccentColorText");
+
+  const expectedAccentColorText = getComputedStyle(document.getElementById("expected-accentcolortext")).fill;
+  const accentColorTextOfExpectedAccentColorText = getComputedStyle(document.getElementById("accentcolortext-of-expected-accentcolortext")).backgroundColor;
+
+  test(() => {
+    const style = getComputedStyle(t3);
+    assert_equals(style.accentColor, expectedAccentColorText);
+    assert_equals(style.fill, expectedAccentColorText);
+    assert_equals(style.backgroundColor, accentColorTextOfExpectedAccentColorText);
+  }, "accent-color: AccentColor when parent has accent-color: currentColor should result in the parent's current color");
+
+  test(() => {
+    const style = getComputedStyle(t4);
+    assert_equals(style.accentColor, expectedAccentColorText);
+    assert_equals(style.fill, expectedAccentColorText);
+    assert_equals(style.backgroundColor, accentColorTextOfExpectedAccentColorText);
+  }, "accent-color: AccentColor when parent has accent-color set to a resolved color should result in the parent's accent-color");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-ui/accent-color-checkbox-checked-001.tentative-expected-mismatch.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-ui/accent-color-checkbox-checked-001.tentative-expected-mismatch.html
@@ -1,0 +1,2 @@
+<!doctype html>
+<input type=checkbox checked style="accent-color: blue">

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-ui/accent-color-current-color-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-ui/accent-color-current-color-expected.txt
@@ -1,0 +1,4 @@
+
+PASS accent-color: currentColor uses the element's current color
+PASS accent-color: currentColor when color: currentColor uses the parent element's current color
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-ui/accent-color-current-color.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-ui/accent-color-current-color.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+
+<title>accent-color: currentColor uses the element's current color</title>
+<link rel="author" title="Kiet Ho" href="mailto:kiet.ho@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-ui-4/#widget-accent">
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<style>
+  #t1 {
+    color: #261200;
+    accent-color: currentColor;
+  }
+
+  #t2_parent { color: #261200; }
+  #t2 { color: currentColor; accent-color: currentColor; }
+</style>
+
+<div id="t1"></div>
+
+<div id="t2_parent">
+  <div id="t2"></div>
+</div>
+
+<script>
+  test(() => {
+    const style = getComputedStyle(t1);
+    assert_equals(style.accentColor, "rgb(38, 18, 0)");
+  }, "accent-color: currentColor uses the element's current color");
+
+  test(() => {
+    const style = getComputedStyle(t2);
+    assert_equals(style.color, "rgb(38, 18, 0)");
+    assert_equals(style.accentColor, "rgb(38, 18, 0)");
+  }, "accent-color: currentColor when color: currentColor uses the parent element's current color");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-ui/accent-color-currentcolor-color-accentcolor-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-ui/accent-color-currentcolor-color-accentcolor-expected.txt
@@ -1,0 +1,6 @@
+
+PASS accent-color: currentColor when color: AccentColor and parent doesn't specify accent color should result in the system default accent color
+PASS accent-color: currentColor when color: AccentColor and parent specifies accent-color: auto should result in the system default accent color
+PASS accent-color: currentColor when color: AccentColor and parent specifies accent-color: currentColor should result in the parent's current color
+PASS accent-color: currentColor when color: AccentColor and parent specifies a resolved accent color should result in that accent color
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-ui/accent-color-currentcolor-color-accentcolor.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-ui/accent-color-currentcolor-color-accentcolor.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+
+<title>accent-color: currentColor when color: AccentColor is the parent accent color</title>
+<link rel="author" title="Kiet Ho" href="mailto:kiet.ho@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-ui-4/#widget-accent">
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<style>
+  #default-accent-color {
+    fill: AccentColor;
+    background-color: AccentColorText;
+  }
+
+  #accentcolortext-expected {
+    accent-color: #261200;
+    background-color: AccentColorText;
+  }
+
+  #parent-no-accent-color { }
+  #parent-accent-color-auto { accent-color: auto; }
+  #parent-accent-color-currentcolor { color: #261200; accent-color: currentColor; }
+  #parent-accent-color-fixed { accent-color: #261200; }
+
+  .target {
+    /* value: accent color of parent */
+    color: AccentColor;
+
+    /* value: current color (the above value) */
+    accent-color: currentColor;
+
+    /* value: current accent value (the above value) */
+    fill: AccentColor;
+
+    /* depends on the current accent value */
+    background-color: AccentColorText;
+  }
+</style>
+
+<div id="default-accent-color"></div>
+<div id="accentcolortext-expected"></div>
+
+<div id="parent-no-accent-color">
+  <div class="target" id="t1"></div>
+</div>
+
+<div id="parent-accent-color-auto">
+  <div class="target" id="t2"></div>
+</div>
+
+<div id="parent-accent-color-currentcolor">
+  <div class="target" id="t3"></div>
+</div>
+
+<div id="parent-accent-color-fixed">
+  <div class="target" id="t4"></div>
+</div>
+
+<script>
+  const defaultAccentColor = getComputedStyle(document.getElementById("default-accent-color")).fill;
+  const defaultAccentColorText = getComputedStyle(document.getElementById("default-accent-color")).backgroundColor;
+
+  test(() => {
+    const style = getComputedStyle(t1);
+    assert_equals(style.color, defaultAccentColor);
+    assert_equals(style.accentColor, defaultAccentColor);
+    assert_equals(style.fill, defaultAccentColor);
+    assert_equals(style.backgroundColor, defaultAccentColorText);
+  }, "accent-color: currentColor when color: AccentColor and parent doesn't specify accent color should result in the system default accent color");
+
+  test(() => {
+    const style = getComputedStyle(t2);
+    assert_equals(style.color, defaultAccentColor);
+    assert_equals(style.accentColor, defaultAccentColor);
+    assert_equals(style.fill, defaultAccentColor);
+    assert_equals(style.backgroundColor, defaultAccentColorText);
+  }, "accent-color: currentColor when color: AccentColor and parent specifies accent-color: auto should result in the system default accent color");
+
+  const accentColorTextExpected = getComputedStyle(document.getElementById("accentcolortext-expected")).backgroundColor;
+
+  test(() => {
+    const style = getComputedStyle(t3);
+    assert_equals(style.color, "rgb(38, 18, 0)");
+    assert_equals(style.accentColor, "rgb(38, 18, 0)");
+    assert_equals(style.fill, "rgb(38, 18, 0)");
+    assert_equals(style.backgroundColor, accentColorTextExpected);
+  }, "accent-color: currentColor when color: AccentColor and parent specifies accent-color: currentColor should result in the parent's current color");
+
+  test(() => {
+    const style = getComputedStyle(t4);
+    assert_equals(style.color, "rgb(38, 18, 0)");
+    assert_equals(style.accentColor, "rgb(38, 18, 0)");
+    assert_equals(style.fill, "rgb(38, 18, 0)");
+    assert_equals(style.backgroundColor, accentColorTextExpected);
+  }, "accent-color: currentColor when color: AccentColor and parent specifies a resolved accent color should result in that accent color");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-ui/accent-color-currentcolor-color-accentcolortext-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-ui/accent-color-currentcolor-color-accentcolortext-expected.txt
@@ -1,0 +1,6 @@
+
+PASS accent-color: currentColor when color: AccentColorText and parent doesn't specify accent color should result in the system default AccentColorText
+PASS accent-color: currentColor when color: AccentColorText and parent specifies accent-color: auto should result in the system default AccentColorText
+PASS accent-color: currentColor when color: AccentColorText and parent specifies accent-color: currentColor should result in the parent's AccentColorText
+PASS accent-color: currentColor when color: AccentColorText and parent specifies a resolved accent color should result in the parent's AccentColorText
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-ui/accent-color-currentcolor-color-accentcolortext.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-ui/accent-color-currentcolor-color-accentcolortext.html
@@ -1,0 +1,111 @@
+<!DOCTYPE html>
+
+<title>accent-color: currentColor when color: AccentColorText is the parent's AccentColorText</title>
+<link rel="author" title="Kiet Ho" href="mailto:kiet.ho@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-ui-4/#widget-accent">
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<style>
+  #default-accentcolortext {
+    fill: AccentColorText;
+  }
+
+  #accentcolortext-of-default-accentcolortext {
+    /* Default AccentColorText is probably #000000 (black) */
+    accent-color: #000000;
+    background-color: AccentColorText;
+  }
+
+  #expected-accentcolortext {
+    accent-color: #261200;
+    fill: AccentColorText;
+  }
+
+  #accentcolortext-of-expected-accentcolortext {
+    /* #261200 is black-ish so AccentColorText should be all white */
+    accent-color: #ffffff;
+    background-color: AccentColorText;
+  }
+
+  #parent-no-accent-color { }
+  #parent-accent-color-auto { accent-color: auto; }
+  #parent-accent-color-currentcolor { color: #261200; accent-color: currentColor; }
+  #parent-accent-color-fixed { accent-color: #261200; }
+
+  .target {
+    /* value: AccentColorText of parent */
+    color: AccentColorText;
+
+    /* value: current color (the above value) */
+    accent-color: currentColor;
+
+    /* value: current accent value (the above value) */
+    fill: AccentColor;
+
+    /* depends on the current accent value */
+    background-color: AccentColorText;
+  }
+</style>
+
+<div id="default-accentcolortext"></div>
+<div id="accentcolortext-of-default-accentcolortext"></div>
+<div id="expected-accentcolortext"></div>
+<div id="accentcolortext-of-expected-accentcolortext"></div>
+
+<div id="parent-no-accent-color">
+  <div class="target" id="t1"></div>
+</div>
+
+<div id="parent-accent-color-auto">
+  <div class="target" id="t2"></div>
+</div>
+
+<div id="parent-accent-color-currentcolor">
+  <div class="target" id="t3"></div>
+</div>
+
+<div id="parent-accent-color-fixed">
+  <div class="target" id="t4"></div>
+</div>
+
+<script>
+  const defaultAccentColorText = getComputedStyle(document.getElementById("default-accentcolortext")).fill;
+  const accentColorTextOfDefaultAccentColorText = getComputedStyle(document.getElementById("accentcolortext-of-default-accentcolortext")).backgroundColor;
+
+  test(() => {
+    const style = getComputedStyle(t1);
+    assert_equals(style.color, defaultAccentColorText);
+    assert_equals(style.accentColor, defaultAccentColorText);
+    assert_equals(style.fill, defaultAccentColorText);
+    assert_equals(style.backgroundColor, accentColorTextOfDefaultAccentColorText);
+  }, "accent-color: currentColor when color: AccentColorText and parent doesn't specify accent color should result in the system default AccentColorText");
+
+  test(() => {
+    const style = getComputedStyle(t2);
+    assert_equals(style.color, defaultAccentColorText);
+    assert_equals(style.accentColor, defaultAccentColorText);
+    assert_equals(style.fill, defaultAccentColorText);
+    assert_equals(style.backgroundColor, accentColorTextOfDefaultAccentColorText);
+  }, "accent-color: currentColor when color: AccentColorText and parent specifies accent-color: auto should result in the system default AccentColorText");
+
+  const expectedAccentColorText = getComputedStyle(document.getElementById("expected-accentcolortext")).fill;
+  const accentColorTextOfExpectedAccentColorText = getComputedStyle(document.getElementById("accentcolortext-of-expected-accentcolortext")).backgroundColor;
+
+  test(() => {
+    const style = getComputedStyle(t3);
+    assert_equals(style.color, expectedAccentColorText);
+    assert_equals(style.accentColor, expectedAccentColorText);
+    assert_equals(style.fill, expectedAccentColorText);
+    assert_equals(style.backgroundColor, accentColorTextOfExpectedAccentColorText);
+  }, "accent-color: currentColor when color: AccentColorText and parent specifies accent-color: currentColor should result in the parent's AccentColorText");
+
+  test(() => {
+    const style = getComputedStyle(t4);
+    assert_equals(style.color, expectedAccentColorText);
+    assert_equals(style.accentColor, expectedAccentColorText);
+    assert_equals(style.fill, expectedAccentColorText);
+    assert_equals(style.backgroundColor, accentColorTextOfExpectedAccentColorText);
+  }, "accent-color: currentColor when color: AccentColorText and parent specifies a resolved accent color should result in the parent's AccentColorText");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-ui/accentcolor-color-keyword-comes-from-accent-color-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-ui/accentcolor-color-keyword-comes-from-accent-color-expected.txt
@@ -1,0 +1,6 @@
+
+PASS When accent-color is set, AccentColor keyword color comes from accent-color
+PASS When accent-color is set, AccentColorText keyword color comes from accent-color
+PASS When accent-color is auto or not set, AccentColor keyword comes from the system color and should match.
+PASS When accent-color is auto or not set, AccentColorText keyword comes from the system color and should match.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-ui/accentcolor-color-keyword-comes-from-accent-color.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-ui/accentcolor-color-keyword-comes-from-accent-color.html
@@ -1,0 +1,113 @@
+<!DOCTYPE html>
+
+<title>AccentColor/AccentColorText system color comes from accent-color</title>
+<link rel="author" title="Kiet Ho" href="mailto:kiet.ho@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-ui-4/#widget-accent">
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<style>
+  .color-set-to-accentcolor {
+    /* Some properties that accept <color> */
+    background-color: white;
+    background-color: AccentColor;
+
+    border-block-end-color: white;
+    border-block-end-color: AccentColor;
+
+    caret-color: white;
+    caret-color: AccentColor;
+
+    fill: white;
+    fill: AccentColor;
+
+    text-decoration-color: white;
+    text-decoration-color: AccentColor;
+  }
+
+  .color-set-to-accentcolortext {
+    /* Some properties that accept <color> */
+    background-color: white;
+    background-color: AccentColorText;
+
+    border-block-end-color: white;
+    border-block-end-color: AccentColorText;
+
+    caret-color: white;
+    caret-color: AccentColorText;
+
+    fill: white;
+    fill: AccentColorText;
+
+    text-decoration-color: white;
+    text-decoration-color: AccentColorText;
+  }
+
+  #t1 { accent-color: #261200; }
+
+  #t2_black { accent-color: #000000; }
+  #t2_white { accent-color: #ffffff; }
+
+  #t3_auto { accent-color: auto; }
+  #t3_unset { }
+
+  #t4_auto { accent-color: auto; }
+  #t4_unset { }
+</style>
+
+<div class="color-set-to-accentcolor" id="t1"></div>
+
+<div class="color-set-to-accentcolortext" id="t2_black"></div>
+<div class="color-set-to-accentcolortext" id="t2_white"></div>
+
+<div class="color-set-to-accentcolor" id="t3_auto"></div>
+<div class="color-set-to-accentcolor" id="t3_unset"></div>
+
+<div class="color-set-to-accentcolortext" id="t4_auto"></div>
+<div class="color-set-to-accentcolortext" id="t4_unset"></div>
+
+<script>
+  function assertColor(computedStyle, expectedColor) {
+    assert_equals(computedStyle.backgroundColor, expectedColor, "background-color");
+    assert_equals(computedStyle.borderBlockEndColor, expectedColor, "border-block-end-color");
+    assert_equals(computedStyle.caretColor, expectedColor, "caret-color");
+    assert_equals(computedStyle.fill, expectedColor, "fill");
+    assert_equals(computedStyle.textDecorationColor, expectedColor, "text-decoration-color");
+  }
+
+  test(() => {
+    assertColor(getComputedStyle(t1), "rgb(38, 18, 0)");
+  }, "When accent-color is set, AccentColor keyword color comes from accent-color");
+
+  test(() => {
+    const blackStyle = getComputedStyle(t2_black);
+    const accentColorTextWhenBlack = blackStyle.fill;
+    assertColor(blackStyle, accentColorTextWhenBlack);
+
+    const whiteStyle = getComputedStyle(t2_white);
+    const accentColorTextWhenWhite = whiteStyle.fill;
+    assertColor(whiteStyle, accentColorTextWhenWhite);
+
+    // Make sure AccentColorText contrasts the background.
+    assert_not_equals(accentColorTextWhenBlack, accentColorTextWhenWhite);
+  }, "When accent-color is set, AccentColorText keyword color comes from accent-color");
+
+  test(() => {
+    const autoStyle = getComputedStyle(t3_auto);
+    const unsetStyle = getComputedStyle(t3_unset);
+
+    const expectedColor = autoStyle.fill;
+    assertColor(autoStyle, expectedColor);
+    assertColor(unsetStyle, expectedColor);
+  }, "When accent-color is auto or not set, AccentColor keyword comes from the system color and should match.");
+
+  test(() => {
+    const autoStyle = getComputedStyle(t4_auto);
+    const unsetStyle = getComputedStyle(t4_unset);
+
+    const expectedColor = autoStyle.fill;
+    assertColor(autoStyle, expectedColor);
+    assertColor(unsetStyle, expectedColor);
+  }, "When accent-color is auto or not set, AccentColorText keyword comes from the system color and should match.");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-ui/color-accentcolor-is-parent-accent-color-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-ui/color-accentcolor-is-parent-accent-color-expected.txt
@@ -1,0 +1,6 @@
+
+PASS color: AccentColor when parent has no accent-color set should result in the system default accent color
+PASS color: AccentColor when parent has accent-color: auto should result in the system default accent color
+PASS color: AccentColor when parent has accent-color: currentColor should result in the parent's current color
+PASS color: AccentColor when parent has accent-color set to a resolved color should result in the parent's accent-color
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-ui/color-accentcolor-is-parent-accent-color.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-ui/color-accentcolor-is-parent-accent-color.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+
+<title>color: AccentColor is the accent color of the parent element</title>
+<link rel="author" title="Kiet Ho" href="mailto:kiet.ho@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-ui-4/#widget-accent">
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<style>
+  #default-accent-color {
+    fill: AccentColor;
+  }
+
+  #parent-no-accent-color { }
+  #parent-accent-color-auto { accent-color: auto; }
+  #parent-accent-color-currentcolor { color: #261200; accent-color: currentColor; }
+  #parent-accent-color-fixed { accent-color: #112233; }
+
+  .target {
+    /*
+      This is to check that color: AccentColor doesn't mistakenly take
+      accent-color of the current element
+    */
+    accent-color: #abcdef;
+    color: AccentColor;
+  }
+</style>
+
+<div id="default-accent-color"></div>
+
+<div id="parent-no-accent-color">
+  <div class="target" id="t1"></div>
+</div>
+
+<div id="parent-accent-color-auto">
+  <div class="target" id="t2"></div>
+</div>
+
+<div id="parent-accent-color-currentcolor">
+  <div class="target" id="t3"></div>
+</div>
+
+<div id="parent-accent-color-fixed">
+  <div class="target" id="t4"></div>
+</div>
+
+<script>
+  const defaultAccentColor = getComputedStyle(document.getElementById("default-accent-color")).fill;
+
+  test(() => {
+    const style = getComputedStyle(t1);
+    assert_equals(style.color, defaultAccentColor);
+  }, "color: AccentColor when parent has no accent-color set should result in the system default accent color");
+
+  test(() => {
+    const style = getComputedStyle(t2);
+    assert_equals(style.color, defaultAccentColor);
+  }, "color: AccentColor when parent has accent-color: auto should result in the system default accent color");
+
+  test(() => {
+    const style = getComputedStyle(t3);
+    assert_equals(style.color, "rgb(38, 18, 0)");
+  }, "color: AccentColor when parent has accent-color: currentColor should result in the parent's current color");
+
+  test(() => {
+    const style = getComputedStyle(t4);
+    assert_equals(style.color, "rgb(17, 34, 51)");
+  }, "color: AccentColor when parent has accent-color set to a resolved color should result in the parent's accent-color");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-ui/color-accentcolortext-is-parent-accentcolortext-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-ui/color-accentcolortext-is-parent-accentcolortext-expected.txt
@@ -1,0 +1,6 @@
+
+PASS color: AccentColorText when parent has no accent-color set should result in the system default AccentColorText
+PASS color: AccentColorText when parent has accent-color: auto should result in the system default AccentColorText
+PASS color: AccentColorText when parent has accent-color: currentColor should result in the parent's AccentColorText
+PASS color: AccentColor when parent has accent-color set to a resolved color should result in the parent's AccentColorText
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-ui/color-accentcolortext-is-parent-accentcolortext.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-ui/color-accentcolortext-is-parent-accentcolortext.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+
+<title>color: AccentColorText is AccentColorText of the parent element</title>
+<link rel="author" title="Kiet Ho" href="mailto:kiet.ho@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-ui-4/#widget-accent">
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<style>
+  #default-accentcolortext {
+    background-color: AccentColorText;
+  }
+
+  #expected-accentcolortext {
+    accent-color: #261200;
+    background-color: AccentColorText;
+  }
+
+  #parent-no-accent-color { }
+  #parent-accent-color-auto { accent-color: auto; }
+  #parent-accent-color-currentcolor { color: #261200; accent-color: currentColor; }
+  #parent-accent-color-fixed { accent-color: #261200; }
+
+  .target {
+    color: AccentColorText;
+  }
+</style>
+
+<div id="default-accentcolortext"></div>
+<div id="expected-accentcolortext"></div>
+
+<div id="parent-no-accent-color">
+  <div class="target" id="t1"></div>
+</div>
+
+<div id="parent-accent-color-auto">
+  <div class="target" id="t2"></div>
+</div>
+
+<div id="parent-accent-color-currentcolor">
+  <div class="target" id="t3"></div>
+</div>
+
+<div id="parent-accent-color-fixed">
+  <div class="target" id="t4"></div>
+</div>
+
+<script>
+  const defaultAccentColorText = getComputedStyle(document.getElementById("default-accentcolortext")).backgroundColor;
+
+  test(() => {
+    const style = getComputedStyle(t1);
+    assert_equals(style.color, defaultAccentColorText);
+  }, "color: AccentColorText when parent has no accent-color set should result in the system default AccentColorText");
+
+  test(() => {
+    const style = getComputedStyle(t2);
+    assert_equals(style.color, defaultAccentColorText);
+  }, "color: AccentColorText when parent has accent-color: auto should result in the system default AccentColorText");
+
+  const expectedAccentColorText = getComputedStyle(document.getElementById("expected-accentcolortext")).backgroundColor;
+
+  test(() => {
+    const style = getComputedStyle(t3);
+    assert_equals(style.color, expectedAccentColorText);
+  }, "color: AccentColorText when parent has accent-color: currentColor should result in the parent's AccentColorText");
+
+  test(() => {
+    const style = getComputedStyle(t4);
+    assert_equals(style.color, expectedAccentColorText);
+  }, "color: AccentColor when parent has accent-color set to a resolved color should result in the parent's AccentColorText");
+</script>

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -3281,6 +3281,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     style/values/color/StyleDynamicRangeLimitMix.h
     style/values/color/StyleOpacity.h
     style/values/color/StyleResolvedColor.h
+    style/values/color/StyleResolvedColors.h
 
     style/values/contain/StyleContain.h
     style/values/contain/StyleContainerName.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -3415,6 +3415,7 @@ style/values/color/StyleLightDarkColor.cpp
 style/values/color/StyleOpacity.cpp
 style/values/color/StyleRelativeAlphaColor.cpp
 style/values/color/StyleResolvedColor.cpp
+style/values/color/StyleResolvedColors.cpp
 style/values/contain/StyleContain.cpp
 style/values/contain/StyleContainerType.cpp
 style/values/content/StyleContent.cpp @header:RenderStyleGetters @cost:6

--- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
+++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
@@ -7158,6 +7158,7 @@
 		EDEC98030AED7E170059137F /* WebCorePrefix.h in Headers */ = {isa = PBXBuildFile; fileRef = EDEC98020AED7E170059137F /* WebCorePrefix.h */; };
 		EE042903F1A0DE0100A1B2C3 /* JSDOMBindingFacade.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EE042901F1A0DE0100A1B2C3 /* JSDOMBindingFacade.cpp */; };
 		EE042904F1A0DE0100A1B2C3 /* JSDOMBindingFacade.h in Headers */ = {isa = PBXBuildFile; fileRef = EE042902F1A0DE0100A1B2C3 /* JSDOMBindingFacade.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		EE0730583035331700B23328 /* StyleResolvedColors.h in Headers */ = {isa = PBXBuildFile; fileRef = EE073056303532EF00B23328 /* StyleResolvedColors.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		EE0C7E042CE845CB0043DAF8 /* CSSPositionTryRule.h in Headers */ = {isa = PBXBuildFile; fileRef = EE0C7E002CE845CB0043DAF8 /* CSSPositionTryRule.h */; };
 		EE0D3C492D2F4B4C00072978 /* StageModeOperations.h in Headers */ = {isa = PBXBuildFile; fileRef = EE0D3C482D2F4AE600072978 /* StageModeOperations.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		EE1A93AA2F2AE00A0054FAE4 /* NavigationActivation.h in Headers */ = {isa = PBXBuildFile; fileRef = DFD9B92D2C29D16200E10B53 /* NavigationActivation.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -23293,6 +23294,8 @@
 		EDEC98020AED7E170059137F /* WebCorePrefix.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; path = WebCorePrefix.h; sourceTree = "<group>"; tabWidth = 4; usesTabs = 0; };
 		EE042901F1A0DE0100A1B2C3 /* JSDOMBindingFacade.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = JSDOMBindingFacade.cpp; sourceTree = "<group>"; };
 		EE042902F1A0DE0100A1B2C3 /* JSDOMBindingFacade.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSDOMBindingFacade.h; sourceTree = "<group>"; };
+		EE073056303532EF00B23328 /* StyleResolvedColors.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StyleResolvedColors.h; sourceTree = "<group>"; };
+		EE073057303532EF00B23328 /* StyleResolvedColors.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = StyleResolvedColors.cpp; sourceTree = "<group>"; };
 		EE0C7E002CE845CB0043DAF8 /* CSSPositionTryRule.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CSSPositionTryRule.h; sourceTree = "<group>"; };
 		EE0C7E012CE845CB0043DAF8 /* CSSPositionTryRule.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CSSPositionTryRule.cpp; sourceTree = "<group>"; };
 		EE0C7E022CE845CB0043DAF8 /* CSSPositionTryRule.idl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = CSSPositionTryRule.idl; sourceTree = "<group>"; };
@@ -38118,6 +38121,8 @@
 				BC2CFBBC2BEFC6F6008CA222 /* StyleRelativeColor.h */,
 				BC4AF4062CF62F0E0037C65C /* StyleResolvedColor.cpp */,
 				BC4AF4052CF62F0E0037C65C /* StyleResolvedColor.h */,
+				EE073057303532EF00B23328 /* StyleResolvedColors.cpp */,
+				EE073056303532EF00B23328 /* StyleResolvedColors.h */,
 			);
 			path = color;
 			sourceTree = "<group>";
@@ -49225,6 +49230,7 @@
 				BC2E5C992E47BF5F0083FFF5 /* StyleRepeatStyle.h in Headers */,
 				BC452A902ED24DE500FD066C /* StyleResize.h in Headers */,
 				BC4AF41A2CF96E070037C65C /* StyleResolvedColor.h in Headers */,
+				EE0730583035331700B23328 /* StyleResolvedColors.h in Headers */,
 				E4D58EB517B4DBDC00CBDCA8 /* StyleResolveForDocument.h in Headers */,
 				E4D68EB517B4DBDC00CBDCA8 /* StyleResolveForFont.h in Headers */,
 				E139866415478474001E3F65 /* StyleResolver.h in Headers */,

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -262,7 +262,9 @@
                 "color-property": true,
                 "color-property-traits-color-custom": true,
                 "color-property-traits-visited-link-color-custom": true,
-                "parser-grammar": "auto | <color>"
+                "parser-grammar": "auto | <color>",
+                "high-priority": true,
+                "style-builder-custom": "Value"
             },
             "specification": {
                 "category": "css-ui",

--- a/Source/WebCore/style/MatchedDeclarationsCache.cpp
+++ b/Source/WebCore/style/MatchedDeclarationsCache.cpp
@@ -108,6 +108,12 @@ bool MatchedDeclarationsCache::isCacheable(const Element& element, const Style::
     if (element.hasRandomCachingKeyMap())
         return false;
 
+    if (!parentStyle.accentColor().isAuto()) {
+        // If parent has accent-color set to a color, it'll affect AccentColor and
+        // AccentColorText in the element's style.
+        return false;
+    }
+
     // FIXME: counter-style: we might need to resolve cache like for fontSelector here (rdar://103018993).
 
     return true;

--- a/Source/WebCore/style/StyleBuilderCustom.h
+++ b/Source/WebCore/style/StyleBuilderCustom.h
@@ -58,6 +58,7 @@
 #include "StylePrimitiveNumericOrKeyword+CSSValueConversion.h"
 #include "StylePrimitiveNumericTypes+CSSValueConversion.h"
 #include "StyleResolveForFont.h"
+#include "StyleResolvedColors.h"
 #include "StyleResolver.h"
 #include "StyleTextEdge+CSSValueConversion.h"
 #include "StyleValueTypes+CSSValueConversion.h"
@@ -679,11 +680,11 @@ inline void BuilderCustom::applyInitialColor(BuilderState& builderState)
 
     if (builderState.applyPropertyToRegularStyle()) {
         auto styleColor = toStyle(initialColor, builderState, ForVisitedLink::No);
-        builderState.style().setColor(styleColor.resolveColor(builderState.parentStyle().color()));
+        builderState.style().setColor(styleColor.resolveColor(ResolvedColors::fromStyle(builderState.parentStyle())));
     }
     if (builderState.applyPropertyToVisitedLinkStyle()) {
         auto styleColor = toStyle(initialColor, builderState, ForVisitedLink::Yes);
-        builderState.style().setVisitedLinkColor(styleColor.resolveColor(builderState.parentStyle().visitedLinkColor()));
+        builderState.style().setVisitedLinkColor(styleColor.resolveColor(ResolvedColors::fromVisitedLinkStyle(builderState.parentStyle())));
     }
 
     builderState.style().setDisallowsFastPathInheritance();
@@ -695,11 +696,11 @@ inline void BuilderCustom::applyValueColor(BuilderState& builderState, CSSValue&
 {
     if (builderState.applyPropertyToRegularStyle()) {
         auto color = toStyleFromCSSValue<Color>(builderState, value, ForVisitedLink::No);
-        builderState.style().setColor(color.resolveColor(builderState.parentStyle().color()));
+        builderState.style().setColor(color.resolveColor(ResolvedColors::fromStyle(builderState.parentStyle())));
     }
     if (builderState.applyPropertyToVisitedLinkStyle()) {
         auto color = toStyleFromCSSValue<Color>(builderState, value, ForVisitedLink::Yes);
-        builderState.style().setVisitedLinkColor(color.resolveColor(builderState.parentStyle().visitedLinkColor()));
+        builderState.style().setVisitedLinkColor(color.resolveColor(ResolvedColors::fromVisitedLinkStyle(builderState.parentStyle())));
     }
 
     builderState.style().setDisallowsFastPathInheritance();

--- a/Source/WebCore/style/StyleBuilderCustom.h
+++ b/Source/WebCore/style/StyleBuilderCustom.h
@@ -63,6 +63,7 @@
 #include "StyleTextEdge+CSSValueConversion.h"
 #include "StyleValueTypes+CSSValueConversion.h"
 #include "TextSpacing.h"
+#include "TransformCurrentColor.h"
 #include "ViewTimeline.h"
 #include <ranges>
 
@@ -113,6 +114,7 @@ public:
     static void applyHighlightValueColor(BuilderState&, CSSValue&);
 
     // Custom handling of value setting only.
+    static void applyValueAccentColor(BuilderState&, CSSValue&);
     static void applyValueWebkitLocale(BuilderState&, CSSValue&);
     static void applyValueTextOrientation(BuilderState&, CSSValue&);
 #if ENABLE(TEXT_AUTOSIZING)
@@ -745,6 +747,24 @@ inline void BuilderCustom::applyHighlightValueColor(BuilderState& builderState, 
 
     if (builderState.applyPropertyToRegularStyle())
         builderState.style().setColorIsCurrentColorForHighlight(valueID(value) == CSSValueCurrentcolor);
+}
+
+inline void BuilderCustom::applyValueAccentColor(BuilderState& builderState, CSSValue& value)
+{
+    auto styleAccentColor = toStyleFromCSSValue<AccentColor>(builderState, value);
+    if (auto accentColor = styleAccentColor.tryColor()) {
+        auto transformedColor = transformCurrentColor(*accentColor, [&](const CurrentColor& currentColor) -> Color {
+            if (currentColor.property() == CurrentColor::Property::AccentColor) {
+                // FIXME: it's unclear what's the behavior when the parent's accent-color is auto.
+                // See https://github.com/w3c/csswg-drafts/issues/14329.
+                return ResolvedColor { builderState.parentStyle().accentColorResolvingCurrentColor() };
+            }
+            return CurrentColor { currentColor.property() };
+        });
+        styleAccentColor = AccentColor { WTF::move(transformedColor) };
+    }
+
+    builderState.style().setAccentColor(WTF::move(styleAccentColor));
 }
 
 } // namespace Style

--- a/Source/WebCore/style/StyleColorResolver.cpp
+++ b/Source/WebCore/style/StyleColorResolver.cpp
@@ -40,7 +40,7 @@ WebCore::Color ColorResolver::colorApplyingColorFilter(const WebCore::Color& col
 
 WebCore::Color ColorResolver::colorResolvingCurrentColor(const Style::Color& color) const
 {
-    return color.resolveColor(m_style->color());
+    return color.resolveColor(ResolvedColors::fromStyle(m_style));
 }
 
 WebCore::Color ColorResolver::colorResolvingCurrentColorApplyingColorFilter(const Style::Color& color) const
@@ -50,7 +50,7 @@ WebCore::Color ColorResolver::colorResolvingCurrentColorApplyingColorFilter(cons
 
 WebCore::Color ColorResolver::visitedLinkColorResolvingCurrentColor(const Style::Color& color) const
 {
-    return color.resolveColor(m_style->visitedLinkColor());
+    return color.resolveColor(ResolvedColors::fromVisitedLinkStyle(m_style));
 }
 
 WebCore::Color ColorResolver::visitedLinkColorResolvingCurrentColorApplyingColorFilter(const Style::Color& color) const

--- a/Source/WebCore/style/StyleColorResolver.h
+++ b/Source/WebCore/style/StyleColorResolver.h
@@ -28,6 +28,7 @@
 #include <WebCore/Color.h>
 #include <WebCore/StyleAppleColorFilter.h>
 #include <WebCore/StyleComputedStyle.h>
+#include <WebCore/StyleResolvedColors.h>
 
 namespace WebCore {
 namespace Style {
@@ -110,7 +111,7 @@ WebCore::Color ColorPropertyResolver<ColorTraits>::colorResolvingCurrentColor() 
     else if constexpr (ImplementsColorResolvingCurrentColor<ColorTraits>)
         return ColorTraits::colorResolvingCurrentColor(m_style);
     else
-        return ColorTraits::color(m_style).resolveColor(m_style->color());
+        return ColorTraits::color(m_style).resolveColor(ResolvedColors::fromStyle(m_style));
 }
 
 template<typename ColorTraits>
@@ -130,7 +131,7 @@ WebCore::Color ColorPropertyResolver<ColorTraits>::visitedLinkColorResolvingCurr
     else if constexpr (ImplementsVisitedLinkColorResolvingCurrentColor<ColorTraits>)
         return ColorTraits::visitedLinkColorResolvingCurrentColor(m_style);
     else
-        return ColorTraits::visitedLinkColor(m_style).resolveColor(m_style->visitedLinkColor());
+        return ColorTraits::visitedLinkColor(m_style).resolveColor(ResolvedColors::fromVisitedLinkStyle(m_style));
 }
 
 template<typename ColorTraits>

--- a/Source/WebCore/style/computed/StyleComputedStyleProperties+GettersCustomInlines.h
+++ b/Source/WebCore/style/computed/StyleComputedStyleProperties+GettersCustomInlines.h
@@ -69,6 +69,7 @@
 #include <WebCore/StyleNonInheritedData.h>
 #include <WebCore/StyleNonInheritedMiscData.h>
 #include <WebCore/StyleNonInheritedRareData.h>
+#include <WebCore/StyleResolvedColors.h>
 #include <WebCore/StyleSVGData.h>
 #include <WebCore/StyleSVGFillData.h>
 #include <WebCore/StyleSVGLayoutData.h>
@@ -325,18 +326,18 @@ inline WebCore::Color ColorPropertyTraits<PropertyNameConstant<CSSPropertyTextDe
         if ((style.hasExplicitlySetStrokeWidth() && style.strokeWidth().isPossiblyPositive()) || style.textStrokeWidth().isPositive()) {
             // Prefer stroke color if possible but not if it's fully transparent.
             if (style.hasExplicitlySetStrokeColor()) {
-                auto strokeColor = style.strokeColor().resolveColor(style.color());
+                auto strokeColor = style.strokeColor().resolveColor(ResolvedColors::fromStyle(style));
                 if (strokeColor.isVisible())
                     return strokeColor;
             } else {
-                auto strokeColor = style.textStrokeColor().resolveColor(style.color());
+                auto strokeColor = style.textStrokeColor().resolveColor(ResolvedColors::fromStyle(style));
                 if (strokeColor.isVisible())
                     return strokeColor;
             }
         }
         return style.color();
     }
-    return result.resolveColor(style.color());
+    return result.resolveColor(ResolvedColors::fromStyle(style));
 }
 
 inline WebCore::Color ColorPropertyTraits<PropertyNameConstant<CSSPropertyTextDecorationColor>>::visitedLinkColorResolvingCurrentColor(const ComputedStyleProperties& style)
@@ -346,18 +347,18 @@ inline WebCore::Color ColorPropertyTraits<PropertyNameConstant<CSSPropertyTextDe
         if ((style.hasExplicitlySetStrokeWidth() && style.strokeWidth().isPossiblyPositive()) || style.textStrokeWidth().isPositive()) {
             // Prefer stroke color if possible but not if it's fully transparent.
             if (style.hasExplicitlySetStrokeColor()) {
-                auto strokeColor = style.visitedLinkStrokeColor().resolveColor(style.visitedLinkColor());
+                auto strokeColor = style.visitedLinkStrokeColor().resolveColor(ResolvedColors::fromVisitedLinkStyle(style));
                 if (strokeColor.isVisible())
                     return strokeColor;
             } else {
-                auto strokeColor = style.visitedLinkTextStrokeColor().resolveColor(style.visitedLinkColor());
+                auto strokeColor = style.visitedLinkTextStrokeColor().resolveColor(ResolvedColors::fromVisitedLinkStyle(style));
                 if (strokeColor.isVisible())
                     return strokeColor;
             }
         }
         return style.visitedLinkColor();
     }
-    return result.resolveColor(style.visitedLinkColor());
+    return result.resolveColor(ResolvedColors::fromVisitedLinkStyle(style));
 }
 
 inline bool ColorPropertyTraits<PropertyNameConstant<CSSPropertyBackgroundColor>>::excludesVisitedLinkColor(const WebCore::Color& visitedLinkColor)

--- a/Source/WebCore/style/computed/StyleComputedStyleProperties+GettersCustomInlines.h
+++ b/Source/WebCore/style/computed/StyleComputedStyleProperties+GettersCustomInlines.h
@@ -286,7 +286,7 @@ inline const Color& ColorPropertyTraits<PropertyNameConstant<CSSPropertyColor>>:
 
 inline const Color& ColorPropertyTraits<PropertyNameConstant<CSSPropertyAccentColor>>::color(const ComputedStyleProperties& style)
 {
-    return style.accentColor().colorOrCurrentColor();
+    return style.accentColor().colorOrDefaultColor();
 }
 
 inline const Color& ColorPropertyTraits<PropertyNameConstant<CSSPropertyCaretColor>>::color(const ComputedStyleProperties& style)

--- a/Source/WebCore/style/values/color/StyleColor.cpp
+++ b/Source/WebCore/style/values/color/StyleColor.cpp
@@ -70,12 +70,12 @@ Color::Color(EmptyToken token)
 }
 
 Color::Color()
-    : value { CurrentColor { } }
+    : value { CurrentColor { CurrentColor::Property::Color } }
 {
 }
 
 Color::Color(CSS::Keyword::Currentcolor)
-    : value { CurrentColor { } }
+    : value { CurrentColor { CurrentColor::Property::Color } }
 {
 }
 
@@ -234,7 +234,7 @@ bool Color::operator==(const Color& other) const = default;
 
 const Color& Color::currentColor()
 {
-    static NeverDestroyed<Style::Color> color { CurrentColor { } };
+    static NeverDestroyed<Style::Color> color { CurrentColor { CurrentColor::Property::Color } };
     return color.get();
 }
 
@@ -257,9 +257,9 @@ WTF::String Color::debugDescription() const
     return ts.release();
 }
 
-WebCore::Color Color::resolveColor(const WebCore::Color& currentColor) const
+WebCore::Color Color::resolveColor(const ResolvedColors& resolvedColors) const
 {
-    return switchOn([&](const auto& kind) { return WebCore::Style::resolveColor(kind, currentColor); });
+    return switchOn([&](const auto& kind) { return WebCore::Style::resolveColor(kind, resolvedColors); });
 }
 
 bool Color::containsCurrentColor() const
@@ -328,9 +328,9 @@ template<typename T> Color::ColorKind Color::makeIndirectColor(T&& colorType)
     return { makeUniqueRef<T>(WTF::move(colorType)) };
 }
 
-WebCore::Color resolveColor(const Color& value, const WebCore::Color& currentColor)
+WebCore::Color resolveColor(const Color& value, const ResolvedColors& resolvedColors)
 {
-    return value.resolveColor(currentColor);
+    return value.resolveColor(resolvedColors);
 }
 
 bool containsCurrentColor(const Color& value)

--- a/Source/WebCore/style/values/color/StyleColor.h
+++ b/Source/WebCore/style/values/color/StyleColor.h
@@ -53,6 +53,7 @@ namespace Style {
 enum class ForVisitedLink : bool;
 
 class ComputedStyle;
+class ResolvedColors;
 
 // The following style color kinds are forward declared and stored in
 // UniqueRefs to avoid unnecessarily growing the size of Color for the
@@ -156,7 +157,7 @@ public:
     bool NODELETE isResolvedColor() const;
     const WebCore::Color& resolvedColor() const;
 
-    WEBCORE_EXPORT WebCore::Color resolveColor(const WebCore::Color& currentColor) const;
+    WEBCORE_EXPORT WebCore::Color resolveColor(const ResolvedColors&) const;
 
     bool isKnownTransparent() const;
 
@@ -174,7 +175,7 @@ private:
     ColorKind value;
 };
 
-WebCore::Color resolveColor(const Color&, const WebCore::Color& currentColor);
+WebCore::Color resolveColor(const Color&, const ResolvedColors&);
 bool containsCurrentColor(const Color&);
 
 void serializationForCSSTokenization(StringBuilder&, const CSS::SerializationContext&, const Color&);

--- a/Source/WebCore/style/values/color/StyleColor.h
+++ b/Source/WebCore/style/values/color/StyleColor.h
@@ -178,6 +178,8 @@ private:
 WebCore::Color resolveColor(const Color&, const ResolvedColors&);
 bool containsCurrentColor(const Color&);
 
+template<class F> Color transformCurrentColor(const Color&, F&&);
+
 void serializationForCSSTokenization(StringBuilder&, const CSS::SerializationContext&, const Color&);
 WTF::String serializationForCSSTokenization(const CSS::SerializationContext&, const Color&);
 

--- a/Source/WebCore/style/values/color/StyleColorLayers.cpp
+++ b/Source/WebCore/style/values/color/StyleColorLayers.cpp
@@ -71,13 +71,13 @@ Color toStyleColor(const CSS::ColorLayers& unresolved, ColorResolutionState& sta
 
 // MARK: Resolve
 
-WebCore::Color resolveColor(const ColorLayers& colorLayers, const WebCore::Color& currentColor)
+WebCore::Color resolveColor(const ColorLayers& colorLayers, const ResolvedColors& resolvedColors)
 {
     return blendSourceOver(
         CSS::ColorLayersResolver {
             .blendMode = colorLayers.blendMode,
             .colors = colorLayers.colors.map([&](auto& color) {
-                return color.resolveColor(currentColor);
+                return color.resolveColor(resolvedColors);
             })
         }
     );

--- a/Source/WebCore/style/values/color/StyleColorLayers.h
+++ b/Source/WebCore/style/values/color/StyleColorLayers.h
@@ -54,7 +54,7 @@ inline bool operator==(const UniqueRef<ColorLayers>& a, const UniqueRef<ColorLay
 }
 
 Color toStyleColor(const CSS::ColorLayers&, ColorResolutionState&);
-WebCore::Color resolveColor(const ColorLayers&, const WebCore::Color& currentColor);
+WebCore::Color resolveColor(const ColorLayers&, const ResolvedColors&);
 bool containsCurrentColor(const ColorLayers&);
 
 void serializationForCSSTokenization(StringBuilder&, const CSS::SerializationContext&, const ColorLayers&);

--- a/Source/WebCore/style/values/color/StyleColorMix.cpp
+++ b/Source/WebCore/style/values/color/StyleColorMix.cpp
@@ -81,14 +81,14 @@ Color toStyleColor(const CSS::ColorMix& unresolved, ColorResolutionState& state)
 
 // MARK: - Resolve
 
-WebCore::Color resolveColor(const ColorMix& colorMix, const WebCore::Color& currentColor)
+WebCore::Color resolveColor(const ColorMix& colorMix, const ResolvedColors& resolvedColors)
 {
     return mix(
         CSS::ColorMixResolver {
             colorMix.colorInterpolationMethod,
             colorMix.components.map([&](auto& component) {
                 return CSS::ColorMixResolver::Component {
-                    component.color.resolveColor(currentColor),
+                    component.color.resolveColor(resolvedColors),
                     component.percentage,
                 };
             })

--- a/Source/WebCore/style/values/color/StyleContrastColor.cpp
+++ b/Source/WebCore/style/values/color/StyleContrastColor.cpp
@@ -60,11 +60,11 @@ Color toStyleColor(const CSS::ContrastColor& unresolved, ColorResolutionState& s
 
 // MARK: - Resolve
 
-WebCore::Color resolveColor(const ContrastColor& contrastColor, const WebCore::Color& currentColor)
+WebCore::Color resolveColor(const ContrastColor& contrastColor, const ResolvedColors& resolvedColors)
 {
     return resolve(
         CSS::ContrastColorResolver {
-            contrastColor.color.resolveColor(currentColor),
+            contrastColor.color.resolveColor(resolvedColors),
         }
     );
 }

--- a/Source/WebCore/style/values/color/StyleContrastColor.h
+++ b/Source/WebCore/style/values/color/StyleContrastColor.h
@@ -50,7 +50,7 @@ inline bool operator==(const UniqueRef<ContrastColor>& a, const UniqueRef<Contra
 }
 
 Color toStyleColor(const CSS::ContrastColor&, ColorResolutionState&);
-WebCore::Color resolveColor(const ContrastColor&, const WebCore::Color& currentColor);
+WebCore::Color resolveColor(const ContrastColor&, const ResolvedColors&);
 bool containsCurrentColor(const ContrastColor&);
 
 void serializationForCSSTokenization(StringBuilder&, const CSS::SerializationContext&, const ContrastColor&);

--- a/Source/WebCore/style/values/color/StyleCurrentColor.cpp
+++ b/Source/WebCore/style/values/color/StyleCurrentColor.cpp
@@ -32,23 +32,52 @@
 namespace WebCore {
 namespace Style {
 
-// MARK: - Serialization
-
-void serializationForCSSTokenization(StringBuilder& builder, const CSS::SerializationContext&, const CurrentColor&)
+CurrentColor::CurrentColor(Property property)
+    : m_property(property)
 {
-    builder.append("currentcolor"_s);
 }
 
-WTF::String serializationForCSSTokenization(const CSS::SerializationContext&, const CurrentColor&)
+// MARK: - Serialization
+
+void serializationForCSSTokenization(StringBuilder& builder, const CSS::SerializationContext&, const CurrentColor& currentColor)
 {
-    return "currentcolor"_s;
+    switch (currentColor.property()) {
+    case CurrentColor::Property::Color:
+        builder.append("currentcolor"_s);
+        return;
+    default:
+        ASSERT_NOT_REACHED();
+        builder.append("<invalid color>"_s);
+        break;
+    }
+}
+
+WTF::String serializationForCSSTokenization(const CSS::SerializationContext&, const CurrentColor& currentColor)
+{
+    switch (currentColor.property()) {
+    case CurrentColor::Property::Color:
+        return "currentcolor"_s;
+    default:
+        break;
+    }
+
+    ASSERT_NOT_REACHED();
+    return "<invalid color>"_s;
 }
 
 // MARK: - TextStream
 
-WTF::TextStream& operator<<(WTF::TextStream& ts, const CurrentColor&)
+WTF::TextStream& operator<<(WTF::TextStream& ts, const CurrentColor& currentColor)
 {
-    return ts << "currentColor"_s;
+    switch (currentColor.property()) {
+    case CurrentColor::Property::Color:
+        return ts << "currentcolor"_s;
+    default:
+        break;
+    }
+
+    ASSERT_NOT_REACHED();
+    return ts << "<invalid color>"_s;
 }
 
 } // namespace Style

--- a/Source/WebCore/style/values/color/StyleCurrentColor.cpp
+++ b/Source/WebCore/style/values/color/StyleCurrentColor.cpp
@@ -45,6 +45,9 @@ void serializationForCSSTokenization(StringBuilder& builder, const CSS::Serializ
     case CurrentColor::Property::Color:
         builder.append("currentcolor"_s);
         return;
+    case CurrentColor::Property::AccentColor:
+        builder.append("AccentColor"_s);
+        return;
     default:
         ASSERT_NOT_REACHED();
         builder.append("<invalid color>"_s);
@@ -57,6 +60,8 @@ WTF::String serializationForCSSTokenization(const CSS::SerializationContext&, co
     switch (currentColor.property()) {
     case CurrentColor::Property::Color:
         return "currentcolor"_s;
+    case CurrentColor::Property::AccentColor:
+        return "AccentColor"_s;
     default:
         break;
     }
@@ -72,6 +77,8 @@ WTF::TextStream& operator<<(WTF::TextStream& ts, const CurrentColor& currentColo
     switch (currentColor.property()) {
     case CurrentColor::Property::Color:
         return ts << "currentcolor"_s;
+    case CurrentColor::Property::AccentColor:
+        return ts << "AccentColor"_s;
     default:
         break;
     }

--- a/Source/WebCore/style/values/color/StyleCurrentColor.h
+++ b/Source/WebCore/style/values/color/StyleCurrentColor.h
@@ -27,6 +27,7 @@
 #pragma once
 
 #include <WebCore/Color.h>
+#include <WebCore/StyleResolvedColors.h>
 #include <wtf/Forward.h>
 
 namespace WebCore {
@@ -37,13 +38,41 @@ struct SerializationContext;
 
 namespace Style {
 
-struct CurrentColor {
+class ComputedStyleProperties;
+
+// CurrentColor refers to a color that is defined in the elemene's style.
+// Note that this is a bit different from CSS 'currentColor' keyword:
+// 'currentColor' keyword refers to the current value of the 'color' property
+// of the element, while this CurrentColor refers to any color that is defined
+// in the style, including 'currentColor'.
+class CurrentColor {
+public:
+    // Represents the CSS property in which to obtain the color from.
+    enum class Property {
+        // 'color' property.
+        Color
+    };
+
+    WEBCORE_EXPORT CurrentColor(Property);
+
+    Property property() const { return m_property; }
+
     constexpr bool operator==(const CurrentColor&) const = default;
+
+private:
+    Property m_property;
 };
 
-inline WebCore::Color resolveColor(const CurrentColor&, const WebCore::Color& currentColor)
+inline WebCore::Color resolveColor(const CurrentColor& currentColor, const ResolvedColors& resolvedColors)
 {
-    return currentColor;
+    switch (currentColor.property()) {
+    case CurrentColor::Property::Color:
+        return resolvedColors.currentColor();
+
+    default:
+        ASSERT_NOT_REACHED();
+        return { };
+    }
 }
 
 constexpr bool containsCurrentColor(const CurrentColor&)

--- a/Source/WebCore/style/values/color/StyleCurrentColor.h
+++ b/Source/WebCore/style/values/color/StyleCurrentColor.h
@@ -50,7 +50,10 @@ public:
     // Represents the CSS property in which to obtain the color from.
     enum class Property {
         // 'color' property.
-        Color
+        Color,
+
+        // CSS 'accent-color' property
+        AccentColor
     };
 
     WEBCORE_EXPORT CurrentColor(Property);
@@ -68,6 +71,9 @@ inline WebCore::Color resolveColor(const CurrentColor& currentColor, const Resol
     switch (currentColor.property()) {
     case CurrentColor::Property::Color:
         return resolvedColors.currentColor();
+
+    case CurrentColor::Property::AccentColor:
+        return resolvedColors.accentColor();
 
     default:
         ASSERT_NOT_REACHED();

--- a/Source/WebCore/style/values/color/StyleKeywordColor.cpp
+++ b/Source/WebCore/style/values/color/StyleKeywordColor.cpp
@@ -51,7 +51,7 @@ Color toStyleColor(const CSS::KeywordColor& unresolved, ColorResolutionState& st
     case CSSValueWebkitFocusRingColor:
         return { RenderTheme::singleton().focusRingColor(state.document->styleColorOptions(state.style.ptr())) };
     case CSSValueCurrentcolor:
-        return { CurrentColor() };
+        return { CurrentColor { CurrentColor::Property::Color } };
     default:
         return { CSS::colorFromKeyword(unresolved.valueID, state.document->styleColorOptions(state.style.ptr())) };
     }

--- a/Source/WebCore/style/values/color/StyleKeywordColor.cpp
+++ b/Source/WebCore/style/values/color/StyleKeywordColor.cpp
@@ -34,6 +34,7 @@
 #include "StyleColor.h"
 #include "StyleColorResolutionState.h"
 #include "StyleComputedStyle.h"
+#include "StyleContrastColor.h"
 #include "StyleCurrentColor.h"
 
 namespace WebCore {
@@ -52,6 +53,10 @@ Color toStyleColor(const CSS::KeywordColor& unresolved, ColorResolutionState& st
         return { RenderTheme::singleton().focusRingColor(state.document->styleColorOptions(state.style.ptr())) };
     case CSSValueCurrentcolor:
         return { CurrentColor { CurrentColor::Property::Color } };
+    case CSSValueAccentcolor:
+        return { CurrentColor { CurrentColor::Property::AccentColor } };
+    case CSSValueAccentcolortext:
+        return { ContrastColor { CurrentColor { CurrentColor::Property::AccentColor } } };
     default:
         return { CSS::colorFromKeyword(unresolved.valueID, state.document->styleColorOptions(state.style.ptr())) };
     }

--- a/Source/WebCore/style/values/color/StyleRelativeAlphaColor.cpp
+++ b/Source/WebCore/style/values/color/StyleRelativeAlphaColor.cpp
@@ -73,11 +73,11 @@ Color toStyleColor(const CSS::RelativeAlphaColor& unresolved, ColorResolutionSta
 
 // MARK: - Resolve
 
-WebCore::Color resolveColor(const RelativeAlphaColor& value, const WebCore::Color& currentColor)
+WebCore::Color resolveColor(const RelativeAlphaColor& value, const ResolvedColors& resolvedColors)
 {
     return resolveNoConversionDataRequired(
         CSS::RelativeAlphaColorResolver {
-            .origin = value.origin.resolveColor(currentColor),
+            .origin = value.origin.resolveColor(resolvedColors),
             .alpha = value.alpha
         }
     );

--- a/Source/WebCore/style/values/color/StyleRelativeAlphaColor.h
+++ b/Source/WebCore/style/values/color/StyleRelativeAlphaColor.h
@@ -57,7 +57,7 @@ inline bool operator==(const UniqueRef<RelativeAlphaColor>& a, const UniqueRef<R
 }
 
 Color toStyleColor(const CSS::RelativeAlphaColor&, ColorResolutionState&);
-WebCore::Color resolveColor(const RelativeAlphaColor&, const WebCore::Color& currentColor);
+WebCore::Color resolveColor(const RelativeAlphaColor&, const ResolvedColors&);
 bool containsCurrentColor(const RelativeAlphaColor&);
 
 void serializationForCSSTokenization(StringBuilder&, const CSS::SerializationContext&, const RelativeAlphaColor&);

--- a/Source/WebCore/style/values/color/StyleRelativeColor.h
+++ b/Source/WebCore/style/values/color/StyleRelativeColor.h
@@ -88,11 +88,11 @@ template<typename D> Style::Color toStyleColor(const CSS::RelativeColor<D>& unre
     return { ResolvedColor { WTF::move(color) } };
 }
 
-template<typename D> WebCore::Color resolveColor(const RelativeColor<D>& relative, const WebCore::Color& currentColor)
+template<typename D> WebCore::Color resolveColor(const RelativeColor<D>& relative, const ResolvedColors& resolvedColors)
 {
     return resolveNoConversionDataRequired(
         CSS::RelativeColorResolver<D> {
-            .origin = relative.origin.resolveColor(currentColor),
+            .origin = relative.origin.resolveColor(resolvedColors),
             .components = relative.components
         }
     );

--- a/Source/WebCore/style/values/color/StyleRelativeColor.h
+++ b/Source/WebCore/style/values/color/StyleRelativeColor.h
@@ -33,6 +33,7 @@
 #include "Color.h"
 #include "ColorSerialization.h"
 #include "StyleColor.h"
+#include "StyleColorResolutionState.h"
 #include "StyleKeyword+Logging.h"
 #include "StylePrimitiveNumericTypes+Logging.h"
 #include "StyleResolvedColor.h"

--- a/Source/WebCore/style/values/color/StyleResolvedColor.h
+++ b/Source/WebCore/style/values/color/StyleResolvedColor.h
@@ -46,7 +46,7 @@ struct ResolvedColor {
 
 Color toStyleColor(const CSS::ResolvedColor&, ColorResolutionState&);
 
-inline WebCore::Color resolveColor(const ResolvedColor& absoluteColor, const WebCore::Color&)
+inline WebCore::Color resolveColor(const ResolvedColor& absoluteColor, const ResolvedColors&)
 {
     return absoluteColor.color;
 }

--- a/Source/WebCore/style/values/color/StyleResolvedColors.cpp
+++ b/Source/WebCore/style/values/color/StyleResolvedColors.cpp
@@ -1,6 +1,5 @@
 /*
- * Copyright (C) 2024 Apple Inc. All rights reserved.
- * Copyright (C) 2025-2026 Samuel Weinig <sam@webkit.org>
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -24,57 +23,26 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
-
-#include "ColorInterpolationMethod.h"
-#include "StyleColor.h"
-#include "StylePrimitiveNumericTypes.h"
-#include <optional>
-#include <wtf/UniqueRef.h>
+#include "config.h"
+#include "StyleResolvedColors.h"
 
 namespace WebCore {
-
-class Color;
-
-namespace CSS {
-struct ColorMix;
-}
-
 namespace Style {
 
-struct ColorResolutionState;
-
-struct ColorMix {
-    WTF_DEPRECATED_MAKE_STRUCT_FAST_ALLOCATED(ColorMix);
-
-    struct Component {
-        using Percentage = Style::Percentage<CSS::Range{0, 100}>;
-
-        Color color;
-        std::optional<Percentage> percentage;
-
-        bool operator==(const Component&) const = default;
-    };
-
-    ColorInterpolationMethod colorInterpolationMethod;
-    CommaSeparatedVector<Component> components;
-
-    bool operator==(const ColorMix&) const = default;
-};
-
-inline bool operator==(const UniqueRef<ColorMix>& a, const UniqueRef<ColorMix>& b)
+ResolvedColors::ResolvedColors(WebCore::Color currentColor)
+    : m_currentColor(currentColor)
 {
-    return a.get() == b.get();
 }
 
-Color toStyleColor(const CSS::ColorMix&, ColorResolutionState&);
-WebCore::Color resolveColor(const ColorMix&, const ResolvedColors&);
-bool containsCurrentColor(const ColorMix&);
+ResolvedColors ResolvedColors::fromStyle(const ComputedStyleProperties& style)
+{
+    return ResolvedColors(style.color());
+}
 
-void serializationForCSSTokenization(StringBuilder&, const CSS::SerializationContext&, const ColorMix&);
-WTF::String serializationForCSSTokenization(const CSS::SerializationContext&, const ColorMix&);
-
-WTF::TextStream& operator<<(WTF::TextStream&, const ColorMix&);
+ResolvedColors ResolvedColors::fromVisitedLinkStyle(const ComputedStyleProperties& style)
+{
+    return ResolvedColors(style.visitedLinkColorResolvingCurrentColor());
+}
 
 } // namespace Style
 } // namespace WebCore

--- a/Source/WebCore/style/values/color/StyleResolvedColors.cpp
+++ b/Source/WebCore/style/values/color/StyleResolvedColors.cpp
@@ -29,19 +29,36 @@
 namespace WebCore {
 namespace Style {
 
-ResolvedColors::ResolvedColors(WebCore::Color currentColor)
+ResolvedColors::ResolvedColors(WebCore::Color currentColor, WebCore::Color accentColor)
     : m_currentColor(currentColor)
+    , m_accentColor(accentColor)
 {
 }
 
 ResolvedColors ResolvedColors::fromStyle(const ComputedStyleProperties& style)
 {
-    return ResolvedColors(style.color());
+    auto currentColor = style.color();
+    WebCore::Color resolvedAccentColor = [&] () {
+        auto accentColorOrDefault = style.accentColor().colorOrDefaultColor();
+
+        // We're sure that style.accentColor() won't have any AccentColor, since those got
+        // replaced with the parent's accent color during style building. So just give a null
+        // color for AccentColor, it doesn't matter since we won't need to use it.
+        return resolveColor(accentColorOrDefault, ResolvedColors { currentColor, { } });
+    }();
+
+    return ResolvedColors(style.color(), resolvedAccentColor);
 }
 
 ResolvedColors ResolvedColors::fromVisitedLinkStyle(const ComputedStyleProperties& style)
 {
-    return ResolvedColors(style.visitedLinkColorResolvingCurrentColor());
+    auto currentColor = style.color();
+    WebCore::Color resolvedAccentColor = [&] () {
+        auto accentColorOrDefault = style.accentColor().colorOrDefaultColor();
+        return resolveColor(accentColorOrDefault, ResolvedColors { currentColor, { } });
+    }();
+
+    return ResolvedColors(style.visitedLinkColorResolvingCurrentColor(), resolvedAccentColor);
 }
 
 } // namespace Style

--- a/Source/WebCore/style/values/color/StyleResolvedColors.h
+++ b/Source/WebCore/style/values/color/StyleResolvedColors.h
@@ -1,6 +1,5 @@
 /*
- * Copyright (C) 2024 Apple Inc. All rights reserved.
- * Copyright (C) 2025-2026 Samuel Weinig <sam@webkit.org>
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,55 +25,30 @@
 
 #pragma once
 
-#include "ColorInterpolationMethod.h"
-#include "StyleColor.h"
-#include "StylePrimitiveNumericTypes.h"
-#include <optional>
-#include <wtf/UniqueRef.h>
+#include <WebCore/Color.h>
 
 namespace WebCore {
-
-class Color;
-
-namespace CSS {
-struct ColorMix;
-}
-
 namespace Style {
 
-struct ColorResolutionState;
+class ComputedStyleProperties;
 
-struct ColorMix {
-    WTF_DEPRECATED_MAKE_STRUCT_FAST_ALLOCATED(ColorMix);
+// Stores colors from a computed style that a CurrentColor will need to resolve.
+class ResolvedColors {
+    WTF_MAKE_TZONE_ALLOCATED(ResolvedColors);
 
-    struct Component {
-        using Percentage = Style::Percentage<CSS::Range{0, 100}>;
+public:
+    explicit ResolvedColors(WebCore::Color);
 
-        Color color;
-        std::optional<Percentage> percentage;
+    static ResolvedColors fromStyle(const ComputedStyleProperties&);
 
-        bool operator==(const Component&) const = default;
-    };
+    // This grabs the visited link color from the style, instead of the 'normal' color.
+    static ResolvedColors fromVisitedLinkStyle(const ComputedStyleProperties&);
 
-    ColorInterpolationMethod colorInterpolationMethod;
-    CommaSeparatedVector<Component> components;
+    WebCore::Color currentColor() const { return m_currentColor; }
 
-    bool operator==(const ColorMix&) const = default;
+private:
+    WebCore::Color m_currentColor;
 };
-
-inline bool operator==(const UniqueRef<ColorMix>& a, const UniqueRef<ColorMix>& b)
-{
-    return a.get() == b.get();
-}
-
-Color toStyleColor(const CSS::ColorMix&, ColorResolutionState&);
-WebCore::Color resolveColor(const ColorMix&, const ResolvedColors&);
-bool containsCurrentColor(const ColorMix&);
-
-void serializationForCSSTokenization(StringBuilder&, const CSS::SerializationContext&, const ColorMix&);
-WTF::String serializationForCSSTokenization(const CSS::SerializationContext&, const ColorMix&);
-
-WTF::TextStream& operator<<(WTF::TextStream&, const ColorMix&);
 
 } // namespace Style
 } // namespace WebCore

--- a/Source/WebCore/style/values/color/StyleResolvedColors.h
+++ b/Source/WebCore/style/values/color/StyleResolvedColors.h
@@ -37,7 +37,7 @@ class ResolvedColors {
     WTF_MAKE_TZONE_ALLOCATED(ResolvedColors);
 
 public:
-    explicit ResolvedColors(WebCore::Color);
+    explicit ResolvedColors(WebCore::Color currentColor, WebCore::Color accentColor);
 
     static ResolvedColors fromStyle(const ComputedStyleProperties&);
 
@@ -45,9 +45,11 @@ public:
     static ResolvedColors fromVisitedLinkStyle(const ComputedStyleProperties&);
 
     WebCore::Color currentColor() const { return m_currentColor; }
+    WebCore::Color accentColor() const { return m_accentColor; }
 
 private:
     WebCore::Color m_currentColor;
+    WebCore::Color m_accentColor;
 };
 
 } // namespace Style

--- a/Source/WebCore/style/values/color/TransformCurrentColor.h
+++ b/Source/WebCore/style/values/color/TransformCurrentColor.h
@@ -1,0 +1,110 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "StyleColor.h"
+#include "StyleColorLayers.h"
+#include "StyleColorMix.h"
+#include "StyleContrastColor.h"
+#include "StyleRelativeAlphaColor.h"
+#include "StyleRelativeColor.h"
+#include "StyleResolvedColor.h"
+
+namespace WebCore {
+namespace Style {
+
+namespace {
+
+template<class F> Color transformCurrentColorInternal(const ColorLayers& colorLayers, F&& f)
+{
+    return ColorLayers {
+        .blendMode = colorLayers.blendMode,
+        .colors = colorLayers.colors.map([&] (const Color& color) { return transformCurrentColor(color, std::forward<F>(f)); })
+    };
+}
+
+
+template<class F> Color transformCurrentColorInternal(const ColorMix& colorMix, F&& f)
+{
+    return ColorMix {
+        .colorInterpolationMethod = colorMix.colorInterpolationMethod,
+        .components = colorMix.components.map([&] (const ColorMix::Component& component) {
+            return ColorMix::Component {
+                .color = transformCurrentColor(component.color, std::forward<F>(f)),
+                .percentage = component.percentage
+            };
+        })
+    };
+}
+
+template<class F> Color transformCurrentColorInternal(const ContrastColor& contrastColor, F&& f)
+{
+    return ContrastColor {
+        .color = transformCurrentColor(contrastColor.color, std::forward<F>(f))
+    };
+}
+
+template<class F> Color transformCurrentColorInternal(const RelativeAlphaColor& relativeAlphaColor, F&& f)
+{
+    return RelativeAlphaColor {
+        .origin = transformCurrentColor(relativeAlphaColor.origin, std::forward<F>(f)),
+        .alpha = relativeAlphaColor.alpha
+    };
+}
+
+template<class F, class D> Color transformCurrentColorInternal(const RelativeColor<D>& relativeColor, F&& f)
+{
+    return RelativeColor<D> {
+        .origin = transformCurrentColor(relativeColor.origin, std::forward<F>(f)),
+        .components = relativeColor.components
+    };
+}
+
+
+template<class F> Color transformCurrentColorInternal(const ResolvedColor& color, F&&)
+{
+    return ResolvedColor { color };
+}
+
+template<class F> Color transformCurrentColorInternal(const CurrentColor& color, F&& f)
+{
+    return f(color);
+}
+
+} // namespace
+
+// Returns a new Color with the same structure as the old color, except with any embedded
+// CurrentColor being replaced with `f(currentColor)`. This is useful for e.g replacing
+// any embedded CurrentColor with another color.
+// E.g: a ContrastColor { CurrentColor { ... } } becomes ContrastColor { f(CurrentColor { ... }) }
+template<class F> Color transformCurrentColor(const Color& color, F&& f)
+{
+    return color.switchOn([&](const auto& kind) { return transformCurrentColorInternal(kind, std::forward<F>(f)); });
+}
+
+
+} // namespace Style
+} // namespace WebCore

--- a/Source/WebCore/style/values/filter-effects/StyleDropShadowFunction.cpp
+++ b/Source/WebCore/style/values/filter-effects/StyleDropShadowFunction.cpp
@@ -34,6 +34,7 @@
 #include "StyleComputedStyle+GettersInlines.h"
 #include "StylePrimitiveNumericTypes+Conversions.h"
 #include "StylePrimitiveNumericTypes+Evaluation.h"
+#include "StyleResolvedColors.h"
 
 namespace WebCore {
 namespace Style {
@@ -95,7 +96,7 @@ auto Evaluation<DropShadow, Ref<FilterEffect>>::operator()(const DropShadow& val
     auto y = Style::roundForImpreciseConversion<int>(evaluate<float>(value.location.y(), zoom));
     auto stdDeviation = Style::roundForImpreciseConversion<int>(evaluate<float>(value.stdDeviation, zoom));
 
-    return FEDropShadow::create(stdDeviation, stdDeviation, x, y, value.color.resolveColor(style.color()), 1);
+    return FEDropShadow::create(stdDeviation, stdDeviation, x, y, value.color.resolveColor(ResolvedColors::fromStyle(style)), 1);
 }
 
 // MARK: - Platform
@@ -105,7 +106,7 @@ auto ToPlatform<DropShadow>::operator()(const DropShadow& value, const Style::Co
     auto zoom = style.usedZoomForLength();
 
     return DropShadowFilterOperation::create(
-        value.color.resolveColor(style.color()),
+        value.color.resolveColor(ResolvedColors::fromStyle(style)),
         IntPoint {
             Style::roundForImpreciseConversion<int>(evaluate<float>(value.location.x(), zoom)),
             Style::roundForImpreciseConversion<int>(evaluate<float>(value.location.y(), zoom)),

--- a/Source/WebCore/style/values/ui/StyleAccentColor.cpp
+++ b/Source/WebCore/style/values/ui/StyleAccentColor.cpp
@@ -27,15 +27,20 @@
 #include "StyleAccentColor.h"
 
 #include "AnimationUtilities.h"
+#include <wtf/NeverDestroyed.h>
 
 namespace WebCore {
 namespace Style {
 
-const Color& AccentColor::colorOrCurrentColor() const
+const Color& AccentColor::colorOrDefaultColor() const
 {
     if (m_value)
         return *m_value;
-    return Color::currentColor();
+
+    // Get the default accent color, which is a constant regardless of StyleColorOptions.
+    // Hence the StyleColorOptions can be a default empty one.
+    static NeverDestroyed<Style::Color> defaultColor { CSS::colorFromKeyword(CSSValueAccentcolor, { }) };
+    return defaultColor;
 }
 
 // MARK: - Blending

--- a/Source/WebCore/style/values/ui/StyleAccentColor.h
+++ b/Source/WebCore/style/values/ui/StyleAccentColor.h
@@ -40,8 +40,8 @@ struct AccentColor : ValueOrKeyword<Color, CSS::Keyword::Auto> {
     bool isColor() const { return isValue(); }
     std::optional<Color> tryColor() const { return tryValue(); }
 
-    // Returns the color or a `currentColor` singleton if `auto`.
-    const Color& colorOrCurrentColor() const;
+    // Returns the color or the default accent color (equivalent to CSS `AccentColor`) if `auto`.
+    const Color& colorOrDefaultColor() const;
 };
 
 // MARK: - Blending

--- a/Tools/TestWebKitAPI/Tests/WebCore/StyleGradient.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/StyleGradient.cpp
@@ -51,7 +51,7 @@ static WebCore::Style::GradientLinearColorStopList someUncacheableStops()
 {
     return {
         {
-            WebCore::Style::Color { WebCore::Style::CurrentColor { } },
+            WebCore::Style::Color { WebCore::Style::CurrentColor { WebCore::Style::CurrentColor::Property::Color } },
             50_css_percentage
         },
         {
@@ -65,11 +65,11 @@ static WebCore::Style::GradientLinearColorStopList allUncacheableStops()
 {
     return {
         {
-            WebCore::Style::Color { WebCore::Style::CurrentColor { } },
+            WebCore::Style::Color { WebCore::Style::CurrentColor { WebCore::Style::CurrentColor::Property::Color } },
             50_css_percentage
         },
         {
-            WebCore::Style::Color { WebCore::Style::CurrentColor { } },
+            WebCore::Style::Color { WebCore::Style::CurrentColor { WebCore::Style::CurrentColor::Property::Color } },
             100_css_percentage
         }
     };


### PR DESCRIPTION
#### 2d5bc85e3f17be7ce3ed962f11c616b90fafc3a8
<pre>
[css-color-4] [css-ui-4] AccentColor system color should use accent-color if set
<a href="https://rdar.apple.com/182555280">rdar://182555280</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=319721">https://bugs.webkit.org/show_bug.cgi?id=319721</a>

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

Tests: imported/w3c/web-platform-tests/css/css-ui/accent-color-accentcolor-is-parent-accent-color.html
       imported/w3c/web-platform-tests/css/css-ui/accent-color-accentcolortext-is-parent-accentcolortext.html
       imported/w3c/web-platform-tests/css/css-ui/accent-color-current-color.html
       imported/w3c/web-platform-tests/css/css-ui/accent-color-currentcolor-color-accentcolor.html
       imported/w3c/web-platform-tests/css/css-ui/accent-color-currentcolor-color-accentcolortext.html
       imported/w3c/web-platform-tests/css/css-ui/accentcolor-color-keyword-comes-from-accent-color.html
       imported/w3c/web-platform-tests/css/css-ui/color-accentcolor-is-parent-accent-color.html
       imported/w3c/web-platform-tests/css/css-ui/color-accentcolortext-is-parent-accentcolortext.html

* LayoutTests/imported/w3c/web-platform-tests/css/css-ui/accent-color-accentcolor-is-parent-accent-color-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-ui/accent-color-accentcolor-is-parent-accent-color.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-ui/accent-color-accentcolortext-is-parent-accentcolortext-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-ui/accent-color-accentcolortext-is-parent-accentcolortext.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-ui/accent-color-checkbox-checked-001.tentative-expected-mismatch.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-ui/accent-color-current-color-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-ui/accent-color-current-color.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-ui/accent-color-currentcolor-color-accentcolor-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-ui/accent-color-currentcolor-color-accentcolor.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-ui/accent-color-currentcolor-color-accentcolortext-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-ui/accent-color-currentcolor-color-accentcolortext.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-ui/accentcolor-color-keyword-comes-from-accent-color-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-ui/accentcolor-color-keyword-comes-from-accent-color.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-ui/color-accentcolor-is-parent-accent-color-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-ui/color-accentcolor-is-parent-accent-color.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-ui/color-accentcolortext-is-parent-accentcolortext-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-ui/color-accentcolortext-is-parent-accentcolortext.html: Added.
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/style/MatchedDeclarationsCache.cpp:
(WebCore::Style::MatchedDeclarationsCache::isCacheable):
* Source/WebCore/style/StyleBuilderCustom.h:
(WebCore::Style::BuilderCustom::applyValueAccentColor):
* Source/WebCore/style/values/color/StyleColor.h:
* Source/WebCore/style/values/color/StyleCurrentColor.cpp:
(WebCore::Style::ResolvedColors::ResolvedColors):
(WebCore::Style::ResolvedColors::fromStyle):
(WebCore::Style::ResolvedColors::fromVisitedLinkStyle):
(WebCore::Style::serializationForCSSTokenization):
(WebCore::Style::operator&lt;&lt;):
* Source/WebCore/style/values/color/StyleCurrentColor.h:
(WebCore::Style::ResolvedColors::accentColor const):
(WebCore::Style::resolveColor):
* Source/WebCore/style/values/color/StyleKeywordColor.cpp:
(WebCore::Style::toStyleColor):
* Source/WebCore/style/values/color/StyleRelativeColor.h:
* Source/WebCore/style/values/color/TransformCurrentColor.h: Added.
(WebCore::Style::transformCurrentColor):
* Source/WebCore/style/values/color/StyleResolvedColors.cpp:
(WebCore::Style::ResolvedColors::ResolvedColors):
(WebCore::Style::ResolvedColors::fromStyle):
(WebCore::Style::ResolvedColors::fromVisitedLinkStyle):
* Source/WebCore/style/values/color/StyleResolvedColors.h:
(WebCore::Style::ResolvedColors::accentColor const):
</pre>
----------------------------------------------------------------------
#### 41c61b0a08db7bc2807b229de23151f871e37482
<pre>
accent-color: auto shouldn&apos;t resolve to currentColor
<a href="https://rdar.apple.com/185139910">rdar://185139910</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=321956">https://bugs.webkit.org/show_bug.cgi?id=321956</a>

Reviewed by NOBODY (OOPS!).

The ColorPropertyTraits implementation for accent-color calls
Style::AccentColor::colorOrCurrentColor, which computes accent-color: auto
to currentColor, which then resolves to the element&apos;s current color. But
according to the spec, accent-color: auto should resolve to an &quot;UA-chosen
color, which should match the accent color of the platform, if any.&quot; [1]
Hence a more sensible default would be to resolve to AccentColor, which
RenderTheme would resolve to a fixed color.

Fix this by renaming colorOrCurrentColor to colorOrDefaultColor, and
changing it to return AccentColor when accent-color is auto.

No tests because nothing exercised this path yet.

[1]: <a href="https://drafts.csswg.org/css-ui/#valdef-accent-color-auto">https://drafts.csswg.org/css-ui/#valdef-accent-color-auto</a>

* Source/WebCore/style/computed/StyleComputedStyleProperties+GettersCustomInlines.h:
(WebCore::Style::ColorPropertyTraits&lt;PropertyNameConstant&lt;CSSPropertyAccentColor&gt;&gt;::color):
* Source/WebCore/style/values/ui/StyleAccentColor.cpp:
(WebCore::Style::AccentColor::colorOrDefaultColor const):
(WebCore::Style::AccentColor::colorOrCurrentColor const): Deleted.
* Source/WebCore/style/values/ui/StyleAccentColor.h:
</pre>
----------------------------------------------------------------------
#### d3066d7634574a3b61723a6e19f3211f144eed84
<pre>
Extend Style::CurrentColor to support future color keywords that take an existing color from a property
<a href="https://rdar.apple.com/184897363">rdar://184897363</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=321775">https://bugs.webkit.org/show_bug.cgi?id=321775</a>

Reviewed by NOBODY (OOPS!).

Style::CurrentColor currently refers to the CSS `currentColor` keyword, which resolves
to the value of the &apos;color&apos; CSS property of the element. CSSWG is receptive to adding
more colors that refer to the value of a property than just `currentColor`. An example
is `AccentColor`, which is the value of `accent-color` if an accent color is set [1].
There&apos;s also a proposal [2] to add `currentBackgroundColor`, which reflects the value
of `background-color`.

To prepare for these new colors, this patch extends Style::CurrentColor to encompass
any color that refers to a property&apos;s value. Style::CurrentColor now includes a
Style::CurrentColor::Property enum, which indicates which CSS property to take the
color value from For now, the only available Property is Color, which corresponds to
CSS `color` property, so it can represent `currentColor`.

Additionally, we add a new class named Style::ResolvedColors. This class stores the
colors necessary to resolve a CurrentColor, and it can be initialized from a computed
style. Style::resolveColor is modified to take a ResolvedColors, instead of just a
Color indicating the current color.

Refactoring - no differences in behavior, tested by existing test suite.

[1]: <a href="https://drafts.csswg.org/css-color-4/#">https://drafts.csswg.org/css-color-4/#</a>:~:text=AccentColor%20takes%20its%20value%20from%20accent%2Dcolor
[2]: <a href="https://github.com/w3c/csswg-drafts/issues/5292">https://github.com/w3c/csswg-drafts/issues/5292</a>

* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/style/StyleBuilderCustom.h:
(WebCore::Style::BuilderCustom::applyInitialColor):
(WebCore::Style::BuilderCustom::applyValueColor):
* Source/WebCore/style/StyleColorResolver.cpp:
(WebCore::Style::ColorResolver::colorResolvingCurrentColor const):
(WebCore::Style::ColorResolver::visitedLinkColorResolvingCurrentColor const):
* Source/WebCore/style/StyleColorResolver.h:
(WebCore::Style::ColorPropertyResolver&lt;ColorTraits&gt;::colorResolvingCurrentColor const):
(WebCore::Style::requires):
* Source/WebCore/style/computed/StyleComputedStyleProperties+GettersCustomInlines.h:
(WebCore::Style::ColorPropertyTraits&lt;PropertyNameConstant&lt;CSSPropertyTextDecorationColor&gt;&gt;::colorResolvingCurrentColor):
(WebCore::Style::ColorPropertyTraits&lt;PropertyNameConstant&lt;CSSPropertyTextDecorationColor&gt;&gt;::visitedLinkColorResolvingCurrentColor):
* Source/WebCore/style/values/color/StyleColor.cpp:
(WebCore::Style::Color::Color):
(WebCore::Style::Color::currentColor):
(WebCore::Style::Color::resolveColor const):
(WebCore::Style::resolveColor):
* Source/WebCore/style/values/color/StyleColor.h:
* Source/WebCore/style/values/color/StyleColorLayers.cpp:
(WebCore::Style::resolveColor):
* Source/WebCore/style/values/color/StyleColorLayers.h:
* Source/WebCore/style/values/color/StyleColorMix.cpp:
(WebCore::Style::resolveColor):
* Source/WebCore/style/values/color/StyleColorMix.h:
* Source/WebCore/style/values/color/StyleContrastColor.cpp:
(WebCore::Style::resolveColor):
* Source/WebCore/style/values/color/StyleContrastColor.h:
* Source/WebCore/style/values/color/StyleCurrentColor.cpp:
(WebCore::Style::CurrentColor::CurrentColor):
(WebCore::Style::serializationForCSSTokenization):
(WebCore::Style::operator&lt;&lt;):
* Source/WebCore/style/values/color/StyleCurrentColor.h:
(WebCore::Style::CurrentColor::property const):
(WebCore::Style::resolveColor):
* Source/WebCore/style/values/color/StyleKeywordColor.cpp:
(WebCore::Style::toStyleColor):
* Source/WebCore/style/values/color/StyleRelativeAlphaColor.cpp:
(WebCore::Style::resolveColor):
* Source/WebCore/style/values/color/StyleRelativeAlphaColor.h:
* Source/WebCore/style/values/color/StyleRelativeColor.h:
(WebCore::Style::resolveColor):
* Source/WebCore/style/values/color/StyleResolvedColor.h:
(WebCore::Style::resolveColor):
* Source/WebCore/style/values/color/StyleResolvedColors.cpp: Copied from Source/WebCore/style/values/color/StyleCurrentColor.cpp.
(WebCore::Style::ResolvedColors::ResolvedColors):
(WebCore::Style::ResolvedColors::fromStyle):
(WebCore::Style::ResolvedColors::fromVisitedLinkStyle):
* Source/WebCore/style/values/color/StyleResolvedColors.h: Copied from Source/WebCore/style/values/color/StyleCurrentColor.cpp.
(WebCore::Style::ResolvedColors::currentColor const):
* Source/WebCore/style/values/filter-effects/StyleDropShadowFunction.cpp:
(WebCore::Style::Ref&lt;FilterEffect&gt;&gt;::operator):
(WebCore::Style::ToPlatform&lt;DropShadow&gt;::operator):
* Tools/TestWebKitAPI/Tests/WebCore/StyleGradient.cpp:
(TestWebKitAPI::someUncacheableStops):
(TestWebKitAPI::allUncacheableStops):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2d5bc85e3f17be7ce3ed962f11c616b90fafc3a8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181803 "2 style errors") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55750 "Hash 2d5bc85e for PR 69706 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49553 "Hash 2d5bc85e for PR 69706 does not build (failure)") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192028 "Hash 2d5bc85e for PR 69706 does not build (failure)") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146132 "Hash 2d5bc85e for PR 69706 does not build (failure)") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183665 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57064 "Hash 2d5bc85e for PR 69706 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55471 "Hash 2d5bc85e for PR 69706 does not build (failure)") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/192028 "Hash 2d5bc85e for PR 69706 does not build (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/146132 "Hash 2d5bc85e for PR 69706 does not build (failure)") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b5869737-7049-4746-82a1-39a9e70f426d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184758 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/57064 "Hash 2d5bc85e for PR 69706 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/168/builds/49553 "Hash 2d5bc85e for PR 69706 does not build (failure)") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/192028 "Hash 2d5bc85e for PR 69706 does not build (failure)") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0c048435-a455-4864-8ca3-df7f3abc186c) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/57064 "Hash 2d5bc85e for PR 69706 does not build (failure)") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/55471 "Hash 2d5bc85e for PR 69706 does not build (failure)") | [❌ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/5/builds/192028 "Hash 2d5bc85e for PR 69706 does not build (failure)") | | 
| [❌ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/168/builds/49553 "Hash 2d5bc85e for PR 69706 does not build (failure)") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/57064 "Hash 2d5bc85e for PR 69706 does not build (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/168/builds/49553 "Hash 2d5bc85e for PR 69706 does not build (failure)") | [❌ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3189 "Hash 2d5bc85e for PR 69706 does not build (failure)") | | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48381 "Failed to build and analyze WebKit") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/55471 "Hash 2d5bc85e for PR 69706 does not build (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193954 "Hash 2d5bc85e for PR 69706 does not build (failure)") | | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55420 "Hash 2d5bc85e for PR 69706 does not build (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/168/builds/49553 "Hash 2d5bc85e for PR 69706 does not build (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/193954 "Hash 2d5bc85e for PR 69706 does not build (failure)") | | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56109 "Hash 2d5bc85e for PR 69706 does not build (failure)") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/168/builds/49553 "Hash 2d5bc85e for PR 69706 does not build (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/193954 "Hash 2d5bc85e for PR 69706 does not build (failure)") | | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/160/builds/56109 "Hash 2d5bc85e for PR 69706 does not build (failure)") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128392 "Failed to build and analyze WebKit") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124147 "Built successfully") | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54622 "Hash 2d5bc85e for PR 69706 does not build (failure)") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/168/builds/49553 "Hash 2d5bc85e for PR 69706 does not build (failure)") | | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54004 "Hash 2d5bc85e for PR 69706 does not build (failure)") | | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54243 "Hash 2d5bc85e for PR 69706 does not build (failure)") | | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54069 "Hash 2d5bc85e for PR 69706 does not build (failure)") | | | | 
<!--EWS-Status-Bubble-End-->