### PR TITLE
HeapSnapshot.js allocates unnecessary intermediate arrays before serializing nodes/edges

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Workers/HeapSnapshot/HeapSnapshot.js
+++ b/Source/WebInspectorUI/UserInterface/Workers/HeapSnapshot/HeapSnapshot.js
@@ -257,10 +257,10 @@ HeapSnapshot = class HeapSnapshot
 
             let classNameTableIndex = nodes[nodeIndex + nodeClassNameOffset];
             if (nodeClassNamesTable[classNameTableIndex] === className)
-                instances.push(nodeIndex);
+                instances.push(snapshot.serializeNode(nodeIndex));
         }
 
-        return instances.map(snapshot.serializeNode, snapshot);
+        return instances;
     }
 
     // Worker Methods
@@ -331,10 +331,10 @@ HeapSnapshot = class HeapSnapshot
         let targetNodeOrdinal = this._nodeIdentifierToOrdinal.get(nodeIdentifier);
         for (let nodeOrdinal = 0; nodeOrdinal < this._nodeCount; ++nodeOrdinal) {
             if (this._nodeOrdinalToDominatorNodeOrdinal[nodeOrdinal] === targetNodeOrdinal)
-                dominatedNodes.push(nodeOrdinal * this._nodeFieldCount);
+                dominatedNodes.push(this.serializeNode(nodeOrdinal * this._nodeFieldCount));
         }
 
-        return dominatedNodes.map(this.serializeNode, this);
+        return dominatedNodes;
     }
 
     retainedNodes(nodeIdentifier)
@@ -348,14 +348,11 @@ HeapSnapshot = class HeapSnapshot
             let toNodeIdentifier = this._edges[edgeIndex + edgeToIdOffset];
             let toNodeOrdinal = this._nodeIdentifierToOrdinal.get(toNodeIdentifier);
             let toNodeIndex = toNodeOrdinal * this._nodeFieldCount;
-            retainedNodes.push(toNodeIndex);
-            edges.push(edgeIndex);
+            retainedNodes.push(this.serializeNode(toNodeIndex));
+            edges.push(this.serializeEdge(edgeIndex));
         }
 
-        return {
-            retainedNodes: retainedNodes.map(this.serializeNode, this),
-            edges: edges.map(this.serializeEdge, this),
-        };
+        return {retainedNodes, edges};
     }
 
     retainers(nodeIdentifier)
@@ -369,14 +366,11 @@ HeapSnapshot = class HeapSnapshot
         for (let edgeIndex = incomingEdgeIndex; edgeIndex < incomingEdgeIndexEnd; ++edgeIndex) {
             let fromNodeOrdinal = this._incomingNodes[edgeIndex];
             let fromNodeIndex = fromNodeOrdinal * this._nodeFieldCount;
-            retainers.push(fromNodeIndex);
-            edges.push(this._incomingEdges[edgeIndex]);
+            retainers.push(this.serializeNode(fromNodeIndex));
+            edges.push(this.serializeEdge(this._incomingEdges[edgeIndex]));
         }
 
-        return {
-            retainers: retainers.map(this.serializeNode, this),
-            edges: edges.map(this.serializeEdge, this),
-        };
+        return {retainers, edges};
     }
 
     updateDeadNodesAndGatherCollectionData(snapshots)


### PR DESCRIPTION
#### 5fe81ead06933befd1839a98c5fe131594fa4f4c
<pre>
HeapSnapshot.js allocates unnecessary intermediate arrays before serializing nodes/edges
<a href="https://bugs.webkit.org/show_bug.cgi?id=319754">https://bugs.webkit.org/show_bug.cgi?id=319754</a>
<a href="https://rdar.apple.com/182605155">rdar://182605155</a>

Reviewed by Devin Rousso.

instancesWithClassName(), dominatedNodes(), retainedNodes(), and
retainers() each collected raw node/edge indices into an array and
then called .map(this.serializeNode/serializeEdge) to produce the
result, allocating and traversing a throwaway array for no reason.
Push the serialized node/edge directly in the collection loop instead.

* Source/WebInspectorUI/UserInterface/Workers/HeapSnapshot/HeapSnapshot.js:
(HeapSnapshot.instancesWithClassName):
(HeapSnapshot.prototype.dominatedNodes):
(HeapSnapshot.prototype.retainedNodes):
(HeapSnapshot.prototype.retainers):

Canonical link: <a href="https://commits.webkit.org/317486@main">https://commits.webkit.org/317486@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4737a4f8b5a555cb0bd776523026be996b9f47b7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175451 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49383 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43164 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185037 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/137596 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/22b3fa92-9b29-4de4-9da4-6afa2f304f98) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50675 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49066 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136601 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/137596 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9a56e4eb-60f4-4f88-9da4-e86c86766e16) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178408 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40015 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157361 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117079 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/32a450f9-3574-410d-94e6-73d22e0e0789) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38657 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37044 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149079 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36854 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33512 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41070 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41247 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187462 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49050 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145566 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39158 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49730 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33478 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145406 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40221 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/121923 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115645 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48236 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11829 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47639 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47869 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47696 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->