### PR TITLE
[JSC] `JSON.parse` should create 8-bit strings for Latin1 values in a 16-bit input

### DIFF
--- a/Source/JavaScriptCore/runtime/JSONAtomStringCacheInlines.h
+++ b/Source/JavaScriptCore/runtime/JSONAtomStringCacheInlines.h
@@ -95,8 +95,12 @@ ALWAYS_INLINE JSString* JSONAtomStringCache::makeJSString(std::span<const Charac
     if (characters.size() == 1) {
         if (firstCharacter <= maxSingleCharacterString)
             return jsSingleCharacterString(vm, firstCharacter);
-    } else if (characters.size() > maxAtomizeStringLength)
-        return jsNontrivialString(vm, String(characters));
+    } else if (characters.size() > maxAtomizeStringLength) {
+        if constexpr (std::is_same_v<CharacterType, char16_t>)
+            return jsNontrivialString(vm, String(StringImpl::create8BitIfPossible(characters)));
+        else
+            return jsNontrivialString(vm, String(characters));
+    }
 
     auto lastCharacter = characters.back();
     unsigned index = cacheIndex(firstCharacter, lastCharacter, characters.size());


### PR DESCRIPTION
#### 5f2a8878118543bfc97b64abd558e5c8e75e33f4
<pre>
[JSC] `JSON.parse` should create 8-bit strings for Latin1 values in a 16-bit input
<a href="https://bugs.webkit.org/show_bug.cgi?id=319782">https://bugs.webkit.org/show_bug.cgi?id=319782</a>

Reviewed by Yusuke Suzuki.

When the input to JSON.parse is a 16-bit string (e.g. it contains a single emoji anywhere),
LiteralParser&lt;char16_t&gt; creates every value string longer than 16 characters via String(characters),
which is unconditionally 16-bit, even when the value itself is pure Latin1. Keys and values up to
16 characters already go through AtomStringImpl::add, which uses create8BitIfPossible.

This makes the value path use StringImpl::create8BitIfPossible as well, matching V8, which decides
one-byte vs two-byte per string in its JSON parser.

* Source/JavaScriptCore/runtime/JSONAtomStringCacheInlines.h:
(JSC::JSONAtomStringCache::makeJSString):

Canonical link: <a href="https://commits.webkit.org/317566@main">https://commits.webkit.org/317566@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e35642b04e2a86ae561b52a1c6ef2388d1229685

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175513 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49445 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43226 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185099 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/137660 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50737 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49128 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136659 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/137660 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178470 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40077 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157415 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117137 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38719 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37105 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/5924 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149141 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36908 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33574 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/36774 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41132 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41308 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187524 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49112 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145628 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39220 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49792 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33532 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145465 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40283 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/121985 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115743 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48299 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11884 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47701 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47931 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47758 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->