### PR TITLE
CrossThreadCopierBase<HashSet<ObjectIdentifierGeneric>> is missing IsNeeded and move-copy overload

### DIFF
--- a/Source/WTF/wtf/CrossThreadCopier.h
+++ b/Source/WTF/wtf/CrossThreadCopier.h
@@ -255,8 +255,10 @@ template<typename T, typename HashFunctions, typename Traits, typename TableTrai
 
 template<typename T, typename U, typename V>
 struct CrossThreadCopierBase<false, false, HashSet<ObjectIdentifierGeneric<T, U, V>>> {
-    typedef HashSet<ObjectIdentifierGeneric<T, U, V>> Type;
+    using Type = HashSet<ObjectIdentifierGeneric<T, U, V>>;
+    static constexpr bool IsNeeded = false;
     static Type copy(const Type& identifiers) { return identifiers; }
+    static Type copy(Type&& identifiers) { return WTF::move(identifiers); }
 };
 
 // Default specialization for HashMaps of CrossThreadCopyable classes


### PR DESCRIPTION
#### b214bd1362ead100935b58d2ff6227347767d52a
<pre>
CrossThreadCopierBase&lt;HashSet&lt;ObjectIdentifierGeneric&gt;&gt; is missing IsNeeded and move-copy overload
<a href="https://bugs.webkit.org/show_bug.cgi?id=319797">https://bugs.webkit.org/show_bug.cgi?id=319797</a>
<a href="https://rdar.apple.com/182674783">rdar://182674783</a>

Reviewed by Chris Dumez.

The HashSet&lt;ObjectIdentifierGeneric&lt;T, U, V&gt;&gt; specialization of
CrossThreadCopierBase predates the IsNeeded flag and move-aware
copy() overload that the generic HashSet specialization gained
later, leaving it inconsistent with its sibling specializations
and any code that queries IsNeeded for such a set.

* Source/WTF/wtf/CrossThreadCopier.h:

Canonical link: <a href="https://commits.webkit.org/317529@main">https://commits.webkit.org/317529@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5e4da37a00d7191e3d2d690251a54fbf57a4a044

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175545 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49477 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43258 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185131 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/137699 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/911c54df-6d5d-44d4-b430-fff8fbb6b6ad) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50769 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49160 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136688 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/137699 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c99184a5-3f66-48ea-8076-78c07ee0d82c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178502 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40109 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157449 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117166 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b28471a8-b1bd-4b1a-82e6-6bc6913ada4d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38750 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37137 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/5958 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149172 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36942 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33606 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/36806 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41165 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41340 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187556 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49144 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145657 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39188 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49824 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33566 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145494 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40316 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122017 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115794 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48331 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11918 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47733 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47963 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47790 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->