### PR TITLE
ShareableGainMap::applyGainMapToBaseImage passes a null value to a kCFTypeDictionaryValueCallBacks dictionary

### DIFF
--- a/Source/WebCore/platform/graphics/cocoa/ShareableGainMap.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/ShareableGainMap.cpp
@@ -153,7 +153,8 @@ PlatformImagePtr ShareableGainMap::applyGainMapToBaseImage(PlatformImagePtr base
 
     RetainPtr applyGainMapOptions = adoptCF(CFDictionaryCreateMutable(nullptr, 0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
     CFDictionarySetValue(applyGainMapOptions, kCGImageAuxiliaryDataInfoMetadata, metadata);
-    CFDictionarySetValue(applyGainMapOptions, kCGImageAuxiliaryDataInfoColorSpace, m_colorSpace ? m_colorSpace->platformColorSpace() : nullptr);
+    if (m_colorSpace)
+        CFDictionarySetValue(applyGainMapOptions, kCGImageAuxiliaryDataInfoColorSpace, m_colorSpace->platformColorSpace());
 
     auto status = CGImageApplyHDRGainMap(baseImagePixelBuffer, gainMapPixelBuffer, targetImagePixelBuffer, applyGainMapOptions);
     if (status != kCVReturnSuccess) {


### PR DESCRIPTION
#### d4eab751dd9fff1730f911f3a0c271e8768bb5b9
<pre>
ShareableGainMap::applyGainMapToBaseImage passes a null value to a kCFTypeDictionaryValueCallBacks dictionary
<a href="https://bugs.webkit.org/show_bug.cgi?id=319806">https://bugs.webkit.org/show_bug.cgi?id=319806</a>
<a href="https://rdar.apple.com/182690269">rdar://182690269</a>

Reviewed by Dan Glastonbury.

applyGainMapOptions is created with kCFTypeDictionaryValueCallBacks,
whose retain/release callbacks are CFRetain/CFRelease. When
m_colorSpace was empty, CFDictionarySetValue() was called with a
null value for kCGImageAuxiliaryDataInfoColorSpace, causing
CFDictionarySetValue() to invoke CFRetain(NULL), which is invalid.
Only set the key when m_colorSpace is present.

* Source/WebCore/platform/graphics/cocoa/ShareableGainMap.cpp:
(WebCore::ShareableGainMap::applyGainMapToBaseImage const):

Canonical link: <a href="https://commits.webkit.org/317596@main">https://commits.webkit.org/317596@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0c2c2fef104c75dda1832de3e902028c374749a8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175566 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49498 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43279 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185152 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/137720 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8227d537-179e-4b9f-b9ee-942cc10560d7) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/177430 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50790 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49181 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136705 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/137720 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/52aa9e48-a945-401f-997a-afb460913576) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178523 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40130 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157466 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117183 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/05d51254-9d03-4f9d-8156-9972e4b2c5f4) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38771 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37158 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149193 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36959 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33627 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41186 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41361 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187577 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49165 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145675 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39239 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49845 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33583 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145513 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40332 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122038 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115834 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48352 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11935 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47754 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47984 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47811 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->