### PR TITLE
Implement "fully active descendant of a top-level traversable with user attention"

### DIFF
--- a/LayoutTests/http/wpt/identity/identitycredentialscontainer-get-hidden.https.html
+++ b/LayoutTests/http/wpt/identity/identitycredentialscontainer-get-hidden.https.html
@@ -57,7 +57,7 @@
         } catch (error) {
             assert_equals(
                 error.message,
-                "The document is not visible."
+                "The document must be focused and visible."
             );
         }
     }, "navigator.credentials.get() can't be used with hidden documents.");

--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/default-permissions-policy.https.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/default-permissions-policy.https.sub-expected.txt
@@ -1,6 +1,6 @@
 
 
-FAIL Permissions-Policy is by default 'self' for get(). assert_true: Digital Credential API expected true got false
+PASS Permissions-Policy is by default 'self' for get().
 FAIL Permissions-Policy is by default 'self' for create(). promise_rejects_js: function "function() { throw e; }" threw object "NotSupportedError: No credential type was specified." ("NotSupportedError") expected instance of function "function TypeError() {
     [native code]
 }" ("TypeError")

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -8608,6 +8608,7 @@ http/wpt/identity/formats/ISO18013/mixed-requests.https.html [ Failure ] # webki
 imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/number-constraint-validation.html [ Pass Failure ] # webkit.org/b/318257
 
 webkit.org/b/317884 imported/w3c/web-platform-tests/digital-credentials/get-non-fully-active.https.html [ Skip ]
+webkit.org/b/256299 imported/w3c/web-platform-tests/digital-credentials/allow-attribute-with-get.https.html [ Pass Failure ]
 
 webkit.org/b/318157 [ Debug ] imported/w3c/web-platform-tests/IndexedDB/interleaved-cursors-small.any.sharedworker.html [ Failure ]
 webkit.org/b/318157 [ Debug ] imported/w3c/web-platform-tests/IndexedDB/interleaved-cursors-small.any.worker.html [ Failure ]

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/digital-credentials/get.https-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/digital-credentials/get.https-expected.txt
@@ -3,9 +3,7 @@
 PASS Type conversion happens on the data member of the DigitalCredentialGetRequest object.
 PASS Calling navigator.credentials.get() without a digital member same origin.
 PASS navigator.credentials.get() API rejects if there are no credential request.
-FAIL navigator.credentials.get() API rejects if there are no credential request for same-origin iframe. promise_rejects_js: function "function() { throw e; }" threw object "NotAllowedError: The document is not focused." ("NotAllowedError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
+PASS navigator.credentials.get() API rejects if there are no credential request for same-origin iframe.
 PASS navigator.credentials.get() API rejects if there are no credential request in cross-origin iframe.
 PASS navigator.credentials.get() promise is rejected if called with an aborted controller.
 PASS navigator.credentials.get() promise is rejected if called with an aborted controller in same-origin iframe.

--- a/LayoutTests/platform/ipad/imported/w3c/web-platform-tests/digital-credentials/allow-attribute-with-get.https-expected.txt
+++ b/LayoutTests/platform/ipad/imported/w3c/web-platform-tests/digital-credentials/allow-attribute-with-get.https-expected.txt
@@ -1,13 +1,13 @@
 
-FAIL With Get: Policy to use: null, is cross-origin: false, is allowed by policy: true assert_true: <iframe src="https://web-platform.test:9443/digital-credentials/support/iframe.html" data-expect-is-allowed="true" width="400" height="200"></iframe> - The document is not focused. expected true got false
+PASS With Get: Policy to use: null, is cross-origin: false, is allowed by policy: true
 PASS With Get: Policy to use: null, is cross-origin: true, is allowed by policy: false
-FAIL With Get: Policy to use: digital-credentials-get, is cross-origin: false, is allowed by policy: true assert_true: <iframe allow="digital-credentials-get" src="https://web-platform.test:9443/digital-credentials/support/iframe.html" data-expect-is-allowed="true" width="400" height="200"></iframe> - The document is not focused. expected true got false
+PASS With Get: Policy to use: digital-credentials-get, is cross-origin: false, is allowed by policy: true
 PASS With Get: Policy to use: digital-credentials-get, is cross-origin: true, is allowed by policy: true
-FAIL With Get: Policy to use: digital-credentials-get *, is cross-origin: false, is allowed by policy: true assert_true: <iframe allow="digital-credentials-get *" src="https://web-platform.test:9443/digital-credentials/support/iframe.html" data-expect-is-allowed="true" width="400" height="200"></iframe> - The document is not focused. expected true got false
+PASS With Get: Policy to use: digital-credentials-get *, is cross-origin: false, is allowed by policy: true
 PASS With Get: Policy to use: digital-credentials-get *, is cross-origin: true, is allowed by policy: true
 PASS With Get: Policy to use: digital-credentials-get 'none', is cross-origin: false, is allowed by policy: false
 PASS With Get: Policy to use: digital-credentials-get 'none', is cross-origin: true, is allowed by policy: false
-FAIL With Get: Policy to use: digital-credentials-get 'self', is cross-origin: false, is allowed by policy: true assert_true: <iframe allow="digital-credentials-get 'self'" src="https://web-platform.test:9443/digital-credentials/support/iframe.html" data-expect-is-allowed="true" width="400" height="200"></iframe> - The document is not focused. expected true got false
+PASS With Get: Policy to use: digital-credentials-get 'self', is cross-origin: false, is allowed by policy: true
 PASS With Get: Policy to use: digital-credentials-get 'self', is cross-origin: true, is allowed by policy: false
 PASS With Get: Policy to use: digital-credentials-get https://www1.web-platform.test:9443, is cross-origin: false, is allowed by policy: false
 PASS With Get: Policy to use: digital-credentials-get https://www1.web-platform.test:9443, is cross-origin: true, is allowed by policy: true

--- a/Source/WebCore/Modules/identity/DigitalCredential.cpp
+++ b/Source/WebCore/Modules/identity/DigitalCredential.cpp
@@ -46,7 +46,6 @@
 #include "MediationRequirement.h"
 #include "PermissionsPolicy.h"
 #include "Settings.h"
-#include "VisibilityState.h"
 #include <JavaScriptCore/ConsoleTypes.h>
 #include <JavaScriptCore/JSONObject.h>
 #include <Logging.h>
@@ -176,13 +175,8 @@ void DigitalCredential::discoverFromExternalSource(const Document& document, Cre
         return;
     }
 
-    if (!document.hasFocus()) {
-        promise.reject(Exception { ExceptionCode::NotAllowedError, "The document is not focused."_s });
-        return;
-    }
-
-    if (document.visibilityState() != VisibilityState::Visible) {
-        promise.reject(Exception { ExceptionCode::NotAllowedError, "The document is not visible."_s });
+    if (!document.isFullyActiveAndHasUserAttention()) {
+        promise.reject(Exception { ExceptionCode::NotAllowedError, "The document must be focused and visible."_s });
         return;
     }
 

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -4205,6 +4205,21 @@ bool Document::isFullyActive() const
     return frame->isMainFrame();
 }
 
+// https://html.spec.whatwg.org/multipage/interaction.html#fully-active-descendant-of-a-top-level-traversable-with-user-attention
+// "System focus" here is a property of the top-level traversable (the window), not of this
+// frame's subtree, so it checks FocusController window state rather than Document::hasFocus().
+// FIXME: the spec also grants user attention while UA widgets (e.g. the URL bar) hold keyboard
+// input; that disjunct is not yet modeled here (webkit.org/b/256299).
+bool Document::isFullyActiveAndHasUserAttention() const
+{
+    if (!isFullyActive() || visibilityState() != VisibilityState::Visible)
+        return false;
+    RefPtr page = this->page();
+    if (!page)
+        return false;
+    return page->focusController().isActive() && page->focusController().isFocused();
+}
+
 void Document::detachParser()
 {
     if (RefPtr parser = std::exchange(m_parser, nullptr))

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -1248,6 +1248,9 @@ public:
 
     WEBCORE_EXPORT bool isFullyActive() const;
 
+    // https://html.spec.whatwg.org/multipage/interaction.html#fully-active-descendant-of-a-top-level-traversable-with-user-attention
+    bool isFullyActiveAndHasUserAttention() const;
+
     // The full URL corresponding to the "site for cookies" in the Same-Site Cookies spec.,
     // <https://tools.ietf.org/html/draft-ietf-httpbis-cookie-same-site-00>. It is either
     // the URL of the top-level document or the null URL depending on whether the registrable


### PR DESCRIPTION
#### b718bc1deb5157a6597ddc2f2d7ec8de71793652
<pre>
Implement &quot;fully active descendant of a top-level traversable with user attention&quot;

<a href="https://bugs.webkit.org/show_bug.cgi?id=256299">https://bugs.webkit.org/show_bug.cgi?id=256299</a>
<a href="https://rdar.apple.com/109191868">rdar://109191868</a>

Reviewed by Ryosuke Niwa.

Add Document::isFullyActiveAndHasUserAttention(), implementing the HTML concept &quot;fully
active descendant of a top-level traversable with user attention&quot;
(<a href="https://html.spec.whatwg.org/multipage/interaction.html#fully-active-descendant-of-a-top-level-traversable-with-user-attention)">https://html.spec.whatwg.org/multipage/interaction.html#fully-active-descendant-of-a-top-level-traversable-with-user-attention)</a>:
the document is fully active, its top-level traversable is system-visible, and the window
has system focus.

Adopt it in Digital Credentials get(), which previously used Document::hasFocus().
hasFocus() additionally requires the focused frame to be within the calling frame&apos;s
subtree, which is stricter than the concept, so a same-origin or permitted cross-origin
child frame in a focused window was rejected as &quot;not focused&quot; even though its top-level
traversable had system focus. The Digital Credentials specification requires exactly this
&quot;user attention&quot; concept, so the change aligns the implementation with the specification.

Update the hidden-document test&apos;s asserted rejection message to the unified message; the
by-default &apos;self&apos; get() subtest in default-permissions-policy.https.sub.html now passes
because get() reaches the permissions-policy check instead of being rejected for focus;
and update the platform/ios get.https baseline, whose same-origin iframe focus subtest now
passes. The same-origin subtests of allow-attribute-with-get.https also now pass, so its
platform/ipad baseline is updated; the test is marked [ Pass Failure ] on iOS because the
test environment&apos;s window focus is racy there.

* LayoutTests/http/wpt/identity/identitycredentialscontainer-get-hidden.https.html:
* LayoutTests/imported/w3c/web-platform-tests/digital-credentials/default-permissions-policy.https.sub-expected.txt:
* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/digital-credentials/get.https-expected.txt:
* LayoutTests/platform/ipad/imported/w3c/web-platform-tests/digital-credentials/allow-attribute-with-get.https-expected.txt:
* Source/WebCore/Modules/identity/DigitalCredential.cpp:
(WebCore::DigitalCredential::discoverFromExternalSource):
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::isFullyActiveAndHasUserAttention const):
* Source/WebCore/dom/Document.h:

Canonical link: <a href="https://commits.webkit.org/317656@main">https://commits.webkit.org/317656@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f17fee50fadd0833682cd49d87b2992d238cfe27

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175855 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49788 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43572 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185448 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/138046 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/45b84f38-6eda-4469-a1d9-6193b746d403) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/177718 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51080 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49470 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136942 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/138046 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3386f9b6-fe93-478f-a27b-ad8300c49ba1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178811 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40401 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157716 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117421 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fd62ef5d-bc2a-4983-a827-6e5342b8b920) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39043 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37423 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149462 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37208 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33918 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41488 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41629 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187869 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49455 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/157267 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145933 "Found 1 new test failure: compositing/color-matching/image-color-matching.html (failure)") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39274 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50135 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33832 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145773 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40569 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122331 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/116189 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48642 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12188 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48044 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48276 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48101 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->