### PR TITLE
Add inverse synthetic click type and modifier flag converters

### DIFF
--- a/Source/WebKit/Shared/WebMouseEvent.cpp
+++ b/Source/WebKit/Shared/WebMouseEvent.cpp
@@ -92,4 +92,15 @@ WebMouseEventSyntheticClickType syntheticClickType(const WebCore::NavigationActi
     return WebMouseEventSyntheticClickType::NoTap;
 }
 
+WebCore::SyntheticClickType NODELETE coreSyntheticClickType(WebMouseEventSyntheticClickType type)
+{
+    switch (type) {
+    case WebMouseEventSyntheticClickType::NoTap: return WebCore::SyntheticClickType::NoTap;
+    case WebMouseEventSyntheticClickType::OneFingerTap: return WebCore::SyntheticClickType::OneFingerTap;
+    case WebMouseEventSyntheticClickType::TwoFingerTap: return WebCore::SyntheticClickType::TwoFingerTap;
+    }
+    ASSERT_NOT_REACHED();
+    return WebCore::SyntheticClickType::NoTap;
+}
+
 } // namespace WebKit

--- a/Source/WebKit/Shared/WebMouseEvent.h
+++ b/Source/WebKit/Shared/WebMouseEvent.h
@@ -37,6 +37,7 @@
 
 namespace WebCore {
 class NavigationAction;
+enum class SyntheticClickType : uint8_t;
 }
 
 namespace WebKit {
@@ -59,6 +60,7 @@ enum class WebMouseEventSyntheticClickType : uint8_t {
     TwoFingerTap
 };
 WebMouseEventSyntheticClickType NODELETE syntheticClickType(const WebCore::NavigationAction&);
+WebCore::SyntheticClickType NODELETE coreSyntheticClickType(WebMouseEventSyntheticClickType);
 
 class WebMouseEvent : public WebEvent {
 public:

--- a/Source/WebKit/Shared/mac/WebEventFactory.h
+++ b/Source/WebKit/Shared/mac/WebEventFactory.h
@@ -55,6 +55,8 @@ public:
 #if defined(__OBJC__)
     static NSEventModifierFlags NODELETE toNSEventModifierFlags(OptionSet<WebKit::WebEventModifier>);
     static NSInteger NODELETE toNSButtonNumber(WebKit::WebMouseEventButton);
+
+    static OptionSet<WebKit::WebEventModifier> NODELETE toWebEventModifierFlags(NSEventModifierFlags);
 #endif
 #endif // USE(APPKIT)
 };

--- a/Source/WebKit/Shared/mac/WebEventFactory.mm
+++ b/Source/WebKit/Shared/mac/WebEventFactory.mm
@@ -290,6 +290,11 @@ NSInteger WebEventFactory::toNSButtonNumber(WebKit::WebMouseEventButton mouseBut
     return 0;
 }
 
+OptionSet<WebKit::WebEventModifier> WebEventFactory::toWebEventModifierFlags(NSEventModifierFlags modifiers)
+{
+    return kit(WebCore::modifiersForModifierFlags(modifiers));
+}
+
 } // namespace WebKit
 
 #endif // USE(APPKIT)


### PR DESCRIPTION
#### c42e31f1f0791a14c01324c2056ab86d3f4144ec
<pre>
Add inverse synthetic click type and modifier flag converters
<a href="https://bugs.webkit.org/show_bug.cgi?id=319747">https://bugs.webkit.org/show_bug.cgi?id=319747</a>
<a href="https://rdar.apple.com/182587030">rdar://182587030</a>

Reviewed by Richard Robinson.

In this patch, we add the reverse of two existing conversions, symmetric
with their forward counterparts in the same files:

- coreSyntheticClickType(): WebMouseEventSyntheticClickType -&gt;
  WebCore::SyntheticClickType, mirrors syntheticClickType().
- WebEventFactory::toWebEventModifierFlags(): NSEventModifierFlags -&gt;
  OptionSet&lt;WebEventModifier&gt;, mirrors toNSEventModifierFlags().

These helpers will be adopted in forthcoming patches.

* Source/WebKit/Shared/WebMouseEvent.cpp:
(WebKit::coreSyntheticClickType):
* Source/WebKit/Shared/WebMouseEvent.h:
* Source/WebKit/Shared/mac/WebEventFactory.h:
* Source/WebKit/Shared/mac/WebEventFactory.mm:
(WebKit::WebEventFactory::toWebEventModifierFlags):

Canonical link: <a href="https://commits.webkit.org/317509@main">https://commits.webkit.org/317509@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9a4d83786e863d81d9f52d1d082b6fb7387c35cb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175425 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49357 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43138 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185011 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/137561 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b8fb5f03-3e5d-4a35-a896-16a6d2c2fa0a) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50649 "Built successfully") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49040 "Hash 9a4d8378 for PR 69719 does not build (failure)") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136576 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/137561 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bfbf02c4-81c7-4cc4-8037-385510835abc) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178382 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39995 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157335 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117054 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/090f5d5c-b09c-42f2-befc-7a15013aecff) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38637 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/49040 "Hash 9a4d8378 for PR 69719 does not build (failure)") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149059 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36828 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33486 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41044 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/49040 "Hash 9a4d8378 for PR 69719 does not build (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187436 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49024 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145542 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49704 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33450 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145382 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26674 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40201 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/121897 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115607 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48210 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11801 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47613 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47843 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47670 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->