### PR TITLE
Port WebExtensionAPIAlarms to C++

### DIFF
--- a/Source/WebKit/CMakeLists.txt
+++ b/Source/WebKit/CMakeLists.txt
@@ -143,7 +143,6 @@ list(APPEND WebKit_UNIFIED_SOURCE_LIST_FILES
 
 set(WebKit_BINDINGS_IN_FILES
     WebProcess/Extensions/Interfaces/WebExtensionAPIAction
-    WebProcess/Extensions/Interfaces/WebExtensionAPIAlarms
     WebProcess/Extensions/Interfaces/WebExtensionAPIBookmarks
     WebProcess/Extensions/Interfaces/WebExtensionAPICommands
     WebProcess/Extensions/Interfaces/WebExtensionAPICookies
@@ -180,6 +179,7 @@ set(WebKit_BINDINGS_IN_FILES
 )
 
 set(WebKit_CPP_BINDINGS_IN_FILES
+    WebProcess/Extensions/Interfaces/WebExtensionAPIAlarms
     WebProcess/Extensions/Interfaces/WebExtensionAPITest
 )
 
@@ -1102,6 +1102,7 @@ list(APPEND WebKit_UNIFIED_SOURCE_EXCLUDES "^[A-Za-z0-9_]+MessageReceiver\\.cpp"
 #   _cpp_inputs are .idl files to generate (CPP sources only).
 macro(GENERATE_IDL_BINDINGS _output_source _inputs _cpp_inputs)
     unset(_input_files)
+    unset(_cpp_input_files)
     unset(_outputs)
     unset(_import_names)
     foreach (_file IN ITEMS ${_inputs})
@@ -1124,7 +1125,7 @@ macro(GENERATE_IDL_BINDINGS _output_source _inputs _cpp_inputs)
 
             ${WebKit_DERIVED_SOURCES_DIR}/JS${_name}.h
         )
-        list(APPEND ${_output_source} ${WebKit_DERIVED_SOURCES_DIR}/JS${_name}.cpp)
+        list(APPEND _cpp_import_names JS${_name}.cpp)
         list(APPEND ${_output_source} ${WebKit_DERIVED_SOURCES_DIR}/JS${_name}.h)
     endforeach ()
 
@@ -1132,6 +1133,7 @@ macro(GENERATE_IDL_BINDINGS _output_source _inputs _cpp_inputs)
         OUTPUT
             ${_outputs}
             ${WebKit_DERIVED_SOURCES_DIR}/JSWebExtensionAPIUnified.mm
+            ${WebKit_DERIVED_SOURCES_DIR}/JSWebExtensionAPIUnified.cpp
         MAIN_DEPENDENCY ${WEBCORE_DIR}/bindings/scripts/generate-bindings-all.pl
         DEPENDS
             ${_input_files}
@@ -1142,7 +1144,8 @@ macro(GENERATE_IDL_BINDINGS _output_source _inputs _cpp_inputs)
            "${WEBKIT_DIR}/WebProcess/Extensions/Bindings/Scripts/GenerateImports.pl"
            "${WEBKIT_DIR}/WebProcess/Extensions/Bindings/Scripts/IDLAttributes.json"
         COMMAND ${PERL_EXECUTABLE} -I "${WEBKIT_DIR}/WebProcess/Extensions/Bindings/Scripts" ${WEBCORE_DIR}/bindings/scripts/generate-bindings.pl --outputDir . --generator Extensions --idlAttributesFile "${WEBKIT_DIR}/WebProcess/Extensions/Bindings/Scripts/IDLAttributes.json" --idlFileNamesList WebExtensionIDLFileNamesList.txt ${_input_files}
-        COMMAND ${PERL_EXECUTABLE} "${WEBKIT_DIR}/WebProcess/Extensions/Bindings/Scripts/GenerateImports.pl" JSWebExtensionAPIUnified.mm ${_import_names}
+        COMMAND ${PERL_EXECUTABLE} "${WEBKIT_DIR}/WebProcess/Extensions/Bindings/Scripts/GenerateImports.pl" --output=JSWebExtensionAPIUnified.mm -- ${_import_names}
+        COMMAND ${PERL_EXECUTABLE} "${WEBKIT_DIR}/WebProcess/Extensions/Bindings/Scripts/GenerateImports.pl" --cpp --output=JSWebExtensionAPIUnified.cpp -- ${_cpp_import_names}
         WORKING_DIRECTORY ${WebKit_DERIVED_SOURCES_DIR}
         VERBATIM
     )
@@ -1179,6 +1182,7 @@ list(APPEND WebKit_DERIVED_SOURCES
     ${WebKit_DERIVED_SOURCES_DIR}/GeneratedSerializersCommon.${WebKit_GENERATED_SERIALIZERS_SUFFIX}
     ${WebKit_DERIVED_SOURCES_DIR}/SerializedTypeInfo.${WebKit_GENERATED_SERIALIZERS_SUFFIX}
     ${WebKit_DERIVED_SOURCES_DIR}/WebKitPlatformGeneratedSerializers.${WebKit_GENERATED_SERIALIZERS_SUFFIX}
+    ${WebKit_DERIVED_SOURCES_DIR}/JSWebExtensionAPIUnified.cpp
 )
 
 set(_serializers_stage_dir ${WebKit_DERIVED_SOURCES_DIR}/.serializers-stage)

--- a/Source/WebKit/DerivedSources-output.xcfilelist
+++ b/Source/WebKit/DerivedSources-output.xcfilelist
@@ -529,7 +529,7 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/ISO18013MobileDocumentRequest+Extras
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPIAction.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPIAction.mm
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPIAlarms.h
-$(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPIAlarms.mm
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPIAlarms.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPIBookmarks.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPIBookmarks.mm
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPICommands.h
@@ -582,6 +582,7 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPITabs.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPITabs.mm
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPITest.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPITest.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPIUnified.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPIUnified.mm
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPIWebNavigation.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPIWebNavigation.mm

--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -1046,7 +1046,6 @@ BINDINGS_SCRIPTS = \
 
 EXTENSION_INTERFACES = \
     WebExtensionAPIAction \
-    WebExtensionAPIAlarms \
     WebExtensionAPIBookmarks \
     WebExtensionAPICommands \
     WebExtensionAPICookies \
@@ -1083,6 +1082,7 @@ EXTENSION_INTERFACES = \
 #
 
 CPP_EXTENSION_INTERFACES = \
+	WebExtensionAPIAlarms \
     WebExtensionAPITest \
 #
 
@@ -1102,9 +1102,13 @@ JS%.h JS%.cpp : %.idl $(BINDINGS_SCRIPTS) $(IDL_ATTRIBUTES_FILE) $(FEATURE_AND_P
 
 JSWebExtensionAPIUnified.mm: $(BINDINGS_SCRIPTS) $(EXTENSION_INTERFACES:%=JS%.mm)
 	@echo "Generating $@..."
-	$(PERL) $(EXTENSIONS_SCRIPTS_DIR)/GenerateImports.pl $@ $(EXTENSION_INTERFACES:%=JS%.mm)
+	$(PERL) $(EXTENSIONS_SCRIPTS_DIR)/GenerateImports.pl --output=$@ -- $(EXTENSION_INTERFACES:%=JS%.mm)
 
-all : JSWebExtensionAPIUnified.mm $(EXTENSION_INTERFACES:%=JS%.h) $(EXTENSION_INTERFACES:%=JS%.mm) $(CPP_EXTENSION_INTERFACES:%=JS%.cpp)
+JSWebExtensionAPIUnified.cpp: $(BINDINGS_SCRIPTS) $(CPP_EXTENSION_INTERFACES:%=JS%.cpp)
+	@echo "Generating $@..."
+	$(PERL) $(EXTENSIONS_SCRIPTS_DIR)/GenerateImports.pl --output=$@ --cpp -- $(CPP_EXTENSION_INTERFACES:%=JS%.cpp)
+
+all : JSWebExtensionAPIUnified.mm $(EXTENSION_INTERFACES:%=JS%.h) $(EXTENSION_INTERFACES:%=JS%.mm) JSWebExtensionAPIUnified.cpp $(CPP_EXTENSION_INTERFACES:%=JS%.h) $(CPP_EXTENSION_INTERFACES:%=JS%.cpp)
 
 ifeq ($(USE_INTERNAL_SDK),YES)
 WEBKIT_ADDITIONS_SWIFT_FILES = \

--- a/Source/WebKit/Shared/Cocoa/InteractionInformationAtPosition.h
+++ b/Source/WebKit/Shared/Cocoa/InteractionInformationAtPosition.h
@@ -41,6 +41,7 @@
 #include <wtf/URL.h>
 #include <wtf/text/WTFString.h>
 
+OBJC_CLASS NSArray;
 OBJC_CLASS DDScannerResult;
 
 namespace WebKit {

--- a/Source/WebKit/Shared/Extensions/WebExtensionUtilities.cpp
+++ b/Source/WebKit/Shared/Extensions/WebExtensionUtilities.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Igalia S.L. All rights reserved.
+ * Copyright (C) 2024-2026 Igalia S.L. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -178,6 +178,146 @@ String toErrorString(const String& callingAPIName, const String& sourceKey, cons
 JSObjectRef toJSError(JSContextRef context, const String& callingAPIName, const String& sourceKey, const String& underlyingErrorString)
 {
     return toJSError(context, toErrorString(callingAPIName, sourceKey, underlyingErrorString));
+}
+
+static String classToClassString(JSON::Value::Type classType)
+{
+    switch (classType) {
+    case JSON::Value::Type::Integer:
+    case JSON::Value::Type::Double:
+        return "a number"_s;
+    case JSON::Value::Type::Null:
+        return "null"_s;
+    case JSON::Value::Type::Boolean:
+        return "a boolean"_s;
+    case JSON::Value::Type::Object:
+        return "an object"_s;
+    case JSON::Value::Type::String:
+        return "a string"_s;
+    case JSON::Value::Type::Array:
+        return "an array"_s;
+    default:
+        return "a value"_s;
+    }
+
+    ASSERT_NOT_REACHED();
+    return "unknown"_s;
+}
+
+static String valueToTypeString(RefPtr<JSON::Value>& value)
+{
+    if (auto number = value->asDouble(); (value->type() == JSON::Value::Type::Double || value->type() == JSON::Value::Type::Integer)) {
+        if (std::isnan(number.value_or(0)))
+            return "NaN"_s;
+
+        if (std::isinf(number.value_or(0)))
+            return "Infinity"_s;
+    }
+
+    return classToClassString(value->type());
+}
+
+static String constructExpectedMessage(const String& key, const String& expected, const String& found)
+{
+    ASSERT(expected);
+    ASSERT(found);
+
+    if (!key.isEmpty())
+        return makeString("'"_s, key, "' is expected to be "_s, expected, ", but "_s, found, " was provided"_s);
+    return makeString("'"_s, expected, "' is expected, but "_s, found, " was provided"_s);
+}
+
+static bool validate(const String& key, RefPtr<JSON::Value> value, JSON::Value::Type expectedValueType, String& outExceptionString)
+{
+    auto number = value->asDouble();
+
+    if (number && std::isnan(number.value_or(0))) {
+        outExceptionString = constructExpectedMessage(key, classToClassString(expectedValueType), valueToTypeString(value));
+        return false;
+    }
+
+    if (number && std::isinf(number.value_or(0))) {
+        outExceptionString = constructExpectedMessage(key, classToClassString(expectedValueType), valueToTypeString(value));
+        return false;
+    }
+
+    if (!(value->type() == expectedValueType)) {
+        outExceptionString = constructExpectedMessage(key, classToClassString(expectedValueType), valueToTypeString(value));
+        return false;
+    }
+
+    if (number && expectedValueType != JSON::Value::Type::Boolean && value->asBoolean()) {
+        outExceptionString = constructExpectedMessage(key, classToClassString(expectedValueType), valueToTypeString(value));
+        return false;
+    }
+
+    return true;
+}
+
+static String formatList(Vector<String>& list)
+{
+    auto count = list.size();
+    if (!count)
+        return emptyString();
+
+    if (count == 1)
+        return makeString("'"_s, list.first(), "'"_s);
+
+    if (count == 2)
+        return makeString("'"_s, list.first(), "' and '"_s, list.last(), "'"_s);
+
+    auto allButLast = list.subvector(0, count - 1);
+    auto formattedInitialItems = makeStringByJoining(allButLast, "', '"_s);
+    return makeString("'"_s, formattedInitialItems, "' and '"_s, list.last(), "'"_s);
+}
+
+bool validateDictionary(RefPtr<JSON::Value> dictionary, const String& sourceKey, Vector<String> requiredKeys, HashMap<String, JSON::Value::Type> keyTypes, String& outExceptionString)
+{
+    ASSERT(!keyTypes.isEmpty());
+
+    RefPtr<JSON::Object> object = dictionary->asObject();
+    if (!object) {
+        outExceptionString = toErrorString(nullString(), sourceKey, "an object is expected"_s);
+        return false;
+    }
+
+    Vector<String> remainingRequiredKeys = requiredKeys;
+    HashSet<String> requiredKeysSet;
+    for (auto& key : requiredKeys)
+        requiredKeysSet.addVoid(key);
+    HashSet<String> optionalKeysSet;
+    for (auto& key : keyTypes.keys())
+        optionalKeysSet.addVoid(key);
+    optionalKeysSet.formDifference(requiredKeysSet);
+
+    String errorString;
+
+    for (auto& key : object->keys()) {
+        if (!requiredKeysSet.contains(key) && !optionalKeysSet.contains(key))
+            continue;
+
+        JSON::Value::Type expectedValueType = keyTypes.get(key);
+        auto value = object->getValue(key);
+
+        if (!validate(key, value, expectedValueType, errorString))
+            break;
+
+        if (requiredKeysSet.contains(key)) {
+            remainingRequiredKeys.removeFirstMatching([&key](auto& k) -> bool {
+                return k == key;
+            });
+        }
+    }
+
+    // Prioritize type errors over missing required key errors, since the dictionary *might* actually have
+    // all the required keys, but we stopped checking. We do know for sure that the type is wrong though.
+    if (!remainingRequiredKeys.isEmpty() && errorString.isEmpty())
+        errorString = makeString("it is missing required keys: "_s, formatList(remainingRequiredKeys));
+
+    if (!errorString.isEmpty())
+        outExceptionString = toErrorString(nullString(), sourceKey, errorString);
+
+    return errorString.isEmpty();
 }
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/Extensions/WebExtensionUtilities.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionUtilities.h
@@ -27,8 +27,13 @@
 
 #if ENABLE(WK_WEB_EXTENSIONS)
 
+#include "Protected.h"
 #include "WebExtensionError.h"
-#include <JavaScriptCore/JSBase.h>
+#if PLATFORM(COCOA)
+#include <JavaScriptCore/JavaScriptCore.h>
+#else
+#include <JavaScriptCore/JavaScript.h>
+#endif
 #include <wtf/Function.h>
 #include <wtf/JSONValues.h>
 #include <wtf/Markable.h>
@@ -69,6 +74,37 @@ JSObjectRef toJSError(JSContextRef, const String& callingAPIName, const String& 
 /// Serializes large data to JSON chunks to avoid StringBuilder overflow.
 void serializeToMultipleJSONStrings(Ref<JSON::Object>, Function<void(String&&)>&&);
 
+enum class UseNullValue : bool { No, Yes };
+
+template<typename T>
+JSValueRef toWebAPI(JSContextRef context, const std::optional<T>& result, UseNullValue useNull = UseNullValue::Yes)
+{
+    if (!result)
+        return useNull == UseNullValue::Yes ? JSValueMakeNull(context) : JSValueMakeUndefined(context);
+    return toWebAPI(context, result.value());
+}
+
+template <typename T>
+static JSObjectRef toWebAPI(JSContextRef context, const Vector<T>& data)
+{
+    if (data.isEmpty())
+        return JSObjectMakeArray(context, 0, nullptr, nullptr);
+
+    auto globalContext = JSContextGetGlobalContext(context);
+    Vector<Protected<JSValueRef>> convertedData;
+    for (auto& value : data)
+        convertedData.append(Protected(globalContext, toWebAPI(context, value)));
+
+    auto rawData = convertedData.map([](const Protected<JSValueRef>& ptr) {
+        return ptr.get();
+    });
+
+    JSObjectRef array = JSObjectMakeArray(context, rawData.size(), rawData.span().data(), nullptr);
+    return array;
+}
+
+bool validateDictionary(RefPtr<JSON::Value> dictionary, const String& sourceKey, Vector<String> requiredKeys, HashMap<String, JSON::Value::Type> keyTypes, String& outExceptionString);
+
 #ifdef __OBJC__
 
 /// Verifies that a dictionary:
@@ -104,8 +140,6 @@ size_t storageSizeOf(NSDictionary<NSString *, NSString *> *);
 
 /// Returns true if the size of any item in the dictionary exceeds the given quota.
 bool anyItemsExceedQuota(NSDictionary *, size_t quota, NSString **outKeyWithError = nullptr);
-
-enum class UseNullValue : bool { No, Yes };
 
 template<typename T>
 id toWebAPI(const std::optional<T>& result, UseNullValue useNull = UseNullValue::Yes)

--- a/Source/WebKit/Sources.txt
+++ b/Source/WebKit/Sources.txt
@@ -613,6 +613,7 @@ UIProcess/Extensions/WebExtensionDeclarativeNetRequestSQLiteStore.cpp
 UIProcess/Extensions/WebExtensionMatchPattern.cpp
 UIProcess/Extensions/WebExtensionStorageSQLiteStore.cpp
 
+UIProcess/Extensions/API/WebExtensionContextAPIAlarms.cpp
 UIProcess/Extensions/API/WebExtensionContextAPIDeclarativeNetRequest.cpp
 UIProcess/Extensions/API/WebExtensionContextAPIStorage.cpp @cost:3
 
@@ -706,6 +707,7 @@ WebProcess/EncryptedMedia/MediaKeySystemPermissionRequestManager.cpp
 WebProcess/Extensions/WebExtensionContextProxy.cpp
 WebProcess/Extensions/WebExtensionControllerProxy.cpp
 
+WebProcess/Extensions/API/WebExtensionAPIAlarms.cpp
 WebProcess/Extensions/API/WebExtensionAPITest.cpp
 
 WebProcess/FileAPI/BlobRegistryProxy.cpp

--- a/Source/WebKit/SourcesCocoa.txt
+++ b/Source/WebKit/SourcesCocoa.txt
@@ -503,7 +503,6 @@ UIProcess/DigitalCredentials/WKDigitalCredentialsPicker.mm @nonARC
 UIProcess/Extensions/Cocoa/_WKWebExtensionDeclarativeNetRequestRule.mm
 UIProcess/Extensions/Cocoa/_WKWebExtensionDeclarativeNetRequestTranslator.mm
 UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIActionCocoa.mm
-UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIAlarmsCocoa.mm
 UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIBookmarksCocoa.mm
 UIProcess/Extensions/Cocoa/API/WebExtensionContextAPICommandsCocoa.mm
 UIProcess/Extensions/Cocoa/API/WebExtensionContextAPICookiesCocoa.mm
@@ -757,7 +756,6 @@ WebProcess/cocoa/IdentityDocumentServices/DigitalCredentialsRequestValidatorBrid
 WebProcess/EntryPoint/Cocoa/XPCService/WebContentServiceEntryPoint.mm @nonARC
 
 WebProcess/Extensions/API/Cocoa/WebExtensionAPIActionCocoa.mm
-WebProcess/Extensions/API/Cocoa/WebExtensionAPIAlarmsCocoa.mm
 WebProcess/Extensions/API/Cocoa/WebExtensionAPIBookmarksCocoa.mm
 WebProcess/Extensions/API/Cocoa/WebExtensionAPICommandsCocoa.mm
 WebProcess/Extensions/API/Cocoa/WebExtensionAPICookiesCocoa.mm

--- a/Source/WebKit/UIProcess/Extensions/API/WebExtensionContextAPIAlarms.cpp
+++ b/Source/WebKit/UIProcess/Extensions/API/WebExtensionContextAPIAlarms.cpp
@@ -23,18 +23,14 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#if !__has_feature(objc_arc)
-#error This file requires ARC. Add the "-fobjc-arc" compiler flag for this file.
-#endif
-
-#import "config.h"
-#import "WebExtensionContext.h"
+#include "config.h"
+#include "WebExtensionContext.h"
 
 #if ENABLE(WK_WEB_EXTENSIONS)
 
-#import "WebExtensionAlarm.h"
-#import "WebExtensionContextProxyMessages.h"
-#import "WebExtensionPermission.h"
+#include "WebExtensionAlarm.h"
+#include "WebExtensionContextProxyMessages.h"
+#include "WebExtensionPermission.h"
 
 namespace WebKit {
 

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 55;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXAggregateTarget section */
@@ -1767,7 +1767,7 @@
 		7CF47FF717275B71008ACB91 /* WKBundlePageBanner.h in Headers */ = {isa = PBXBuildFile; fileRef = 7CF47FF517275B71008ACB91 /* WKBundlePageBanner.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		7CF47FFB17275C57008ACB91 /* PageBanner.h in Headers */ = {isa = PBXBuildFile; fileRef = 7CF47FF917275C57008ACB91 /* PageBanner.h */; };
 		7CF47FFF17276AE3008ACB91 /* WKBundlePageBannerMac.h in Headers */ = {isa = PBXBuildFile; fileRef = 7CF47FFD17276AE3008ACB91 /* WKBundlePageBannerMac.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		7DF6CAA12EC06B0D00AE220C /* JSWebExtensionAPITest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1C15497E2926C05A001B9E5B /* JSWebExtensionAPITest.cpp */; };
+		7D2F27C4301C2EF50043C2CE /* JSWebExtensionAPIUnified.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7D2F27C3301C10470043C2CE /* JSWebExtensionAPIUnified.cpp */; };
 		7E0E785501701FB501FB7E03 /* GeneratedSerializersSharedExtensions.mm in Sources */ = {isa = PBXBuildFile; fileRef = 7E0E785501701FB501FB7E04 /* GeneratedSerializersSharedExtensions.mm */; };
 		7E70A07B501701FB501FB510 /* GeneratedSerializersSharedWebCoreArgumentCodersAuth.mm in Sources */ = {isa = PBXBuildFile; fileRef = 7E70A07B501701FB501FB511 /* GeneratedSerializersSharedWebCoreArgumentCodersAuth.mm */; };
 		7E70A07B501701FB501FB512 /* GeneratedSerializersSharedWebCoreArgumentCodersMedia.mm in Sources */ = {isa = PBXBuildFile; fileRef = 7E70A07B501701FB501FB513 /* GeneratedSerializersSharedWebCoreArgumentCodersMedia.mm */; };
@@ -4224,14 +4224,11 @@
 		1C2184012233872800BAC700 /* NSAttributedStringPrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NSAttributedStringPrivate.h; sourceTree = "<group>"; };
 		1C2B4D3C2A8091FF00C528A1 /* WebExtensionAlarm.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WebExtensionAlarm.cpp; sourceTree = "<group>"; };
 		1C2B4D3D2A8091FF00C528A1 /* WebExtensionAlarm.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebExtensionAlarm.h; sourceTree = "<group>"; };
-		1C2B4D3E2A815ACC00C528A1 /* WebExtensionContextAPIAlarmsCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebExtensionContextAPIAlarmsCocoa.mm; sourceTree = "<group>"; };
 		1C2B4D402A817D6A00C528A1 /* WebExtensionAlarmParameters.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = WebExtensionAlarmParameters.serialization.in; sourceTree = "<group>"; };
 		1C2B4D412A817D6B00C528A1 /* WebExtensionAlarmParameters.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebExtensionAlarmParameters.h; sourceTree = "<group>"; };
-		1C2B4D432A8199C100C528A1 /* WebExtensionAPIAlarmsCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebExtensionAPIAlarmsCocoa.mm; sourceTree = "<group>"; };
 		1C2B4D452A8199CC00C528A1 /* WebExtensionAPIAlarms.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebExtensionAPIAlarms.h; sourceTree = "<group>"; };
 		1C2B4D472A819C4700C528A1 /* WebExtensionAPIAlarms.idl */ = {isa = PBXFileReference; lastKnownFileType = text; path = WebExtensionAPIAlarms.idl; sourceTree = "<group>"; };
 		1C2B4D482A819D0C00C528A1 /* JSWebExtensionAPIAlarms.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSWebExtensionAPIAlarms.h; sourceTree = "<group>"; };
-		1C2B4D492A819D0C00C528A1 /* JSWebExtensionAPIAlarms.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = JSWebExtensionAPIAlarms.mm; sourceTree = "<group>"; };
 		1C2BBF922B82BC5D001DBDFC /* WebExtensionError.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebExtensionError.h; sourceTree = "<group>"; };
 		1C386F2E2AF407B1004108F0 /* WebExtensionAPINotifications.idl */ = {isa = PBXFileReference; lastKnownFileType = text; path = WebExtensionAPINotifications.idl; sourceTree = "<group>"; };
 		1C386F2F2AF4082F004108F0 /* WebExtensionAPINotifications.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebExtensionAPINotifications.h; sourceTree = "<group>"; };
@@ -7245,6 +7242,8 @@
 		7D1A8A0A2D405B34001715DF /* WebExtensionContextAPIStorage.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WebExtensionContextAPIStorage.cpp; sourceTree = "<group>"; };
 		7D1A8A0C2D405B34001715DF /* WebExtensionStorageSQLiteStore.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebExtensionStorageSQLiteStore.h; sourceTree = "<group>"; };
 		7D1A8A0D2D405B34001715DF /* WebExtensionStorageSQLiteStore.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WebExtensionStorageSQLiteStore.cpp; sourceTree = "<group>"; };
+		7D2F27C3301C10470043C2CE /* JSWebExtensionAPIUnified.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = JSWebExtensionAPIUnified.cpp; sourceTree = "<group>"; };
+		7D3FF7012ECBBDB100A26C20 /* JSWebExtensionAPIAlarms.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = JSWebExtensionAPIAlarms.cpp; sourceTree = "<group>"; };
 		7D49D11F2D1AA1AE00C6855E /* WebExtensionSQLiteDatabase.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebExtensionSQLiteDatabase.h; sourceTree = "<group>"; };
 		7D49D1202D1AA1AE00C6855E /* WebExtensionSQLiteDatabase.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WebExtensionSQLiteDatabase.cpp; sourceTree = "<group>"; };
 		7D49D1212D1AA1AE00C6855E /* WebExtensionSQLiteDatatypeTraits.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebExtensionSQLiteDatatypeTraits.h; sourceTree = "<group>"; };
@@ -7259,6 +7258,8 @@
 		7D51514A2CF818CA0035DD16 /* WebExtensionLocalization.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WebExtensionLocalization.cpp; sourceTree = "<group>"; };
 		7D51514B2CF818CA0035DD16 /* WebExtensionUtilities.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WebExtensionUtilities.cpp; sourceTree = "<group>"; };
 		7D5ADAB42E50438300B9AA45 /* WebExtensionRegisteredScriptsSQLiteStoreCocoa.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WebExtensionRegisteredScriptsSQLiteStoreCocoa.mm; sourceTree = "<group>"; };
+		7D6A7F372ED0D4C50082F746 /* WebExtensionContextAPIAlarms.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WebExtensionContextAPIAlarms.cpp; sourceTree = "<group>"; };
+		7DB312D82ED01B42002CD05F /* WebExtensionAPIAlarms.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WebExtensionAPIAlarms.cpp; sourceTree = "<group>"; };
 		7DDEC9D32D4C5DDA000B1353 /* WebExtensionRegisteredScriptsSQLiteStore.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebExtensionRegisteredScriptsSQLiteStore.h; sourceTree = "<group>"; };
 		7DDEC9D42D4C5DDA000B1353 /* WebExtensionRegisteredScriptsSQLiteStore.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WebExtensionRegisteredScriptsSQLiteStore.cpp; sourceTree = "<group>"; };
 		7DE4AC4A2E55521C00475DD8 /* WebExtensionDeclarativeNetRequestSQLiteStoreCocoa.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WebExtensionDeclarativeNetRequestSQLiteStoreCocoa.mm; sourceTree = "<group>"; };
@@ -11066,7 +11067,6 @@
 			isa = PBXGroup;
 			children = (
 				1CC94E592AC941C40045F269 /* WebExtensionContextAPIActionCocoa.mm */,
-				1C2B4D3E2A815ACC00C528A1 /* WebExtensionContextAPIAlarmsCocoa.mm */,
 				96CC7DBD2E15DA2900233E69 /* WebExtensionContextAPIBookmarksCocoa.mm */,
 				1C8ECFEB2AFC8033007BAA62 /* WebExtensionContextAPICommandsCocoa.mm */,
 				1C7308812B33580D00B341DE /* WebExtensionContextAPICookiesCocoa.mm */,
@@ -11107,6 +11107,7 @@
 			children = (
 				1C5DC4502908A9D00061EC62 /* Cocoa */,
 				1CC94E552AC92F960045F269 /* WebExtensionAPIAction.h */,
+				7DB312D82ED01B42002CD05F /* WebExtensionAPIAlarms.cpp */,
 				1C2B4D452A8199CC00C528A1 /* WebExtensionAPIAlarms.h */,
 				96EE6CE72DFA4975000F90BD /* WebExtensionAPIBookmarks.h */,
 				1C8ECFE32AFC79E9007BAA62 /* WebExtensionAPICommands.h */,
@@ -11120,6 +11121,7 @@
 				1C05906E2DFA1039000406F9 /* WebExtensionAPIDOM.h */,
 				B6544F912937E45000034EB0 /* WebExtensionAPIEvent.h */,
 				1C5DC468290B239C0061EC62 /* WebExtensionAPIExtension.h */,
+				760CF4A4920709706E98B98C /* WebExtensionAPIKeys.h */,
 				B6E5F2A4299C105500DBCEA3 /* WebExtensionAPILocalization.h */,
 				1CCEE4542B098B070034E059 /* WebExtensionAPIMenus.h */,
 				1C5DC44F290888140061EC62 /* WebExtensionAPINamespace.h */,
@@ -11152,7 +11154,6 @@
 			isa = PBXGroup;
 			children = (
 				1CC94E572AC92FA50045F269 /* WebExtensionAPIActionCocoa.mm */,
-				1C2B4D432A8199C100C528A1 /* WebExtensionAPIAlarmsCocoa.mm */,
 				96D1B84C2E01F06300D2D42E /* WebExtensionAPIBookmarksCocoa.mm */,
 				1C8ECFE52AFC79F9007BAA62 /* WebExtensionAPICommandsCocoa.mm */,
 				1C4005282B2B938D00F2D9EE /* WebExtensionAPICookiesCocoa.mm */,
@@ -11165,7 +11166,6 @@
 				1C0590702DFA1115000406F9 /* WebExtensionAPIDOMCocoa.mm */,
 				B6544F952937E46900034EB0 /* WebExtensionAPIEventCocoa.mm */,
 				1C5DC465290B23890061EC62 /* WebExtensionAPIExtensionCocoa.mm */,
-				760CF4A4920709706E98B98C /* WebExtensionAPIKeys.h */,
 				B6E5F2A6299C10B100DBCEA3 /* WebExtensionAPILocalizationCocoa.mm */,
 				1CCEE4562B098B4C0034E059 /* WebExtensionAPIMenusCocoa.mm */,
 				1C5DC4512908A9D00061EC62 /* WebExtensionAPINamespaceCocoa.mm */,
@@ -15160,6 +15160,7 @@
 		7D1A8A0B2D405B34001715DF /* API */ = {
 			isa = PBXGroup;
 			children = (
+				7D6A7F372ED0D4C50082F746 /* WebExtensionContextAPIAlarms.cpp */,
 				7D199FE52E1B4EE10042147F /* WebExtensionContextAPIDeclarativeNetRequest.cpp */,
 				7D1A8A0A2D405B34001715DF /* WebExtensionContextAPIStorage.cpp */,
 			);
@@ -17242,6 +17243,7 @@
 		C0CE729D1247E71D00BC0EC4 /* Derived Sources */ = {
 			isa = PBXGroup;
 			children = (
+				7D2F27C3301C10470043C2CE /* JSWebExtensionAPIUnified.cpp */,
 				38DE371D763C9F8323F87E41 /* IPC */,
 				2D7DEBE221269E4B00B9F73C /* unified-sources */,
 				9955A6F01C79866400EB6A93 /* AutomationBackendDispatchers.cpp */,
@@ -17260,8 +17262,8 @@
 				996D00452D7AA0FD0049C7D8 /* CombinedWebDriverBidiDomains.json */,
 				1CC94E522AC92F190045F269 /* JSWebExtensionAPIAction.h */,
 				1CC94E512AC92F190045F269 /* JSWebExtensionAPIAction.mm */,
+				7D3FF7012ECBBDB100A26C20 /* JSWebExtensionAPIAlarms.cpp */,
 				1C2B4D482A819D0C00C528A1 /* JSWebExtensionAPIAlarms.h */,
-				1C2B4D492A819D0C00C528A1 /* JSWebExtensionAPIAlarms.mm */,
 				96418A5D2DFA4B8100C19CDC /* JSWebExtensionAPIBookmarks.h */,
 				96418A5F2DFA4BA900C19CDC /* JSWebExtensionAPIBookmarks.mm */,
 				1C8ECFE72AFC7DCB007BAA62 /* JSWebExtensionAPICommands.h */,
@@ -22155,7 +22157,6 @@
 				074D6A652F385435006089F6 /* IntRectCG.swift in Sources */,
 				5CF250AF2EE06491006A7172 /* IPCTesterReceiver.swift in Sources */,
 				5C448C662EE06E11008931C7 /* IPCTesterReceiverMessageReceiver.swift in Sources */,
-				7DF6CAA12EC06B0D00AE220C /* JSWebExtensionAPITest.cpp in Sources */,
 				1C0F05BE2CFA5D2E007D1F62 /* JSWebExtensionAPIUnified.mm in Sources */,
 				E385F3672E86D6C900461B0C /* LaunchLogHook.mm in Sources */,
 				C14D37FE24ACE086007FF014 /* LaunchServicesDatabaseManager.mm in Sources */,
@@ -22186,6 +22187,7 @@
 				2D72A1FA212BF46E00517A20 /* RemoteLayerTreeDrawingArea.mm in Sources */,
 				2DC18FB4218A6E9E0025A88D /* RemoteLayerTreeViews.mm in Sources */,
 				0701789E23BE9CFC005F0FAA /* RemoteMediaPlayerMIMETypeCache.cpp in Sources */,
+				7D2F27C4301C2EF50043C2CE /* JSWebExtensionAPIUnified.cpp in Sources */,
 				1AF572302D690813008266F2 /* RemoteScrollingTreeCocoa.mm in Sources */,
 				7BCF70DE2615D06E00E4FB70 /* ScopedRenderingResourcesRequestCocoa.mm in Sources */,
 				E3D0A9422D62B1C90094538A /* ServiceWorkerDebuggableFrontendChannel.cpp in Sources */,

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIAlarms.cpp
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIAlarms.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Igalia, S.L. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,67 +24,66 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#if !__has_feature(objc_arc)
-#error This file requires ARC. Add the "-fobjc-arc" compiler flag for this file.
-#endif
+#include "config.h"
+#include "WebExtensionAPIAlarms.h"
 
-#import "config.h"
-#import "WebExtensionAPIAlarms.h"
-#import "WebExtensionAPIKeys.h"
+#include "WebExtensionAPIKeys.h"
 
 #if ENABLE(WK_WEB_EXTENSIONS)
-
-#import "CocoaHelpers.h"
-#import "Logging.h"
-#import "MessageSenderInlines.h"
-#import "WebExtensionAPINamespace.h"
-#import "WebExtensionConstants.h"
-#import "WebExtensionContextMessages.h"
-#import "WebExtensionContextProxy.h"
-#import "WebExtensionUtilities.h"
-#import "WebProcess.h"
-#import <wtf/DateMath.h>
+#include "Logging.h"
+#include "MessageSenderInlines.h"
+#include "WebExtensionAPINamespace.h"
+#include "WebExtensionConstants.h"
+#include "WebExtensionContextMessages.h"
+#include "WebExtensionContextProxy.h"
+#include "WebExtensionUtilities.h"
+#include "WebProcess.h"
+#include <wtf/DateMath.h>
 
 namespace WebKit {
 
-static inline NSDictionary *toWebAPI(const WebExtensionAlarmParameters& alarm)
-{
-    NSMutableDictionary *result = [NSMutableDictionary dictionaryWithCapacity:3];
+static constexpr auto nameKey = "name"_s;
 
-    result[nameKey] = alarm.name.createNSString().get();
-    result[scheduledTimeKey] = @(floor(alarm.nextScheduledTime.approximate<WallTime>().secondsSinceEpoch().milliseconds()));
+static inline JSValueRef toWebAPI(JSContextRef context, const WebExtensionAlarmParameters& alarm)
+{
+    JSObjectRef result = JSObjectMake(context, 0, 0);
+
+    JSObjectSetProperty(context, result, toJSString(nameKey).get(), toJSValueRef(context, alarm.name), 0, nullptr);
+    JSObjectSetProperty(context, result, toJSString(scheduledTimeKey).get(), JSValueMakeNumber(context, floor(alarm.nextScheduledTime.approximate<WallTime>().secondsSinceEpoch().milliseconds())), 0, nullptr);
 
     if (alarm.repeatInterval)
-        result[periodInMinutesKey] = @(alarm.repeatInterval.minutes());
+        JSObjectSetProperty(context, result, toJSString(periodInMinutesKey).get(), JSValueMakeNumber(context, alarm.repeatInterval.minutes()), 0, nullptr);
 
-    return [result copy];
+    return result;
 }
 
-void WebExtensionAPIAlarms::createAlarm(NSString *name, NSDictionary *alarmInfo, NSString **outExceptionString)
+void WebExtensionAPIAlarms::createAlarm(const String& name, RefPtr<JSON::Value> alarmInfo, String& outExceptionString)
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/alarms/create
 
-    static NSDictionary<NSString *, id> *types = @{
-        whenKey: NSNumber.class,
-        delayInMinutesKey: NSNumber.class,
-        periodInMinutesKey: NSNumber.class,
-    };
-
-    if (!validateDictionary(alarmInfo, @"info", nil, types, outExceptionString))
+    if (!validateDictionary(alarmInfo, "info"_s, { }, {
+        { whenKey, JSON::Value::Type::Double },
+        { delayInMinutesKey, JSON::Value::Type::Double },
+        { periodInMinutesKey, JSON::Value::Type::Double },
+    }, outExceptionString))
         return;
 
-    auto *whenNumber = objectForKey<NSNumber>(alarmInfo, whenKey);
-    auto *delayNumber = objectForKey<NSNumber>(alarmInfo, delayInMinutesKey);
-    auto *periodNumber = objectForKey<NSNumber>(alarmInfo, periodInMinutesKey);
+    auto alarmObject = alarmInfo->asObject();
+    if (!alarmObject)
+        return;
+
+    auto whenNumber = alarmObject->getDouble(whenKey);
+    auto delayNumber = alarmObject->getDouble(delayInMinutesKey);
+    auto periodNumber = alarmObject->getDouble(periodInMinutesKey);
 
     if (whenNumber && delayNumber) {
-        *outExceptionString = toErrorString(nullString(), @"info", @"it cannot specify both 'delayInMinutes' and 'when'").createNSString().autorelease();
+        outExceptionString = toErrorString(nullString(), "info"_s, "it cannot specify both 'delayInMinutes' and 'when'"_s);
         return;
     }
 
-    Seconds when = Seconds::fromMilliseconds(whenNumber.doubleValue);
-    Seconds delay = Seconds::fromMinutes(delayNumber.doubleValue);
-    Seconds period = Seconds::fromMinutes(periodNumber.doubleValue);
+    Seconds when = Seconds::fromMilliseconds(whenNumber.value_or(0));
+    Seconds delay = Seconds::fromMinutes(delayNumber.value_or(0));
+    Seconds period = Seconds::fromMinutes(periodNumber.value_or(0));
     Seconds currentTime = Seconds::fromMilliseconds(jsCurrentTime());
 
     Seconds initialInterval;
@@ -107,15 +107,15 @@ void WebExtensionAPIAlarms::createAlarm(NSString *name, NSDictionary *alarmInfo,
         repeatInterval = repeatInterval ? std::max(repeatInterval, webExtensionMinimumAlarmInterval) : 0_s;
     }
 
-    WebProcess::singleton().send(Messages::WebExtensionContext::AlarmsCreate(name ?: emptyAlarmName, initialInterval, repeatInterval), extensionContext().identifier());
+    WebProcess::singleton().send(Messages::WebExtensionContext::AlarmsCreate(!name.isEmpty() ? name : emptyAlarmName, initialInterval, repeatInterval), extensionContext().identifier());
 }
 
-void WebExtensionAPIAlarms::get(NSString *name, Ref<WebExtensionCallbackHandler>&& callback)
+void WebExtensionAPIAlarms::get(const String& name, Ref<WebExtensionCallbackHandler>&& callback)
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/alarms/get
 
-    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::AlarmsGet(name ?: emptyAlarmName), [protectedThis = Ref { *this }, callback = WTF::move(callback)](std::optional<WebExtensionAlarmParameters>&& alarm) {
-        callback->call(toJSValueRef(callback->globalContext(), toWebAPI(alarm)));
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::AlarmsGet(!name.isEmpty() ? name : emptyAlarmName), [protectedThis = Ref { *this }, callback = WTF::move(callback)](std::optional<WebExtensionAlarmParameters>&& alarm) {
+        callback->call(toWebAPI(callback->globalContext(), alarm));
     }, extensionContext().identifier());
 }
 
@@ -124,15 +124,15 @@ void WebExtensionAPIAlarms::getAll(Ref<WebExtensionCallbackHandler>&& callback)
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/alarms/getAll
 
     WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::AlarmsGetAll(), [protectedThis = Ref { *this }, callback = WTF::move(callback)](Vector<WebExtensionAlarmParameters> alarms) {
-        callback->call(toJSValueRef(callback->globalContext(), toWebAPI(alarms)));
+        callback->call(toWebAPI(callback->globalContext(), alarms));
     }, extensionContext().identifier());
 }
 
-void WebExtensionAPIAlarms::clear(NSString *name, Ref<WebExtensionCallbackHandler>&& callback)
+void WebExtensionAPIAlarms::clear(const String& name, Ref<WebExtensionCallbackHandler>&& callback)
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/alarms/clear
 
-    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::AlarmsClear(name ?: emptyAlarmName), [protectedThis = Ref { *this }, callback = WTF::move(callback)]() {
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::AlarmsClear(!name.isEmpty() ? name : emptyAlarmName), [protectedThis = Ref { *this }, callback = WTF::move(callback)]() {
         callback->call();
     }, extensionContext().identifier());
 }
@@ -160,10 +160,8 @@ void WebExtensionContextProxy::dispatchAlarmsEvent(const WebExtensionAlarmParame
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/alarms/onAlarm
 
-    auto *details = toWebAPI(alarm);
-
     enumerateNamespaceObjects([&](auto& namespaceObject) {
-        namespaceObject.alarms().onAlarm().invokeListenersWithArgument(details);
+        namespaceObject.alarms().onAlarm().invokeListenersWithParametersArgument(alarm);
     });
 }
 

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIAlarms.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIAlarms.h
@@ -31,29 +31,24 @@
 #include "WebExtensionAPIEvent.h"
 #include "WebExtensionAPIObject.h"
 
-OBJC_CLASS NSDictionary;
-OBJC_CLASS NSString;
-
 namespace WebKit {
 
 class WebExtensionAPIAlarms : public WebExtensionAPIObject, public JSWebExtensionWrappable {
     WEB_EXTENSION_DECLARE_JS_WRAPPER_CLASS(WebExtensionAPIAlarms, alarms, alarms);
 
 public:
-#if PLATFORM(COCOA)
-    void createAlarm(NSString *name, NSDictionary *alarmInfo, NSString **outExceptionString);
+    void createAlarm(const String& name, RefPtr<JSON::Value> alarmInfo, String& outExceptionString);
 
-    void get(NSString *name, Ref<WebExtensionCallbackHandler>&&);
+    void get(const String& name, Ref<WebExtensionCallbackHandler>&&);
     void getAll(Ref<WebExtensionCallbackHandler>&&);
 
-    void clear(NSString *name, Ref<WebExtensionCallbackHandler>&&);
+    void clear(const String& name, Ref<WebExtensionCallbackHandler>&&);
     void clearAll(Ref<WebExtensionCallbackHandler>&&);
 
     WebExtensionAPIEvent& onAlarm();
 
 private:
     RefPtr<WebExtensionAPIEvent> m_onAlarm;
-#endif
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIEvent.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIEvent.h
@@ -51,6 +51,21 @@ public:
     void invokeListenersWithJSONArgument(const String& argument1);
     void invokeListenersWithJSONArgument(const String& argument1, const String& argument2);
 
+    template<typename T>
+    void invokeListenersWithParametersArgument(T& argument)
+    {
+        if (m_listeners.isEmpty())
+            return;
+
+        // Copy the listeners since call() can trigger a mutation of the listeners.
+        auto listenersCopy = m_listeners;
+
+        for (RefPtr listener : listenersCopy) {
+            // This is a safer cpp false positive (rdar://163760990).
+            SUPPRESS_UNCOUNTED_ARG listener->call(toWebAPI(listener->globalContext(), argument));
+        }
+    }
+
     const ListenerVector& listeners() const LIFETIME_BOUND { return m_listeners; }
 
     void addListener(WebCore::FrameIdentifier, RefPtr<WebExtensionCallbackHandler>);

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIKeys.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIKeys.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#ifdef __OBJC__
+
 #import <Foundation/Foundation.h>
 
 static NSString * const accessLevelKey = @"accessLevel";
@@ -64,7 +66,6 @@ static NSString * const cssOriginKey = @"cssOrigin";
 static NSString * const currentWindowKey = @"currentWindow";
 static NSString * const darkKey = @"dark";
 static NSString * const dateAddedKey = @"dateAdded";
-static NSString * const delayInMinutesKey = @"delayInMinutes";
 static NSString * const deprecatedColorSchemesKey = @"color_schemes";
 static NSString * const deprecatedIconVariantsKey = @"icon_variants";
 static NSString * const descriptionKey = @"description";
@@ -79,7 +80,6 @@ static NSString * const documentStart = @"document_start";
 static NSString * const documentURLPatternsKey = @"documentUrlPatterns";
 static NSString * const domainKey = @"domain";
 static NSString * const editableKey = @"editable";
-static NSString * const emptyAlarmName = @"";
 static NSString * const emptyDataURLValue = @"data:,";
 static NSString * const emptyTitleValue = @"";
 static NSString * const emptyURLValue = @"";
@@ -171,7 +171,6 @@ static NSString * const parentFrameIdKey = @"parentFrameId";
 static NSString * const parentIdKey = @"parentId";
 static NSString * const parentMenuItemIDKey = @"parentMenuItemId";
 static NSString * const pathKey = @"path";
-static NSString * const periodInMinutesKey = @"periodInMinutes";
 static NSString * const permissionsKey = @"permissions";
 static NSString * const persistAcrossSessionsKey = @"persistAcrossSessions";
 static NSString * const persistentPrefix = @"persistent-";
@@ -203,7 +202,6 @@ static NSString * const ruleKey = @"rule";
 static NSString * const rulesetIdKey = @"rulesetId";
 static NSString * const runAtKey = @"runAt";
 static NSString * const sameSiteKey = @"sameSite";
-static NSString * const scheduledTimeKey = @"scheduledTime";
 static NSString * const schemeKey = @"scheme";
 static NSString * const secureKey = @"secure";
 static NSString * const selectedKey = @"selected";
@@ -240,9 +238,16 @@ static NSString * const versionKey = @"version";
 static NSString * const videoKey = @"video";
 static NSString * const visibleKey = @"visible";
 static NSString * const wasCheckedKey = @"wasChecked";
-static NSString * const whenKey = @"when";
 static NSString * const widthKey = @"width";
 static NSString * const windowIdKey = @"windowId";
 static NSString * const windowTypeKey = @"windowType";
 static NSString * const windowTypesKey = @"windowTypes";
 static NSString * const worldKey = @"world";
+
+#endif
+
+static constexpr auto delayInMinutesKey = "delayInMinutes"_s;
+static constexpr auto emptyAlarmName = ""_s;
+static constexpr auto periodInMinutesKey = "periodInMinutes"_s;
+static constexpr auto scheduledTimeKey = "scheduledTime"_s;
+static constexpr auto whenKey = "when"_s;

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPINamespace.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPINamespace.h
@@ -68,7 +68,9 @@ public:
     bool isPropertyAllowed(const ASCIILiteral& propertyName, WebPage*);
 
     WebExtensionAPIAction& action();
+#endif
     WebExtensionAPIAlarms& alarms();
+#if PLATFORM(COCOA)
     WebExtensionAPIAction& browserAction() { return action(); }
     WebExtensionAPICommands& commands();
     WebExtensionAPICookies& cookies();

--- a/Source/WebKit/WebProcess/Extensions/Bindings/JSWebExtensionWrapper.cpp
+++ b/Source/WebKit/WebProcess/Extensions/Bindings/JSWebExtensionWrapper.cpp
@@ -631,6 +631,107 @@ Vector<Protected<JSValueRef>> toVector<Protected<JSValueRef>>(JSContextRef conte
     return result;
 }
 
+static RefPtr<JSON::Value> toJSONArray(JSContextRef context, JSValueRef value)
+{
+    ASSERT(context);
+
+    if (!JSValueIsArray(context, value))
+        return nullptr;
+
+    JSObjectRef object = JSValueToObject(context, value, nullptr);
+    if (!object)
+        return nullptr;
+
+    // This is a safer cpp false positive (rdar://163760990).
+    SUPPRESS_UNCOUNTED_ARG size_t length = JSValueToInt32(context, JSObjectGetProperty(context, object, toJSString("length"_s).get(), nullptr), nullptr);
+    Ref result = JSON::Array::create();
+
+    for (size_t i = 0; i < length; ++i) {
+        JSValueRef itemValue = JSObjectGetPropertyAtIndex(context, object, i, nullptr);
+        RefPtr jsonValue = fromJSValue(context, itemValue);
+        result->pushValue(jsonValue ? jsonValue.releaseNonNull() : JSON::Value::null());
+    }
+
+    return result;
+}
+
+RefPtr<JSON::Value> fromJSValue(JSContextRef context, JSValueRef value)
+{
+    switch (JSValueGetType(context, value)) {
+    case kJSTypeBoolean:
+        return JSON::Value::create(JSValueToBoolean(context, value));
+    case kJSTypeNumber:
+        return JSON::Value::create(JSValueToNumber(context, value, nullptr));
+    case kJSTypeString:
+        return JSON::Value::create(toString(context, value));
+    case kJSTypeObject:
+        if (JSValueIsArray(context, value))
+            return toJSONArray(context, value);
+        return toJSONValue(context, value);
+    case kJSTypeNull:
+        return JSON::Value::null();
+    case kJSTypeUndefined:
+    default:
+        return nullptr;
+    }
+
+    return JSON::Value::null();
+}
+
+RefPtr<JSON::Value> toJSONValue(JSContextRef context, JSValueRef value, NullValuePolicy nullPolicy, ValuePolicy valuePolicy)
+{
+    ASSERT(context);
+
+    if (!JSValueIsObject(context, value))
+        return nullptr;
+
+    JSObjectRef object = JSValueToObject(context, value, nullptr);
+    if (!object)
+        return nullptr;
+
+    if (!isDictionary(context, value))
+        return nullptr;
+
+    JSPropertyNameArrayRef propertyNames = JSObjectCopyPropertyNames(context, object);
+    size_t propertyNameCount = JSPropertyNameArrayGetCount(propertyNames);
+
+    Ref<JSON::Object> result = JSON::Object::create();
+
+    for (size_t i = 0; i < propertyNameCount; ++i) {
+        JSRetainPtr propertyName = JSPropertyNameArrayGetNameAtIndex(propertyNames, i);
+        if (!propertyName)
+            continue;
+
+        // This is a safer cpp false positive (rdar://163760990).
+        SUPPRESS_UNCOUNTED_ARG JSValueRef item = JSObjectGetProperty(context, object, propertyName.get(), 0);
+
+        // Chrome does not include null values in dictionaries for web extensions.
+        if (nullPolicy == NullValuePolicy::NotAllowed && JSValueIsNull(context, item))
+            continue;
+
+        auto key = toString(propertyName.get());
+        auto itemValue = fromJSValue(context, item);
+        if (!itemValue)
+            continue;
+
+        if (valuePolicy == ValuePolicy::StopAtTopLevel) {
+            if (itemValue)
+                result->setValue(key, itemValue.releaseNonNull()); // FIXME: stringify
+            continue;
+        }
+
+        if (isDictionary(context, item)) {
+            if (RefPtr itemDictionary = toJSONValue(context, item, nullPolicy))
+                result->setValue(key, itemDictionary.releaseNonNull());
+        } else
+            result->setValue(key, itemValue.releaseNonNull());
+    }
+
+    JSPropertyNameArrayRelease(propertyNames);
+
+    return result;
+}
+
 } // namespace WebKit
 
 #endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/WebProcess/Extensions/Bindings/JSWebExtensionWrapper.h
+++ b/Source/WebKit/WebProcess/Extensions/Bindings/JSWebExtensionWrapper.h
@@ -207,6 +207,9 @@ JSValueRef toJSValueRef(JSContextRef, const String&, NullOrEmptyString = NullOrE
 JSValueRef toWindowObject(JSContextRef, WebFrame&);
 JSValueRef toWindowObject(JSContextRef, WebPage&);
 
+RefPtr<JSON::Value> fromJSValue(JSContextRef, JSValueRef);
+RefPtr<JSON::Value> toJSONValue(JSContextRef, JSValueRef, NullValuePolicy = NullValuePolicy::NotAllowed, ValuePolicy = ValuePolicy::Recursive);
+
 #ifdef __OBJC__
 
 id toNSObject(JSContextRef, JSValueRef, Class containingObjectsOfClass = Nil, NullValuePolicy = NullValuePolicy::NotAllowed, ValuePolicy = ValuePolicy::Recursive);

--- a/Source/WebKit/WebProcess/Extensions/Bindings/Scripts/CodeGeneratorExtensions.pm
+++ b/Source/WebKit/WebProcess/Extensions/Bindings/Scripts/CodeGeneratorExtensions.pm
@@ -1043,7 +1043,7 @@ sub _hasAutomaticExceptions
     my ($self, $signature) = @_;
 
     return $signature->extendedAttributes->{"CannotBeEmpty"} || $signature->extendedAttributes->{"Serialization"} eq "JSON" || $signature->extendedAttributes->{"NSArray"}
-        || $signature->extendedAttributes->{"NSDictionary"} || $signature->extendedAttributes->{"NSObject"} || $signature->extendedAttributes->{"URL"}
+        || $signature->extendedAttributes->{"NSDictionary"} || $signature->extendedAttributes->{"NSObject"} || $signature->extendedAttributes->{"URL"} || $signature->extendedAttributes->{"JSONValue"}
         || $signature->type->name eq "function" || $$self{codeGenerator}->IsPrimitiveType($signature->type) || $$self{codeGenerator}->IsStringType($signature->type);
 }
 
@@ -1157,7 +1157,7 @@ ${indentString}}
 EOF
     }
 
-    if ($signature->type->name eq "any" && ($signature->extendedAttributes->{"NSDictionary"} || $signature->extendedAttributes->{"Serialization"})) {
+    if ($signature->type->name eq "any" && ($signature->extendedAttributes->{"NSDictionary"} || $signature->extendedAttributes->{"JSONValue"} || $signature->extendedAttributes->{"Serialization"})) {
         $hasExceptions = 1;
 
         push(@$contents, <<EOF);
@@ -1169,7 +1169,7 @@ ${indentString}}
 EOF
     }
 
-    if ($signature->type->name eq "any" && !($signature->extendedAttributes->{"NSDictionary"} || $signature->extendedAttributes->{"Serialization"}) && !$signature->extendedAttributes->{"NSObject"} && !$signature->extendedAttributes->{"ValuesAllowed"}) {
+    if ($signature->type->name eq "any" && !($signature->extendedAttributes->{"NSDictionary"} || $signature->extendedAttributes->{"JSONValue"} || $signature->extendedAttributes->{"Serialization"}) && !$signature->extendedAttributes->{"NSObject"} && !$signature->extendedAttributes->{"ValuesAllowed"}) {
         $hasExceptions = 1;
 
         push(@$contents, <<EOF);
@@ -1255,7 +1255,7 @@ EOF
 EOF
     }
 
-    if ($signature->type->name eq "any" && ($signature->extendedAttributes->{"NSDictionary"} || $signature->extendedAttributes->{"NSObject"}) && !$signature->extendedAttributes->{"Optional"}) {
+    if ($signature->type->name eq "any" && ($signature->extendedAttributes->{"NSDictionary"} || $signature->extendedAttributes->{"JSONValue"} || $signature->extendedAttributes->{"NSObject"}) && !$signature->extendedAttributes->{"Optional"}) {
         $hasExceptions = 1;
 
         push(@$contents, <<EOF);
@@ -1267,7 +1267,7 @@ EOF
 EOF
     }
 
-    if (!$interface->extendedAttributes->{"UseCPPAPI"} && $signature->type->name eq "any" && !($signature->extendedAttributes->{"NSDictionary"} || $signature->extendedAttributes->{"NSObject"} || $signature->extendedAttributes->{"Serialization"}) && !$signature->extendedAttributes->{"Optional"} && !$signature->extendedAttributes->{"ValuesAllowed"}) {
+    if (!$interface->extendedAttributes->{"UseCPPAPI"} && $signature->type->name eq "any" && !($signature->extendedAttributes->{"NSDictionary"} || $signature->extendedAttributes->{"JSONValue"} || $signature->extendedAttributes->{"NSObject"} || $signature->extendedAttributes->{"Serialization"}) && !$signature->extendedAttributes->{"Optional"} && !$signature->extendedAttributes->{"ValuesAllowed"}) {
         $hasExceptions = 1;
 
         push(@$contents, <<EOF);
@@ -1279,7 +1279,7 @@ EOF
 EOF
     }
 
-    if ($interface->extendedAttributes->{"UseCPPAPI"} && $signature->type->name eq "any" && !($signature->extendedAttributes->{"NSDictionary"} || $signature->extendedAttributes->{"NSObject"} || $signature->extendedAttributes->{"Serialization"}) && !$signature->extendedAttributes->{"Optional"} && !$signature->extendedAttributes->{"ValuesAllowed"}) {
+    if ($interface->extendedAttributes->{"UseCPPAPI"} && $signature->type->name eq "any" && !($signature->extendedAttributes->{"NSDictionary"} || $signature->extendedAttributes->{"JSONValue"} || $signature->extendedAttributes->{"NSObject"} || $signature->extendedAttributes->{"Serialization"}) && !$signature->extendedAttributes->{"Optional"} && !$signature->extendedAttributes->{"ValuesAllowed"}) {
         $hasExceptions = 1;
 
         push(@$contents, <<EOF);
@@ -1428,7 +1428,7 @@ sub _javaScriptTypeCondition
 
     return "isDictionary(context, ${argument}) || JSValueIsString(context, ${argument})${nullOrUndefined}" if $idlTypeName eq "any" && $signature->extendedAttributes->{"NSObject"} && $signature->extendedAttributes->{"DOMString"};
     return "(!JSValueIsNull(context, ${argument}) && !JSValueIsUndefined(context, ${argument}) && !JSObjectIsFunction(context, JSValueToObject(context, ${argument}, nullptr)))${nullOrUndefined}" if $idlTypeName eq "any" && $signature->extendedAttributes->{"Serialization"};
-    return "isDictionary(context, ${argument})${nullOrUndefined}" if $idlTypeName eq "any" && $signature->extendedAttributes->{"NSDictionary"};
+    return "isDictionary(context, ${argument})${nullOrUndefined}" if $idlTypeName eq "any" && ($signature->extendedAttributes->{"NSDictionary"} || $signature->extendedAttributes->{"JSONValue"});
     return "JSValueIsObject(context, ${argument})${nullOrUndefined}" if $idlTypeName eq "any" && $signature->extendedAttributes->{"NSObject"};
     return "JSValueIsObject(context, ${argument})${nullOrUndefined}" if $idlTypeName eq "any" && !$signature->extendedAttributes->{"ValuesAllowed"};
     return "(JSValueIsObject(context, ${argument}) && JSObjectIsFunction(context, JSValueToObject(context, ${argument}, nullptr)))${nullOrUndefined}" if $idlTypeName eq "function";
@@ -1455,6 +1455,7 @@ sub _platformType
     return "Vector<$arrayType>" if $interface->extendedAttributes->{"UseCPPAPI"} && $idlTypeName eq "array" && $arrayType ne "JSValueRef";
     return "Vector<Protected<$arrayType>>" if $interface->extendedAttributes->{"UseCPPAPI"} && $idlTypeName eq "array" && $arrayType eq "JSValueRef";
     return "String" if $idlTypeName eq "any" && $signature->extendedAttributes->{"Serialization"};
+    return "RefPtr<JSON::Value>" if $idlTypeName eq "any" && $signature && $signature->extendedAttributes->{"JSONValue"};
     return "NSDictionary" if $idlTypeName eq "any" && $signature && $signature->extendedAttributes->{"NSDictionary"};
     return "NSObject" if $idlTypeName eq "any" && $signature && $signature->extendedAttributes->{"NSObject"};
     return "JSValue" if !$interface->extendedAttributes->{"UseCPPAPI"} && ($idlTypeName eq "DOMWindow" || $idlTypeName eq "function" || $idlTypeName eq "any");
@@ -1487,6 +1488,9 @@ sub _platformTypeConstructor
         return "toNSDictionary(context, $argumentName, NullValuePolicy::Allowed, ValuePolicy::StopAtTopLevel)" if $signature->extendedAttributes->{"NSDictionary"} && $signature->extendedAttributes->{"NSDictionary"} eq "StopAtTopLevel";
         return "toNSDictionary(context, $argumentName, NullValuePolicy::Allowed)" if $signature->extendedAttributes->{"NSDictionary"} && $signature->extendedAttributes->{"NSDictionary"} eq "NullAllowed";
         return "toNSDictionary(context, $argumentName, NullValuePolicy::NotAllowed)" if $signature->extendedAttributes->{"NSDictionary"};
+        return "toJSONValue(context, $argumentName, NullValuePolicy::Allowed, ValuePolicy::StopAtTopLevel)" if $signature->extendedAttributes->{"JSONValue"} && $signature->extendedAttributes->{"JSONValue"} eq "StopAtTopLevel";
+        return "toJSONValue(context, $argumentName, NullValuePolicy::Allowed)" if $signature->extendedAttributes->{"JSONValue"} && $signature->extendedAttributes->{"JSONValue"} eq "NullAllowed";
+        return "toJSONValue(context, $argumentName, NullValuePolicy::NotAllowed)" if $signature->extendedAttributes->{"JSONValue"};
         return "toNSObject(context, $argumentName, Nil, NullValuePolicy::Allowed, ValuePolicy::StopAtTopLevel)" if $signature->extendedAttributes->{"NSObject"} && $signature->extendedAttributes->{"NSObject"} eq "StopAtTopLevel";
         return "toNSObject(context, $argumentName, Nil, NullValuePolicy::Allowed)" if $signature->extendedAttributes->{"NSObject"} && $signature->extendedAttributes->{"NSObject"} eq "NullAllowed";
         return "toNSObject(context, $argumentName)" if $signature->extendedAttributes->{"NSObject"};
@@ -1544,7 +1548,7 @@ sub _platformTypeVariableDeclaration
         die "DefaultValue extended attribute is currently only supported for numeric types";
     }
 
-    if ($platformType eq "JSValueRef" or $platformType eq "JSObjectRef" or $platformType eq "RefPtr<WebExtensionCallbackHandler>" or $platformType eq "double" or $platformType eq "bool" or $platformType eq "String" or $signature->extendedAttributes->{"Vector"}) {
+    if ($platformType eq "JSValueRef" or $platformType eq "JSObjectRef" or $platformType eq "RefPtr<WebExtensionCallbackHandler>" or $platformType eq "RefPtr<JSON::Value>" or $platformType eq "double" or $platformType eq "bool" or $platformType eq "String" or $signature->extendedAttributes->{"Vector"}) {
         $platformType .= " ";
     } else {
         $platformType .= $isObjCType ? " *" : "* ";

--- a/Source/WebKit/WebProcess/Extensions/Bindings/Scripts/GenerateImports.pl
+++ b/Source/WebKit/WebProcess/Extensions/Bindings/Scripts/GenerateImports.pl
@@ -2,15 +2,24 @@
 use strict;
 use warnings;
 
-die "Usage: $0 output_file import1 import2 ... importN\n" if @ARGV < 2;
+use Getopt::Long;
 
-my $output_file = shift @ARGV;
+my $output_file;
+my $generate_cpp;
+
+die "Usage: $0 --cpp=true --output=output_file -- import1 import2 ... importN\n" if @ARGV < 2;
+
+GetOptions('cpp' => \$generate_cpp,
+           'output=s' => \$output_file);
+
 my @import_files = @ARGV;
 
 open(my $fh, '>', $output_file) or die "Cannot open $output_file: $!";
 
+my $import_macro = $generate_cpp ? "#include" : "#import";
+
 foreach my $file (@import_files) {
-    print $fh "#import \"$file\"\n";
+    print $fh "$import_macro \"$file\"\n";
 }
 
 close($fh);

--- a/Source/WebKit/WebProcess/Extensions/Bindings/Scripts/IDLAttributes.json
+++ b/Source/WebKit/WebProcess/Extensions/Bindings/Scripts/IDLAttributes.json
@@ -112,6 +112,9 @@
         "NSDictionary": {
             "contextsAllowed": ["argument", "attribute", "operation"]
         },
+        "JSONValue": {
+            "contextsAllowed": ["argument", "attribute", "operation"]
+        },
         "NSObject": {
             "contextsAllowed": ["argument", "attribute", "operation"]
         },

--- a/Source/WebKit/WebProcess/Extensions/Cocoa/_WKWebExtensionWebRequestFilter.mm
+++ b/Source/WebKit/WebProcess/Extensions/Cocoa/_WKWebExtensionWebRequestFilter.mm
@@ -38,7 +38,7 @@
 #import "WebExtensionTabIdentifier.h"
 #import "WebExtensionUtilities.h"
 #import "WebExtensionWindowIdentifier.h"
-#import "WebProcess/Extensions/API/Cocoa/WebExtensionAPIKeys.h"
+#import "WebProcess/Extensions/API/WebExtensionAPIKeys.h"
 #import "_WKResourceLoadInfo.h"
 #import <wtf/text/MakeString.h>
 

--- a/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIAlarms.idl
+++ b/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIAlarms.idl
@@ -27,9 +27,9 @@
     Conditional=WK_WEB_EXTENSIONS,
     MainWorldOnly,
     ReturnsPromiseWhenCallbackIsOmitted,
+    UseCPPAPI
 ] interface WebExtensionAPIAlarms {
-
-    [RaisesException, ImplementedAs=createAlarm] void create([Optional] DOMString name, [NSDictionary] any info);
+    [RaisesStringException, ImplementedAs=createAlarm] void create([Optional] DOMString name, [JSONValue] any info);
 
     void get([Optional] DOMString name, [Optional, CallbackHandler] function callback);
     void getAll([Optional, CallbackHandler] function callback);


### PR DESCRIPTION
#### 40fe2aa4f091b0ebe6e1a3cd69e38b9a374f92ff
<pre>
Port WebExtensionAPIAlarms to C++
<a href="https://bugs.webkit.org/show_bug.cgi?id=319792">https://bugs.webkit.org/show_bug.cgi?id=319792</a>

Reviewed by Timothy Hatcher.

Following up the work performed for WebExtensionAPITest, this ports the Alarms
API code to C++. Also creates a unified C++ build of the derived JavaScript APIs
for C++.

* Source/WebKit/CMakeLists.txt:
* Source/WebKit/DerivedSources-output.xcfilelist:
* Source/WebKit/DerivedSources.make:
* Source/WebKit/Shared/Extensions/WebExtensionUtilities.cpp:
(WebKit::classToClassString):
(WebKit::valueToTypeString):
(WebKit::constructExpectedMessage):
(WebKit::validate):
(WebKit::formatList):
(WebKit::validateDictionary):
* Source/WebKit/Shared/Extensions/WebExtensionUtilities.h:
(WebKit::toWebAPI):
* Source/WebKit/Sources.txt:
* Source/WebKit/SourcesCocoa.txt:
* Source/WebKit/UIProcess/Extensions/API/WebExtensionContextAPIAlarms.cpp: Renamed from Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIAlarmsCocoa.mm.
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIAlarms.cpp: Renamed from Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIAlarmsCocoa.mm.
(WebKit::toWebAPI):
(WebKit::WebExtensionAPIAlarms::createAlarm):
(WebKit::WebExtensionAPIAlarms::get):
(WebKit::WebExtensionAPIAlarms::getAll):
(WebKit::WebExtensionAPIAlarms::clear):
(WebKit::WebExtensionContextProxy::dispatchAlarmsEvent):
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIAlarms.h:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIEvent.h:
(WebKit::WebExtensionAPIEvent::invokeListenersWithParametersArgument):
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIKeys.h: Renamed from Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIKeys.h.
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPINamespace.h:
* Source/WebKit/WebProcess/Extensions/Bindings/JSWebExtensionWrapper.cpp:
(WebKit::toJSONArray):
(WebKit::fromJSValue):
(WebKit::toJSONValue):
* Source/WebKit/WebProcess/Extensions/Bindings/JSWebExtensionWrapper.h:
* Source/WebKit/WebProcess/Extensions/Bindings/Scripts/CodeGeneratorExtensions.pm:
(_hasAutomaticExceptions):
(_installArgumentTypeExceptions):
(_installAutomaticExceptions):
(_javaScriptTypeCondition):
(_platformType):
(_platformTypeConstructor):
(_platformTypeVariableDeclaration):
* Source/WebKit/WebProcess/Extensions/Bindings/Scripts/GenerateImports.pl:
* Source/WebKit/WebProcess/Extensions/Bindings/Scripts/IDLAttributes.json:
* Source/WebKit/WebProcess/Extensions/Cocoa/_WKWebExtensionWebRequestFilter.mm:
* Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIAlarms.idl:
* Source/WebKit/Shared/Cocoa/InteractionInformationAtPosition.h:

Canonical link: <a href="https://commits.webkit.org/318390@main">https://commits.webkit.org/318390@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/40abc3f6d1e17aa7e3c0936ece5435eaebd911a7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178178 "Passed style check") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52116 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45911 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187792 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/141425 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/180041 "Build is in progress. Recent messages:") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53410 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51825 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138894 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/141425 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181135 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42452 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159656 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119350 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41118 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39470 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151518 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39152 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36249 "Built successfully") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/39451 "Build is in progress. Recent messages:") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44716 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43713 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190219 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51784 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148046 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/39757 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52466 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35777 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147816 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27021 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42532 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124730 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/119276 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50984 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14128 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50369 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50609 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50431 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->