### PR TITLE
[Site Isolation] Determine the notifyDone()/forceImmediateCompletion() dump target in the UI process

### DIFF
--- a/LayoutTests/http/tests/site-isolation/force-immediate-completion-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/force-immediate-completion-expected.txt
@@ -1,0 +1,8 @@
+This test passes if it doesn't time out.
+
+
+
+--------
+Frame: '<!--frame1-->'
+--------
+I am a simple document that calls forceImmediateCompletion when done loading.

--- a/LayoutTests/http/tests/site-isolation/force-immediate-completion.html
+++ b/LayoutTests/http/tests/site-isolation/force-immediate-completion.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<script>
+if (window.testRunner) {
+    testRunner.dumpChildFramesAsText();
+    testRunner.waitUntilDone();
+}
+</script>
+<body>
+<p>This test passes if it doesn't time out.</p>
+<iframe src="http://localhost:8000/site-isolation/resources/frame-force-immediate-completion.html"></iframe>
+</body>

--- a/LayoutTests/http/tests/site-isolation/resources/frame-force-immediate-completion.html
+++ b/LayoutTests/http/tests/site-isolation/resources/frame-force-immediate-completion.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<head>
+<script>
+function finish()
+{
+    // Call forceImmediateCompletion from a remote (cross-origin) subframe after the main frame has loaded.
+    // The dump must be routed to the main-frame process; the test passes if it doesn't time out.
+    setTimeout(() => {
+        if (window.testRunner)
+            testRunner.forceImmediateCompletion();
+    }, 30);
+}
+</script>
+</head>
+<body onload="finish()">
+<p>I am a simple document that calls forceImmediateCompletion when done loading.</p>
+</body>

--- a/LayoutTests/http/tests/site-isolation/resources/pointer-lock.html
+++ b/LayoutTests/http/tests/site-isolation/resources/pointer-lock.html
@@ -30,7 +30,11 @@
             console.error("Element still not found after timeout!");
         }
 
-        if (window.eventSender) {
+        // Only activate when pointer lock is actually supported (i.e. not iOS). There is nothing to
+        // activate otherwise, and on iOS UIHelper.activateElement() posts a UI script that relies on
+        // window.webkit.createJSHandle, which is unavailable in this cross-origin subframe under site
+        // isolation and would surface as an unhandled promise rejection.
+        if (window.eventSender && 'pointerLockElement' in document) {
             await UIHelper.activateElement(element);
         }
     };

--- a/LayoutTests/platform/ios/http/tests/site-isolation/pointer-lock-expected.txt
+++ b/LayoutTests/platform/ios/http/tests/site-isolation/pointer-lock-expected.txt
@@ -1,2 +1,5 @@
 CONSOLE MESSAGE: Pointerlock not supported
+PASS successfullyParsed is true
+
+TEST COMPLETE
 

--- a/Source/WebKit/UIProcess/API/C/WKPageInjectedBundleClient.h
+++ b/Source/WebKit/UIProcess/API/C/WKPageInjectedBundleClient.h
@@ -32,6 +32,7 @@ typedef void (*WKPageDidReceiveMessageFromInjectedBundleCallback)(WKPageRef page
 typedef void (*WKPageDidReceiveSynchronousMessageFromInjectedBundleCallback)(WKPageRef page, WKStringRef messageName, WKTypeRef messageBody, WKTypeRef* returnData, const void *clientInfo);
 typedef WKTypeRef (*WKPageGetInjectedBundleInitializationUserDataCallback)(WKPageRef page, const void *clientInfo);
 typedef void (*WKPageDidReceiveSynchronousMessageFromInjectedBundleWithListenerCallback)(WKPageRef page, WKStringRef messageName, WKTypeRef messageBody, WKMessageListenerRef listener, const void* clientInfo);
+typedef void (*WKPageDidReceiveSynchronousMessageFromInjectedBundleWithListenerFromMainFrameProcessCallback)(WKPageRef page, WKStringRef messageName, WKTypeRef messageBody, bool fromMainFrameProcess, WKMessageListenerRef listener, const void* clientInfo);
 
 typedef struct WKPageInjectedBundleClientBase {
     int                                                                 version;
@@ -56,5 +57,19 @@ typedef struct WKPageInjectedBundleClientV1 {
     // Version 1.
     WKPageDidReceiveSynchronousMessageFromInjectedBundleWithListenerCallback didReceiveSynchronousMessageFromInjectedBundleWithListener;
 } WKPageInjectedBundleClientV1;
+
+typedef struct WKPageInjectedBundleClientV2 {
+    WKPageInjectedBundleClientBase                                   base;
+
+    // Version 0.
+    WKPageDidReceiveMessageFromInjectedBundleCallback                didReceiveMessageFromInjectedBundle;
+    WKPageDidReceiveSynchronousMessageFromInjectedBundleCallback     didReceiveSynchronousMessageFromInjectedBundle;
+
+    // Version 1.
+    WKPageDidReceiveSynchronousMessageFromInjectedBundleWithListenerCallback didReceiveSynchronousMessageFromInjectedBundleWithListener;
+
+    // Version 2.
+    WKPageDidReceiveSynchronousMessageFromInjectedBundleWithListenerFromMainFrameProcessCallback didReceiveSynchronousMessageFromInjectedBundleWithListenerFromMainFrameProcess;
+} WKPageInjectedBundleClientV2;
 
 #endif // WKPageInjectedBundleClient_h

--- a/Source/WebKit/UIProcess/WebPageInjectedBundleClient.cpp
+++ b/Source/WebKit/UIProcess/WebPageInjectedBundleClient.cpp
@@ -46,10 +46,11 @@ void WebPageInjectedBundleClient::didReceiveMessageFromInjectedBundle(WebPagePro
     m_client.didReceiveMessageFromInjectedBundle(toAPI(page), toAPI(messageName.impl()), toAPI(messageBody), m_client.base.clientInfo);
 }
 
-void WebPageInjectedBundleClient::didReceiveSynchronousMessageFromInjectedBundle(WebPageProxy* page, const String& messageName, API::Object* messageBody, CompletionHandler<void(RefPtr<API::Object>)>&& completionHandler)
+void WebPageInjectedBundleClient::didReceiveSynchronousMessageFromInjectedBundle(WebPageProxy* page, const String& messageName, API::Object* messageBody, bool fromMainFrameProcess, CompletionHandler<void(RefPtr<API::Object>)>&& completionHandler)
 {
     if (!m_client.didReceiveSynchronousMessageFromInjectedBundle
-        && !m_client.didReceiveSynchronousMessageFromInjectedBundleWithListener)
+        && !m_client.didReceiveSynchronousMessageFromInjectedBundleWithListener
+        && !m_client.didReceiveSynchronousMessageFromInjectedBundleWithListenerFromMainFrameProcess)
         return completionHandler(nullptr);
 
     if (m_client.didReceiveSynchronousMessageFromInjectedBundle) {
@@ -57,6 +58,9 @@ void WebPageInjectedBundleClient::didReceiveSynchronousMessageFromInjectedBundle
         m_client.didReceiveSynchronousMessageFromInjectedBundle(toAPI(page), toAPI(messageName.impl()), toAPI(messageBody), &returnDataRef, m_client.base.clientInfo);
         return completionHandler(adoptRef(toImpl(returnDataRef)));
     }
+
+    if (m_client.didReceiveSynchronousMessageFromInjectedBundleWithListenerFromMainFrameProcess)
+        return m_client.didReceiveSynchronousMessageFromInjectedBundleWithListenerFromMainFrameProcess(toAPI(page), toAPI(messageName.impl()), toAPI(messageBody), fromMainFrameProcess, toAPI(API::MessageListener::create(WTF::move(completionHandler)).ptr()), m_client.base.clientInfo);
 
     m_client.didReceiveSynchronousMessageFromInjectedBundleWithListener(toAPI(page), toAPI(messageName.impl()), toAPI(messageBody), toAPI(API::MessageListener::create(WTF::move(completionHandler)).ptr()), m_client.base.clientInfo);
 }

--- a/Source/WebKit/UIProcess/WebPageInjectedBundleClient.h
+++ b/Source/WebKit/UIProcess/WebPageInjectedBundleClient.h
@@ -34,7 +34,7 @@ namespace API {
 class Object;
 
 template<> struct ClientTraits<WKPageInjectedBundleClientBase> {
-    typedef std::tuple<WKPageInjectedBundleClientV0, WKPageInjectedBundleClientV1> Versions;
+    typedef std::tuple<WKPageInjectedBundleClientV0, WKPageInjectedBundleClientV1, WKPageInjectedBundleClientV2> Versions;
 };
 }
 
@@ -46,7 +46,7 @@ class WebPageInjectedBundleClient : public API::Client<WKPageInjectedBundleClien
     WTF_MAKE_TZONE_ALLOCATED(WebPageInjectedBundleClient);
 public:
     void didReceiveMessageFromInjectedBundle(WebPageProxy*, const String&, API::Object*);
-    void didReceiveSynchronousMessageFromInjectedBundle(WebPageProxy*, const String&, API::Object*, CompletionHandler<void(RefPtr<API::Object>)>&&);
+    void didReceiveSynchronousMessageFromInjectedBundle(WebPageProxy*, const String&, API::Object*, bool fromMainFrameProcess, CompletionHandler<void(RefPtr<API::Object>)>&&);
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -1397,9 +1397,11 @@ void WebPageProxy::handleSynchronousMessage(IPC::Connection& connection, const S
     if (!m_injectedBundleClient)
         return completionHandler({ });
 
-    RefPtr<API::Object> returnData;
     Ref process = WebProcessProxy::fromConnection(connection);
-    m_injectedBundleClient->didReceiveSynchronousMessageFromInjectedBundle(this, messageName, process->transformHandlesToObjects(protect(messageBody.object()).get()).get(), [completionHandler = WTF::move(completionHandler), process] (RefPtr<API::Object>&& returnData) mutable {
+    // Whether the sender hosts the committed local main frame (false for a cross-origin subframe process).
+    RefPtr mainFrame = m_mainFrame;
+    bool fromMainFrameProcess = mainFrame && process.ptr() == &mainFrame->process();
+    m_injectedBundleClient->didReceiveSynchronousMessageFromInjectedBundle(this, messageName, process->transformHandlesToObjects(protect(messageBody.object()).get()).get(), fromMainFrameProcess, [completionHandler = WTF::move(completionHandler), process] (RefPtr<API::Object>&& returnData) mutable {
         completionHandler(UserData(process->transformObjectsToHandles(returnData.get())));
     });
 }

--- a/Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.cpp
@@ -187,15 +187,6 @@ WKBundlePageRef InjectedBundle::pageRef() const
     return page ? page->page() : nullptr;
 }
 
-bool InjectedBundle::pageHasLocalMainFrame() const
-{
-    auto page = this->page();
-    // WKBundleFrameGetJavaScriptContext returns null for remote frames; a local main frame has one.
-    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    return page && WKBundleFrameGetJavaScriptContext(WKBundlePageGetMainFrame(page->page()));
-    ALLOW_DEPRECATED_DECLARATIONS_END
-}
-
 void InjectedBundle::didReceiveMessage(WKStringRef, WKTypeRef)
 {
     WKBundlePostMessage(m_bundle.get(), toWK("Error").get(), toWK("Unknown").get());

--- a/Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.h
@@ -59,8 +59,6 @@ public:
     AccessibilityController* accessibilityController() { return m_accessibilityController.get(); }
 
     InjectedBundlePage* page() const;
-    // True if the active page's main frame is local to this process (not remote under site isolation).
-    bool pageHasLocalMainFrame() const;
     WKBundlePageRef pageRef() const;
     uint64_t testIdentifier() const { return m_testIdentifier; }
     size_t pageCount() const { return m_pages.size(); }

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
@@ -247,11 +247,10 @@ void TestRunner::notifyDone()
     auto& injectedBundle = InjectedBundle::singleton();
     if (!injectedBundle.isTestRunning())
         return;
-    // notifyDone() defers the dump while the main frame is still loading (see InjectedBundlePage::notifyDone),
-    // so it can only complete synchronously once loading has finished. When called mid-load, fall back to the
-    // asynchronous path that dumps after load, matching non-site-isolation behavior.
-    bool canCompleteSynchronously = injectedBundle.pageHasLocalMainFrame() && !injectedBundle.topLoadingFrame();
-    if (!postSynchronousMessageReturningBoolean("ResolveNotifyDone", adoptWK(WKBooleanCreate(canCompleteSynchronously))))
+    // The UI process replies true when this came from the main-frame process; then the injected bundle
+    // completes notifyDone() locally (deferring while loading, as without site isolation). Otherwise the UI
+    // process routes the dump to the process that owns the main frame.
+    if (!postSynchronousPageMessageReturningBoolean("ResolveNotifyDone"))
         return;
     if (!injectedBundle.page())
         return;
@@ -263,8 +262,8 @@ void TestRunner::forceImmediateCompletion()
     auto& injectedBundle = InjectedBundle::singleton();
     if (!injectedBundle.isTestRunning())
         return;
-    bool canCompleteSynchronously = injectedBundle.pageHasLocalMainFrame();
-    if (!postSynchronousMessageReturningBoolean("ResolveForceImmediateCompletion", adoptWK(WKBooleanCreate(canCompleteSynchronously))))
+    // Reply true when this came from the main-frame process; otherwise the UI process routes the dump.
+    if (!postSynchronousPageMessageReturningBoolean("ResolveForceImmediateCompletion"))
         return;
     if (!injectedBundle.page())
         return;

--- a/Tools/WebKitTestRunner/TestController.cpp
+++ b/Tools/WebKitTestRunner/TestController.cpp
@@ -888,11 +888,12 @@ PlatformWebView* TestController::createOtherPlatformWebView(PlatformWebView* par
     };
     WKPageSetPageNavigationClient(newPage, &pageNavigationClient.base);
 
-    WKPageInjectedBundleClientV1 injectedBundleClient = {
-        { 1, this },
+    WKPageInjectedBundleClientV2 injectedBundleClient = {
+        { 2, this },
         didReceivePageMessageFromInjectedBundle,
         nullptr,
-        didReceiveSynchronousPageMessageFromInjectedBundleWithListener,
+        nullptr,
+        didReceiveSynchronousPageMessageFromInjectedBundleWithListenerFromMainFrameProcess,
     };
     WKPageSetPageInjectedBundleClient(newPage, &injectedBundleClient.base);
 
@@ -1382,11 +1383,12 @@ void TestController::createWebViewWithOptions(const TestOptions& options)
     WKPageSetPageNavigationClient(m_mainWebView->page(), &pageNavigationClient.base);
     
     // this should just be done on the page?
-    WKPageInjectedBundleClientV1 injectedBundleClient = {
-        { 1, this },
+    WKPageInjectedBundleClientV2 injectedBundleClient = {
+        { 2, this },
         didReceivePageMessageFromInjectedBundle,
         nullptr,
-        didReceiveSynchronousPageMessageFromInjectedBundleWithListener,
+        nullptr,
+        didReceiveSynchronousPageMessageFromInjectedBundleWithListenerFromMainFrameProcess,
     };
     WKPageSetPageInjectedBundleClient(m_mainWebView->page(), &injectedBundleClient.base);
 
@@ -3416,9 +3418,9 @@ void TestController::didReceivePageMessageFromInjectedBundle(WKPageRef page, WKS
     testController->didReceiveMessageFromInjectedBundle(messageName, messageBody);
 }
 
-void TestController::didReceiveSynchronousPageMessageFromInjectedBundleWithListener(WKPageRef page, WKStringRef messageName, WKTypeRef messageBody, WKMessageListenerRef listener, const void* clientInfo)
+void TestController::didReceiveSynchronousPageMessageFromInjectedBundleWithListenerFromMainFrameProcess(WKPageRef page, WKStringRef messageName, WKTypeRef messageBody, bool fromMainFrameProcess, WKMessageListenerRef listener, const void* clientInfo)
 {
-    static_cast<TestController*>(const_cast<void*>(clientInfo))->didReceiveSynchronousMessageFromInjectedBundle(messageName, messageBody, listener);
+    static_cast<TestController*>(const_cast<void*>(clientInfo))->didReceiveSynchronousMessageFromInjectedBundle(messageName, messageBody, listener, fromMainFrameProcess);
 }
 
 void TestController::networkProcessDidCrashWithDetails(WKContextRef context, WKProcessID processID, WKProcessTerminationReason reason, const void *clientInfo)
@@ -3558,7 +3560,7 @@ RefPtr<TestInvocation> TestController::protectedCurrentInvocation()
     return m_currentInvocation;
 }
 
-void TestController::didReceiveSynchronousMessageFromInjectedBundle(WKStringRef messageName, WKTypeRef messageBody, WKMessageListenerRef listener)
+void TestController::didReceiveSynchronousMessageFromInjectedBundle(WKStringRef messageName, WKTypeRef messageBody, WKMessageListenerRef listener, bool fromMainFrameProcess)
 {
     auto completionHandler = [listener = retainWK(listener)] (WKTypeRef reply) {
         WKMessageListenerSendReply(listener.get(), reply);
@@ -3827,7 +3829,7 @@ void TestController::didReceiveSynchronousMessageFromInjectedBundle(WKStringRef 
         return;
     }
 
-    completionHandler(protectedCurrentInvocation()->didReceiveSynchronousMessageFromInjectedBundle(messageName, messageBody).get());
+    completionHandler(protectedCurrentInvocation()->didReceiveSynchronousMessageFromInjectedBundle(messageName, messageBody, fromMainFrameProcess).get());
 }
 
 WKRetainPtr<WKTypeRef> TestController::getInjectedBundleInitializationUserData()

--- a/Tools/WebKitTestRunner/TestController.h
+++ b/Tools/WebKitTestRunner/TestController.h
@@ -610,10 +610,10 @@ private:
 
     // WKPageInjectedBundleClient
     static void didReceivePageMessageFromInjectedBundle(WKPageRef, WKStringRef messageName, WKTypeRef messageBody, const void*);
-    static void didReceiveSynchronousPageMessageFromInjectedBundleWithListener(WKPageRef, WKStringRef messageName, WKTypeRef messageBody, WKMessageListenerRef, const void*);
+    static void didReceiveSynchronousPageMessageFromInjectedBundleWithListenerFromMainFrameProcess(WKPageRef, WKStringRef messageName, WKTypeRef messageBody, bool fromMainFrameProcess, WKMessageListenerRef, const void*);
 
     void didReceiveMessageFromInjectedBundle(WKStringRef messageName, WKTypeRef messageBody);
-    void didReceiveSynchronousMessageFromInjectedBundle(WKStringRef messageName, WKTypeRef messageBody, WKMessageListenerRef);
+    void didReceiveSynchronousMessageFromInjectedBundle(WKStringRef messageName, WKTypeRef messageBody, WKMessageListenerRef, bool fromMainFrameProcess = false);
     WKRetainPtr<WKTypeRef> getInjectedBundleInitializationUserData();
 
     void didReceiveKeyDownMessageFromInjectedBundle(WKDictionaryRef messageBodyDictionary, bool synchronous);

--- a/Tools/WebKitTestRunner/TestInvocation.cpp
+++ b/Tools/WebKitTestRunner/TestInvocation.cpp
@@ -578,7 +578,7 @@ void TestInvocation::didReceiveMessageFromInjectedBundle(WKStringRef messageName
     ASSERT_NOT_REACHED();
 }
 
-WKRetainPtr<WKTypeRef> TestInvocation::didReceiveSynchronousMessageFromInjectedBundle(WKStringRef messageName, WKTypeRef messageBody)
+WKRetainPtr<WKTypeRef> TestInvocation::didReceiveSynchronousMessageFromInjectedBundle(WKStringRef messageName, WKTypeRef messageBody, bool fromMainFrameProcess)
 {
     if (WKStringIsEqualToUTF8CString(messageName, "Initialization")) {
         auto settings = createTestSettingsDictionary();
@@ -631,10 +631,10 @@ WKRetainPtr<WKTypeRef> TestInvocation::didReceiveSynchronousMessageFromInjectedB
     }
 
     if (WKStringIsEqualToUTF8CString(messageName, "ResolveNotifyDone"))
-        return adoptWK(WKBooleanCreate(resolveNotifyDone(booleanValue(messageBody))));
+        return adoptWK(WKBooleanCreate(resolveNotifyDone(fromMainFrameProcess)));
 
     if (WKStringIsEqualToUTF8CString(messageName, "ResolveForceImmediateCompletion"))
-        return adoptWK(WKBooleanCreate(resolveForceImmediateCompletion(booleanValue(messageBody))));
+        return adoptWK(WKBooleanCreate(resolveForceImmediateCompletion(fromMainFrameProcess)));
 
     if (WKStringIsEqualToUTF8CString(messageName, "SetWindowIsKey")) {
         TestController::singleton().mainWebView()->setWindowIsKey(booleanValue(messageBody));
@@ -1483,7 +1483,7 @@ bool TestInvocation::resolveNotifyDone(bool canCompleteSynchronously)
     if (m_options.siteIsolationEnabled()) {
         // If notifyDone() arrived mid-work-queue, defer it until the queue drains.
         bool deferForWorkQueue = TestController::singleton().useWorkQueue() && !TestController::singleton().workQueueManager().isWorkQueueEmpty();
-        // The caller can dump synchronously only if it hosts the local main frame and nothing is pending.
+        // Complete locally only from the main-frame process with no pending work queue; the bundle handles deferral.
         if (canCompleteSynchronously && !deferForWorkQueue)
             return true;
         m_notifyDoneMessageSent = true;

--- a/Tools/WebKitTestRunner/TestInvocation.h
+++ b/Tools/WebKitTestRunner/TestInvocation.h
@@ -65,7 +65,7 @@ public:
 
     void invoke();
     void didReceiveMessageFromInjectedBundle(WKStringRef messageName, WKTypeRef messageBody);
-    WKRetainPtr<WKTypeRef> didReceiveSynchronousMessageFromInjectedBundle(WKStringRef messageName, WKTypeRef messageBody);
+    WKRetainPtr<WKTypeRef> didReceiveSynchronousMessageFromInjectedBundle(WKStringRef messageName, WKTypeRef messageBody, bool fromMainFrameProcess);
 
     static void dumpWebProcessUnresponsiveness(const char* errorMessage);
     void outputText(const String&);
@@ -107,9 +107,9 @@ private:
     void done();
     void setWaitUntilDone(bool);
 
-    // Returns true if the caller bundle should proceed with dumping synchronously.
-    // Returns false if the WKTR invokes dumping through page, asynchronously.
-    // Resets waitUntilDone. canCompleteSynchronously is true when the caller hosts the local main frame.
+    // Returns true if the caller bundle should complete the dump locally (as without site isolation), false if
+    // the WKTR routes it to the main-frame process. Resets waitUntilDone. canCompleteSynchronously reflects
+    // whether the message came from the main-frame process.
     bool resolveNotifyDone(bool canCompleteSynchronously);
     bool resolveForceImmediateCompletion(bool canCompleteSynchronously);
 


### PR DESCRIPTION
#### 44e1c809f0e06146f13e2d24683928402be51ace
<pre>
[Site Isolation] Determine the notifyDone()/forceImmediateCompletion() dump target in the UI process
<a href="https://bugs.webkit.org/show_bug.cgi?id=319764">https://bugs.webkit.org/show_bug.cgi?id=319764</a>
<a href="https://rdar.apple.com/182625550">rdar://182625550</a>

Reviewed by Alex Christensen.

Follow-up to the previous fix in b/317789.
Instead of the web process self-reporting whether it
hosts the local main frame via InjectedBundle::pageHasLocalMainFrame(),
the UI process now determines whether the synchronous notifyDone()/forceImmediateCompletion() message came from the process hosting the main frame and tells WebKitTestRunner via a new WKPageInjectedBundleClient callback.

When the message is from the main-frame process, the injected bundle completes the
dump locally, matching the non-site-isolation behavior. Otherwise the dump is routed
to the process that owns the main frame. These messages are now sent as page-level
synchronous messages so the UI process has the page context needed to make that
determination.

* Source/WebKit/UIProcess/API/C/WKPageInjectedBundleClient.h:
* Source/WebKit/UIProcess/WebPageInjectedBundleClient.cpp:
(WebKit::WebPageInjectedBundleClient::didReceiveSynchronousMessageFromInjectedBundle):
* Source/WebKit/UIProcess/WebPageInjectedBundleClient.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::handleSynchronousMessage):
* Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.cpp:
(WTR::InjectedBundle::pageHasLocalMainFrame const): Deleted.
* Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.h:
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp:
(WTR::TestRunner::notifyDone):
(WTR::TestRunner::forceImmediateCompletion):
* Tools/WebKitTestRunner/TestController.cpp:
(WTR::TestController::createOtherPlatformWebView):
(WTR::TestController::createWebViewWithOptions):
* Tools/WebKitTestRunner/TestController.h:
* Tools/WebKitTestRunner/TestInvocation.cpp:
(WTR::TestInvocation::didReceiveSynchronousMessageFromInjectedBundle):
(WTR::TestInvocation::resolveNotifyDone):
* Tools/WebKitTestRunner/TestInvocation.h:
* LayoutTests/http/tests/site-isolation/force-immediate-completion-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/force-immediate-completion.html: Added.
* LayoutTests/http/tests/site-isolation/resources/frame-force-immediate-completion.html: Added.
* LayoutTests/http/tests/site-isolation/resources/pointer-lock.html:
* LayoutTests/platform/ios/http/tests/site-isolation/pointer-lock-expected.txt:

Canonical link: <a href="https://commits.webkit.org/318189@main">https://commits.webkit.org/318189@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c826178aa1540d3c2e37e63b81c72ddb2d6f3365

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175932 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49865 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43649 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185525 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/138230 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/06d56c5f-9cda-44c7-a0d8-e418c3f526e6) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/177795 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51157 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49547 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137004 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96228 "3 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178888 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40476 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157786 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117483 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/56a0fd18-603a-48ef-b4f2-6860eb5ff037) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39118 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37497 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149537 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37278 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33995 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41565 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41703 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187947 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49532 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/157337 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146004 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39619 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50212 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33903 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145843 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40637 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122408 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/116285 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48719 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12259 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48121 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48353 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48178 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->