### PR TITLE
[WPE][Accessibility] focus change accessibility event is not exposed

### DIFF
--- a/LayoutTests/accessibility/focus-notification-without-prior-tree-access-expected.txt
+++ b/LayoutTests/accessibility/focus-notification-without-prior-tree-access-expected.txt
@@ -1,0 +1,9 @@
+This test verifies that a focus notification is delivered even when nothing has queried the accessibility tree before the focus change (e.g. accessibleElementById, rootElement or focusedElement). This matters because some platform implementations only create the AXObjectCache lazily, and a naive implementation may only do so as a side effect of an earlier tree query rather than in response to the focus change itself.
+
+PASS: sawFocusNotification === true
+PASS: accessibilityController.focusedElement.domIdentifier === 'item'
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/focus-notification-without-prior-tree-access.html
+++ b/LayoutTests/accessibility/focus-notification-without-prior-tree-access.html
@@ -1,0 +1,49 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../resources/accessibility-helper.js"></script>
+<script src="../resources/js-test.js"></script>
+</head>
+<body>
+
+<div id="item" role="listitem" tabindex="0" aria-posinset="1" aria-setsize="10">Item 1</div>
+
+<script>
+let output = "This test verifies that a focus notification is delivered even when nothing has " +
+    "queried the accessibility tree before the focus change (e.g. accessibleElementById, " +
+    "rootElement or focusedElement). This matters because some platform implementations only " +
+    "create the AXObjectCache lazily, and a naive implementation may only do so as a side effect " +
+    "of an earlier tree query rather than in response to the focus change itself.\n\n";
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    var sawFocusNotification = false;
+    // Intentionally register the listener without calling accessibleElementById,
+    // rootElement, or focusedElement first, so nothing has forced the platform
+    // accessibility tree/cache into existence yet.
+    accessibilityController.addNotificationListener((axElement, notification) => {
+        if (notification == "AXFocusChanged" || notification == "AXFocusedUIElementChanged")
+            sawFocusNotification = true;
+    });
+
+    // A plain DOM focus call, not going through any accessibility API.
+    document.getElementById("item").focus();
+
+    setTimeout(async () => {
+        await waitFor(() => sawFocusNotification);
+        output += expect("sawFocusNotification", "true");
+        if (sawFocusNotification)
+            output += expect("accessibilityController.focusedElement.domIdentifier", "'item'");
+
+        document.getElementById("item").style.visibility = "hidden";
+        accessibilityController.removeNotificationListener();
+        debug(output);
+        finishJSTest();
+    }, 0);
+} else {
+    debug(output);
+}
+</script>
+</body>
+</html>

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -6758,7 +6758,7 @@ bool Document::setFocusedElement(Element* newFocusedElement, const FocusOptions&
             window()->navigation().setFocusChanged(FocusDidChange::Yes);
     }
 
-#if PLATFORM(GTK)
+#if PLATFORM(GTK) || PLATFORM(WPE)
     // GTK relies on creating the AXObjectCache when a focus change happens.
     if (CheckedPtr cache = axObjectCache())
 #else


### PR DESCRIPTION
#### 48f6c283035d211286fa0ce6c2d2cf14e7f97d3b
<pre>
[WPE][Accessibility] focus change accessibility event is not exposed
<a href="https://bugs.webkit.org/show_bug.cgi?id=319475">https://bugs.webkit.org/show_bug.cgi?id=319475</a>

Reviewed by Tyler Wilcock.

On WPE, if nothing else has queried the accessibility tree yet (e.g. a fresh
AT-SPI client that goes straight to listening for focus events), the very first
focus change finds no AXObjectCache and is silently dropped: onFocusChange() is
never called, and no &quot;focused&quot; state-changed notification is ever sent.

Add WPE alongside GTK to the platforms that lazily create the AXObjectCache on
the first focus change, matching how GTK already behaves.

Test: accessibility/focus-notification-without-prior-tree-access.html

* LayoutTests/accessibility/focus-notification-without-prior-tree-access-expected.txt: Added.
* LayoutTests/accessibility/focus-notification-without-prior-tree-access.html: Added.
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::setFocusedElement):

Canonical link: <a href="https://commits.webkit.org/317504@main">https://commits.webkit.org/317504@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d9c5e6b04649e0a99cbe1129822360f4fef9cffe

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175438 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49370 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43151 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185024 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/137578 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/177302 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50662 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49053 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136588 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/137578 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178395 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40005 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157343 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117066 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38647 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37033 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149069 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36836 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33499 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41057 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41236 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187449 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49037 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/156899 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145553 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39171 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49717 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33458 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145393 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40211 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/121910 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115625 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48223 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11810 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47626 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47856 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47683 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->