### PR TITLE
[CMake] Fix the iOS simulator release build

### DIFF
--- a/Source/WebKit/PlatformIOS.cmake
+++ b/Source/WebKit/PlatformIOS.cmake
@@ -1659,12 +1659,15 @@ target_compile_options(WebKitSwift PRIVATE
 
 # Explicit-module-build for WebKitSwift Swift compile. Mirrors the macro
 # WEBKIT_SETUP_SWIFT_AND_GENERATE_SWIFT_CPP_INTEROP_HEADER's enablement of the
-# same flag for WebKit / WebGPU / PAL. https://bugs.webkit.org/show_bug.cgi?id=312083
+# same flags for WebKit / WebGPU / PAL. https://bugs.webkit.org/show_bug.cgi?id=312083
 target_compile_options(WebKitSwift PRIVATE
     "$<$<COMPILE_LANGUAGE:Swift>:-explicit-module-build>"
     "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -fexperimental-late-parse-attributes>"
     "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -fexperimental-bounds-safety-attributes>"
     "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-module-cache-path ${CMAKE_BINARY_DIR}/SwiftModuleCache>"
+    # Swift macro expansion runs swift-plugin-server under sandbox-exec;
+    # -disable-sandbox avoids a nested sandbox_apply failure in a sandboxed build.
+    "$<$<COMPILE_LANGUAGE:Swift>:-disable-sandbox>"
 )
 
 target_compile_options(WebKitSwift PRIVATE
@@ -1776,6 +1779,9 @@ target_compile_options(_WebKit_SwiftUI PRIVATE
     "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -fexperimental-late-parse-attributes>"
     "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -fexperimental-bounds-safety-attributes>"
     "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-module-cache-path ${CMAKE_BINARY_DIR}/SwiftModuleCache>"
+    # @Entry and other SwiftUI macros run swift-plugin-server under sandbox-exec;
+    # -disable-sandbox avoids a nested sandbox_apply failure in a sandboxed build.
+    "$<$<COMPILE_LANGUAGE:Swift>:-disable-sandbox>"
 )
 
 target_link_libraries(_WebKit_SwiftUI PRIVATE

--- a/Source/WebKit/WebProcess/WebPage/ios/FindIndicatorIOS.cpp
+++ b/Source/WebKit/WebProcess/WebPage/ios/FindIndicatorIOS.cpp
@@ -39,6 +39,7 @@
 #include <WebCore/GraphicsContext.h>
 #include <WebCore/ImageOverlay.h>
 #include <WebCore/LocalFrame.h>
+#include <WebCore/LocalFrameInlines.h>
 #include <WebCore/LocalFrameView.h>
 #include <WebCore/Page.h>
 #include <WebCore/PageOverlayController.h>

--- a/Source/WebKitLegacy/PlatformIOS.cmake
+++ b/Source/WebKitLegacy/PlatformIOS.cmake
@@ -1088,12 +1088,6 @@ foreach (_file ${WebKitLegacy_LEGACY_FORWARDING_HEADERS_FILES})
     endif ()
 endforeach ()
 
-# Symlink WebKit/ -> WebKitLegacy/ for <WebKit/...> imports.
-if (NOT EXISTS "${WebKitLegacy_FRAMEWORK_HEADERS_DIR}/WebKit")
-    file(CREATE_LINK "${WebKitLegacy_FRAMEWORK_HEADERS_DIR}/WebKitLegacy"
-                     "${WebKitLegacy_FRAMEWORK_HEADERS_DIR}/WebKit" SYMBOLIC)
-endif ()
-
 set(_wkl_fw "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/WebKitLegacy.framework")
 make_directory("${_wkl_fw}")
 make_directory("${_wkl_fw}/Modules")

--- a/Tools/WebKitTestRunner/CMakeLists.txt
+++ b/Tools/WebKitTestRunner/CMakeLists.txt
@@ -28,7 +28,9 @@ set(WebKitTestRunner_FRAMEWORKS
     WebKit
     bmalloc
 )
-if (APPLE)
+# WKTR uses WebKit2 only and needs no WebKitLegacy (WebKit1) headers, so skip it
+# on iOS. It is kept on macOS for now; removing it there is separate cleanup.
+if (APPLE AND NOT CMAKE_SYSTEM_NAME STREQUAL "iOS")
     list(APPEND WebKitTestRunner_FRAMEWORKS WebKitLegacy)
 endif ()
 

--- a/Tools/WebKitTestRunner/PlatformIOS.cmake
+++ b/Tools/WebKitTestRunner/PlatformIOS.cmake
@@ -38,7 +38,6 @@ target_sources(TestRunnerInjectedBundle PRIVATE ${_wktr_fonts})
 list(APPEND WebKitTestRunner_INCLUDE_DIRECTORIES
     ${WebKit_FRAMEWORK_HEADERS_DIR}
     ${WebKit_PRIVATE_FRAMEWORK_HEADERS_DIR}
-    ${WebKitLegacy_FRAMEWORK_HEADERS_DIR}
     ${WEBKIT_DIR}/UIProcess/API/C/mac
     ${WEBKIT_DIR}/UIProcess/API/Cocoa
     ${WEBKIT_DIR}/UIProcess/Cocoa


### PR DESCRIPTION
#### 8af1803f244592309456e88b61fe8cc2fa7cd3d9
<pre>
[CMake] Fix the iOS simulator release build
<a href="https://bugs.webkit.org/show_bug.cgi?id=319760">https://bugs.webkit.org/show_bug.cgi?id=319760</a>
<a href="https://rdar.apple.com/182614984">rdar://182614984</a>

Reviewed by David Kilzer.

Three independent failures caused failures for the iOS simulator CMake build:

- FindIndicatorIOS.cpp called LocalFrame::editor()/selection() without
  including LocalFrameInlines.h, leaving the inline accessors undefined at
  link time. Include it, as other WebKit consumers do.

- The hand-rolled WebKitSwift and _WebKit_SwiftUI Swift targets did not pass
  -disable-sandbox, so @Entry macro expansion failed when the build ran inside
  a sandbox (swift-plugin-server cannot nest sandbox-exec). Mirror the flag the
  shared Swift macro already sets for WebKit / WebGPU / PAL.

- WebKitLegacy&apos;s iOS forwarding-header step symlinked Headers/WebKit -&gt;
  Headers/WebKitLegacy so &lt;WebKit/...&gt; imports resolved to the legacy umbrella.
  That WebKit1 &lt;WebKit/WebKit.h&gt; (no WKWebView) shadowed modern WebKit2&apos;s on the              CMake include path, collapsing WebKitTestRunner&apos;s TestRunnerWKWebView to a root
  class. The shipped SDK&apos;s &lt;WebKit/WebKit.h&gt; is WebKit2 and the migrated legacy
  headers are reachable as &lt;WebKitLegacy/...&gt;, so drop the symlink. Also stop                 pulling WebKitLegacy into WebKitTestRunner on iOS, which uses WebKit2 only.

* Source/WebKit/PlatformIOS.cmake:
* Source/WebKit/WebProcess/WebPage/ios/FindIndicatorIOS.cpp:
* Tools/WebKitTestRunner/CMakeLists.txt:
* Tools/WebKitTestRunner/PlatformIOS.cmake:
* Source/WebKitLegacy/PlatformIOS.cmake:

Canonical link: <a href="https://commits.webkit.org/317605@main">https://commits.webkit.org/317605@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fd24af26dea616ae14af091d010e6a48d45ee924

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175793 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49726 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43510 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185386 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/137976 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/177656 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51018 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49408 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136882 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/137976 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d52396c3-b267-41bf-bc57-6e34b6f2ff02) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178749 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40338 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157653 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117361 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2809f7ee-bda7-43f2-8b10-b327cc8edf07) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38980 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/37362 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149399 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37145 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33855 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41422 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/41568 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187807 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49393 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145875 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39245 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50073 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/33769 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145716 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40505 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122269 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/116095 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48580 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12123 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47982 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48214 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48039 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->