### PR TITLE
[JSC][Temporal] Fix Ethioaa arithmetic year

### DIFF
--- a/JSTests/stress/temporal-calendar-icu-bridge-non-iso.js
+++ b/JSTests/stress/temporal-calendar-icu-bridge-non-iso.js
@@ -5,6 +5,17 @@ function shouldBe(actual, expected, label) {
         throw new Error(`${label}: expected ${expected}, got ${actual}`);
 }
 
+function shouldThrow(func, errorType, label) {
+    try {
+        func();
+    } catch (error) {
+        if (error instanceof errorType)
+            return;
+        throw new Error(`${label}: expected ${errorType.name}, got ${error.constructor.name}`);
+    }
+    throw new Error(`${label}: expected ${errorType.name}, but no exception was thrown`);
+}
+
 // Buddhist: `year` is BE (Gregorian + 543). BE 2567 = Gregorian 2024.
 {
     const pd = Temporal.PlainDate.from({year:2567, month:1, day:1, calendar:"buddhist"});
@@ -41,6 +52,32 @@ function shouldBe(actual, expected, label) {
     const pd = Temporal.PlainDate.from({era:"am", eraYear:2016, month:1, day:1, calendar:"ethiopic"});
     shouldBe(pd.toString(), "2023-09-12[u-ca=ethiopic]", "ethiopic am 2016 -> ISO 2023-09-12");
     shouldBe(pd.year, 2016, "ethiopic .year");
+}
+
+// Ethioaa has one era, so its arithmetic year is the same as its era year.
+const modernEthioaaYear = 7518; // ICU 74 reports extended year 2018 here; ICU 78 reports 7518.
+for (const year of [-1, 0, 1, modernEthioaaYear]) {
+    const fromEra = Temporal.PlainDate.from({era:"aa", eraYear:year, month:1, day:1, calendar:"ethioaa"}, {overflow:"reject"});
+    shouldBe(fromEra.year, year, `ethioaa eraYear:${year} -> year`);
+    shouldBe(fromEra.era, "aa", `ethioaa eraYear:${year} -> era`);
+    shouldBe(fromEra.eraYear, year, `ethioaa eraYear:${year} round-trip`);
+
+    const fromYear = Temporal.PlainDate.from({year, month:1, day:1, calendar:"ethioaa"}, {overflow:"reject"});
+    shouldBe(fromYear.toString(), fromEra.toString(), `ethioaa year:${year} matches eraYear:${year}`);
+
+    const consistent = Temporal.PlainDate.from({year, era:"aa", eraYear:year, month:1, day:1, calendar:"ethioaa"}, {overflow:"reject"});
+    shouldBe(consistent.toString(), fromEra.toString(), `ethioaa consistent year and eraYear ${year}`);
+    shouldBe(fromEra.with({day:2}).year, year, `ethioaa year ${year} survives with()`);
+}
+
+// Inconsistent year and eraYear must be rejected across distinct calendar field-resolution paths.
+shouldThrow(() => Temporal.PlainDate.from({year:-1, era:"aa", eraYear:0, month:1, day:1, calendar:"ethioaa"}), RangeError, "ethioaa PlainDate inconsistent non-positive years");
+shouldThrow(() => Temporal.PlainYearMonth.from({year:0, era:"aa", eraYear:-1, month:1, calendar:"ethioaa"}), RangeError, "ethioaa PlainYearMonth inconsistent non-positive years");
+shouldThrow(() => Temporal.PlainMonthDay.from({year:-1, era:"aa", eraYear:0, monthCode:"M01", day:1, calendar:"ethioaa"}), RangeError, "ethioaa PlainMonthDay inconsistent non-positive years");
+
+{
+    const date = Temporal.PlainDate.from({era:"aa", eraYear:-1, month:1, day:1, calendar:"ethioaa"});
+    shouldThrow(() => date.with({year:0, era:"aa", eraYear:-1}), RangeError, "ethioaa PlainDate.with inconsistent non-positive years");
 }
 
 // Japanese pre-1582: proleptic Gregorian. 1500 is Julian-leap but not Gregorian-leap.

--- a/Source/JavaScriptCore/runtime/temporal/core/CalendarICUBridge.cpp
+++ b/Source/JavaScriptCore/runtime/temporal/core/CalendarICUBridge.cpp
@@ -478,6 +478,8 @@ TemporalResult<CalendarFields> isoToCalendarFields(CalendarID calendarId, const 
     fields.year = raw.extendedYear;
     if (calendarId == rocCalendarID())
         fields.year = !raw.ucalEra ? -(raw.ucalYear - 1) : raw.ucalYear;
+    else if (calendarId == ethioaaCalendarID())
+        fields.year = raw.ucalYear;
     fields.month = *raw.ordinalMonth;
     fields.day = static_cast<uint8_t>(raw.day);
     fields.monthCode = WTF::move(*raw.monthCode);
@@ -527,8 +529,9 @@ TemporalResult<int32_t> calendarYear(CalendarID calendarId, const ISO8601::Plain
                 return makeUnexpected(rangeError(icuReadCalendarFailed));
             return !era ? -(eraYear - 1) : eraYear;
         }
-        // Buddhist: UCAL_EXTENDED_YEAR is the Gregorian year; UCAL_YEAR is the BE year.
-        if (calendarId == buddhistCalendarID()) {
+        // Use UCAL_YEAR for these calendars' native arithmetic year. Older ICU versions expose an
+        // Amete Mihret-relative UCAL_EXTENDED_YEAR for Ethioaa; newer versions may make the fields equal.
+        if (calendarId == buddhistCalendarID() || calendarId == ethioaaCalendarID()) {
             int32_t eraYear = ucal_get(cal, UCAL_YEAR, &status);
             if (U_FAILURE(status)) [[unlikely]]
                 return makeUnexpected(rangeError(icuReadCalendarFailed));
@@ -1687,9 +1690,9 @@ TemporalResult<ISO8601::PlainDate> calendarDateFromFields(CalendarID calendarId,
                 ucal_set(cal, UCAL_ERA, 1); // roc
                 ucal_set(cal, UCAL_YEAR, y);
             }
-        } else if (calendarId == buddhistCalendarID()) {
-            // Buddhist: `year` is the BE year (= Gregorian + 543). UCAL_YEAR is BE; UCAL_EXTENDED_YEAR is Gregorian.
-            ucal_set(cal, UCAL_ERA, 0); // be
+        } else if (calendarId == buddhistCalendarID() || calendarId == ethioaaCalendarID()) {
+            // These one-era calendars use calendar-native UCAL_YEAR for arithmetic.
+            ucal_set(cal, UCAL_ERA, 0);
             ucal_set(cal, UCAL_YEAR, year.value_or(0));
         } else
             ucal_set(cal, UCAL_EXTENDED_YEAR, year.value_or(0));
@@ -1934,7 +1937,9 @@ TemporalResult<ISO8601::PlainDate> calendarDateFromFields(CalendarID calendarId,
                 int32_t era = ucal_get(cal, UCAL_ERA, &yearStatus);
                 int32_t ey = ucal_get(cal, UCAL_YEAR, &yearStatus);
                 resolvedYear = !era ? -(ey - 1) : ey;
-            } else
+            } else if (calendarId == ethioaaCalendarID())
+                resolvedYear = ucal_get(cal, UCAL_YEAR, &yearStatus);
+            else
                 resolvedYear = ucal_get(cal, UCAL_EXTENDED_YEAR, &yearStatus);
             if (!U_FAILURE(yearStatus) && resolvedYear != *year) [[unlikely]]
                 return makeUnexpected(rangeError("year is inconsistent with era and eraYear"_s));


### PR DESCRIPTION
#### 6aaccf24c3d5771482f1f8d763b89d1bffd01f27
<pre>
[JSC][Temporal] Fix Ethioaa arithmetic year

<a href="https://bugs.webkit.org/show_bug.cgi?id=319785">https://bugs.webkit.org/show_bug.cgi?id=319785</a>

Reviewed by Yijia Huang.

UCAL_YEAR is the calendar-native field for Ethioaa&apos;s single AA era and matches Temporal&apos;s arithmetic year. Older ICU versions expose an Amete Mihret-relative UCAL_EXTENDED_YEAR, while newer versions may make the fields equal after ICU-23167. Use UCAL_YEAR consistently when converting, reading, setting, and validating Ethioaa years so the behavior is correct with older ICU and compatible with newer ICU.

Test: JSTests/stress/temporal-calendar-icu-bridge-non-iso.js

* JSTests/stress/temporal-calendar-icu-bridge-non-iso.js:
  - Add version-independent arithmetic-year round-trip and consistency coverage for Ethioaa.

* Source/JavaScriptCore/runtime/temporal/core/CalendarICUBridge.cpp:
  (JSC::Temporal::isoToCalendarFields):
  (JSC::Temporal::calendarYear):
  (JSC::Temporal::calendarDateFromFields):
  - Use calendar-native UCAL_YEAR for Ethioaa arithmetic-year operations.

Canonical link: <a href="https://commits.webkit.org/317552@main">https://commits.webkit.org/317552@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/80d3430ee9bea31a93684cc923655ee0fd8ca73a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175573 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49505 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43286 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185159 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/137727 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50797 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49188 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136713 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/137727 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178530 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40136 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157477 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117191 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38777 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37162 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/5986 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149199 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36970 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-highlight-api/painting/custom-highlight-dynamic-font-metrics-001.html (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33634 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/36834 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41194 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41365 "Found 1 new test failure: http/wpt/background-fetch/change-documents-in-progress-event.window.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187584 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49172 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145682 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39207 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49852 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33594 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145520 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40344 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122045 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/115853 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48359 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11948 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47761 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47991 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47818 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->