### PR TITLE
[JSC][Temporal] Fix proleptic Gregorian fields for ROC and Buddhist calendars

### DIFF
--- a/JSTests/stress/temporal-calendar-icu-bridge-non-iso.js
+++ b/JSTests/stress/temporal-calendar-icu-bridge-non-iso.js
@@ -5,6 +5,52 @@ function shouldBe(actual, expected, label) {
         throw new Error(`${label}: expected ${expected}, got ${actual}`);
 }
 
+function shouldThrowRangeError(callback, label) {
+    try {
+        callback();
+    } catch (error) {
+        if (error instanceof RangeError)
+            return;
+        throw error;
+    }
+    throw new Error(`${label}: expected RangeError`);
+}
+
+function shouldHaveCalendarDateFields(date, expectedYear, expectedEra, expectedEraYear, expectedMonth, expectedDay, label) {
+    shouldBe(date.year, expectedYear, `${label} year`);
+    shouldBe(date.era, expectedEra, `${label} era`);
+    shouldBe(date.eraYear, expectedEraYear, `${label} eraYear`);
+    shouldBe(date.month, expectedMonth, `${label} month`);
+    shouldBe(date.monthCode, `M0${expectedMonth}`, `${label} monthCode`);
+    shouldBe(date.day, expectedDay, `${label} day`);
+}
+
+function shouldHaveISODate(date, expectedMonth, expectedDay, label) {
+    const isoDate = date.withCalendar("iso8601");
+    shouldBe(isoDate.year, 1500, `${label} ISO year`);
+    shouldBe(isoDate.month, expectedMonth, `${label} ISO month`);
+    shouldBe(isoDate.day, expectedDay, `${label} ISO day`);
+}
+
+function shouldRoundTripGregorianDate(date, createFromFields, expectedYear, expectedEra, expectedEraYear, expectedMonth, label) {
+    shouldHaveCalendarDateFields(date, expectedYear, expectedEra, expectedEraYear, expectedMonth, 1, label);
+
+    const result = date.with({ day: 2 });
+    shouldHaveISODate(result, expectedMonth, 2, `${label} after with`);
+    shouldHaveCalendarDateFields(result, expectedYear, expectedEra, expectedEraYear, expectedMonth, 2, `${label} after with`);
+
+    const roundTrip = createFromFields({
+        year: date.year,
+        era: date.era,
+        eraYear: date.eraYear,
+        monthCode: date.monthCode,
+        day: date.day,
+        calendar: date.calendarId,
+    });
+    shouldHaveISODate(roundTrip, expectedMonth, 1, `${label} field round-trip`);
+    shouldHaveCalendarDateFields(roundTrip, expectedYear, expectedEra, expectedEraYear, expectedMonth, 1, `${label} field round-trip`);
+}
+
 // Buddhist: `year` is BE (Gregorian + 543). BE 2567 = Gregorian 2024.
 {
     const pd = Temporal.PlainDate.from({year:2567, month:1, day:1, calendar:"buddhist"});
@@ -22,6 +68,79 @@ function shouldBe(actual, expected, label) {
     const pd = Temporal.PlainDate.from({era:"be", eraYear:2567, month:1, day:1, calendar:"buddhist"});
     shouldBe(pd.year, 2567, "buddhist era:be eraYear:2567 -> year");
     shouldBe(pd.toString(), "2024-01-01[u-ca=buddhist]", "buddhist era -> ISO");
+}
+
+// ROC and Buddhist use proleptic Gregorian date fields before 1582.
+for (const calendar of ["roc", "buddhist"]) {
+    const expectedYear = calendar === "roc" ? -411 : 2043;
+    const expectedEra = calendar === "roc" ? "broc" : "be";
+    const expectedEraYear = calendar === "roc" ? 412 : 2043;
+    for (const month of [1, 2]) {
+        const isoMonth = `0${month}`;
+        const dates = [
+            ["PlainDate", Temporal.PlainDate.from(`1500-${isoMonth}-01`).withCalendar(calendar), fields => Temporal.PlainDate.from(fields)],
+            ["PlainDateTime", Temporal.PlainDateTime.from(`1500-${isoMonth}-01T12:00`).withCalendar(calendar), fields => Temporal.PlainDateTime.from({ ...fields, hour: 12 })],
+            ["ZonedDateTime", Temporal.ZonedDateTime.from(`1500-${isoMonth}-01T12:00Z[UTC]`).withCalendar(calendar), fields => Temporal.ZonedDateTime.from({ ...fields, hour: 12, timeZone: "UTC" })],
+        ];
+        for (const [type, date, createFromFields] of dates) {
+            const label = `${calendar} ${type} 1500-${isoMonth}`;
+            shouldRoundTripGregorianDate(date, createFromFields, expectedYear, expectedEra, expectedEraYear, month, label);
+        }
+    }
+}
+
+// ROC year 0 is the year before ROC year 1.
+for (const [isoDate, year, era, eraYear] of [
+    ["1911-12-31", 0, "broc", 1],
+    ["1912-01-01", 1, "roc", 1],
+]) {
+    const date = Temporal.PlainDate.from(isoDate).withCalendar("roc");
+    shouldBe(date.year, year, `${isoDate} ROC year`);
+    shouldBe(date.era, era, `${isoDate} ROC era`);
+    shouldBe(date.eraYear, eraYear, `${isoDate} ROC eraYear`);
+    const roundTrip = Temporal.PlainDate.from({ year, era, eraYear, monthCode: date.monthCode, day: date.day, calendar: "roc" });
+    shouldBe(roundTrip.withCalendar("iso8601").toString(), isoDate, `${isoDate} ROC round-trip`);
+}
+
+// Buddhist has one era and its arithmetic year may be non-positive.
+for (const [year, isoDate] of [
+    [-1, "-000544-01-01"],
+    [0, "-000543-01-01"],
+    [1, "-000542-01-01"],
+]) {
+    const date = Temporal.PlainDate.from({ year, era: "be", eraYear: year, monthCode: "M01", day: 1, calendar: "buddhist" });
+    shouldBe(date.withCalendar("iso8601").toString(), isoDate, `Buddhist year ${year} ISO date`);
+    shouldBe(date.year, year, `Buddhist year ${year}`);
+    shouldBe(date.era, "be", `Buddhist year ${year} era`);
+    shouldBe(date.eraYear, year, `Buddhist year ${year} eraYear`);
+}
+
+shouldThrowRangeError(() => Temporal.PlainDate.from({ year: 0, era: "roc", eraYear: 1, monthCode: "M01", day: 1, calendar: "roc" }), "inconsistent ROC year and eraYear");
+shouldThrowRangeError(() => Temporal.PlainDate.from({ year: 0, era: "be", eraYear: 1, monthCode: "M01", day: 1, calendar: "buddhist" }), "inconsistent Buddhist year and eraYear");
+
+for (const [calendar, year] of [["roc", -411], ["buddhist", 2043]]) {
+    const constrainedDay = Temporal.PlainDate.from({ year, month: 2, day: 29, calendar }, { overflow: "constrain" });
+    shouldBe(constrainedDay.withCalendar("iso8601").toString(), "1500-02-28", `${calendar} day constrain`);
+    shouldThrowRangeError(() => Temporal.PlainDate.from({ year, month: 2, day: 29, calendar }, { overflow: "reject" }), `${calendar} day reject`);
+
+    const constrainedMonth = Temporal.PlainDate.from({ year, month: 13, day: 1, calendar }, { overflow: "constrain" });
+    shouldBe(constrainedMonth.withCalendar("iso8601").toString(), "1500-12-01", `${calendar} month constrain`);
+    shouldThrowRangeError(() => Temporal.PlainDate.from({ year, month: 13, day: 1, calendar }, { overflow: "reject" }), `${calendar} month reject`);
+}
+
+// The exact Temporal PlainDate limits support stable calendar-field round-trips.
+for (const [isoDate, calendar, year, era, eraYear] of [
+    ["-271821-04-19", "roc", -273732, "broc", 273733],
+    ["-271821-04-19", "buddhist", -271278, "be", -271278],
+    ["+275760-09-13", "roc", 273849, "roc", 273849],
+    ["+275760-09-13", "buddhist", 276303, "be", 276303],
+]) {
+    const date = Temporal.PlainDate.from(isoDate).withCalendar(calendar);
+    shouldBe(date.year, year, `${calendar} ${isoDate} year`);
+    shouldBe(date.era, era, `${calendar} ${isoDate} era`);
+    shouldBe(date.eraYear, eraYear, `${calendar} ${isoDate} eraYear`);
+    const roundTrip = Temporal.PlainDate.from({ year, era, eraYear, monthCode: date.monthCode, day: date.day, calendar });
+    shouldBe(roundTrip.withCalendar("iso8601").toString(), isoDate, `${calendar} ${isoDate} round-trip`);
 }
 
 // Coptic `am` era: AM 1740 M01 D01 = ISO 2023-09-12.

--- a/Source/JavaScriptCore/runtime/temporal/core/CalendarICUBridge.cpp
+++ b/Source/JavaScriptCore/runtime/temporal/core/CalendarICUBridge.cpp
@@ -76,8 +76,8 @@ static std::unique_ptr<UCalendar, ICUDeleter<ucal_close>> buildCalendarTemplate(
     // use proleptic Gregorian for all valid dates (effectively -infinity for our purposes).
     // ucal_setGregorianChange is only supported on the base Gregorian calendar; ICU returns
     // U_UNSUPPORTED_ERROR for derived calendars (Japanese, Buddhist, ROC). Those derived
-    // calendars already use proleptic-Gregorian arithmetic in the years Temporal cares about,
-    // so calling ucal_setGregorianChange would be a no-op and we skip it.
+    // calendars cannot be configured this way, so Gregorian-arithmetic accessors route through
+    // the base Gregorian calendar below.
     if (calendarId == gregoryCalendarID() || calendarIsISO(calendarId)) {
         const double prolepticGregorianChangeMs = -8.64e15; // ExactTime::minValue / nsPerMillisecond
         ucal_setGregorianChange(cal.get(), prolepticGregorianChangeMs, &status);
@@ -96,14 +96,37 @@ public:
 WTF_MAKE_TZONE_ALLOCATED_IMPL(CalendarCacheEntry);
 
 // Japanese/ROC/Buddhist derive from Gregorian and reject ucal_setGregorianChange
-// (U_UNSUPPORTED_ERROR), so year-length / month-length / leap-year accessors
-// route through gregory to get proleptic Gregorian. Era-facing paths keep the
-// derived calendar so era labels remain correct.
+// (U_UNSUPPORTED_ERROR), so Gregorian-arithmetic accessors route through gregory
+// to get proleptic Gregorian. Calendar-native year and era fields are handled
+// separately.
 static CalendarID gregorianArithmeticCalendarFor(CalendarID calendarId)
 {
     if (calendarId == japaneseCalendarID() || calendarId == rocCalendarID() || calendarId == buddhistCalendarID())
         return gregoryCalendarID();
     return calendarId;
+}
+
+static constexpr int32_t rocCalendarYearOffset = 1911;
+static constexpr int32_t buddhistCalendarYearOffset = 543;
+
+struct GregorianArithmeticYearFields {
+    int32_t year;
+    ASCIILiteral era;
+    int32_t eraYear;
+};
+
+static GregorianArithmeticYearFields gregorianArithmeticYearFieldsFor(CalendarID calendarId, int32_t isoYear)
+{
+    ASSERT(calendarId == rocCalendarID() || calendarId == buddhistCalendarID());
+    if (calendarId == buddhistCalendarID()) {
+        int32_t year = isoYear + buddhistCalendarYearOffset;
+        return { year, "be"_s, year };
+    }
+
+    int32_t year = isoYear - rocCalendarYearOffset;
+    if (year > 0)
+        return { year, "roc"_s, year };
+    return { year, "broc"_s, 1 - year };
 }
 
 struct CalendarLRUCachePolicy {
@@ -426,9 +449,21 @@ static std::optional<int32_t> mapTemporalEraToICUEra(CalendarID calendarId, Stri
     return std::nullopt;
 }
 
-// isoToCalendarFields — no single temporal_rs equivalent; aggregates Calendar::year/month/month_code/day/era into one ICU pass.
+// isoToCalendarFields — no single temporal_rs equivalent; aggregates Calendar::year/month/month_code/day/era.
 TemporalResult<CalendarFields> isoToCalendarFields(CalendarID calendarId, const ISO8601::PlainDate& isoDate)
 {
+    if (calendarId == rocCalendarID() || calendarId == buddhistCalendarID()) {
+        auto yearFields = gregorianArithmeticYearFieldsFor(calendarId, isoDate.year());
+        CalendarFields fields;
+        fields.year = yearFields.year;
+        fields.era = String(yearFields.era);
+        fields.eraYear = yearFields.eraYear;
+        fields.month = isoDate.month();
+        fields.day = isoDate.day();
+        fields.monthCode = ISO8601::monthCode(isoDate.month());
+        return fields;
+    }
+
     struct RawFields {
         int32_t extendedYear { 0 };
         int32_t ucalEra { 0 };
@@ -447,7 +482,6 @@ TemporalResult<CalendarFields> isoToCalendarFields(CalendarID calendarId, const 
 
         UErrorCode status = U_ZERO_ERROR;
         RawFields raw;
-        // NOTE: ROC UCAL_EXTENDED_YEAR may return Gregorian year on some ICU versions; handled below.
         raw.extendedYear = ucal_get(cal, UCAL_EXTENDED_YEAR, &status);
         if (U_FAILURE(status)) [[unlikely]]
             return makeUnexpected(rangeError(icuReadCalendarFailed));
@@ -476,8 +510,6 @@ TemporalResult<CalendarFields> isoToCalendarFields(CalendarID calendarId, const 
 
     CalendarFields fields;
     fields.year = raw.extendedYear;
-    if (calendarId == rocCalendarID())
-        fields.year = !raw.ucalEra ? -(raw.ucalYear - 1) : raw.ucalYear;
     fields.month = *raw.ordinalMonth;
     fields.day = static_cast<uint8_t>(raw.day);
     fields.monthCode = WTF::move(*raw.monthCode);
@@ -511,29 +543,14 @@ TemporalResult<CalendarFields> isoToCalendarFields(CalendarID calendarId, const 
 TemporalResult<int32_t> calendarYear(CalendarID calendarId, const ISO8601::PlainDate& isoDate)
 {
     // 1. Return the extended year of isoDate in calendarId.
+    if (calendarId == rocCalendarID() || calendarId == buddhistCalendarID())
+        return gregorianArithmeticYearFieldsFor(calendarId, isoDate.year()).year;
     return withCalendar(calendarId, [&](UCalendar* cal) -> TemporalResult<int32_t> {
         if (!cal) [[unlikely]]
             return makeUnexpected(rangeError(icuOpenCalendarFailed));
         if (!setCalendarToISODate(cal, isoDate)) [[unlikely]]
             return makeUnexpected(rangeError(icuSetCalendarFailed));
         UErrorCode status = U_ZERO_ERROR;
-        // NOTE: ROC UCAL_EXTENDED_YEAR may return Gregorian year on some ICU versions; compute from era+year.
-        if (calendarId == rocCalendarID()) {
-            int32_t era = ucal_get(cal, UCAL_ERA, &status);
-            if (U_FAILURE(status)) [[unlikely]]
-                return makeUnexpected(rangeError(icuReadCalendarFailed));
-            int32_t eraYear = ucal_get(cal, UCAL_YEAR, &status);
-            if (U_FAILURE(status)) [[unlikely]]
-                return makeUnexpected(rangeError(icuReadCalendarFailed));
-            return !era ? -(eraYear - 1) : eraYear;
-        }
-        // Buddhist: UCAL_EXTENDED_YEAR is the Gregorian year; UCAL_YEAR is the BE year.
-        if (calendarId == buddhistCalendarID()) {
-            int32_t eraYear = ucal_get(cal, UCAL_YEAR, &status);
-            if (U_FAILURE(status)) [[unlikely]]
-                return makeUnexpected(rangeError(icuReadCalendarFailed));
-            return eraYear;
-        }
         auto result = ucal_get(cal, UCAL_EXTENDED_YEAR, &status);
         if (U_FAILURE(status)) [[unlikely]]
             return makeUnexpected(rangeError(icuReadCalendarFailed));
@@ -553,7 +570,7 @@ TemporalResult<uint8_t> calendarMonth(CalendarID calendarId, const ISO8601::Plai
     // NOTE: Japanese pre-1873 "ce"/"bce" eras use ISO month directly to bypass ICU Julian conversion.
     if (calendarId == japaneseCalendarID() && isoDate.year() < japaneseCalendarGregorianTransitionYear)
         return isoDate.month();
-    return withCalendar(calendarId, [&](UCalendar* cal) -> TemporalResult<uint8_t> {
+    return withCalendar(gregorianArithmeticCalendarFor(calendarId), [&](UCalendar* cal) -> TemporalResult<uint8_t> {
         if (!cal) [[unlikely]]
             return makeUnexpected(rangeError(icuOpenCalendarFailed));
         if (!setCalendarToISODate(cal, isoDate)) [[unlikely]]
@@ -577,7 +594,7 @@ TemporalResult<String> calendarMonthCode(CalendarID calendarId, const ISO8601::P
     // NOTE: Japanese pre-1873 "ce"/"bce" eras use ISO month code directly to bypass ICU Julian conversion.
     if (calendarId == japaneseCalendarID() && isoDate.year() < japaneseCalendarGregorianTransitionYear)
         return ISO8601::monthCode(isoDate.month());
-    return withCalendar(calendarId, [&](UCalendar* cal) -> TemporalResult<String> {
+    return withCalendar(gregorianArithmeticCalendarFor(calendarId), [&](UCalendar* cal) -> TemporalResult<String> {
         if (!cal) [[unlikely]]
             return makeUnexpected(rangeError(icuOpenCalendarFailed));
         if (!setCalendarToISODate(cal, isoDate)) [[unlikely]]
@@ -601,7 +618,7 @@ TemporalResult<uint8_t> calendarDay(CalendarID calendarId, const ISO8601::PlainD
     // NOTE: Japanese pre-1873 "ce"/"bce" eras return ISO day directly to bypass ICU Julian conversion.
     if (calendarId == japaneseCalendarID() && isoDate.year() < japaneseCalendarGregorianTransitionYear)
         return isoDate.day();
-    return withCalendar(calendarId, [&](UCalendar* cal) -> TemporalResult<uint8_t> {
+    return withCalendar(gregorianArithmeticCalendarFor(calendarId), [&](UCalendar* cal) -> TemporalResult<uint8_t> {
         if (!cal) [[unlikely]]
             return makeUnexpected(rangeError(icuOpenCalendarFailed));
         if (!setCalendarToISODate(cal, isoDate)) [[unlikely]]
@@ -640,6 +657,8 @@ TemporalResult<std::optional<String>> calendarEra(CalendarID calendarId, const I
     // 1. If calendarId has no eras, return undefined.
     if (!calendarHasEras(calendarId))
         return std::optional<String>(std::nullopt);
+    if (calendarId == rocCalendarID() || calendarId == buddhistCalendarID())
+        return std::optional<String>(String(gregorianArithmeticYearFieldsFor(calendarId, isoDate.year()).era));
     // 2. Return the era string for isoDate in calendarId (e.g. "ce", "bce", "reiwa").
     // NOTE: Japanese dates before 1873 use "ce"/"bce" per spec, not ICU era names.
     if (calendarId == japaneseCalendarID() && isoDate.year() < japaneseCalendarGregorianTransitionYear)
@@ -673,6 +692,8 @@ TemporalResult<std::optional<int32_t>> calendarEraYear(CalendarID calendarId, co
     // 1. If calendarId has no eras, return undefined.
     if (!calendarHasEras(calendarId))
         return std::optional<int32_t>(std::nullopt);
+    if (calendarId == rocCalendarID() || calendarId == buddhistCalendarID())
+        return std::optional<int32_t>(gregorianArithmeticYearFieldsFor(calendarId, isoDate.year()).eraYear);
     // 2. Return the era year (year within the current era) of isoDate in calendarId.
     // NOTE: Japanese "ce"/"bce" fallback: eraYear is the Gregorian year.
     if (calendarId == japaneseCalendarID() && isoDate.year() < japaneseCalendarGregorianTransitionYear)
@@ -1663,6 +1684,30 @@ TemporalResult<ISO8601::PlainDate> calendarDateFromFields(CalendarID calendarId,
         icuEraCode = mapTemporalEraToICUEra(calendarId, *era);
         if (!icuEraCode) [[unlikely]]
             return makeUnexpected(rangeError("era is not valid for this calendar"_s));
+    }
+
+    if (calendarId == rocCalendarID() || calendarId == buddhistCalendarID()) {
+        CheckedInt32 checkedCalendarYear = year.value_or(0);
+        if (tookEraPath) {
+            checkedCalendarYear = *eraYear;
+            if (calendarId == rocCalendarID() && !*icuEraCode) {
+                checkedCalendarYear = 1;
+                checkedCalendarYear -= *eraYear;
+            }
+            if (checkedCalendarYear.hasOverflowed()) [[unlikely]]
+                return makeUnexpected(rangeError("Resolved calendar date is outside representable range"_s));
+            if (year && *year != checkedCalendarYear.value()) [[unlikely]]
+                return makeUnexpected(rangeError("year is inconsistent with era and eraYear"_s));
+        }
+
+        CheckedInt32 checkedISOYear = checkedCalendarYear;
+        if (calendarId == rocCalendarID())
+            checkedISOYear += rocCalendarYearOffset;
+        else
+            checkedISOYear -= buddhistCalendarYearOffset;
+        if (checkedISOYear.hasOverflowed() || !ISO8601::isYearWithinLimits(checkedISOYear.value())) [[unlikely]]
+            return makeUnexpected(rangeError("Resolved calendar date is outside representable range"_s));
+        return calendarDateFromFields(gregoryCalendarID(), checkedISOYear.value(), month, day, std::nullopt, std::nullopt, monthCode, overflow);
     }
 
     return withCalendar(calendarId, [&](UCalendar* cal) -> TemporalResult<ISO8601::PlainDate> {


### PR DESCRIPTION
[JSC][Temporal] Fix proleptic Gregorian fields for ROC and Buddhist calendars

https://bugs.webkit.org/show_bug.cgi?id=319783

Reviewed by NOBODY (OOPS!).

ICU's derived ROC and Buddhist calendars apply a historical Julian-to-Gregorian
cutover, which produces incorrect Temporal date fields before 1582. Route their
Gregorian-arithmetic fields through the base Gregorian calendar and derive native
years and eras from fixed offsets so getters and property-bag round trips agree.

Test: JSTests/stress/temporal-calendar-icu-bridge-non-iso.js

* JSTests/stress/temporal-calendar-icu-bridge-non-iso.js:
  - Add pre-1582 getter and round-trip coverage for PlainDate, PlainDateTime,
    and ZonedDateTime, plus era boundaries, overflow, and exact date limits.

* Source/JavaScriptCore/runtime/temporal/core/CalendarICUBridge.cpp:
  (JSC::Temporal::gregorianArithmeticYearFieldsFor):
  (JSC::Temporal::isoToCalendarFields):
  (JSC::Temporal::calendarYear):
  (JSC::Temporal::calendarMonth):
  (JSC::Temporal::calendarMonthCode):
  (JSC::Temporal::calendarDay):
  (JSC::Temporal::calendarEra):
  (JSC::Temporal::calendarEraYear):
  (JSC::Temporal::calendarDateFromFields):
  - Use proleptic Gregorian arithmetic for ROC and Buddhist calendar fields.
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4b2212ab6f4552976bba928b957fcf206d71f660

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175516 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49448 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43229 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185102 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/137663 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50740 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49131 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136661 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/137663 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178473 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40079 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157420 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117139 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38721 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37107 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/5929 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149143 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36913 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33577 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/36777 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41135 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41310 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187527 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49115 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145630 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49795 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33537 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145467 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40285 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/121988 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/115747 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48302 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11889 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47704 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47934 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47761 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->