### PR TITLE
Silence deadcode.DeadStores analyzer findings in lldbWebKitTester

### DIFF
--- a/Tools/lldb/lldbWebKitTester/main.cpp
+++ b/Tools/lldb/lldbWebKitTester/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2018-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -58,16 +58,16 @@ enum class ExampleFlags {
 static void testSummaryProviders()
 {
     String aNullString { ""_s };
-    StringImpl* aNullStringImpl = aNullString.impl();
+    [[maybe_unused]] StringImpl* aNullStringImpl = aNullString.impl();
 
     String anEmptyString { ""_s };
-    StringImpl* anEmptyStringImpl = anEmptyString.impl();
+    [[maybe_unused]] StringImpl* anEmptyStringImpl = anEmptyString.impl();
 
     auto an8BitString = String::fromLatin1("résumé");
     StringImpl* an8BitStringImpl = an8BitString.impl();
 
     String a16BitString = utf16String(u"\u1680Cappuccino\u1680");
-    StringImpl* a16BitStringImpl = a16BitString.impl();
+    [[maybe_unused]] StringImpl* a16BitStringImpl = a16BitString.impl();
 
     Vector<int> anEmptyVector;
     Vector<int> aVectorWithOneItem;


### PR DESCRIPTION
#### f8db9267080e51a24becf80663602b7b03010cc8
<pre>
Silence deadcode.DeadStores analyzer findings in lldbWebKitTester
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=319767">https://bugs.webkit.org/show_bug.cgi?id=319767</a>&gt;
&lt;<a href="https://rdar.apple.com/182627956">rdar://182627956</a>&gt;

Reviewed by Zak Ridouh.

The `StringImpl*` locals in `testSummaryProviders()` exist only so a
developer can inspect how the `lldb_webkit.py` summary providers render
them at the `breakForTestingSummaryProviders()` breakpoint; the compiled
program never reads them.  Three of them are not otherwise consumed, so
the `deadcode.DeadStores` static analyzer flags each initialization as a
dead store.

Mark those three declarations `[[maybe_unused]]` to record that they are
intentionally never read.  `deadcode.DeadStores` is an AST-based checker
that skips any variable carrying the unused attribute, so this silences
the finding at its source while keeping the values available for
inspection.  `an8BitStringImpl` is left unannotated because the
`CompactPointerTuple` examples below read it.

* Tools/lldb/lldbWebKitTester/main.cpp:
(testSummaryProviders):

Canonical link: <a href="https://commits.webkit.org/317505@main">https://commits.webkit.org/317505@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a6c71ecb3cbd0d2b101cd47513402e093cfc7bbb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175495 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49427 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43208 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185081 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/137641 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b507dd69-a31b-43d1-b2b4-01d09461a02b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/177359 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50719 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49110 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136641 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/137641 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/13102055-0750-47db-991f-7ccd3aeddf01) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178452 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40057 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157398 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117119 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d07708d7-e3ce-4670-b73d-fcdca1c82465) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/174819 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38699 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37086 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/5907 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149121 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36891 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33556 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/36756 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41114 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/41289 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187506 "Built successfully") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/174899 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49094 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/156954 "") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/145609 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49774 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33515 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145447 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26671 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40264 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/121967 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115713 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48280 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11867 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47683 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47913 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47740 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->