### PR TITLE
[WPE] webkit://gpu doesn't show the preferred format device when using the default

### DIFF
--- a/Source/WebKit/UIProcess/API/glib/WebKitProtocolHandler.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitProtocolHandler.cpp
@@ -307,23 +307,24 @@ static String preferredBufferFormats(WebKitURISchemeRequest* request, JSON::Arra
     StringBuilder builder;
     builder.append("<ul>"_s);
     for (const auto& tranche : formats) {
+        const auto& drmDevice = !tranche.drmDevice.isNull() ? tranche.drmDevice : drmMainDevice();
         auto jsonObject = JSON::Object::create();
         builder.append("<li>Formats for "_s);
         switch (tranche.usage) {
         case RendererBufferFormat::Usage::Rendering:
-            builder.append("<b>rendering</b> using device <i>"_s, !tranche.drmDevice.renderNode.isNull() ? tranche.drmDevice.renderNode : tranche.drmDevice.primaryNode, "</i>"_s);
+            builder.append("<b>rendering</b> using device <i>"_s, !drmDevice.renderNode.isNull() ? drmDevice.renderNode : drmDevice.primaryNode, "</i>"_s);
             jsonObject->setString("Usage"_s, "Rendering"_s);
-            jsonObject->setString("Device"_s, String::fromUTF8(!tranche.drmDevice.renderNode.isNull() ? tranche.drmDevice.renderNode.span() : tranche.drmDevice.primaryNode.span()));
+            jsonObject->setString("Device"_s, String::fromUTF8(!drmDevice.renderNode.isNull() ? drmDevice.renderNode.span() : drmDevice.primaryNode.span()));
             break;
         case RendererBufferFormat::Usage::Scanout:
-            builder.append("<b>scanout</b> using device <i>"_s, tranche.drmDevice.primaryNode, "</i>"_s);
+            builder.append("<b>scanout</b> using device <i>"_s, drmDevice.primaryNode, "</i>"_s);
             jsonObject->setString("Usage"_s, "Scanout"_s);
-            jsonObject->setString("Device"_s, String::fromUTF8(tranche.drmDevice.primaryNode.span()));
+            jsonObject->setString("Device"_s, String::fromUTF8(drmDevice.primaryNode.span()));
             break;
         case RendererBufferFormat::Usage::Mapping:
-            builder.append("<b>mapping</b> using device <i>"_s, tranche.drmDevice.primaryNode, "</i>"_s);
+            builder.append("<b>mapping</b> using device <i>"_s, drmDevice.primaryNode, "</i>"_s);
             jsonObject->setString("Usage"_s, "Mapping"_s);
-            jsonObject->setString("Device"_s, String::fromUTF8(tranche.drmDevice.primaryNode.span()));
+            jsonObject->setString("Device"_s, String::fromUTF8(drmDevice.primaryNode.span()));
             break;
         }
         builder.append("<br>"_s);


### PR DESCRIPTION
#### 9e6e8ccd4bcff98bb0646258a4b9cabe48f896c0
<pre>
[WPE] webkit://gpu doesn&apos;t show the preferred format device when using the default
<a href="https://bugs.webkit.org/show_bug.cgi?id=319810">https://bugs.webkit.org/show_bug.cgi?id=319810</a>

Reviewed by Adrian Perez de Castro.

A null device in a preferred buffer format tranche means using the main
device, so check if tranche device is null and use the main one instead.

* Source/WebKit/UIProcess/API/glib/WebKitProtocolHandler.cpp:
(WebKit::preferredBufferFormats):

Canonical link: <a href="https://commits.webkit.org/317536@main">https://commits.webkit.org/317536@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/03f6c2f34eece3f960582b6a78e6043ddd1909fe

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175577 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49509 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43290 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185163 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/137731 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50801 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49192 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136717 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/137731 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178534 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40141 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157480 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117195 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38782 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37164 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149204 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36973 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33638 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41198 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/41367 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187588 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49176 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145686 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49856 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/33597 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145524 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26685 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40341 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122049 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115862 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48363 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11951 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47765 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47995 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47822 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->