### PR TITLE
Web Inspector: Uncaught Exception: Missing node for given nodeId when calling toggleClass or scrollIntoView on a removed node

### DIFF
--- a/LayoutTests/inspector/dom/resolveNode-after-node-removed-expected.txt
+++ b/LayoutTests/inspector/dom/resolveNode-after-node-removed-expected.txt
@@ -1,0 +1,20 @@
+Testing that resolving a DOM node that has already been removed from the page rejects gracefully instead of causing an unhandled promise rejection.
+
+
+== Running test suite: DOM.resolveNodeAfterNodeRemoved
+-- Running test case: DOM.resolveNodeAfterNodeRemoved.ResolveNodeDirectly
+Removing #resolve-node-target from the page...
+PASS: #resolve-node-target should be marked as destroyed.
+PASS: Should produce an exception.
+ERROR: node is destroyed
+
+-- Running test case: DOM.resolveNodeAfterNodeRemoved.ToggleClass
+Removing #toggle-class-target from the page...
+PASS: #toggle-class-target should be marked as destroyed.
+PASS: Should not cause an unhandled promise rejection.
+
+-- Running test case: DOM.resolveNodeAfterNodeRemoved.ScrollIntoView
+Removing #scroll-into-view-target from the page...
+PASS: #scroll-into-view-target should be marked as destroyed.
+PASS: Should not cause an unhandled promise rejection.
+

--- a/LayoutTests/inspector/dom/resolveNode-after-node-removed.html
+++ b/LayoutTests/inspector/dom/resolveNode-after-node-removed.html
@@ -1,0 +1,94 @@
+<!doctype html>
+<html>
+<head>
+<script src="../../http/tests/inspector/resources/inspector-test.js"></script>
+<script>
+function removeElement(id)
+{
+    document.getElementById(id).remove();
+}
+</script>
+<script>
+function test()
+{
+    let suite = InspectorTest.createAsyncSuite("DOM.resolveNodeAfterNodeRemoved");
+
+    async function getRemovedNode(id) {
+        let documentNode = await WI.domManager.requestDocument();
+        let nodeId = await documentNode.querySelector("#" + id);
+        let node = WI.domManager.nodeForId(nodeId);
+        InspectorTest.assert(node, "Missing test node for id " + id);
+
+        InspectorTest.log(`Removing #${id} from the page...`);
+        await Promise.all([
+            InspectorTest.evaluateInPage(`removeElement("${id}")`),
+            WI.domManager.awaitEvent(WI.DOMManager.Event.NodeRemoved),
+        ]);
+
+        InspectorTest.expectTrue(node.destroyed, `#${id} should be marked as destroyed.`);
+        return node;
+    }
+
+    async function expectNoUnhandledPromiseRejection(work) {
+        let sawUnhandledRejection = false;
+        let handler = (event) => { sawUnhandledRejection = true; };
+
+        window.addEventListener("unhandledrejection", handler);
+
+        work();
+
+        // Give the unhandled promise rejection, if any, a chance to be reported.
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        window.removeEventListener("unhandledrejection", handler);
+
+        InspectorTest.expectFalse(sawUnhandledRejection, "Should not cause an unhandled promise rejection.");
+    }
+
+    suite.addTestCase({
+        name: "DOM.resolveNodeAfterNodeRemoved.ResolveNodeDirectly",
+        description: "WI.RemoteObject.resolveNode should reject its promise, not throw, when called with an already-removed node.",
+        async test() {
+            let node = await getRemovedNode("resolve-node-target");
+
+            await InspectorTest.expectException(async () => {
+                await WI.RemoteObject.resolveNode(node);
+            });
+        }
+    });
+
+    suite.addTestCase({
+        name: "DOM.resolveNodeAfterNodeRemoved.ToggleClass",
+        description: "Calling WI.DOMNode.prototype.toggleClass on an already-removed node should not cause an unhandled promise rejection.",
+        async test() {
+            let node = await getRemovedNode("toggle-class-target");
+
+            await expectNoUnhandledPromiseRejection(() => {
+                node.toggleClass("test-class", true);
+            });
+        }
+    });
+
+    suite.addTestCase({
+        name: "DOM.resolveNodeAfterNodeRemoved.ScrollIntoView",
+        description: "Calling WI.DOMNode.prototype.scrollIntoView on an already-removed node should not cause an unhandled promise rejection.",
+        async test() {
+            let node = await getRemovedNode("scroll-into-view-target");
+
+            await expectNoUnhandledPromiseRejection(() => {
+                node.scrollIntoView();
+            });
+        }
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+</head>
+<body onload="runTest()">
+<p>Testing that resolving a DOM node that has already been removed from the page rejects gracefully instead of causing an unhandled promise rejection.</p>
+<div id="resolve-node-target"></div>
+<div id="toggle-class-target"></div>
+<div id="scroll-into-view-target"></div>
+</body>
+</html>

--- a/Source/WebInspectorUI/UserInterface/Models/DOMNode.js
+++ b/Source/WebInspectorUI/UserInterface/Models/DOMNode.js
@@ -602,6 +602,9 @@ WI.DOMNode = class DOMNode extends WI.Object
 
             object.callFunction(inspectedPage_node_toggleClass, [className, flag]);
             object.release();
+        }).catch((error) => {
+            // Bail if the DOM node was removed while we were waiting for the async response.
+            console.assert(false, "Cannot resolve node.", error, this);
         });
     }
 
@@ -816,6 +819,9 @@ WI.DOMNode = class DOMNode extends WI.Object
 
             object.callFunction(inspectedPage_node_scrollIntoView);
             object.release();
+        }).catch((error) => {
+            // Bail if the DOM node was removed while we were waiting for the async response.
+            console.assert(false, "Cannot resolve node.", error, this);
         });
     }
 


### PR DESCRIPTION
#### 6c410008f97187e7af14114c40c25726a36ecb9c
<pre>
Web Inspector: Uncaught Exception: Missing node for given nodeId when calling toggleClass or scrollIntoView on a removed node
<a href="https://bugs.webkit.org/show_bug.cgi?id=319744">https://bugs.webkit.org/show_bug.cgi?id=319744</a>
<a href="https://rdar.apple.com/182583133">rdar://182583133</a>

Reviewed by NOBODY (OOPS!).

`WI.RemoteObject.resolveNode` correctly rejects its promise when given a
`WI.DOMNode` that has already been removed from the inspected page (or is
removed while the command is in flight, in which case the backend returns
a &quot;Missing node for given nodeId&quot; protocol error). `WI.DOMNode.prototype.toggleClass`
and `WI.DOMNode.prototype.scrollIntoView` did not handle this rejection, so
calling either on a node that had just been removed produced an unhandled
promise rejection, which the frontend reports as an uncaught exception and
can present as an internal-error crash sheet.

Add a `.catch` to both methods, matching the handling already used
elsewhere (e.g. `WI.DOMNodeDetailsSidebarPanel`), so the failure is
reported via `console.assert` instead of going unhandled.

Test: inspector/dom/resolveNode-after-node-removed.html

* LayoutTests/inspector/dom/resolveNode-after-node-removed-expected.txt: Added.
* LayoutTests/inspector/dom/resolveNode-after-node-removed.html: Added.
* Source/WebInspectorUI/UserInterface/Models/DOMNode.js:
(WI.DOMNode.prototype.toggleClass):
(WI.DOMNode.prototype.scrollIntoView):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6c410008f97187e7af14114c40c25726a36ecb9c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175423 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49355 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43136 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185009 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/137582 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c51f67b8-c08b-43d7-b44f-2198cf1270e1) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50647 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49038 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136573 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96198 "2 flakes 3 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/269cce76-ecf0-47a0-a2e6-2305e332b469) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178380 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39992 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157331 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117051 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/32cb5705-34ff-4153-93a1-c8d71bcaf5de) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38634 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37019 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149056 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36824 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33484 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41042 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41223 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187434 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49022 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/156887 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145539 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49702 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33446 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145380 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40197 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/121895 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115604 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48208 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11797 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47611 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47841 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47668 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->