### PR TITLE
[Web Inspector] Network ResourceTiming reports non-zero redirectStart/redirectEnd for non-redirected resources

### DIFF
--- a/LayoutTests/http/tests/inspector/network/resource-timing-expected.txt
+++ b/LayoutTests/http/tests/inspector/network/resource-timing-expected.txt
@@ -6,6 +6,9 @@ Tests that a resource has timing information.
 PASS: Resource should be created.
 PASS: Added Resource received a response.
 PASS: Added Resource did finish loading.
+PASS: Should have captured a raw ResourceTiming payload.
+PASS: Non-redirected resource should have a redirectStart of 0 in the raw protocol payload.
+PASS: Non-redirected resource should have a redirectEnd of 0 in the raw protocol payload.
 PASS: Newly added resource should have a resource timing model.
 PASS: Resource should have a start time.
 PASS: Resource should have a fetch start time.

--- a/LayoutTests/http/tests/inspector/network/resource-timing.html
+++ b/LayoutTests/http/tests/inspector/network/resource-timing.html
@@ -6,7 +6,7 @@
 <script>
 function createImageRequest() {
     let img = document.createElement("img");
-    img.src = "https://localhost:8443/resources/square100.png";
+    img.src = "https://localhost:8443/resources/square100.png?" + Math.random();
     document.body.appendChild(img);
 }
 
@@ -24,6 +24,16 @@ function test()
         name: "Resource.TimingData.Basic",
         description: "Check if a resource has timing information.",
         test(resolve, reject) {
+            // Capture the raw `Network.ResourceTiming` payload sent by the backend, before it
+            // passes through WI.ResourceTimingData's own (separately buggy) sanitization, so
+            // that this test verifies exactly what InspectorNetworkAgent computed.
+            let rawTimingPayload = null;
+            let originalFromPayload = WI.ResourceTimingData.fromPayload;
+            WI.ResourceTimingData.fromPayload = function(payload, resource) {
+                rawTimingPayload = payload;
+                return originalFromPayload.call(WI.ResourceTimingData, payload, resource);
+            };
+
             Promise.all([
                 WI.Frame.awaitEvent(WI.Frame.Event.ResourceWasAdded),
                 WI.Resource.awaitEvent(WI.Resource.Event.ResponseReceived),
@@ -35,6 +45,10 @@ function test()
                 InspectorTest.expectThat(resource instanceof WI.Resource, "Resource should be created.");
                 InspectorTest.expectThat(resource === responseReceivedEvent.target, "Added Resource received a response.");
                 InspectorTest.expectThat(resource === loadingDidFinishEvent.target, "Added Resource did finish loading.");
+
+                InspectorTest.expectThat(!!rawTimingPayload, "Should have captured a raw ResourceTiming payload.");
+                InspectorTest.expectEqual(rawTimingPayload.redirectStart, 0, "Non-redirected resource should have a redirectStart of 0 in the raw protocol payload.");
+                InspectorTest.expectEqual(rawTimingPayload.redirectEnd, 0, "Non-redirected resource should have a redirectEnd of 0 in the raw protocol payload.");
 
                 let timingData = resource.timingData;
                 InspectorTest.expectThat(timingData instanceof WI.ResourceTimingData, "Newly added resource should have a resource timing model.");
@@ -50,6 +64,12 @@ function test()
                 InspectorTest.expectThat(isNaN(timingData.secureConnectionStart) || timingData.connectStart <= timingData.secureConnectionStart, "A secure connection should be reused or secureConnectionStart should come after connectStart.");
                 InspectorTest.expectLessThanOrEqual(timingData.requestStart, timingData.responseStart, "responseStart should come after requestStart.");
                 InspectorTest.expectLessThanOrEqual(timingData.responseStart, timingData.responseEnd, "responseEnd should come after responseStart.");
+            })
+            .then(() => {
+                WI.ResourceTimingData.fromPayload = originalFromPayload;
+            }, (error) => {
+                WI.ResourceTimingData.fromPayload = originalFromPayload;
+                throw error;
             })
             .then(resolve, reject);
 

--- a/Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp
@@ -165,8 +165,8 @@ Ref<Inspector::Protocol::Network::ResourceTiming> InspectorNetworkAgent::buildOb
 
     return Inspector::Protocol::Network::ResourceTiming::create()
         .setStartTime(elapsedTimeSince(resourceLoader.loadTiming().startTime()))
-        .setRedirectStart(elapsedTimeSince(timing.redirectStart))
-        .setRedirectEnd(elapsedTimeSince(timing.fetchStart))
+        .setRedirectStart(timing.redirectCount ? elapsedTimeSince(timing.redirectStart) : 0.0)
+        .setRedirectEnd(timing.redirectCount ? elapsedTimeSince(timing.fetchStart) : 0.0)
         .setFetchStart(elapsedTimeSince(timing.fetchStart))
         .setDomainLookupStart(millisecondsSinceFetchStart(timing.domainLookupStart))
         .setDomainLookupEnd(millisecondsSinceFetchStart(timing.domainLookupEnd))


### PR DESCRIPTION
#### b2e4eaa5d716b4a8413ed450ecd72ebc195b2009
<pre>
[Web Inspector] Network ResourceTiming reports non-zero redirectStart/redirectEnd for non-redirected resources
<a href="https://bugs.webkit.org/show_bug.cgi?id=319775">https://bugs.webkit.org/show_bug.cgi?id=319775</a>
<a href="https://rdar.apple.com/182633657">rdar://182633657</a>

Reviewed by NOBODY (OOPS!).

InspectorNetworkAgent::buildObjectForTiming computed redirectStart and
redirectEnd unconditionally from NetworkLoadMetrics::redirectStart, but
every network backend (Cocoa, curl, soup) populates redirectStart with a
real, non-zero timestamp even when no redirect occurred. As a result,
non-redirected resources reported bogus non-zero redirect timing over
the protocol. Gate both fields on redirectCount instead, matching how
PerformanceResourceTiming already determines whether a load was
redirected.

* LayoutTests/http/tests/inspector/network/resource-timing.html:
* LayoutTests/http/tests/inspector/network/resource-timing-expected.txt:
Capture the raw Network.ResourceTiming payload (bypassing
WI.ResourceTimingData&apos;s own client-side sanitization) and assert
redirectStart/redirectEnd are exactly 0 for a non-redirected resource.

* Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp:
(WebCore::InspectorNetworkAgent::buildObjectForTiming):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b2e4eaa5d716b4a8413ed450ecd72ebc195b2009

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175538 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49470 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43251 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185124 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/137689 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c47b2d18-fc34-458f-8d8d-09cf9668f050) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/177402 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50762 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49153 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136680 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96207 "1 flakes 3 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3821b99e-0f56-4e53-8727-6a27258fd991) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178495 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40101 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157440 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117158 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/771d42da-1103-46f8-9c39-47363b4c3809) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38742 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37128 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149164 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36933 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33599 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41158 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41331 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187549 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49137 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/156996 "") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145649 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49817 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33557 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/held.https.any.sharedworker.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145486 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40306 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122010 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115779 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48324 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11909 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47726 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47956 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47783 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->