### PR TITLE
WeakPtr::is()/UniqueRef::is() const variadic overloads should be named isAnyOf

### DIFF
--- a/Source/WTF/wtf/UniqueRef.h
+++ b/Source/WTF/wtf/UniqueRef.h
@@ -138,7 +138,7 @@ inline bool isAnyOf(UniqueRef<ArgType>& source)
 }
 
 template<typename... ExpectedTypes, typename ArgType>
-inline bool is(const UniqueRef<ArgType>& source)
+inline bool isAnyOf(const UniqueRef<ArgType>& source)
 {
     return isAnyOf<ExpectedTypes...>(source.get());
 }

--- a/Source/WTF/wtf/WeakPtr.h
+++ b/Source/WTF/wtf/WeakPtr.h
@@ -384,7 +384,7 @@ inline bool isAnyOf(WeakPtr<ArgType, WeakPtrImpl, PtrTraits>& source)
 }
 
 template<typename... ExpectedTypes, typename ArgType, typename WeakPtrImpl, typename PtrTraits>
-inline bool is(const WeakPtr<ArgType, WeakPtrImpl, PtrTraits>& source)
+inline bool isAnyOf(const WeakPtr<ArgType, WeakPtrImpl, PtrTraits>& source)
 {
     return isAnyOf<ExpectedTypes...>(source.get());
 }


### PR DESCRIPTION
#### cd0d2eee8a72a46efa4993c6c40e730768bae0db
<pre>
WeakPtr::is()/UniqueRef::is() const variadic overloads should be named isAnyOf
<a href="https://bugs.webkit.org/show_bug.cgi?id=319815">https://bugs.webkit.org/show_bug.cgi?id=319815</a>
<a href="https://rdar.apple.com/182714057">rdar://182714057</a>

Reviewed by Sam Weinig.

The const variadic overloads in WeakPtr.h and UniqueRef.h were
mistakenly named is() instead of isAnyOf(), colliding with the
const single-argument is() overload and leaving isAnyOf() without
a const overload for these two types. Ref.h, RefPtr.h, CheckedPtr.h,
and CheckedRef.h all name this overload isAnyOf() correctly.

* Source/WTF/wtf/UniqueRef.h:
(WTF::isAnyOf):
* Source/WTF/wtf/WeakPtr.h:
(WTF::isAnyOf):

Canonical link: <a href="https://commits.webkit.org/317716@main">https://commits.webkit.org/317716@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/06db4aba6f882b3f426bebaca5a145f8272e0a67

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175598 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49531 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43315 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185191 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/137767 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7aa07286-9b55-4d44-8886-4c25f5007432) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50824 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49214 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136755 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/137767 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0e0b7138-5638-4b56-9616-e0392e122fc1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178555 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40168 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157507 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117233 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/78da41a8-d035-4cc3-9bd4-e913f03f1ff9) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38811 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37192 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/6016 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149230 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36999 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33661 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/36863 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41223 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41398 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187611 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49199 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145719 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39322 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49879 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33623 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145556 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40367 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122074 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115898 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48386 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11976 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47788 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48030 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47845 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->