### PR TITLE
[JSC][Temporal] Resolve supported Chinese and Dangi field resolution

### DIFF
--- a/JSTests/stress/temporal-lunisolar-ordinal-month.js
+++ b/JSTests/stress/temporal-lunisolar-ordinal-month.js
@@ -1,0 +1,135 @@
+//@ requireOptions("--useTemporal=1")
+
+function shouldBe(actual, expected, message) {
+    if (actual !== expected)
+        throw new Error(`${message}: expected ${expected}, got ${actual}`);
+}
+
+function shouldThrow(errorType, callback, message) {
+    try {
+        callback();
+    } catch (error) {
+        if (error instanceof errorType)
+            return;
+        throw new Error(`${message}: expected ${errorType.name}, got ${error}`);
+    }
+    throw new Error(`${message}: expected ${errorType.name}`);
+}
+
+for (const { calendar, year, ordinal, monthCode } of [
+    { calendar: "chinese", year: 2012, ordinal: 5, monthCode: "M04L" },
+    { calendar: "dangi", year: 2012, ordinal: 4, monthCode: "M03L" },
+]) {
+    const fields = { calendar, year, month: ordinal, day: 1 };
+    const coded = Temporal.PlainDate.from({ calendar, year, monthCode, day: 1 });
+    for (const { name, create } of [
+        { name: "PlainDate", create: () => Temporal.PlainDate.from(fields) },
+        { name: "PlainDateTime", create: () => Temporal.PlainDateTime.from({ ...fields, hour: 12 }) },
+        { name: "PlainYearMonth", create: () => Temporal.PlainYearMonth.from(fields) },
+        { name: "ZonedDateTime", create: () => Temporal.ZonedDateTime.from({ ...fields, hour: 12, timeZone: "UTC" }) },
+    ]) {
+        const result = create();
+        shouldBe(result.month, ordinal, `${name} ${calendar} ordinal month`);
+        shouldBe(result.monthCode, monthCode, `${name} ${calendar} leap month code`);
+    }
+    shouldBe(Temporal.PlainDate.from(fields).equals(coded), true, `${calendar} numeric/coded equality`);
+    const previous = Temporal.PlainDate.from({ calendar, year, month: ordinal - 1, day: 1 });
+    shouldBe(previous.with({ month: ordinal }).monthCode, monthCode, `${calendar} PlainDate.with`);
+    shouldBe(Temporal.PlainDateTime.from({ ...fields, month: ordinal - 1 }).with({ month: ordinal }).monthCode, monthCode, `${calendar} PlainDateTime.with`);
+    shouldBe(Temporal.PlainYearMonth.from({ ...fields, month: ordinal - 1 }).with({ month: ordinal }).monthCode, monthCode, `${calendar} PlainYearMonth.with`);
+    shouldBe(Temporal.ZonedDateTime.from({ ...fields, month: ordinal - 1, timeZone: "UTC" }).with({ month: ordinal }).monthCode, monthCode, `${calendar} ZonedDateTime.with`);
+    shouldThrow(RangeError, () => Temporal.PlainDate.from({ ...fields, month: ordinal + 1, monthCode }), `${calendar} month/monthCode consistency`);
+    shouldThrow(TypeError, () => Temporal.PlainMonthDay.from({ calendar, month: ordinal, monthCode, day: 1 }), `${calendar} PlainMonthDay.from year requirement`);
+    shouldBe(Temporal.PlainMonthDay.from({ ...fields, monthCode }).monthCode, monthCode, `${calendar} PlainMonthDay.from with year`);
+    const monthDay = Temporal.PlainMonthDay.from({ calendar, monthCode, day: 1 });
+    shouldThrow(TypeError, () => monthDay.with({ month: ordinal, monthCode }), `${calendar} PlainMonthDay.with year requirement`);
+    shouldBe(monthDay.with({ year, month: ordinal, monthCode }).monthCode, monthCode, `${calendar} PlainMonthDay.with with year`);
+}
+
+for (const { calendar, isoDate, year, month, monthCode } of [
+    { calendar: "chinese", isoDate: "2012-05-21", year: 2012, month: 5, monthCode: "M04L" },
+    { calendar: "dangi", isoDate: "2020-05-23", year: 2020, month: 5, monthCode: "M04L" },
+]) {
+    const date = Temporal.PlainDate.from(`${isoDate}[u-ca=${calendar}]`);
+    shouldBe(date.year, year, `${calendar} related year`);
+    shouldBe(date.month, month, `${calendar} extracted ordinal month`);
+    shouldBe(date.monthCode, monthCode, `${calendar} extracted month code`);
+}
+
+for (const [calendar, monthCode, oldMonth, newMonth] of [["chinese", "M06L", 7, 6], ["dangi", "M05L", 6, 5]]) {
+    const date = Temporal.PlainDate.from({ calendar, year: 2017, monthCode, day: 1 });
+    shouldBe(date.month, oldMonth, `${calendar} source leap ordinal`);
+    shouldBe(date.with({ year: 2024 }).month, newMonth, `${calendar} with year inherits monthCode only`);
+}
+
+for (let i = 0; i < 100; ++i)
+    shouldBe(Temporal.PlainDate.from({ calendar: "chinese", year: 2012, month: 5, day: 1 }).monthCode, "M04L", "JIT ordinal month");
+
+for (const relativeTo of [
+    { calendar: "chinese", year: 2012, month: 5, monthCode: "M04L", day: 1 },
+    { calendar: "dangi", year: 2012, month: 4, monthCode: "M03L", day: 1 },
+    { calendar: "hebrew", year: 5784, month: 7, monthCode: "M06", day: 1 },
+]) {
+    const monthCodeOnly = { ...relativeTo };
+    delete monthCodeOnly.month;
+    const duration = Temporal.Duration.from({ months: 1, days: 15 });
+    const mismatch = { ...relativeTo, month: relativeTo.month + 1 };
+    shouldBe(Temporal.Duration.compare({ months: 1 }, { days: 29 }, { relativeTo }), Temporal.Duration.compare({ months: 1 }, { days: 29 }, { relativeTo: monthCodeOnly }), `${relativeTo.calendar} Duration.compare relativeTo ordinal month`);
+    shouldBe(duration.round({ largestUnit: "days", relativeTo }).toString(), duration.round({ largestUnit: "days", relativeTo: monthCodeOnly }).toString(), `${relativeTo.calendar} Duration.round relativeTo ordinal month`);
+    shouldBe(duration.total({ unit: "days", relativeTo }), duration.total({ unit: "days", relativeTo: monthCodeOnly }), `${relativeTo.calendar} Duration.total relativeTo ordinal month`);
+    shouldThrow(RangeError, () => Temporal.Duration.compare({ months: 1 }, { days: 29 }, { relativeTo: mismatch }), `${relativeTo.calendar} Duration.compare rejects ordinal mismatch`);
+    shouldThrow(RangeError, () => duration.round({ largestUnit: "days", relativeTo: mismatch }), `${relativeTo.calendar} Duration.round rejects ordinal mismatch`);
+    shouldThrow(RangeError, () => duration.total({ unit: "days", relativeTo: mismatch }), `${relativeTo.calendar} Duration.total rejects ordinal mismatch`);
+}
+
+for (const { calendar, year, month, monthCode } of [
+    { calendar: "gregory", year: 2021, month: 4, monthCode: "M04" },
+    { calendar: "hebrew", year: 5784, month: 7, monthCode: "M06" },
+    { calendar: "islamic-civil", year: 1445, month: 4, monthCode: "M04" },
+]) {
+    shouldThrow(TypeError, () => Temporal.PlainMonthDay.from({ calendar, month, monthCode, day: 1 }), `${calendar} PlainMonthDay.from year requirement`);
+    shouldThrow(TypeError, () => Temporal.PlainMonthDay.from({ calendar, year, day: 32 }, { overflow: "reject" }), `${calendar} missing month before day range`);
+    shouldThrow(TypeError, () => Temporal.PlainMonthDay.from({ calendar, year, month, monthCode: "M01" }), `${calendar} missing day before month conflict`);
+    shouldThrow(TypeError, () => Temporal.PlainMonthDay.from({ calendar, year: 300001, monthCode }), `${calendar} missing day before year range`);
+    shouldThrow(TypeError, () => Temporal.PlainMonthDay.from({ calendar, year: 300001, day: 1 }), `${calendar} missing month before year range`);
+    const monthDay = Temporal.PlainMonthDay.from({ calendar, monthCode, day: 1 });
+    shouldBe(monthDay.monthCode, monthCode, `${calendar} monthCode-only reference year`);
+    shouldThrow(TypeError, () => monthDay.with({ month, monthCode }), `${calendar} PlainMonthDay.with year requirement`);
+    shouldBe(monthDay.with({ year, month, monthCode }).monthCode, monthCode, `${calendar} PlainMonthDay.with with year`);
+    shouldThrow(RangeError, () => monthDay.with({ year: 300001 }), `${calendar} PlainMonthDay.with year range`);
+}
+
+shouldBe(Temporal.PlainMonthDay.from({ calendar: "gregory", era: "ce", eraYear: 2021, month: 4, monthCode: "M04", day: 1 }).monthCode, "M04", "PlainMonthDay era and eraYear identify the year");
+
+for (const { calendar, year, month, monthCode, daysInMonth } of [
+    { calendar: "chinese", year: 2012, month: 5, monthCode: "M04L", daysInMonth: 29 },
+    { calendar: "dangi", year: 2020, month: 5, monthCode: "M04L", daysInMonth: 29 },
+]) {
+    const date = Temporal.PlainDate.from({ calendar, year, month, monthCode, day: 1 });
+    shouldBe(date.daysInMonth, daysInMonth, `${calendar} direct daysInMonth`);
+    shouldBe(date.monthsInYear, 13, `${calendar} direct monthsInYear`);
+    shouldBe(Temporal.PlainDate.from({ calendar, year, month: 1e9, day: 1 }).month, 13, `${calendar} large ordinal constrains`);
+    shouldThrow(RangeError, () => Temporal.PlainDate.from({ calendar, year, month: 1e9, day: 1 }, { overflow: "reject" }), `${calendar} large ordinal rejects`);
+    shouldThrow(RangeError, () => Temporal.PlainDate.from({ calendar, year: 300001, month: 1, day: 1 }), `${calendar} large year rejects`);
+}
+
+for (const [calendar, before, leapStart, leapEnd, after] of [
+    ["chinese", "2012-05-20", "2012-05-21", "2012-06-18", "2012-06-19"],
+    ["dangi", "2020-05-22", "2020-05-23", "2020-06-20", "2020-06-21"],
+]) {
+    const dates = [before, leapStart, leapEnd, after].map(date => Temporal.PlainDate.from(`${date}[u-ca=${calendar}]`));
+    shouldBe(`${dates[0].month}/${dates[0].monthCode}/${dates[0].day}`, "4/M04/30", `${calendar} before leap boundary`);
+    shouldBe(`${dates[1].month}/${dates[1].monthCode}/${dates[1].day}`, "5/M04L/1", `${calendar} leap boundary start`);
+    shouldBe(`${dates[2].month}/${dates[2].monthCode}/${dates[2].day}`, "5/M04L/29", `${calendar} leap boundary end`);
+    shouldBe(`${dates[3].month}/${dates[3].monthCode}/${dates[3].day}`, "6/M05/1", `${calendar} after leap boundary`);
+    const regularStart = Temporal.PlainDate.from(`${calendar === "chinese" ? "2012-04-21" : "2020-04-23"}[u-ca=${calendar}]`);
+    shouldBe(regularStart.add({ months: 1 }).toString(), `${leapStart}[u-ca=${calendar}]`, `${calendar} baseline add parity`);
+    shouldBe(dates[3].subtract({ months: 1 }).toString(), `${leapStart}[u-ca=${calendar}]`, `${calendar} baseline subtract parity`);
+    shouldBe(regularStart.until(dates[3], { largestUnit: "months" }).toString(), "P2M", `${calendar} baseline until parity`);
+    shouldBe(dates[3].since(regularStart, { largestUnit: "months" }).toString(), "P2M", `${calendar} baseline since parity`);
+}
+
+const hebrew = Temporal.PlainDate.from({ calendar: "hebrew", year: 5784, monthCode: "M05L", day: 1 });
+shouldBe(`${hebrew.month}/${hebrew.monthCode}/${hebrew.daysInMonth}/${hebrew.monthsInYear}`, "6/M05L/30/13", "Hebrew controls unchanged");
+const gregory = Temporal.PlainDate.from({ calendar: "gregory", year: 2021, month: 2, day: 1 });
+shouldBe(`${gregory.daysInMonth}/${gregory.monthsInYear}`, "28/12", "non-target calendar controls unchanged");

--- a/Source/JavaScriptCore/runtime/TemporalDuration.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalDuration.cpp
@@ -430,10 +430,6 @@ static RelativeToRecord toRelativeTemporalObject(JSGlobalObject* globalObject, J
                 throwRangeError(globalObject, scope, "month property must be positive and finite"_s);
                 return { };
             }
-            if (otherMonth && static_cast<double>(otherMonth->monthNumber) != month) [[unlikely]] {
-                throwRangeError(globalObject, scope, "month and monthCode properties must match"_s);
-                return { };
-            }
         }
 
         // Step 5.f: dateTimeResult = ? InterpretTemporalDateTimeFields(calendar, fields, ~constrain~).

--- a/Source/JavaScriptCore/runtime/TemporalPlainMonthDayPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainMonthDayPrototype.cpp
@@ -240,9 +240,8 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainMonthDayPrototypeFuncWith, (JSGlobalObject
             merged.month = std::optional<uint32_t>(monthDay->plainMonthDay().month());
     }
 
-    // For non-ISO: month ordinal alone is ambiguous without monthCode (depends on year).
-    if (!isISO && merged.month.has_value() && !merged.monthCode) [[unlikely]]
-        return throwVMTypeError(globalObject, scope, "monthCode is required for non-ISO calendar PlainMonthDay.with()"_s);
+    if (!isISO && merged.month.has_value() && !merged.year && !(merged.era && merged.eraYear)) [[unlikely]]
+        return throwVMTypeError(globalObject, scope, "year is required with month for non-ISO calendar PlainMonthDay.with()"_s);
 
     // Step 10: isoDate = ? CalendarMonthDayFromFields(calendar, fields, overflow).
     auto resolved = TemporalCore::monthDayFromFields(calendarId, merged, overflow);

--- a/Source/JavaScriptCore/runtime/temporal/core/CalendarFields.cpp
+++ b/Source/JavaScriptCore/runtime/temporal/core/CalendarFields.cpp
@@ -58,6 +58,19 @@ static TemporalResult<void> checkYearRange(const CalendarFieldsIn& fields)
     return { };
 }
 
+static TemporalResult<void> checkLunisolarMonthConsistency(CalendarID calendarId, const CalendarFieldsIn& fields, const ISO8601::PlainDate& resolvedDate)
+{
+    if (!calendarIsLunisolar(calendarId) || !fields.month || !fields.monthCode)
+        return { };
+
+    auto resolvedFields = isoToCalendarFields(calendarId, resolvedDate);
+    if (!resolvedFields)
+        return makeUnexpected(resolvedFields.error());
+    if (*fields.month != resolvedFields->month)
+        return makeUnexpected(rangeError("month does not match monthCode"_s));
+    return { };
+}
+
 // temporal_rs: types.rs ResolvedIsoFields::try_from_fields (ISO-only resolution)
 enum class ISOResolveType : uint8_t {
     Date,
@@ -202,6 +215,8 @@ TemporalResult<ResolvedCalendarDate> dateFromFields(CalendarID calendarId, const
     auto result = calendarDateFromFields(calendarId, fields.year, month, *fields.day, era, fields.eraYear, fields.monthCode, overflow);
     if (!result)
         return makeUnexpected(result.error());
+    if (auto consistencyCheck = checkLunisolarMonthConsistency(calendarId, fields, *result); !consistencyCheck)
+        return makeUnexpected(consistencyCheck.error());
 
     // Step 3: If ISODateWithinLimits(result) is false, throw RangeError.
     if (!ISO8601::isDateTimeWithinLimits(result->year(), result->month(), result->day(), 12, 0, 0, 0, 0, 0))
@@ -270,6 +285,8 @@ TemporalResult<ResolvedCalendarDate> yearMonthFromFields(CalendarID calendarId, 
     auto result = calendarDateFromFields(calendarId, fields.year, month, 1, era, fields.eraYear, fields.monthCode, overflow);
     if (!result)
         return makeUnexpected(result.error());
+    if (auto consistencyCheck = checkLunisolarMonthConsistency(calendarId, fields, *result); !consistencyCheck)
+        return makeUnexpected(consistencyCheck.error());
 
     // Step 4: If ISOYearMonthWithinLimits(result) is false, throw RangeError.
     if (!ISO8601::isYearMonthWithinLimits(result->year(), result->month()))
@@ -320,29 +337,23 @@ TemporalResult<ResolvedCalendarDate> monthDayFromFields(CalendarID calendarId, c
     }
 
     // Steps 1-2 (non-ISO): CalendarResolveFields + CalendarMonthDayToISOReferenceDate via ICU bridge.
+    if (!fields.day)
+        return makeUnexpected(typeError("day property must be present"_s));
+    if (fields.month && !fields.year && !(fields.era && fields.eraYear))
+        return makeUnexpected(typeError("year is required with month for non-ISO calendar MonthDay"_s));
+    if (!fields.month && !fields.monthCode)
+        return makeUnexpected(typeError("month or monthCode is required for non-ISO calendar MonthDay"_s));
     auto rangeCheck = checkYearRange(fields);
     if (!rangeCheck)
         return makeUnexpected(rangeCheck.error());
 
-    // Non-lunisolar calendars have no leap months — reject leap month codes.
     if (fields.monthCode && fields.monthCode->isLeapMonth && !calendarIsLunisolar(calendarId))
         return makeUnexpected(rangeError("Leap month codes are not valid for this calendar"_s));
-
-    // Reject month/monthCode conflicts on non-ISO non-lunisolar calendars (see analog check in dateFromFields).
     if (fields.month && fields.monthCode && !calendarIsLunisolar(calendarId)) {
         uint8_t codeMonth = static_cast<uint8_t>(fields.monthCode->monthNumber);
         if (clampTo<uint8_t>(*fields.month) != codeMonth)
             return makeUnexpected(rangeError("month does not match monthCode"_s));
     }
-
-    if (!fields.day)
-        return makeUnexpected(typeError("day property must be present"_s));
-
-    // Non-ISO MonthDay requires monthCode OR a year identifier (year / era+eraYear). test262
-    // `intl402/Temporal/PlainMonthDay/from/fields-missing-properties.js` pins the TypeError.
-    bool hasEraYear = fields.era.has_value() && fields.eraYear.has_value();
-    if (!fields.monthCode && !fields.year && !hasEraYear)
-        return makeUnexpected(typeError("monthCode is required for non-ISO calendar MonthDay"_s));
 
     uint8_t month = 1;
     if (fields.month)
@@ -375,12 +386,6 @@ TemporalResult<ResolvedCalendarDate> monthDayFromFields(CalendarID calendarId, c
             localYear = *refYear;
     }
 
-    // ecmaReferenceYear returns ISO proleptic years. On older Apple ICU, UCAL_EXTENDED_YEAR
-    // uses epoch-based counting for lunisolar calendars; probe the offset per calendar.
-    auto calStr = calendarIDToString(calendarId);
-    bool isChineseOrDangi = (calStr == "chinese"_s || calStr == "dangi"_s);
-    if (localYear && !fields.year && isChineseOrDangi)
-        *localYear += lunarCalendarExtendedYearFor1972(calendarId) - 1972;
     std::optional<StringView> era;
     if (fields.era)
         era = StringView(*fields.era);
@@ -401,6 +406,8 @@ TemporalResult<ResolvedCalendarDate> monthDayFromFields(CalendarID calendarId, c
     auto result = calendarDateFromFields(calendarId, yearArg, month, *fields.day, era, fields.eraYear, *effectiveMonthCode, overflow);
     if (!result)
         return makeUnexpected(result.error());
+    if (auto consistencyCheck = checkLunisolarMonthConsistency(calendarId, fields, *result); !consistencyCheck)
+        return makeUnexpected(consistencyCheck.error());
 
     // For MonthDay with year provided: validate ISO range, then re-resolve with
     // reference year to get canonical reference ISO date per spec.
@@ -431,8 +438,6 @@ TemporalResult<ResolvedCalendarDate> monthDayFromFields(CalendarID calendarId, c
                     }
                 } else
                     refYear = *refYearOr;
-                if (isChineseOrDangi)
-                    refYear += lunarCalendarExtendedYearFor1972(calendarId) - 1972;
                 auto refResult = calendarDateFromFields(calendarId, std::optional<int32_t>(refYear), resolvedFields->month, resolvedFields->day, std::nullopt, std::nullopt, effectiveRefMonthCode, TemporalOverflow::Constrain);
                 if (refResult)
                     return ResolvedCalendarDate { *refResult, calendarId };
@@ -561,10 +566,10 @@ TemporalResult<ResolvedCalendarDate> plainDateWith(CalendarID calendarId, const 
     if (!keysToIgnoreYear && !merged.year)
         merged.year = std::optional<int32_t>(calFields->year);
 
-    // month: user's value if provided; suppress base month when monthCode is provided (they're mutually exclusive).
+    // Keep an inherited month as monthCode only, so it can be constrained in a different year.
     if (partialFields.month.has_value())
         merged.month = *partialFields.month;
-    else if (!partialFields.monthCode.has_value())
+    else if (!partialFields.monthCode.has_value() && calFields->monthCode.isEmpty())
         merged.month = static_cast<uint32_t>(calFields->month);
     merged.day = partialFields.day.has_value() ? *partialFields.day : calFields->day;
 

--- a/Source/JavaScriptCore/runtime/temporal/core/CalendarICUBridge.cpp
+++ b/Source/JavaScriptCore/runtime/temporal/core/CalendarICUBridge.cpp
@@ -187,15 +187,14 @@ int32_t lunarCalendarExtendedYearFor1972(CalendarID calendarId)
         int32_t extYear = ucal_get(cal, UCAL_EXTENDED_YEAR, &status);
         if (U_FAILURE(status)) [[unlikely]]
             return 1972; // fallback: assume ISO-proleptic
-        // Return the raw EXTENDED_YEAR: 1972 on ISO-proleptic ICU,
-        // epoch-based year (whatever the current ICU uses) on older Apple ICU.
         return extYear;
     });
     cached.store(value, std::memory_order_relaxed);
     return value;
 }
 
-// isoDateToEpochMs — internal: converts ISO PlainDate to epoch ms at noon UTC (avoids DST boundary issues)
+// isoDateToEpochMs — internal: converts ISO PlainDate to epoch ms at noon UTC
+// (avoids DST boundary issues).
 static double isoDateToEpochMs(const ISO8601::PlainDate& date)
 {
     const double noonEpochOffsetMs = 43'200'000.0; // nsPerDay / nsPerMillisecond / 2
@@ -328,9 +327,8 @@ static std::optional<String> mapICUEraToTemporalEra(CalendarID calendarId, int32
 // Read-only: does not modify cal.
 // icu4x: components/calendar/src/cal/hebrew.rs (Hebrew special case)
 // icu4x: components/calendar/src/cal/chinese_based.rs (Chinese/Dangi IS_LEAP_MONTH)
-static std::optional<String> getMonthCode(UCalendar* cal, CalendarID calendarId)
+static std::optional<String> getMonthCode(UCalendar* cal, CalendarID calendarId, UErrorCode& status)
 {
-    UErrorCode status = U_ZERO_ERROR;
     int32_t ucalMonth = ucal_get(cal, UCAL_MONTH, &status);
     if (U_FAILURE(status)) [[unlikely]]
         return std::nullopt;
@@ -361,6 +359,160 @@ static std::optional<String> getMonthCode(UCalendar* cal, CalendarID calendarId)
     if (isLeap)
         return makeString("M"_s, month < 10 ? "0"_s : ""_s, month, "L"_s);
     return makeString("M"_s, month < 10 ? "0"_s : ""_s, month);
+}
+
+static std::optional<String> getMonthCode(UCalendar* cal, CalendarID calendarId)
+{
+    UErrorCode status = U_ZERO_ERROR;
+    return getMonthCode(cal, calendarId, status);
+}
+
+static bool addUTCCalendarDays(UCalendar* cal, int32_t days, UErrorCode& status)
+{
+    static constexpr double millisecondsPerDay = 86'400'000.0;
+    double epochMs = ucal_getMillis(cal, &status);
+    if (U_FAILURE(status)) [[unlikely]]
+        return false;
+    return ucal_setMillis(cal, epochMs + days * millisecondsPerDay, &status), U_SUCCESS(status);
+}
+
+static bool setCalendarToLunisolarYearStart(UCalendar* cal, CalendarID calendarId, std::optional<int32_t> year, UErrorCode& status)
+{
+    if (calendarId != chineseCalendarID() && calendarId != dangiCalendarID()) {
+        ucal_set(cal, UCAL_MONTH, 0);
+        ucal_set(cal, UCAL_IS_LEAP_MONTH, 0);
+        ucal_set(cal, UCAL_DAY_OF_MONTH, 1);
+        ucal_getMillis(cal, &status);
+        return U_SUCCESS(status);
+    }
+    if (year && !ISO8601::isYearWithinLimits(*year)) [[unlikely]]
+        return false;
+    if (year && !setCalendarToISODate(cal, ISO8601::PlainDate(*year, 7, 1))) [[unlikely]]
+        return false;
+    int32_t day = ucal_get(cal, UCAL_DAY_OF_MONTH, &status);
+    if (U_FAILURE(status) || !addUTCCalendarDays(cal, 1 - day, status)) [[unlikely]]
+        return false;
+    for (int i = 0; i < 14; ++i) {
+        auto monthCode = getMonthCode(cal, calendarId);
+        if (!monthCode) [[unlikely]]
+            return false;
+        if (*monthCode == "M01"_s)
+            return true;
+        if (!addUTCCalendarDays(cal, -1, status)) [[unlikely]]
+            return false;
+        day = ucal_get(cal, UCAL_DAY_OF_MONTH, &status);
+        if (U_FAILURE(status) || !addUTCCalendarDays(cal, 1 - day, status)) [[unlikely]]
+            return false;
+    }
+    return false;
+}
+
+static std::optional<std::pair<double, double>> lunisolarYearAnchor(UCalendar* cal, CalendarID calendarId, UErrorCode& status)
+{
+    double targetMs = ucal_getMillis(cal, &status);
+    auto targetISODate = isoDateFromCalendarChecked(cal);
+    if (U_FAILURE(status) || !targetISODate) [[unlikely]]
+        return std::nullopt;
+    CheckedInt32 anchorYear = targetISODate->year();
+    if (!setCalendarToLunisolarYearStart(cal, calendarId, anchorYear.value(), status)) [[unlikely]]
+        return std::nullopt;
+    double yearStartMs = ucal_getMillis(cal, &status);
+    if (U_FAILURE(status)) [[unlikely]]
+        return std::nullopt;
+    return std::pair { targetMs, yearStartMs };
+}
+
+enum class LunisolarMonthAdvanceResult : uint8_t {
+    Advanced,
+    Error,
+};
+
+static LunisolarMonthAdvanceResult advanceToNextLunisolarMonth(UCalendar* cal, CalendarID calendarId, UErrorCode& status)
+{
+    if (calendarId != chineseCalendarID() && calendarId != dangiCalendarID())
+        return ucal_add(cal, UCAL_MONTH, 1, &status), U_SUCCESS(status) ? LunisolarMonthAdvanceResult::Advanced : LunisolarMonthAdvanceResult::Error;
+
+    auto currentMonthCode = getMonthCode(cal, calendarId, status);
+    if (!currentMonthCode) [[unlikely]]
+        return LunisolarMonthAdvanceResult::Error;
+    for (int i = 0; i < 32; ++i) {
+        if (!addUTCCalendarDays(cal, 1, status)) [[unlikely]]
+            return LunisolarMonthAdvanceResult::Error;
+        auto adjacentMonthCode = getMonthCode(cal, calendarId, status);
+        if (!adjacentMonthCode) [[unlikely]]
+            return LunisolarMonthAdvanceResult::Error;
+        if (*adjacentMonthCode != *currentMonthCode)
+            return LunisolarMonthAdvanceResult::Advanced;
+    }
+    return LunisolarMonthAdvanceResult::Error;
+}
+
+static std::optional<int32_t> stableLunisolarYear(UCalendar* cal, CalendarID calendarId, UErrorCode& status)
+{
+    auto anchor = lunisolarYearAnchor(cal, calendarId, status);
+    if (!anchor) [[unlikely]]
+        return std::nullopt;
+    ucal_setMillis(cal, anchor->first, &status);
+    if (U_FAILURE(status)) [[unlikely]]
+        return std::nullopt;
+    WTF::Int64Milliseconds msWT(static_cast<int64_t>(anchor->second));
+    auto [year, month, day] = WTF::yearMonthDayFromDays(WTF::msToDays(msWT));
+    CheckedInt32 relatedYear = year;
+    relatedYear += static_cast<int32_t>(month + 1 > 7 || (month + 1 == 7 && day > 1)) - static_cast<int32_t>(anchor->second > anchor->first);
+    return relatedYear.hasOverflowed() ? std::nullopt : std::optional<int32_t> { relatedYear.value() };
+}
+
+static std::optional<int32_t> actualLunisolarMonthLength(UCalendar* cal, CalendarID calendarId, UErrorCode& status)
+{
+    if (calendarId != chineseCalendarID() && calendarId != dangiCalendarID())
+        return ucal_getLimit(cal, UCAL_DAY_OF_MONTH, UCAL_ACTUAL_MAXIMUM, &status);
+    if (U_FAILURE(status)) [[unlikely]]
+        return std::nullopt;
+    double savedMs = ucal_getMillis(cal, &status);
+    if (U_FAILURE(status)) [[unlikely]]
+        return std::nullopt;
+
+    auto restoreCalendar = [&] {
+        UErrorCode operationStatus = status;
+        UErrorCode restoreStatus = U_ZERO_ERROR;
+        ucal_setMillis(cal, savedMs, &restoreStatus);
+        if (U_FAILURE(restoreStatus)) [[unlikely]] {
+            if (U_SUCCESS(operationStatus))
+                status = restoreStatus;
+            else
+                status = operationStatus;
+            return false;
+        }
+        status = operationStatus;
+        return true;
+    };
+
+    int32_t day = ucal_get(cal, UCAL_DAY_OF_MONTH, &status);
+    if (U_FAILURE(status)) [[unlikely]] {
+        restoreCalendar();
+        return std::nullopt;
+    }
+
+    auto advanceResult = advanceToNextLunisolarMonth(cal, calendarId, status);
+    if (advanceResult == LunisolarMonthAdvanceResult::Error) {
+        restoreCalendar();
+        return std::nullopt;
+    }
+    double nextMonthStartMs = ucal_getMillis(cal, &status);
+    bool operationSucceeded = U_SUCCESS(status);
+    if (!restoreCalendar()) [[unlikely]]
+        return std::nullopt;
+    if (!operationSucceeded) [[unlikely]]
+        return std::nullopt;
+    int32_t length = day - 1 + static_cast<int32_t>((nextMonthStartMs - savedMs) / 86'400'000.0);
+    return length >= 29 && length <= 30 ? std::optional<int32_t> { length } : std::nullopt;
+}
+
+static bool addLunisolarCalendarDays(UCalendar* cal, CalendarID calendarId, int32_t days, UErrorCode& status)
+{
+    if (calendarId == chineseCalendarID() || calendarId == dangiCalendarID())
+        return addUTCCalendarDays(cal, days, status);
+    return ucal_add(cal, UCAL_DAY_OF_MONTH, days, &status), U_SUCCESS(status);
 }
 
 // computeOrdinalMonth — internal: returns 1-based ordinal month position in year, counting leap months for lunisolar
@@ -404,6 +556,55 @@ static std::optional<uint8_t> computeOrdinalMonth(UCalendar* cal, CalendarID cal
     }
 
     return static_cast<uint8_t>(ordinal);
+}
+
+static std::optional<uint8_t> computeFieldResolutionOrdinalMonth(UCalendar* cal, CalendarID calendarId)
+{
+    if (calendarId != chineseCalendarID() && calendarId != dangiCalendarID())
+        return computeOrdinalMonth(cal, calendarId);
+
+    UErrorCode status = U_ZERO_ERROR;
+    auto targetCode = getMonthCode(cal, calendarId);
+    auto parsedTargetCode = targetCode ? ISO8601::parseMonthCode(*targetCode) : std::nullopt;
+    if (!parsedTargetCode) [[unlikely]]
+        return std::nullopt;
+    auto anchor = lunisolarYearAnchor(cal, calendarId, status);
+    if (!anchor) [[unlikely]]
+        return std::nullopt;
+
+    if (anchor->second > anchor->first) {
+        ucal_setMillis(cal, anchor->first, &status);
+        int32_t daysInYear = ucal_getLimit(cal, UCAL_DAY_OF_YEAR, UCAL_ACTUAL_MAXIMUM, &status);
+        if (U_FAILURE(status)) [[unlikely]]
+            return std::nullopt;
+        uint8_t ordinal = parsedTargetCode->monthNumber + parsedTargetCode->isLeapMonth;
+        if (daysInYear > 360 && !parsedTargetCode->isLeapMonth) {
+            bool leapFollows = false;
+            for (uint8_t i = 0; i < 13; ++i) {
+                if (advanceToNextLunisolarMonth(cal, calendarId, status) != LunisolarMonthAdvanceResult::Advanced) [[unlikely]]
+                    return std::nullopt;
+                auto code = getMonthCode(cal, calendarId);
+                if (!code) [[unlikely]]
+                    return std::nullopt;
+                if (*code == "M01"_s)
+                    return ordinal + !leapFollows;
+                leapFollows |= code->endsWith("L"_s);
+            }
+            return std::nullopt;
+        }
+        return ordinal <= 13 ? std::optional<uint8_t> { ordinal } : std::nullopt;
+    }
+
+    for (uint8_t ordinal = 1; ordinal <= 13; ++ordinal) {
+        auto code = getMonthCode(cal, calendarId);
+        if (!code) [[unlikely]]
+            return std::nullopt;
+        if (*code == *targetCode)
+            return ordinal;
+        if (advanceToNextLunisolarMonth(cal, calendarId, status) != LunisolarMonthAdvanceResult::Advanced) [[unlikely]]
+            return std::nullopt;
+    }
+    return std::nullopt;
 }
 
 // mapTemporalEraToICUEra — ICU4C has no set-by-era-name API; ucal_set only accepts UCAL_ERA as integer.
@@ -492,8 +693,9 @@ TemporalResult<CalendarFields> isoToCalendarFields(CalendarID calendarId, const 
 
         UErrorCode status = U_ZERO_ERROR;
         RawFields raw;
-        raw.extendedYear = ucal_get(cal, UCAL_EXTENDED_YEAR, &status);
-        if (U_FAILURE(status)) [[unlikely]]
+        auto stableYear = calendarId == chineseCalendarID() || calendarId == dangiCalendarID() ? stableLunisolarYear(cal, calendarId, status) : std::nullopt;
+        raw.extendedYear = stableYear ? *stableYear : ucal_get(cal, UCAL_EXTENDED_YEAR, &status);
+        if (U_FAILURE(status) || ((calendarId == chineseCalendarID() || calendarId == dangiCalendarID()) && !stableYear)) [[unlikely]]
             return makeUnexpected(rangeError(icuReadCalendarFailed));
         raw.ucalEra = ucal_get(cal, UCAL_ERA, &status);
         if (U_FAILURE(status)) [[unlikely]]
@@ -508,7 +710,7 @@ TemporalResult<CalendarFields> isoToCalendarFields(CalendarID calendarId, const 
         if (!raw.monthCode) [[unlikely]]
             return makeUnexpected(rangeError(icuReadCalendarFailed));
         raw.hasEra = calendarHasEras(calendarId);
-        raw.ordinalMonth = computeOrdinalMonth(cal, calendarId);
+        raw.ordinalMonth = computeFieldResolutionOrdinalMonth(cal, calendarId);
         if (!raw.ordinalMonth) [[unlikely]]
             return makeUnexpected(rangeError(icuReadCalendarFailed));
         return raw;
@@ -575,6 +777,12 @@ TemporalResult<int32_t> calendarYear(CalendarID calendarId, const ISO8601::Plain
         if (!setCalendarToISODate(cal, isoDate)) [[unlikely]]
             return makeUnexpected(rangeError(icuSetCalendarFailed));
         UErrorCode status = U_ZERO_ERROR;
+        if (calendarId == chineseCalendarID() || calendarId == dangiCalendarID()) {
+            auto year = stableLunisolarYear(cal, calendarId, status);
+            if (!year) [[unlikely]]
+                return makeUnexpected(rangeError(icuReadCalendarFailed));
+            return *year;
+        }
         // Older ICU versions expose an Amete Mihret-relative UCAL_EXTENDED_YEAR for Ethioaa;
         // newer versions may make UCAL_YEAR and UCAL_EXTENDED_YEAR equal.
         if (calendarId == ethioaaCalendarID()) {
@@ -609,7 +817,7 @@ TemporalResult<uint8_t> calendarMonth(CalendarID calendarId, const ISO8601::Plai
             return makeUnexpected(rangeError(icuOpenCalendarFailed));
         if (!setCalendarToISODate(cal, isoDate)) [[unlikely]]
             return makeUnexpected(rangeError(icuSetCalendarFailed));
-        auto ordinal = computeOrdinalMonth(cal, calendarId);
+        auto ordinal = computeFieldResolutionOrdinalMonth(cal, calendarId);
         if (!ordinal) [[unlikely]]
             return makeUnexpected(rangeError(icuReadCalendarFailed));
         return *ordinal;
@@ -785,6 +993,12 @@ TemporalResult<int32_t> calendarDaysInMonth(CalendarID calendarId, const ISO8601
         if (!setCalendarToISODate(cal, isoDate)) [[unlikely]]
             return makeUnexpected(rangeError(icuSetCalendarFailed));
         UErrorCode status = U_ZERO_ERROR;
+        if (calendarId == chineseCalendarID() || calendarId == dangiCalendarID()) {
+            auto result = actualLunisolarMonthLength(cal, calendarId, status);
+            if (!result) [[unlikely]]
+                return makeUnexpected(rangeError(icuReadCalendarFailed));
+            return *result;
+        }
         auto result = ucal_getLimit(cal, UCAL_DAY_OF_MONTH, UCAL_ACTUAL_MAXIMUM, &status);
         if (U_FAILURE(status)) [[unlikely]]
             return makeUnexpected(rangeError(icuReadCalendarFailed));
@@ -834,27 +1048,42 @@ TemporalResult<int32_t> calendarMonthsInYear(CalendarID calendarId, const ISO860
         if (calendarIsLunisolar(calendarId)) {
             // For lunisolar calendars, count months by walking from month 1 to end of year.
             // cal is local; mutating it has no observable effect outside this function.
-            int32_t savedYear = ucal_get(cal, UCAL_EXTENDED_YEAR, &status);
+            bool isChineseBased = calendarId == chineseCalendarID() || calendarId == dangiCalendarID();
+            int32_t savedYear = isChineseBased ? 0 : ucal_get(cal, UCAL_EXTENDED_YEAR, &status);
             if (U_FAILURE(status)) [[unlikely]]
                 return makeUnexpected(rangeError(icuReadCalendarFailed));
-            ucal_set(cal, UCAL_MONTH, 0);
-            ucal_set(cal, UCAL_IS_LEAP_MONTH, 0);
-            ucal_set(cal, UCAL_DAY_OF_MONTH, 1);
-            ucal_getMillis(cal, &status); // resolve
-            if (U_FAILURE(status)) [[unlikely]]
+            if (isChineseBased) {
+                auto anchor = lunisolarYearAnchor(cal, calendarId, status);
+                if (!anchor) [[unlikely]]
+                    return makeUnexpected(rangeError(icuCalendarArithmeticFailed));
+                if (anchor->second > anchor->first) {
+                    ucal_setMillis(cal, anchor->first, &status);
+                    int32_t daysInYear = ucal_getLimit(cal, UCAL_DAY_OF_YEAR, UCAL_ACTUAL_MAXIMUM, &status);
+                    if (U_FAILURE(status)) [[unlikely]]
+                        return makeUnexpected(rangeError(icuReadCalendarFailed));
+                    return daysInYear > 360 ? 13 : 12;
+                }
+            } else if (!setCalendarToLunisolarYearStart(cal, calendarId, std::nullopt, status)) [[unlikely]]
                 return makeUnexpected(rangeError(icuCalendarArithmeticFailed));
             int32_t count = 1;
+            bool reachedNextYear = false;
             for (int i = 0; i < 14; i++) {
-                ucal_add(cal, UCAL_MONTH, 1, &status);
-                if (U_FAILURE(status)) [[unlikely]]
+                if (advanceToNextLunisolarMonth(cal, calendarId, status) != LunisolarMonthAdvanceResult::Advanced) [[unlikely]]
                     return makeUnexpected(rangeError(icuCalendarArithmeticFailed));
-                int32_t curYear = ucal_get(cal, UCAL_EXTENDED_YEAR, &status);
+                int32_t curYear = isChineseBased ? savedYear : ucal_get(cal, UCAL_EXTENDED_YEAR, &status);
                 if (U_FAILURE(status)) [[unlikely]]
                     return makeUnexpected(rangeError(icuReadCalendarFailed));
-                if (curYear != savedYear)
+                auto monthCode = isChineseBased ? getMonthCode(cal, calendarId) : std::optional<String> { };
+                if (isChineseBased && !monthCode) [[unlikely]]
+                    return makeUnexpected(rangeError(icuReadCalendarFailed));
+                if ((isChineseBased && *monthCode == "M01"_s) || (!isChineseBased && curYear != savedYear)) {
+                    reachedNextYear = true;
                     break;
+                }
                 count++;
             }
+            if (!reachedNextYear || count > 13) [[unlikely]]
+                return makeUnexpected(rangeError(icuCalendarArithmeticFailed));
             return count;
         }
 
@@ -1977,6 +2206,7 @@ TemporalResult<ISO8601::PlainDate> calendarDateFromFields(CalendarID calendarId,
         } else
             ucal_set(cal, UCAL_EXTENDED_YEAR, year.value_or(0));
 
+        bool isChineseBased = calendarId == chineseCalendarID() || calendarId == dangiCalendarID();
         if (monthCode) {
             // Month codes > M13 are always invalid. M13 is only valid for Coptic/Ethiopian.
             if (monthCode->monthNumber > 13) [[unlikely]]
@@ -1988,16 +2218,13 @@ TemporalResult<ISO8601::PlainDate> calendarDateFromFields(CalendarID calendarId,
                 // Lunisolar: walk months from start of year to find target monthCode.
                 // ICU4X uses precomputed year.packed.leap_month() for O(1) lookup; ICU4C
                 // doesn't expose this data, so we walk. The walk is correct and safe.
-                ucal_set(cal, UCAL_MONTH, 0);
-                ucal_set(cal, UCAL_IS_LEAP_MONTH, 0);
-                ucal_set(cal, UCAL_DAY_OF_MONTH, 1);
-                ucal_getMillis(cal, &status);
-                if (U_FAILURE(status)) [[unlikely]]
+                if (!setCalendarToLunisolarYearStart(cal, calendarId, year, status)) [[unlikely]]
                     return makeUnexpected(rangeError(icuCalendarArithmeticFailed));
 
                 String targetCode = makeString("M"_s, monthCode->monthNumber < 10 ? "0"_s : ""_s,
                     monthCode->monthNumber, monthCode->isLeapMonth ? "L"_s : ""_s);
-                int32_t savedYear = ucal_get(cal, UCAL_EXTENDED_YEAR, &status);
+                int32_t savedYear = isChineseBased ? 0 : ucal_get(cal, UCAL_EXTENDED_YEAR, &status);
+                double previousMonthMs = ucal_getMillis(cal, &status);
                 if (U_FAILURE(status)) [[unlikely]]
                     return makeUnexpected(rangeError(icuReadCalendarFailed));
                 bool found = false;
@@ -2018,32 +2245,37 @@ TemporalResult<ISO8601::PlainDate> calendarDateFromFields(CalendarID calendarId,
                                 found = true;
                             } else {
                                 // Chinese/Dangi: M01L->M01, revert one step.
-                                ucal_add(cal, UCAL_MONTH, -1, &status);
+                                ucal_setMillis(cal, previousMonthMs, &status);
                                 if (U_FAILURE(status)) [[unlikely]]
-                                    return makeUnexpected(rangeError(icuCalendarArithmeticFailed));
+                                    return makeUnexpected(rangeError(icuSetCalendarFailed));
                                 found = true;
                             }
                         }
                         break;
                     }
-                    ucal_add(cal, UCAL_MONTH, 1, &status);
-                    if (U_FAILURE(status)) [[unlikely]]
-                        return makeUnexpected(rangeError(icuCalendarArithmeticFailed));
-                    int32_t curYear = ucal_get(cal, UCAL_EXTENDED_YEAR, &status);
+                    previousMonthMs = ucal_getMillis(cal, &status);
                     if (U_FAILURE(status)) [[unlikely]]
                         return makeUnexpected(rangeError(icuReadCalendarFailed));
-                    if (curYear != savedYear) {
-                        ucal_add(cal, UCAL_MONTH, -1, &status);
+                    auto advanceResult = advanceToNextLunisolarMonth(cal, calendarId, status);
+                    if (advanceResult == LunisolarMonthAdvanceResult::Error)
+                        return makeUnexpected(rangeError(U_FAILURE(status) ? icuReadCalendarFailed : icuCalendarArithmeticFailed));
+                    int32_t curYear = isChineseBased ? savedYear : ucal_get(cal, UCAL_EXTENDED_YEAR, &status);
+                    auto nextCode = isChineseBased ? getMonthCode(cal, calendarId) : std::optional<String> { };
+                    if (U_FAILURE(status) || (isChineseBased && !nextCode)) [[unlikely]]
+                        return makeUnexpected(rangeError(icuReadCalendarFailed));
+                    if ((isChineseBased && *nextCode == "M01"_s) || (!isChineseBased && curYear != savedYear)) {
+                        ucal_setMillis(cal, previousMonthMs, &status);
                         if (U_FAILURE(status)) [[unlikely]]
-                            return makeUnexpected(rangeError(icuCalendarArithmeticFailed));
+                            return makeUnexpected(rangeError(icuSetCalendarFailed));
                         break;
                     }
                 }
                 if (!found && overflow == TemporalOverflow::Reject) [[unlikely]]
                     return makeUnexpected(rangeError("monthCode does not exist in this calendar year"_s)); // Clamp day via ucal_add.
-                int32_t maxDay = ucal_getLimit(cal, UCAL_DAY_OF_MONTH, UCAL_ACTUAL_MAXIMUM, &status);
-                if (U_FAILURE(status)) [[unlikely]]
+                auto maxDayOrError = actualLunisolarMonthLength(cal, calendarId, status);
+                if (!maxDayOrError) [[unlikely]]
                     return makeUnexpected(rangeError(icuReadCalendarFailed));
+                int32_t maxDay = *maxDayOrError;
                 uint8_t clampedDay = day;
                 if (day > maxDay) {
                     if (overflow == TemporalOverflow::Reject) [[unlikely]]
@@ -2051,8 +2283,7 @@ TemporalResult<ISO8601::PlainDate> calendarDateFromFields(CalendarID calendarId,
                     clampedDay = static_cast<uint8_t>(maxDay);
                 }
                 if (clampedDay > 1) {
-                    ucal_add(cal, UCAL_DAY_OF_MONTH, clampedDay - 1, &status);
-                    if (U_FAILURE(status)) [[unlikely]]
+                    if (!addLunisolarCalendarDays(cal, calendarId, clampedDay - 1, status)) [[unlikely]]
                         return makeUnexpected(rangeError(icuCalendarArithmeticFailed));
                 }
             } else if (calendarId == hebrewCalendarID()) [[unlikely]] {
@@ -2084,31 +2315,32 @@ TemporalResult<ISO8601::PlainDate> calendarDateFromFields(CalendarID calendarId,
         } else if (calendarIsLunisolar(calendarId)) {
             // For lunisolar calendars, 'month' is the ordinal month (1-indexed).
             // Count monthsInYear using a separate calendar to avoid state corruption.
-            ucal_set(cal, UCAL_MONTH, 0);
-            ucal_set(cal, UCAL_IS_LEAP_MONTH, 0);
-            ucal_set(cal, UCAL_DAY_OF_MONTH, 1);
-            ucal_getMillis(cal, &status);
-            if (U_FAILURE(status)) [[unlikely]]
+            if (!setCalendarToLunisolarYearStart(cal, calendarId, year, status)) [[unlikely]]
                 return makeUnexpected(rangeError("Failed to resolve lunisolar calendar"_s));
             // Count months in year by walking cal forward, then reset to year start.
             double calMs = ucal_getMillis(cal, &status);
             if (U_FAILURE(status)) [[unlikely]]
                 return makeUnexpected(rangeError(icuReadCalendarFailed));
-            int32_t savedYear = ucal_get(cal, UCAL_EXTENDED_YEAR, &status);
+            int32_t savedYear = isChineseBased ? 0 : ucal_get(cal, UCAL_EXTENDED_YEAR, &status);
             if (U_FAILURE(status)) [[unlikely]]
                 return makeUnexpected(rangeError(icuReadCalendarFailed));
             int32_t monthsInYear = 1;
+            bool reachedNextYear = false;
             for (int i = 0; i < 14; i++) {
-                ucal_add(cal, UCAL_MONTH, 1, &status);
-                if (U_FAILURE(status)) [[unlikely]]
+                if (advanceToNextLunisolarMonth(cal, calendarId, status) != LunisolarMonthAdvanceResult::Advanced) [[unlikely]]
                     return makeUnexpected(rangeError(icuCalendarArithmeticFailed));
-                int32_t curYear = ucal_get(cal, UCAL_EXTENDED_YEAR, &status);
-                if (U_FAILURE(status)) [[unlikely]]
+                int32_t curYear = isChineseBased ? savedYear : ucal_get(cal, UCAL_EXTENDED_YEAR, &status);
+                auto nextCode = isChineseBased ? getMonthCode(cal, calendarId) : std::optional<String> { };
+                if (U_FAILURE(status) || (isChineseBased && !nextCode)) [[unlikely]]
                     return makeUnexpected(rangeError(icuReadCalendarFailed));
-                if (curYear != savedYear)
+                if ((isChineseBased && *nextCode == "M01"_s) || (!isChineseBased && curYear != savedYear)) {
+                    reachedNextYear = true;
                     break;
+                }
                 monthsInYear++;
             }
+            if (!reachedNextYear || monthsInYear > 13) [[unlikely]]
+                return makeUnexpected(rangeError("Failed to resolve lunisolar calendar"_s));
             // Reset to year start before advancing to target month.
             ucal_setMillis(cal, calMs, &status);
             if (U_FAILURE(status)) [[unlikely]]
@@ -2123,27 +2355,26 @@ TemporalResult<ISO8601::PlainDate> calendarDateFromFields(CalendarID calendarId,
             }
 
             // Advance the original calendar to the target month.
-            if (resolvedMonth > 1) {
-                ucal_add(cal, UCAL_MONTH, resolvedMonth - 1, &status);
-                if (U_FAILURE(status)) [[unlikely]]
-                    return makeUnexpected(rangeError("Failed to resolve lunisolar month"_s));
+            for (uint8_t ordinal = 1; ordinal < resolvedMonth; ++ordinal) {
+                auto advanceResult = advanceToNextLunisolarMonth(cal, calendarId, status);
+                if (advanceResult == LunisolarMonthAdvanceResult::Error) [[unlikely]]
+                    return makeUnexpected(rangeError(U_FAILURE(status) ? icuReadCalendarFailed : icuCalendarArithmeticFailed));
             }
 
             // Clamp day to daysInMonth if constrain.
-            int32_t maxDay = ucal_getLimit(cal, UCAL_DAY_OF_MONTH, UCAL_ACTUAL_MAXIMUM, &status);
-            if (U_FAILURE(status)) [[unlikely]]
+            auto maxDayOrError = actualLunisolarMonthLength(cal, calendarId, status);
+            if (!maxDayOrError) [[unlikely]]
                 return makeUnexpected(rangeError(icuReadCalendarFailed));
+            int32_t maxDay = *maxDayOrError;
             uint8_t resolvedDay = day;
             if (day > maxDay) {
                 if (overflow == TemporalOverflow::Reject) [[unlikely]]
                     return makeUnexpected(rangeError("Day is out of range for the given month in this calendar"_s));
                 resolvedDay = static_cast<uint8_t>(maxDay);
             }
-            // Use ucal_add (not ucal_set) to advance within the month — avoids
-            // ICU's lazy-field resolution resetting the month position.
+            // Advance from day 1 to preserve the resolved month position.
             if (resolvedDay > 1) {
-                ucal_add(cal, UCAL_DAY_OF_MONTH, resolvedDay - 1, &status);
-                if (U_FAILURE(status)) [[unlikely]]
+                if (!addLunisolarCalendarDays(cal, calendarId, resolvedDay - 1, status)) [[unlikely]]
                     return makeUnexpected(rangeError(icuCalendarArithmeticFailed));
             }
         } else {
@@ -2213,11 +2444,7 @@ TemporalResult<ISO8601::PlainDate> calendarDateFromFields(CalendarID calendarId,
                 return makeUnexpected(rangeError(icuSetCalendarFailed));
             UErrorCode yearStatus = U_ZERO_ERROR;
             int32_t resolvedYear;
-            if (calendarId == rocCalendarID()) {
-                int32_t era = ucal_get(cal, UCAL_ERA, &yearStatus);
-                int32_t ey = ucal_get(cal, UCAL_YEAR, &yearStatus);
-                resolvedYear = !era ? -(ey - 1) : ey;
-            } else if (calendarId == ethioaaCalendarID())
+            if (calendarId == ethioaaCalendarID())
                 resolvedYear = ucal_get(cal, UCAL_YEAR, &yearStatus);
             else
                 resolvedYear = ucal_get(cal, UCAL_EXTENDED_YEAR, &yearStatus);


### PR DESCRIPTION
#### 76de9fe5aa14384920ede9b66991607d8a9e29b3
<pre>
[JSC][Temporal] Resolve supported Chinese and Dangi field resolution

<a href="https://bugs.webkit.org/show_bug.cgi?id=319814">https://bugs.webkit.org/show_bug.cgi?id=319814</a>

Reviewed by Yijia Huang.

Resolve ordinary supported Chinese and Dangi related-year and ordinal numeric-month field resolution without relying on ICU extended-year identity. Keep year/era/eraYear and monthCode/ordinal-month consistency, with({year}), Duration relativeTo, Hebrew month behavior, and PlainMonthDay required-field ordering consistent.

Tests: JSTests/stress/temporal-lunisolar-ordinal-month.js

Tests: jsc --useTemporal=1 JSTests/stress/temporal-lunisolar-ordinal-month.js

Tests: readable focused Temporal field-resolution, Duration, Hebrew, PlainMonthDay ordering, and arithmetic tests
Canonical link: <a href="https://commits.webkit.org/317928@main">https://commits.webkit.org/317928@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1477310c8982482f829770eeb8c4992c2e34b8da

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176746 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50683 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44475 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186348 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/139982 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51976 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50369 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137689 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/139982 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179702 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41196 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158480 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118163 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39850 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38218 "Passed tests") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/251/builds/128 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/6987 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150262 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37978 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34816 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/38017 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42427 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42434 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188772 "Built successfully") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50350 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; Compiled WebKit (warnings)") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146754 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39462 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51033 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34599 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146559 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41324 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123241 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/117395 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49538 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12957 "") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48937 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49173 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48998 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->