### PR TITLE
Deduplicate buildArrayForVector/mapToArray in Inspector canvas recording code

### DIFF
--- a/Source/JavaScriptCore/inspector/InspectorProtocolTypes.h
+++ b/Source/JavaScriptCore/inspector/InspectorProtocolTypes.h
@@ -29,6 +29,7 @@
 #include <wtf/Assertions.h>
 #include <wtf/Expected.h>
 #include <wtf/JSONValues.h>
+#include <wtf/Vector.h>
 #include <wtf/text/WTFString.h>
 
 namespace Inspector {
@@ -83,6 +84,14 @@ template<> struct BindingTraits<String> : PrimitiveBindingTraits<JSON::Value::Ty
 template<> struct BindingTraits<bool> : PrimitiveBindingTraits<JSON::Value::Type::Boolean> { };
 template<> struct BindingTraits<double> : PrimitiveBindingTraits<JSON::Value::Type::Double> { };
 template<> struct BindingTraits<int> : PrimitiveBindingTraits<JSON::Value::Type::Integer> { };
+
+template<typename T> Ref<JSON::ArrayOf<JSON::Value>> buildArray(const Vector<T>& vector)
+{
+    auto array = JSON::ArrayOf<JSON::Value>::create();
+    for (auto& item : vector)
+        array->addItem(item);
+    return array;
+}
 
 }
 

--- a/Source/WebCore/inspector/InspectorCanvas.cpp
+++ b/Source/WebCore/inspector/InspectorCanvas.cpp
@@ -181,14 +181,6 @@ bool InspectorCanvas::currentFrameHasData() const
     return !!m_frames;
 }
 
-template<typename T> static Ref<JSON::ArrayOf<JSON::Value>> buildArrayForVector(const Vector<T>& vector)
-{
-    auto array = JSON::ArrayOf<JSON::Value>::create();
-    for (auto& item : vector)
-        array->addItem(item);
-    return array;
-}
-
 static bool shouldSnapshotBitmapRendererAction(const String& name)
 {
     return name == "transferFromImageBitmap"_s;
@@ -712,7 +704,7 @@ Ref<Inspector::Protocol::Recording::InitialState> InspectorCanvas::buildInitialS
             // The parameter to `setLineDash` is itself an array, so we need to wrap the parameters
             // list in an array to allow spreading.
             auto setLineDash = JSON::ArrayOf<JSON::Value>::create();
-            setLineDash->addItem(buildArrayForVector(state.lineDash));
+            setLineDash->addItem(Inspector::Protocol::buildArray(state.lineDash));
             statePayload->setArray(stringIndexForKey("setLineDash"_s), WTF::move(setLineDash));
 
             statePayload->setDouble(stringIndexForKey("lineDashOffset"_s), state.lineDashOffset);

--- a/Source/WebCore/inspector/InspectorCanvasArguments.cpp
+++ b/Source/WebCore/inspector/InspectorCanvasArguments.cpp
@@ -350,14 +350,6 @@ auto InspectorCanvasArgumentProcessor<IDLUint32ListUnion>::operator()(InspectorC
 
 // MARK: - Sequences
 
-static Ref<JSON::ArrayOf<JSON::Value>> mapToArray(const auto& range)
-{
-    auto array = JSON::ArrayOf<JSON::Value>::create();
-    for (auto& item : range)
-        array->addItem(item);
-    return array;
-}
-
 static Ref<JSON::ArrayOf<JSON::Value>> mapToArray(const auto& range, NOESCAPE auto&& functor)
 {
     auto array = JSON::ArrayOf<JSON::Value>::create();
@@ -373,12 +365,12 @@ auto InspectorCanvasArgumentProcessor<IDLSequence<IDLDOMString>>::operator()(Ins
 
 auto InspectorCanvasArgumentProcessor<IDLSequence<IDLUnrestrictedDouble>>::operator()(InspectorCanvas&, const Vector<double>& argument) -> std::optional<InspectorCanvasProcessedArgument>
 {
-    return {{ mapToArray(argument), RecordingSwizzleType::Array }};
+    return {{ Inspector::Protocol::buildArray(argument), RecordingSwizzleType::Array }};
 }
 
 auto InspectorCanvasArgumentProcessor<IDLSequence<IDLUnrestrictedFloat>>::operator()(InspectorCanvas&, const Vector<float>& argument) -> std::optional<InspectorCanvasProcessedArgument>
 {
-    return {{ mapToArray(argument), RecordingSwizzleType::Array }};
+    return {{ Inspector::Protocol::buildArray(argument), RecordingSwizzleType::Array }};
 }
 
 auto InspectorCanvasArgumentProcessor<IDLSequence<IDLUnsignedLong>>::operator()(InspectorCanvas&, const Vector<uint32_t>& argument) -> std::optional<InspectorCanvasProcessedArgument>


### PR DESCRIPTION
#### 40772733505bef5ce93894e6cda61196687b9593
<pre>
Deduplicate buildArrayForVector/mapToArray in Inspector canvas recording code
<a href="https://bugs.webkit.org/show_bug.cgi?id=319740">https://bugs.webkit.org/show_bug.cgi?id=319740</a>
<a href="https://rdar.apple.com/182580121">rdar://182580121</a>

Reviewed by Devin Rousso.

InspectorCanvas.cpp&apos;s buildArrayForVector&lt;T&gt; was structurally identical
to the no-functor mapToArray overload in InspectorCanvasArguments.cpp.
Move the shared helper into InspectorProtocolTypes.h, as buildArray, so
both files use one implementation.

* Source/JavaScriptCore/inspector/InspectorProtocolTypes.h:
(Inspector::Protocol::buildArray):
* Source/WebCore/inspector/InspectorCanvas.cpp:
(WebCore::InspectorCanvas::buildInitialState):
(WebCore::buildArrayForVector): Deleted.
* Source/WebCore/inspector/InspectorCanvas.h:
(WebCore::mapToArray): Deleted.
* Source/WebCore/inspector/InspectorCanvasArguments.cpp:
(WebCore::mapToArray): Deleted.

Canonical link: <a href="https://commits.webkit.org/317481@main">https://commits.webkit.org/317481@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/927ad9993878ed635beeaca1a4e71df727f87060

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175444 "4 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49376 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43157 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185030 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/137589 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/93d5a225-d278-4dad-b7fd-5126e3eb532c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/177308 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50668 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49059 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136595 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/137589 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6245f194-a460-4370-be79-f2d3d334c86b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178401 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40011 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157350 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117073 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/be0e2d30-87ac-4479-95b4-398d4fa7ab51) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38653 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37037 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/5859 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149075 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36843 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33505 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/36705 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41063 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41240 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187455 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49043 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145560 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39153 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49723 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/33466 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145400 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40216 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/121916 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115635 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48229 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11817 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47632 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47862 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47689 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->