### PR TITLE
[Swift in WebKit] WTFExtras.swift should use typed throws instead of existential throws

### DIFF
--- a/Source/WebCore/PAL/pal/crypto/WTFExtras.swift
+++ b/Source/WebCore/PAL/pal/crypto/WTFExtras.swift
@@ -22,7 +22,7 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 
 public import Foundation
-internal import wtf
+import wtf
 
 // BorrowedBytes exposes borrowed C++ bytes to Foundation/CryptoKit consumers
 // with no copy and no `unsafe` at the call sites. The single audited `unsafe`
@@ -34,9 +34,9 @@ internal import wtf
 @safe
 extension WTF.BorrowedBytes: ContiguousBytes {
     /// Calls `body` with a raw buffer pointer over the borrowed bytes, valid only for the call.
-    public func withUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R {
+    public func withUnsafeBytes<R, E>(_ body: (UnsafeRawBufferPointer) throws(E) -> R) throws(E) -> R where E: Error {
         // Safe: data()/size() describe the same live span, and data() traps if the borrow was revoked, so misuse crashes rather than reading freed memory.
-        try unsafe body(UnsafeRawBufferPointer(start: self.data(), count: self.size()))
+        try unsafe body(UnsafeRawBufferPointer(start: data(), count: size()))
     }
 }
 
@@ -44,12 +44,14 @@ extension WTF.BorrowedBytes: ContiguousBytes {
 extension WTF.BorrowedBytes: RandomAccessCollection {
     /// The position of the first byte.
     public var startIndex: Int { 0 }
+
     /// The position one past the last byte.
-    public var endIndex: Int { self.size() }
+    public var endIndex: Int { size() }
+
     /// The byte at `position`.
     public subscript(position: Int) -> UInt8 {
         // Safe: UnsafeRawBufferPointer's own subscript bounds-checks position and traps if it's out of range.
-        unsafe UnsafeRawBufferPointer(start: self.data(), count: self.size())[position]
+        unsafe UnsafeRawBufferPointer(start: data(), count: size())[position]
     }
 }
 
@@ -74,13 +76,13 @@ public struct NonNullBytes: ContiguousBytes, DataProtocol, RandomAccessCollectio
     }
 
     /// Calls `body` with a raw buffer pointer over the bytes, valid only for the call.
-    public func withUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R {
+    public func withUnsafeBytes<R, E>(_ body: (UnsafeRawBufferPointer) throws(E) -> R) throws(E) -> R where E: Error {
         if bytes.isEmpty {
             // Safe: `placeholder` is a live local, so its address is non-null; we expose it
             // with a zero count, so `body` can never read through it. This gives CryptoKit the
             // non-null base pointer it requires even for an empty buffer.
             var placeholder: UInt8 = 0
-            return try unsafe Swift.withUnsafeBytes(of: &placeholder) { raw in
+            return try unsafe Swift.withUnsafeBytes(of: &placeholder) { (raw: UnsafeRawBufferPointer) throws(E) in
                 try unsafe body(UnsafeRawBufferPointer(start: raw.baseAddress, count: 0))
             }
         }


### PR DESCRIPTION
#### 15accea208cba1b35acb8ec71f8b0fe7d6c3df2e
<pre>
[Swift in WebKit] WTFExtras.swift should use typed throws instead of existential throws
<a href="https://bugs.webkit.org/show_bug.cgi?id=319757">https://bugs.webkit.org/show_bug.cgi?id=319757</a>
<a href="https://rdar.apple.com/182608428">rdar://182608428</a>

Reviewed by Abrar Rahman Protyasha.

It&apos;s always preferable to use typed throws instead of existential throws when dealing with generic
Error types (they are much more performant and ergonomic for clients).

Also clean up some `self.` that aren&apos;t needed.

* Source/WebCore/PAL/pal/crypto/WTFExtras.swift:
(WTF.endIndex):

Canonical link: <a href="https://commits.webkit.org/317557@main">https://commits.webkit.org/317557@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a8659c4a11fc27f6896ca5c2044a4d6c38e57ac3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175627 "3 style errors") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/49559 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/43343 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185219 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/137795 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bfc8f5aa-4ec7-4cf6-913c-7f8bb29a3252) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/177490 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50852 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49242 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/136753 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/137795 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d1ab8b49-ee7c-41ff-be4f-cb8e59df0fe1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178583 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40188 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/157526 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117231 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/39b4581e-480c-49b1-9274-b1ef61b2851f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38830 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/37217 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149249 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/37018 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33689 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41251 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/41423 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187639 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49227 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/157077 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/145736 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39210 "Built successfully and passed tests") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/49907 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/33642 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145573 "Passed tests") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/49907 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122102 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115928 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48414 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/11995 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/47816 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/48048 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/47873 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->