### PR TITLE
Web Inspector: HTMLTreeBuilderFormatter dead store to didClose in tbody/tfoot cases

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Workers/Formatter/HTMLTreeBuilderFormatter.js
+++ b/Source/WebInspectorUI/UserInterface/Workers/Formatter/HTMLTreeBuilderFormatter.js
@@ -179,13 +179,13 @@ HTMLTreeBuilderFormatter = class HTMLTreeBuilderFormatter
         case "tbody": {
             let didClose = this._implicitlyCloseTagNamesInsideParentTagNames(["thead"], ["table"]);
             if (!didClose)
-                didClose = this._implicitlyCloseTagNamesInsideParentTagNames(["tr"], ["table"]);
+                this._implicitlyCloseTagNamesInsideParentTagNames(["tr"], ["table"]);
             break;
         }
         case "tfoot": {
             let didClose = this._implicitlyCloseTagNamesInsideParentTagNames(["tbody"], ["table"]);
             if (!didClose)
-                didClose = this._implicitlyCloseTagNamesInsideParentTagNames(["tr"], ["table"]);
+                this._implicitlyCloseTagNamesInsideParentTagNames(["tr"], ["table"]);
             break;
         }
         case "colgroup":


### PR DESCRIPTION
#### 885d6d83bc5aa88a20bc9d5d193816d66f23448b
<pre>
Web Inspector: HTMLTreeBuilderFormatter dead store to didClose in tbody/tfoot cases
<a href="https://bugs.webkit.org/show_bug.cgi?id=319768">https://bugs.webkit.org/show_bug.cgi?id=319768</a>
<a href="https://rdar.apple.com/182628287">rdar://182628287</a>

Reviewed by Devin Rousso.

The tbody and tfoot cases assign the result of the second
_implicitlyCloseTagNamesInsideParentTagNames() call back into
didClose, but nothing after that reads it before the switch breaks.
Drop the pointless reassignment; no behavior change.

* Source/WebInspectorUI/UserInterface/Workers/Formatter/HTMLTreeBuilderFormatter.js:
(HTMLTreeBuilderFormatter.prototype._implicitlyCloseHTMLNodesForOpenTag):

Canonical link: <a href="https://commits.webkit.org/317512@main">https://commits.webkit.org/317512@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1a482607ed7862bed442acca68d8193ef5d226c5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175494 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49426 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43207 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185080 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/137640 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/cf9ffe7f-e98a-472d-aa27-8eef271d4cc0) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50718 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49109 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136640 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/137640 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4273f53f-082f-46bf-97d0-d4309dfdef52) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178451 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40058 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157397 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117118 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2c37f57a-37ed-4e8d-b914-711fa1c6f67d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38700 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37084 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149122 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36890 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33555 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41113 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41287 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187505 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49093 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145608 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39174 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49773 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33514 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145446 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40262 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/121966 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115712 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48279 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11866 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47682 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47912 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47739 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->