### PR TITLE
[JSC] Wire ARM64 min / max specialized thunks into `thunkGeneratorForIntrinsic`

### DIFF
--- a/JSTests/microbenchmarks/math-max-3args.js
+++ b/JSTests/microbenchmarks/math-max-3args.js
@@ -1,0 +1,12 @@
+function max3(a, b, c)
+{
+    return Math.max(a, b, c);
+}
+noInline(max3);
+
+for (var i = 0; i < 1e6; ++i) {
+    max3(5, 5, 3);
+    max3(5, 400.2, 1);
+    max3(400.2, 5, 2.5);
+    max3(24.3, 400.2, 8);
+}

--- a/JSTests/microbenchmarks/math-min.js
+++ b/JSTests/microbenchmarks/math-min.js
@@ -1,0 +1,12 @@
+function min(a, b)
+{
+    return Math.min(a, b);
+}
+noInline(min);
+
+for (var i = 0; i < 1e6; ++i) {
+    min(5, 5);
+    min(5, 400.2);
+    min(400.2, 5);
+    min(24.3, 400.2);
+}

--- a/Source/JavaScriptCore/runtime/VM.cpp
+++ b/Source/JavaScriptCore/runtime/VM.cpp
@@ -803,6 +803,12 @@ static ThunkGenerator NODELETE thunkGeneratorForIntrinsic(Intrinsic intrinsic)
         return logThunkGenerator;
     case IMulIntrinsic:
         return imulThunkGenerator;
+#if CPU(ARM64)
+    case MaxIntrinsic:
+        return maxThunkGenerator;
+    case MinIntrinsic:
+        return minThunkGenerator;
+#endif
     case RandomIntrinsic:
         return randomThunkGenerator;
 #if USE(JSVALUE64)


### PR DESCRIPTION
#### a6f9b723771ef40d176aaae2cd3f3e3f99e9750c
<pre>
[JSC] Wire ARM64 min / max specialized thunks into `thunkGeneratorForIntrinsic`
<a href="https://bugs.webkit.org/show_bug.cgi?id=319795">https://bugs.webkit.org/show_bug.cgi?id=319795</a>

Reviewed by Yusuke Suzuki.

281118@main added maxThunkGenerator / minThunkGenerator for ARM64, which have fast paths for
Int32-Int32 / Int32-Double / Double-Int32 / Double-Double using fmax / fmin, but did not
add cases for MaxIntrinsic / MinIntrinsic in thunkGeneratorForIntrinsic. So the thunks were
never installed and Math.max / Math.min calls from LLInt / Baseline always went to the C++
host functions. This patch wires them up.

With DFG / FTL disabled (LLInt / Baseline):

                                              Baseline                  Patched

    math-max                              31.9392+-0.6313     ^     23.8925+-0.2638        ^ definitely 1.3368x faster
    math-min                              31.7652+-0.3611     ^     23.8972+-0.1425        ^ definitely 1.3292x faster
    int-or-other-max-then-get-by-val       6.4980+-0.0923     ^      5.3080+-0.1749        ^ definitely 1.2242x faster
    int-or-other-min-then-get-by-val       6.4999+-0.0749     ^      5.2814+-0.0590        ^ definitely 1.2307x faster

Neutral in the default configuration since DFG / FTL handle ArithMin / ArithMax by themselves.

Tests: JSTests/microbenchmarks/math-max-3args.js
       JSTests/microbenchmarks/math-min.js

* JSTests/microbenchmarks/math-max-3args.js: Added.
(max3):
* JSTests/microbenchmarks/math-min.js: Added.
(min):
* Source/JavaScriptCore/runtime/VM.cpp:
(JSC::thunkGeneratorForIntrinsic):

Canonical link: <a href="https://commits.webkit.org/317568@main">https://commits.webkit.org/317568@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e8b8ffd24ea28d5ed6f47c1d856b31b0425c1b3e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175542 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49474 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43255 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185128 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/137696 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50766 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49157 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136683 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/137696 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178499 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40106 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157444 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117161 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38747 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37133 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/5953 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149169 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36937 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33603 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/36803 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41162 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41336 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187553 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49141 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145652 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39221 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49821 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33561 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145489 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40310 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122014 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115787 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48328 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11913 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47730 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47960 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47787 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->