### PR TITLE
[JSC] `DFG::Plan` should not keep `mustHandleValues` alive

### DIFF
--- a/JSTests/stress/dfg-plan-must-not-keep-must-handle-values-alive.js
+++ b/JSTests/stress/dfg-plan-must-not-keep-must-handle-values-alive.js
@@ -1,0 +1,44 @@
+//@ requireOptions("--numberOfDFGCompilerThreads=0")
+
+// With no DFG compiler threads, the DFG plan for work() is enqueued at the loop tier-up
+// point and stays in the JITWorklist queue forever. Its mustHandleValues snapshot contains
+// the object that was live in that frame; a queued plan must not keep such objects alive.
+
+const rounds = 12;
+const refs = [];
+
+function work(o) {
+    let s = 0;
+    for (let i = 0; i < 300000; i++)
+        s += o.v;
+    return s;
+}
+noInline(work);
+
+function iter() {
+    const o = { v: 1 };
+    refs.push(new WeakRef(o));
+    return work(o);
+}
+noInline(iter);
+
+function clobber(d) { let a = { x: d }; if (d) return clobber(d - 1) + a.x; return 0; }
+noInline(clobber);
+
+for (let k = 0; k < rounds; k++) {
+    iter();
+    $.clearKeptObjects(); // WeakRef construction adds the target to [[KeptAlive]]; drop it before GC.
+    clobber(300);
+    fullGC();
+}
+fullGC();
+
+// The last couple of objects may still be reachable via stale stack slots (conservative
+// scan), but everything older than that must have been collected.
+let survivors = [];
+for (let i = 0; i < rounds - 2; i++) {
+    if (refs[i].deref() !== undefined)
+        survivors.push(i);
+}
+if (survivors.length)
+    throw new Error("Objects captured by a queued DFG plan were kept alive: " + survivors);

--- a/Source/JavaScriptCore/dfg/DFGPlan.cpp
+++ b/Source/JavaScriptCore/dfg/DFGPlan.cpp
@@ -160,6 +160,20 @@ void Plan::finalizeInGC()
     ASSERT(m_vm);
     if (m_recordedStatuses)
         m_recordedStatuses->finalizeWithoutDeleting(*m_vm);
+
+    // The compiler threads are suspended here, so it is OK to null out the entries
+    // that nothing else marked -- every reader of mustHandleValues treats nullopt as unknown.
+    cleanMustHandleValuesIfNecessary();
+    {
+        Locker locker { m_mustHandleValueCleaningLock };
+        for (unsigned i = m_mustHandleValues.size(); i--;) {
+            std::optional<JSValue>& value = m_mustHandleValues[i];
+            if (!value || !*value || !value->isCell())
+                continue;
+            if (!m_vm->heap.isMarked(value->asCell()))
+                value = std::nullopt;
+        }
+    }
 }
 
 void Plan::notifyReady()
@@ -658,13 +672,7 @@ bool Plan::checkLivenessAndVisitChildren(AbstractSlotVisitor& visitor)
     if (!Base::checkLivenessAndVisitChildren(visitor))
         return false;
 
-    cleanMustHandleValuesIfNecessary();
-    for (unsigned i = m_mustHandleValues.size(); i--;) {
-        std::optional<JSValue> value = m_mustHandleValues[i];
-        if (value)
-            visitor.appendUnbarriered(value.value());
-    }
-
+    // m_mustHandleValues is deliberately not visited here; see finalizeInGC().
     if (m_recordedStatuses) {
         m_recordedStatuses->visitAggregate(visitor);
         m_recordedStatuses->markIfCheap(visitor);


### PR DESCRIPTION
#### 4c4a0cb40219539d4aca82c7cbc422d0407f6cb3
<pre>
[JSC] `DFG::Plan` should not keep `mustHandleValues` alive
<a href="https://bugs.webkit.org/show_bug.cgi?id=319779">https://bugs.webkit.org/show_bug.cgi?id=319779</a>

Reviewed by NOBODY (OOPS!).

When a loop triggers Baseline-&gt;DFG (or DFG-&gt;FTL) OSR entry, operationOptimize snapshots
the frame&apos;s live locals into Plan::m_mustHandleValues to seed OSR entry predictions.
Plan::checkLivenessAndVisitChildren visited those values as roots, so any object that
happened to be in a local at the tier-up point stayed alive until the plan was finalized.
For example, a per-iteration object in a hot loop survives a full GC while its plan is
queued or ready, and shows up in heap snapshots with RootMarkReason::JITWorkList.

The compiler does not need those objects kept alive. mustHandleValues only seeds
PredictionInjection, CFA::injectOSR and TypeCheckHoisting, and all of them already treat
nullopt as unknown since <a href="https://commits.webkit.org/209485@main">209485@main</a>. This patch stops visiting m_mustHandleValues and,
like RecordedStatuses::finalizeWithoutDeleting, clears entries whose cells were not marked
in Plan::finalizeInGC(), which runs after marking with the compiler threads suspended.
Values that are still reachable, or that a phase already froze into the Graph, are
unaffected. Note that when the injected value is the only source for an OSR entry block
(the ForceOSRExit case from 159687), CFA::injectOSR proves the exact value
(AbstractValue::m_value), so an entry for a dead object could never validate anyway.

    // Before: refs[k] for the object live at work()&apos;s tier-up point survives forever
    // while its DFG plan sits in the queue (--numberOfDFGCompilerThreads=0).
    function work(o) {
        let s = 0;
        for (let i = 0; i &lt; 300000; i++) s += o.v;
        return s;
    }
    for (let k = 0; k &lt; 12; k++) {
        let o = { v: 1 };
        refs.push(new WeakRef(o));
        work(o);
        fullGC();
    }

Test: JSTests/stress/dfg-plan-must-not-keep-must-handle-values-alive.js

* JSTests/stress/dfg-plan-must-not-keep-must-handle-values-alive.js: Added.
(iter):
(clobber):
* Source/JavaScriptCore/dfg/DFGPlan.cpp:
(JSC::DFG::Plan::finalizeInGC):
(JSC::DFG::Plan::checkLivenessAndVisitChildren):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4c4a0cb40219539d4aca82c7cbc422d0407f6cb3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175508 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49440 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43221 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185094 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/137654 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50732 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49123 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136653 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96203 "1 flakes 4 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178465 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40072 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157411 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117131 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38714 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37099 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/5920 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149136 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36904 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33569 "Built successfully") | 
| [❌ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/36769 "Found 7 new JSC stress test failures: stress/dfg-plan-must-not-keep-must-handle-values-alive.js.bytecode-cache, stress/dfg-plan-must-not-keep-must-handle-values-alive.js.default, stress/dfg-plan-must-not-keep-must-handle-values-alive.js.dfg-eager, stress/dfg-plan-must-not-keep-must-handle-values-alive.js.ftl-eager, stress/dfg-plan-must-not-keep-must-handle-values-alive.js.mini-mode, stress/dfg-plan-must-not-keep-must-handle-values-alive.js.no-ftl, stress/dfg-plan-must-not-keep-must-handle-values-alive.js.no-llint (failure)") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41127 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41302 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187519 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49107 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145622 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49787 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33528 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145459 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40277 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/121980 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115736 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48294 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11880 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47696 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47926 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47753 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->