### PR TITLE
Web Inspector: Network table load-time polling interval never backs off from 100ms

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/NetworkTableContentView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/NetworkTableContentView.js
@@ -2610,12 +2610,12 @@ WI.NetworkTableContentView = class NetworkTableContentView extends WI.ContentVie
         let duration = Date.now() - loadTimeStatistic.start;
 
         let delay = loadTimeStatistic.delay;
-        if (duration >= 1_000) // 1 second
-            delay = 100;
+        if (duration >= 3_600_000) // 1 hour
+            delay = 10_000;
         else if (duration >= 60_000) // 60 seconds
             delay = 1_000;
-        else if (duration >= 3_600_000) // 1 minute
-            delay = 10_000;
+        else if (duration >= 1_000) // 1 second
+            delay = 100;
 
         if (delay !== loadTimeStatistic.delay) {
             loadTimeStatistic.delay = delay;


### PR DESCRIPTION
#### 1d226849e11eff5877a424e3d57b6a19172a350b
<pre>
Web Inspector: Network table load-time polling interval never backs off from 100ms
<a href="https://bugs.webkit.org/show_bug.cgi?id=319765">https://bugs.webkit.org/show_bug.cgi?id=319765</a>
<a href="https://rdar.apple.com/182627473">rdar://182627473</a>

Reviewed by Devin Rousso.

_updateLoadTimeStatistic() picked the polling delay using ascending
`else if` thresholds (&gt;= 1 second, then &gt;= 60 seconds, then &gt;= 1 hour).
Since each later threshold is a strict superset of the first, the
1 second and 1 hour branches were unreachable once duration passed
1 second, so the timer stayed at a 100ms delay indefinitely instead of
backing off to 1s after a minute and 10s after an hour.

Also corrected a comment that mislabeled the 3,600,000ms threshold as
&quot;1 minute&quot; instead of &quot;1 hour&quot;.

* Source/WebInspectorUI/UserInterface/Views/NetworkTableContentView.js:
(WI.NetworkTableContentView.prototype._updateLoadTimeStatistic): Check
thresholds in descending order so the correct delay tier is selected.

Canonical link: <a href="https://commits.webkit.org/317515@main">https://commits.webkit.org/317515@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3ad226835f51d442dc85505b8d6445e08bb99421

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175512 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49444 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/43225 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185098 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/137659 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b0b7b717-375f-4b29-a347-5ab417dbadf7) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50736 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49127 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/136657 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/137659 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/972b8cab-7290-4be2-9da6-7682d05fd8e7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178469 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40075 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/157418 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117135 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4f00adfd-72f8-407c-a411-ab01a9c0756d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38717 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37103 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149139 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/36911 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33573 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41131 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/41306 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187523 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49111 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/156974 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/145626 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39177 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49791 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/33535 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145463 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40281 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/121984 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115741 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48298 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/11887 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47700 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47930 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47757 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->