### PR TITLE
Web Inspector: <style> elements not created by the HTML parser (e.g. in Shadow DOM) link to the wrong location in the Sources tab

### DIFF
--- a/LayoutTests/inspector/css/getAllStyleSheets-expected.txt
+++ b/LayoutTests/inspector/css/getAllStyleSheets-expected.txt
@@ -14,7 +14,7 @@ URL: <style> on inspector/css/getAllStyleSheets.html
 OFFSET: (6, 7)
 PASS: Stylesheet should have a frame.
 
-URL: inspector/css/getAllStyleSheets.html
+URL: (anonymous)
 OFFSET: (0, 0)
 PASS: Stylesheet should have a frame.
 

--- a/LayoutTests/inspector/css/getAllStyleSheets.html
+++ b/LayoutTests/inspector/css/getAllStyleSheets.html
@@ -25,7 +25,7 @@ function test()
 
         for (let styleSheet of styleSheets) {
             InspectorTest.log("");
-            InspectorTest.log(`URL: ${styleSheet.isInlineStyleTag() ? "<style> on " : ""}${sanitizeURL(styleSheet.url)}`);
+            InspectorTest.log(`URL: ${styleSheet.anonymous ? "(anonymous)" : (styleSheet.isInlineStyleTag() ? "<style> on " : "") + sanitizeURL(styleSheet.url)}`);
             InspectorTest.log(`OFFSET: (${styleSheet.startLineNumber}, ${styleSheet.startColumnNumber})`);
             InspectorTest.expectThat(styleSheet.parentFrame, "Stylesheet should have a frame.");
         }

--- a/LayoutTests/inspector/css/getMatchedStylesForNodeScriptCreatedStyleElement-expected.txt
+++ b/LayoutTests/inspector/css/getMatchedStylesForNodeScriptCreatedStyleElement-expected.txt
@@ -1,0 +1,14 @@
+Tests that a <style> element not created by the HTML parser (e.g. via document.createElement, as shadow-DOM libraries like Polymer do when cloning templates) is not misattributed to a bogus location in the page's HTML source.
+
+
+== Running test suite: CSS.getMatchedStylesForNode.ScriptCreatedStyleElement
+-- Running test case: CSS.getMatchedStylesForNode.ScriptCreatedStyleElement.ParserCreatedStyleTagHasSourceCodeLocation
+PASS: Stylesheet parsed inline by the HTML parser should not be anonymous.
+PASS: Rule should have a source code location.
+PASS: Source code location should point into a Resource (the page's HTML document).
+
+-- Running test case: CSS.getMatchedStylesForNode.ScriptCreatedStyleElement.ScriptCreatedStyleTagInShadowRootIsAnonymous
+PASS: Stylesheet with no valid parser position should be anonymous.
+PASS: Rule should still have a source code location, pointing into the stylesheet's own extracted content.
+PASS: Source code location should point at the anonymous CSSStyleSheet itself, not at the page's HTML document.
+

--- a/LayoutTests/inspector/css/getMatchedStylesForNodeScriptCreatedStyleElement.html
+++ b/LayoutTests/inspector/css/getMatchedStylesForNodeScriptCreatedStyleElement.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../http/tests/inspector/resources/inspector-test.js"></script>
+<script>
+function test()
+{
+    let suite = InspectorTest.createAsyncSuite("CSS.getMatchedStylesForNode.ScriptCreatedStyleElement");
+
+    function nodeForId(id) {
+        return WI.domManager.nodeForId(id);
+    }
+
+    function findMatchedRule(domNodeStyles, selectorText) {
+        return domNodeStyles.matchedRules.find((rule) => rule.selectorText === selectorText);
+    }
+
+    suite.addTestCase({
+        name: "CSS.getMatchedStylesForNode.ScriptCreatedStyleElement.ParserCreatedStyleTagHasSourceCodeLocation",
+        description: "A <style> tag created by the HTML parser should be attributed to the document's URL with a valid source code location.",
+        async test() {
+            let documentNode = await WI.domManager.requestDocument();
+            let domNode = nodeForId(await documentNode.querySelector("#light-dom-target"));
+            InspectorTest.assert(domNode, "Should find DOM Node '#light-dom-target'.");
+
+            let domNodeStyles = WI.cssManager.stylesForNode(domNode);
+            await domNodeStyles.refreshIfNeeded();
+
+            let rule = findMatchedRule(domNodeStyles, "#light-dom-target");
+            InspectorTest.assert(rule, "Should find matched rule for '#light-dom-target'.");
+
+            InspectorTest.expectFalse(rule.ownerStyleSheet.anonymous, "Stylesheet parsed inline by the HTML parser should not be anonymous.");
+            InspectorTest.expectThat(!!rule.sourceCodeLocation, "Rule should have a source code location.");
+            InspectorTest.expectThat(rule.sourceCodeLocation && rule.sourceCodeLocation.sourceCode instanceof WI.Resource, "Source code location should point into a Resource (the page's HTML document).");
+        },
+    });
+
+    suite.addTestCase({
+        name: "CSS.getMatchedStylesForNode.ScriptCreatedStyleElement.ScriptCreatedStyleTagInShadowRootIsAnonymous",
+        description: "A <style> tag created with document.createElement (not by the HTML parser) and inserted into a shadow root -- as shadow-DOM libraries like Polymer do when cloning templates -- has no meaningful position in any document's source. It should be reported as an anonymous stylesheet instead of being wrongly attributed to a bogus location in the page's HTML.",
+        async test() {
+            let documentNode = await WI.domManager.requestDocument();
+            let hostNode = nodeForId(await documentNode.querySelector("#shadow-host"));
+            InspectorTest.assert(hostNode, "Should find DOM Node '#shadow-host'.");
+            InspectorTest.assert(hostNode.hasShadowRoots(), "Host node should have a shadow root.");
+
+            let domNodeStyles = WI.cssManager.stylesForNode(hostNode);
+            await domNodeStyles.refreshIfNeeded();
+
+            let rule = findMatchedRule(domNodeStyles, ":host");
+            InspectorTest.assert(rule, "Should find matched ':host' rule.");
+
+            let styleSheet = rule.ownerStyleSheet;
+            InspectorTest.expectThat(styleSheet.anonymous, "Stylesheet with no valid parser position should be anonymous.");
+            InspectorTest.expectThat(!!rule.sourceCodeLocation, "Rule should still have a source code location, pointing into the stylesheet's own extracted content.");
+            InspectorTest.expectEqual(rule.sourceCodeLocation && rule.sourceCodeLocation.sourceCode, styleSheet, "Source code location should point at the anonymous CSSStyleSheet itself, not at the page's HTML document.");
+        },
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+</head>
+<body onload="runTest()">
+<p>Tests that a &lt;style&gt; element not created by the HTML parser (e.g. via document.createElement, as shadow-DOM libraries like Polymer do when cloning templates) is not misattributed to a bogus location in the page's HTML source.</p>
+<style>#light-dom-target { color: red; }</style>
+<div id="light-dom-target"></div>
+<div id="shadow-host"></div>
+<script>
+(function() {
+    let shadowRoot = document.getElementById("shadow-host").attachShadow({mode: "open"});
+    let style = document.createElement("style");
+    style.textContent = ":host { color: blue; }";
+    shadowRoot.appendChild(style);
+})();
+</script>
+</body>
+</html>

--- a/Source/WebCore/inspector/InspectorStyleSheet.cpp
+++ b/Source/WebCore/inspector/InspectorStyleSheet.cpp
@@ -616,6 +616,11 @@ static String sourceURLForCSSRule(CSSRule& rule)
         if (auto sourceURL = parentStyleSheet->contents().baseURL().string(); !sourceURL.isEmpty())
             return sourceURL;
 
+        // See the comment in InspectorStyleSheet::finalURL() for why an inline stylesheet
+        // without a trustworthy parser position shouldn't be attributed to its owner document's URL.
+        if (parentStyleSheet->isInline() && parentStyleSheet->startPosition() == TextPosition())
+            return nullString();
+
         if (RefPtr ownerDocument = parentStyleSheet->ownerDocument())
             return InspectorDOMAgent::documentURLString(ownerDocument.get());
     }
@@ -1056,6 +1061,13 @@ InspectorStyleSheet::~InspectorStyleSheet()
 
 String InspectorStyleSheet::finalURL() const
 {
+    // A <style> element that wasn't created by the document's parser (e.g. cloned into a
+    // shadow tree, or inserted via document.write) has no meaningful position within any
+    // document's source text, so falling back to the document URL would produce a source
+    // location that doesn't correspond to where this stylesheet's content actually lives.
+    if (RefPtr styleSheet = m_pageStyleSheet; styleSheet && styleSheet->isInline() && styleSheet->startPosition() == TextPosition())
+        return emptyString();
+
     String url = styleSheetURL(m_pageStyleSheet.get());
     return url.isEmpty() ? m_documentURL : url;
 }


### PR DESCRIPTION
#### 3857dea9db8d025a6d829d2d4902ec849c5a5bde
<pre>
Web Inspector: &lt;style&gt; elements not created by the HTML parser (e.g. in Shadow DOM) link to the wrong location in the Sources tab
<a href="https://bugs.webkit.org/show_bug.cgi?id=272874">https://bugs.webkit.org/show_bug.cgi?id=272874</a>
<a href="https://rdar.apple.com/126660552">rdar://126660552</a>

Reviewed by NOBODY (OOPS!).

A &lt;style&gt; element that wasn&apos;t created by the document&apos;s HTML parser -- for example
one cloned into a shadow tree, inserted via document.write(), or created with
document.createElement(), as shadow-DOM libraries like Polymer do when cloning
templates -- has no meaningful position in any document&apos;s source text.
InspectorStyleSheet still fell back to attributing these stylesheets to the owner
document&apos;s URL, producing a source link in the Styles sidebar (e.g. &quot;result:1&quot;)
that was clickable but pointed at the wrong location, or no matching CSS, in the
Sources tab.

Detect this case via CSSStyleSheet::isInline() combined with a default-constructed
startPosition(), and omit the sourceURL instead of misattributing it to the owner
document. The existing frontend already handles a missing sourceURL gracefully,
falling back to &quot;Anonymous Style Sheet N&quot; and linking directly to the extracted
stylesheet content.

Also update getAllStyleSheets.html, which creates a &lt;style&gt; element via
document.createElement() and appends it without going through the parser. Its
stylesheet is now correctly reported as anonymous (no sourceURL), so the test&apos;s
inline sanitizeURL() helper -- which unlike TestHarness.sanitizeURL() does not
guard against a null URL -- needs to special-case that stylesheet instead of
crashing on it.

* Source/WebCore/inspector/InspectorStyleSheet.cpp:
(WebCore::sourceURLForCSSRule):
(WebCore::InspectorStyleSheet::finalURL const):
* LayoutTests/inspector/css/getAllStyleSheets-expected.txt:
* LayoutTests/inspector/css/getAllStyleSheets.html:
* LayoutTests/inspector/css/getMatchedStylesForNodeScriptCreatedStyleElement-expected.txt: Added.
* LayoutTests/inspector/css/getMatchedStylesForNodeScriptCreatedStyleElement.html: Added.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3857dea9db8d025a6d829d2d4902ec849c5a5bde

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175481 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49413 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43194 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185067 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/137627 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c9f68175-83c6-4dea-9d72-94679962f086) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/177345 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50705 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49096 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136627 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96201 "1 flakes 3 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c6df539c-587e-4855-80b9-76bdbca148fe) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178438 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40044 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157383 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117105 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5895f3dc-28c4-4ce2-8f3e-257f61241aa2) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38686 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37072 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149108 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36876 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33542 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41100 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41275 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187492 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49080 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/156939 "") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145596 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49760 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33500 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145434 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40250 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/121953 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115694 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48266 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11852 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47669 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47899 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47726 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->