### PR TITLE
[GTK][WPE] Function webkitDrmGetFormatName produces wrong string when trimming trailing spaces

### DIFF
--- a/Source/WebKit/UIProcess/API/glib/WebKitProtocolHandler.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitProtocolHandler.cpp
@@ -215,18 +215,18 @@ static String webkitDrmGetFormatName(uint32_t format)
     if (!format)
         return "INVALID"_s;
 
-    std::span<char> buffer;
-    CString code = CString::newUninitialized(4, buffer);
+    std::array<char, 4> buffer;
     buffer[0] = static_cast<char>((format >> 0) & 0xFF);
     buffer[1] = static_cast<char>((format >> 8) & 0xFF);
     buffer[2] = static_cast<char>((format >> 16) & 0xFF);
     buffer[3] = static_cast<char>((format >> 24) & 0xFF);
 
     // Trim spaces at the end.
-    for (size_t i = 3; i > 0 && buffer[i] == ' '; --i)
-        buffer[i] = '\0';
+    size_t bufferSize = buffer.size();
+    while (bufferSize > 1 && buffer[bufferSize - 1] == ' ')
+        bufferSize--;
 
-    return makeString(code, isBigEndian ? "_BE"_s : ""_s);
+    return makeString(unsafeMakeSpan(buffer.data(), bufferSize), isBigEndian ? "_BE"_s : ""_s);
 }
 
 static String webkitDrmGetModifierName(uint64_t modifier)


### PR DESCRIPTION
#### 7b34c82d13a834bce7e40335ec32c39ee8b2cdb8
<pre>
[GTK][WPE] Function webkitDrmGetFormatName produces wrong string when trimming trailing spaces
<a href="https://bugs.webkit.org/show_bug.cgi?id=319809">https://bugs.webkit.org/show_bug.cgi?id=319809</a>

Reviewed by Adrian Perez de Castro.

It replaces the empty spaces with null characters, but the size of the
CString doesn&apos;t change. This is causing that the formats string shown in
webkit://gpu is garbled. It doesn&apos;t affect GTK for me because it doesn&apos;t
show any format with trailing spaces, but the bug is present anyway. We
can use a std::array instead of a CString, wich also saves a heap
allocation for every format, and then construct a std::span with the
buffer size without the trailing spaces.

* Source/WebKit/UIProcess/API/glib/WebKitProtocolHandler.cpp:
(WebKit::webkitDrmGetFormatName):

Canonical link: <a href="https://commits.webkit.org/317535@main">https://commits.webkit.org/317535@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/36c480d92d5df505d832e5f077ed6f81a19f97e4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175575 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49507 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43288 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185161 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/137729 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50799 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49190 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136714 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/137729 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178532 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40135 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157478 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117192 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38776 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37166 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149198 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36971 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33636 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41196 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/41369 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187586 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49174 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145683 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49854 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33595 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145521 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26684 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40340 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122047 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115859 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48361 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11949 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47763 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47993 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47820 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->