### PR TITLE
Web Inspector: JSFormatter._isRangeWhitespace should avoid allocating a substring to scan

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Workers/Formatter/JSFormatter.js
+++ b/Source/WebInspectorUI/UserInterface/Workers/Formatter/JSFormatter.js
@@ -214,9 +214,11 @@ JSFormatter = class JSFormatter
 
     _isRangeWhitespace(from, to)
     {
-        let substring = this._sourceText.substring(from, to);
-        for (let i = 0; i < substring.length; ++i) {
-            if (!JSFormatter.isWhitespace(substring.charCodeAt(i)))
+        if (from > to)
+            [from, to] = [to, from];
+
+        for (let i = from; i < to; ++i) {
+            if (!JSFormatter.isWhitespace(this._sourceText.charCodeAt(i)))
                 return false;
         }
 


### PR DESCRIPTION
#### e51cb5fa24f6b3641bb0e4e0eedd42a4cdec0afd
<pre>
Web Inspector: JSFormatter._isRangeWhitespace should avoid allocating a substring to scan
<a href="https://bugs.webkit.org/show_bug.cgi?id=319739">https://bugs.webkit.org/show_bug.cgi?id=319739</a>
<a href="https://rdar.apple.com/182579545">rdar://182579545</a>

Reviewed by Devin Rousso.

_isRangeWhitespace() called this._sourceText.substring(from, to) and
then scanned the resulting substring character-by-character, even
though it only needed to read character codes out of the original
source text.

JSC&apos;s String.prototype.substring() doesn&apos;t copy the underlying
character buffer; it shares the source StringImpl via a small
substring-view JSString. But outside a few no-allocation fast paths
(empty result, single character, or the whole string), it still
allocates that view object on every call, and reading through it via
charCodeAt() adds an extra layer of indirection versus indexing the
original string directly.

Scan this._sourceText directly by index instead, avoiding that
per-call allocation and indirection. This requires handling from &gt; to
explicitly, since String.prototype.substring() silently swaps its
arguments when indexStart &gt; indexEnd, and some call sites (e.g.
ForStatement semicolon handling) rely on that behavior to check
ranges where the &quot;from&quot; token comes after the &quot;to&quot; node in the
source.

* Source/WebInspectorUI/UserInterface/Workers/Formatter/JSFormatter.js:
(JSFormatter.prototype._isRangeWhitespace):

Canonical link: <a href="https://commits.webkit.org/317482@main">https://commits.webkit.org/317482@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/16f9ababc52036d8000223b8255c3697b79171bf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175450 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49382 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43163 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185036 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/137595 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5ab1a300-6bbf-4134-bc44-2ff4a27add71) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50674 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49065 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/136600 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/137595 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/86c75fce-f693-472e-bfdb-c359aee2432d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178407 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40014 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157354 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117078 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f4ab281c-f32b-4e7a-819e-5cfe9154bb2b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38656 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37043 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149078 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36847 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33511 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41069 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/41246 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187461 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49049 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145565 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39155 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49729 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/33470 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145405 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40218 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/121922 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115642 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48235 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11821 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47638 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47868 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47695 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->