### PR TITLE
[JSC] Inline `ArrayBuffer.isView` in DFG/FTL by extending `IsCellWithType` to a JSType range

### DIFF
--- a/JSTests/microbenchmarks/array-buffer-is-view.js
+++ b/JSTests/microbenchmarks/array-buffer-is-view.js
@@ -1,0 +1,27 @@
+function isView(value)
+{
+    return ArrayBuffer.isView(value);
+}
+noInline(isView);
+
+let buffer = new ArrayBuffer(64);
+let values = [
+    [ new Int32Array(buffer), true ],
+    [ new Uint8Array(4), true ],
+    [ new Float64Array(2), true ],
+    [ new DataView(buffer), true ],
+    [ buffer, false ],
+    [ [], false ],
+    [ {}, false ],
+    [ 42, false ],
+    [ "text", false ],
+    [ null, false ],
+    [ undefined, false ],
+];
+
+for (var i = 0; i < 1e6; ++i) {
+    for (let pair of values) {
+        if (isView(pair[0]) != pair[1])
+            throw new Error(`bad value: ${String(pair[0])}`);
+    }
+}

--- a/JSTests/stress/array-buffer-is-view.js
+++ b/JSTests/stress/array-buffer-is-view.js
@@ -1,0 +1,84 @@
+function shouldBe(actual, expected)
+{
+    if (actual !== expected)
+        throw new Error(`bad value: ${String(actual)}, expected: ${String(expected)}`);
+}
+
+function isView(value)
+{
+    return ArrayBuffer.isView(value);
+}
+noInline(isView);
+
+let buffer = new ArrayBuffer(16);
+let otherGlobalObject = createGlobalObject();
+class DerivedUint8Array extends Uint8Array { }
+class DerivedDataView extends DataView { }
+
+let cases = [
+    [ new Int8Array(1), true ],
+    [ new Uint8Array(1), true ],
+    [ new Uint8ClampedArray(1), true ],
+    [ new Int16Array(1), true ],
+    [ new Uint16Array(1), true ],
+    [ new Int32Array(1), true ],
+    [ new Uint32Array(1), true ],
+    [ new Float16Array(1), true ],
+    [ new Float32Array(1), true ],
+    [ new Float64Array(1), true ],
+    [ new BigInt64Array(1), true ],
+    [ new BigUint64Array(1), true ],
+    [ new DataView(buffer), true ],
+    [ new DerivedUint8Array(1), true ],
+    [ new DerivedDataView(buffer), true ],
+    [ new otherGlobalObject.Uint8Array(1), true ],
+    [ new otherGlobalObject.DataView(new otherGlobalObject.ArrayBuffer(8)), true ],
+    [ new Proxy(new Uint8Array(1), {}), false ],
+    [ buffer, false ],
+    [ new SharedArrayBuffer(8), false ],
+    [ [], false ],
+    [ {}, false ],
+    [ { buffer, byteLength: 16, byteOffset: 0 }, false ],
+    [ 42, false ],
+    [ 4.2, false ],
+    [ "text", false ],
+    [ Symbol("symbol"), false ],
+    [ 42n, false ],
+    [ true, false ],
+    [ null, false ],
+    [ undefined, false ],
+];
+
+let detached = new Uint8Array(4);
+transferArrayBuffer(detached.buffer);
+cases.push([ detached, true ]);
+
+for (let i = 0; i < 1e4; ++i) {
+    for (let pair of cases)
+        shouldBe(isView(pair[0]), pair[1]);
+    shouldBe(isView(), false);
+}
+
+function isViewOfTypedArray()
+{
+    return ArrayBuffer.isView(new Uint8Array(1));
+}
+noInline(isViewOfTypedArray);
+
+function isViewOfDataView()
+{
+    return ArrayBuffer.isView(new DataView(new ArrayBuffer(4)));
+}
+noInline(isViewOfDataView);
+
+function isViewOfArrayBuffer()
+{
+    return ArrayBuffer.isView(new ArrayBuffer(4));
+}
+noInline(isViewOfArrayBuffer);
+
+for (let i = 0; i < 1e4; ++i) {
+    shouldBe(isViewOfTypedArray(), true);
+    shouldBe(isViewOfDataView(), true);
+    shouldBe(isViewOfArrayBuffer(), false);
+}

--- a/Source/JavaScriptCore/builtins/BuiltinNames.h
+++ b/Source/JavaScriptCore/builtins/BuiltinNames.h
@@ -53,7 +53,6 @@ namespace JSC {
     macro(callFunction) \
     macro(charCodeAt) \
     macro(executor) \
-    macro(isView) \
     macro(iteratedObject) \
     macro(iteratedString) \
     macro(promise) \

--- a/Source/JavaScriptCore/bytecode/SpeculatedType.cpp
+++ b/Source/JavaScriptCore/bytecode/SpeculatedType.cpp
@@ -734,9 +734,26 @@ std::optional<SpeculatedType> speculationFromJSType(JSType type)
         return SpecMapIteratorObject;
     case JSSetIteratorType:
         return SpecSetIteratorObject;
+#define JSC_DEFINE_TYPED_ARRAY_SPECULATION(type) \
+    case type##ArrayType: \
+        return Spec##type##Array;
+    FOR_EACH_TYPED_ARRAY_TYPE_EXCLUDING_DATA_VIEW(JSC_DEFINE_TYPED_ARRAY_SPECULATION)
+#undef JSC_DEFINE_TYPED_ARRAY_SPECULATION
     default:
         return std::nullopt;
     }
+}
+
+std::optional<SpeculatedType> speculationFromJSTypeRange(JSTypeRange range)
+{
+    SpeculatedType result = SpecNone;
+    for (unsigned type = range.first; type <= range.last; ++type) {
+        std::optional<SpeculatedType> speculatedType = speculationFromJSType(static_cast<JSType>(type));
+        if (!speculatedType)
+            return std::nullopt;
+        result |= speculatedType.value();
+    }
+    return result;
 }
 
 SpeculatedType leastUpperBoundOfStrictlyEquivalentSpeculations(SpeculatedType type)

--- a/Source/JavaScriptCore/bytecode/SpeculatedType.h
+++ b/Source/JavaScriptCore/bytecode/SpeculatedType.h
@@ -29,6 +29,7 @@
 #pragma once
 
 #include <JavaScriptCore/CPU.h>
+#include <JavaScriptCore/JSType.h>
 #include <wtf/Forward.h>
 
 namespace JSC {
@@ -40,7 +41,6 @@ class Structure;
 struct ClassInfo;
 
 using IndexingType = uint8_t;
-enum JSType : uint8_t;
 enum TypedArrayType : uint8_t;
 
 typedef uint64_t SpeculatedType;
@@ -568,6 +568,7 @@ SpeculatedType NODELETE speculationFromValue(JSValue);
 // Otherwise, it'll return types from the JSValue lattice.
 JS_EXPORT_PRIVATE SpeculatedType NODELETE int52AwareSpeculationFromValue(JSValue);
 std::optional<SpeculatedType> NODELETE speculationFromJSType(JSType);
+std::optional<SpeculatedType> NODELETE speculationFromJSTypeRange(JSTypeRange);
 
 SpeculatedType NODELETE speculationFromTypedArrayType(TypedArrayType); // only valid for typed views.
 TypedArrayType NODELETE typedArrayTypeFromSpeculation(SpeculatedType);

--- a/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
@@ -1768,14 +1768,13 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
     case IsObject:
     case IsCallable:
     case IsConstructor:
-    case IsCellWithType:
-    case IsTypedArrayView: {
+    case IsCellWithType: {
         AbstractValue& child = forNode(node->child1());
         if (child.value()) {
             bool constantWasSet = true;
             switch (node->op()) {
             case IsCellWithType:
-                setConstant(node, jsBoolean(child.value().isCell() && child.value().asCell()->type() == node->queriedType()));
+                setConstant(node, jsBoolean(child.value().isCell() && node->queriedType().contains(child.value().asCell()->type())));
                 break;
             case TypeOfIsUndefined:
                 setConstant(node, jsBoolean(
@@ -1836,9 +1835,6 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
             case IsEmpty:
                 setConstant(node, jsBoolean(child.value().isEmpty()));
                 break;
-            case IsTypedArrayView:
-                setConstant(node, jsBoolean(child.value().isObject() && isTypedView(child.value().getObject()->type())));
-                break;
             default:
                 constantWasSet = false;
                 break;
@@ -1856,7 +1852,7 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
                     std::optional<bool> result;
                     child.m_structure.forEach(
                         [&] (RegisteredStructure structure) {
-                            bool matched = structure->typeInfo().type() == node->queriedType();
+                            bool matched = node->queriedType().contains(structure->typeInfo().type());
                             if (!result)
                                 result = matched;
                             else {
@@ -2069,19 +2065,6 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
             }
             break;
         }
-
-        case IsTypedArrayView:
-            if (!(child.m_type & ~SpecTypedArrayView)) {
-                setConstant(node, jsBoolean(true));
-                constantWasSet = true;
-                break;
-            }
-            if (!(child.m_type & SpecTypedArrayView)) {
-                setConstant(node, jsBoolean(false));
-                constantWasSet = true;
-                break;
-            }
-            break;
 
         default:
             break;

--- a/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
+++ b/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
@@ -3199,7 +3199,7 @@ auto ByteCodeParser::handleIntrinsicCall(Node* callee, Operand resultOperand, Ca
                 return CallOptimizationResult::DidNothing;
 
             insertChecks();
-            setResult(addToGraph(IsCellWithType, OpInfo(ErrorInstanceType), get(virtualRegisterForArgumentIncludingThis(1, registerOffset))));
+            setResult(addToGraph(IsCellWithType, OpInfo(JSTypeRange { ErrorInstanceType, ErrorInstanceType }), get(virtualRegisterForArgumentIncludingThis(1, registerOffset))));
             return CallOptimizationResult::Inlined;
         }
 
@@ -4056,7 +4056,16 @@ auto ByteCodeParser::handleIntrinsicCall(Node* callee, Operand resultOperand, Ca
             ASSERT(argumentCountIncludingThis == 2);
 
             insertChecks();
-            setResult(addToGraph(IsTypedArrayView, OpInfo(prediction), get(virtualRegisterForArgumentIncludingThis(1, registerOffset))));
+            setResult(addToGraph(IsCellWithType, OpInfo(JSTypeRange { static_cast<JSType>(FirstTypedArrayType), static_cast<JSType>(LastTypedArrayTypeExcludingDataView) }), get(virtualRegisterForArgumentIncludingThis(1, registerOffset))));
+            return CallOptimizationResult::Inlined;
+        }
+
+        case ArrayBufferIsViewIntrinsic: {
+            if (argumentCountIncludingThis < 2)
+                return CallOptimizationResult::DidNothing;
+
+            insertChecks();
+            setResult(addToGraph(IsCellWithType, OpInfo(JSTypeRange { static_cast<JSType>(FirstTypedArrayType), static_cast<JSType>(LastTypedArrayType) }), get(virtualRegisterForArgumentIncludingThis(1, registerOffset))));
             return CallOptimizationResult::Inlined;
         }
 
@@ -8797,7 +8806,7 @@ void ByteCodeParser::parseBlock(unsigned limit)
         case op_is_cell_with_type: {
             auto bytecode = currentInstruction->as<OpIsCellWithType>();
             Node* value = get(bytecode.m_operand);
-            set(bytecode.m_dst, addToGraph(IsCellWithType, OpInfo(bytecode.m_type), value));
+            set(bytecode.m_dst, addToGraph(IsCellWithType, OpInfo(JSTypeRange { bytecode.m_type, bytecode.m_type }), value));
             NEXT_OPCODE(op_is_cell_with_type);
         }
 
@@ -11650,7 +11659,7 @@ void ByteCodeParser::handleIteratorOpen(const JSInstruction* currentInstruction,
             failedBlock = allocateUntargetableBlock();
 
             Node* isKnownIterFunction = addToGraph(CompareEqPtr, OpInfo(frozenSymbolIteratorFunction), get(bytecode.m_symbolIterator));
-            Node* isArray = addToGraph(IsCellWithType, OpInfo(ArrayType), get(bytecode.m_iterable));
+            Node* isArray = addToGraph(IsCellWithType, OpInfo(JSTypeRange { ArrayType, ArrayType }), get(bytecode.m_iterable));
 
             BranchData* branchData = m_graph.m_branchData.add();
             branchData->taken = BranchTarget(fastArrayBlock);

--- a/Source/JavaScriptCore/dfg/DFGClobberize.h
+++ b/Source/JavaScriptCore/dfg/DFGClobberize.h
@@ -255,7 +255,6 @@ void clobberize(Graph& graph, Node* node, const ReadFunctor& read, const WriteFu
     case IsBigInt:
     case NumberIsInteger:
     case IsObject:
-    case IsTypedArrayView:
     case CheckInBounds:
     case CheckInBoundsInt52:
     case DoubleRep:
@@ -362,7 +361,7 @@ void clobberize(Graph& graph, Node* node, const ReadFunctor& read, const WriteFu
         return;
 
     case IsCellWithType:
-        def(PureValue(node, node->queriedType()));
+        def(PureValue(node, node->queriedType().rawValue()));
         return;
 
     case ValueBitNot:

--- a/Source/JavaScriptCore/dfg/DFGDoesGC.cpp
+++ b/Source/JavaScriptCore/dfg/DFGDoesGC.cpp
@@ -148,7 +148,6 @@ bool doesGC(Graph& graph, Node* node)
     case IsCallable:
     case IsConstructor:
     case IsCellWithType:
-    case IsTypedArrayView:
     case TypeOf:
     case ToBoolean:
     case LogicalNot:

--- a/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
@@ -3812,7 +3812,6 @@ private:
         case NewSet:
         case NewWeakMap:
         case NewWeakSet:
-        case IsTypedArrayView:
         case IsEmpty:
         case TypeOfIsUndefined:
         case TypeOfIsObject:

--- a/Source/JavaScriptCore/dfg/DFGGraph.cpp
+++ b/Source/JavaScriptCore/dfg/DFGGraph.cpp
@@ -309,8 +309,13 @@ void Graph::dump(PrintStream& out, const char* prefixStr, Node* node, DumpContex
             }
         }
     }
-    if (node->hasQueriedType())
-        out.print(comma, node->queriedType());
+    if (node->hasQueriedType()) {
+        JSTypeRange range = node->queriedType();
+        if (range.first == range.last)
+            out.print(comma, range.first);
+        else
+            out.print(comma, range.first, "..."_s, range.last);
+    }
     if (node->hasStructureFlags())
         out.print(comma, node->structureFlags());
     if (node->hasStorageAccessData()) {

--- a/Source/JavaScriptCore/dfg/DFGNode.h
+++ b/Source/JavaScriptCore/dfg/DFGNode.h
@@ -1718,10 +1718,11 @@ public:
         return op() == IsCellWithType;
     }
 
-    JSType queriedType()
+    JSTypeRange queriedType()
     {
+        ASSERT(hasQueriedType());
         static_assert(std::same_as<uint8_t, std::underlying_type_t<JSType>>);
-        return static_cast<JSType>(m_opInfo.as<uint32_t>());
+        return JSTypeRange::fromRawValue(m_opInfo.as<uint32_t>());
     }
 
     bool hasSpeculatedTypeForQuery()
@@ -1731,7 +1732,7 @@ public:
 
     std::optional<SpeculatedType> speculatedTypeForQuery()
     {
-        return speculationFromJSType(queriedType());
+        return speculationFromJSTypeRange(queriedType());
     }
 
     bool hasStructureFlags()

--- a/Source/JavaScriptCore/dfg/DFGNodeType.h
+++ b/Source/JavaScriptCore/dfg/DFGNodeType.h
@@ -503,7 +503,6 @@ namespace JSC { namespace DFG {
     macro(IsObject, NodeResultBoolean) \
     macro(IsCallable, NodeResultBoolean) \
     macro(IsConstructor, NodeResultBoolean) \
-    macro(IsTypedArrayView, NodeResultBoolean) \
     macro(TypeOf, NodeResultJS) \
     macro(ToBoolean, NodeResultBoolean) \
     macro(LogicalNot, NodeResultBoolean) \

--- a/Source/JavaScriptCore/dfg/DFGOpInfo.h
+++ b/Source/JavaScriptCore/dfg/DFGOpInfo.h
@@ -28,6 +28,7 @@
 #include "CacheableIdentifier.h"
 #include "DFGRegisteredStructure.h"
 #include "HeapCell.h"
+#include "JSType.h"
 #include "Operands.h"
 #include "PrivateFieldPutKind.h"
 #include <JavaScriptCore/ECMAMode.h>
@@ -55,6 +56,8 @@ struct OpInfo {
     explicit OpInfo(Operand op) : m_value(op.asBits()) { }
     explicit OpInfo(CacheableIdentifier identifier) : m_value(static_cast<uint64_t>(identifier.rawBits())) { }
     explicit OpInfo(ECMAMode ecmaMode) : m_value(ecmaMode.value()) { }
+    explicit OpInfo(JSTypeRange range)
+        : m_value(range.rawValue()) { }
     explicit OpInfo(PrivateFieldPutKind putKind) : m_value(putKind.value()) { }
     template<typename EnumType>
     explicit OpInfo(OptionSet<EnumType> optionSet) : m_value(optionSet.toRaw()) { }

--- a/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
@@ -1324,7 +1324,6 @@ private:
         case IsCallable:
         case IsConstructor:
         case IsCellWithType:
-        case IsTypedArrayView:
         case ArrayIsArray:
         case HasStructureWithFlags:
         case MatchStructure: {

--- a/Source/JavaScriptCore/dfg/DFGSafeToExecute.h
+++ b/Source/JavaScriptCore/dfg/DFGSafeToExecute.h
@@ -280,7 +280,6 @@ bool safeToExecute(AbstractStateType& state, Graph& graph, Node* node, bool igno
     case IsCallable:
     case IsConstructor:
     case IsCellWithType:
-    case IsTypedArrayView:
     case ArrayIsArray:
     case HasStructureWithFlags:
     case TypeOf:

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -5112,6 +5112,24 @@ void SpeculativeJIT::compileInstanceOfCustom(Node* node)
 
 void SpeculativeJIT::compileIsCellWithType(Node* node)
 {
+    JSTypeRange range = node->queriedType();
+    auto compareType = [&](GPRReg cellGPR, GPRReg resultGPR) {
+        if (range.first == range.last) {
+            compare8(Equal,
+                Address(cellGPR, JSCell::typeInfoTypeOffset()),
+                TrustedImm32(range.first),
+                resultGPR);
+            return;
+        }
+
+        load8(Address(cellGPR, JSCell::typeInfoTypeOffset()), resultGPR);
+        sub32(TrustedImm32(range.first), resultGPR);
+        compare32(BelowOrEqual,
+            resultGPR,
+            TrustedImm32(range.last - range.first),
+            resultGPR);
+    };
+
     switch (node->child1().useKind()) {
     case UntypedUse: {
         JSValueOperand value(this, node->child1());
@@ -5122,10 +5140,7 @@ void SpeculativeJIT::compileIsCellWithType(Node* node)
 
         Jump isNotCell = branchIfNotCell(valueRegs);
 
-        compare8(Equal,
-            Address(valueRegs.payloadGPR(), JSCell::typeInfoTypeOffset()),
-            TrustedImm32(node->queriedType()),
-            resultGPR);
+        compareType(valueRegs.payloadGPR(), resultGPR);
         blessBoolean(resultGPR);
         Jump done = jump();
 
@@ -5144,10 +5159,7 @@ void SpeculativeJIT::compileIsCellWithType(Node* node)
         GPRReg cellGPR = cell.gpr();
         GPRReg resultGPR = result.gpr();
 
-        compare8(Equal,
-            Address(cellGPR, JSCell::typeInfoTypeOffset()),
-            TrustedImm32(node->queriedType()),
-            resultGPR);
+        compareType(cellGPR, resultGPR);
         blessBoolean(resultGPR);
         blessedBooleanResult(resultGPR, node);
         return;
@@ -5157,32 +5169,6 @@ void SpeculativeJIT::compileIsCellWithType(Node* node)
         RELEASE_ASSERT_NOT_REACHED();
         break;
     }
-}
-
-void SpeculativeJIT::compileIsTypedArrayView(Node* node)
-{
-    JSValueOperand value(this, node->child1());
-    GPRTemporary result(this, Reuse, value, PayloadWord);
-
-    JSValueRegs valueRegs = value.jsValueRegs();
-    GPRReg resultGPR = result.gpr();
-
-    Jump isNotCell = branchIfNotCell(valueRegs);
-
-    load8(Address(valueRegs.payloadGPR(), JSCell::typeInfoTypeOffset()), resultGPR);
-    sub32(TrustedImm32(FirstTypedArrayType), resultGPR);
-    compare32(Below,
-        resultGPR,
-        TrustedImm32(NumberOfTypedArrayTypesExcludingDataView),
-        resultGPR);
-    blessBoolean(resultGPR);
-    Jump done = jump();
-
-    isNotCell.link(this);
-    moveFalseTo(resultGPR);
-
-    done.link(this);
-    blessedBooleanResult(resultGPR, node);
 }
 
 void SpeculativeJIT::compileArrayIsArray(Node* node)

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
@@ -756,7 +756,6 @@ public:
     void compileOverridesHasInstance(Node*);
 
     void compileIsCellWithType(Node*);
-    void compileIsTypedArrayView(Node*);
     void compileArrayIsArray(Node*);
 
     void emitCall(Node*);

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
@@ -3983,11 +3983,6 @@ void SpeculativeJIT::compile(Node* node)
         break;
     }
 
-    case IsTypedArrayView: {
-        compileIsTypedArrayView(node);
-        break;
-    }
-
     case ArrayIsArray: {
         compileArrayIsArray(node);
         break;

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
@@ -5897,11 +5897,6 @@ void SpeculativeJIT::compile(Node* node)
         break;
     }
 
-    case IsTypedArrayView: {
-        compileIsTypedArrayView(node);
-        break;
-    }
-
     case ArrayIsArray: {
         compileArrayIsArray(node);
         break;

--- a/Source/JavaScriptCore/ftl/FTLCapabilities.cpp
+++ b/Source/JavaScriptCore/ftl/FTLCapabilities.cpp
@@ -332,7 +332,6 @@ inline CapabilityLevel canCompile(DFG::Node* node)
     case IsObject:
     case IsCallable:
     case IsConstructor:
-    case IsTypedArrayView:
     case ArrayIsArray:
     case CheckTypeInfoFlags:
     case HasStructureWithFlags:

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -1744,9 +1744,6 @@ private:
         case IsConstructor:
             compileIsConstructor();
             break;
-        case IsTypedArrayView:
-            compileIsTypedArrayView();
-            break;
         case ParseInt:
             compileParseInt();
             break;
@@ -17162,24 +17159,6 @@ IGNORE_CLANG_WARNINGS_END
         JSGlobalObject* globalObject = m_graph.globalObjectFor(m_origin.semantic);
         LValue value = lowJSValue(m_node->child1());
         setBoolean(vmCall(Int32, operationIsConstructor, weakPointer(globalObject), value));
-    }
-
-    void compileIsTypedArrayView()
-    {
-        LValue value = lowJSValue(m_node->child1());
-
-        LBasicBlock isCellCase = m_out.newBlock();
-        LBasicBlock continuation = m_out.newBlock();
-
-        ValueFromBlock notCellResult = m_out.anchor(m_out.booleanFalse);
-        m_out.branch(isCell(value, provenType(m_node->child1())), unsure(isCellCase), unsure(continuation));
-
-        LBasicBlock lastNext = m_out.appendTo(isCellCase, continuation);
-        ValueFromBlock cellResult = m_out.anchor(isTypedArrayView(value, provenType(m_node->child1())));
-        m_out.jump(continuation);
-
-        m_out.appendTo(continuation, lastNext);
-        setBoolean(m_out.phi(Int32, notCellResult, cellResult));
     }
 
     void compileTypeOf()

--- a/Source/JavaScriptCore/runtime/Intrinsic.h
+++ b/Source/JavaScriptCore/runtime/Intrinsic.h
@@ -168,6 +168,7 @@ namespace JSC {
     macro(TypedArrayKeysIntrinsic) \
     macro(TypedArrayEntriesIntrinsic) \
     macro(IsTypedArrayViewIntrinsic) \
+    macro(ArrayBufferIsViewIntrinsic) \
     macro(BoundFunctionCallIntrinsic) \
     macro(RemoteFunctionCallIntrinsic) \
     macro(IteratorIntrinsic) \

--- a/Source/JavaScriptCore/runtime/JSArrayBufferConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/JSArrayBufferConstructor.cpp
@@ -26,7 +26,6 @@
 #include "config.h"
 #include "JSArrayBufferConstructor.h"
 
-#include "BuiltinNames.h"
 #include "JSArrayBuffer.h"
 #include "JSArrayBufferPrototype.h"
 #include "JSArrayBufferView.h"
@@ -66,10 +65,8 @@ void JSGenericArrayBufferConstructor<sharingMode>::finishCreation(VM& vm, JSArra
     JSGlobalObject* globalObject = this->globalObject();
     putDirectNonIndexAccessorWithoutTransition(vm, vm.propertyNames->speciesSymbol, globalObject->arrayBufferSpeciesGetterSetter(sharingMode), PropertyAttribute::Accessor | PropertyAttribute::ReadOnly | PropertyAttribute::DontEnum);
 
-    if (sharingMode == ArrayBufferSharingMode::Default) {
-        JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->isView, arrayBufferFuncIsView, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Public);
-        JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().isViewPrivateName(), arrayBufferFuncIsView, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Public);
-    }
+    if (sharingMode == ArrayBufferSharingMode::Default)
+        JSC_NATIVE_INTRINSIC_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->isView, arrayBufferFuncIsView, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Public, ArrayBufferIsViewIntrinsic);
 }
 
 template<ArrayBufferSharingMode sharingMode>

--- a/Source/JavaScriptCore/runtime/JSCast.h
+++ b/Source/JavaScriptCore/runtime/JSCast.h
@@ -30,14 +30,6 @@
 
 namespace JSC {
 
-// The first and last JSType are inclusive
-struct JSTypeRange {
-    bool contains(JSType type) const { return first <= type && type <= last; }
-
-    JSType first;
-    JSType last;
-};
-
 // Specific type overloads.
 
 template<typename>

--- a/Source/JavaScriptCore/runtime/JSType.h
+++ b/Source/JavaScriptCore/runtime/JSType.h
@@ -170,6 +170,17 @@ enum JSType : uint8_t {
     MaxJSType = 0b11111111,
 };
 
+// The first and last JSType are inclusive
+struct JSTypeRange {
+    static constexpr JSTypeRange fromRawValue(uint16_t value) { return JSTypeRange { static_cast<JSType>(value & 0xff), static_cast<JSType>(value >> 8) }; }
+
+    bool contains(JSType type) const { return first <= type && type <= last; }
+    constexpr uint16_t rawValue() const { return static_cast<uint16_t>(first) | (static_cast<uint16_t>(last) << 8); }
+
+    JSType first;
+    JSType last;
+};
+
 static constexpr uint8_t EmbedderArrayLikeType = 0b11101101;
 
 static constexpr uint32_t LastValueCompareCellType = HeapBigIntType;


### PR DESCRIPTION
#### a88a607d357e17b158c318100fac93ce2407c2b1
<pre>
[JSC] Inline `ArrayBuffer.isView` in DFG/FTL by extending `IsCellWithType` to a JSType range
<a href="https://bugs.webkit.org/show_bug.cgi?id=319796">https://bugs.webkit.org/show_bug.cgi?id=319796</a>

Reviewed by Yusuke Suzuki.

ArrayBuffer.isView had no intrinsic, so DFG/FTL emitted a host function call
for it.

This patch adds ArrayBufferIsViewIntrinsic and inlines it as IsCellWithType,
which now takes a JSTypeRange instead of a single JSType. ArrayBuffer.isView
is IsCellWithType[Int8ArrayType, DataViewType] and @isTypedArrayView is
IsCellWithType[Int8ArrayType, BigUint64ArrayType], so the IsTypedArrayView
node is removed and both get the folding, CSE and CellUse fixup that
IsCellWithType already had. speculationFromJSTypeRange unions the range so
that the type based folding still applies.

@isView, the private name alias of ArrayBuffer.isView, has no user and is
removed.

                               Baseline                  Patched

    array-buffer-is-view   48.8141+-0.8753     ^     32.3578+-0.2090        ^ definitely 1.5086x faster

Tests: JSTests/microbenchmarks/array-buffer-is-view.js
       JSTests/stress/array-buffer-is-view.js

* JSTests/microbenchmarks/array-buffer-is-view.js: Added.
(isView):
* JSTests/stress/array-buffer-is-view.js: Added.
(shouldBe):
(DerivedUint8Array):
(DerivedDataView):
(new.Proxy.new.Uint8Array):
(isViewOfTypedArray):
(isViewOfDataView):
(isViewOfArrayBuffer):
* Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h:
(JSC::DFG::AbstractInterpreter&lt;AbstractStateType&gt;::executeEffects):
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::handleIntrinsicCall):
* Source/JavaScriptCore/dfg/DFGClobberize.h:
(JSC::DFG::clobberize):
* Source/JavaScriptCore/dfg/DFGDoesGC.cpp:
(JSC::DFG::doesGC):
* Source/JavaScriptCore/dfg/DFGFixupPhase.cpp:
(JSC::DFG::FixupPhase::fixupNode):
* Source/JavaScriptCore/dfg/DFGNodeType.h:
* Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp:
* Source/JavaScriptCore/dfg/DFGSafeToExecute.h:
(JSC::DFG::safeToExecute):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp:
(JSC::DFG::SpeculativeJIT::compile):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp:
(JSC::DFG::SpeculativeJIT::compile):
* Source/JavaScriptCore/ftl/FTLCapabilities.cpp:
(JSC::FTL::canCompile):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileNode):
(JSC::FTL::DFG::LowerDFGToB3::compileCompareStrictEq):
* Source/JavaScriptCore/runtime/Intrinsic.h:
* Source/JavaScriptCore/runtime/JSArrayBufferConstructor.cpp:
(JSC::JSGenericArrayBufferConstructor&lt;sharingMode&gt;::finishCreation):

Canonical link: <a href="https://commits.webkit.org/317660@main">https://commits.webkit.org/317660@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2fd221bcc505f6c9b9b06308983a648089bb8e24

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175820 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49753 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43537 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185413 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/138007 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51045 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49435 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136909 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/138007 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178776 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40369 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157685 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117388 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39011 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37389 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/6194 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149430 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37177 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33883 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/37084 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41450 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41595 "Found 1 new test failure: http/wpt/background-fetch/change-documents-in-progress-event.window.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187834 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49420 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145902 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39280 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50100 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33801 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145743 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40536 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122296 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/116127 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48607 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12157 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48009 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48241 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48066 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->