### PR TITLE
Digital Credentials get() should consume transient activation before serializing requests

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/user-activation-get.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/user-activation-get.https-expected.txt
@@ -1,6 +1,6 @@
 
 PASS navigator.credentials.get() calling the API without user activation should reject with NotAllowedError.
-FAIL navigator.credentials.get() with non-serializable data and no user activation should reject with NotAllowedError. promise_rejects_dom: function "function() { throw e; }" threw object "TypeError: JSON.stringify cannot serialize BigInt." that is not a DOMException NotAllowedError: property "code" is equal to undefined, expected 0
+PASS navigator.credentials.get() with non-serializable data and no user activation should reject with NotAllowedError.
 PASS navigator.credentials.get() with empty protocol array and no user activation needed should reject with TypeError.
 PASS navigator.credentials.get() with early abort does not consume user activation.
 PASS navigator.credentials.get() with late abort consumes user activation.

--- a/Source/WebCore/Modules/identity/DigitalCredential.cpp
+++ b/Source/WebCore/Modules/identity/DigitalCredential.cpp
@@ -207,14 +207,29 @@ void DigitalCredential::discoverFromExternalSource(const Document& document, Cre
         return;
     }
 
-    auto presentationRequestsOrException = convertObjectsToDigitalPresentationRequests(document, options.digital->requests);
-    if (presentationRequestsOrException.hasException()) {
-        promise.reject(presentationRequestsOrException.releaseException());
+    options.digital->requests.removeAllMatching([&](auto& request) {
+        if (userAgentAllowsProtocol(document, request.protocol))
+            return false;
+        if (RefPtr context = document.scriptExecutionContext()) {
+            String warning = makeString("Ignoring DigitalCredentialGetRequest with unsupported protocol: \""_s, request.protocol, "\""_s);
+            context->addConsoleMessage(MessageSource::Other, MessageLevel::Warning, warning);
+        }
+        return true;
+    });
+
+    if (options.digital->requests.isEmpty()) {
+        promise.reject(Exception { ExceptionCode::TypeError, "At least one supported DigitalCredentialGetRequest must be present."_s });
         return;
     }
 
     if (!window->consumeTransientActivation()) {
         promise.reject(Exception { ExceptionCode::NotAllowedError, "Calling get() needs to be triggered by an activation triggering user event."_s });
+        return;
+    }
+
+    auto presentationRequestsOrException = convertObjectsToDigitalPresentationRequests(document, options.digital->requests);
+    if (presentationRequestsOrException.hasException()) {
+        promise.reject(presentationRequestsOrException.releaseException());
         return;
     }
 


### PR DESCRIPTION
#### 6f080b99cb9bc24d70ce427426221eff0eefe9e2
<pre>
Digital Credentials get() should consume transient activation before serializing requests

<a href="https://bugs.webkit.org/show_bug.cgi?id=319583">https://bugs.webkit.org/show_bug.cgi?id=319583</a>
<a href="https://rdar.apple.com/problem/182412996">rdar://problem/182412996</a>

Reviewed by Abrar Rahman Protyasha.

get() serialized the requested credentials, which can reject with a TypeError,
before consuming the document&apos;s transient activation. A page could therefore
probe whether its request data was serializable without spending its user
activation. Filter the requests down to those with a supported protocol first,
reject with a TypeError if none remain, then consume transient activation, and
only then serialize the surviving requests.

Aligns with the Digital Credentials specification change in
<a href="https://github.com/w3c-fedid/digital-credentials/pull/558.">https://github.com/w3c-fedid/digital-credentials/pull/558.</a>

* LayoutTests/imported/w3c/web-platform-tests/digital-credentials/user-activation-get.https-expected.txt:
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/digital-credentials/get.https-expected.txt:
* Source/WebCore/Modules/identity/DigitalCredential.cpp:
(WebCore::DigitalCredential::discoverFromExternalSource):

Canonical link: <a href="https://commits.webkit.org/318122@main">https://commits.webkit.org/318122@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3ebea1cc34cb918a0404d86e9c1c554ff3e355b8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177107 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51044 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44839 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186710 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140343 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4eb3c0a0-5b48-412e-b30f-1d71fab69fa6) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178970 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52337 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50730 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137996 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140343 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8ee71427-b3f3-4955-b663-34d11ca2e53b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180063 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41503 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158775 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118463 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/58944ada-4c28-498c-ae58-d4d49b648b6c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40159 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38525 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150569 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38274 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35178 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42820 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42743 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189136 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50711 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147078 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39580 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51394 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34898 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146870 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41607 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123608 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117895 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49899 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13254 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49298 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49535 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49359 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->