### PR TITLE
[SaferCPP] Address warnings in Source/WebKit

### DIFF
--- a/Source/JavaScriptCore/SaferCPPExpectations/NoDeleteCheckerExpectations
+++ b/Source/JavaScriptCore/SaferCPPExpectations/NoDeleteCheckerExpectations
@@ -1,8 +1,6 @@
-b3/B3ReduceStrength.cpp
 dfg/DFGIntegerRangeOptimizationPhase.cpp
 jit/ScratchRegisterAllocator.cpp
 jsc.cpp
-runtime/ISO8601.cpp
 runtime/IndexingType.cpp
 runtime/JSObject.cpp
 yarr/YarrInterpreter.cpp

--- a/Source/WTF/SaferCPPExpectations/NoDeleteCheckerExpectations
+++ b/Source/WTF/SaferCPPExpectations/NoDeleteCheckerExpectations
@@ -1,6 +1,5 @@
 wtf/Assertions.cpp
 wtf/AutomaticThread.cpp
-wtf/MediaTime.cpp
 wtf/MetaAllocator.cpp
 wtf/StdLibExtras.h
 wtf/text/StringBuilder.cpp

--- a/Source/WTF/wtf/OverflowHandler.h
+++ b/Source/WTF/wtf/OverflowHandler.h
@@ -41,7 +41,7 @@ public:
 
     void clearOverflow() { }
 
-    static NO_RETURN_DUE_TO_CRASH void crash()
+    SUPPRESS_NODELETE static NO_RETURN_DUE_TO_CRASH void NODELETE crash()
     {
         CRASH();
     }
@@ -82,7 +82,7 @@ protected:
         m_overflowed = false;
     }
 
-    static NO_RETURN_DUE_TO_CRASH void crash()
+    SUPPRESS_NODELETE static NO_RETURN_DUE_TO_CRASH void NODELETE crash()
     {
         CRASH();
     }

--- a/Source/WebCore/SaferCPPExpectations/NoDeleteCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/NoDeleteCheckerExpectations
@@ -1,4 +1,3 @@
-Modules/WebGPU/Implementation/WebGPUAdapterImpl.cpp
 Modules/indexeddb/server/IndexValueStore.cpp
 Modules/notifications/NotificationPayload.cpp
 Modules/streams/ReadableByteStreamController.cpp
@@ -12,7 +11,6 @@ css/DOMMatrixReadOnly.cpp
 css/PropertySetCSSDescriptors.cpp
 css/SelectorChecker.cpp
 css/StyleSheetList.cpp
-css/calc/CSSCalcType.cpp
 css/parser/CSSPropertyParserConsumer+String.cpp
 dom/ContainerNode.cpp
 dom/Document.cpp
@@ -23,12 +21,10 @@ editing/FrameSelection.cpp
 html/HTMLFormControlsCollection.cpp
 html/HTMLTableElement.cpp
 html/HTMLTableRowsCollection.cpp
-html/parser/HTMLEntityParser.cpp
 [ macOS ] inspector/InspectorFrontendHost.cpp
 layout/formattingContexts/inline/InlineLineBuilder.cpp
 layout/formattingContexts/inline/InlineTextItem.cpp
 loader/EmptyClients.cpp
-loader/ResourceMonitor.cpp
 loader/TextResourceDecoder.cpp
 loader/cache/CachedSVGFont.cpp
 page/DragController.cpp
@@ -37,15 +33,7 @@ page/LocalFrameView.cpp
 [ iOS ] page/Quirks.cpp
 page/scrolling/ScrollingStateNode.cpp
 page/text-extraction/TextExtraction.cpp
-platform/audio/cocoa/CARingBuffer.cpp
-platform/graphics/GraphicsContextGL.cpp
-platform/graphics/ImageBufferBackend.cpp
-platform/graphics/IntRect.cpp
-platform/graphics/PixelBuffer.cpp
-platform/graphics/Region.cpp
-platform/graphics/cg/ImageBufferCGBackend.cpp
 platform/sql/SQLiteStatementAutoResetScope.cpp
-rendering/CounterNode.cpp
 rendering/RenderGeometryMap.cpp
 rendering/RenderObject.cpp
 rendering/StyledMarkedText.cpp

--- a/Source/WebGPU/SaferCPPExpectations/NoDeleteCheckerExpectations
+++ b/Source/WebGPU/SaferCPPExpectations/NoDeleteCheckerExpectations
@@ -1,5 +1,2 @@
-Buffer.mm
-CommandEncoder.mm
-CommandsMixin.mm
+[ macOS ] Buffer.mm
 [ macOS ] HardwareCapabilities.mm
-Texture.mm

--- a/Source/WebKit/SaferCPPExpectations/NoDeleteCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/NoDeleteCheckerExpectations
@@ -1,8 +1,1 @@
-Platform/IPC/cocoa/MachMessage.cpp
-UIProcess/WebFullScreenManagerProxy.cpp
-WebProcess/GPU/graphics/ImageBufferRemotePDFDocumentBackend.cpp
-WebProcess/Network/WebResourceLoader.cpp
-WebProcess/Network/webrtc/WebRTCResolver.cpp
 WebProcess/WebPage/WebFrame.cpp
-WebProcess/WebPage/WebPage.cpp
-WebProcess/WebProcess.cpp

--- a/Source/WebKit/SaferCPPExpectations/RetainPtrCtorAdoptCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/RetainPtrCtorAdoptCheckerExpectations
@@ -1,1 +1,0 @@
-Shared/Cocoa/CoreIPCNSURLRequest.mm

--- a/Source/WebKit/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
@@ -1,2 +1,0 @@
-WebProcess/WebPage/WebFrame.cpp
-WebProcess/WebPage/WebPage.cpp

--- a/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -1,1 +1,0 @@
-Shared/WebBackForwardListFrameItem.cpp

--- a/Source/WebKit/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -1,2 +1,0 @@
-WebProcess/WebPage/WebFrame.cpp
-WebProcess/WebPage/WebPage.cpp

--- a/Source/WebKit/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
@@ -1,1 +1,0 @@
-[ macOS ] UIProcess/mac/WebViewImpl.mm

--- a/Source/WebKit/Shared/Cocoa/CoreIPCNSURLRequest.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCNSURLRequest.mm
@@ -119,7 +119,7 @@ static bool isReservedProtocolPropertyKeyPrefix(NSString *key)
 
 static bool isTypedAllowlistKey(NSString *key)
 {
-    static NSSet<NSString *> *allowlist = [[NSSet alloc] initWithArray:@[
+    static NeverDestroyed<RetainPtr<NSSet<NSString *>>> allowlist = adoptNS([[NSSet alloc] initWithArray:@[
         @"_kCFHTTPCookiePolicyPropertyIsTopLevelNavigation",
         @"kCFURLRequestAllowAllPOSTCaching",
         @"_kCFHTTPCookiePolicyPropertySiteForCookies",
@@ -132,8 +132,8 @@ static bool isTypedAllowlistKey(NSString *key)
         @"maximumRequestCount",
         @"com.apple.ap.pc.proxy-is-recursive",
         @"requestType",
-    ]];
-    return [allowlist containsObject:key];
+    ]]);
+    return [allowlist.get() containsObject:key];
 }
 
 static void populateAppProperties(NSDictionary *protocolPropertiesDict, ProtocolProperties& props)

--- a/Source/WebKit/Shared/WebBackForwardListFrameItem.h
+++ b/Source/WebKit/Shared/WebBackForwardListFrameItem.h
@@ -83,7 +83,7 @@ private:
 
     WeakPtr<WebBackForwardListItem> m_backForwardListItem;
     const WebCore::BackForwardFrameItemIdentifier m_identifier;
-    Ref<FrameState> m_frameState;
+    const Ref<FrameState> m_frameState;
     WeakPtr<WebBackForwardListFrameItem> m_parent;
     Vector<Ref<WebBackForwardListFrameItem>> m_children;
 

--- a/Source/WebKit/UIProcess/WebFullScreenManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFullScreenManagerProxy.cpp
@@ -194,7 +194,8 @@ void WebFullScreenManagerProxy::detachFromClient()
     m_client = nullptr;
 }
 
-void WebFullScreenManagerProxy::attachToNewClient(WebFullScreenManagerProxyClient& client)
+// FIXME: This should be detected as NODELETE (rdar://182377452).
+SUPPRESS_NODELETE void WebFullScreenManagerProxy::attachToNewClient(WebFullScreenManagerProxyClient& client)
 {
     m_client = &client;
 }

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -3903,7 +3903,7 @@ void WebViewImpl::contentRelativeViewsHysteresisTimerFired(PAL::HysteresisState 
     }
 
     if (m_contentRelativeViewsNeedToBeRepositioned != started && std::exchange(m_contentRelativeViewsNeedToBeRepositioned, started))
-        [inputContextForSelectionUpdates() textInputClientDidUpdateSelection];
+        [protect(inputContextForSelectionUpdates()) textInputClientDidUpdateSelection];
 }
 
 void WebViewImpl::pageScrollingHysteresisFired(PAL::HysteresisState state)

--- a/Source/WebKit/WebProcess/Network/webrtc/WebRTCResolver.h
+++ b/Source/WebKit/WebProcess/Network/webrtc/WebRTCResolver.h
@@ -46,7 +46,7 @@ class LibWebRTCSocketFactory;
 class WebRTCResolver : public RefCounted<WebRTCResolver> {
     WTF_MAKE_TZONE_ALLOCATED(WebRTCResolver);
 public:
-    static Ref<WebRTCResolver> NODELETE create(LibWebRTCSocketFactory&, LibWebRTCResolverIdentifier);
+    static Ref<WebRTCResolver> create(LibWebRTCSocketFactory&, LibWebRTCResolverIdentifier);
     ~WebRTCResolver();
 
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&);

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -2411,8 +2411,8 @@ void WebPage::didFlushLayerTreeAtTime(MonotonicTime timestamp, bool flushSucceed
 #endif
 #if ENABLE(GPU_PROCESS)
     if (!flushSucceeded) {
-        if (RefPtr proxy = m_remoteRenderingBackendProxy)
-            proxy->didBecomeUnresponsive();
+        if (m_remoteRenderingBackendProxy)
+            m_remoteRenderingBackendProxy->didBecomeUnresponsive();
     }
 #endif
 }

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -1127,15 +1127,15 @@ bool WebFrame::containsAnyFormElements() const
 
 bool WebFrame::containsAnyFormControls() const
 {
-    auto* localFrame = dynamicDowncast<LocalFrame>(m_coreFrame.get());
+    RefPtr localFrame = dynamicDowncast<LocalFrame>(m_coreFrame.get());
     if (!localFrame)
         return false;
 
-    auto* document = localFrame->document();
+    RefPtr document = localFrame->document();
     if (!document)
         return false;
 
-    for (auto& child : childrenOfType<Element>(*document)) {
+    for (Ref child : childrenOfType<Element>(*document)) {
         if (is<HTMLTextFormControlElement>(child) || is<HTMLSelectElement>(child))
             return true;
     }

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -5456,8 +5456,8 @@ void WebPage::didUpdateRendering(OptionSet<DidUpdateRenderingFlags> flags)
 {
     if (flags & DidUpdateRenderingFlags::PaintedLayers) {
 #if ENABLE(GPU_PROCESS)
-        if (RefPtr proxy = m_remoteRenderingBackendProxy)
-            proxy->didPaintLayers();
+        if (m_remoteRenderingBackendProxy)
+            m_remoteRenderingBackendProxy->didPaintLayers();
 #endif
     }
 
@@ -5480,8 +5480,7 @@ bool WebPage::shouldTriggerRenderingUpdate(unsigned rescheduledRenderingUpdateCo
         return true;
 
     static constexpr unsigned maxDelayedRenderingUpdateCount = 2;
-    auto* proxy = m_remoteRenderingBackendProxy.get();
-    if (proxy && proxy->delayedRenderingUpdateCount() > maxDelayedRenderingUpdateCount)
+    if (m_remoteRenderingBackendProxy && m_remoteRenderingBackendProxy->delayedRenderingUpdateCount() > maxDelayedRenderingUpdateCount)
         return false;
 #endif
     return true;
@@ -5495,8 +5494,8 @@ void WebPage::finalizeRenderingUpdate(OptionSet<FinalizeRenderingUpdateFlags> fl
 
     protect(corePage())->finalizeRenderingUpdate(flags);
 #if ENABLE(GPU_PROCESS)
-    if (RefPtr proxy = m_remoteRenderingBackendProxy)
-        proxy->finalizeRenderingUpdate();
+    if (m_remoteRenderingBackendProxy)
+        m_remoteRenderingBackendProxy->finalizeRenderingUpdate();
 #endif
     flushDeferredDidReceiveMouseEvent();
 
@@ -5529,8 +5528,8 @@ void WebPage::didCompleteRenderingFrame()
 void WebPage::releaseMemory(Critical critical)
 {
 #if ENABLE(GPU_PROCESS)
-    if (RefPtr renderingBackend = m_remoteRenderingBackendProxy)
-        renderingBackend->releaseMemory();
+    if (m_remoteRenderingBackendProxy)
+        m_remoteRenderingBackendProxy->releaseMemory();
 #endif
 
 #if USE(COORDINATED_GRAPHICS)
@@ -5548,8 +5547,8 @@ void WebPage::willDestroyDecodedDataForAllImages()
 unsigned WebPage::remoteImagesCountForTesting() const
 {
 #if ENABLE(GPU_PROCESS)
-    if (auto* renderingBackend = m_remoteRenderingBackendProxy.get())
-        return renderingBackend->nativeImageCountForTesting();
+    if (m_remoteRenderingBackendProxy)
+        return m_remoteRenderingBackendProxy->nativeImageCountForTesting();
 #endif
     return 0;
 }
@@ -9849,7 +9848,7 @@ void WebPage::notifyPageOfAppBoundBehavior()
 RemoteRenderingBackendProxy& WebPage::ensureRemoteRenderingBackendProxy()
 {
     if (!m_remoteRenderingBackendProxy)
-        m_remoteRenderingBackendProxy = RemoteRenderingBackendProxy::create(*this);
+        lazyInitialize(m_remoteRenderingBackendProxy, RemoteRenderingBackendProxy::create(*this));
     return *m_remoteRenderingBackendProxy;
 }
 #endif

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -3354,7 +3354,7 @@ private:
 #endif
 
 #if ENABLE(GPU_PROCESS)
-    RefPtr<RemoteRenderingBackendProxy> m_remoteRenderingBackendProxy;
+    const RefPtr<RemoteRenderingBackendProxy> m_remoteRenderingBackendProxy;
 #endif
 
 #if ENABLE(IMAGE_ANALYSIS)

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -1350,7 +1350,7 @@ void WebProcess::setInjectedBundleParameters(std::span<const uint8_t> value)
     injectedBundle->setBundleParameters(value);
 }
 
-[[noreturn]] inline void NODELETE failedToGetNetworkProcessConnection()
+[[noreturn]] inline void failedToGetNetworkProcessConnection()
 {
 #if PLATFORM(GTK) || PLATFORM(WPE)
     // GTK and WPE ports don't exit on send sync message failure.


### PR DESCRIPTION
#### 8f92bfdda93f83bbccb356464e001f89944a543e
<pre>
[SaferCPP] Address warnings in Source/WebKit
<a href="https://bugs.webkit.org/show_bug.cgi?id=319555">https://bugs.webkit.org/show_bug.cgi?id=319555</a>

Reviewed by Ryosuke Niwa.

* Source/WTF/wtf/OverflowHandler.h:
(WTF::AssertNoOverflow::crash):
(WTF::RecordOverflow::crash):
* Source/WebKit/Shared/Cocoa/CoreIPCNSURLRequest.mm:
(WebKit::isTypedAllowlistKey):
* Source/WebKit/Shared/WebBackForwardListFrameItem.h:
* Source/WebKit/UIProcess/WebFullScreenManagerProxy.cpp:
(WebKit::WebFullScreenManagerProxy::attachToNewClient):
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::contentRelativeViewsHysteresisTimerFired):
* Source/WebKit/WebProcess/Network/webrtc/WebRTCResolver.h:
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::didFlushLayerTreeAtTime):
* Source/WebKit/WebProcess/WebPage/WebFrame.cpp:
(WebKit::WebFrame::containsAnyFormControls const):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::didUpdateRendering):
(WebKit::WebPage::shouldTriggerRenderingUpdate const):
(WebKit::WebPage::finalizeRenderingUpdate):
(WebKit::WebPage::releaseMemory):
(WebKit::WebPage::remoteImagesCountForTesting const):
(WebKit::WebPage::ensureRemoteRenderingBackendProxy):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::failedToGetNetworkProcessConnection):
* Source/JavaScriptCore/SaferCPPExpectations/NoDeleteCheckerExpectations:
* Source/WTF/SaferCPPExpectations/NoDeleteCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/NoDeleteCheckerExpectations:
* Source/WebGPU/SaferCPPExpectations/NoDeleteCheckerExpectations:
* Source/WebKit/SaferCPPExpectations/NoDeleteCheckerExpectations:
* Source/WebKit/SaferCPPExpectations/RetainPtrCtorAdoptCheckerExpectations:
* Source/WebKit/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations:
* Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebKit/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:
* Source/WebKit/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations:

Canonical link: <a href="https://commits.webkit.org/317532@main">https://commits.webkit.org/317532@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/445d402f9716c83c8355628857951253c6f4e223

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175569 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/49501 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/43282 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185155 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/137723 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/177433 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/50793 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49184 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/136709 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/137723 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178526 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/50793 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/157471 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/117187 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/50793 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/37159 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/218/builds/5980 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/50793 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/36964 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33630 "Failed to checkout and rebase branch from PR 69768") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/36830 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41189 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/41362 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187580 "Failed to checkout and rebase branch from PR 69768") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49168 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/157027 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/187580 "Failed to checkout and rebase branch from PR 69768") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49848 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/33588 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/187580 "Failed to checkout and rebase branch from PR 69768") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26681 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/40337 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122041 "Built successfully") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115844 "Failed to checkout and rebase branch from PR 69768") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48355 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/11941 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47757 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47987 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47814 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->