### PR TITLE
run-api-tests --test-parallel-safety never terminates and emits unbounded output when a DISABLED_ test is in the test list

### DIFF
--- a/Tools/Scripts/webkitpy/api_tests/runner.py
+++ b/Tools/Scripts/webkitpy/api_tests/runner.py
@@ -163,6 +163,29 @@ class Runner(object):
                 shards[f"{test}.{i}"] = [test]
         return shards
 
+    @staticmethod
+    def _is_disabled_test(test_name):
+        # gtest never runs a test whose method component is prefixed with
+        # DISABLED_.  test_name is the full binary.suite.method form; strip the
+        # binary name, then check the method component.
+        components = test_name.split('.')[1:]
+        return len(components) > 1 and components[1].startswith('DISABLED_')
+
+    @staticmethod
+    def _partition_parallel_safety_tests(tests):
+        # In test-parallel-safety mode each supplied test is dispatched as a
+        # repeat=True task, so a disabled test loops as an instant no-op and
+        # emits "Disabled" without bound until the log limit is hit.  Partition
+        # disabled tests out of the repeat set.
+        runnable = []
+        disabled = []
+        for test in tests:
+            if Runner._is_disabled_test(test):
+                disabled.append(test)
+            else:
+                runnable.append(test)
+        return runnable, disabled
+
     def run(self, tests, num_workers):
         if not tests:
             return
@@ -207,6 +230,9 @@ class Runner(object):
             if supplied_tests_raw:
                 for test_arg in supplied_tests_raw:
                     supplied_tests.extend(test_arg.split())
+                supplied_tests, disabled_tests = Runner._partition_parallel_safety_tests(supplied_tests)
+                if disabled_tests:
+                    _log.warning(f'Test-parallel-safety mode: skipping {len(disabled_tests)} disabled test(s) that cannot be repeat-run: {disabled_tests}')
                 _log.info(f'Test-parallel-safety mode: creating repeat loop tasks for tests: {supplied_tests}')
 
                 if len(supplied_tests) <= max_repeat_workers:
@@ -341,8 +367,7 @@ class _Worker(object):
             env=self._port.environment_for_api_tests())
 
         status = Runner.STATUS_RUNNING
-        split_test = test.split('.')
-        if len(split_test) > 1 and split_test[1].startswith('DISABLED_') and not self._port.get_option('force'):
+        if Runner._is_disabled_test(f'{binary_name}.{test}') and not self._port.get_option('force'):
             status = Runner.STATUS_DISABLED
 
         stdout_buffer = ''

--- a/Tools/Scripts/webkitpy/api_tests/runner_unittest.py
+++ b/Tools/Scripts/webkitpy/api_tests/runner_unittest.py
@@ -1,0 +1,65 @@
+# Copyright (C) 2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""Unit tests for runner.py."""
+
+import unittest
+
+from webkitpy.api_tests.runner import Runner
+
+
+class RunnerTest(unittest.TestCase):
+    def test_is_disabled_test_detects_disabled_method(self):
+        self.assertTrue(Runner._is_disabled_test(
+            "TestWebKitAPI.SiteIsolation.DISABLED_PostMessageWithMessagePorts"))
+
+    def test_is_disabled_test_allows_enabled_test(self):
+        self.assertFalse(Runner._is_disabled_test(
+            "TestWebKitAPI.SiteIsolation.LoadingCallbacksAndPostMessage"))
+
+    def test_parallel_safety_tests_excludes_disabled(self):
+        supplied = [
+            "TestWebKitAPI.SiteIsolation.LoadingCallbacksAndPostMessage",
+            "TestWebKitAPI.SiteIsolation.DISABLED_PostMessageWithMessagePorts",
+            "TestWebKitAPI.SiteIsolation.GrandchildIframe",
+        ]
+        runnable, disabled = Runner._partition_parallel_safety_tests(supplied)
+        self.assertEqual(runnable, [
+            "TestWebKitAPI.SiteIsolation.LoadingCallbacksAndPostMessage",
+            "TestWebKitAPI.SiteIsolation.GrandchildIframe",
+        ])
+        self.assertEqual(disabled, [
+            "TestWebKitAPI.SiteIsolation.DISABLED_PostMessageWithMessagePorts",
+        ])
+
+    def test_partition_keeps_all_enabled_tests(self):
+        supplied = [
+            "TestWebKitAPI.WebKit.Foo",
+            "TestWebKitAPI.WebKit.Bar",
+        ]
+        runnable, disabled = Runner._partition_parallel_safety_tests(supplied)
+        self.assertEqual(runnable, supplied)
+        self.assertEqual(disabled, [])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
#### 89a5bd3e4c0e63659094e0be2104bf3b3faba224
<pre>
run-api-tests --test-parallel-safety never terminates and emits unbounded output when a DISABLED_ test is in the test list
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=319772">https://bugs.webkit.org/show_bug.cgi?id=319772</a>&gt;
&lt;<a href="https://rdar.apple.com/182630802">rdar://182630802</a>&gt;

Unreviewed test fix.

In test-parallel-safety mode every supplied test is dispatched as a
repeat=True task so it runs continuously to surface parallelization
problems.  A gtest test whose method name is prefixed with DISABLED_
never executes, so its iteration returns immediately having done no
work.  Repeating an instant no-op spins as fast as the CPU allows,
emitting one &quot;Disabled&quot; status line per iteration until the log limit
trips and the run is killed, so any modified-test set that includes a
disabled test can never complete.

Partition disabled tests out of the repeat set before dispatch and log
which ones were skipped.  A disabled test carries no parallel-safety
signal, so excluding it loses nothing.  Detect them with a shared
`_is_disabled_test()` helper that the per-run check in `_run_single_test`
also uses, so the two paths cannot disagree on what &quot;disabled&quot; means.

Tests: Added unit tests covering disabled-test detection and the
partitioning helper.

* Tools/Scripts/webkitpy/api_tests/runner.py:
(Runner._is_disabled_test): Add.
(Runner._partition_parallel_safety_tests): Add.
(Runner.run):
(_Worker._run_single_test):
* Tools/Scripts/webkitpy/api_tests/runner_unittest.py: Add.
(RunnerTest.test_is_disabled_test_detects_disabled_method): Add.
(RunnerTest.test_is_disabled_test_allows_enabled_test): Add.
(RunnerTest.test_parallel_safety_tests_excludes_disabled): Add.
(RunnerTest.test_partition_keeps_all_enabled_tests): Add.

Canonical link: <a href="https://commits.webkit.org/317681@main">https://commits.webkit.org/317681@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4e6bcbdb5326ebc17907c979c0a231fe1ef3b72e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176017 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49950 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/43734 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185611 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/138233 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e473bd2e-17fc-4441-aea4-690c72d72e7a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/177880 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51242 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49632 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/137075 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/138233 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d2cab17c-aca7-41aa-9102-517e6e9ff332) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178973 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40542 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/157845 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117554 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/68737af0-6e59-442a-8863-26b429104ab4) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/175340 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/39185 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/37561 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/149603 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/37337 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34080 "Built successfully") | | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/41767 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188033 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49617 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/157396 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/146082 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50298 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/33962 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145919 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26743 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40693 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/116371 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48804 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/12318 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48206 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48438 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48263 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->