### PR TITLE
Cherry-pick 317504@main (48f6c283035d). https://bugs.webkit.org/show_bug.cgi?id=319475

### DIFF
--- a/LayoutTests/accessibility/focus-notification-without-prior-tree-access-expected.txt
+++ b/LayoutTests/accessibility/focus-notification-without-prior-tree-access-expected.txt
@@ -1,0 +1,9 @@
+This test verifies that a focus notification is delivered even when nothing has queried the accessibility tree before the focus change (e.g. accessibleElementById, rootElement or focusedElement). This matters because some platform implementations only create the AXObjectCache lazily, and a naive implementation may only do so as a side effect of an earlier tree query rather than in response to the focus change itself.
+
+PASS: sawFocusNotification === true
+PASS: accessibilityController.focusedElement.domIdentifier === 'item'
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/focus-notification-without-prior-tree-access.html
+++ b/LayoutTests/accessibility/focus-notification-without-prior-tree-access.html
@@ -1,0 +1,49 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../resources/accessibility-helper.js"></script>
+<script src="../resources/js-test.js"></script>
+</head>
+<body>
+
+<div id="item" role="listitem" tabindex="0" aria-posinset="1" aria-setsize="10">Item 1</div>
+
+<script>
+let output = "This test verifies that a focus notification is delivered even when nothing has " +
+    "queried the accessibility tree before the focus change (e.g. accessibleElementById, " +
+    "rootElement or focusedElement). This matters because some platform implementations only " +
+    "create the AXObjectCache lazily, and a naive implementation may only do so as a side effect " +
+    "of an earlier tree query rather than in response to the focus change itself.\n\n";
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    var sawFocusNotification = false;
+    // Intentionally register the listener without calling accessibleElementById,
+    // rootElement, or focusedElement first, so nothing has forced the platform
+    // accessibility tree/cache into existence yet.
+    accessibilityController.addNotificationListener((axElement, notification) => {
+        if (notification == "AXFocusChanged" || notification == "AXFocusedUIElementChanged")
+            sawFocusNotification = true;
+    });
+
+    // A plain DOM focus call, not going through any accessibility API.
+    document.getElementById("item").focus();
+
+    setTimeout(async () => {
+        await waitFor(() => sawFocusNotification);
+        output += expect("sawFocusNotification", "true");
+        if (sawFocusNotification)
+            output += expect("accessibilityController.focusedElement.domIdentifier", "'item'");
+
+        document.getElementById("item").style.visibility = "hidden";
+        accessibilityController.removeNotificationListener();
+        debug(output);
+        finishJSTest();
+    }, 0);
+} else {
+    debug(output);
+}
+</script>
+</body>
+</html>

--- a/Source/WTF/wtf/URLHelpers.cpp
+++ b/Source/WTF/wtf/URLHelpers.cpp
@@ -923,7 +923,7 @@ String userVisibleURL(const CString& url)
                 after[afterIndex++] = c;
                 
                 // Check for "xn--" in an efficient, non-case-sensitive, way.
-                if (c == '-' && i >= 3 && !mayNeedHostNameDecoding && (after[afterIndex - 4] | 0x20) == 'x' && (after[afterIndex - 3] | 0x20) == 'n' && after[afterIndex - 2] == '-')
+                if (c == '-' && afterIndex >= 4 && !mayNeedHostNameDecoding && (after[afterIndex - 4] | 0x20) == 'x' && (after[afterIndex - 3] | 0x20) == 'n' && after[afterIndex - 2] == '-')
                     mayNeedHostNameDecoding = true;
             }
         }

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -6738,7 +6738,7 @@ bool Document::setFocusedElement(Element* newFocusedElement, const FocusOptions&
             window()->navigation().setFocusChanged(FocusDidChange::Yes);
     }
 
-#if PLATFORM(GTK)
+#if PLATFORM(GTK) || PLATFORM(WPE)
     // GTK relies on creating the AXObjectCache when a focus change happens.
     if (CheckedPtr cache = axObjectCache())
 #else

--- a/Source/WebKit/UIProcess/API/glib/WebKitProtocolHandler.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitProtocolHandler.cpp
@@ -221,18 +221,18 @@ static String webkitDrmGetFormatName(uint32_t format)
     if (!format)
         return "INVALID"_s;
 
-    std::span<char> buffer;
-    CString code = CString::newUninitialized(4, buffer);
+    std::array<char, 4> buffer;
     buffer[0] = static_cast<char>((format >> 0) & 0xFF);
     buffer[1] = static_cast<char>((format >> 8) & 0xFF);
     buffer[2] = static_cast<char>((format >> 16) & 0xFF);
     buffer[3] = static_cast<char>((format >> 24) & 0xFF);
 
     // Trim spaces at the end.
-    for (size_t i = 3; i > 0 && buffer[i] == ' '; --i)
-        buffer[i] = '\0';
+    size_t bufferSize = buffer.size();
+    while (bufferSize > 1 && buffer[bufferSize - 1] == ' ')
+        bufferSize--;
 
-    return makeString(code, isBigEndian ? "_BE"_s : ""_s);
+    return makeString(unsafeMakeSpan(buffer.data(), bufferSize), isBigEndian ? "_BE"_s : ""_s);
 }
 
 static String webkitDrmGetModifierName(uint64_t modifier)

--- a/Source/WebKit/UIProcess/API/glib/WebKitProtocolHandler.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitProtocolHandler.cpp
@@ -313,23 +313,24 @@ static String preferredBufferFormats(WebKitURISchemeRequest* request, JSON::Arra
     StringBuilder builder;
     builder.append("<ul>"_s);
     for (const auto& tranche : formats) {
+        const auto& drmDevice = !tranche.drmDevice.isNull() ? tranche.drmDevice : drmMainDevice();
         auto jsonObject = JSON::Object::create();
         builder.append("<li>Formats for "_s);
         switch (tranche.usage) {
         case RendererBufferFormat::Usage::Rendering:
-            builder.append("<b>rendering</b> using device <i>"_s, !tranche.drmDevice.renderNode.isNull() ? tranche.drmDevice.renderNode : tranche.drmDevice.primaryNode, "</i>"_s);
+            builder.append("<b>rendering</b> using device <i>"_s, !drmDevice.renderNode.isNull() ? drmDevice.renderNode : drmDevice.primaryNode, "</i>"_s);
             jsonObject->setString("Usage"_s, "Rendering"_s);
-            jsonObject->setString("Device"_s, String::fromUTF8(!tranche.drmDevice.renderNode.isNull() ? tranche.drmDevice.renderNode.span() : tranche.drmDevice.primaryNode.span()));
+            jsonObject->setString("Device"_s, String::fromUTF8(!drmDevice.renderNode.isNull() ? drmDevice.renderNode.span() : drmDevice.primaryNode.span()));
             break;
         case RendererBufferFormat::Usage::Scanout:
-            builder.append("<b>scanout</b> using device <i>"_s, tranche.drmDevice.primaryNode, "</i>"_s);
+            builder.append("<b>scanout</b> using device <i>"_s, drmDevice.primaryNode, "</i>"_s);
             jsonObject->setString("Usage"_s, "Scanout"_s);
-            jsonObject->setString("Device"_s, String::fromUTF8(tranche.drmDevice.primaryNode.span()));
+            jsonObject->setString("Device"_s, String::fromUTF8(drmDevice.primaryNode.span()));
             break;
         case RendererBufferFormat::Usage::Mapping:
-            builder.append("<b>mapping</b> using device <i>"_s, tranche.drmDevice.primaryNode, "</i>"_s);
+            builder.append("<b>mapping</b> using device <i>"_s, drmDevice.primaryNode, "</i>"_s);
             jsonObject->setString("Usage"_s, "Mapping"_s);
-            jsonObject->setString("Device"_s, String::fromUTF8(tranche.drmDevice.primaryNode.span()));
+            jsonObject->setString("Device"_s, String::fromUTF8(drmDevice.primaryNode.span()));
             break;
         }
         builder.append("<br>"_s);

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitURIUtilities.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitURIUtilities.cpp
@@ -40,10 +40,21 @@ static void testURIForDisplayAffected(Test*, gconstpointer)
     g_assert_cmpstr(displayURI.get(), ==, "http://site.com\xC3\xB7othersite.org");
 }
 
+static void testURIForDisplayShortPercentEncoded(Test*, gconstpointer)
+{
+    // A '-' that lands before four bytes have been written to the output buffer
+    // used to index it out of bounds while probing for "xn--". The leading
+    // percent escape decodes to one byte, so the input index runs ahead of the
+    // output index.
+    GUniquePtr<char> displayURI(webkit_uri_for_display("%AB-"));
+    g_assert_cmpstr(displayURI.get(), ==, "%AB-");
+}
+
 void beforeAll()
 {
     Test::add("WebKitURIUtilities", "uri-for-display-unaffected", testURIForDisplayUnaffected);
     Test::add("WebKitURIUtilities", "uri-for-display-affected", testURIForDisplayAffected);
+    Test::add("WebKitURIUtilities", "uri-for-display-short-percent-encoded", testURIForDisplayShortPercentEncoded);
 }
 
 void afterAll()


### PR DESCRIPTION
#### 9d13dd1044b113a8cd37bd86774056a240482cc8
<pre>
Cherry-pick 317504@main (48f6c283035d). <a href="https://bugs.webkit.org/show_bug.cgi?id=319475">https://bugs.webkit.org/show_bug.cgi?id=319475</a>

    [WPE][Accessibility] focus change accessibility event is not exposed
    <a href="https://bugs.webkit.org/show_bug.cgi?id=319475">https://bugs.webkit.org/show_bug.cgi?id=319475</a>

    Reviewed by Tyler Wilcock.

    On WPE, if nothing else has queried the accessibility tree yet (e.g. a fresh
    AT-SPI client that goes straight to listening for focus events), the very first
    focus change finds no AXObjectCache and is silently dropped: onFocusChange() is
    never called, and no &quot;focused&quot; state-changed notification is ever sent.

    Add WPE alongside GTK to the platforms that lazily create the AXObjectCache on
    the first focus change, matching how GTK already behaves.

    Test: accessibility/focus-notification-without-prior-tree-access.html

    * LayoutTests/accessibility/focus-notification-without-prior-tree-access-expected.txt: Added.
    * LayoutTests/accessibility/focus-notification-without-prior-tree-access.html: Added.
    * Source/WebCore/dom/Document.cpp:
    (WebCore::Document::setFocusedElement):

    Canonical link: <a href="https://commits.webkit.org/317504@main">https://commits.webkit.org/317504@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.1013@webkitglib/2.52">https://commits.webkit.org/305877.1013@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### bce095daa5ecbf53239c50b887fd2f2ec758a60d
<pre>
Cherry-pick 317537@main (e08a16763c94). <a href="https://bugs.webkit.org/show_bug.cgi?id=319161">https://bugs.webkit.org/show_bug.cgi?id=319161</a>

    Fix out-of-bounds buffer index in userVisibleURL when probing for xn--
    <a href="https://bugs.webkit.org/show_bug.cgi?id=319161">https://bugs.webkit.org/show_bug.cgi?id=319161</a>

    Reviewed by Patrick Griffis.

    userVisibleURL() probes the output buffer for an &quot;xn--&quot; prefix by reading
    back from the index it just wrote (after[afterIndex - 4 .. afterIndex - 2]),
    but it gated those reads on the input index (i &gt;= 3) rather than the output
    index. When an earlier percent escape decodes to a single byte (for example
    %AB, which is &gt; 0x7f), the input index advances three positions while the
    output index advances one, so a &apos;-&apos; can be reached while afterIndex &lt; 4.
    afterIndex - 4 then wraps around as size_t and indexes the bounds-checked
    Vector out of range.

    Gate the probe on afterIndex &gt;= 4 so it tracks the buffer it actually reads.
    A legitimate &quot;xn--&quot; prefix always writes four literal output bytes, so its
    detection is unaffected. The input is reachable from untrusted data through
    the public webkit_uri_for_display() API and Internals.userVisibleString; the
    minimal trigger is &quot;%AB-&quot;.

    * Source/WTF/wtf/URLHelpers.cpp:
    (WTF::URLHelpers::userVisibleURL):
    * Tools/TestWebKitAPI/Tests/WebKit/WKPage/glib/TestWebKitURIUtilities.cpp:
    (testURIForDisplayShortPercentEncoded):
    (beforeAll):

    Canonical link: <a href="https://commits.webkit.org/317537@main">https://commits.webkit.org/317537@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.1012@webkitglib/2.52">https://commits.webkit.org/305877.1012@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 8c2ed3b35c7f802167742b42c76f191ab40688f2
<pre>
Cherry-pick 317535@main (7b34c82d13a8). <a href="https://bugs.webkit.org/show_bug.cgi?id=319809">https://bugs.webkit.org/show_bug.cgi?id=319809</a>

    [GTK][WPE] Function webkitDrmGetFormatName produces wrong string when trimming trailing spaces
    <a href="https://bugs.webkit.org/show_bug.cgi?id=319809">https://bugs.webkit.org/show_bug.cgi?id=319809</a>

    Reviewed by Adrian Perez de Castro.

    It replaces the empty spaces with null characters, but the size of the
    CString doesn&apos;t change. This is causing that the formats string shown in
    webkit://gpu is garbled. It doesn&apos;t affect GTK for me because it doesn&apos;t
    show any format with trailing spaces, but the bug is present anyway. We
    can use a std::array instead of a CString, wich also saves a heap
    allocation for every format, and then construct a std::span with the
    buffer size without the trailing spaces.

    * Source/WebKit/UIProcess/API/glib/WebKitProtocolHandler.cpp:
    (WebKit::webkitDrmGetFormatName):

    Canonical link: <a href="https://commits.webkit.org/317535@main">https://commits.webkit.org/317535@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.1011@webkitglib/2.52">https://commits.webkit.org/305877.1011@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### b2efd5099a8798816f425bd401efda65d966efa2
<pre>
Cherry-pick 317536@main (9e6e8ccd4bcf). <a href="https://bugs.webkit.org/show_bug.cgi?id=319810">https://bugs.webkit.org/show_bug.cgi?id=319810</a>

    [WPE] webkit://gpu doesn&apos;t show the preferred format device when using the default
    <a href="https://bugs.webkit.org/show_bug.cgi?id=319810">https://bugs.webkit.org/show_bug.cgi?id=319810</a>

    Reviewed by Adrian Perez de Castro.

    A null device in a preferred buffer format tranche means using the main
    device, so check if tranche device is null and use the main one instead.

    * Source/WebKit/UIProcess/API/glib/WebKitProtocolHandler.cpp:
    (WebKit::preferredBufferFormats):

    Canonical link: <a href="https://commits.webkit.org/317536@main">https://commits.webkit.org/317536@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.1010@webkitglib/2.52">https://commits.webkit.org/305877.1010@webkitglib/2.52</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/99bf581c8c59db4f983fac21a4f00776441611df

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175592 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/49524 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/43305 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185178 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/137759 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/177456 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/50816 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/49207 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136730 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/137759 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178549 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/50816 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/43305 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117208 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/50816 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/49207 "The change is no longer eligible for processing.") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/43305 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/50816 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/43305 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33653 "Built successfully") | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/36853 "The change is no longer eligible for processing.") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/41213 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/49207 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187603 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/49191 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/43305 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145700 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/49871 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/43305 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145538 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26695 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/49871 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/122064 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/115884 "The change is no longer eligible for processing.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/48379 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/43305 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/47780 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/48010 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/47837 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->