### PR TITLE
[JSC][Temporal] Fix fixed-solar non-ISO calendar arithmetic

### DIFF
--- a/JSTests/stress/temporal-calendar-icu-bridge-non-iso.js
+++ b/JSTests/stress/temporal-calendar-icu-bridge-non-iso.js
@@ -16,6 +16,21 @@ function shouldThrow(func, errorType, label) {
     throw new Error(`${label}: expected ${errorType.name}, but no exception was thrown`);
 }
 
+function shouldBeDate(actual, year, month, day, label) {
+    shouldBe(actual.year, year, `${label} year`);
+    shouldBe(actual.month, month, `${label} month`);
+    shouldBe(actual.day, day, `${label} day`);
+}
+
+function shouldRoundTripDuration(start, end, largestUnit, expected, label) {
+    const forward = start.until(end, {largestUnit});
+    shouldBe(forward.toString(), expected, `${label} forward difference`);
+    shouldBe(start.add(forward).equals(end), true, `${label} forward inverse`);
+    const reverse = end.until(start, {largestUnit});
+    shouldBe(reverse.toString(), `-${expected}`, `${label} reverse difference`);
+    shouldBe(end.add(reverse).equals(start), true, `${label} reverse inverse`);
+}
+
 // Buddhist: `year` is BE (Gregorian + 543). BE 2567 = Gregorian 2024.
 {
     const pd = Temporal.PlainDate.from({year:2567, month:1, day:1, calendar:"buddhist"});
@@ -107,4 +122,109 @@ shouldThrow(() => Temporal.PlainMonthDay.from({year:-1, era:"aa", eraYear:0, mon
     const pd = Temporal.PlainDate.from({era:"ce", eraYear:1600, month:2, day:29, calendar:"japanese"});
     shouldBe(pd.inLeapYear, true, "japanese ce 1600 inLeapYear");
     shouldBe(pd.daysInYear, 366, "japanese ce 1600 daysInYear");
+}
+
+// Month arithmetic uses calendar-native months, not ISO months.
+const indianMonthDate = Temporal.PlainDate.from({year:1945, month:12, day:29, calendar:"indian"});
+const indianAddedMonth = indianMonthDate.add({months:1});
+shouldBeDate(indianAddedMonth, 1946, 1, 29, "indian add month");
+shouldBeDate(indianAddedMonth.subtract({months:1}), 1945, 12, 29, "indian subtract month");
+
+// Calendar-native add/until balances years and months, including month correction and day remainders.
+for (const [calendar, label, startFields, endFields, largestUnit, expected] of [
+    ["persian", "add/until", {year:1402, month:10, day:15}, {year:1404, month:1, day:15}, "years", "P1Y3M"],
+    ["coptic", "add/until", {year:1739, month:11, day:15}, {year:1741, month:1, day:15}, "years", "P1Y3M"],
+    ["persian", "end-of-month surpass", {year:1402, month:6, day:31}, {year:1402, month:7, day:30}, "months", "P30D"],
+    ["persian", "month/day remainder", {year:1402, month:1, day:15}, {year:1402, month:3, day:20}, "months", "P2M5D"],
+]) {
+    const start = Temporal.PlainDate.from({...startFields, calendar});
+    const end = Temporal.PlainDate.from({...endFields, calendar});
+    shouldRoundTripDuration(start, end, largestUnit, expected, `${calendar} ${label}`);
+}
+
+// Constrain and reject apply after calendar-native month and leap-day year arithmetic.
+for (const [label, unit, fields, expected] of [
+    ["persian", "month", {year:1402, month:11, day:30, calendar:"persian"}, [1402, 12, 29]],
+    ["coptic", "month", {year:1740, month:12, day:30, calendar:"coptic"}, [1740, 13, 5]],
+    ["indian", "month", {year:1945, month:6, day:31, calendar:"indian"}, [1945, 7, 30]],
+    ["persian", "year", {year:1399, month:12, day:30, calendar:"persian"}, [1400, 12, 29]],
+    ["coptic", "year", {year:1739, month:13, day:6, calendar:"coptic"}, [1740, 13, 5]],
+    ["indian", "year", {year:1946, month:1, day:31, calendar:"indian"}, [1947, 1, 30]],
+]) {
+    const pd = Temporal.PlainDate.from(fields);
+    const duration = unit === "month" ? {months:1} : {years:1};
+    shouldBeDate(pd.add(duration), ...expected, `${label} constrained ${unit}`);
+    shouldThrow(() => pd.add(duration, {overflow:"reject"}), RangeError, `${label} rejected ${unit}`);
+}
+
+// Weeks and days are applied after calendar-native years and months for both signs.
+const positiveMixedDate = Temporal.PlainDate.from({year:1402, month:12, day:29, calendar:"persian"});
+shouldBeDate(positiveMixedDate.add({months:1, weeks:1, days:1}), 1403, 2, 6, "persian positive mixed duration");
+const negativeMixedDate = Temporal.PlainDate.from({year:1403, month:1, day:29, calendar:"persian"});
+shouldBeDate(negativeMixedDate.subtract({months:1, weeks:1, days:1}), 1402, 12, 21, "persian negative mixed duration");
+
+// Ethiopic calendars use the same 13-month solar arithmetic as Coptic.
+for (const calendar of ["ethiopic", "ethioaa"]) {
+    const pd = Temporal.PlainDate.from({year:2015, month:13, day:5, calendar});
+    shouldBeDate(pd.add({months:1}), 2016, 1, 5, `${calendar} add month`);
+}
+
+// A Gregorian-derived calendar keeps exact ISO proleptic-Gregorian arithmetic.
+const gregorianMonthDate = Temporal.PlainDate.from("2024-01-31").withCalendar("gregory");
+shouldBe(gregorianMonthDate.add({months:1}).withCalendar("iso8601").toString(), "2024-02-29", "gregory add month");
+
+// Representative existing lunisolar arithmetic still enters intercalary months.
+for (const [date, expectedMonthCode, expectedDay, calendar] of [
+    [Temporal.PlainDate.from("2023-02-20").withCalendar("chinese"), "M02L", 1, "chinese"],
+    [Temporal.PlainDate.from({year:5784, monthCode:"M05", day:15, calendar:"hebrew"}), "M05L", 15, "hebrew"],
+]) {
+    const added = date.add({months:1});
+    shouldBe(added.monthCode, expectedMonthCode, `${calendar} add into leap month monthCode`);
+    shouldBe(added.day, expectedDay, `${calendar} add into leap month day`);
+}
+
+// ICU must not silently clamp native month arithmetic at Temporal's representable limits.
+shouldBe(Temporal.PlainDate.from("-271821-05-19").withCalendar("indian").add({months:-1}).withCalendar("iso8601").toString(), "-271821-04-19", "indian exact minimum boundary");
+shouldBe(Temporal.PlainDate.from("-271821-04-19").withCalendar("indian").add({months:1}).withCalendar("iso8601").toString(), "-271821-05-19", "indian add from exact minimum boundary");
+shouldThrow(() => Temporal.PlainDate.from("-271821-04-20").withCalendar("indian").add({months:-1}), RangeError, "indian minimum boundary");
+shouldThrow(() => Temporal.PlainDate.from("-271821-05-20").withCalendar("indian").add({months:-2}), RangeError, "indian multi-month partial minimum clamp");
+shouldThrow(() => Temporal.PlainDate.from("-271821-06-20").withCalendar("indian").add({months:-3}), RangeError, "indian longer partial minimum clamp");
+shouldBe(Temporal.PlainDate.from("-271821-06-19").withCalendar("indian").add({months:-2}).withCalendar("iso8601").toString(), "-271821-04-19", "indian exact multi-month minimum boundary");
+const indianMinimum = Temporal.PlainDate.from("-271821-04-19").withCalendar("indian");
+const indianMinimumNextMonth = indianMinimum.add({months:1});
+shouldBe(indianMinimum.until(indianMinimumNextMonth, {largestUnit:"months"}).toString(), "P1M", "indian minimum until progress");
+shouldBe(indianMinimumNextMonth.until(indianMinimum, {largestUnit:"months"}).toString(), "-P1M", "indian minimum reverse until progress");
+
+// Calendar-native arithmetic must enforce the exact partial-year ISO limits.
+shouldBe(Temporal.PlainDate.from("+275760-08-13").withCalendar("indian").add({months:1}).withCalendar("iso8601").toString(), "+275760-09-13", "indian exact maximum boundary");
+shouldThrow(() => Temporal.PlainDate.from("+275760-08-14").withCalendar("indian").add({months:1}), RangeError, "indian maximum boundary");
+shouldThrow(() => Temporal.PlainDate.from("+275760-07-14").withCalendar("indian").add({months:2}), RangeError, "indian multi-month partial maximum clamp");
+const copticMaximum = Temporal.PlainDate.from("+275760-09-13").withCalendar("coptic");
+const copticPriorYear = copticMaximum.subtract({months:13});
+shouldBe(copticPriorYear.add({months:13}).equals(copticMaximum), true, "coptic exact 13-month maximum boundary");
+shouldBe(copticPriorYear.until(copticMaximum, {largestUnit:"months"}).toString(), "P13M", "coptic extreme 13-month difference");
+
+// Final ISO day/week movement is checked after the native year/month baseline.
+shouldThrow(() => Temporal.PlainDate.from("+275760-08-13").withCalendar("indian").add({months:1, days:1}), RangeError, "indian final day beyond maximum");
+shouldThrow(() => Temporal.PlainDate.from("+275760-09-07").withCalendar("indian").add({weeks:1}), RangeError, "indian final week beyond maximum");
+
+// Partial Temporal types use their own limits and may canonicalize an out-of-PlainDate-range reference date.
+shouldBe(Temporal.PlainYearMonth.from({year:275682, monthCode:"M07", calendar:"indian"}).toString(), "+275760-09-23[u-ca=indian]", "indian maximum PlainYearMonth");
+shouldBe(Temporal.PlainYearMonth.from({year:-272442, monthCode:"M01", calendar:"persian"}).toString(), "-271821-04-11[u-ca=persian]", "persian boundary PlainYearMonth");
+shouldBe(Temporal.PlainMonthDay.from({year:-272442, monthCode:"M01", day:1, calendar:"persian"}).toString(), "1972-03-21[u-ca=persian]", "persian boundary PlainMonthDay");
+shouldThrow(() => Temporal.PlainYearMonth.from("+275760-09-01[u-ca=indian]").add({months:1}), RangeError, "indian PlainYearMonth maximum boundary");
+
+// Fixed-solar month differences must not walk millions of native months one at a time.
+for (const [calendar, startFields, endFields, expectedMonths] of [
+    ["indian", "-250000-01-01", "+250000-01-01", 6000000],
+    ["persian", {year:-250000, month:1, day:15}, {year:250000, month:1, day:15}, 6000000],
+    ["coptic", {year:-250000, month:1, day:15}, {year:250000, month:1, day:15}, 6500000],
+]) {
+    const start = typeof startFields === "string" ? Temporal.PlainDate.from(startFields).withCalendar(calendar) : Temporal.PlainDate.from({...startFields, calendar});
+    const end = typeof endFields === "string" ? Temporal.PlainDate.from(endFields).withCalendar(calendar) : Temporal.PlainDate.from({...endFields, calendar});
+    const forward = start.until(end, {largestUnit:"months"});
+    const reverse = end.until(start, {largestUnit:"months"});
+    shouldBe(forward.toString(), `P${expectedMonths}M`, `${calendar} wide forward month difference`);
+    shouldBe(reverse.toString(), `-P${expectedMonths}M`, `${calendar} wide reverse month difference`);
+    shouldBe(start.until(end, {largestUnit:"years"}).toString(), "P500000Y", `${calendar} wide year difference`);
 }

--- a/Source/JavaScriptCore/runtime/temporal/core/CalendarICUBridge.cpp
+++ b/Source/JavaScriptCore/runtime/temporal/core/CalendarICUBridge.cpp
@@ -190,7 +190,7 @@ static bool setCalendarToISODate(UCalendar* cal, const ISO8601::PlainDate& isoDa
     return U_SUCCESS(status);
 }
 
-// isoDateFromCalendarChecked — internal: reads back ISO date from ICU calendar's current epoch ms; returns nullopt if out of representable range
+// isoDateFromCalendarChecked — internal: reads back ISO date from ICU calendar's current epoch ms; returns nullopt if outside the supported ISO year range
 static std::optional<ISO8601::PlainDate> isoDateFromCalendarChecked(UCalendar* cal)
 {
     UErrorCode status = U_ZERO_ERROR;
@@ -973,6 +973,11 @@ static bool compareSurpassesOrdinally(
     return false;
 }
 
+static UCalendarDateFields calendarArithmeticYearField(CalendarID calendarId)
+{
+    return calendarId == ethioaaCalendarID() ? UCAL_YEAR : UCAL_EXTENDED_YEAR;
+}
+
 // resolveMonthCodeToOrdinal — internal: resolves a monthCode to its 1-based ordinal position in the given year
 static int32_t resolveMonthCodeToOrdinal(CalendarID calendarId, const String& monthCode, int32_t year)
 {
@@ -980,7 +985,10 @@ static int32_t resolveMonthCodeToOrdinal(CalendarID calendarId, const String& mo
         if (!cal)
             return 1;
         UErrorCode status = U_ZERO_ERROR;
-        ucal_set(cal, UCAL_EXTENDED_YEAR, year);
+        auto yearField = calendarArithmeticYearField(calendarId);
+        if (yearField == UCAL_YEAR)
+            ucal_set(cal, UCAL_ERA, 0);
+        ucal_set(cal, yearField, year);
         ucal_set(cal, UCAL_MONTH, 0);
         ucal_set(cal, UCAL_IS_LEAP_MONTH, 0);
         ucal_set(cal, UCAL_DAY_OF_MONTH, 1);
@@ -988,7 +996,7 @@ static int32_t resolveMonthCodeToOrdinal(CalendarID calendarId, const String& mo
         if (U_FAILURE(status)) [[unlikely]]
             return 1;
 
-        int32_t savedYear = ucal_get(cal, UCAL_EXTENDED_YEAR, &status);
+        int32_t savedYear = ucal_get(cal, yearField, &status);
         if (U_FAILURE(status)) [[unlikely]]
             return 1;
         int32_t lastOrdinal = 1;
@@ -1010,7 +1018,7 @@ static int32_t resolveMonthCodeToOrdinal(CalendarID calendarId, const String& mo
             ucal_add(cal, UCAL_MONTH, 1, &status);
             if (U_FAILURE(status)) [[unlikely]]
                 return lastOrdinal;
-            int32_t curYear = ucal_get(cal, UCAL_EXTENDED_YEAR, &status);
+            int32_t curYear = ucal_get(cal, yearField, &status);
             if (U_FAILURE(status)) [[unlikely]]
                 return lastOrdinal;
             if (curYear != savedYear)
@@ -1040,6 +1048,151 @@ static bool nonISODateSurpasses(
     return compareSurpassesOrdinally(sign, y0, m0, sourceDay, targetYear, targetOrdinalMonth, targetDay);
 }
 
+static bool calendarIsNonISOSolar(CalendarID calendarId)
+{
+    return calendarId == copticCalendarID() || calendarId == ethiopicCalendarID() || calendarId == ethioaaCalendarID()
+        || calendarId == indianCalendarID() || calendarId == persianCalendarID();
+}
+
+static int32_t fixedSolarMonthsInYear(CalendarID calendarId)
+{
+    ASSERT(calendarIsNonISOSolar(calendarId));
+    return calendarId == copticCalendarID() || calendarId == ethiopicCalendarID() || calendarId == ethioaaCalendarID() ? 13 : 12;
+}
+
+struct FixedSolarYearMonth {
+    int32_t year;
+    int32_t month;
+};
+
+static std::optional<FixedSolarYearMonth> balanceFixedSolarYearMonth(int32_t sourceYear, int32_t sourceMonth, int32_t monthsInYear, int64_t years, int64_t months)
+{
+    CheckedInt64 checkedBalancedMonth = CheckedInt64(sourceMonth) + months;
+    if (checkedBalancedMonth.hasOverflowed()) [[unlikely]]
+        return std::nullopt;
+    int64_t balancedMonth = checkedBalancedMonth;
+    int64_t yearDelta = balancedMonth / monthsInYear;
+    int32_t expectedMonth = balancedMonth % monthsInYear;
+    if (expectedMonth < 0) {
+        expectedMonth += monthsInYear;
+        --yearDelta;
+    }
+
+    CheckedInt64 checkedExpectedYear = CheckedInt64(sourceYear) + years + yearDelta;
+    if (checkedExpectedYear.hasOverflowed()) [[unlikely]]
+        return std::nullopt;
+    CheckedInt32 expectedYear = checkedExpectedYear;
+    if (expectedYear.hasOverflowed()) [[unlikely]]
+        return std::nullopt;
+    return FixedSolarYearMonth { expectedYear, expectedMonth };
+}
+
+// Clear and construct an exact native year/month at day 1. Noon preserves Temporal's partial-day
+// endpoints. At ICU's extreme millisecond boundary, directly set fields can resolve one day off;
+// correct only that rounding after the expected year/month resolve, then verify every field.
+static std::optional<bool> setFixedSolarCalendarToYearMonth(UCalendar* cal, CalendarID calendarId, const FixedSolarYearMonth& expected)
+{
+    ucal_clear(cal);
+    auto yearField = calendarArithmeticYearField(calendarId);
+    if (yearField == UCAL_YEAR)
+        ucal_set(cal, UCAL_ERA, 0);
+    ucal_set(cal, yearField, expected.year);
+    ucal_set(cal, UCAL_MONTH, expected.month);
+    ucal_set(cal, UCAL_DAY_OF_MONTH, 1);
+    ucal_set(cal, UCAL_HOUR_OF_DAY, 12);
+
+    UErrorCode status = U_ZERO_ERROR;
+    ucal_getMillis(cal, &status);
+    if (U_FAILURE(status)) [[unlikely]]
+        return std::nullopt;
+    int32_t actualYear = ucal_get(cal, yearField, &status);
+    int32_t actualMonth = ucal_get(cal, UCAL_MONTH, &status);
+    int32_t actualDay = ucal_get(cal, UCAL_DAY_OF_MONTH, &status);
+    if (U_FAILURE(status)) [[unlikely]]
+        return std::nullopt;
+    if (actualYear == expected.year && actualMonth == expected.month && std::abs(actualDay - 1) == 1) {
+        ucal_add(cal, UCAL_DAY_OF_MONTH, 1 - actualDay, &status);
+        if (U_FAILURE(status)) [[unlikely]]
+            return std::nullopt;
+        actualYear = ucal_get(cal, yearField, &status);
+        actualMonth = ucal_get(cal, UCAL_MONTH, &status);
+        actualDay = ucal_get(cal, UCAL_DAY_OF_MONTH, &status);
+        if (U_FAILURE(status)) [[unlikely]]
+            return std::nullopt;
+    }
+    return actualYear == expected.year && actualMonth == expected.month && actualDay == 1;
+}
+
+static TemporalResult<ISO8601::PlainDate> fixedSolarDateAdd(CalendarID calendarId, const ISO8601::PlainDate& isoDate, const ISO8601::Duration& duration, TemporalOverflow overflow)
+{
+    auto baselineOrError = withCalendar(calendarId, [&](UCalendar* cal) -> TemporalResult<ISO8601::PlainDate> {
+        if (!cal) [[unlikely]]
+            return makeUnexpected(rangeError(icuOpenCalendarFailed));
+        if (!setCalendarToISODate(cal, isoDate)) [[unlikely]]
+            return makeUnexpected(rangeError(icuSetCalendarFailed));
+
+        UErrorCode status = U_ZERO_ERROR;
+        auto yearField = calendarArithmeticYearField(calendarId);
+        int32_t sourceYear = ucal_get(cal, yearField, &status);
+        int32_t sourceMonth = ucal_get(cal, UCAL_MONTH, &status);
+        int32_t sourceDay = ucal_get(cal, UCAL_DAY_OF_MONTH, &status);
+        if (U_FAILURE(status)) [[unlikely]]
+            return makeUnexpected(rangeError(icuReadCalendarFailed));
+
+        auto expected = balanceFixedSolarYearMonth(sourceYear, sourceMonth, fixedSolarMonthsInYear(calendarId), duration.years(), duration.months());
+        if (!expected) [[unlikely]]
+            return makeUnexpected(rangeError("Result of calendar date addition is outside representable range"_s));
+        auto constructedExactly = setFixedSolarCalendarToYearMonth(cal, calendarId, *expected);
+        if (!constructedExactly) [[unlikely]]
+            return makeUnexpected(rangeError(icuCalendarArithmeticFailed));
+        if (!*constructedExactly) [[unlikely]]
+            return makeUnexpected(rangeError("Result of calendar date addition is outside representable range"_s));
+
+        int32_t maxDay = ucal_getLimit(cal, UCAL_DAY_OF_MONTH, UCAL_ACTUAL_MAXIMUM, &status);
+        if (U_FAILURE(status)) [[unlikely]]
+            return makeUnexpected(rangeError(icuReadCalendarFailed));
+        if (overflow == TemporalOverflow::Reject && sourceDay > maxDay) [[unlikely]]
+            return makeUnexpected(rangeError("day is out of range for the resulting month (overflow: reject)"_s));
+        int32_t regulatedDay = std::min(sourceDay, maxDay);
+        ucal_set(cal, UCAL_DAY_OF_MONTH, regulatedDay);
+        ucal_getMillis(cal, &status);
+        if (U_FAILURE(status)) [[unlikely]]
+            return makeUnexpected(rangeError(icuCalendarArithmeticFailed));
+        int32_t actualYear = ucal_get(cal, yearField, &status);
+        int32_t actualMonth = ucal_get(cal, UCAL_MONTH, &status);
+        int32_t actualDay = ucal_get(cal, UCAL_DAY_OF_MONTH, &status);
+        if (U_FAILURE(status)) [[unlikely]]
+            return makeUnexpected(rangeError(icuReadCalendarFailed));
+        // At ICU's extreme millisecond boundary, resolving a directly set day can round to
+        // the adjacent day even though that native day is representable. Correct only the day
+        // after the expected year/month have resolved exactly, then verify all fields again.
+        if (actualYear == expected->year && actualMonth == expected->month && std::abs(actualDay - regulatedDay) == 1) {
+            ucal_add(cal, UCAL_DAY_OF_MONTH, regulatedDay - actualDay, &status);
+            if (U_FAILURE(status)) [[unlikely]]
+                return makeUnexpected(rangeError(icuCalendarArithmeticFailed));
+            actualYear = ucal_get(cal, yearField, &status);
+            actualMonth = ucal_get(cal, UCAL_MONTH, &status);
+            actualDay = ucal_get(cal, UCAL_DAY_OF_MONTH, &status);
+            if (U_FAILURE(status)) [[unlikely]]
+                return makeUnexpected(rangeError(icuReadCalendarFailed));
+        }
+        if (actualYear != expected->year || actualMonth != expected->month || actualDay != regulatedDay) [[unlikely]]
+            return makeUnexpected(rangeError("Result of calendar date addition is outside representable range"_s));
+
+        auto baseline = isoDateFromCalendarChecked(cal);
+        if (!baseline || !ISO8601::isDateTimeWithinLimits(baseline->year(), baseline->month(), baseline->day(), 12, 0, 0, 0, 0, 0)) [[unlikely]]
+            return makeUnexpected(rangeError("Result of calendar date addition is outside representable range"_s));
+        return *baseline;
+    });
+    if (!baselineOrError)
+        return makeUnexpected(baselineOrError.error());
+
+    ISO8601::Duration remaining;
+    remaining.setWeeks(duration.weeks());
+    remaining.setDays(duration.days());
+    return isoDateAdd(*baselineOrError, remaining, overflow);
+}
+
 // calendarDateAdd — temporal_rs: Calendar::date_add (src/builtins/core/calendar.rs)
 //   temporal_rs delegates to icu4x: AnyCalendar::add -> ArithmeticDate::added (components/calendar/src/calendar_arithmetic.rs)
 //   ICU4C has no equivalent: we use ucal_add(UCAL_EXTENDED_YEAR/UCAL_MONTH) with month-code re-resolution for lunisolar.
@@ -1047,19 +1200,22 @@ static bool nonISODateSurpasses(
 // CalendarDateAdd steps:
 //   1. If iso8601 -> isoDateAdd (BalanceISOYearMonth + RegulateISODate + AddDaysToISODate). (our steps 1–2)
 //   2. (else) NonISODateAdd — implementation-defined. (our steps 3–9)
-//   3. If ISODateWithinLimits(result) is false, throw RangeError. (checked via isoDateFromCalendarChecked)
+//   3. If ISODateWithinLimits(result) is false, throw RangeError. (checked after conversion)
 //   4. Return result.
 TemporalResult<ISO8601::PlainDate> calendarDateAdd(CalendarID calendarId, const ISO8601::PlainDate& isoDate, const ISO8601::Duration& duration, TemporalOverflow overflow)
 {
-    // 1. If calendarId is not a lunisolar calendar, use ISO proleptic-Gregorian arithmetic.
-    // NOTE: Non-lunisolar calendars share proleptic Gregorian arithmetic; bypass ICU (gregory uses Julian pre-1582).
-    if (!calendarIsLunisolar(calendarId))
-        return isoDateAdd(isoDate, duration, overflow);
-    // 2. If there are no year or month components, day/week addition is calendar-independent; use isoDateAdd.
+    // 1. If there are no year or month components, day/week addition is calendar-independent; use isoDateAdd.
     // NOTE: ICU's Chinese/Dangi approximation gives wrong results for far-future dates (year > ~2100).
     if (!duration.years() && !duration.months())
         return isoDateAdd(isoDate, duration, overflow);
-    // 3. Let totalDays be duration.[[Days]] + 7 × duration.[[Weeks]].
+    // 2. Fixed solar calendars construct the exact expected native fields directly.
+    if (calendarIsNonISOSolar(calendarId))
+        return fixedSolarDateAdd(calendarId, isoDate, duration, overflow);
+    // 3. Gregorian-derived calendars use ISO proleptic-Gregorian arithmetic.
+    // NOTE: ICU's gregory uses Julian arithmetic before 1582; keep the ISO path for Gregorian-derived calendars.
+    if (!calendarIsLunisolar(calendarId))
+        return isoDateAdd(isoDate, duration, overflow);
+    // 4. Let totalDays be duration.[[Days]] + 7 × duration.[[Weeks]].
     // NOTE: ucal_add takes int32_t; any component outside int32_t exceeds Temporal's representable range.
     auto fitsInt32 = [](int64_t v) -> bool {
         return v >= INT32_MIN && v <= INT32_MAX;
@@ -1086,19 +1242,17 @@ TemporalResult<ISO8601::PlainDate> calendarDateAdd(CalendarID calendarId, const 
         int32_t originalDay = ucal_get(cal, UCAL_DAY_OF_MONTH, &status);
         if (U_FAILURE(status)) [[unlikely]]
             return makeUnexpected(rangeError(icuReadCalendarFailed));
-        // 7. If duration.[[Years]] ≠ 0, add years; for lunisolar, re-resolve the original month code in the new year.
+        // 7. If duration.[[Years]] ≠ 0, add years and re-resolve the original month code in the new year.
         if (duration.years()) {
             ucal_add(cal, UCAL_EXTENDED_YEAR, clampTo<int32_t>(duration.years()), &status);
             if (U_FAILURE(status)) [[unlikely]]
                 return makeUnexpected(rangeError(icuCalendarArithmeticFailed));
-            if (calendarIsLunisolar(calendarId)) {
-                auto foundState = setCalendarToMonthCode(cal, calendarId, origMonthCode);
-                if (!foundState) [[unlikely]]
-                    return makeUnexpected(rangeError("Failed to resolve month code after year addition"_s));
-                //    a. If overflow is ~reject~ and month code doesn't exist in new year, throw RangeError.
-                if (!foundState.value() && overflow == TemporalOverflow::Reject) [[unlikely]]
-                    return makeUnexpected(rangeError("month code does not exist in the target year (overflow: reject)"_s));
-            }
+            auto foundState = setCalendarToMonthCode(cal, calendarId, origMonthCode);
+            if (!foundState) [[unlikely]]
+                return makeUnexpected(rangeError("Failed to resolve month code after year addition"_s));
+            //    a. If overflow is ~reject~ and month code doesn't exist in new year, throw RangeError.
+            if (!foundState.value() && overflow == TemporalOverflow::Reject) [[unlikely]]
+                return makeUnexpected(rangeError("month code does not exist in the target year (overflow: reject)"_s));
         }
 
         // 8. If duration.[[Months]] ≠ 0, add months.
@@ -1162,10 +1316,27 @@ static std::optional<bool> surpassesMonths(
     int32_t targetDay)
 {
     UErrorCode status = U_ZERO_ERROR;
-    ucal_add(trialCal, UCAL_MONTH, sign, &status);
-    if (U_FAILURE(status)) [[unlikely]]
-        return std::nullopt;
-    int32_t trialYear = ucal_get(trialCal, UCAL_EXTENDED_YEAR, &status);
+    if (calendarIsNonISOSolar(calendarId)) {
+        auto yearField = calendarArithmeticYearField(calendarId);
+        int32_t sourceYear = ucal_get(trialCal, yearField, &status);
+        int32_t sourceMonth = ucal_get(trialCal, UCAL_MONTH, &status);
+        if (U_FAILURE(status)) [[unlikely]]
+            return std::nullopt;
+        auto expected = balanceFixedSolarYearMonth(sourceYear, sourceMonth, fixedSolarMonthsInYear(calendarId), 0, sign);
+        if (!expected)
+            return true;
+        auto advancedExactly = setFixedSolarCalendarToYearMonth(trialCal, calendarId, *expected);
+        if (!advancedExactly)
+            return std::nullopt;
+        if (!*advancedExactly)
+            return true;
+    } else {
+        ucal_add(trialCal, UCAL_MONTH, sign, &status);
+        if (U_FAILURE(status)) [[unlikely]]
+            return std::nullopt;
+    }
+    auto yearField = calendarArithmeticYearField(calendarId);
+    int32_t trialYear = ucal_get(trialCal, yearField, &status);
     if (U_FAILURE(status)) [[unlikely]]
         return std::nullopt;
     auto trialMonthCode = getMonthCode(trialCal, calendarId);
@@ -1215,7 +1386,7 @@ static std::optional<bool> setMonths(UCalendar* cal, int32_t sourceDay)
 
 // calendarDateUntil — temporal_rs: Calendar::date_until (src/builtins/core/calendar.rs)
 //   temporal_rs delegates to icu4x: AnyCalendar::until -> ArithmeticDate::until + SurpassesChecker (components/calendar/src/calendar_arithmetic.rs)
-//   ICU4C has no equivalent: we use epoch-ms comparison + iterative ucal_add(UCAL_MONTH) walking.
+//   ICU4C has no equivalent: fixed-solar calendars balance native fields directly; lunisolar calendars walk months with ucal_add.
 // https://tc39.es/proposal-temporal/#sec-temporal-calendardateuntil
 // CalendarDateUntil steps:
 //   1. Let sign be CompareISODate(one, two). (our step 4)
@@ -1227,9 +1398,9 @@ TemporalResult<ISO8601::Duration> calendarDateUntil(CalendarID calendarId, const
     // CalendarDateUntil takes "largestUnit: a date unit" — spec guarantees Year/Month/Week/Day only.
     ASSERT(largestUnit == TemporalUnit::Year || largestUnit == TemporalUnit::Month || largestUnit == TemporalUnit::Week || largestUnit == TemporalUnit::Day);
 
-    // 1. If calendarId is not lunisolar, use ISO proleptic-Gregorian arithmetic (route through diffISODate).
+    // 1. If calendarId is neither fixed solar nor lunisolar, use ISO proleptic-Gregorian arithmetic.
     // NOTE: ICU's 'gregory' uses Julian before 1582, causing field mismatches; always route through ISO.
-    if (!calendarIsLunisolar(calendarId))
+    if (!calendarIsNonISOSolar(calendarId) && !calendarIsLunisolar(calendarId))
         return diffISODate(one, two, largestUnit);
     // 2. If largestUnit is ~day~ or ~week~, use pure ISO day count (calendar-independent).
     // NOTE: ICU Chinese/Dangi epoch ms is approximate for dates beyond ~year 2100; pure ISO is exact.
@@ -1254,7 +1425,7 @@ TemporalResult<ISO8601::Duration> calendarDateUntil(CalendarID calendarId, const
         t.epochMs = ucal_getMillis(cal, &status);
         if (U_FAILURE(status)) [[unlikely]]
             return makeUnexpected(rangeError(icuReadCalendarFailed));
-        t.year = ucal_get(cal, UCAL_EXTENDED_YEAR, &status);
+        t.year = ucal_get(cal, calendarArithmeticYearField(calendarId), &status);
         if (U_FAILURE(status)) [[unlikely]]
             return makeUnexpected(rangeError(icuReadCalendarFailed));
         auto monthCodeOpt = getMonthCode(cal, calendarId);
@@ -1279,6 +1450,7 @@ TemporalResult<ISO8601::Duration> calendarDateUntil(CalendarID calendarId, const
         double epochMs { 0 };
         int32_t year { 0 };
         String monthCode;
+        int32_t ordinalMonth { 0 };
         int32_t day { 0 };
     };
     auto sourceOrError = withCalendar(calendarId, [&](UCalendar* cal) -> TemporalResult<SourceFields> {
@@ -1291,13 +1463,14 @@ TemporalResult<ISO8601::Duration> calendarDateUntil(CalendarID calendarId, const
         s.epochMs = ucal_getMillis(cal, &status);
         if (U_FAILURE(status)) [[unlikely]]
             return makeUnexpected(rangeError(icuReadCalendarFailed));
-        s.year = ucal_get(cal, UCAL_EXTENDED_YEAR, &status);
+        s.year = ucal_get(cal, calendarArithmeticYearField(calendarId), &status);
         if (U_FAILURE(status)) [[unlikely]]
             return makeUnexpected(rangeError(icuReadCalendarFailed));
         auto monthCodeOpt = getMonthCode(cal, calendarId);
         if (!monthCodeOpt) [[unlikely]]
             return makeUnexpected(rangeError(icuReadCalendarFailed));
         s.monthCode = WTF::move(*monthCodeOpt);
+        s.ordinalMonth = ucal_get(cal, UCAL_MONTH, &status) + 1;
         s.day = ucal_get(cal, UCAL_DAY_OF_MONTH, &status);
         if (U_FAILURE(status)) [[unlikely]]
             return makeUnexpected(rangeError(icuReadCalendarFailed));
@@ -1316,6 +1489,27 @@ TemporalResult<ISO8601::Duration> calendarDateUntil(CalendarID calendarId, const
         sign = -1;
     else
         return ISO8601::Duration { };
+
+    // Fixed-solar calendars have a constant month count, so jump directly to the native
+    // total-month difference. At most one candidate can surpass because it is already in
+    // the target year/month; preserve the existing unregulated source-day comparison.
+    if (calendarIsNonISOSolar(calendarId) && largestUnit == TemporalUnit::Month) {
+        CheckedInt64 checkedMonths = (CheckedInt64(target.year) - source.year) * fixedSolarMonthsInYear(calendarId);
+        checkedMonths += target.ordinalMonth - source.ordinalMonth;
+        if (checkedMonths.hasOverflowed()) [[unlikely]]
+            return makeUnexpected(rangeError(icuCalendarArithmeticFailed));
+        int64_t months = checkedMonths;
+        if (compareSurpassesOrdinally(sign, target.year, target.ordinalMonth, source.day, target.year, target.ordinalMonth, target.day))
+            months -= sign;
+
+        ISO8601::Duration monthDuration;
+        monthDuration.setMonths(months);
+        auto intermediate = calendarDateAdd(calendarId, one, monthDuration, TemporalOverflow::Constrain);
+        if (!intermediate) [[unlikely]]
+            return makeUnexpected(intermediate.error());
+        auto remainder = diffISODate(*intermediate, two, TemporalUnit::Day);
+        return ISO8601::Duration { 0, months, 0, remainder.days(), 0, 0, 0, 0, Int128(0), Int128(0) };
+    }
 
     // NOTE: min_years fast-forward: pre-guess year delta that doesn't surpass (icu4x optimization).
     int32_t yearDiff = target.year - source.year;
@@ -1359,7 +1553,8 @@ TemporalResult<ISO8601::Duration> calendarDateUntil(CalendarID calendarId, const
             return makeUnexpected(rangeError(icuSetCalendarFailed));
 
         UErrorCode status = U_ZERO_ERROR;
-        // NOTE: lunisolar months per year vary; iterate one at a time (no min_months fast-forward).
+        // Lunisolar month counts vary. Fixed-solar calendars reach this loop only for
+        // largestUnit year, so direct construction is bounded to at most one native year.
         int32_t candidateMonths = sign;
         //    d. Set cal to (one + years) with day=1 for clamping-free month advancement.
         double startMs = ucal_getMillis(cal, &status);
@@ -1382,14 +1577,27 @@ TemporalResult<ISO8601::Duration> calendarDateUntil(CalendarID calendarId, const
             // ucal_setMillis(cal, startMs) below resets it before applying the final months count.
         }
 
-        // Restore cal to (one + years), apply total months in one ucal_add (avoids undo asymmetry).
+        // Restore cal to (one + years), then apply total months without undoing trial steps.
         ucal_setMillis(cal, startMs, &status);
         if (U_FAILURE(status)) [[unlikely]]
             return makeUnexpected(rangeError(icuSetCalendarFailed));
         if (months) {
-            ucal_add(cal, UCAL_MONTH, months, &status);
-            if (U_FAILURE(status)) [[unlikely]]
-                return makeUnexpected(rangeError(icuCalendarArithmeticFailed));
+            if (calendarIsNonISOSolar(calendarId)) {
+                int32_t sourceYear = ucal_get(cal, calendarArithmeticYearField(calendarId), &status);
+                int32_t sourceMonth = ucal_get(cal, UCAL_MONTH, &status);
+                if (U_FAILURE(status)) [[unlikely]]
+                    return makeUnexpected(rangeError(icuReadCalendarFailed));
+                auto expected = balanceFixedSolarYearMonth(sourceYear, sourceMonth, fixedSolarMonthsInYear(calendarId), 0, months);
+                if (!expected) [[unlikely]]
+                    return makeUnexpected(rangeError(icuCalendarArithmeticFailed));
+                auto advancedExactly = setFixedSolarCalendarToYearMonth(cal, calendarId, *expected);
+                if (!advancedExactly || !*advancedExactly) [[unlikely]]
+                    return makeUnexpected(rangeError(icuCalendarArithmeticFailed));
+            } else {
+                ucal_add(cal, UCAL_MONTH, months, &status);
+                if (U_FAILURE(status)) [[unlikely]]
+                    return makeUnexpected(rangeError(icuCalendarArithmeticFailed));
+            }
         }
         //    e. Apply regulated day = min(sourceDay, end_of_month) via setMonths.
         if (!setMonths(cal, source.day)) [[unlikely]]
@@ -1633,7 +1841,7 @@ Expected<int32_t, EcmaReferenceYearError> ecmaReferenceYear(CalendarID calendarI
 //   2. Let result be ? CalendarDateToISO(calendar, fields, overflow).
 //      -> iso8601: handled by the JS layer before reaching here.
 //      -> non-ISO: implementation-defined (NonISOCalendarDateToISO); no concrete spec steps.
-//   3. If ISODateWithinLimits(result) is false, throw a RangeError.  (checked via isoDateFromCalendarChecked)
+//   3. Date-producing callers enforce ISODateWithinLimits; partial callers enforce their own limits.
 //   4. Return result.
 TemporalResult<ISO8601::PlainDate> calendarDateFromFields(CalendarID calendarId, std::optional<int32_t> year, uint8_t month, uint8_t day, std::optional<StringView> era, std::optional<int32_t> eraYear, std::optional<ParsedMonthCode> monthCode, TemporalOverflow overflow)
 {


### PR DESCRIPTION
#### 9dd0abc261828479fac8134d26d7138b962df5a3
<pre>
[JSC][Temporal] Fix fixed-solar non-ISO calendar arithmetic

<a href="https://bugs.webkit.org/show_bug.cgi?id=319804">https://bugs.webkit.org/show_bug.cgi?id=319804</a>

Reviewed by Yijia Huang.

ICU calendar arithmetic can clamp at the supported instant boundaries, leaving partially clamped native fields for fixed-solar non-ISO calendars. Construct and verify native year, month, and day fields directly for Coptic, Ethiopic, Ethioaa, Indian, and Persian, balance their 12/13-month years explicitly, and finish weeks and days in ISO space. Use the same checked construction for dateUntil so large month differences remain direct and add/until stay consistent. Keep Ethioaa arithmetic on its calendar-native UCAL_YEAR field.

Test: JSTests/stress/temporal-calendar-icu-bridge-non-iso.js

The focused stress/JIT coverage and the supported Temporal Test262 suite passed, including boundary and overflow cases; 10 unsupported files remained configured skips.

* JSTests/stress/temporal-calendar-icu-bridge-non-iso.js:

  - Add fixed-solar add/until, overflow, balancing, inverse, and boundary coverage.

* Source/JavaScriptCore/runtime/temporal/core/CalendarICUBridge.cpp:

  (JSC::Temporal::calendarArithmeticYearField):

  (JSC::Temporal::resolveMonthCodeToOrdinal):

  (JSC::Temporal::fixedSolarMonthsInYear):

  (JSC::Temporal::balanceFixedSolarYearMonth):

  (JSC::Temporal::setFixedSolarCalendarToYearMonth):

  (JSC::Temporal::fixedSolarDateAdd):

  (JSC::Temporal::calendarDateAdd):

  (JSC::Temporal::calendarDateUntil):

  - Add direct checked fixed-solar native calendar arithmetic.

Canonical link: <a href="https://commits.webkit.org/317627@main">https://commits.webkit.org/317627@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2482861a70f331b456c856cedfc108859c4e4d13

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175848 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49781 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43565 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185441 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/138039 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51073 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49463 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136932 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/138039 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178804 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40397 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157709 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117411 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39039 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37416 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/6218 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149458 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37201 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33911 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/37112 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41481 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/41622 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187862 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49448 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145926 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39259 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50128 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/33825 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145766 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40561 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122324 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/116173 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48635 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12181 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48037 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48269 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48094 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->