### PR TITLE
Vectorize URL component parsing (path, query, fragment, opaque path)

### DIFF
--- a/Source/WTF/wtf/URLParser.cpp
+++ b/Source/WTF/wtf/URLParser.cpp
@@ -28,6 +28,7 @@
 
 #include <array>
 #include <functional>
+#include <wtf/SIMDHelpers.h>
 #include <wtf/text/CodePointIterator.h>
 #include <wtf/text/MakeString.h>
 
@@ -324,17 +325,17 @@ bool isForbiddenHostCodePoint(char16_t character)
     return character <= 0x7F && characterClassTable[character] & ForbiddenHost;
 }
 
-template<typename CharacterType> ALWAYS_INLINE static bool isC0Control(CharacterType character) { return character <= 0x1F; }
-template<typename CharacterType> ALWAYS_INLINE static bool isC0ControlOrSpace(CharacterType character) { return character <= 0x20; }
-template<typename CharacterType> ALWAYS_INLINE static bool isTabOrNewline(CharacterType character) { return character <= 0xD && character >= 0x9 && character != 0xB && character != 0xC; }
-template<typename CharacterType> ALWAYS_INLINE static bool isInC0ControlEncodeSet(CharacterType character) { return character > 0x7E || isC0Control(character); }
-template<typename CharacterType> ALWAYS_INLINE static bool isInFragmentEncodeSet(CharacterType character) { return character > 0x7E || character == '`' || ((characterClassTable[character] & QueryEncode) && character != '#'); }
-template<typename CharacterType> ALWAYS_INLINE static bool isInPathEncodeSet(CharacterType character) { return character > 0x7E || characterClassTable[character] & PathEncode; }
-template<typename CharacterType> ALWAYS_INLINE static bool isInUserInfoEncodeSet(CharacterType character) { return character > 0x7E || characterClassTable[character] & UserInfoEncode; }
-template<typename CharacterType> ALWAYS_INLINE static bool isPercentOrNonASCII(CharacterType character) { return !isASCII(character) || character == '%'; }
-template<typename CharacterType> ALWAYS_INLINE static bool isSlashQuestionOrHash(CharacterType character) { return character <= '\\' && characterClassTable[character] & SlashQuestionOrHash; }
-template<typename CharacterType> ALWAYS_INLINE static bool isValidSchemeCharacter(CharacterType character) { return character <= 'z' && characterClassTable[character] & ValidScheme; }
-template<typename CharacterType> ALWAYS_INLINE static bool isSpecialCharacterForFragmentDirective(CharacterType character) { return !isASCII(character) || character == ',' || character == '-'; }
+template<typename CharacterType> ALWAYS_INLINE static constexpr bool isC0Control(CharacterType character) { return character <= 0x1F; }
+template<typename CharacterType> ALWAYS_INLINE static constexpr bool isC0ControlOrSpace(CharacterType character) { return character <= 0x20; }
+template<typename CharacterType> ALWAYS_INLINE static constexpr bool isTabOrNewline(CharacterType character) { return character <= 0xD && character >= 0x9 && character != 0xB && character != 0xC; }
+template<typename CharacterType> ALWAYS_INLINE static constexpr bool isInC0ControlEncodeSet(CharacterType character) { return character > 0x7E || isC0Control(character); }
+template<typename CharacterType> ALWAYS_INLINE static constexpr bool isInFragmentEncodeSet(CharacterType character) { return character > 0x7E || character == '`' || ((characterClassTable[character] & QueryEncode) && character != '#'); }
+template<typename CharacterType> ALWAYS_INLINE static constexpr bool isInPathEncodeSet(CharacterType character) { return character > 0x7E || characterClassTable[character] & PathEncode; }
+template<typename CharacterType> ALWAYS_INLINE static constexpr bool isInUserInfoEncodeSet(CharacterType character) { return character > 0x7E || characterClassTable[character] & UserInfoEncode; }
+template<typename CharacterType> ALWAYS_INLINE static constexpr bool isPercentOrNonASCII(CharacterType character) { return !isASCII(character) || character == '%'; }
+template<typename CharacterType> ALWAYS_INLINE static constexpr bool isSlashQuestionOrHash(CharacterType character) { return character <= '\\' && characterClassTable[character] & SlashQuestionOrHash; }
+template<typename CharacterType> ALWAYS_INLINE static constexpr bool isValidSchemeCharacter(CharacterType character) { return character <= 'z' && characterClassTable[character] & ValidScheme; }
+template<typename CharacterType> ALWAYS_INLINE static constexpr bool isSpecialCharacterForFragmentDirective(CharacterType character) { return !isASCII(character) || character == ',' || character == '-'; }
 
 template<typename CharacterType>
 ALWAYS_INLINE bool URLParser::isForbiddenHostCodePoint(CharacterType character)
@@ -350,7 +351,7 @@ ALWAYS_INLINE bool URLParser::isForbiddenDomainCodePoint(CharacterType character
     return character <= 0x7F && characterClassTable[character] & ForbiddenDomain;
 }
 
-ALWAYS_INLINE static bool shouldPercentEncodeQueryByte(uint8_t byte, bool urlIsSpecial)
+ALWAYS_INLINE static constexpr bool shouldPercentEncodeQueryByte(uint8_t byte, bool urlIsSpecial)
 {
     if (characterClassTable[byte] & QueryEncode)
         return true;
@@ -418,6 +419,86 @@ ALWAYS_INLINE void URLParser::appendToASCIIBuffer(std::span<const Latin1Characte
 {
     if (m_didSeeSyntaxViolation) [[unlikely]]
         m_asciiBuffer.append(characters);
+}
+
+ALWAYS_INLINE void URLParser::appendToASCIIBuffer(std::span<const char16_t> characters)
+{
+    if (!m_didSeeSyntaxViolation) [[likely]]
+        return;
+    ASSERT_WITH_SECURITY_IMPLICATION(charactersAreAllASCII(characters));
+    size_t offset = m_asciiBuffer.size();
+    m_asciiBuffer.grow(offset + characters.size());
+    copyElements(m_asciiBuffer.mutableSpan().subspan(offset), characters);
+}
+
+template<bool special> static constexpr bool isInQueryEncodeSet(Latin1Character character) { return shouldPercentEncodeQueryByte(character, special); }
+
+template<auto isInEncodeSet, Latin1Character... stopCharacters>
+static consteval bool stopCharactersCoverEncodeSet()
+{
+    for (unsigned character = 0x21; character <= 0x7E; ++character) {
+        if (isInEncodeSet(static_cast<Latin1Character>(character)) && !((character == stopCharacters) || ...))
+            return false;
+    }
+    return true;
+}
+
+template<typename CharacterType, auto isInEncodeSet, Latin1Character... stopCharacters>
+ALWAYS_INLINE static std::span<const CharacterType> trivialCodePointPrefix(std::span<const CharacterType> span)
+{
+    static_assert(stopCharactersCoverEncodeSet<isInEncodeSet, stopCharacters...>());
+    using UnsignedType = SameSizeUnsignedInteger<CharacterType>;
+    auto vectorMatch = [&](auto vec) ALWAYS_INLINE_LAMBDA {
+        return SIMD::findFirstNonZeroIndex(SIMD::bitOr(
+            SIMD::lessThanOrEqual(vec, SIMD::splat<UnsignedType>(0x20)),
+            SIMD::greaterThanOrEqual(vec, SIMD::splat<UnsignedType>(0x7F)),
+            SIMD::equal<stopCharacters...>(vec)));
+    };
+    auto scalarMatch = [&](auto character) ALWAYS_INLINE_LAMBDA {
+        return character <= 0x20 || character >= 0x7F || ((character == stopCharacters) || ...);
+    };
+    return span.first(SIMD::find<CharacterType>(span, vectorMatch, scalarMatch) - span.data());
+}
+
+template<typename CharacterType>
+ALWAYS_INLINE static std::span<const CharacterType> trivialPathCodePointPrefix(std::span<const CharacterType> span, bool special)
+{
+    if (special)
+        return trivialCodePointPrefix<CharacterType, isInPathEncodeSet<Latin1Character>, '"', '#', '<', '>', '?', '^', '`', '{', '}', '/', '\\'>(span);
+    return trivialCodePointPrefix<CharacterType, isInPathEncodeSet<Latin1Character>, '"', '#', '<', '>', '?', '^', '`', '{', '}', '/'>(span);
+}
+
+template<typename CharacterType>
+ALWAYS_INLINE static std::span<const CharacterType> trivialFragmentCodePointPrefix(std::span<const CharacterType> span)
+{
+    return trivialCodePointPrefix<CharacterType, isInFragmentEncodeSet<Latin1Character>, '"', '<', '>', '`'>(span);
+}
+
+template<typename CharacterType>
+ALWAYS_INLINE static std::span<const CharacterType> trivialQueryCodePointPrefix(std::span<const CharacterType> span, bool special)
+{
+    if (special)
+        return trivialCodePointPrefix<CharacterType, isInQueryEncodeSet<true>, '"', '#', '<', '>', '\''>(span);
+    return trivialCodePointPrefix<CharacterType, isInQueryEncodeSet<false>, '"', '#', '<', '>'>(span);
+}
+
+template<typename CharacterType>
+ALWAYS_INLINE static std::span<const CharacterType> trivialOpaquePathCodePointPrefix(std::span<const CharacterType> span)
+{
+    return trivialCodePointPrefix<CharacterType, isInC0ControlEncodeSet<Latin1Character>, '?', '#', '/'>(span);
+}
+
+template<typename CharacterType, typename TrivialCodePointPrefix>
+ALWAYS_INLINE void URLParser::consumeTrivialCodePoints(CodePointIterator<CharacterType>& c, NOESCAPE const TrivialCodePointPrefix& trivialCodePointPrefix)
+{
+    if (c.atEnd())
+        return;
+    auto span = c.span();
+    if (m_didSeeSyntaxViolation && span.size() < SIMD::stride<CharacterType>)
+        return;
+    auto prefix = trivialCodePointPrefix(span);
+    appendToASCIIBuffer(prefix);
+    c.advanceBy(prefix.size());
 }
 
 template<typename CharacterType>
@@ -794,12 +875,8 @@ void URLParser::copyASCIIStringUntil(const String& string, size_t length)
     ASSERT(m_asciiBuffer.isEmpty());
     if (string.is8Bit())
         appendToASCIIBuffer(string.span8().first(length));
-    else {
-        for (auto character : string.span16().first(length)) {
-            ASSERT_WITH_SECURITY_IMPLICATION(isASCII(character));
-            appendToASCIIBuffer(character);
-        }
-    }
+    else
+        appendToASCIIBuffer(string.span16().first(length));
 }
 
 template<typename CharacterType>
@@ -1773,6 +1850,7 @@ void URLParser::parse(std::span<const CharacterType> input, const URL& base, con
             }
             utf8PercentEncode<isInPathEncodeSet>(c);
             ++c;
+            consumeTrivialCodePoints(c, [&](auto span) { return trivialPathCodePointPrefix<CharacterType>(span, m_urlIsSpecial); });
             break;
         case State::OpaquePath:
             LOG_STATE("OpaquePath");
@@ -1806,6 +1884,7 @@ void URLParser::parse(std::span<const CharacterType> input, const URL& base, con
             } else {
                 utf8PercentEncode<isInC0ControlEncodeSet>(c);
                 ++c;
+                consumeTrivialCodePoints(c, [&](auto span) { return trivialOpaquePathCodePointPrefix<CharacterType>(span); });
             }
             break;
         case State::UTF8Query:
@@ -1819,6 +1898,7 @@ void URLParser::parse(std::span<const CharacterType> input, const URL& base, con
             ASSERT(!nonUTF8QueryEncoding);
             utf8QueryEncode(c);
             ++c;
+            consumeTrivialCodePoints(c, [&](auto span) { return trivialQueryCodePointPrefix<CharacterType>(span, m_urlIsSpecial); });
             break;
         case State::NonUTF8Query:
             do {
@@ -1838,6 +1918,7 @@ void URLParser::parse(std::span<const CharacterType> input, const URL& base, con
             URL_PARSER_LOG("State Fragment");
             utf8PercentEncode<isInFragmentEncodeSet>(c);
             ++c;
+            consumeTrivialCodePoints(c, [&](auto span) { return trivialFragmentCodePointPrefix<CharacterType>(span); });
             break;
         }
     }

--- a/Source/WTF/wtf/URLParser.h
+++ b/Source/WTF/wtf/URLParser.h
@@ -124,6 +124,8 @@ private:
     void percentEncodeByte(uint8_t);
     void appendToASCIIBuffer(char32_t);
     void appendToASCIIBuffer(std::span<const Latin1Character>);
+    void appendToASCIIBuffer(std::span<const char16_t>);
+    template<typename CharacterType, typename TrivialCodePointPrefix> void consumeTrivialCodePoints(CodePointIterator<CharacterType>&, NOESCAPE const TrivialCodePointPrefix&);
     template<typename CharacterType> void encodeNonUTF8Query(const Vector<char16_t>& source, const URLTextEncoding&, CodePointIterator<CharacterType>);
     void copyASCIIStringUntil(const String&, size_t length);
     bool copyBaseWindowsDriveLetter(const URL&);

--- a/Source/WTF/wtf/text/CodePointIterator.h
+++ b/Source/WTF/wtf/text/CodePointIterator.h
@@ -73,7 +73,14 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     {
         return codeUnitsSince(other.m_data.data());
     }
-    
+
+    ALWAYS_INLINE std::span<const CharacterType> span() const LIFETIME_BOUND { return m_data; }
+
+    // Advances by a number of code units. Only safe when the skipped units are
+    // known to be single-unit code points (e.g., ASCII), so it never splits a
+    // surrogate pair or a UTF-8 sequence.
+    ALWAYS_INLINE void advanceBy(size_t codeUnits) { skip(m_data, codeUnits); }
+
 private:
     std::span<const CharacterType> m_data;
 };

--- a/Tools/TestWebKitAPI/Tests/WTF/URLParser.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/URLParser.cpp
@@ -1141,4 +1141,42 @@ TEST_F(WTF_URLParser, FilePathStartBackslash)
     checkURL("file://\\C|\\path"_s, { "file"_s, ""_s, ""_s, ""_s, 0, "/C:/path"_s, ""_s, ""_s, "file:///C:/path"_s }, TestTabs::No);
 }
 
+TEST_F(WTF_URLParser, Utf16BulkAppend)
+{
+    // Covers appending a run of 16-bit code units to the ASCII buffer in bulk, which needs a
+    // 16-bit input string (forced here by a non-Latin-1 code point, since a Latin-1-only string
+    // stays 8-bit), a syntax violation before the run, and a run of at least one SIMD stride.
+    // The tab sweep in checkURL additionally supplies a violation at every offset.
+    checkURL(utf16String(u"http://host/aaaaaaaaaaaaaaaa^bbbbbbbbbbbbbbbb?cccccccccccccccc#ddddddddddddddddП"),
+        { "http"_s, ""_s, ""_s, "host"_s, 0, "/aaaaaaaaaaaaaaaa%5Ebbbbbbbbbbbbbbbb"_s, "cccccccccccccccc"_s, "dddddddddddddddd%D0%9F"_s,
+            "http://host/aaaaaaaaaaaaaaaa%5Ebbbbbbbbbbbbbbbb?cccccccccccccccc#dddddddddddddddd%D0%9F"_s });
+    checkURL(utf16String(u"about:Пaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbb"),
+        { "about"_s, ""_s, ""_s, ""_s, 0, "%D0%9Faaaaaaaaaaaaaaaabbbbbbbbbbbbbbbb"_s, ""_s, ""_s,
+            "about:%D0%9Faaaaaaaaaaaaaaaabbbbbbbbbbbbbbbb"_s });
+}
+
+TEST_F(WTF_URLParser, DotSegmentsInLongPaths)
+{
+    // A ".." segment reports a syntax violation and pops the buffer, so everything after it is
+    // parsed while building the output buffer. These cases make the surrounding segments long
+    // enough for the vectorized scan to consume them in bulk on both sides of the dot segments,
+    // and the tab sweep in checkURL moves the violation through every offset.
+    checkURL("http://host/aaaaaaaaaaaaaaaa/../bbbbbbbbbbbbbbbb/./cccccccccccccccc"_s,
+        { "http"_s, ""_s, ""_s, "host"_s, 0, "/bbbbbbbbbbbbbbbb/cccccccccccccccc"_s, ""_s, ""_s,
+            "http://host/bbbbbbbbbbbbbbbb/cccccccccccccccc"_s });
+    checkURL("http://host/aaaaaaaaaaaaaaaa/%2e%2e/bbbbbbbbbbbbbbbb"_s,
+        { "http"_s, ""_s, ""_s, "host"_s, 0, "/bbbbbbbbbbbbbbbb"_s, ""_s, ""_s,
+            "http://host/bbbbbbbbbbbbbbbb"_s });
+    checkURL(utf16String(u"http://host/aaaaaaaaaaaaaaaa/../bbbbbbbbbbbbbbbb/./ccccccccccccccccП"),
+        { "http"_s, ""_s, ""_s, "host"_s, 0, "/bbbbbbbbbbbbbbbb/cccccccccccccccc%D0%9F"_s, ""_s, ""_s,
+            "http://host/bbbbbbbbbbbbbbbb/cccccccccccccccc%D0%9F"_s });
+    // Resolving against a base copies the base into the buffer first, so here the pop walks back
+    // over copied bytes rather than bulk-appended ones.
+    checkRelativeURL("../cccccccccccccccc"_s, "http://host/aaaaaaaaaaaaaaaa/bbbbbbbbbbbbbbbb"_s,
+        { "http"_s, ""_s, ""_s, "host"_s, 0, "/cccccccccccccccc"_s, ""_s, ""_s, "http://host/cccccccccccccccc"_s });
+    checkRelativeURL("./cccccccccccccccc"_s, "http://host/aaaaaaaaaaaaaaaa/bbbbbbbbbbbbbbbb"_s,
+        { "http"_s, ""_s, ""_s, "host"_s, 0, "/aaaaaaaaaaaaaaaa/cccccccccccccccc"_s, ""_s, ""_s,
+            "http://host/aaaaaaaaaaaaaaaa/cccccccccccccccc"_s });
+}
+
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### eb44b6cfaa64548b24158a0550d3f6850a65d513
<pre>
Vectorize URL component parsing (path, query, fragment, opaque path)
<a href="https://bugs.webkit.org/show_bug.cgi?id=319750">https://bugs.webkit.org/show_bug.cgi?id=319750</a>

Reviewed by Yusuke Suzuki.

The URL parser walks its input one code point at a time, and for each one
checks whether it is a component delimiter or a member of that component&apos;s
percent-encode set. For the common case of long runs of ordinary characters
(path segments, query strings, fragments) this is the dominant cost.

This patch scans those runs with SIMD to find the first code point that
actually needs individual handling -- a delimiter, an encode-set member, a
control, or a non-ASCII code point -- and the parser then consumes the whole
preceding run at once. Every &quot;trivial&quot; code point in such a run is copied
verbatim, so:

- When the output is unchanged from the input (canonical URLs, no syntax
  violation), the run is simply skipped and the offsets advanced.
- When the output buffer is being built (relative URLs and other
  non-canonical input), the run is appended in a single bulk copy rather than
  one code point at a time.

Because SIMD::find only vectorizes runs of at least one 16-byte stride, and
the bulk-append path must additionally scan a run before copying it, short
buffer-building runs are gated behind a one-stride length guard so they keep
using the existing per-code-point loop; the fast (no-copy) path is always
scanned since its leaner loop wins even below a stride.

Measured with a same-binary A/B of the parser (SIMD scanning on vs. off):

- On the corpus used by PerformanceTests/Parser/url-parser.html
  (resources/final-url-en, 82,257 real-world absolute URLs), throughput
  improves ~1.33x (203 -&gt; 153 ns/URL, denoised with 10 runs).
- On a corpus of URLs extracted from the HTML Standard (66,944 hrefs,
  ~77% relative fragments), throughput improves ~1.3-1.4x.
- Synthetic long components (path/query/fragment of ~100 code points) improve
  3-4x, with the win scaling with component length. Short components are
  unchanged.

Canonical link: <a href="https://commits.webkit.org/319305@main">https://commits.webkit.org/319305@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9d69013fce934ef85d4d05eaff80986ad8ab431b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181092 "5 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55037 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48835 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191309 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145415 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e7d57338-a9c6-4a46-9c7a-e1a119bd31fc) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182954 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56335 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54753 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141309 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98004 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a4be7ac0-ef1e-4d56-9272-7df6951a07a7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184047 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44974 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162059 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121760 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0bc9741f-56e0-45e6-b02a-9a906b919194) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43647 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41928 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/3725 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/10542 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154051 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41587 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2466 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/42366 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47649 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46183 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193241 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54703 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150702 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40332 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55391 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38207 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150413 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45002 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127657 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123202 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53908 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16583 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53290 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53527 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53355 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->