### PR TITLE
[JSC][Temporal] Fix Ethiopic AA era mapping

### DIFF
--- a/JSTests/stress/temporal-calendar-icu-bridge-non-iso.js
+++ b/JSTests/stress/temporal-calendar-icu-bridge-non-iso.js
@@ -52,6 +52,21 @@ function shouldThrow(func, errorType, label) {
     const pd = Temporal.PlainDate.from({era:"am", eraYear:2016, month:1, day:1, calendar:"ethiopic"});
     shouldBe(pd.toString(), "2023-09-12[u-ca=ethiopic]", "ethiopic am 2016 -> ISO 2023-09-12");
     shouldBe(pd.year, 2016, "ethiopic .year");
+    shouldBe(pd.era, "am", "ethiopic .era");
+    shouldBe(pd.eraYear, 2016, "ethiopic .eraYear");
+}
+
+// Ethiopic `aa` era: ISO 0001-01-01 is AA 5493 M05 D08.
+{
+    const historical = Temporal.PlainDate.from({era:"aa", eraYear:-1, monthCode:"M02", day:21, calendar:"ethiopic"}, {overflow:"reject"});
+    shouldBe(historical.toString(), "-005494-09-05[u-ca=ethiopic]", "ethiopic aa -1 -> ISO -5494-09-05");
+    shouldBe(historical.year, -5501, "ethiopic aa -1 -> year");
+    shouldBe(historical.era, "aa", "ethiopic aa -1 -> era");
+    shouldBe(historical.eraYear, -1, "ethiopic aa -1 -> eraYear");
+    const pd = Temporal.PlainDate.from("0001-01-01[u-ca=ethiopic]");
+    shouldBe(pd.year, -7, "ethiopic historical .year");
+    shouldBe(pd.era, "aa", "ethiopic historical .era");
+    shouldBe(pd.eraYear, 5493, "ethiopic historical .eraYear");
 }
 
 // Ethioaa has one era, so its arithmetic year is the same as its era year.

--- a/Source/JavaScriptCore/runtime/temporal/core/CalendarICUBridge.cpp
+++ b/Source/JavaScriptCore/runtime/temporal/core/CalendarICUBridge.cpp
@@ -283,8 +283,10 @@ static std::optional<String> mapICUEraToTemporalEra(CalendarID calendarId, int32
     }
     if (calendarId == rocCalendarID())
         return !icuEra ? "broc"_s : "roc"_s;
-    if (calendarId == copticCalendarID() || calendarId == ethiopicCalendarID())
+    if (calendarId == copticCalendarID())
         return "am"_s;
+    if (calendarId == ethiopicCalendarID())
+        return !icuEra ? "aa"_s : "am"_s;
     if (calendarId == ethioaaCalendarID())
         return "aa"_s;
     if (calendarId == hebrewCalendarID())
@@ -411,8 +413,15 @@ static std::optional<int32_t> mapTemporalEraToICUEra(CalendarID calendarId, Stri
             return 1;
         return std::nullopt;
     }
-    if (calendarId == copticCalendarID() || calendarId == ethiopicCalendarID())
+    if (calendarId == copticCalendarID())
         return era == "am"_s ? std::optional<int32_t>(1) : std::nullopt;
+    if (calendarId == ethiopicCalendarID()) {
+        if (era == "aa"_s)
+            return 0;
+        if (era == "am"_s)
+            return 1;
+        return std::nullopt;
+    }
     if (calendarId == ethioaaCalendarID())
         return era == "aa"_s ? std::optional<int32_t>(0) : std::nullopt;
     if (calendarId == hebrewCalendarID())


### PR DESCRIPTION
#### c46df7f6e142a38fc92073960ce90389913387f4
<pre>
[JSC][Temporal] Fix Ethiopic AA era mapping

<a href="https://bugs.webkit.org/show_bug.cgi?id=319787">https://bugs.webkit.org/show_bug.cgi?id=319787</a>

Reviewed by Yijia Huang.

ICU represents the historical Ethiopic AA era as era 0 and the modern AM era as era 1. Map those values explicitly in both directions so Temporal accepts AA property bags and reports the correct era for historical dates.

Test: JSTests/stress/temporal-calendar-icu-bridge-non-iso.js

* JSTests/stress/temporal-calendar-icu-bridge-non-iso.js:
  - Add modern AM and historical AA parsing and field-output coverage.

* Source/JavaScriptCore/runtime/temporal/core/CalendarICUBridge.cpp:
  (JSC::Temporal::mapICUEraToTemporalEra):
  (JSC::Temporal::mapTemporalEraToICUEra):
  - Distinguish Ethiopic AA and AM ICU era values.

Canonical link: <a href="https://commits.webkit.org/317558@main">https://commits.webkit.org/317558@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b041b5c9c9dbba263b4ea1a0927e4b28903b9091

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175523 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49455 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43236 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185109 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/137670 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50747 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49138 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136668 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/137670 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178480 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40086 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157426 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117146 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38728 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37114 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/5935 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149150 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36919 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33584 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/36784 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41142 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41317 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187534 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49122 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145637 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39213 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49802 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33543 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145474 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40292 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/121995 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/115756 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48309 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11895 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47711 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47941 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47768 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->