### PR TITLE
Cherry-pick 317461@main (c35e39f72086). https://bugs.webkit.org/show_bug.cgi?id=319686

### DIFF
--- a/Tools/Scripts/filter-test-logs
+++ b/Tools/Scripts/filter-test-logs
@@ -23,6 +23,7 @@
 
 import os
 import argparse
+import datetime
 import sys
 import re
 import time
@@ -31,20 +32,21 @@ import time
 # by buildbot because "command timed out: XXX seconds without output running YYY"
 class KeepAliveStdoutProgress:
 
-    def __init__(self, interval_seconds=300, check_every_n_lines=100):
+    def __init__(self, interval_seconds=60):
         self.line_count = 0
         self.last_progress_time = time.time()
         self.interval_seconds = interval_seconds
-        self.check_every_n_lines = check_every_n_lines
+        self.last_count = 0
 
     def maybe_update_progress(self):
         self.line_count += 1
-        # Only check time every N lines to avoid expensive system calls
-        if self.line_count % self.check_every_n_lines == 0:
-            current_time = time.time()
-            if current_time - self.last_progress_time >= self.interval_seconds:
-                print(f'filter-test-logs progress: {self.line_count} lines processed', flush=True)
-                self.last_progress_time = current_time
+        current_time = time.time()
+        if current_time - self.last_progress_time >= self.interval_seconds:
+            delta = self.line_count - self.last_count
+            timestamp = datetime.datetime.now().astimezone().strftime("%Y-%m-%d|%H:%M:%S|%Z")
+            print(f"[{timestamp}] filter-test-logs progress: {self.line_count} lines processed ({delta} since last update)", flush=True)
+            self.last_progress_time = current_time
+            self.last_count = self.line_count
 
 
 def parser():


### PR DESCRIPTION
#### df0b845ff38040972e60dafe9a3b0e8efaadc094
<pre>
Cherry-pick 317461@main (c35e39f72086). <a href="https://bugs.webkit.org/show_bug.cgi?id=319686">https://bugs.webkit.org/show_bug.cgi?id=319686</a>

    [WKCI] filter-test-logs can cause that buildbot ends killing an in-progress step when the test runner produces output slowly
    <a href="https://bugs.webkit.org/show_bug.cgi?id=319686">https://bugs.webkit.org/show_bug.cgi?id=319686</a>

    Reviewed by Nikolas Zimmermann.

    When a build step runs through filter-test-logs, buildbot only sees the
    few lines the filter prints, since the full output goes to a log file.
    To avoid buildbot killing the step for lack of output, filter-test-logs
    prints a progress line from time to time. But the check to wether it
    should print the summary por not ran only once every 100 lines.
    With a command that prints slowly (for example one line every 15 seconds),
    the check ran once every 1500 seconds which is above the standard 1200
    buildbot timeout, so buildbot killed the step with &quot;command timed
    out: XXX seconds without output&quot;.

    This patch changes it to run the check if it should print the summary for
    every line received. Calling time.time() is way cheaper than I thought at
    303319@main
    I have benchmarked this an the cost is well under 100 nanoseconds per call,
    so doing it once per line adds only a few milliseconds to a standard layout
    test run with ~150k lines.

    The format to print the summary is also improved, now includes a timestamp
    and how many lines arrived since the last update.
    The frequency to print the summary is changed to once per minute instead of
    once each 5 minutes, that should not be an issue for buildbot to handle, and
    makes more interactive and helpful to look at the progress of a filtered
    on-going build.

    * Tools/Scripts/filter-test-logs:
    (KeepAliveStdoutProgress):
    (KeepAliveStdoutProgress.__init__):
    (KeepAliveStdoutProgress.maybe_update_progress):

    Canonical link: <a href="https://commits.webkit.org/317461@main">https://commits.webkit.org/317461@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.1002@webkitglib/2.52">https://commits.webkit.org/305877.1002@webkitglib/2.52</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d3e52d70fc46daa9ac9905f114538fd7f777523e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175429 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/49361 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/43142 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185015 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/137568 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/177293 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/50653 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/49044 "The change is no longer eligible for processing.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/136578 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/137568 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178386 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/50653 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/43142 "The change is no longer eligible for processing.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/117056 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/50653 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/49044 "The change is no longer eligible for processing.") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/43142 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/50653 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/43142 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33490 "Built successfully") | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/49044 "The change is no longer eligible for processing.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/187440 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/49028 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/43142 "The change is no longer eligible for processing.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/187440 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/49708 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/43142 "The change is no longer eligible for processing.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/187440 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26662 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/49708 "The change is no longer eligible for processing.") | | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/115612 "The change is no longer eligible for processing.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/48214 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/43142 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/47617 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/47847 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/47674 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->