### PR TITLE
[baseline-source] Implement initial parsing support.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -37,6 +37,7 @@ PASS background-position-y
 PASS background-repeat
 PASS background-size
 PASS baseline-shift
+PASS baseline-source
 PASS block-ellipsis
 PASS block-size
 PASS block-step-align

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-revert-layer-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-revert-layer-expected.txt
@@ -31,6 +31,7 @@ PASS background-position-y
 PASS background-repeat
 PASS background-size
 PASS baseline-shift
+PASS baseline-source
 PASS block-size
 PASS border-block-end-color
 PASS border-block-end-style

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-inline/baseline-source/baseline-source-computed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-inline/baseline-source/baseline-source-computed-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL Property baseline-source value 'auto' assert_true: baseline-source doesn't seem to be supported in the computed style expected true got false
-FAIL Property baseline-source value 'first' assert_true: baseline-source doesn't seem to be supported in the computed style expected true got false
-FAIL Property baseline-source value 'last' assert_true: baseline-source doesn't seem to be supported in the computed style expected true got false
+PASS Property baseline-source value 'auto'
+PASS Property baseline-source value 'first'
+PASS Property baseline-source value 'last'
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-inline/baseline-source/baseline-source-first-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-inline/baseline-source/baseline-source-first-002-expected.txt
@@ -40,7 +40,7 @@ FAIL .target > * 4 assert_equals:
 offsetLeft expected 10 but got 20
 FAIL .target > * 5 assert_equals:
 <span data-offset-x="60"></span>
-offsetLeft expected 60 but got 45
+offsetLeft expected 60 but got 15
 PASS .target > * 6
 FAIL .target > * 7 assert_equals:
 <span data-offset-x="65"></span>
@@ -52,7 +52,7 @@ FAIL .target > * 8 assert_equals:
     <div><span></span></div>
     <div><span></span></div>
   </div>
-offsetLeft expected 10 but got 53
+offsetLeft expected 10 but got 50
 FAIL .target > * 9 assert_equals:
 <span data-offset-x="90"></span>
 offsetLeft expected 90 but got 30
@@ -77,21 +77,6 @@ PASS .target > * 19
 PASS .target > * 20
 FAIL .target > * 21 assert_equals:
 <span data-offset-x="160"></span>
-offsetLeft expected 160 but got 10
-FAIL .target > * 22 assert_equals:
-<div class="inner" style="display: inline-block;" data-offset-x="10">
-    <table>
-      <caption></caption>
-      <tbody><tr>
-        <td style="font-size: 10px;"><span></span><br><span></span></td>
-        <td><span></span><br><span></span></td>
-      </tr>
-      <tr>
-        <td><span></span><br><span></span></td>
-        <td style="font-size: 10px;"><span></span><br><span></span></td>
-      </tr>
-      </tbody><caption style="caption-side: bottom;"></caption>
-    </table>
-  </div>
-offsetLeft expected 10 but got 20
+offsetLeft expected 160 but got 115
+PASS .target > * 22
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-inline/baseline-source/baseline-source-first-003-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-inline/baseline-source/baseline-source-first-003-expected.txt
@@ -25,32 +25,22 @@
 
 
 
-PASS .target > * 1
+FAIL .target > * 1 assert_equals:
+<span data-offset-x="30"></span>
+offsetLeft expected 30 but got 60
 PASS .target > * 2
 FAIL .target > * 3 assert_equals:
 <span data-offset-x="30"></span>
-offsetLeft expected 30 but got 10
-FAIL .target > * 4 assert_equals:
-<div class="inner" style="overflow: hidden; display: inline-block;" data-offset-x="10">
-    <div><span></span></div>
-    <div><span></span></div>
-  </div>
-offsetLeft expected 10 but got 20
+offsetLeft expected 30 but got 90
+PASS .target > * 4
 FAIL .target > * 5 assert_equals:
 <span data-offset-x="30"></span>
-offsetLeft expected 30 but got 45
+offsetLeft expected 30 but got 75
 PASS .target > * 6
 FAIL .target > * 7 assert_equals:
 <span data-offset-x="25"></span>
-offsetLeft expected 25 but got 10
-FAIL .target > * 8 assert_equals:
-<div class="inner" style="display: inline-block; columns: 2;" data-offset-x="10">
-    <div style="font-size: 20px;"><span></span></div>
-    <div style="font-size: 20px;"><span></span></div>
-    <div><span></span></div>
-    <div><span></span></div>
-  </div>
-offsetLeft expected 10 but got 53
+offsetLeft expected 25 but got 120
+PASS .target > * 8
 PASS .target > * 9
 PASS .target > * 10
 FAIL .target > * 11 assert_equals:
@@ -63,33 +53,16 @@ offsetLeft expected 30 but got 45
 PASS .target > * 14
 FAIL .target > * 15 assert_equals:
 <span data-offset-x="55"></span>
-offsetLeft expected 55 but got 100
+offsetLeft expected 55 but got 15
 PASS .target > * 16
 FAIL .target > * 17 assert_equals:
 <span data-offset-x="55"></span>
 offsetLeft expected 55 but got 57
 PASS .target > * 18
-FAIL .target > * 19 assert_equals:
-<span data-offset-x="70"></span>
-offsetLeft expected 70 but got 160
+PASS .target > * 19
 PASS .target > * 20
 FAIL .target > * 21 assert_equals:
 <span data-offset-x="70"></span>
-offsetLeft expected 70 but got 10
-FAIL .target > * 22 assert_equals:
-<div class="inner" style="display: inline-block;" data-offset-x="10">
-    <table>
-      <caption></caption>
-      <tbody><tr>
-        <td style="font-size: 10px;"><span></span><br><span></span></td>
-        <td><span></span><br><span></span></td>
-      </tr>
-      <tr>
-        <td><span></span><br><span></span></td>
-        <td style="font-size: 10px;"><span></span><br><span></span></td>
-      </tr>
-      </tbody><caption style="caption-side: bottom;"></caption>
-    </table>
-  </div>
-offsetLeft expected 10 but got 20
+offsetLeft expected 70 but got 115
+PASS .target > * 22
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-inline/baseline-source/baseline-source-last-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-inline/baseline-source/baseline-source-last-002-expected.txt
@@ -38,7 +38,7 @@ FAIL .target > * 4 assert_equals:
 offsetLeft expected 10 but got 20
 FAIL .target > * 5 assert_equals:
 <span data-offset-x="30"></span>
-offsetLeft expected 30 but got 45
+offsetLeft expected 30 but got 15
 PASS .target > * 6
 FAIL .target > * 7 assert_equals:
 <span data-offset-x="30"></span>
@@ -50,7 +50,7 @@ FAIL .target > * 8 assert_equals:
     <div><span></span></div>
     <div><span></span></div>
   </div>
-offsetLeft expected 10 but got 53
+offsetLeft expected 10 but got 50
 PASS .target > * 9
 PASS .target > * 10
 FAIL .target > * 11 assert_equals:
@@ -75,21 +75,6 @@ offsetLeft expected 100 but got 160
 PASS .target > * 20
 FAIL .target > * 21 assert_equals:
 <span data-offset-x="100"></span>
-offsetLeft expected 100 but got 10
-FAIL .target > * 22 assert_equals:
-<div class="inner" style="display: inline-block;" data-offset-x="10">
-    <table>
-      <caption></caption>
-      <tbody><tr>
-        <td style="font-size: 10px;"><span></span><br><span></span></td>
-        <td><span></span><br><span></span></td>
-      </tr>
-      <tr>
-        <td><span></span><br><span></span></td>
-        <td style="font-size: 10px;"><span></span><br><span></span></td>
-      </tr>
-      </tbody><caption style="caption-side: bottom;"></caption>
-    </table>
-  </div>
-offsetLeft expected 10 but got 20
+offsetLeft expected 100 but got 115
+PASS .target > * 22
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-inline/baseline-source/baseline-source-last-003-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-inline/baseline-source/baseline-source-last-003-expected.txt
@@ -25,34 +25,20 @@
 
 
 
-FAIL .target > * 1 assert_equals:
-<span data-offset-x="60"></span>
-offsetLeft expected 60 but got 30
+PASS .target > * 1
 PASS .target > * 2
 FAIL .target > * 3 assert_equals:
 <span data-offset-x="60"></span>
-offsetLeft expected 60 but got 10
-FAIL .target > * 4 assert_equals:
-<div class="inner" style="overflow: hidden; display: inline-block;" data-offset-x="10">
-    <div><span></span></div>
-    <div><span></span></div>
-  </div>
-offsetLeft expected 10 but got 20
+offsetLeft expected 60 but got 90
+PASS .target > * 4
 FAIL .target > * 5 assert_equals:
 <span data-offset-x="60"></span>
-offsetLeft expected 60 but got 45
+offsetLeft expected 60 but got 75
 PASS .target > * 6
 FAIL .target > * 7 assert_equals:
 <span data-offset-x="60"></span>
-offsetLeft expected 60 but got 10
-FAIL .target > * 8 assert_equals:
-<div class="inner" style="display: inline-block; columns: 2;" data-offset-x="10">
-    <div style="font-size: 20px;"><span></span></div>
-    <div style="font-size: 20px;"><span></span></div>
-    <div><span></span></div>
-    <div><span></span></div>
-  </div>
-offsetLeft expected 10 but got 53
+offsetLeft expected 60 but got 120
+PASS .target > * 8
 FAIL .target > * 9 assert_equals:
 <span data-offset-x="90"></span>
 offsetLeft expected 90 but got 30
@@ -67,7 +53,7 @@ offsetLeft expected 60 but got 45
 PASS .target > * 14
 FAIL .target > * 15 assert_equals:
 <span data-offset-x="85"></span>
-offsetLeft expected 85 but got 100
+offsetLeft expected 85 but got 15
 PASS .target > * 16
 FAIL .target > * 17 assert_equals:
 <span data-offset-x="85"></span>
@@ -75,25 +61,10 @@ offsetLeft expected 85 but got 57
 PASS .target > * 18
 FAIL .target > * 19 assert_equals:
 <span data-offset-x="130"></span>
-offsetLeft expected 130 but got 160
+offsetLeft expected 130 but got 70
 PASS .target > * 20
 FAIL .target > * 21 assert_equals:
 <span data-offset-x="130"></span>
-offsetLeft expected 130 but got 10
-FAIL .target > * 22 assert_equals:
-<div class="inner" style="display: inline-block;" data-offset-x="10">
-    <table>
-      <caption></caption>
-      <tbody><tr>
-        <td style="font-size: 10px;"><span></span><br><span></span></td>
-        <td><span></span><br><span></span></td>
-      </tr>
-      <tr>
-        <td><span></span><br><span></span></td>
-        <td style="font-size: 10px;"><span></span><br><span></span></td>
-      </tr>
-      </tbody><caption style="caption-side: bottom;"></caption>
-    </table>
-  </div>
-offsetLeft expected 10 but got 20
+offsetLeft expected 130 but got 115
+PASS .target > * 22
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-inline/baseline-source/baseline-source-no-interpolation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-inline/baseline-source/baseline-source-no-interpolation-expected.txt
@@ -1,44 +1,44 @@
 
-FAIL CSS Transitions with transition-behavior:allow-discrete: property <baseline-source> from [initial] to [last] at (-0.3) should be [initial] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition-behavior:allow-discrete: property <baseline-source> from [initial] to [last] at (0) should be [initial] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition-behavior:allow-discrete: property <baseline-source> from [initial] to [last] at (0.3) should be [initial] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition-behavior:allow-discrete: property <baseline-source> from [initial] to [last] at (0.5) should be [last] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition-behavior:allow-discrete: property <baseline-source> from [initial] to [last] at (0.6) should be [last] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition-behavior:allow-discrete: property <baseline-source> from [initial] to [last] at (1) should be [last] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition-behavior:allow-discrete: property <baseline-source> from [initial] to [last] at (1.5) should be [last] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <baseline-source> from [initial] to [last] at (-0.3) should be [initial] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <baseline-source> from [initial] to [last] at (0) should be [initial] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <baseline-source> from [initial] to [last] at (0.3) should be [initial] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <baseline-source> from [initial] to [last] at (0.5) should be [last] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <baseline-source> from [initial] to [last] at (0.6) should be [last] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <baseline-source> from [initial] to [last] at (1) should be [last] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <baseline-source> from [initial] to [last] at (1.5) should be [last] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions: property <baseline-source> from [initial] to [last] at (-0.3) should be [last] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions: property <baseline-source> from [initial] to [last] at (0) should be [last] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions: property <baseline-source> from [initial] to [last] at (0.3) should be [last] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions: property <baseline-source> from [initial] to [last] at (0.5) should be [last] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions: property <baseline-source> from [initial] to [last] at (0.6) should be [last] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions: property <baseline-source> from [initial] to [last] at (1) should be [last] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions: property <baseline-source> from [initial] to [last] at (1.5) should be [last] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition: all: property <baseline-source> from [initial] to [last] at (-0.3) should be [last] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition: all: property <baseline-source> from [initial] to [last] at (0) should be [last] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition: all: property <baseline-source> from [initial] to [last] at (0.3) should be [last] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition: all: property <baseline-source> from [initial] to [last] at (0.5) should be [last] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition: all: property <baseline-source> from [initial] to [last] at (0.6) should be [last] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition: all: property <baseline-source> from [initial] to [last] at (1) should be [last] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition: all: property <baseline-source> from [initial] to [last] at (1.5) should be [last] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Animations: property <baseline-source> from [initial] to [last] at (-0.3) should be [initial] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Animations: property <baseline-source> from [initial] to [last] at (0) should be [initial] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Animations: property <baseline-source> from [initial] to [last] at (0.3) should be [initial] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Animations: property <baseline-source> from [initial] to [last] at (0.5) should be [last] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Animations: property <baseline-source> from [initial] to [last] at (0.6) should be [last] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Animations: property <baseline-source> from [initial] to [last] at (1) should be [last] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Animations: property <baseline-source> from [initial] to [last] at (1.5) should be [last] assert_true: 'from' value should be supported expected true got false
-FAIL Web Animations: property <baseline-source> from [initial] to [last] at (-0.3) should be [initial] assert_true: 'from' value should be supported expected true got false
-FAIL Web Animations: property <baseline-source> from [initial] to [last] at (0) should be [initial] assert_true: 'from' value should be supported expected true got false
-FAIL Web Animations: property <baseline-source> from [initial] to [last] at (0.3) should be [initial] assert_true: 'from' value should be supported expected true got false
-FAIL Web Animations: property <baseline-source> from [initial] to [last] at (0.5) should be [last] assert_true: 'from' value should be supported expected true got false
-FAIL Web Animations: property <baseline-source> from [initial] to [last] at (0.6) should be [last] assert_true: 'from' value should be supported expected true got false
-FAIL Web Animations: property <baseline-source> from [initial] to [last] at (1) should be [last] assert_true: 'from' value should be supported expected true got false
-FAIL Web Animations: property <baseline-source> from [initial] to [last] at (1.5) should be [last] assert_true: 'from' value should be supported expected true got false
+PASS CSS Transitions with transition-behavior:allow-discrete: property <baseline-source> from [initial] to [last] at (-0.3) should be [initial]
+PASS CSS Transitions with transition-behavior:allow-discrete: property <baseline-source> from [initial] to [last] at (0) should be [initial]
+PASS CSS Transitions with transition-behavior:allow-discrete: property <baseline-source> from [initial] to [last] at (0.3) should be [initial]
+PASS CSS Transitions with transition-behavior:allow-discrete: property <baseline-source> from [initial] to [last] at (0.5) should be [last]
+PASS CSS Transitions with transition-behavior:allow-discrete: property <baseline-source> from [initial] to [last] at (0.6) should be [last]
+PASS CSS Transitions with transition-behavior:allow-discrete: property <baseline-source> from [initial] to [last] at (1) should be [last]
+PASS CSS Transitions with transition-behavior:allow-discrete: property <baseline-source> from [initial] to [last] at (1.5) should be [last]
+PASS CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <baseline-source> from [initial] to [last] at (-0.3) should be [initial]
+PASS CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <baseline-source> from [initial] to [last] at (0) should be [initial]
+PASS CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <baseline-source> from [initial] to [last] at (0.3) should be [initial]
+PASS CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <baseline-source> from [initial] to [last] at (0.5) should be [last]
+PASS CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <baseline-source> from [initial] to [last] at (0.6) should be [last]
+PASS CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <baseline-source> from [initial] to [last] at (1) should be [last]
+PASS CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <baseline-source> from [initial] to [last] at (1.5) should be [last]
+PASS CSS Transitions: property <baseline-source> from [initial] to [last] at (-0.3) should be [last]
+PASS CSS Transitions: property <baseline-source> from [initial] to [last] at (0) should be [last]
+PASS CSS Transitions: property <baseline-source> from [initial] to [last] at (0.3) should be [last]
+PASS CSS Transitions: property <baseline-source> from [initial] to [last] at (0.5) should be [last]
+PASS CSS Transitions: property <baseline-source> from [initial] to [last] at (0.6) should be [last]
+PASS CSS Transitions: property <baseline-source> from [initial] to [last] at (1) should be [last]
+PASS CSS Transitions: property <baseline-source> from [initial] to [last] at (1.5) should be [last]
+PASS CSS Transitions with transition: all: property <baseline-source> from [initial] to [last] at (-0.3) should be [last]
+PASS CSS Transitions with transition: all: property <baseline-source> from [initial] to [last] at (0) should be [last]
+PASS CSS Transitions with transition: all: property <baseline-source> from [initial] to [last] at (0.3) should be [last]
+PASS CSS Transitions with transition: all: property <baseline-source> from [initial] to [last] at (0.5) should be [last]
+PASS CSS Transitions with transition: all: property <baseline-source> from [initial] to [last] at (0.6) should be [last]
+PASS CSS Transitions with transition: all: property <baseline-source> from [initial] to [last] at (1) should be [last]
+PASS CSS Transitions with transition: all: property <baseline-source> from [initial] to [last] at (1.5) should be [last]
+PASS CSS Animations: property <baseline-source> from [initial] to [last] at (-0.3) should be [initial]
+PASS CSS Animations: property <baseline-source> from [initial] to [last] at (0) should be [initial]
+PASS CSS Animations: property <baseline-source> from [initial] to [last] at (0.3) should be [initial]
+PASS CSS Animations: property <baseline-source> from [initial] to [last] at (0.5) should be [last]
+PASS CSS Animations: property <baseline-source> from [initial] to [last] at (0.6) should be [last]
+PASS CSS Animations: property <baseline-source> from [initial] to [last] at (1) should be [last]
+PASS CSS Animations: property <baseline-source> from [initial] to [last] at (1.5) should be [last]
+PASS Web Animations: property <baseline-source> from [initial] to [last] at (-0.3) should be [initial]
+PASS Web Animations: property <baseline-source> from [initial] to [last] at (0) should be [initial]
+PASS Web Animations: property <baseline-source> from [initial] to [last] at (0.3) should be [initial]
+PASS Web Animations: property <baseline-source> from [initial] to [last] at (0.5) should be [last]
+PASS Web Animations: property <baseline-source> from [initial] to [last] at (0.6) should be [last]
+PASS Web Animations: property <baseline-source> from [initial] to [last] at (1) should be [last]
+PASS Web Animations: property <baseline-source> from [initial] to [last] at (1.5) should be [last]
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-inline/baseline-source/baseline-source-valid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-inline/baseline-source/baseline-source-valid-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL e.style['baseline-source'] = "auto" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['baseline-source'] = "first" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['baseline-source'] = "last" should set the property value assert_not_equals: property should be set got disallowed value ""
+PASS e.style['baseline-source'] = "auto" should set the property value
+PASS e.style['baseline-source'] = "first" should set the property value
+PASS e.style['baseline-source'] = "last" should set the property value
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-inline/baseline-source/baseline-source-vertical-align-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-inline/baseline-source/baseline-source-vertical-align-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL baseline-source-vertical-align assert_equals: expected (string) "auto" but got (undefined) undefined
+FAIL baseline-source-vertical-align assert_equals: expected "auto" but got "first"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/serialize-values-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/serialize-values-expected.txt
@@ -207,10 +207,10 @@ PASS baseline-shift: 0px
 PASS baseline-shift: 1px
 PASS baseline-shift: .1em
 PASS baseline-shift: inherit
-FAIL baseline-source: auto assert_equals: baseline-source raw inline style declaration expected (string) "auto" but got (undefined) undefined
-FAIL baseline-source: first assert_equals: baseline-source raw inline style declaration expected (string) "first" but got (undefined) undefined
-FAIL baseline-source: last assert_equals: baseline-source raw inline style declaration expected (string) "last" but got (undefined) undefined
-FAIL baseline-source: inherit assert_equals: baseline-source raw inline style declaration expected (string) "inherit" but got (undefined) undefined
+PASS baseline-source: auto
+PASS baseline-source: first
+PASS baseline-source: last
+PASS baseline-source: inherit
 PASS border-collapse: collapse
 PASS border-collapse: separate
 PASS border-collapse: inherit

--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/shadow-dom-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/shadow-dom-expected.txt
@@ -1,9 +1,9 @@
 
 
-FAIL <video controls=""></video> has a shadow tree with no slots assert_equals: child should be outside the flat tree expected 0 but got 453
-FAIL <video></video> has a shadow tree with no slots assert_equals: child should be outside the flat tree expected 0 but got 453
-FAIL <audio></audio> has a shadow tree with no slots assert_equals: child should be outside the flat tree expected 0 but got 453
-FAIL <audio controls=""></audio> has a shadow tree with no slots assert_equals: child should be outside the flat tree expected 0 but got 454
+FAIL <video controls=""></video> has a shadow tree with no slots assert_equals: child should be outside the flat tree expected 0 but got 454
+FAIL <video></video> has a shadow tree with no slots assert_equals: child should be outside the flat tree expected 0 but got 454
+FAIL <audio></audio> has a shadow tree with no slots assert_equals: child should be outside the flat tree expected 0 but got 454
+FAIL <audio controls=""></audio> has a shadow tree with no slots assert_equals: child should be outside the flat tree expected 0 but got 455
 PASS <select></select> has a shadow tree with slot
 PASS <select multiple=""></select> has a shadow tree with slot
 PASS <select size="4"></select> has a shadow tree with slot

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -37,6 +37,7 @@ PASS background-position-y
 PASS background-repeat
 PASS background-size
 PASS baseline-shift
+PASS baseline-source
 PASS block-ellipsis
 PASS block-size
 PASS block-step-align

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -1099,6 +1099,20 @@ CSSAxisRelativePositionKeywordsEnabled:
     WebCore:
       default: true
 
+CSSBaselineSourceEnabled:
+  type: bool
+  status: testable
+  category: css
+  humanReadableName: "CSS baseline-source"
+  humanReadableDescription: "Enable CSS baseline-source"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 CSSCalcMixEnabled:
   type: bool
   category: css

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -2476,6 +2476,27 @@
                 "url": "https://www.w3.org/TR/SVG11/text.html#BaselineShiftProperty"
             }
         },
+        "baseline-source": {
+            "animation-type": "discrete",
+            "initial": "auto",
+            "values": [
+                "auto",
+                "first",
+                "last"
+            ],
+            "codegen-properties": {
+                "settings-flag": "cssBaselineSourceEnabled",
+                "computed-style-storage-path": ["m_nonInheritedData", "boxData"],
+                "computed-style-storage-kind": "enum",
+                "computed-style-type": "BaselineSource",
+                "parser-grammar": "<<values>>"
+            },
+            "specification": {
+                "category": "css-inline",
+                "url": "https://drafts.csswg.org/css-inline-3/#baseline-source"
+            },
+            "status": "experimental"
+        },
         "block-ellipsis": {
             "animation-type": "discrete",
             "inherited": true,

--- a/Source/WebCore/rendering/style/RenderStyleConstants.cpp
+++ b/Source/WebCore/rendering/style/RenderStyleConstants.cpp
@@ -533,6 +533,16 @@ TextStream& operator<<(TextStream& ts, FieldSizing sizing)
     return ts;
 }
 
+TextStream& operator<<(TextStream& ts, BaselineSource source)
+{
+    switch (source) {
+    case BaselineSource::Auto: ts << "auto"_s; break;
+    case BaselineSource::First: ts << "first"_s; break;
+    case BaselineSource::Last: ts << "last"_s; break;
+    }
+    return ts;
+}
+
 TextStream& operator<<(TextStream& ts, FillAttachment attachment)
 {
     switch (attachment) {

--- a/Source/WebCore/rendering/style/RenderStyleConstants.h
+++ b/Source/WebCore/rendering/style/RenderStyleConstants.h
@@ -1034,6 +1034,12 @@ enum class FieldSizing : bool {
     Content
 };
 
+enum class BaselineSource : uint8_t {
+    Auto,
+    First,
+    Last
+};
+
 enum class NinePieceImageRule : uint8_t {
     Stretch,
     Round,
@@ -1252,6 +1258,7 @@ WTF::TextStream& operator<<(WTF::TextStream&, MathShift);
 WTF::TextStream& operator<<(WTF::TextStream&, MathStyle);
 WTF::TextStream& operator<<(WTF::TextStream&, ContainIntrinsicSizeType);
 WTF::TextStream& operator<<(WTF::TextStream&, FieldSizing);
+WTF::TextStream& operator<<(WTF::TextStream&, BaselineSource);
 WTF::TextStream& operator<<(WTF::TextStream&, OverflowContinue);
 
 WTF::TextStream& operator<<(WTF::TextStream&, AlignmentBaseline);

--- a/Source/WebCore/style/computed/StyleComputedStyleBase.h
+++ b/Source/WebCore/style/computed/StyleComputedStyleBase.h
@@ -68,6 +68,7 @@ enum class ApplePayButtonStyle : uint8_t;
 enum class ApplePayButtonType : uint8_t;
 enum class AppleVisualEffect : uint8_t;
 enum class BackfaceVisibility : uint8_t;
+enum class BaselineSource : uint8_t;
 enum class BlendMode : uint8_t;
 enum class FlowDirection : uint8_t;
 enum class BlockStepAlign : uint8_t;

--- a/Source/WebCore/style/computed/data/StyleBoxData.cpp
+++ b/Source/WebCore/style/computed/data/StyleBoxData.cpp
@@ -53,6 +53,7 @@ BoxData::BoxData()
     , hasAutoUsedZIndex(static_cast<uint8_t>(ComputedStyle::initialUsedZIndex().m_isAuto))
     , boxSizing(static_cast<uint8_t>(BoxSizing::ContentBox))
     , boxDecorationBreak(static_cast<uint8_t>(BoxDecorationBreak::Slice))
+    , baselineSource(static_cast<uint8_t>(ComputedStyle::initialBaselineSource()))
     , specifiedZIndexValue(ComputedStyle::initialSpecifiedZIndex().m_value)
     , usedZIndexValue(ComputedStyle::initialUsedZIndex().m_value)
 {
@@ -71,6 +72,7 @@ inline BoxData::BoxData(const BoxData& o)
     , hasAutoUsedZIndex(o.hasAutoUsedZIndex)
     , boxSizing(o.boxSizing)
     , boxDecorationBreak(o.boxDecorationBreak)
+    , baselineSource(o.baselineSource)
     , specifiedZIndexValue(o.specifiedZIndexValue)
     , usedZIndexValue(o.usedZIndexValue)
 {
@@ -94,6 +96,7 @@ bool BoxData::operator==(const BoxData& o) const
         && hasAutoUsedZIndex == o.hasAutoUsedZIndex
         && boxSizing == o.boxSizing
         && boxDecorationBreak == o.boxDecorationBreak
+        && baselineSource == o.baselineSource
         && specifiedZIndexValue == o.specifiedZIndexValue
         && hasAutoSpecifiedZIndex == o.hasAutoSpecifiedZIndex;
 }
@@ -117,6 +120,7 @@ void BoxData::dumpDifferences(TextStream& ts, const BoxData& other) const
 
     LOG_IF_DIFFERENT_WITH_CAST(BoxSizing, boxSizing);
     LOG_IF_DIFFERENT_WITH_CAST(BoxDecorationBreak, boxDecorationBreak);
+    LOG_IF_DIFFERENT_WITH_CAST(BaselineSource, baselineSource);
 
     LOG_IF_DIFFERENT(specifiedZIndexValue);
     LOG_IF_DIFFERENT(usedZIndexValue);

--- a/Source/WebCore/style/computed/data/StyleBoxData.h
+++ b/Source/WebCore/style/computed/data/StyleBoxData.h
@@ -65,6 +65,7 @@ public:
     PREFERRED_TYPE(bool) uint8_t hasAutoUsedZIndex : 1;
     PREFERRED_TYPE(BoxSizing) uint8_t boxSizing : 1;
     PREFERRED_TYPE(BoxDecorationBreak) uint8_t boxDecorationBreak : 1;
+    PREFERRED_TYPE(BaselineSource) uint8_t baselineSource : 2;
 
     ZIndex::Value specifiedZIndexValue;
     ZIndex::Value usedZIndexValue;

--- a/Source/WebCore/style/values/primitives/StyleKeyword+Mappings.h
+++ b/Source/WebCore/style/values/primitives/StyleKeyword+Mappings.h
@@ -412,6 +412,12 @@ DEFINE_TO_FROM_CSS_VALUE_ID_FUNCTIONS
 #undef TYPE
 #undef FOR_EACH
 
+#define TYPE BaselineSource
+#define FOR_EACH(CASE) CASE(Auto) CASE(First) CASE(Last)
+DEFINE_TO_FROM_CSS_VALUE_ID_FUNCTIONS
+#undef TYPE
+#undef FOR_EACH
+
 constexpr CSSValueID toCSSValueID(FillAttachment e)
 {
     switch (e) {


### PR DESCRIPTION
#### a6a0396a9e02089a03e589d157692d466273a56b
<pre>
[baseline-source] Implement initial parsing support.
<a href="https://bugs.webkit.org/show_bug.cgi?id=319819">https://bugs.webkit.org/show_bug.cgi?id=319819</a>
<a href="https://rdar.apple.com/problem/182718020">rdar://problem/182718020</a>

Reviewed by Tim Nguyen.

Initial piece of work for baseline-source that adds the feature flag as
well as the initial parsing.

<a href="https://drafts.csswg.org/css-inline/#baseline-source">https://drafts.csswg.org/css-inline/#baseline-source</a>

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
Feature flag is currently set to testable since we have some WPTs that
should exercise code that was added in this patch.

* Source/WebCore/css/CSSProperties.json:
Have it live next to vertical-align since this is supposed to be a
longhand of it. This is currently not the how that property is
implemented but we may want to change that in the future so it might be
better to place it here for now.

Canonical link: <a href="https://commits.webkit.org/317634@main">https://commits.webkit.org/317634@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4f0a2d9b627a4e3e81fa9c5b2b1dc241bcceb8ad

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175728 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49661 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43444 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185321 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/137906 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/177591 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50953 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49343 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136835 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/137906 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/52bf68d2-24e6-4e31-808c-4577e5d0564f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178684 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40279 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157601 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117313 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ffb1fc4a-c72e-42a0-82eb-c625504f1fcd) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38921 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37305 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/6110 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149340 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37093 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33790 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/36992 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41353 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41511 "Found 1 new test failure: http/wpt/service-workers/persistent-importScripts.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187742 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49328 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145822 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39263 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50008 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33717 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145664 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40455 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122204 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/116029 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48515 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12071 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47917 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48149 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47974 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->