### PR TITLE
IOSurface::convertToFormat leaks the completion callback and destination surface when the accelerator fails

### DIFF
--- a/Source/WebCore/platform/graphics/cocoa/IOSurface.mm
+++ b/Source/WebCore/platform/graphics/cocoa/IOSurface.mm
@@ -803,15 +803,26 @@ void IOSurface::convertToFormat(IOSurfacePool* pool, std::unique_ptr<IOSurface>&
 {
     static IOSurfaceAcceleratorRef accelerator;
     if (!accelerator) {
-        IOSurfaceAcceleratorCreate(nullptr, nullptr, &accelerator);
+        IOSurfaceAcceleratorRef newAccelerator = nullptr;
+        IOSurfaceAcceleratorCreate(nullptr, nullptr, &newAccelerator);
 
-        if (!accelerator) {
+        if (!newAccelerator) {
             callback(nullptr);
             return;
         }
 
-        auto runLoopSource = IOSurfaceAcceleratorGetRunLoopSource(accelerator);
+        // Without a run loop source, the accelerator can never deliver a completion, so
+        // don't cache it; every subsequent transform would silently never complete.
+        auto runLoopSource = IOSurfaceAcceleratorGetRunLoopSource(newAccelerator);
+        if (!runLoopSource) {
+            RELEASE_LOG_ERROR(IOSurface, "IOSurface::convertToFormat: failed to get a run loop source for the accelerator");
+            CFRelease(newAccelerator);
+            callback(nullptr);
+            return;
+        }
+
         CFRunLoopAddSource(CFRunLoopGetMain(), runLoopSource, kCFRunLoopDefaultMode);
+        accelerator = newAccelerator;
     }
 
     if (inSurface->pixelFormat() == format) {
@@ -829,18 +840,22 @@ void IOSurface::convertToFormat(IOSurfacePool* pool, std::unique_ptr<IOSurface>&
     IOSurfaceAcceleratorCompletion completion;
     completion.completionRefCon = new WTF::Function<void(std::unique_ptr<IOSurface>)> (WTF::move(callback));
     completion.completionRefCon2 = destinationSurface.release();
-    completion.completionCallback = [](void *completionRefCon, IOReturn, void * completionRefCon2) {
+    completion.completionCallback = [](void *completionRefCon, IOReturn result, void * completionRefCon2) {
         auto* callback = static_cast<WTF::Function<void(std::unique_ptr<IOSurface>)>*>(completionRefCon);
         auto destinationSurface = std::unique_ptr<IOSurface>(static_cast<IOSurface*>(completionRefCon2));
-        
-        (*callback)(WTF::move(destinationSurface));
+
+        (*callback)(result == kIOReturnSuccess ? WTF::move(destinationSurface) : nullptr);
         delete callback;
     };
 
     NSDictionary *options = @{ (id)kIOSurfaceAcceleratorUnwireSurfaceKey : @YES };
 
     IOReturn ret = IOSurfaceAcceleratorTransformSurface(accelerator, inSurface->surface(), destinationIOSurfaceRef, (CFDictionaryRef)options, nullptr, &completion, nullptr, nullptr);
-    ASSERT_UNUSED(ret, ret == kIOReturnSuccess);
+    if (ret != kIOReturnSuccess) {
+        RELEASE_LOG_ERROR(IOSurface, "IOSurface::convertToFormat: IOSurfaceAcceleratorTransformSurface failed for size (%d, %d), error %d", inSurface->size().width(), inSurface->size().height(), ret);
+        completion.completionCallback(completion.completionRefCon, ret, completion.completionRefCon2);
+        return;
+    }
 }
 
 #endif // HAVE(IOSURFACE_ACCELERATOR)


### PR DESCRIPTION
#### 8e980f978de665f7960aab424b917f4ad89c316d
<pre>
IOSurface::convertToFormat leaks the completion callback and destination surface when the accelerator fails
<a href="https://bugs.webkit.org/show_bug.cgi?id=319805">https://bugs.webkit.org/show_bug.cgi?id=319805</a>
<a href="https://rdar.apple.com/182688059">rdar://182688059</a>

Reviewed by Mike Wyrzykowski.

If IOSurfaceAcceleratorTransformSurface() fails synchronously, the
heap-allocated completion WTF::Function and the released
destinationSurface raw pointer both leaked, since the completion
callback that would normally free them never fires. This was silent
in release builds because ASSERT_UNUSED compiles out the check.

Synchronous failure is observable rather than theoretical. The
accelerator validates the request and can reject it before queuing
anything, for surfaces below the hardware&apos;s minimum dimensions, for
unsupported format or option combinations, and when it cannot acquire
the resources needed to wire and map the surfaces. Log the error
instead of asserting, since none of those are programming errors on
our side.

Fix the leak by having the synchronous failure path invoke the same
completionCallback that the accelerator would have invoked
asynchronously, instead of duplicating its cleanup logic. Since that
shared callback previously ignored its IOReturn result and always
handed the (possibly untransformed) destination surface to the
caller, also fix it to pass nullptr on failure, matching the failure
contract already used earlier in the function for accelerator
creation and destination surface creation failures. This corrects
both the synchronous failure this bug is about and any true
asynchronous transform failure reported later by the OS, which can
leave the destination surface only partially written.

Also stop ignoring a null return from
IOSurfaceAcceleratorGetRunLoopSource(). Adding a null source to the
main run loop is invalid, and because the accelerator was cached in a
static before it was known to be usable, every later conversion would
have issued a transform whose completion could never be delivered,
leaking the WTF::Function and an entire destination surface each time
for the life of the process. Only cache the accelerator once it has a
run loop source.

* Source/WebCore/platform/graphics/cocoa/IOSurface.mm:
(WebCore::IOSurface::convertToFormat):

Canonical link: <a href="https://commits.webkit.org/319262@main">https://commits.webkit.org/319262@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/510fc4dd3d2a8adcfa8bbf80fc93a23e2449bf4c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180982 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54927 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48725 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191196 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145305 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/21701213-a2c4-4e40-a73d-9406b0648633) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182844 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56225 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54643 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141209 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97903 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d389f591-c28c-4e94-b116-164cc138fdb5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183937 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44869 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161959 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121661 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/64761bf0-4ed2-4eaf-b93d-e2d592319219) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43542 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41820 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153946 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41486 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2356 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47539 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46075 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193131 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54593 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150594 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40292 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55281 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38104 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150311 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44897 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127547 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123040 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53798 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16480 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53180 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53417 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53245 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->