### PR TITLE
Web Inspector: Console _mousemove can throw when the selection's focus node has no parentElement

### DIFF
--- a/LayoutTests/inspector/console/log-content-view-mousemove-detached-focus-node-expected.txt
+++ b/LayoutTests/inspector/console/log-content-view-mousemove-detached-focus-node-expected.txt
@@ -1,0 +1,9 @@
+Testing that WI.LogContentView.prototype._mousemove does not throw when the selection's focus node has no parentElement.
+
+
+== Running test suite: WI.LogContentView.prototype._mousemove
+-- Running test case: LogContentView.mousemove.SelectionFocusNodeIsDocument
+PASS: Selection should not be collapsed.
+PASS: Selection's focusNode should be the Document.
+PASS: Should not throw when focusNode is a Document node with no parentElement.
+

--- a/LayoutTests/inspector/console/log-content-view-mousemove-detached-focus-node.html
+++ b/LayoutTests/inspector/console/log-content-view-mousemove-detached-focus-node.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../http/tests/inspector/resources/inspector-test.js"></script>
+<script>
+function test() {
+    let suite = InspectorTest.createAsyncSuite("WI.LogContentView.prototype._mousemove");
+
+    suite.addTestCase({
+        name: "LogContentView.mousemove.SelectionFocusNodeIsDocument",
+        description: "Ensure that _mousemove does not throw when the selection's focus node has no parentElement (e.g. the Document node, which the selection can be extended to when dragging above the topmost console message).",
+        test(resolve, reject) {
+            let textNode = document.createTextNode("test message text");
+            document.body.appendChild(textNode);
+
+            let selection = window.getSelection();
+            selection.setBaseAndExtent(textNode, 0, document, 1);
+
+            InspectorTest.expectFalse(selection.isCollapsed, "Selection should not be collapsed.");
+            InspectorTest.expectThat(selection.focusNode === document, "Selection's focusNode should be the Document.");
+
+            let caughtException = null;
+            try {
+                WI.LogContentView.prototype._mousemove.call({}, {target: document.body});
+            } catch (e) {
+                caughtException = e;
+            }
+
+            InspectorTest.expectNull(caughtException, "Should not throw when focusNode is a Document node with no parentElement.");
+
+            selection.removeAllRanges();
+            textNode.remove();
+
+            resolve();
+        }
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+</head>
+<body onload="runTest()">
+<p>Testing that WI.LogContentView.prototype._mousemove does not throw when the selection's focus node has no parentElement.</p>
+</body>
+</html>

--- a/Source/WebInspectorUI/UserInterface/Test.html
+++ b/Source/WebInspectorUI/UserInterface/Test.html
@@ -300,6 +300,8 @@
     <script src="Views/CodeMirrorAdditions.js"></script>
     <script src="Views/EditingSupport.js"></script>
     <script src="Views/View.js"></script>
+    <script src="Views/ContentView.js"></script>
+    <script src="Views/LogContentView.js"></script>
 
     <script src="Controllers/DiagnosticController.js"></script>
     <script src="Controllers/DiagnosticEventRecorder.js"></script>

--- a/Source/WebInspectorUI/UserInterface/Views/LogContentView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/LogContentView.js
@@ -628,7 +628,7 @@ WI.LogContentView = class LogContentView extends WI.ContentView
                 let focusElement = selection.focusNode;
                 if (!(focusElement instanceof Element))
                     focusElement = focusElement.parentElement;
-                wrapper = focusElement.closest("." + WI.LogContentView.ItemWrapperStyleClassName);
+                wrapper = focusElement?.closest("." + WI.LogContentView.ItemWrapperStyleClassName);
             }
 
             if (!wrapper) {


### PR DESCRIPTION
#### de41ba9882cdd3a6faf825e29df45444600ab818
<pre>
Web Inspector: Console _mousemove can throw when the selection&apos;s focus node has no parentElement
<a href="https://bugs.webkit.org/show_bug.cgi?id=319742">https://bugs.webkit.org/show_bug.cgi?id=319742</a>
<a href="https://rdar.apple.com/182581561">rdar://182581561</a>

Reviewed by NOBODY (OOPS!).

LogContentView.prototype._mousemove looks up the console message wrapper under
the mouse via the current selection when no wrapper is directly under the
cursor. If the selection&apos;s focusNode is not an Element (e.g. a Text node), it
falls back to focusNode.parentElement before calling .closest(). But
parentElement can itself be null -- for example, dragging a selection above
the topmost console message can extend focusNode to the Document itself,
which has no parentElement -- causing an uncaught TypeError.

Use optional chaining so the lookup safely resolves to undefined instead of
throwing when there is no element to call .closest() on.

Test: inspector/console/log-content-view-mousemove-detached-focus-node.html

* LayoutTests/inspector/console/log-content-view-mousemove-detached-focus-node-expected.txt: Added.
* LayoutTests/inspector/console/log-content-view-mousemove-detached-focus-node.html: Added.
* Source/WebInspectorUI/UserInterface/Test.html:
* Source/WebInspectorUI/UserInterface/Views/LogContentView.js:
(WI.LogContentView.prototype._mousemove):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/de41ba9882cdd3a6faf825e29df45444600ab818

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175418 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49350 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43131 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185004 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/137548 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bf540628-0e6f-4666-a7dd-05a06e1a28f0) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50642 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49033 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136569 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96196 "1 flakes 3 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e4c4e79d-139c-443d-b46a-93a29069d45f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178375 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39989 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157325 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117047 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ea5b09fc-bc48-47d7-aac1-ccc791600eb2) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38631 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37015 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149053 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36818 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33479 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41037 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41219 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187429 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49017 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/156881 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145534 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49697 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33440 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145375 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40193 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/121890 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115595 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48203 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11791 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47606 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47836 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47663 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->