### PR TITLE
Web Inspector: HeapSnapshotWorkerProxy silently drops pending callback on worker error response, causing callers to hang forever

### DIFF
--- a/LayoutTests/inspector/unit-tests/heap-snapshot-expected.txt
+++ b/LayoutTests/inspector/unit-tests/heap-snapshot-expected.txt
@@ -43,3 +43,7 @@ PASS: Number of retainer nodes should match.
 PASS: Number of edges should match the number of nodes.
 PASS: Node values should match.
 
+-- Running test case: HeapSnapshotWorkerProxy.prototype.callMethod error response invokes callback
+ERROR: HeapSnapshotWorker Error:
+PASS: Callback should be invoked with null when the worker reports an error.
+

--- a/LayoutTests/inspector/unit-tests/heap-snapshot.html
+++ b/LayoutTests/inspector/unit-tests/heap-snapshot.html
@@ -260,6 +260,21 @@ function test()
         }
     });
 
+    suite.addTestCase({
+        name: "HeapSnapshotWorkerProxy.prototype.callMethod error response invokes callback",
+        test(resolve, reject) {
+            // An objectId that the HeapSnapshotWorker has never seen triggers its
+            // "No such object." error response. The pending callback must still be
+            // invoked (with `null`) instead of being silently dropped, or callers
+            // awaiting a result would hang forever.
+            let bogusObjectId = 0xffffffff;
+            WI.HeapSnapshotWorkerProxy.singleton().callMethod(bogusObjectId, "update", (result) => {
+                InspectorTest.expectThat(result === null, "Callback should be invoked with null when the worker reports an error.");
+                resolve();
+            });
+        }
+    });
+
     suite.runTestCasesAndFinish();
 }
 </script>

--- a/Source/WebInspectorUI/UserInterface/Proxies/HeapSnapshotWorkerProxy.js
+++ b/Source/WebInspectorUI/UserInterface/Proxies/HeapSnapshotWorkerProxy.js
@@ -123,7 +123,10 @@ WI.HeapSnapshotWorkerProxy = class HeapSnapshotWorkerProxy extends WI.Object
         // Error.
         if (data.error) {
             console.assert(data.callId);
-            this._callbacks.delete(data.callId);
+            let callback = this._callbacks.take(data.callId);
+            WI.reportInternalError("HeapSnapshotWorker Error:", data.error);
+            if (callback)
+                callback(null);
             return;
         }
 


### PR DESCRIPTION
#### 25266e4a0ac99640e7f43cb4e581a531f50edb96
<pre>
Web Inspector: HeapSnapshotWorkerProxy silently drops pending callback on worker error response, causing callers to hang forever
<a href="https://bugs.webkit.org/show_bug.cgi?id=319766">https://bugs.webkit.org/show_bug.cgi?id=319766</a>
<a href="https://rdar.apple.com/182627846">rdar://182627846</a>

Reviewed by Devin Rousso.

HeapSnapshotWorkerProxy._handleMessage&apos;s error branch deleted the
pending callback for a callId without ever invoking it, so any caller
of callMethod()/performAction() (e.g. HeapSnapshotProxy.update,
HeapSnapshotNodeProxy.dominatedNodes/retainers/shortestGCRootPath)
would hang forever if the worker ever responded with an error, such as
HeapSnapshotWorker&apos;s &quot;No such object.&quot; response for a stale objectId.

* UserInterface/Proxies/HeapSnapshotWorkerProxy.js:
(WI.HeapSnapshotWorkerProxy.prototype._handleMessage): Invoke the
pending callback with null instead of dropping it, using Map.take()
to combine the get/delete pair. Report the error via
WI.reportInternalError instead of console.error so it surfaces in the
Uncaught Exception Reporter UI instead of only being visible when
inspecting Web Inspector itself.

* LayoutTests/inspector/unit-tests/heap-snapshot.html:
* LayoutTests/inspector/unit-tests/heap-snapshot-expected.txt:
Add a test that triggers the worker&apos;s error response path via an
unrecognized objectId and verifies the callback is still invoked.
Rebaseline the expected console output for the switch to
WI.reportInternalError, whose details argument is only shown in the
Uncaught Exception Reporter UI, not the console text.

Canonical link: <a href="https://commits.webkit.org/317516@main">https://commits.webkit.org/317516@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8a4c83562d83be5dffbe9a284946d74f1336569b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175514 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49446 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43227 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185100 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/137661 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5f913f07-b8f9-4676-bef9-06fd94f066b9) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50738 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49129 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/136658 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/137661 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a0b584e0-74c5-48b1-9b13-6c1743700e50) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178471 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40076 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/157416 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117136 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d21d5cb5-c7c6-4a5c-b10e-2ffe7c355cbb) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38718 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/37104 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149140 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36909 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33575 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41133 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/41307 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187525 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49113 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/156972 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/145627 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39178 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49793 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/33533 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145464 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40282 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/121986 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115744 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48300 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11885 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47702 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47932 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47759 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->