### PR TITLE
Web Inspector: Cannot expand "TypeError.prototype" to see its properties

### DIFF
--- a/LayoutTests/inspector/model/remote-object/error-expected.txt
+++ b/LayoutTests/inspector/model/remote-object/error-expected.txt
@@ -121,3 +121,84 @@ EXPRESSION: error = null; try { document.createTextNode("").splitText(100); } ca
   }
 }
 
+-----------------------------------------------------
+EXPRESSION: Error.prototype
+{
+  "_type": "object",
+  "_objectId": "<filtered>",
+  "_description": "Error",
+  "_preview": {
+    "_type": "object",
+    "_description": "Error",
+    "_lossless": true,
+    "_overflow": false,
+    "_properties": [
+      {
+        "_name": "name",
+        "_type": "string",
+        "_value": "Error"
+      },
+      {
+        "_name": "message",
+        "_type": "string",
+        "_value": ""
+      }
+    ],
+    "_entries": null
+  }
+}
+
+-----------------------------------------------------
+EXPRESSION: TypeError.prototype
+{
+  "_type": "object",
+  "_objectId": "<filtered>",
+  "_description": "TypeError",
+  "_preview": {
+    "_type": "object",
+    "_description": "TypeError",
+    "_lossless": false,
+    "_overflow": false,
+    "_properties": [
+      {
+        "_name": "name",
+        "_type": "string",
+        "_value": "TypeError"
+      },
+      {
+        "_name": "message",
+        "_type": "string",
+        "_value": ""
+      }
+    ],
+    "_entries": null
+  }
+}
+
+-----------------------------------------------------
+EXPRESSION: RangeError.prototype
+{
+  "_type": "object",
+  "_objectId": "<filtered>",
+  "_description": "RangeError",
+  "_preview": {
+    "_type": "object",
+    "_description": "RangeError",
+    "_lossless": false,
+    "_overflow": false,
+    "_properties": [
+      {
+        "_name": "name",
+        "_type": "string",
+        "_value": "RangeError"
+      },
+      {
+        "_name": "message",
+        "_type": "string",
+        "_value": ""
+      }
+    ],
+    "_entries": null
+  }
+}
+

--- a/LayoutTests/inspector/model/remote-object/error.html
+++ b/LayoutTests/inspector/model/remote-object/error.html
@@ -11,6 +11,11 @@ function test()
         {expression: `error = null; try { [].x.x; } catch (e) { error = e; }; error`},
         {expression: `error = null; try { eval("if()"); } catch (e) { error = e; }; error`},
         {expression: `error = null; try { document.createTextNode("").splitText(100); } catch (e) { error = e; }; error`},
+
+        // Error constructor prototypes are not Error instances and should not be given the "error" subtype.
+        {expression: `Error.prototype`},
+        {expression: `TypeError.prototype`},
+        {expression: `RangeError.prototype`},
     ];
 
     if (!window.WI) {


### PR DESCRIPTION
#### cb0e5d64a64fec4c9ddbb92526b8d5faa61a50e2
<pre>
Web Inspector: Cannot expand &quot;TypeError.prototype&quot; to see its properties
<a href="https://bugs.webkit.org/show_bug.cgi?id=153259">https://bugs.webkit.org/show_bug.cgi?id=153259</a>
<a href="https://rdar.apple.com/24249467">rdar://24249467</a>

Reviewed by NOBODY (OOPS!).

No longer reproducible. JSInjectedScriptHost::subtype() only assigns the
&quot;error&quot; subtype when isErrorInstance() is true (JSType == ErrorInstanceType).
Error.prototype/TypeError.prototype/RangeError.prototype are
ErrorPrototypeBase objects, not ErrorInstance, so they are no longer
misclassified as &quot;error&quot; objects, and the frontend no longer routes them
through ErrorObjectView (which crashed looking for a non-existent &quot;stack&quot;
property). Add regression test coverage.

* LayoutTests/inspector/model/remote-object/error-expected.txt:
* LayoutTests/inspector/model/remote-object/error.html:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cb0e5d64a64fec4c9ddbb92526b8d5faa61a50e2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175411 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49343 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43124 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184997 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/137537 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b811e51c-85e5-4572-ae67-88965ea071a8) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50635 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49026 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136562 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96192 "1 flakes 4 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fc939cb9-9aa5-4ee2-a8fb-c129a354cd14) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178368 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39981 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157319 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117040 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/45960cc1-71f2-46b3-8c1d-90b0996a0063) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38623 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37008 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149045 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36812 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33472 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41212 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187422 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49010 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/156875 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145527 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49690 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33434 "Found 1 new test failure: imported/w3c/web-platform-tests/webrtc/RTCRtpReceiver-getSynchronizationSources.https.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145368 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40189 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115587 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48196 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11785 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47599 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47829 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47656 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->