### PR TITLE
Web Inspector: Sources: `file://` URLs have nameless ancestor folders when "Group by Path"

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/GeneralTreeElement.js
+++ b/Source/WebInspectorUI/UserInterface/Views/GeneralTreeElement.js
@@ -197,8 +197,7 @@ WI.GeneralTreeElement = class GeneralTreeElement extends WI.TreeElement
             return this;
 
         let components = subpath.split("/");
-        if (components.length === 1)
-            return this;
+        components.pop();
 
         if (!this._subpathFolderTreeElementMap)
             this._subpathFolderTreeElementMap = new Map;
@@ -207,8 +206,8 @@ WI.GeneralTreeElement = class GeneralTreeElement extends WI.TreeElement
         let currentFolderTreeElement = this;
 
         for (let component of components) {
-            if (component === components.lastValue)
-                break;
+            if (!component)
+                continue;
 
             if (currentPath)
                 currentPath += "/";

--- a/Source/WebInspectorUI/UserInterface/Views/SourcesNavigationSidebarPanel.js
+++ b/Source/WebInspectorUI/UserInterface/Views/SourcesNavigationSidebarPanel.js
@@ -908,6 +908,23 @@ WI.SourcesNavigationSidebarPanel = class SourcesNavigationSidebarPanel extends W
 
     // Private
 
+    _originForURLComponents(urlComponents, securityOrigin)
+    {
+        if (urlComponents.origin)
+            return urlComponents.origin;
+
+        if (securityOrigin && (securityOrigin === "file://" || parseURL(securityOrigin).origin === securityOrigin))
+            return securityOrigin;
+
+        if (urlComponents.scheme === "file")
+            return "file://";
+
+        if (urlComponents.scheme)
+            return urlComponents.scheme + ":";
+
+        return WI.Resource.displayNameForType(WI.Resource.Type.Other);
+    }
+
     _willDismissLocalOverridePopover(popover)
     {
         let serializedData = popover.serializedData;
@@ -1077,7 +1094,7 @@ WI.SourcesNavigationSidebarPanel = class SourcesNavigationSidebarPanel extends W
             }
             this._originTreeElementMap.clear();
 
-            let origin = mainFrame.urlComponents.origin;
+            let origin = this._originForURLComponents(mainFrame.urlComponents, mainFrame.securityOrigin);
             this._mainFrameTreeElement = new WI.OriginTreeElement(origin, mainFrame, {hasChildren: true});
             this._originTreeElementMap.set(origin, this._mainFrameTreeElement);
             break;
@@ -1151,25 +1168,19 @@ WI.SourcesNavigationSidebarPanel = class SourcesNavigationSidebarPanel extends W
             }
 
             if (!parentTreeElement) {
-                let origin = resource.urlComponents.origin;
-                if (origin) {
-                    let originTreeElement = this._originTreeElementMap.get(origin);
-                    if (!originTreeElement) {
-                        let representedObject = resource.type === WI.Resource.Type.Document ? resource.parentFrame : null;
-                        originTreeElement = new WI.OriginTreeElement(origin, representedObject, {hasChildren: true});
-                        this._originTreeElementMap.set(origin, originTreeElement);
+                let origin = this._originForURLComponents(resource.urlComponents, resource.parentFrame?.securityOrigin);
+                let originTreeElement = this._originTreeElementMap.get(origin);
+                if (!originTreeElement) {
+                    let representedObject = resource.type === WI.Resource.Type.Document ? resource.parentFrame : null;
+                    originTreeElement = new WI.OriginTreeElement(origin, representedObject, {hasChildren: true});
+                    this._originTreeElementMap.set(origin, originTreeElement);
 
-                        let index = insertionIndexForObjectInListSortedByFunction(originTreeElement, this._resourcesTreeOutline.children, this._boundCompareTreeElements);
-                        this._resourcesTreeOutline.insertChild(originTreeElement, index);
-                    }
+                    let index = insertionIndexForObjectInListSortedByFunction(originTreeElement, this._resourcesTreeOutline.children, this._boundCompareTreeElements);
+                    this._resourcesTreeOutline.insertChild(originTreeElement, index);
+                }
 
-                    let subpath = resource.urlComponents.path;
-                    if (subpath && subpath[0] === "/")
-                        subpath = subpath.substring(1);
-
-                    parentTreeElement = originTreeElement.createFoldersAsNeededForSubpath(subpath, this._boundCompareTreeElements);
-                } else
-                    parentTreeElement = this._resourcesTreeOutline;
+                let subpath = resource.urlComponents.scheme === "blob" ? resource.urlComponents.lastPathComponent : resource.urlComponents.path;
+                parentTreeElement = originTreeElement.createFoldersAsNeededForSubpath(subpath, this._boundCompareTreeElements);
             }
 
             let resourceTreeElement = null;


### PR DESCRIPTION
#### c81ca28ecaec67aae3d468094d633e2d3011511c
<pre>
Web Inspector: Sources: `file://` URLs have nameless ancestor folders when &quot;Group by Path&quot;
<a href="https://bugs.webkit.org/show_bug.cgi?id=319752">https://bugs.webkit.org/show_bug.cgi?id=319752</a>

Reviewed by Taher Ali.

`parseURL(url).origin` is `null` for `file://` and other URLs with opaque origins.
Prefer the owning frame&apos;s valid security origin, then use the URL scheme or `WI.Resource.Type.Other` as a stable grouping title.

* Source/WebInspectorUI/UserInterface/Views/SourcesNavigationSidebarPanel.js:
(WI.SourcesNavigationSidebarPanel.originForURLComponents): Added.
(WI.SourcesNavigationSidebarPanel.prototype._updateMainFrameTreeElement):
(WI.SourcesNavigationSidebarPanel.prototype._addResource):
Ensure a valid grouping origin for `file://`, opaque, invalid, and empty URLs.
Always place &quot;Group by Path&quot; resources below that origin so malformed URLs cannot add unexpected top-level folders.
`blob:` URLs include their creator&apos;s origin in `urlComponents.path`; use only their final path component when creating folders.

* Source/WebInspectorUI/UserInterface/Views/GeneralTreeElement.js:
(WI.GeneralTreeElement.prototype.createFoldersAsNeededForSubpath):
Ignore empty path components and remove the filename before creating folders.
This also allows a directory to have the same name as the resource.

Canonical link: <a href="https://commits.webkit.org/317518@main">https://commits.webkit.org/317518@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/466b384e420b595843ac9495863c045a6c7f0f2f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175442 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49374 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43155 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185028 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/137587 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50666 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49057 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136592 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/137587 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178399 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40010 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157349 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117070 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38652 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37035 "Found 2 new API test failures: TestWebKitAPI.WKWebExtensionAPIDevTools.MessagePassingFromPanelToDevToolsBackground, TestWebKitAPI.ProcessSwap.SessionStorage (failure)") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149074 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36842 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33503 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41061 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41238 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187453 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49041 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145557 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39180 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49721 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33465 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145397 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40215 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/121914 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115631 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48227 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11816 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47630 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47860 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47687 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->