### PR TITLE
Sync `css-link-params` from WPT Upstream

### DIFF
--- a/LayoutTests/imported/w3c/resources/import-expectations.json
+++ b/LayoutTests/imported/w3c/resources/import-expectations.json
@@ -96,6 +96,7 @@
     "web-platform-tests/css/css-images": "import",
     "web-platform-tests/css/css-inline": "import",
     "web-platform-tests/css/css-layout-api": "skip",
+    "web-platform-tests/css/css-link-params": "import",
     "web-platform-tests/css/css-lists": "import",
     "web-platform-tests/css/css-logical": "import",
     "web-platform-tests/css/css-masking": "import",

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-link-params/inheritance-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-link-params/inheritance-expected.txt
@@ -1,0 +1,4 @@
+
+FAIL Property link-parameters has initial value none assert_true: link-parameters doesn't seem to be supported in the computed style expected true got false
+FAIL Property link-parameters does not inherit assert_true: expected true got false
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-link-params/inheritance.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-link-params/inheritance.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Inheritance of link-parameters properties</title>
+<link rel="help" href="https://drafts.csswg.org/css-link-params-1/#link-param-prop">
+<meta name="assert" content="Properties inherit according to the spec.">
+<meta name="assert" content="Properties have initial values according to the spec.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/inheritance-testcommon.js"></script>
+</head>
+<body>
+<div id="container">
+  <div id="target"></div>
+</div>
+<script>
+assert_not_inherited('link-parameters', 'none', 'param(--a)')
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-link-params/link-parameters-computed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-link-params/link-parameters-computed-expected.txt
@@ -1,0 +1,7 @@
+
+FAIL Property link-parameters value 'none' assert_true: link-parameters doesn't seem to be supported in the computed style expected true got false
+FAIL Property link-parameters value 'param(--a, orange)' assert_true: link-parameters doesn't seem to be supported in the computed style expected true got false
+FAIL Property link-parameters value 'param(--a, orange), param(--b, blue)' assert_true: link-parameters doesn't seem to be supported in the computed style expected true got false
+FAIL Property link-parameters value 'param(--a, )' assert_true: link-parameters doesn't seem to be supported in the computed style expected true got false
+FAIL Property link-parameters value 'param(--a, ), param(--b, )' assert_true: link-parameters doesn't seem to be supported in the computed style expected true got false
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-link-params/link-parameters-computed.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-link-params/link-parameters-computed.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Linked Parameters Module Level 1: getComputedStyle().linkParameters</title>
+<link rel="author" title="Tyler Thrailkill" href="mailto:tyler@programming.dev">
+<link rel="help" href="https://drafts.csswg.org/css-link-params-1/#link-param-prop">
+<meta name="assert" content="link-parameters computed value is as specified">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/computed-testcommon.js"></script>
+</head>
+<body>
+<div id="target"></div>
+<script>
+    test_computed_value("link-parameters", "none");
+
+    test_computed_value("link-parameters", "param(--a, orange)");
+    test_computed_value("link-parameters", "param(--a, orange), param(--b, blue)");
+
+    test_computed_value("link-parameters", "param(--a, )");
+    test_computed_value("link-parameters", "param(--a, ), param(--b, )");
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-link-params/link-parameters-invalid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-link-params/link-parameters-invalid-expected.txt
@@ -1,0 +1,14 @@
+
+PASS e.style['link-parameters'] = "non" should not set the property value
+PASS e.style['link-parameters'] = "param(--a, red) param(--b, blue)" should not set the property value
+PASS e.style['link-parameters'] = "param(-a)" should not set the property value
+PASS e.style['link-parameters'] = "param(-a, )" should not set the property value
+PASS e.style['link-parameters'] = "param(-a, blue)" should not set the property value
+PASS e.style['link-parameters'] = "param--a)" should not set the property value
+PASS e.style['link-parameters'] = "para(--a)" should not set the property value
+PASS e.style['link-parameters'] = "param(--a red)" should not set the property value
+PASS e.style['link-parameters'] = "param(--a)" should not set the property value
+PASS e.style['link-parameters'] = "param(--a), param(--b)" should not set the property value
+PASS e.style['link-parameters'] = "param(--a" should not set the property value
+PASS e.style['link-parameters'] = "param(--)" should not set the property value
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-link-params/link-parameters-invalid.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-link-params/link-parameters-invalid.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Linked Parameters Module Level 1: parsing link-parameters with valid values</title>
+<link rel="author" title="Tyler Thrailkill" href="mailto:tyler@programming.dev">
+<link rel="help" href="https://drafts.csswg.org/css-link-params-1/#link-param-prop">
+<meta name="assert" content="link-parameters supports only the grammar 'none | <param()>#'.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+    test_invalid_value("link-parameters", "non");
+
+    test_invalid_value("link-parameters", "param(--a, red) param(--b, blue)");
+
+    test_invalid_value("link-parameters", "param(-a)");
+    test_invalid_value("link-parameters", "param(-a, )");
+    test_invalid_value("link-parameters", "param(-a, blue)");
+    test_invalid_value("link-parameters", "param--a)");
+    test_invalid_value("link-parameters", "para(--a)");
+
+    test_invalid_value("link-parameters", "param(--a red)");
+
+    // param() without a comma is invalid per
+    // https://github.com/w3c/csswg-drafts/issues/13767
+    test_invalid_value("link-parameters", "param(--a)");
+    test_invalid_value("link-parameters", "param(--a), param(--b)");
+    test_invalid_value("link-parameters", "param(--a");
+    test_invalid_value("link-parameters", "param(--)");
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-link-params/link-parameters-valid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-link-params/link-parameters-valid-expected.txt
@@ -1,0 +1,8 @@
+
+FAIL e.style['link-parameters'] = "none" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['link-parameters'] = "param(--a, orange)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['link-parameters'] = "param(--a, orange), param(--b, blue)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['link-parameters'] = "param(--a, )" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['link-parameters'] = "param(--a, ), param(--b, )" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['link-parameters'] = "param(--, --)" should set the property value assert_not_equals: property should be set got disallowed value ""
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-link-params/link-parameters-valid.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-link-params/link-parameters-valid.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Linked Parameters Module Level 1: parsing link-parameters with valid values</title>
+<link rel="author" title="Tyler Thrailkill" href="mailto:tyler@programming.dev">
+<link rel="help" href="https://drafts.csswg.org/css-link-params-1/#link-param-prop">
+<meta name="assert" content="link-parameters supports the full grammar 'none | <param()>#'.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+    test_valid_value("link-parameters", "none", "none");
+
+    test_valid_value("link-parameters", "param(--a, orange)", 'param(--a, orange)');
+    test_valid_value("link-parameters", "param(--a, orange), param(--b, blue)", "param(--a, orange), param(--b, blue)");
+
+    test_valid_value("link-parameters", "param(--a, )", "param(--a, )");
+    test_valid_value("link-parameters", "param(--a, ), param(--b, )", "param(--a, ), param(--b, )");
+
+    test_valid_value("link-parameters", "param(--, --)");
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-link-params/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-link-params/w3c-import.log
@@ -1,0 +1,18 @@
+The tests in this directory were imported from the W3C repository.
+Do NOT modify these tests directly in WebKit.
+Instead, create a pull request on the WPT github:
+	https://github.com/web-platform-tests/wpt
+
+Then run the Tools/Scripts/import-w3c-tests in WebKit to reimport
+
+Do NOT modify or remove this file.
+
+------------------------------------------------------------------------
+Properties requiring vendor prefixes:
+None
+------------------------------------------------------------------------
+List of files:
+/LayoutTests/imported/w3c/web-platform-tests/css/css-link-params/inheritance.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-link-params/link-parameters-computed.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-link-params/link-parameters-invalid.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-link-params/link-parameters-valid.html


### PR DESCRIPTION
#### 9b980d56e14553998ef3118d2fa7777634b0b952
<pre>
Sync `css-link-params` from WPT Upstream
<a href="https://bugs.webkit.org/show_bug.cgi?id=319763">https://bugs.webkit.org/show_bug.cgi?id=319763</a>
<a href="https://rdar.apple.com/182622185">rdar://182622185</a>

Reviewed by Taher Ali.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/d3ed97f7b225e4aa3051c532bf13380027e2550e">https://github.com/web-platform-tests/wpt/commit/d3ed97f7b225e4aa3051c532bf13380027e2550e</a>

* LayoutTests/imported/w3c/resources/import-expectations.json:
* LayoutTests/imported/w3c/web-platform-tests/css/css-link-params/inheritance-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-link-params/inheritance.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-link-params/link-parameters-computed-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-link-params/link-parameters-computed.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-link-params/link-parameters-invalid-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-link-params/link-parameters-invalid.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-link-params/link-parameters-valid-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-link-params/link-parameters-valid.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-link-params/w3c-import.log: Added.

Canonical link: <a href="https://commits.webkit.org/317501@main">https://commits.webkit.org/317501@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a45dc41622cc4c4cc61e0a8bb62ae06d1c7252b2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175476 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49408 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43189 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185062 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/137622 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/571adaf4-72bb-4455-bbca-0e043116887a) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50700 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49091 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136623 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/137622 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bdf3ac78-23da-4dc7-b5e6-6ca4d167ab95) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178433 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40040 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157378 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117101 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/92e7d6f8-7473-4175-a16b-5de36dd39ded) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38682 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37067 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149104 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36871 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33537 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41270 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187487 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49075 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/156934 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145592 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39168 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49755 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33495 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145430 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40245 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115682 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48261 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11847 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47664 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47894 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47721 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->