### PR TITLE
Web Inspector: WorkerManager.workerTerminated leaks nested subworkers' Target/map entries

### DIFF
--- a/LayoutTests/inspector/worker/worker-terminate-nested-subworker-expected.txt
+++ b/LayoutTests/inspector/worker/worker-terminate-nested-subworker-expected.txt
@@ -1,0 +1,17 @@
+Test that terminating a Worker also removes Targets for its nested (grandchild) Subworkers.
+
+
+== Running test suite: Worker.Terminate.NestedSubworker
+-- Running test case: Worker.Terminate.NestedSubworker.SetUp
+PASS: Should have a Target for the top-level Worker.
+PASS: Should have a Target for the Subworker.
+PASS: Should have a Target for the Subworker's Subworker.
+
+-- Running test case: Worker.Terminate.NestedSubworker.Terminate
+PASS: Should remove the Target for the top-level Worker.
+PASS: Should remove the Target for the Subworker.
+PASS: Should remove the Target for the Subworker's Subworker.
+PASS: Worker Targets should no longer include the top-level Worker.
+PASS: Worker Targets should no longer include the Subworker.
+PASS: Worker Targets should no longer include the Subworker's Subworker.
+

--- a/LayoutTests/inspector/worker/worker-terminate-nested-subworker.html
+++ b/LayoutTests/inspector/worker/worker-terminate-nested-subworker.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../http/tests/inspector/resources/inspector-test.js"></script>
+<script src="resources/worker-utilities.js"></script>
+<script>
+let worker = new Worker("resources/subworker-manager.js");
+
+function createSubworker() {
+    worker.postMessage({url: "subworker-manager.js", data: null});
+}
+
+function createGrandchildWorker() {
+    worker.postMessage({url: "subworker-manager.js", data: {url: "worker-1.js", data: null}});
+}
+
+function terminateWorker() {
+    worker.terminate();
+}
+
+async function test()
+{
+    function isTopWorker(target) {
+        return target instanceof WI.WorkerTarget && target.displayName.endsWith("subworker-manager.js") && !(target.parentTarget instanceof WI.WorkerTarget);
+    }
+
+    function isSubworker(target) {
+        return target instanceof WI.WorkerTarget && target.displayName.endsWith("subworker-manager.js") && target.parentTarget instanceof WI.WorkerTarget;
+    }
+
+    function isGrandchildWorker(target) {
+        return target instanceof WI.WorkerTarget && target.displayName.endsWith("worker-1.js");
+    }
+
+    let topWorkerTarget = await window.awaitTarget(isTopWorker);
+
+    await Promise.all([
+        window.awaitTarget(isSubworker),
+        InspectorTest.evaluateInPage("createSubworker()"),
+    ]);
+
+    let [grandchildWorkerTarget] = await Promise.all([
+        window.awaitTarget(isGrandchildWorker),
+        InspectorTest.evaluateInPage("createGrandchildWorker()"),
+    ]);
+
+    let subworkerTarget = grandchildWorkerTarget.parentTarget;
+
+    let suite = InspectorTest.createAsyncSuite("Worker.Terminate.NestedSubworker");
+
+    suite.addTestCase({
+        name: "Worker.Terminate.NestedSubworker.SetUp",
+        description: "There should be Targets for the Worker, its Subworker, and the Subworker's Subworker.",
+        async test() {
+            InspectorTest.expectThat(WI.targetManager.workerTargets.includes(topWorkerTarget), "Should have a Target for the top-level Worker.");
+            InspectorTest.expectThat(WI.targetManager.workerTargets.includes(subworkerTarget), "Should have a Target for the Subworker.");
+            InspectorTest.expectThat(WI.targetManager.workerTargets.includes(grandchildWorkerTarget), "Should have a Target for the Subworker's Subworker.");
+        }
+    });
+
+    suite.addTestCase({
+        name: "Worker.Terminate.NestedSubworker.Terminate",
+        description: "Terminating the top-level Worker should remove Targets for all of its nested Subworkers.",
+        async test() {
+            let removedTargets = [];
+            let listener = WI.targetManager.addEventListener(WI.TargetManager.Event.TargetRemoved, (event) => {
+                removedTargets.push(event.data.target);
+            });
+
+            await InspectorTest.evaluateInPage("terminateWorker()");
+
+            // Give any (incorrect) asynchronous cleanup a chance to happen before checking.
+            await new Promise((resolve) => setTimeout(resolve, 0));
+
+            WI.targetManager.removeEventListener(WI.TargetManager.Event.TargetRemoved, listener);
+
+            InspectorTest.expectThat(removedTargets.includes(topWorkerTarget), "Should remove the Target for the top-level Worker.");
+            InspectorTest.expectThat(removedTargets.includes(subworkerTarget), "Should remove the Target for the Subworker.");
+            InspectorTest.expectThat(removedTargets.includes(grandchildWorkerTarget), "Should remove the Target for the Subworker's Subworker.");
+
+            InspectorTest.expectFalse(WI.targetManager.workerTargets.includes(topWorkerTarget), "Worker Targets should no longer include the top-level Worker.");
+            InspectorTest.expectFalse(WI.targetManager.workerTargets.includes(subworkerTarget), "Worker Targets should no longer include the Subworker.");
+            InspectorTest.expectFalse(WI.targetManager.workerTargets.includes(grandchildWorkerTarget), "Worker Targets should no longer include the Subworker's Subworker.");
+        }
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+</head>
+<body onload="runTest()">
+<p>Test that terminating a Worker also removes Targets for its nested (grandchild) Subworkers.</p>
+</body>
+</html>

--- a/Source/WebInspectorUI/UserInterface/Controllers/WorkerManager.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/WorkerManager.js
@@ -66,13 +66,13 @@ WI.WorkerManager = class WorkerManager extends WI.Object
     workerTerminated(workerId)
     {
         let worker = this._workerForId.take(workerId);
-        let subworkers = this._subworkersForWorker.take(worker) || new Set;
 
-        WI.targetManager.removeTarget(worker);
+        // This may already have been cleaned up if it was a nested subworker
+        // of another worker that was terminated first.
+        if (!worker)
+            return;
 
-        // The main `Worker` will be destroyed before any sub-`Worker`, so manually do cleanup here.
-        for (let subworker of subworkers)
-            WI.targetManager.removeTarget(subworker);
+        this._cleanUpWorker(worker);
     }
 
     dispatchMessageFromWorker(workerId, message)
@@ -84,5 +84,18 @@ WI.WorkerManager = class WorkerManager extends WI.Object
             return;
 
         worker.connection.dispatch(message);
+    }
+
+    // Private
+
+    _cleanUpWorker(worker)
+    {
+        // The main `Worker` will be destroyed before any sub-`Worker`, so manually do cleanup here.
+        for (let subworker of (this._subworkersForWorker.take(worker) || [])) {
+            this._workerForId.delete(subworker.identifier);
+            this._cleanUpWorker(subworker);
+        }
+
+        WI.targetManager.removeTarget(worker);
     }
 };


### PR DESCRIPTION
#### 1cc5dfa320db9ecf0bf3fbb27fb291398b7bf1fa
<pre>
Web Inspector: WorkerManager.workerTerminated leaks nested subworkers&apos; Target/map entries
<a href="https://bugs.webkit.org/show_bug.cgi?id=319771">https://bugs.webkit.org/show_bug.cgi?id=319771</a>
<a href="https://rdar.apple.com/182629416">rdar://182629416</a>

Reviewed by Devin Rousso.

WorkerManager.workerTerminated() only removed the direct subworkers of a
terminated Worker, so grandchild subworkers (a subworker&apos;s own subworker)
were never removed from the WorkerTarget map or Multimap, and their
WI.WorkerTarget objects were never passed to WI.targetManager.removeTarget().
Make cleanup recursive so terminating any Worker also tears down its full
subworker tree, and guard against re-processing a worker that a
previously-terminated ancestor already cleaned up.

Test: inspector/worker/worker-terminate-nested-subworker.html

* LayoutTests/inspector/worker/worker-terminate-nested-subworker-expected.txt: Added.
* LayoutTests/inspector/worker/worker-terminate-nested-subworker.html: Added.
* Source/WebInspectorUI/UserInterface/Controllers/WorkerManager.js:
(WI.WorkerManager.prototype.workerTerminated):
(WI.WorkerManager.prototype._cleanUpWorker): Added.
(WI.WorkerManager):

Canonical link: <a href="https://commits.webkit.org/317517@main">https://commits.webkit.org/317517@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4e0fa63c14d794ffa2d749474edc61ea816d1e11

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175515 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49447 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43228 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185101 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/137662 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/12ab9a7c-14a7-4c8a-be08-76d1a190126d) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50739 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49130 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/136660 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/137662 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1295da2c-fed0-4e2b-9cbd-ae95806f22ef) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178472 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40078 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157417 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117138 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7a387674-394b-41d2-9a8c-f33762cfb793) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/38720 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37106 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149142 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36910 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33576 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41134 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/41309 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187526 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49114 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/156973 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/145629 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39179 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49794 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/33534 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145466 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40284 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/121987 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115745 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48301 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11886 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47703 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47933 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47760 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->