### PR TITLE
[Text Extraction] Add option to include tag names for blocks with inline children.

### DIFF
--- a/Source/WebCore/page/text-extraction/TextExtraction.cpp
+++ b/Source/WebCore/page/text-extraction/TextExtraction.cpp
@@ -1152,6 +1152,15 @@ static inline void extractRecursive(Node& node, Item& parentItem, TraversalConte
         if (shouldIdentifyClickableElement)
             return FallbackPolicy::Extract;
 
+        // With tag names requested, also extract a generic block that renders its own inline content like
+        // a paragraph, heading, caption, etc so its tag prefixes that text. Semantic containers are already
+        // extracted above; a generic structural wrapper (block-level children) still collapses.
+        if (context.originalRequest.includeTagName && isBlock) {
+            CheckedPtr renderer = node.renderer();
+            if (renderer->childrenInline())
+                return FallbackPolicy::Extract;
+        }
+
         return FallbackPolicy::Skip;
     }();
 

--- a/Source/WebCore/page/text-extraction/TextExtractionTypes.h
+++ b/Source/WebCore/page/text-extraction/TextExtractionTypes.h
@@ -108,6 +108,7 @@ struct Request {
     bool includeAccessibilityAttributes { false };
     bool includeTextInAutoFilledControls { false };
     bool includeOffscreenPasswordFields { false };
+    bool includeTagName { false };
 #if ENABLE(DATA_DETECTION)
     OptionSet<DataDetectorType> dataDetectorTypes;
 #endif

--- a/Source/WebKit/Shared/TextExtractionToStringConversion.cpp
+++ b/Source/WebKit/Shared/TextExtractionToStringConversion.cpp
@@ -705,6 +705,11 @@ public:
         return !usePlainTextOutput() && m_options.flags.contains(TextExtractionOptionFlag::IncludeSelectOptions);
     }
 
+    bool NODELETE includeTagName() const
+    {
+        return useTextTreeOutput() && m_options.flags.contains(TextExtractionOptionFlag::IncludeTagName);
+    }
+
     bool NODELETE includeURLs() const
     {
         return !usePlainTextOutput() && m_options.flags.contains(TextExtractionOptionFlag::IncludeURLs);
@@ -1638,6 +1643,8 @@ static void addPartsForItem(const TextExtraction::Item& item, std::optional<Node
                 bool isGenericContainer = containerString.isEmpty();
                 if (!containerString.isEmpty())
                     parts.append(WTF::move(containerString));
+                else if (aggregator.includeTagName() && !item.nodeName.isEmpty())
+                    parts.append(item.nodeName.convertToASCIILowercase());
 
                 parts.appendVector(partsForItem(item, aggregator, includeRectForParentItem));
 

--- a/Source/WebKit/Shared/TextExtractionToStringConversion.h
+++ b/Source/WebKit/Shared/TextExtractionToStringConversion.h
@@ -55,6 +55,7 @@ enum class TextExtractionOptionFlag : uint8_t {
     IncludeRects         = 1 << 1,
     ShortenURLs          = 1 << 2,
     IncludeSelectOptions = 1 << 3,
+    IncludeTagName       = 1 << 4,
 };
 
 enum class TextExtractionOutputFormat : uint8_t {

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -4893,6 +4893,7 @@ header: <WebCore/TextExtractionTypes.h>
     bool includeAccessibilityAttributes;
     bool includeTextInAutoFilledControls;
     bool includeOffscreenPasswordFields;
+    bool includeTagName;
 #if ENABLE(DATA_DETECTION)
     OptionSet<WebCore::DataDetectorType> dataDetectorTypes;
 #endif

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView+TextExtraction.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView+TextExtraction.mm
@@ -260,6 +260,7 @@ static WebKit::TextExtractionOutputFormat textExtractionOutputFormat(_WKTextExtr
         filterUsingRules,
         includeURLs = configuration.includeURLs,
         includeRects = configuration.includeRects,
+        includeTagName = configuration.includeTagName,
         includeSelectOptions = configuration.includeSelectOptions,
         applyDiscretionaryWordLimit = configuration.maxWordsPerParagraphPolicy == _WKTextExtractionWordLimitPolicyDiscretionary,
         shortenURLs = configuration.shortenURLs,
@@ -359,6 +360,8 @@ static WebKit::TextExtractionOutputFormat textExtractionOutputFormat(_WKTextExtr
             optionFlags.add(ShortenURLs);
         if (includeSelectOptions)
             optionFlags.add(IncludeSelectOptions);
+        if (includeTagName)
+            optionFlags.add(IncludeTagName);
         RefPtr urlCache = strongSelf->_textExtractionURLCache;
         WebKit::TextExtractionOptions options {
             WTF::move(mainFrameIdentifier),
@@ -754,6 +757,7 @@ static OptionSet<WebCore::DataDetectorType> NODELETE coreDataDetectorTypes(_WKTe
             .includeAccessibilityAttributes = !!configuration.includeAccessibilityAttributes,
             .includeTextInAutoFilledControls = !!configuration.includeTextInAutoFilledControls,
             .includeOffscreenPasswordFields = !!configuration.includeOffscreenPasswordFields,
+            .includeTagName = !!configuration.includeTagName,
 #if ENABLE(DATA_DETECTION)
             .dataDetectorTypes = coreDataDetectorTypes(configuration.dataDetectorTypes),
 #endif

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.h
@@ -126,6 +126,13 @@ WK_CLASS_AVAILABLE(macos(26.4), ios(26.4), visionos(26.4))
 @property (nonatomic) BOOL includeRects;
 
 /*!
+ Prefix each element line in `.textTree` output with its lowercased tag name (e.g. `h1 'Title'`), including
+ for elements that would otherwise render as bare text such as headings and paragraphs. Only affects the
+ `.textTree` output format. The default value is `NO`.
+ */
+@property (nonatomic) BOOL includeTagName;
+
+/*!
  Include options for `select` elements in text extraction output.
  The default value is `YES`.
  */

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.mm
@@ -50,6 +50,7 @@
     _filterOptions = _WKTextExtractionFilterAll;
     _includeURLs = YES;
     _includeRects = YES;
+    _includeTagName = NO;
     _includeSelectOptions = YES;
     _nodeIdentifierInclusion = _WKTextExtractionNodeIdentifierInclusionInteractive;
     _eventListenerCategories = _WKTextExtractionEventListenerCategoryAll;
@@ -75,6 +76,7 @@
     _outputFormat = _WKTextExtractionOutputFormatPlainText;
     _includeURLs = NO;
     _includeRects = NO;
+    _includeTagName = NO;
     _includeSelectOptions = NO;
     _nodeIdentifierInclusion = _WKTextExtractionNodeIdentifierInclusionNone;
     _eventListenerCategories = _WKTextExtractionEventListenerCategoryNone;

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/TextExtractionTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/TextExtractionTests.mm
@@ -615,6 +615,177 @@ TEST(TextExtractionTests, TargetNodeWithSameOriginSubframe)
     EXPECT_TRUE([debugText containsString:@"subframe content"]);
 }
 
+TEST(TextExtractionTests, IncludeTagNamePrefixesContentBlocks)
+{
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:^{
+        RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+        [[configuration preferences] _setTextExtractionEnabled:YES];
+        return configuration.autorelease();
+    }()]);
+
+    [webView synchronouslyLoadHTMLString:@"<h1>Alpha</h1><p>Bravo</p><div><h2>Charlie</h2></div>"];
+
+    RetainPtr debugText = [webView synchronouslyGetDebugText:^{
+        RetainPtr configuration = adoptNS([_WKTextExtractionConfiguration new]);
+        [configuration setOutputFormat:_WKTextExtractionOutputFormatTextTree];
+        [configuration setFilterOptions:_WKTextExtractionFilterNone];
+        [configuration setIncludeTagName:YES];
+        return configuration.autorelease();
+    }()];
+
+    // A block that renders its own inline content is prefixed with its lowercased tag name.
+    EXPECT_TRUE([debugText containsString:@"h1 'Alpha'"]);
+    EXPECT_TRUE([debugText containsString:@"p 'Bravo'"]);
+    EXPECT_TRUE([debugText containsString:@"h2 'Charlie'"]);
+
+    // The <div> only holds a block-level child, so it is a structural wrapper and collapses rather than being tagged.
+    EXPECT_FALSE([debugText containsString:@"div"]);
+}
+
+TEST(TextExtractionTests, IncludeTagNameTagsBlockWithOnlyInlineContent)
+{
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:^{
+        RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+        [[configuration preferences] _setTextExtractionEnabled:YES];
+        return configuration.autorelease();
+    }()]);
+
+    [webView synchronouslyLoadHTMLString:@"<div>Delta</div>"];
+
+    RetainPtr debugText = [webView synchronouslyGetDebugText:^{
+        RetainPtr configuration = adoptNS([_WKTextExtractionConfiguration new]);
+        [configuration setOutputFormat:_WKTextExtractionOutputFormatTextTree];
+        [configuration setFilterOptions:_WKTextExtractionFilterNone];
+        [configuration setIncludeTagName:YES];
+        return configuration.autorelease();
+    }()];
+
+    // A generic block whose children are all inline (here, just text) renders its own text, so it is tagged.
+    EXPECT_TRUE([debugText containsString:@"div 'Delta'"]);
+}
+
+TEST(TextExtractionTests, IncludeTagNameDisabledByDefault)
+{
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:^{
+        RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+        [[configuration preferences] _setTextExtractionEnabled:YES];
+        return configuration.autorelease();
+    }()]);
+
+    [webView synchronouslyLoadHTMLString:@"<h1>Alpha</h1><p>Bravo</p>"];
+
+    RetainPtr debugText = [webView synchronouslyGetDebugText:^{
+        RetainPtr configuration = adoptNS([_WKTextExtractionConfiguration new]);
+        [configuration setOutputFormat:_WKTextExtractionOutputFormatTextTree];
+        [configuration setFilterOptions:_WKTextExtractionFilterNone];
+        return configuration.autorelease();
+    }()];
+
+    // Without includeTagName the text is still extracted, but no tag-name prefix is emitted.
+    EXPECT_TRUE([debugText containsString:@"'Alpha'"]);
+    EXPECT_TRUE([debugText containsString:@"'Bravo'"]);
+    EXPECT_FALSE([debugText containsString:@"h1 '"]);
+    EXPECT_FALSE([debugText containsString:@"p '"]);
+}
+
+TEST(TextExtractionTests, IncludeTagNameCollapsesMixedInlineAndBlockContent)
+{
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:^{
+        RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+        [[configuration preferences] _setTextExtractionEnabled:YES];
+        return configuration.autorelease();
+    }()]);
+
+    [webView synchronouslyLoadHTMLString:@"<div>lead text<h2>Charlie</h2></div>"];
+
+    RetainPtr debugText = [webView synchronouslyGetDebugText:^{
+        RetainPtr configuration = adoptNS([_WKTextExtractionConfiguration new]);
+        [configuration setOutputFormat:_WKTextExtractionOutputFormatTextTree];
+        [configuration setFilterOptions:_WKTextExtractionFilterNone];
+        [configuration setIncludeTagName:YES];
+        return configuration.autorelease();
+    }()];
+
+    // The <div> mixes direct text with a block-level child, which forces a block formatting context, so it is a
+    // structural wrapper and collapses. Its own text is still extracted (untagged) and the inner block is tagged.
+    EXPECT_TRUE([debugText containsString:@"h2 'Charlie'"]);
+    EXPECT_TRUE([debugText containsString:@"'lead text'"]);
+    EXPECT_FALSE([debugText containsString:@"div"]);
+}
+
+TEST(TextExtractionTests, IncludeTagNameDropsEmptyAndWhitespaceBlocks)
+{
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:^{
+        RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+        [[configuration preferences] _setTextExtractionEnabled:YES];
+        return configuration.autorelease();
+    }()]);
+
+    [webView synchronouslyLoadHTMLString:@"<p>Alpha</p><div>   </div>"];
+
+    RetainPtr debugText = [webView synchronouslyGetDebugText:^{
+        RetainPtr configuration = adoptNS([_WKTextExtractionConfiguration new]);
+        [configuration setOutputFormat:_WKTextExtractionOutputFormatTextTree];
+        [configuration setFilterOptions:_WKTextExtractionFilterNone];
+        [configuration setIncludeTagName:YES];
+        return configuration.autorelease();
+    }()];
+
+    // A whitespace-only block has an inline formatting context, but pruning drops it once its whitespace text is
+    // removed, so it is never tagged.
+    EXPECT_TRUE([debugText containsString:@"p 'Alpha'"]);
+    EXPECT_FALSE([debugText containsString:@"div"]);
+}
+
+TEST(TextExtractionTests, IncludeTagNameKeepsSemanticLabelForStructuralContainers)
+{
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:^{
+        RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+        [[configuration preferences] _setTextExtractionEnabled:YES];
+        return configuration.autorelease();
+    }()]);
+
+    [webView synchronouslyLoadHTMLString:@"<blockquote>Quote text.</blockquote>"];
+
+    RetainPtr debugText = [webView synchronouslyGetDebugText:^{
+        RetainPtr configuration = adoptNS([_WKTextExtractionConfiguration new]);
+        [configuration setOutputFormat:_WKTextExtractionOutputFormatTextTree];
+        [configuration setFilterOptions:_WKTextExtractionFilterNone];
+        [configuration setIncludeTagName:YES];
+        return configuration.autorelease();
+    }()];
+
+    // Semantic containers are extracted independently of includeTagName and keep their descriptive label rather
+    // than the raw tag name; the flag only tags otherwise-generic blocks.
+    EXPECT_TRUE([debugText containsString:@"block-quote 'Quote text.'"]);
+    EXPECT_FALSE([debugText containsString:@"blockquote"]);
+}
+
+TEST(TextExtractionTests, IncludeTagNameFlattensInlineElementsIntoBlockText)
+{
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:^{
+        RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+        [[configuration preferences] _setTextExtractionEnabled:YES];
+        return configuration.autorelease();
+    }()]);
+
+    [webView synchronouslyLoadHTMLString:@"<p>First <b>bold</b> and <span>emphasized</span> text.</p>"];
+
+    RetainPtr debugText = [webView synchronouslyGetDebugText:^{
+        RetainPtr configuration = adoptNS([_WKTextExtractionConfiguration new]);
+        [configuration setOutputFormat:_WKTextExtractionOutputFormatTextTree];
+        [configuration setFilterOptions:_WKTextExtractionFilterNone];
+        [configuration setIncludeTagName:YES];
+        return configuration.autorelease();
+    }()];
+
+    // Inline elements (<b>, <span>, …) have inline renderers, so they collapse and their text merges into the
+    // enclosing block's single text run; only the block itself is tagged.
+    EXPECT_TRUE([debugText containsString:@"p 'First bold and emphasized text.'"]);
+    EXPECT_FALSE([debugText containsString:@"b '"]);
+    EXPECT_FALSE([debugText containsString:@"span"]);
+}
+
 TEST(TextExtractionTests, ExtractFromDocumentWithoutBody)
 {
     RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:^{


### PR DESCRIPTION
#### 2a2cb3b391a49d217d46149a72dda16107a8e33e
<pre>
[Text Extraction] Add option to include tag names for blocks with inline children.
<a href="https://webkit.org/b/319821">https://webkit.org/b/319821</a>
<a href="https://rdar.apple.com/problem/182720339">rdar://problem/182720339</a>

Reviewed by Wenson Hsieh.

The `.textTree` output collapses generic blocks such as headings and paragraphs into bare quoted text, which
reads well but discards the element type, leaving structure-aware clients no way to recover it.

Add an `includeTagName` option that prefixes each such block&apos;s line in `.textTree` output with its lowercased
tag name (e.g. `h1 &apos;Title&apos;`). Semantic containers already carry a descriptive label, so the option only tags
otherwise-generic blocks that render their own inline content (renderer has inline children); block-level
wrappers still collapse and empty blocks are still pruned. Off by default; affects only `.textTree`.

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/TextExtractionTests.mm

* Source/WebCore/page/text-extraction/TextExtraction.cpp:
(WebCore::TextExtraction::extractRecursive): When includeTagName is set, extract a generic block whose
renderer has inline children so its tag prefixes the text; block-level wrappers still collapse.
* Source/WebCore/page/text-extraction/TextExtractionTypes.h: Add the includeTagName request flag.
* Source/WebKit/Shared/TextExtractionToStringConversion.cpp:
(WebKit::TextExtractionAggregator::includeTagName const): True only for .textTree output with the flag set.
(WebKit::addPartsForItem): Emit the lowercased tag name as a generic container&apos;s line prefix when it has no label.
* Source/WebKit/Shared/TextExtractionToStringConversion.h: Add the IncludeTagName option flag.
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in: Serialize the new request flag.
* Source/WebKit/UIProcess/API/Cocoa/WKWebView+TextExtraction.mm:
(-[WKWebView _extractDebugTextWithConfigurationWithoutUpdatingFilterRules:assertionScope:completionHandler:]):
Map the configuration property onto the IncludeTagName option flag.
(-[WKWebView _requestTextExtractionInternal:completion:]): Thread the configuration property into the request.
* Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.h: Declare the includeTagName property.
* Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.mm:
(-[_WKTextExtractionConfiguration init]): Default includeTagName to NO.
(-[_WKTextExtractionConfiguration configureForMinimalOutput]): Leave includeTagName off for minimal output.
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/TextExtractionTests.mm:
(TestWebKitAPI::TEST(TextExtractionTests, IncludeTagNamePrefixesContentBlocks)): Added.
(TestWebKitAPI::TEST(TextExtractionTests, IncludeTagNameTagsBlockWithOnlyInlineContent)): Added.
(TestWebKitAPI::TEST(TextExtractionTests, IncludeTagNameDisabledByDefault)): Added.
(TestWebKitAPI::TEST(TextExtractionTests, IncludeTagNameCollapsesMixedInlineAndBlockContent)): Added.
(TestWebKitAPI::TEST(TextExtractionTests, IncludeTagNameDropsEmptyAndWhitespaceBlocks)): Added.
(TestWebKitAPI::TEST(TextExtractionTests, IncludeTagNameKeepsSemanticLabelForStructuralContainers)): Added.
(TestWebKitAPI::TEST(TextExtractionTests, IncludeTagNameFlattensInlineElementsIntoBlockText)): Added.

Canonical link: <a href="https://commits.webkit.org/317575@main">https://commits.webkit.org/317575@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fb3564718eaf872d66f85f6a455b73e668c3eef9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175613 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49545 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43329 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185205 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/137781 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/177476 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50838 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49228 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136741 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/137781 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178569 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40178 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157511 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117219 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4cd69bea-b0a1-49a7-8841-7ad33ac3746c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38821 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37205 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149240 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37003 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33675 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41237 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41411 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187625 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49213 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145723 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49893 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33627 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145560 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26697 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40374 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122088 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115914 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48400 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11980 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47802 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48034 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47859 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->