### PR TITLE
JSTests/stress/array-prototype-flat-reentrant-mutation.js uses $memoryHog which is not available in 2.52. branch

### DIFF
--- a/JSTests/stress/array-prototype-flat-reentrant-mutation.js
+++ b/JSTests/stress/array-prototype-flat-reentrant-mutation.js
@@ -1,6 +1,5 @@
-//@ skip if $addressBits <= 32
-//@ runDefault
-//@ memoryHog!
+//@ skip if $memoryLimited or $addressBits <= 32
+//@ runDefault()
 
 try {
     let iterations = 0;


### PR DESCRIPTION
#### abb2dc51831254f7778315424c04d77aa8f4090f
<pre>
JSTests/stress/array-prototype-flat-reentrant-mutation.js uses $memoryHog which is not available in 2.52. branch
<a href="https://bugs.webkit.org/show_bug.cgi?id=319746">https://bugs.webkit.org/show_bug.cgi?id=319746</a>

Unreviewed gardening test fix.

This test is failing with:
  `block (3 levels) in parseRunCommands&apos;: undefined method `memoryHog!&apos;

The problem is that the $memoryHog tag was introduced in 311130@main which is not
backported to this branch.

I tried to backport 311130@main but doesn&apos;t merge clean, several conflicts because
it touches lot of tests and also introduces major changes to the test runner.

It seems this is the only one test in this branch that needs that definition,
so switch it to use the old $memoryLimited tag.

* JSTests/stress/array-prototype-flat-reentrant-mutation.js:

Canonical link: <a href="https://commits.webkit.org/305877.1003@webkitglib/2.52">https://commits.webkit.org/305877.1003@webkitglib/2.52</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4e66db40ac955846c6d338f55ca1e8700e6c5080

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175428 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/49360 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/43141 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185014 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/137567 "The change is no longer eligible for processing.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/50652 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/49043 "The change is no longer eligible for processing.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/136579 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/137567 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178385 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/50652 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/43141 "The change is no longer eligible for processing.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/117057 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/50652 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/49043 "The change is no longer eligible for processing.") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/43141 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/50652 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/43141 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33489 "Built successfully") | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/36689 "The change is no longer eligible for processing.") | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/49043 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187439 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/49027 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/43141 "The change is no longer eligible for processing.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/145544 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/49707 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/43141 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145384 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26663 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/49707 "The change is no longer eligible for processing.") | | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/115610 "The change is no longer eligible for processing.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/48213 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/43141 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/47616 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/47846 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/47673 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->