### PR TITLE
Web Inspector: Add "Reset Columns" context menu item to restore default table column visibility

### DIFF
--- a/LayoutTests/inspector/table/table-column-and-row-boundaries-expected.txt
+++ b/LayoutTests/inspector/table/table-column-and-row-boundaries-expected.txt
@@ -1,4 +1,4 @@
-Tests Table row-visibility boundary checks and showing a column into an empty visible column set.
+Tests Table row-visibility boundary checks, showing a column into an empty visible column set, and resetting column visibility to defaults.
 
 
 == Running test suite: Table.ColumnAndRowBoundaries
@@ -12,4 +12,12 @@ PASS: End index is exclusive, so row 20 should not be visible.
 PASS: No columns should be visible.
 PASS: The shown column should no longer be hidden.
 PASS: Only the shown column should be visible.
+
+-- Running test case: Table.ResetColumnVisibility
+PASS: Index column should be hidden before reset.
+PASS: Name column should be hidden before reset.
+PASS: Extra column should be visible before reset.
+PASS: Index column should be restored to its default visible state.
+PASS: Name column should be restored to its default visible state.
+PASS: Extra column should be restored to its default hidden state.
 

--- a/LayoutTests/inspector/table/table-column-and-row-boundaries.html
+++ b/LayoutTests/inspector/table/table-column-and-row-boundaries.html
@@ -55,11 +55,42 @@ function test()
         }
     });
 
+    suite.addTestCase({
+        name: "Table.ResetColumnVisibility",
+        description: "resetColumnVisibility should restore each hideable column to its default hidden state.",
+        test() {
+            let table = InspectorTest.createTable(10);
+
+            let indexColumn = table.columnWithIdentifier("index");
+            let nameColumn = table.columnWithIdentifier("name");
+
+            let extraColumn = new WI.TableColumn("extra", "Extra", {hidden: true});
+            table.addColumn(extraColumn);
+
+            // Deviate every column from its default visibility.
+            table.hideColumn(indexColumn);
+            table.hideColumn(nameColumn);
+            table.showColumn(extraColumn);
+
+            InspectorTest.expectTrue(indexColumn.hidden, "Index column should be hidden before reset.");
+            InspectorTest.expectTrue(nameColumn.hidden, "Name column should be hidden before reset.");
+            InspectorTest.expectFalse(extraColumn.hidden, "Extra column should be visible before reset.");
+
+            table.resetColumnVisibility();
+
+            InspectorTest.expectFalse(indexColumn.hidden, "Index column should be restored to its default visible state.");
+            InspectorTest.expectFalse(nameColumn.hidden, "Name column should be restored to its default visible state.");
+            InspectorTest.expectTrue(extraColumn.hidden, "Extra column should be restored to its default hidden state.");
+
+            return true;
+        }
+    });
+
     suite.runTestCasesAndFinish();
 }
 </script>
 </head>
 <body onLoad="runTest()">
-    <p>Tests Table row-visibility boundary checks and showing a column into an empty visible column set.</p>
+    <p>Tests Table row-visibility boundary checks, showing a column into an empty visible column set, and resetting column visibility to defaults.</p>
 </body>
 </html>

--- a/Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js
+++ b/Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js
@@ -1444,6 +1444,8 @@ localizedStrings["Requesting \u201C%s\u201D"] = "Requesting \u201C%s\u201D";
 localizedStrings["Required"] = "Required";
 /* Context menu action for resetting the breakpoint to its initial configuration. */
 localizedStrings["Reset Breakpoint @ Breakpoint Context Menu"] = "Reset Breakpoint";
+/* Context menu action for restoring the default set of visible table columns. */
+localizedStrings["Reset Columns"] = "Reset Columns";
 /* Title for Resolution row in Media Sidebar */
 localizedStrings["Resolution @ Media Sidebar"] = "Resolution";
 localizedStrings["Resource"] = "Resource";

--- a/Source/WebInspectorUI/UserInterface/Views/Table.js
+++ b/Source/WebInspectorUI/UserInterface/Views/Table.js
@@ -528,6 +528,22 @@ WI.Table = class Table extends WI.View
         }
     }
 
+    resetColumnVisibility()
+    {
+        for (let column of this._columnSpecs.values()) {
+            if (column.locked || !column.hideable)
+                continue;
+
+            if (column.hidden === column.defaultHidden)
+                continue;
+
+            if (column.defaultHidden)
+                this.hideColumn(column);
+            else
+                this.showColumn(column);
+        }
+    }
+
     hideColumn(column)
     {
         console.assert(this._columnSpecs.get(column.identifier) === column, "Column not in this table.");
@@ -1434,6 +1450,13 @@ WI.Table = class Table extends WI.View
                 else
                     this.hideColumn(column);
             }, checked);
+        }
+
+        if (didAppendHeaderItem) {
+            contextMenu.appendSeparator();
+            contextMenu.appendItem(WI.UIString("Reset Columns"), () => {
+                this.resetColumnVisibility();
+            });
         }
     }
 


### PR DESCRIPTION
#### cbd17f8cac92fa401db2c8b75624f253c0b7ab89
<pre>
Web Inspector: Add &quot;Reset Columns&quot; context menu item to restore default table column visibility
<a href="https://bugs.webkit.org/show_bug.cgi?id=319758">https://bugs.webkit.org/show_bug.cgi?id=319758</a>
<a href="https://rdar.apple.com/182612212">rdar://182612212</a>

Reviewed by NOBODY (OOPS!).

Table headers already let users hide/show individual columns via checkboxes
in the context menu, but there was no way to get back to the default set of
visible columns without toggling them one by one. Add
WI.Table.prototype.resetColumnVisibility, which restores every hideable
column to its default hidden state, and surface it as a &quot;Reset Columns&quot; item
in the header context menu, right after the &quot;Displayed Columns&quot; checkbox
list.

* LayoutTests/inspector/table/table-column-and-row-boundaries-expected.txt: Updated.
* LayoutTests/inspector/table/table-column-and-row-boundaries.html:  Add a Table.ResetColumnVisibility test case.
* Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js:
* Source/WebInspectorUI/UserInterface/Views/Table.js:
(WI.Table.prototype.resetColumnVisibility):
(WI.Table.prototype._handleHeaderContextMenu): Add a &quot;Reset Columns&quot; item
that calls resetColumnVisibility.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cbd17f8cac92fa401db2c8b75624f253c0b7ab89

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175465 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49397 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43178 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185051 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/137610 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2d2839fd-dba0-4e47-b253-5c09ef2e4c66) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50689 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49080 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136615 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96200 "4 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/defd2608-f076-4d83-808b-a30fb9d9f1f4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178422 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40031 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157369 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117093 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e00d421f-0125-4fb0-822d-fe378d115e96) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38673 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37058 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149095 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36862 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33526 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41084 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41261 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187476 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49064 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/156925 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145580 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49744 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33486 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145420 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40237 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/121937 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115664 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48250 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11838 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47653 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47883 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47710 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->