### PR TITLE
Fix css/css-overflow/parsing/line-clamp-valid.html

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/parsing/line-clamp-valid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/parsing/line-clamp-valid-expected.txt
@@ -2,12 +2,12 @@
 PASS e.style['line-clamp'] = "none" should set the property value
 PASS e.style['line-clamp'] = "1" should set the property value
 PASS e.style['line-clamp'] = "6" should set the property value
-FAIL e.style['line-clamp'] = "auto" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['line-clamp'] = "\" etc., etc. \"" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['line-clamp'] = "7 no-ellipsis" should set the property value assert_not_equals: property should be set got disallowed value ""
+PASS e.style['line-clamp'] = "auto" should set the property value
+PASS e.style['line-clamp'] = "\" etc., etc. \"" should set the property value
+PASS e.style['line-clamp'] = "7 no-ellipsis" should set the property value
 PASS e.style['line-clamp'] = "8 auto" should set the property value
 PASS e.style['line-clamp'] = "9 \" etc., etc. \"" should set the property value
-FAIL e.style['line-clamp'] = "no-ellipsis 10" should set the property value assert_not_equals: property should be set got disallowed value ""
+PASS e.style['line-clamp'] = "no-ellipsis 10" should set the property value
 PASS e.style['line-clamp'] = "auto 11" should set the property value
 PASS e.style['line-clamp'] = "\" etc., etc. \" 12" should set the property value
 FAIL e.style['line-clamp'] = "1 -webkit-legacy" should set the property value assert_not_equals: property should be set got disallowed value ""

--- a/Source/WebCore/css/ShorthandSerializer.cpp
+++ b/Source/WebCore/css/ShorthandSerializer.cpp
@@ -1492,17 +1492,18 @@ String ShorthandSerializer::serializePositionTry() const
 
 String ShorthandSerializer::serializeLineClamp() const
 {
-    auto isMaxLinesInitial = isLonghandInitialValue(0);
-    auto isBlockEllipsisInitial = isLonghandInitialValue(1);
-    if (isMaxLinesInitial && isBlockEllipsisInitial)
-        return nameString(CSSValueNone);
-
-    if (isMaxLinesInitial != isBlockEllipsisInitial)
-        return { };
-
     auto blockEllipsis = longhandValueID(1);
-    if (isBlockEllipsisInitial || (!isMaxLinesInitial && blockEllipsis == CSSValueAuto))
-        return serializeLonghands(1);
+    auto maxLines = longhandValueID(0);
+    if (blockEllipsis == CSSValueAuto) {
+        if (maxLines == CSSValueNone)
+            return nameString(CSSValueAuto);
+        return serializeLonghandValue(0);
+    }
+    if (maxLines == CSSValueNone) {
+        if (blockEllipsis == CSSValueNoEllipsis)
+            return nameString(CSSValueNone);
+        return serializeLonghandValue(1);
+    }
 
     // FIXME: Add check for correct order.
     return serializeLonghands(2);


### PR DESCRIPTION
#### fa2a0e2504b5611104b1e48c7c6df3385f50cbc6
<pre>
Fix css/css-overflow/parsing/line-clamp-valid.html
<a href="https://bugs.webkit.org/show_bug.cgi?id=319812">https://bugs.webkit.org/show_bug.cgi?id=319812</a>

Reviewed by NOBODY (OOPS!).

Improve css/css-overflow/parsing/line-clamp-valid.html results by checking more
specifically for values of the longhands. Note that this discards the continue
longhand and line-clamp: -webkit-legacy has to be supported for this test to be fully fixed.

* LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/parsing/line-clamp-valid-expected.txt:
* Source/WebCore/css/ShorthandSerializer.cpp:
(WebCore::ShorthandSerializer::serializeLineClamp const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fa2a0e2504b5611104b1e48c7c6df3385f50cbc6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176073 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50008 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43798 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185669 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/138300 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/177936 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51300 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49692 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137128 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96232 "1 flakes 5 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179029 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40600 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157901 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117603 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39249 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37620 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149665 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37398 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34137 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41724 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41831 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188090 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49673 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146141 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50356 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34016 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145971 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40751 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122559 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/116476 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48861 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12370 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48262 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48497 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48321 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->