### PR TITLE
[Site Isolation] Check the requesting process before returning back/forward FrameState

### DIFF
--- a/Source/WebKit/UIProcess/WebBackForwardList.cpp
+++ b/Source/WebKit/UIProcess/WebBackForwardList.cpp
@@ -924,8 +924,39 @@ void WebBackForwardList::backForwardGoToItemShared(BackForwardItemIdentifier ite
     goToItem(*item);
 }
 
-void WebBackForwardList::backForwardAllItems(FrameIdentifier frameID, CompletionHandler<void(Vector<Ref<FrameState>>&&)>&& completionHandler)
+// The provisional-load allowance is needed because the hosting process changes mid-navigation. The
+// main-frame allowance is needed because a site-isolated subframe resolves history navigations against
+// the main frame's item tree; see BackForwardController::itemAtIndex.
+//
+// FIXME: This is not a process boundary for FrameState. A process swap leaves the new process able to
+// read the origins the frame visited earlier, and a main-frame request still returns the whole item
+// tree. Closing either one needs these messages removed rather than filtered, which
+// UseUIProcessForBackForwardItemLoading makes possible by driving back/forward loading from the UI
+// process.
+static bool webProcessCanAccessFrameState(WebProcessProxy& process, WebFrameProxy& frame)
 {
+    return &frame.process() == &process
+        || &frame.provisionalLoadProcess() == &process
+        || frame.isMainFrame();
+}
+
+// A frame whose process is shutting down has already cleared its page (WebFrameProxy::webProcessWillShutDown),
+// so a page mismatch is reachable during teardown and must not be a fatal message check.
+bool WebBackForwardList::canSendFrameStateToProcess(IPC::Connection& connection, FrameIdentifier frameID)
+{
+    RefPtr page = m_page.get();
+    RefPtr frame = WebFrameProxy::webFrame(frameID);
+    if (!page || !frame || frame->page() != page)
+        return false;
+
+    return webProcessCanAccessFrameState(WebProcessProxy::fromConnection(connection), *frame);
+}
+
+void WebBackForwardList::backForwardAllItems(IPC::Connection& connection, FrameIdentifier frameID, CompletionHandler<void(Vector<Ref<FrameState>>&&)>&& completionHandler)
+{
+    if (!canSendFrameStateToProcess(connection, frameID))
+        return completionHandler({ });
+
     auto frameItems = WTF::compactMap(entries(), [frameID](const auto& item) -> RefPtr<WebBackForwardListFrameItem> {
         return item->mainFrameItem().childItemForFrameID(frameID);
     });
@@ -939,10 +970,15 @@ void WebBackForwardList::backForwardItemAtIndexForWebContent(IPC::Connection& co
 {
     MESSAGE_CHECK_COMPLETION_BASE(delta != std::numeric_limits<int32_t>::min(), connection, completionHandler(nullptr));
 
-    // FIXME: This should verify that the web process requesting the item hosts the specified frame.
+    if (!canSendFrameStateToProcess(connection, frameID))
+        return completionHandler(nullptr);
+
     if (RefPtr item = itemAtDeltaFromCurrentIndex(delta, AllowSkippingBackForwardItems::No)) {
         if (RefPtr frameItem = item->mainFrameItem().childItemForFrameID(frameID))
             return completionHandler(frameItem->copyFrameStateWithChildren());
+        // A restored item records no FrameIdentifier, so every lookup misses and the sender needs the
+        // tree to match children by unique name; see FrameLoader::loadChildHistoryItemIntoFrame. This
+        // returns no more than a request for the main frame already returns.
         completionHandler(item->copyMainFrameStateWithChildren());
     } else
         completionHandler(nullptr);

--- a/Source/WebKit/UIProcess/WebBackForwardList.h
+++ b/Source/WebKit/UIProcess/WebBackForwardList.h
@@ -130,6 +130,7 @@ private:
     const BackForwardListItemVector& entries() const LIFETIME_BOUND { return m_entries; }
     WebBackForwardListCounts NODELETE rawCounts() const;
     Ref<FrameState> completeFrameStateForNavigation(Ref<FrameState>&&);
+    bool canSendFrameStateToProcess(IPC::Connection&, WebCore::FrameIdentifier);
 
     // IPC messages
     void backForwardAddItem(IPC::Connection&, Ref<FrameState>&&);
@@ -137,7 +138,7 @@ private:
     void backForwardClearChildren(WebCore::BackForwardItemIdentifier, WebCore::BackForwardFrameItemIdentifier);
     void backForwardUpdateItem(IPC::Connection&, Ref<FrameState>&&);
     void backForwardGoToItem(WebCore::BackForwardItemIdentifier);
-    void backForwardAllItems(WebCore::FrameIdentifier, CompletionHandler<void(Vector<Ref<FrameState>>&&)>&&);
+    void backForwardAllItems(IPC::Connection&, WebCore::FrameIdentifier, CompletionHandler<void(Vector<Ref<FrameState>>&&)>&&);
     void backForwardItemAtIndexForWebContent(IPC::Connection&, int32_t index, WebCore::FrameIdentifier, CompletionHandler<void(RefPtr<FrameState>&&)>&&);
     void backForwardListContainsItem(WebCore::BackForwardItemIdentifier, CompletionHandler<void(bool)>&&);
     void backForwardListCounts(CompletionHandler<void(WebBackForwardListCounts&&)>&&);

--- a/Source/WebKit/UIProcess/WebBackForwardList.swift
+++ b/Source/WebKit/UIProcess/WebBackForwardList.swift
@@ -1247,11 +1247,38 @@ final class WebBackForwardList {
         }
     }
 
+    // Mirror of C++ WebBackForwardList::canSendFrameStateToProcess.
+    private func canSendFrameStateToProcess(
+        connection: IPC.Connection,
+        frameID: WebCore.FrameIdentifier
+    ) -> Bool {
+        guard let listPage = page.get(), let frame = WebKit.WebFrameProxy.webFrame(.init(frameID)), let framePage = frame.page() else {
+            return false
+        }
+
+        // We can't use == here due to rdar://162357139.
+        guard contentsMatch(framePage.identifier(), listPage.identifier()) else {
+            return false
+        }
+
+        // The process accessors need shims due to rdar://168057355.
+        let processID = WebKit.WebProcessProxy.fromConnection(connection).ptr().coreProcessIdentifier()
+        return contentsMatch(frameProcessIdentifier(frame), processID)
+            || contentsMatch(frameProvisionalLoadProcessIdentifier(frame), processID)
+            || frame.isMainFrame()
+    }
+
     @used
     func backForwardAllItems(
+        connection: IPC.Connection,
         frameID: WebCore.FrameIdentifier,
         completionHandler: CompletionHandlers.WebBackForwardList.BackForwardAllItemsCompletionHandler
     ) {
+        guard canSendFrameStateToProcess(connection: connection, frameID: frameID) else {
+            completionHandler.pointee(consuming: WebKit.VectorRefFrameState())
+            return
+        }
+
         var frameStates: [WebKit.FrameState] = []
         for item in entries {
             if let frameItem = item.mainFrameItem().childItemForFrameID(frameID) {
@@ -1277,13 +1304,19 @@ final class WebBackForwardList {
             return
         }
 
-        // FIXME: This should verify that the web process requesting the item hosts the specified frame.
+        guard canSendFrameStateToProcess(connection: connection, frameID: frameID) else {
+            completionHandler.pointee(consuming: WebKit.RefPtrFrameState())
+            return
+        }
+
         let delta = Int(delta)
         guard let item = itemAtDeltaFromCurrentIndex(delta: delta, allowSkipping: false) else {
             completionHandler.pointee(consuming: WebKit.RefPtrFrameState())
             return
         }
         guard let frameItem = item.mainFrameItem().childItemForFrameID(frameID) else {
+            // A restored item records no FrameIdentifier, so every lookup misses and the sender needs
+            // the tree to match children by unique name; see the C++ receiver.
             completionHandler.pointee(consuming: WebKit.RefPtrFrameState(item.copyMainFrameStateWithChildren().ptr()))
             return
         }

--- a/Source/WebKit/UIProcess/WebBackForwardListSwiftUtilities.h
+++ b/Source/WebKit/UIProcess/WebBackForwardListSwiftUtilities.h
@@ -29,6 +29,7 @@
 #include "WebBackForwardListFrameItem.h"
 #include "WebBackForwardListItem.h"
 #include "WebBackForwardListMessages.h"
+#include "WebFrameProxy.h"
 #include "WebProcessProxy.h"
 #include <cstdint>
 #include <wtf/Function.h>
@@ -71,6 +72,16 @@ using WebBackForwardListItemFilter = WTF::RefCountable<WTF::Function<bool (WebKi
 inline WebKit::FrameState* getFrameState(WebKit::WebBackForwardListFrameItem& item)
 {
     return &item.frameState();
+}
+
+inline WebCore::ProcessIdentifier frameProcessIdentifier(WebKit::WebFrameProxy& frame)
+{
+    return frame.process().coreProcessIdentifier();
+}
+
+inline WebCore::ProcessIdentifier frameProvisionalLoadProcessIdentifier(WebKit::WebFrameProxy& frame)
+{
+    return frame.provisionalLoadProcess().coreProcessIdentifier();
 }
 
 void setFrameStateBackForwardItemIdentifier(WebKit::FrameState&, const WebCore::BackForwardItemIdentifier&);

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKBackForwardListTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKBackForwardListTests.mm
@@ -2546,4 +2546,59 @@ TEST(WKBackForwardList, ForgedFileURLItemIsRejected)
     EXPECT_WK_STREQ([webView _test_waitForAlert], "PASS: forged file:// back-forward item was rejected by MESSAGE_CHECK");
 }
 
+// A process that hosts no frame in a page must not be able to read that page's FrameState by naming
+// one of its own frames, which would otherwise satisfy the main-frame allowance.
+TEST(WKBackForwardList, FrameStateRequestFromForeignPageProcessIsRejected)
+{
+    TestWebKitAPI::HTTPServer server({
+        { "/target-first"_s, { "<!DOCTYPE html><body>first</body>"_s } },
+        { "/target-second"_s, { "<!DOCTYPE html><body>second</body>"_s } },
+        { "/attacker"_s, { "<!DOCTYPE html><body>attacker</body>"_s } },
+    }, TestWebKitAPI::HTTPServer::Protocol::Http);
+
+    RetainPtr pool = adoptNS([[WKProcessPool alloc] init]);
+
+    RetainPtr targetConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    [targetConfiguration setProcessPool:pool.get()];
+    enableIPCTestingAPI(targetConfiguration.get());
+    RetainPtr targetWebView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:targetConfiguration.get()]);
+    [targetWebView synchronouslyLoadRequest:server.request("/target-first"_s)];
+    [targetWebView synchronouslyLoadRequest:server.request("/target-second"_s)];
+
+    RetainPtr attackerConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    [attackerConfiguration setProcessPool:pool.get()];
+    enableIPCTestingAPI(attackerConfiguration.get());
+    RetainPtr attackerWebView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:attackerConfiguration.get()]);
+    [attackerWebView synchronouslyLoadRequest:server.request("/attacker"_s)];
+
+    // The two pages must be in different processes for this to test anything.
+    EXPECT_NE([targetWebView _webProcessIdentifier], [attackerWebView _webProcessIdentifier]);
+
+    RetainPtr targetPageID = [targetWebView stringByEvaluatingJavaScript:@"String(IPC.webPageProxyID)"];
+    EXPECT_GT([targetPageID length], 0u);
+
+    // The attacker names its own main frame, which is a main frame, and addresses the target's list.
+    RetainPtr probe = [NSString stringWithFormat:
+        @"(function() {"
+        "    var reply = IPC.sendSyncMessage('UI', BigInt('%@'),"
+        "        IPC.messages.WebBackForwardList_BackForwardItemAtIndexForWebContent.name, 1000,"
+        "        [{ type: 'int32_t', value: -1 }, { type: 'FrameID', value: IPC.frameID }]);"
+        "    if (!reply || !reply.buffer)"
+        "        return 'no-reply';"
+        "    var bytes = new Uint8Array(reply.buffer);"
+        "    var needle = 'target-first';"
+        "    for (var i = 0; i + needle.length <= bytes.length; i++) {"
+        "        var found = true;"
+        "        for (var j = 0; j < needle.length; j++) {"
+        "            if (bytes[i + j] !== needle.charCodeAt(j)) { found = false; break; }"
+        "        }"
+        "        if (found) return 'leaked';"
+        "    }"
+        "    return 'rejected';"
+        "})()", targetPageID.get()];
+
+    RetainPtr result = [attackerWebView stringByEvaluatingJavaScript:probe.get()];
+    EXPECT_WK_STREQ(result.get(), "rejected");
+}
+
 #endif // ENABLE(IPC_TESTING_API)


### PR DESCRIPTION
#### 82029154a20a9ff112e6f5e5dc5c7d97bd60f605
<pre>
[Site Isolation] Check the requesting process before returning back/forward FrameState
<a href="https://bugs.webkit.org/show_bug.cgi?id=319788">https://bugs.webkit.org/show_bug.cgi?id=319788</a>
<a href="https://rdar.apple.com/172058205">rdar://172058205</a>

Reviewed by NOBODY (OOPS!).

WebBackForwardList::backForwardAllItems and backForwardItemAtIndexForWebContent
filtered the back/forward list by the FrameIdentifier in the message but never
checked that the sending WebContent process was entitled to that frame, so a
process hosting no frame in the page could name one of its own frames and read the
page&apos;s FrameState (URLs, referrers, form and history-state data).
backForwardItemAtIndexForWebContent already carried a FIXME noting the missing
check.

Only return FrameState when the sender hosts the requested frame, is provisionally
loading it, or the main frame is requested. The provisional-load allowance is
required because a cross-process history traversal routes through the incoming
provisional process before commit; the main-frame allowance is required because
BackForwardController::itemAtIndex and allItems default to the main frame&apos;s
FrameIdentifier, which a site-isolated subframe process does not host. Anything
else returns an empty result rather than a fatal message check, since the
legitimate process/frame relationship shifts during navigation. A page mismatch
also returns empty rather than a message check, because WebFrameProxy clears its
page in webProcessWillShutDown, so a mismatch is reachable during teardown.

This narrows the reachable set. It is not a process boundary for FrameState, and
two holes remain:

- The sender need not be the process that created the state it receives. A frame
  keeps the entries of the origins it visited earlier, so after a process swap the
  new process can read the previous origin&apos;s URL, referrer, form data and document
  state.
- copyFrameStateWithChildren() serializes descendants hosted by other processes, so
  a main-frame request still returns the whole item tree. The allowance cannot be
  dropped while BackForwardController defaults to the main frame&apos;s FrameIdentifier.

The lookup miss in backForwardItemAtIndexForWebContent keeps answering with the
whole tree for the same reason. Session state records no per-FrameState
FrameIdentifier, so every restored entry misses and the sender needs the tree to
match children by unique name (FrameLoader::loadChildHistoryItemIntoFrame).
Returning the main frame&apos;s own state there breaks subframe restore after a session
restore, and it would withhold nothing, since a request for the main frame returns
the same tree.

Closing either hole needs the lookup removed rather than filtered. A WebContent
process does not need FrameState from the UI process once
UseUIProcessForBackForwardItemLoading drives back/forward loading from the UI
process, and a FIXME records that as the fix.

The check is applied to both the C++ and Swift receivers. The Swift path calls new
interop shims in WebBackForwardListSwiftUtilities.h because WebFrameProxy&apos;s
reference-returning process accessors are not importable into Swift
(<a href="https://rdar.apple.com/168057355">rdar://168057355</a>).

* Source/WebKit/UIProcess/WebBackForwardList.cpp:
(WebKit::webProcessCanAccessFrameState):
(WebKit::WebBackForwardList::canSendFrameStateToProcess):
(WebKit::WebBackForwardList::backForwardAllItems):
(WebKit::WebBackForwardList::backForwardItemAtIndexForWebContent):
* Source/WebKit/UIProcess/WebBackForwardList.h:
* Source/WebKit/UIProcess/WebBackForwardList.swift:
(MakeAPIArray.canSendFrameStateToProcess(connection:frameID:)):
* Source/WebKit/UIProcess/WebBackForwardListSwiftUtilities.h:
(frameProcessIdentifier):
(frameProvisionalLoadProcessIdentifier):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKBackForwardListTests.mm:
(TEST(WKBackForwardList, FrameStateRequestFromForeignPageProcessIsRejected)):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/82029154a20a9ff112e6f5e5dc5c7d97bd60f605

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180812 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54757 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48555 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191026 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145135 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/317f2fa2-9016-416e-b549-26646130e34d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182674 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56055 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54473 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141046 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/97751 "1 flakes 6 failures") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/57992d34-3601-45c6-a618-b13106b4e9b7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183767 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44716 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161798 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121498 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8430f720-4468-437a-be75-8c9fb6317e56) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43389 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41666 "Found 1 new API test failure: TestWebKitAPI.WKBackForwardList.FrameStateRequestFromForeignPageProcessIsRejected (failure)") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153793 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41326 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2186 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47369 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45921 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192960 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54423 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150429 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55111 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37944 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150147 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44743 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127377 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122677 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53628 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16319 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53010 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53247 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53075 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->