### PR TITLE
Update WebTransport wpt test expectations

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/back-forward-cache-with-closed-webtransport-connection.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/back-forward-cache-with-closed-webtransport-connection.https.window-expected.txt
@@ -1,0 +1,3 @@
+
+NOTRUN Testing BFCache support for page with closed WebTransport connection. BFCache not supported.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/back-forward-cache-with-open-webtransport-connection.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/back-forward-cache-with-open-webtransport-connection.https.window-expected.txt
@@ -1,0 +1,3 @@
+
+NOTRUN Testing BFCache support for page with open WebTransport connection. BFCache not supported.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/close.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/close.https.any-expected.txt
@@ -1,15 +1,14 @@
 
-Harness Error (TIMEOUT), message = null
-
-FAIL close promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'close_info.closeCode')"
-FAIL close without waiting for ready promise_rejects_exactly: ready promise should be rejected function "function() { throw e }" threw object "NetworkError:  A network error occurred." but we expected it to throw object "NetworkError:  A network error occurred."
-FAIL close with code and reason promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'close_info.closeCode')"
-FAIL close with code and long reason promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'close_info.closeCode')"
-TIMEOUT server initiated closure without code and reason Test timed out
-NOTRUN server initiated closure with code and reason
-NOTRUN server initiated connection closure
-NOTRUN opening unidirectional stream before ready
-NOTRUN opening bidirectional stream before ready
-NOTRUN server initiated closure while opening unidirectional stream before ready
-NOTRUN server initiated closure while opening bidirectional stream before ready
+FAIL close assert_own_property: expected property "session-close-info" missing
+PASS close without waiting for ready
+FAIL close with code and reason assert_own_property: expected property "session-close-info" missing
+FAIL close with code and long reason assert_own_property: expected property "session-close-info" missing
+PASS server initiated closure without code and reason
+PASS server initiated closure with code and reason
+PASS server initiated connection closure
+PASS opening unidirectional stream before ready
+PASS opening bidirectional stream before ready
+FAIL server initiated closure while opening unidirectional stream before ready assert_unreached: Should have rejected: undefined Reached unreachable code
+FAIL server initiated closure while opening bidirectional stream before ready assert_unreached: Should have rejected: undefined Reached unreachable code
+PASS reading closed property after close should work
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/close.https.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/close.https.any.serviceworker-expected.txt
@@ -1,15 +1,14 @@
 
-Harness Error (TIMEOUT), message = null
-
-FAIL close promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'close_info.closeCode')"
-FAIL close without waiting for ready promise_rejects_exactly: ready promise should be rejected function "function() { throw e }" threw object "NetworkError:  A network error occurred." but we expected it to throw object "NetworkError:  A network error occurred."
-FAIL close with code and reason promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'close_info.closeCode')"
-FAIL close with code and long reason promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'close_info.closeCode')"
-TIMEOUT server initiated closure without code and reason Test timed out
-NOTRUN server initiated closure with code and reason
-NOTRUN server initiated connection closure
-NOTRUN opening unidirectional stream before ready
-NOTRUN opening bidirectional stream before ready
-NOTRUN server initiated closure while opening unidirectional stream before ready
-NOTRUN server initiated closure while opening bidirectional stream before ready
+FAIL close assert_own_property: expected property "session-close-info" missing
+PASS close without waiting for ready
+FAIL close with code and reason assert_own_property: expected property "session-close-info" missing
+FAIL close with code and long reason assert_own_property: expected property "session-close-info" missing
+PASS server initiated closure without code and reason
+PASS server initiated closure with code and reason
+PASS server initiated connection closure
+PASS opening unidirectional stream before ready
+PASS opening bidirectional stream before ready
+FAIL server initiated closure while opening unidirectional stream before ready assert_unreached: Should have rejected: undefined Reached unreachable code
+FAIL server initiated closure while opening bidirectional stream before ready assert_unreached: Should have rejected: undefined Reached unreachable code
+PASS reading closed property after close should work
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/close.https.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/close.https.any.sharedworker-expected.txt
@@ -1,15 +1,14 @@
 
-Harness Error (TIMEOUT), message = null
-
-FAIL close promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'close_info.closeCode')"
-FAIL close without waiting for ready promise_rejects_exactly: ready promise should be rejected function "function() { throw e }" threw object "NetworkError:  A network error occurred." but we expected it to throw object "NetworkError:  A network error occurred."
-FAIL close with code and reason promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'close_info.closeCode')"
-FAIL close with code and long reason promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'close_info.closeCode')"
-TIMEOUT server initiated closure without code and reason Test timed out
-NOTRUN server initiated closure with code and reason
-NOTRUN server initiated connection closure
-NOTRUN opening unidirectional stream before ready
-NOTRUN opening bidirectional stream before ready
-NOTRUN server initiated closure while opening unidirectional stream before ready
-NOTRUN server initiated closure while opening bidirectional stream before ready
+FAIL close assert_own_property: expected property "session-close-info" missing
+PASS close without waiting for ready
+FAIL close with code and reason assert_own_property: expected property "session-close-info" missing
+FAIL close with code and long reason assert_own_property: expected property "session-close-info" missing
+PASS server initiated closure without code and reason
+PASS server initiated closure with code and reason
+PASS server initiated connection closure
+PASS opening unidirectional stream before ready
+PASS opening bidirectional stream before ready
+FAIL server initiated closure while opening unidirectional stream before ready assert_unreached: Should have rejected: undefined Reached unreachable code
+FAIL server initiated closure while opening bidirectional stream before ready assert_unreached: Should have rejected: undefined Reached unreachable code
+PASS reading closed property after close should work
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/close.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/close.https.any.worker-expected.txt
@@ -1,15 +1,14 @@
 
-Harness Error (TIMEOUT), message = null
-
-FAIL close promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'close_info.closeCode')"
-FAIL close without waiting for ready promise_rejects_exactly: ready promise should be rejected function "function() { throw e }" threw object "NetworkError:  A network error occurred." but we expected it to throw object "NetworkError:  A network error occurred."
-FAIL close with code and reason promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'close_info.closeCode')"
-FAIL close with code and long reason promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'close_info.closeCode')"
-TIMEOUT server initiated closure without code and reason Test timed out
-NOTRUN server initiated closure with code and reason
-NOTRUN server initiated connection closure
-NOTRUN opening unidirectional stream before ready
-NOTRUN opening bidirectional stream before ready
-NOTRUN server initiated closure while opening unidirectional stream before ready
-NOTRUN server initiated closure while opening bidirectional stream before ready
+FAIL close assert_own_property: expected property "session-close-info" missing
+PASS close without waiting for ready
+FAIL close with code and reason assert_own_property: expected property "session-close-info" missing
+FAIL close with code and long reason assert_own_property: expected property "session-close-info" missing
+PASS server initiated closure without code and reason
+PASS server initiated closure with code and reason
+PASS server initiated connection closure
+PASS opening unidirectional stream before ready
+PASS opening bidirectional stream before ready
+FAIL server initiated closure while opening unidirectional stream before ready assert_unreached: Should have rejected: undefined Reached unreachable code
+FAIL server initiated closure while opening bidirectional stream before ready assert_unreached: Should have rejected: undefined Reached unreachable code
+PASS reading closed property after close should work
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/datagrams.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/datagrams.https.any-expected.txt
@@ -1,14 +1,12 @@
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT Datagrams are echoed successfully Test timed out
-NOTRUN Successfully reading datagrams with BYOB reader.
-NOTRUN Reading datagrams with insufficient buffer should be rejected.
-NOTRUN Transfer max-size datagram
-NOTRUN Fail to transfer max-size+1 datagram
-NOTRUN Sending and receiving datagrams is ready to use before session is established
-NOTRUN Datagram's outgoingHighWaterMark correctly regulates written datagrams
-NOTRUN Datagrams read is less than or equal to the incomingHighWaterMark
-NOTRUN Datagram MaxAge getters/setters work correctly
-NOTRUN Datagram HighWaterMark getters/setters work correctly
+PASS Datagrams are echoed successfully
+FAIL Successfully reading datagrams with BYOB reader. promise_test: Unhandled rejection with value: object "TypeError: Invalid mode is specified"
+FAIL Reading datagrams with insufficient buffer should be rejected. promise_test: Unhandled rejection with value: object "TypeError: Invalid mode is specified"
+FAIL Transfer max-size datagram promise_test: Unhandled rejection with value: object "NetworkError:  A network error occurred."
+FAIL Fail to transfer max-size+1 datagram, handle PMTUD increases promise_test: Unhandled rejection with value: object "NetworkError:  A network error occurred."
+PASS Sending and receiving datagrams is ready to use before session is established
+FAIL Datagram's outgoingMaxBufferedDatagrams correctly regulates written datagrams assert_true: expected true got false
+FAIL Datagrams read is less than or equal to the incomingMaxBufferedDatagrams assert_less_than_equal: expected a number less than or equal to 5 but got 48
+PASS Datagram MaxAge getters/setters work correctly
+FAIL Datagram MaxBufferedDatagrams getters/setters work correctly assert_greater_than_equal: expected a number but got a "undefined"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/datagrams.https.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/datagrams.https.any.serviceworker-expected.txt
@@ -1,14 +1,12 @@
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT Datagrams are echoed successfully Test timed out
-NOTRUN Successfully reading datagrams with BYOB reader.
-NOTRUN Reading datagrams with insufficient buffer should be rejected.
-NOTRUN Transfer max-size datagram
-NOTRUN Fail to transfer max-size+1 datagram
-NOTRUN Sending and receiving datagrams is ready to use before session is established
-NOTRUN Datagram's outgoingHighWaterMark correctly regulates written datagrams
-NOTRUN Datagrams read is less than or equal to the incomingHighWaterMark
-NOTRUN Datagram MaxAge getters/setters work correctly
-NOTRUN Datagram HighWaterMark getters/setters work correctly
+PASS Datagrams are echoed successfully
+FAIL Successfully reading datagrams with BYOB reader. promise_test: Unhandled rejection with value: object "TypeError: Invalid mode is specified"
+FAIL Reading datagrams with insufficient buffer should be rejected. promise_test: Unhandled rejection with value: object "TypeError: Invalid mode is specified"
+FAIL Transfer max-size datagram promise_test: Unhandled rejection with value: object "NetworkError:  A network error occurred."
+FAIL Fail to transfer max-size+1 datagram, handle PMTUD increases promise_test: Unhandled rejection with value: object "NetworkError:  A network error occurred."
+PASS Sending and receiving datagrams is ready to use before session is established
+FAIL Datagram's outgoingMaxBufferedDatagrams correctly regulates written datagrams assert_true: expected true got false
+FAIL Datagrams read is less than or equal to the incomingMaxBufferedDatagrams assert_less_than_equal: expected a number less than or equal to 5 but got 42
+PASS Datagram MaxAge getters/setters work correctly
+FAIL Datagram MaxBufferedDatagrams getters/setters work correctly assert_greater_than_equal: expected a number but got a "undefined"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/datagrams.https.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/datagrams.https.any.sharedworker-expected.txt
@@ -1,14 +1,12 @@
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT Datagrams are echoed successfully Test timed out
-NOTRUN Successfully reading datagrams with BYOB reader.
-NOTRUN Reading datagrams with insufficient buffer should be rejected.
-NOTRUN Transfer max-size datagram
-NOTRUN Fail to transfer max-size+1 datagram
-NOTRUN Sending and receiving datagrams is ready to use before session is established
-NOTRUN Datagram's outgoingHighWaterMark correctly regulates written datagrams
-NOTRUN Datagrams read is less than or equal to the incomingHighWaterMark
-NOTRUN Datagram MaxAge getters/setters work correctly
-NOTRUN Datagram HighWaterMark getters/setters work correctly
+PASS Datagrams are echoed successfully
+FAIL Successfully reading datagrams with BYOB reader. promise_test: Unhandled rejection with value: object "TypeError: Invalid mode is specified"
+FAIL Reading datagrams with insufficient buffer should be rejected. promise_test: Unhandled rejection with value: object "TypeError: Invalid mode is specified"
+FAIL Transfer max-size datagram promise_test: Unhandled rejection with value: object "NetworkError:  A network error occurred."
+FAIL Fail to transfer max-size+1 datagram, handle PMTUD increases promise_test: Unhandled rejection with value: object "NetworkError:  A network error occurred."
+PASS Sending and receiving datagrams is ready to use before session is established
+FAIL Datagram's outgoingMaxBufferedDatagrams correctly regulates written datagrams assert_true: expected true got false
+FAIL Datagrams read is less than or equal to the incomingMaxBufferedDatagrams assert_less_than_equal: expected a number less than or equal to 5 but got 46
+PASS Datagram MaxAge getters/setters work correctly
+FAIL Datagram MaxBufferedDatagrams getters/setters work correctly assert_greater_than_equal: expected a number but got a "undefined"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/datagrams.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/datagrams.https.any.worker-expected.txt
@@ -1,14 +1,12 @@
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT Datagrams are echoed successfully Test timed out
-NOTRUN Successfully reading datagrams with BYOB reader.
-NOTRUN Reading datagrams with insufficient buffer should be rejected.
-NOTRUN Transfer max-size datagram
-NOTRUN Fail to transfer max-size+1 datagram
-NOTRUN Sending and receiving datagrams is ready to use before session is established
-NOTRUN Datagram's outgoingHighWaterMark correctly regulates written datagrams
-NOTRUN Datagrams read is less than or equal to the incomingHighWaterMark
-NOTRUN Datagram MaxAge getters/setters work correctly
-NOTRUN Datagram HighWaterMark getters/setters work correctly
+PASS Datagrams are echoed successfully
+FAIL Successfully reading datagrams with BYOB reader. promise_test: Unhandled rejection with value: object "TypeError: Invalid mode is specified"
+FAIL Reading datagrams with insufficient buffer should be rejected. promise_test: Unhandled rejection with value: object "TypeError: Invalid mode is specified"
+FAIL Transfer max-size datagram promise_test: Unhandled rejection with value: object "NetworkError:  A network error occurred."
+FAIL Fail to transfer max-size+1 datagram, handle PMTUD increases promise_test: Unhandled rejection with value: object "NetworkError:  A network error occurred."
+PASS Sending and receiving datagrams is ready to use before session is established
+FAIL Datagram's outgoingMaxBufferedDatagrams correctly regulates written datagrams assert_true: expected true got false
+FAIL Datagrams read is less than or equal to the incomingMaxBufferedDatagrams assert_less_than_equal: expected a number less than or equal to 5 but got 47
+PASS Datagram MaxAge getters/setters work correctly
+FAIL Datagram MaxBufferedDatagrams getters/setters work correctly assert_greater_than_equal: expected a number but got a "undefined"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/historical.https.sub.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/historical.https.sub.any-expected.txt
@@ -1,0 +1,5 @@
+
+PASS WebTransportDatagramDuplexStream#writable is removed
+FAIL WebTransportDatagramDuplexStream#incomingHighWaterMark is removed assert_false: expected false got true
+FAIL WebTransportDatagramDuplexStream#outgoingHighWaterMark is removed assert_false: expected false got true
+

--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/historical.https.sub.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/historical.https.sub.any.serviceworker-expected.txt
@@ -1,0 +1,5 @@
+
+PASS WebTransportDatagramDuplexStream#writable is removed
+FAIL WebTransportDatagramDuplexStream#incomingHighWaterMark is removed assert_false: expected false got true
+FAIL WebTransportDatagramDuplexStream#outgoingHighWaterMark is removed assert_false: expected false got true
+

--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/historical.https.sub.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/historical.https.sub.any.sharedworker-expected.txt
@@ -1,0 +1,5 @@
+
+PASS WebTransportDatagramDuplexStream#writable is removed
+FAIL WebTransportDatagramDuplexStream#incomingHighWaterMark is removed assert_false: expected false got true
+FAIL WebTransportDatagramDuplexStream#outgoingHighWaterMark is removed assert_false: expected false got true
+

--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/historical.https.sub.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/historical.https.sub.any.worker-expected.txt
@@ -1,0 +1,5 @@
+
+PASS WebTransportDatagramDuplexStream#writable is removed
+FAIL WebTransportDatagramDuplexStream#incomingHighWaterMark is removed assert_false: expected false got true
+FAIL WebTransportDatagramDuplexStream#outgoingHighWaterMark is removed assert_false: expected false got true
+

--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/idlharness.https.sub.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/idlharness.https.sub.any-expected.txt
@@ -1,0 +1,123 @@
+
+PASS idl_test setup
+FAIL idl_test validation Validation error at line 20 in streams:
+  async iterable<any>
+  ^ `async iterable` is now changed to `async_iterable`.
+PASS WebTransportDatagramsWritable interface: existence and properties of interface object
+PASS WebTransportDatagramsWritable interface object length
+PASS WebTransportDatagramsWritable interface object name
+PASS WebTransportDatagramsWritable interface: existence and properties of interface prototype object
+PASS WebTransportDatagramsWritable interface: existence and properties of interface prototype object's "constructor" property
+PASS WebTransportDatagramsWritable interface: existence and properties of interface prototype object's @@unscopables property
+PASS WebTransportDatagramsWritable interface: attribute sendGroup
+PASS WebTransportDatagramsWritable interface: attribute sendOrder
+PASS WebTransportDatagramDuplexStream interface: existence and properties of interface object
+PASS WebTransportDatagramDuplexStream interface object length
+PASS WebTransportDatagramDuplexStream interface object name
+PASS WebTransportDatagramDuplexStream interface: existence and properties of interface prototype object
+PASS WebTransportDatagramDuplexStream interface: existence and properties of interface prototype object's "constructor" property
+PASS WebTransportDatagramDuplexStream interface: existence and properties of interface prototype object's @@unscopables property
+PASS WebTransportDatagramDuplexStream interface: operation createWritable(optional WebTransportSendOptions)
+PASS WebTransportDatagramDuplexStream interface: attribute readable
+PASS WebTransportDatagramDuplexStream interface: attribute maxDatagramSize
+PASS WebTransportDatagramDuplexStream interface: attribute incomingMaxAge
+PASS WebTransportDatagramDuplexStream interface: attribute outgoingMaxAge
+PASS WebTransportDatagramDuplexStream interface: attribute incomingHighWaterMark
+PASS WebTransportDatagramDuplexStream interface: attribute outgoingHighWaterMark
+PASS WebTransport interface: existence and properties of interface object
+PASS WebTransport interface object length
+PASS WebTransport interface object name
+PASS WebTransport interface: existence and properties of interface prototype object
+PASS WebTransport interface: existence and properties of interface prototype object's "constructor" property
+PASS WebTransport interface: existence and properties of interface prototype object's @@unscopables property
+PASS WebTransport interface: operation getStats()
+FAIL WebTransport interface: operation exportKeyingMaterial(BufferSource, optional BufferSource) assert_own_property: interface prototype object missing non-static operation expected property "exportKeyingMaterial" missing
+PASS WebTransport interface: attribute ready
+PASS WebTransport interface: attribute reliability
+PASS WebTransport interface: attribute congestionControl
+PASS WebTransport interface: attribute anticipatedConcurrentIncomingUnidirectionalStreams
+PASS WebTransport interface: attribute anticipatedConcurrentIncomingBidirectionalStreams
+PASS WebTransport interface: attribute protocol
+PASS WebTransport interface: attribute closed
+PASS WebTransport interface: attribute draining
+PASS WebTransport interface: operation close(optional WebTransportCloseInfo)
+PASS WebTransport interface: attribute datagrams
+PASS WebTransport interface: operation createBidirectionalStream(optional WebTransportSendStreamOptions)
+PASS WebTransport interface: attribute incomingBidirectionalStreams
+PASS WebTransport interface: operation createUnidirectionalStream(optional WebTransportSendStreamOptions)
+PASS WebTransport interface: attribute incomingUnidirectionalStreams
+PASS WebTransport interface: operation createSendGroup()
+PASS WebTransport interface: attribute supportsReliableOnly
+PASS WebTransport must be primary interface of webTransport
+PASS Stringification of webTransport
+PASS WebTransport interface: webTransport must inherit property "getStats()" with the proper type
+FAIL WebTransport interface: webTransport must inherit property "exportKeyingMaterial(BufferSource, optional BufferSource)" with the proper type assert_inherits: property "exportKeyingMaterial" not found in prototype chain
+FAIL WebTransport interface: calling exportKeyingMaterial(BufferSource, optional BufferSource) on webTransport with too few arguments must throw TypeError assert_inherits: property "exportKeyingMaterial" not found in prototype chain
+PASS WebTransport interface: webTransport must inherit property "ready" with the proper type
+PASS WebTransport interface: webTransport must inherit property "reliability" with the proper type
+PASS WebTransport interface: webTransport must inherit property "congestionControl" with the proper type
+PASS WebTransport interface: webTransport must inherit property "anticipatedConcurrentIncomingUnidirectionalStreams" with the proper type
+PASS WebTransport interface: webTransport must inherit property "anticipatedConcurrentIncomingBidirectionalStreams" with the proper type
+PASS WebTransport interface: webTransport must inherit property "protocol" with the proper type
+PASS WebTransport interface: webTransport must inherit property "closed" with the proper type
+PASS WebTransport interface: webTransport must inherit property "draining" with the proper type
+PASS WebTransport interface: webTransport must inherit property "close(optional WebTransportCloseInfo)" with the proper type
+PASS WebTransport interface: calling close(optional WebTransportCloseInfo) on webTransport with too few arguments must throw TypeError
+PASS WebTransport interface: webTransport must inherit property "datagrams" with the proper type
+PASS WebTransport interface: webTransport must inherit property "createBidirectionalStream(optional WebTransportSendStreamOptions)" with the proper type
+PASS WebTransport interface: calling createBidirectionalStream(optional WebTransportSendStreamOptions) on webTransport with too few arguments must throw TypeError
+PASS WebTransport interface: webTransport must inherit property "incomingBidirectionalStreams" with the proper type
+PASS WebTransport interface: webTransport must inherit property "createUnidirectionalStream(optional WebTransportSendStreamOptions)" with the proper type
+PASS WebTransport interface: calling createUnidirectionalStream(optional WebTransportSendStreamOptions) on webTransport with too few arguments must throw TypeError
+PASS WebTransport interface: webTransport must inherit property "incomingUnidirectionalStreams" with the proper type
+PASS WebTransport interface: webTransport must inherit property "createSendGroup()" with the proper type
+PASS WebTransport interface: webTransport must inherit property "supportsReliableOnly" with the proper type
+PASS WebTransportSendStream interface: existence and properties of interface object
+PASS WebTransportSendStream interface object length
+PASS WebTransportSendStream interface object name
+PASS WebTransportSendStream interface: existence and properties of interface prototype object
+PASS WebTransportSendStream interface: existence and properties of interface prototype object's "constructor" property
+PASS WebTransportSendStream interface: existence and properties of interface prototype object's @@unscopables property
+PASS WebTransportSendStream interface: attribute sendGroup
+PASS WebTransportSendStream interface: attribute sendOrder
+PASS WebTransportSendStream interface: operation getStats()
+FAIL WebTransportSendStream interface: operation getWriter() assert_own_property: interface prototype object missing non-static operation expected property "getWriter" missing
+PASS WebTransportSendGroup interface: existence and properties of interface object
+PASS WebTransportSendGroup interface object length
+PASS WebTransportSendGroup interface object name
+PASS WebTransportSendGroup interface: existence and properties of interface prototype object
+PASS WebTransportSendGroup interface: existence and properties of interface prototype object's "constructor" property
+PASS WebTransportSendGroup interface: existence and properties of interface prototype object's @@unscopables property
+PASS WebTransportSendGroup interface: operation getStats()
+PASS WebTransportReceiveStream interface: existence and properties of interface object
+PASS WebTransportReceiveStream interface object length
+PASS WebTransportReceiveStream interface object name
+PASS WebTransportReceiveStream interface: existence and properties of interface prototype object
+PASS WebTransportReceiveStream interface: existence and properties of interface prototype object's "constructor" property
+PASS WebTransportReceiveStream interface: existence and properties of interface prototype object's @@unscopables property
+PASS WebTransportReceiveStream interface: operation getStats()
+PASS WebTransportBidirectionalStream interface: existence and properties of interface object
+PASS WebTransportBidirectionalStream interface object length
+PASS WebTransportBidirectionalStream interface object name
+PASS WebTransportBidirectionalStream interface: existence and properties of interface prototype object
+PASS WebTransportBidirectionalStream interface: existence and properties of interface prototype object's "constructor" property
+PASS WebTransportBidirectionalStream interface: existence and properties of interface prototype object's @@unscopables property
+PASS WebTransportBidirectionalStream interface: attribute readable
+PASS WebTransportBidirectionalStream interface: attribute writable
+FAIL WebTransportWriter interface: existence and properties of interface object assert_own_property: self does not have own property "WebTransportWriter" expected property "WebTransportWriter" missing
+FAIL WebTransportWriter interface object length assert_own_property: self does not have own property "WebTransportWriter" expected property "WebTransportWriter" missing
+FAIL WebTransportWriter interface object name assert_own_property: self does not have own property "WebTransportWriter" expected property "WebTransportWriter" missing
+FAIL WebTransportWriter interface: existence and properties of interface prototype object assert_own_property: self does not have own property "WebTransportWriter" expected property "WebTransportWriter" missing
+FAIL WebTransportWriter interface: existence and properties of interface prototype object's "constructor" property assert_own_property: self does not have own property "WebTransportWriter" expected property "WebTransportWriter" missing
+FAIL WebTransportWriter interface: existence and properties of interface prototype object's @@unscopables property assert_own_property: self does not have own property "WebTransportWriter" expected property "WebTransportWriter" missing
+FAIL WebTransportWriter interface: operation atomicWrite(optional any) assert_own_property: self does not have own property "WebTransportWriter" expected property "WebTransportWriter" missing
+FAIL WebTransportWriter interface: operation commit() assert_own_property: self does not have own property "WebTransportWriter" expected property "WebTransportWriter" missing
+PASS WebTransportError interface: existence and properties of interface object
+PASS WebTransportError interface object length
+PASS WebTransportError interface object name
+PASS WebTransportError interface: existence and properties of interface prototype object
+PASS WebTransportError interface: existence and properties of interface prototype object's "constructor" property
+PASS WebTransportError interface: existence and properties of interface prototype object's @@unscopables property
+PASS WebTransportError interface: attribute source
+PASS WebTransportError interface: attribute streamErrorCode
+

--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/idlharness.https.sub.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/idlharness.https.sub.any.serviceworker-expected.txt
@@ -1,0 +1,123 @@
+
+PASS idl_test setup
+FAIL idl_test validation Validation error at line 20 in streams:
+  async iterable<any>
+  ^ `async iterable` is now changed to `async_iterable`.
+PASS WebTransportDatagramsWritable interface: existence and properties of interface object
+PASS WebTransportDatagramsWritable interface object length
+PASS WebTransportDatagramsWritable interface object name
+PASS WebTransportDatagramsWritable interface: existence and properties of interface prototype object
+PASS WebTransportDatagramsWritable interface: existence and properties of interface prototype object's "constructor" property
+PASS WebTransportDatagramsWritable interface: existence and properties of interface prototype object's @@unscopables property
+PASS WebTransportDatagramsWritable interface: attribute sendGroup
+PASS WebTransportDatagramsWritable interface: attribute sendOrder
+PASS WebTransportDatagramDuplexStream interface: existence and properties of interface object
+PASS WebTransportDatagramDuplexStream interface object length
+PASS WebTransportDatagramDuplexStream interface object name
+PASS WebTransportDatagramDuplexStream interface: existence and properties of interface prototype object
+PASS WebTransportDatagramDuplexStream interface: existence and properties of interface prototype object's "constructor" property
+PASS WebTransportDatagramDuplexStream interface: existence and properties of interface prototype object's @@unscopables property
+PASS WebTransportDatagramDuplexStream interface: operation createWritable(optional WebTransportSendOptions)
+PASS WebTransportDatagramDuplexStream interface: attribute readable
+PASS WebTransportDatagramDuplexStream interface: attribute maxDatagramSize
+PASS WebTransportDatagramDuplexStream interface: attribute incomingMaxAge
+PASS WebTransportDatagramDuplexStream interface: attribute outgoingMaxAge
+PASS WebTransportDatagramDuplexStream interface: attribute incomingHighWaterMark
+PASS WebTransportDatagramDuplexStream interface: attribute outgoingHighWaterMark
+PASS WebTransport interface: existence and properties of interface object
+PASS WebTransport interface object length
+PASS WebTransport interface object name
+PASS WebTransport interface: existence and properties of interface prototype object
+PASS WebTransport interface: existence and properties of interface prototype object's "constructor" property
+PASS WebTransport interface: existence and properties of interface prototype object's @@unscopables property
+PASS WebTransport interface: operation getStats()
+FAIL WebTransport interface: operation exportKeyingMaterial(BufferSource, optional BufferSource) assert_own_property: interface prototype object missing non-static operation expected property "exportKeyingMaterial" missing
+PASS WebTransport interface: attribute ready
+PASS WebTransport interface: attribute reliability
+PASS WebTransport interface: attribute congestionControl
+PASS WebTransport interface: attribute anticipatedConcurrentIncomingUnidirectionalStreams
+PASS WebTransport interface: attribute anticipatedConcurrentIncomingBidirectionalStreams
+PASS WebTransport interface: attribute protocol
+PASS WebTransport interface: attribute closed
+PASS WebTransport interface: attribute draining
+PASS WebTransport interface: operation close(optional WebTransportCloseInfo)
+PASS WebTransport interface: attribute datagrams
+PASS WebTransport interface: operation createBidirectionalStream(optional WebTransportSendStreamOptions)
+PASS WebTransport interface: attribute incomingBidirectionalStreams
+PASS WebTransport interface: operation createUnidirectionalStream(optional WebTransportSendStreamOptions)
+PASS WebTransport interface: attribute incomingUnidirectionalStreams
+PASS WebTransport interface: operation createSendGroup()
+PASS WebTransport interface: attribute supportsReliableOnly
+PASS WebTransport must be primary interface of webTransport
+PASS Stringification of webTransport
+PASS WebTransport interface: webTransport must inherit property "getStats()" with the proper type
+FAIL WebTransport interface: webTransport must inherit property "exportKeyingMaterial(BufferSource, optional BufferSource)" with the proper type assert_inherits: property "exportKeyingMaterial" not found in prototype chain
+FAIL WebTransport interface: calling exportKeyingMaterial(BufferSource, optional BufferSource) on webTransport with too few arguments must throw TypeError assert_inherits: property "exportKeyingMaterial" not found in prototype chain
+PASS WebTransport interface: webTransport must inherit property "ready" with the proper type
+PASS WebTransport interface: webTransport must inherit property "reliability" with the proper type
+PASS WebTransport interface: webTransport must inherit property "congestionControl" with the proper type
+PASS WebTransport interface: webTransport must inherit property "anticipatedConcurrentIncomingUnidirectionalStreams" with the proper type
+PASS WebTransport interface: webTransport must inherit property "anticipatedConcurrentIncomingBidirectionalStreams" with the proper type
+PASS WebTransport interface: webTransport must inherit property "protocol" with the proper type
+PASS WebTransport interface: webTransport must inherit property "closed" with the proper type
+PASS WebTransport interface: webTransport must inherit property "draining" with the proper type
+PASS WebTransport interface: webTransport must inherit property "close(optional WebTransportCloseInfo)" with the proper type
+PASS WebTransport interface: calling close(optional WebTransportCloseInfo) on webTransport with too few arguments must throw TypeError
+PASS WebTransport interface: webTransport must inherit property "datagrams" with the proper type
+PASS WebTransport interface: webTransport must inherit property "createBidirectionalStream(optional WebTransportSendStreamOptions)" with the proper type
+PASS WebTransport interface: calling createBidirectionalStream(optional WebTransportSendStreamOptions) on webTransport with too few arguments must throw TypeError
+PASS WebTransport interface: webTransport must inherit property "incomingBidirectionalStreams" with the proper type
+PASS WebTransport interface: webTransport must inherit property "createUnidirectionalStream(optional WebTransportSendStreamOptions)" with the proper type
+PASS WebTransport interface: calling createUnidirectionalStream(optional WebTransportSendStreamOptions) on webTransport with too few arguments must throw TypeError
+PASS WebTransport interface: webTransport must inherit property "incomingUnidirectionalStreams" with the proper type
+PASS WebTransport interface: webTransport must inherit property "createSendGroup()" with the proper type
+PASS WebTransport interface: webTransport must inherit property "supportsReliableOnly" with the proper type
+PASS WebTransportSendStream interface: existence and properties of interface object
+PASS WebTransportSendStream interface object length
+PASS WebTransportSendStream interface object name
+PASS WebTransportSendStream interface: existence and properties of interface prototype object
+PASS WebTransportSendStream interface: existence and properties of interface prototype object's "constructor" property
+PASS WebTransportSendStream interface: existence and properties of interface prototype object's @@unscopables property
+PASS WebTransportSendStream interface: attribute sendGroup
+PASS WebTransportSendStream interface: attribute sendOrder
+PASS WebTransportSendStream interface: operation getStats()
+FAIL WebTransportSendStream interface: operation getWriter() assert_own_property: interface prototype object missing non-static operation expected property "getWriter" missing
+PASS WebTransportSendGroup interface: existence and properties of interface object
+PASS WebTransportSendGroup interface object length
+PASS WebTransportSendGroup interface object name
+PASS WebTransportSendGroup interface: existence and properties of interface prototype object
+PASS WebTransportSendGroup interface: existence and properties of interface prototype object's "constructor" property
+PASS WebTransportSendGroup interface: existence and properties of interface prototype object's @@unscopables property
+PASS WebTransportSendGroup interface: operation getStats()
+PASS WebTransportReceiveStream interface: existence and properties of interface object
+PASS WebTransportReceiveStream interface object length
+PASS WebTransportReceiveStream interface object name
+PASS WebTransportReceiveStream interface: existence and properties of interface prototype object
+PASS WebTransportReceiveStream interface: existence and properties of interface prototype object's "constructor" property
+PASS WebTransportReceiveStream interface: existence and properties of interface prototype object's @@unscopables property
+PASS WebTransportReceiveStream interface: operation getStats()
+PASS WebTransportBidirectionalStream interface: existence and properties of interface object
+PASS WebTransportBidirectionalStream interface object length
+PASS WebTransportBidirectionalStream interface object name
+PASS WebTransportBidirectionalStream interface: existence and properties of interface prototype object
+PASS WebTransportBidirectionalStream interface: existence and properties of interface prototype object's "constructor" property
+PASS WebTransportBidirectionalStream interface: existence and properties of interface prototype object's @@unscopables property
+PASS WebTransportBidirectionalStream interface: attribute readable
+PASS WebTransportBidirectionalStream interface: attribute writable
+FAIL WebTransportWriter interface: existence and properties of interface object assert_own_property: self does not have own property "WebTransportWriter" expected property "WebTransportWriter" missing
+FAIL WebTransportWriter interface object length assert_own_property: self does not have own property "WebTransportWriter" expected property "WebTransportWriter" missing
+FAIL WebTransportWriter interface object name assert_own_property: self does not have own property "WebTransportWriter" expected property "WebTransportWriter" missing
+FAIL WebTransportWriter interface: existence and properties of interface prototype object assert_own_property: self does not have own property "WebTransportWriter" expected property "WebTransportWriter" missing
+FAIL WebTransportWriter interface: existence and properties of interface prototype object's "constructor" property assert_own_property: self does not have own property "WebTransportWriter" expected property "WebTransportWriter" missing
+FAIL WebTransportWriter interface: existence and properties of interface prototype object's @@unscopables property assert_own_property: self does not have own property "WebTransportWriter" expected property "WebTransportWriter" missing
+FAIL WebTransportWriter interface: operation atomicWrite(optional any) assert_own_property: self does not have own property "WebTransportWriter" expected property "WebTransportWriter" missing
+FAIL WebTransportWriter interface: operation commit() assert_own_property: self does not have own property "WebTransportWriter" expected property "WebTransportWriter" missing
+PASS WebTransportError interface: existence and properties of interface object
+PASS WebTransportError interface object length
+PASS WebTransportError interface object name
+PASS WebTransportError interface: existence and properties of interface prototype object
+PASS WebTransportError interface: existence and properties of interface prototype object's "constructor" property
+PASS WebTransportError interface: existence and properties of interface prototype object's @@unscopables property
+PASS WebTransportError interface: attribute source
+PASS WebTransportError interface: attribute streamErrorCode
+

--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/idlharness.https.sub.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/idlharness.https.sub.any.sharedworker-expected.txt
@@ -1,0 +1,123 @@
+
+PASS idl_test setup
+FAIL idl_test validation Validation error at line 20 in streams:
+  async iterable<any>
+  ^ `async iterable` is now changed to `async_iterable`.
+PASS WebTransportDatagramsWritable interface: existence and properties of interface object
+PASS WebTransportDatagramsWritable interface object length
+PASS WebTransportDatagramsWritable interface object name
+PASS WebTransportDatagramsWritable interface: existence and properties of interface prototype object
+PASS WebTransportDatagramsWritable interface: existence and properties of interface prototype object's "constructor" property
+PASS WebTransportDatagramsWritable interface: existence and properties of interface prototype object's @@unscopables property
+PASS WebTransportDatagramsWritable interface: attribute sendGroup
+PASS WebTransportDatagramsWritable interface: attribute sendOrder
+PASS WebTransportDatagramDuplexStream interface: existence and properties of interface object
+PASS WebTransportDatagramDuplexStream interface object length
+PASS WebTransportDatagramDuplexStream interface object name
+PASS WebTransportDatagramDuplexStream interface: existence and properties of interface prototype object
+PASS WebTransportDatagramDuplexStream interface: existence and properties of interface prototype object's "constructor" property
+PASS WebTransportDatagramDuplexStream interface: existence and properties of interface prototype object's @@unscopables property
+PASS WebTransportDatagramDuplexStream interface: operation createWritable(optional WebTransportSendOptions)
+PASS WebTransportDatagramDuplexStream interface: attribute readable
+PASS WebTransportDatagramDuplexStream interface: attribute maxDatagramSize
+PASS WebTransportDatagramDuplexStream interface: attribute incomingMaxAge
+PASS WebTransportDatagramDuplexStream interface: attribute outgoingMaxAge
+PASS WebTransportDatagramDuplexStream interface: attribute incomingHighWaterMark
+PASS WebTransportDatagramDuplexStream interface: attribute outgoingHighWaterMark
+PASS WebTransport interface: existence and properties of interface object
+PASS WebTransport interface object length
+PASS WebTransport interface object name
+PASS WebTransport interface: existence and properties of interface prototype object
+PASS WebTransport interface: existence and properties of interface prototype object's "constructor" property
+PASS WebTransport interface: existence and properties of interface prototype object's @@unscopables property
+PASS WebTransport interface: operation getStats()
+FAIL WebTransport interface: operation exportKeyingMaterial(BufferSource, optional BufferSource) assert_own_property: interface prototype object missing non-static operation expected property "exportKeyingMaterial" missing
+PASS WebTransport interface: attribute ready
+PASS WebTransport interface: attribute reliability
+PASS WebTransport interface: attribute congestionControl
+PASS WebTransport interface: attribute anticipatedConcurrentIncomingUnidirectionalStreams
+PASS WebTransport interface: attribute anticipatedConcurrentIncomingBidirectionalStreams
+PASS WebTransport interface: attribute protocol
+PASS WebTransport interface: attribute closed
+PASS WebTransport interface: attribute draining
+PASS WebTransport interface: operation close(optional WebTransportCloseInfo)
+PASS WebTransport interface: attribute datagrams
+PASS WebTransport interface: operation createBidirectionalStream(optional WebTransportSendStreamOptions)
+PASS WebTransport interface: attribute incomingBidirectionalStreams
+PASS WebTransport interface: operation createUnidirectionalStream(optional WebTransportSendStreamOptions)
+PASS WebTransport interface: attribute incomingUnidirectionalStreams
+PASS WebTransport interface: operation createSendGroup()
+PASS WebTransport interface: attribute supportsReliableOnly
+PASS WebTransport must be primary interface of webTransport
+PASS Stringification of webTransport
+PASS WebTransport interface: webTransport must inherit property "getStats()" with the proper type
+FAIL WebTransport interface: webTransport must inherit property "exportKeyingMaterial(BufferSource, optional BufferSource)" with the proper type assert_inherits: property "exportKeyingMaterial" not found in prototype chain
+FAIL WebTransport interface: calling exportKeyingMaterial(BufferSource, optional BufferSource) on webTransport with too few arguments must throw TypeError assert_inherits: property "exportKeyingMaterial" not found in prototype chain
+PASS WebTransport interface: webTransport must inherit property "ready" with the proper type
+PASS WebTransport interface: webTransport must inherit property "reliability" with the proper type
+PASS WebTransport interface: webTransport must inherit property "congestionControl" with the proper type
+PASS WebTransport interface: webTransport must inherit property "anticipatedConcurrentIncomingUnidirectionalStreams" with the proper type
+PASS WebTransport interface: webTransport must inherit property "anticipatedConcurrentIncomingBidirectionalStreams" with the proper type
+PASS WebTransport interface: webTransport must inherit property "protocol" with the proper type
+PASS WebTransport interface: webTransport must inherit property "closed" with the proper type
+PASS WebTransport interface: webTransport must inherit property "draining" with the proper type
+PASS WebTransport interface: webTransport must inherit property "close(optional WebTransportCloseInfo)" with the proper type
+PASS WebTransport interface: calling close(optional WebTransportCloseInfo) on webTransport with too few arguments must throw TypeError
+PASS WebTransport interface: webTransport must inherit property "datagrams" with the proper type
+PASS WebTransport interface: webTransport must inherit property "createBidirectionalStream(optional WebTransportSendStreamOptions)" with the proper type
+PASS WebTransport interface: calling createBidirectionalStream(optional WebTransportSendStreamOptions) on webTransport with too few arguments must throw TypeError
+PASS WebTransport interface: webTransport must inherit property "incomingBidirectionalStreams" with the proper type
+PASS WebTransport interface: webTransport must inherit property "createUnidirectionalStream(optional WebTransportSendStreamOptions)" with the proper type
+PASS WebTransport interface: calling createUnidirectionalStream(optional WebTransportSendStreamOptions) on webTransport with too few arguments must throw TypeError
+PASS WebTransport interface: webTransport must inherit property "incomingUnidirectionalStreams" with the proper type
+PASS WebTransport interface: webTransport must inherit property "createSendGroup()" with the proper type
+PASS WebTransport interface: webTransport must inherit property "supportsReliableOnly" with the proper type
+PASS WebTransportSendStream interface: existence and properties of interface object
+PASS WebTransportSendStream interface object length
+PASS WebTransportSendStream interface object name
+PASS WebTransportSendStream interface: existence and properties of interface prototype object
+PASS WebTransportSendStream interface: existence and properties of interface prototype object's "constructor" property
+PASS WebTransportSendStream interface: existence and properties of interface prototype object's @@unscopables property
+PASS WebTransportSendStream interface: attribute sendGroup
+PASS WebTransportSendStream interface: attribute sendOrder
+PASS WebTransportSendStream interface: operation getStats()
+FAIL WebTransportSendStream interface: operation getWriter() assert_own_property: interface prototype object missing non-static operation expected property "getWriter" missing
+PASS WebTransportSendGroup interface: existence and properties of interface object
+PASS WebTransportSendGroup interface object length
+PASS WebTransportSendGroup interface object name
+PASS WebTransportSendGroup interface: existence and properties of interface prototype object
+PASS WebTransportSendGroup interface: existence and properties of interface prototype object's "constructor" property
+PASS WebTransportSendGroup interface: existence and properties of interface prototype object's @@unscopables property
+PASS WebTransportSendGroup interface: operation getStats()
+PASS WebTransportReceiveStream interface: existence and properties of interface object
+PASS WebTransportReceiveStream interface object length
+PASS WebTransportReceiveStream interface object name
+PASS WebTransportReceiveStream interface: existence and properties of interface prototype object
+PASS WebTransportReceiveStream interface: existence and properties of interface prototype object's "constructor" property
+PASS WebTransportReceiveStream interface: existence and properties of interface prototype object's @@unscopables property
+PASS WebTransportReceiveStream interface: operation getStats()
+PASS WebTransportBidirectionalStream interface: existence and properties of interface object
+PASS WebTransportBidirectionalStream interface object length
+PASS WebTransportBidirectionalStream interface object name
+PASS WebTransportBidirectionalStream interface: existence and properties of interface prototype object
+PASS WebTransportBidirectionalStream interface: existence and properties of interface prototype object's "constructor" property
+PASS WebTransportBidirectionalStream interface: existence and properties of interface prototype object's @@unscopables property
+PASS WebTransportBidirectionalStream interface: attribute readable
+PASS WebTransportBidirectionalStream interface: attribute writable
+FAIL WebTransportWriter interface: existence and properties of interface object assert_own_property: self does not have own property "WebTransportWriter" expected property "WebTransportWriter" missing
+FAIL WebTransportWriter interface object length assert_own_property: self does not have own property "WebTransportWriter" expected property "WebTransportWriter" missing
+FAIL WebTransportWriter interface object name assert_own_property: self does not have own property "WebTransportWriter" expected property "WebTransportWriter" missing
+FAIL WebTransportWriter interface: existence and properties of interface prototype object assert_own_property: self does not have own property "WebTransportWriter" expected property "WebTransportWriter" missing
+FAIL WebTransportWriter interface: existence and properties of interface prototype object's "constructor" property assert_own_property: self does not have own property "WebTransportWriter" expected property "WebTransportWriter" missing
+FAIL WebTransportWriter interface: existence and properties of interface prototype object's @@unscopables property assert_own_property: self does not have own property "WebTransportWriter" expected property "WebTransportWriter" missing
+FAIL WebTransportWriter interface: operation atomicWrite(optional any) assert_own_property: self does not have own property "WebTransportWriter" expected property "WebTransportWriter" missing
+FAIL WebTransportWriter interface: operation commit() assert_own_property: self does not have own property "WebTransportWriter" expected property "WebTransportWriter" missing
+PASS WebTransportError interface: existence and properties of interface object
+PASS WebTransportError interface object length
+PASS WebTransportError interface object name
+PASS WebTransportError interface: existence and properties of interface prototype object
+PASS WebTransportError interface: existence and properties of interface prototype object's "constructor" property
+PASS WebTransportError interface: existence and properties of interface prototype object's @@unscopables property
+PASS WebTransportError interface: attribute source
+PASS WebTransportError interface: attribute streamErrorCode
+

--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/idlharness.https.sub.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/idlharness.https.sub.any.worker-expected.txt
@@ -1,0 +1,123 @@
+
+PASS idl_test setup
+FAIL idl_test validation Validation error at line 20 in streams:
+  async iterable<any>
+  ^ `async iterable` is now changed to `async_iterable`.
+PASS WebTransportDatagramsWritable interface: existence and properties of interface object
+PASS WebTransportDatagramsWritable interface object length
+PASS WebTransportDatagramsWritable interface object name
+PASS WebTransportDatagramsWritable interface: existence and properties of interface prototype object
+PASS WebTransportDatagramsWritable interface: existence and properties of interface prototype object's "constructor" property
+PASS WebTransportDatagramsWritable interface: existence and properties of interface prototype object's @@unscopables property
+PASS WebTransportDatagramsWritable interface: attribute sendGroup
+PASS WebTransportDatagramsWritable interface: attribute sendOrder
+PASS WebTransportDatagramDuplexStream interface: existence and properties of interface object
+PASS WebTransportDatagramDuplexStream interface object length
+PASS WebTransportDatagramDuplexStream interface object name
+PASS WebTransportDatagramDuplexStream interface: existence and properties of interface prototype object
+PASS WebTransportDatagramDuplexStream interface: existence and properties of interface prototype object's "constructor" property
+PASS WebTransportDatagramDuplexStream interface: existence and properties of interface prototype object's @@unscopables property
+PASS WebTransportDatagramDuplexStream interface: operation createWritable(optional WebTransportSendOptions)
+PASS WebTransportDatagramDuplexStream interface: attribute readable
+PASS WebTransportDatagramDuplexStream interface: attribute maxDatagramSize
+PASS WebTransportDatagramDuplexStream interface: attribute incomingMaxAge
+PASS WebTransportDatagramDuplexStream interface: attribute outgoingMaxAge
+PASS WebTransportDatagramDuplexStream interface: attribute incomingHighWaterMark
+PASS WebTransportDatagramDuplexStream interface: attribute outgoingHighWaterMark
+PASS WebTransport interface: existence and properties of interface object
+PASS WebTransport interface object length
+PASS WebTransport interface object name
+PASS WebTransport interface: existence and properties of interface prototype object
+PASS WebTransport interface: existence and properties of interface prototype object's "constructor" property
+PASS WebTransport interface: existence and properties of interface prototype object's @@unscopables property
+PASS WebTransport interface: operation getStats()
+FAIL WebTransport interface: operation exportKeyingMaterial(BufferSource, optional BufferSource) assert_own_property: interface prototype object missing non-static operation expected property "exportKeyingMaterial" missing
+PASS WebTransport interface: attribute ready
+PASS WebTransport interface: attribute reliability
+PASS WebTransport interface: attribute congestionControl
+PASS WebTransport interface: attribute anticipatedConcurrentIncomingUnidirectionalStreams
+PASS WebTransport interface: attribute anticipatedConcurrentIncomingBidirectionalStreams
+PASS WebTransport interface: attribute protocol
+PASS WebTransport interface: attribute closed
+PASS WebTransport interface: attribute draining
+PASS WebTransport interface: operation close(optional WebTransportCloseInfo)
+PASS WebTransport interface: attribute datagrams
+PASS WebTransport interface: operation createBidirectionalStream(optional WebTransportSendStreamOptions)
+PASS WebTransport interface: attribute incomingBidirectionalStreams
+PASS WebTransport interface: operation createUnidirectionalStream(optional WebTransportSendStreamOptions)
+PASS WebTransport interface: attribute incomingUnidirectionalStreams
+PASS WebTransport interface: operation createSendGroup()
+PASS WebTransport interface: attribute supportsReliableOnly
+PASS WebTransport must be primary interface of webTransport
+PASS Stringification of webTransport
+PASS WebTransport interface: webTransport must inherit property "getStats()" with the proper type
+FAIL WebTransport interface: webTransport must inherit property "exportKeyingMaterial(BufferSource, optional BufferSource)" with the proper type assert_inherits: property "exportKeyingMaterial" not found in prototype chain
+FAIL WebTransport interface: calling exportKeyingMaterial(BufferSource, optional BufferSource) on webTransport with too few arguments must throw TypeError assert_inherits: property "exportKeyingMaterial" not found in prototype chain
+PASS WebTransport interface: webTransport must inherit property "ready" with the proper type
+PASS WebTransport interface: webTransport must inherit property "reliability" with the proper type
+PASS WebTransport interface: webTransport must inherit property "congestionControl" with the proper type
+PASS WebTransport interface: webTransport must inherit property "anticipatedConcurrentIncomingUnidirectionalStreams" with the proper type
+PASS WebTransport interface: webTransport must inherit property "anticipatedConcurrentIncomingBidirectionalStreams" with the proper type
+PASS WebTransport interface: webTransport must inherit property "protocol" with the proper type
+PASS WebTransport interface: webTransport must inherit property "closed" with the proper type
+PASS WebTransport interface: webTransport must inherit property "draining" with the proper type
+PASS WebTransport interface: webTransport must inherit property "close(optional WebTransportCloseInfo)" with the proper type
+PASS WebTransport interface: calling close(optional WebTransportCloseInfo) on webTransport with too few arguments must throw TypeError
+PASS WebTransport interface: webTransport must inherit property "datagrams" with the proper type
+PASS WebTransport interface: webTransport must inherit property "createBidirectionalStream(optional WebTransportSendStreamOptions)" with the proper type
+PASS WebTransport interface: calling createBidirectionalStream(optional WebTransportSendStreamOptions) on webTransport with too few arguments must throw TypeError
+PASS WebTransport interface: webTransport must inherit property "incomingBidirectionalStreams" with the proper type
+PASS WebTransport interface: webTransport must inherit property "createUnidirectionalStream(optional WebTransportSendStreamOptions)" with the proper type
+PASS WebTransport interface: calling createUnidirectionalStream(optional WebTransportSendStreamOptions) on webTransport with too few arguments must throw TypeError
+PASS WebTransport interface: webTransport must inherit property "incomingUnidirectionalStreams" with the proper type
+PASS WebTransport interface: webTransport must inherit property "createSendGroup()" with the proper type
+PASS WebTransport interface: webTransport must inherit property "supportsReliableOnly" with the proper type
+PASS WebTransportSendStream interface: existence and properties of interface object
+PASS WebTransportSendStream interface object length
+PASS WebTransportSendStream interface object name
+PASS WebTransportSendStream interface: existence and properties of interface prototype object
+PASS WebTransportSendStream interface: existence and properties of interface prototype object's "constructor" property
+PASS WebTransportSendStream interface: existence and properties of interface prototype object's @@unscopables property
+PASS WebTransportSendStream interface: attribute sendGroup
+PASS WebTransportSendStream interface: attribute sendOrder
+PASS WebTransportSendStream interface: operation getStats()
+FAIL WebTransportSendStream interface: operation getWriter() assert_own_property: interface prototype object missing non-static operation expected property "getWriter" missing
+PASS WebTransportSendGroup interface: existence and properties of interface object
+PASS WebTransportSendGroup interface object length
+PASS WebTransportSendGroup interface object name
+PASS WebTransportSendGroup interface: existence and properties of interface prototype object
+PASS WebTransportSendGroup interface: existence and properties of interface prototype object's "constructor" property
+PASS WebTransportSendGroup interface: existence and properties of interface prototype object's @@unscopables property
+PASS WebTransportSendGroup interface: operation getStats()
+PASS WebTransportReceiveStream interface: existence and properties of interface object
+PASS WebTransportReceiveStream interface object length
+PASS WebTransportReceiveStream interface object name
+PASS WebTransportReceiveStream interface: existence and properties of interface prototype object
+PASS WebTransportReceiveStream interface: existence and properties of interface prototype object's "constructor" property
+PASS WebTransportReceiveStream interface: existence and properties of interface prototype object's @@unscopables property
+PASS WebTransportReceiveStream interface: operation getStats()
+PASS WebTransportBidirectionalStream interface: existence and properties of interface object
+PASS WebTransportBidirectionalStream interface object length
+PASS WebTransportBidirectionalStream interface object name
+PASS WebTransportBidirectionalStream interface: existence and properties of interface prototype object
+PASS WebTransportBidirectionalStream interface: existence and properties of interface prototype object's "constructor" property
+PASS WebTransportBidirectionalStream interface: existence and properties of interface prototype object's @@unscopables property
+PASS WebTransportBidirectionalStream interface: attribute readable
+PASS WebTransportBidirectionalStream interface: attribute writable
+FAIL WebTransportWriter interface: existence and properties of interface object assert_own_property: self does not have own property "WebTransportWriter" expected property "WebTransportWriter" missing
+FAIL WebTransportWriter interface object length assert_own_property: self does not have own property "WebTransportWriter" expected property "WebTransportWriter" missing
+FAIL WebTransportWriter interface object name assert_own_property: self does not have own property "WebTransportWriter" expected property "WebTransportWriter" missing
+FAIL WebTransportWriter interface: existence and properties of interface prototype object assert_own_property: self does not have own property "WebTransportWriter" expected property "WebTransportWriter" missing
+FAIL WebTransportWriter interface: existence and properties of interface prototype object's "constructor" property assert_own_property: self does not have own property "WebTransportWriter" expected property "WebTransportWriter" missing
+FAIL WebTransportWriter interface: existence and properties of interface prototype object's @@unscopables property assert_own_property: self does not have own property "WebTransportWriter" expected property "WebTransportWriter" missing
+FAIL WebTransportWriter interface: operation atomicWrite(optional any) assert_own_property: self does not have own property "WebTransportWriter" expected property "WebTransportWriter" missing
+FAIL WebTransportWriter interface: operation commit() assert_own_property: self does not have own property "WebTransportWriter" expected property "WebTransportWriter" missing
+PASS WebTransportError interface: existence and properties of interface object
+PASS WebTransportError interface object length
+PASS WebTransportError interface object name
+PASS WebTransportError interface: existence and properties of interface prototype object
+PASS WebTransportError interface: existence and properties of interface prototype object's "constructor" property
+PASS WebTransportError interface: existence and properties of interface prototype object's @@unscopables property
+PASS WebTransportError interface: attribute source
+PASS WebTransportError interface: attribute streamErrorCode
+

--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/sendorder.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/sendorder.https.any-expected.txt
@@ -1,7 +1,5 @@
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT WebTransport client should be able to create and handle a bidirectional stream with sendOrder Test timed out
-NOTRUN WebTransport client should be able to modify unset sendOrder after stream creation
-NOTRUN WebTransport client should be able to modify existing sendOrder after stream creation
+FAIL WebTransport client should be able to create and handle a bidirectional stream with sendOrder assert_equals: expected (number) 3 but got (object) null
+FAIL WebTransport client should be able to modify unset sendOrder after stream creation assert_equals: expected (number) 0 but got (object) null
+FAIL WebTransport client should be able to modify existing sendOrder after stream creation assert_equals: expected (number) 3 but got (object) null
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/sendorder.https.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/sendorder.https.any.serviceworker-expected.txt
@@ -1,7 +1,5 @@
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT WebTransport client should be able to create and handle a bidirectional stream with sendOrder Test timed out
-NOTRUN WebTransport client should be able to modify unset sendOrder after stream creation
-NOTRUN WebTransport client should be able to modify existing sendOrder after stream creation
+FAIL WebTransport client should be able to create and handle a bidirectional stream with sendOrder assert_equals: expected (number) 3 but got (object) null
+FAIL WebTransport client should be able to modify unset sendOrder after stream creation assert_equals: expected (number) 0 but got (object) null
+FAIL WebTransport client should be able to modify existing sendOrder after stream creation assert_equals: expected (number) 3 but got (object) null
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/sendorder.https.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/sendorder.https.any.sharedworker-expected.txt
@@ -1,7 +1,5 @@
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT WebTransport client should be able to create and handle a bidirectional stream with sendOrder Test timed out
-NOTRUN WebTransport client should be able to modify unset sendOrder after stream creation
-NOTRUN WebTransport client should be able to modify existing sendOrder after stream creation
+FAIL WebTransport client should be able to create and handle a bidirectional stream with sendOrder assert_equals: expected (number) 3 but got (object) null
+FAIL WebTransport client should be able to modify unset sendOrder after stream creation assert_equals: expected (number) 0 but got (object) null
+FAIL WebTransport client should be able to modify existing sendOrder after stream creation assert_equals: expected (number) 3 but got (object) null
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/sendorder.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/sendorder.https.any.worker-expected.txt
@@ -1,7 +1,5 @@
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT WebTransport client should be able to create and handle a bidirectional stream with sendOrder Test timed out
-NOTRUN WebTransport client should be able to modify unset sendOrder after stream creation
-NOTRUN WebTransport client should be able to modify existing sendOrder after stream creation
+FAIL WebTransport client should be able to create and handle a bidirectional stream with sendOrder assert_equals: expected (number) 3 but got (object) null
+FAIL WebTransport client should be able to modify unset sendOrder after stream creation assert_equals: expected (number) 0 but got (object) null
+FAIL WebTransport client should be able to modify existing sendOrder after stream creation assert_equals: expected (number) 3 but got (object) null
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/stats.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/stats.https.any-expected.txt
@@ -1,12 +1,10 @@
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT WebTransport client should be able to provide stats after connection has been established Test timed out
-NOTRUN WebTransport client should be able to provide stats after connection has been closed
-NOTRUN WebTransport client should be able to provide stats requested right before connection has been closed
-NOTRUN WebTransport client should be able to provide valid stats when requested before connection established
-NOTRUN WebTransport client should throw an error when stats are requested for a failed connection
-NOTRUN WebTransport client should be able to handle multiple concurrent stats requests
-NOTRUN WebTransport client should be able to handle multiple sequential stats requests
-NOTRUN WebTransport client should be able to provide droppedIncoming values for datagrams
+FAIL WebTransport client should be able to provide stats after connection has been established assert_greater_than: minRtt expected a number greater than 0 but got 0
+FAIL WebTransport client should be able to provide stats after connection has been closed promise_test: Unhandled rejection with value: object "InvalidStateError: The object is in an invalid state."
+FAIL WebTransport client should be able to provide stats requested right before connection has been closed assert_greater_than: minRtt expected a number greater than 0 but got 0
+FAIL WebTransport client should be able to provide valid stats when requested before connection established assert_greater_than: minRtt expected a number greater than 0 but got 0
+FAIL WebTransport client should throw an error when stats are requested for a failed connection assert_equals: expected (number) 11 but got (undefined) undefined
+FAIL WebTransport client should be able to handle multiple concurrent stats requests assert_greater_than: minRtt expected a number greater than 0 but got 0
+FAIL WebTransport client should be able to handle multiple sequential stats requests assert_greater_than: minRtt expected a number greater than 0 but got 0
+FAIL WebTransport client should be able to provide droppedIncoming values for datagrams assert_greater_than: expected a number greater than 0 but got 0
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/stats.https.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/stats.https.any.serviceworker-expected.txt
@@ -1,12 +1,10 @@
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT WebTransport client should be able to provide stats after connection has been established Test timed out
-NOTRUN WebTransport client should be able to provide stats after connection has been closed
-NOTRUN WebTransport client should be able to provide stats requested right before connection has been closed
-NOTRUN WebTransport client should be able to provide valid stats when requested before connection established
-NOTRUN WebTransport client should throw an error when stats are requested for a failed connection
-NOTRUN WebTransport client should be able to handle multiple concurrent stats requests
-NOTRUN WebTransport client should be able to handle multiple sequential stats requests
-NOTRUN WebTransport client should be able to provide droppedIncoming values for datagrams
+FAIL WebTransport client should be able to provide stats after connection has been established assert_greater_than: minRtt expected a number greater than 0 but got 0
+FAIL WebTransport client should be able to provide stats after connection has been closed promise_test: Unhandled rejection with value: object "InvalidStateError: The object is in an invalid state."
+FAIL WebTransport client should be able to provide stats requested right before connection has been closed assert_greater_than: minRtt expected a number greater than 0 but got 0
+FAIL WebTransport client should be able to provide valid stats when requested before connection established assert_greater_than: minRtt expected a number greater than 0 but got 0
+FAIL WebTransport client should throw an error when stats are requested for a failed connection assert_equals: expected (number) 11 but got (undefined) undefined
+FAIL WebTransport client should be able to handle multiple concurrent stats requests assert_greater_than: minRtt expected a number greater than 0 but got 0
+FAIL WebTransport client should be able to handle multiple sequential stats requests assert_greater_than: minRtt expected a number greater than 0 but got 0
+FAIL WebTransport client should be able to provide droppedIncoming values for datagrams assert_greater_than: expected a number greater than 0 but got 0
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/stats.https.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/stats.https.any.sharedworker-expected.txt
@@ -1,12 +1,10 @@
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT WebTransport client should be able to provide stats after connection has been established Test timed out
-NOTRUN WebTransport client should be able to provide stats after connection has been closed
-NOTRUN WebTransport client should be able to provide stats requested right before connection has been closed
-NOTRUN WebTransport client should be able to provide valid stats when requested before connection established
-NOTRUN WebTransport client should throw an error when stats are requested for a failed connection
-NOTRUN WebTransport client should be able to handle multiple concurrent stats requests
-NOTRUN WebTransport client should be able to handle multiple sequential stats requests
-NOTRUN WebTransport client should be able to provide droppedIncoming values for datagrams
+FAIL WebTransport client should be able to provide stats after connection has been established assert_greater_than: minRtt expected a number greater than 0 but got 0
+FAIL WebTransport client should be able to provide stats after connection has been closed promise_test: Unhandled rejection with value: object "InvalidStateError: The object is in an invalid state."
+FAIL WebTransport client should be able to provide stats requested right before connection has been closed assert_greater_than: minRtt expected a number greater than 0 but got 0
+FAIL WebTransport client should be able to provide valid stats when requested before connection established assert_greater_than: minRtt expected a number greater than 0 but got 0
+FAIL WebTransport client should throw an error when stats are requested for a failed connection assert_equals: expected (number) 11 but got (undefined) undefined
+FAIL WebTransport client should be able to handle multiple concurrent stats requests assert_greater_than: minRtt expected a number greater than 0 but got 0
+FAIL WebTransport client should be able to handle multiple sequential stats requests assert_greater_than: minRtt expected a number greater than 0 but got 0
+FAIL WebTransport client should be able to provide droppedIncoming values for datagrams assert_greater_than: expected a number greater than 0 but got 0
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/stats.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/stats.https.any.worker-expected.txt
@@ -1,12 +1,10 @@
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT WebTransport client should be able to provide stats after connection has been established Test timed out
-NOTRUN WebTransport client should be able to provide stats after connection has been closed
-NOTRUN WebTransport client should be able to provide stats requested right before connection has been closed
-NOTRUN WebTransport client should be able to provide valid stats when requested before connection established
-NOTRUN WebTransport client should throw an error when stats are requested for a failed connection
-NOTRUN WebTransport client should be able to handle multiple concurrent stats requests
-NOTRUN WebTransport client should be able to handle multiple sequential stats requests
-NOTRUN WebTransport client should be able to provide droppedIncoming values for datagrams
+FAIL WebTransport client should be able to provide stats after connection has been established assert_greater_than: minRtt expected a number greater than 0 but got 0
+FAIL WebTransport client should be able to provide stats after connection has been closed promise_test: Unhandled rejection with value: object "InvalidStateError: The object is in an invalid state."
+FAIL WebTransport client should be able to provide stats requested right before connection has been closed assert_greater_than: minRtt expected a number greater than 0 but got 0
+FAIL WebTransport client should be able to provide valid stats when requested before connection established assert_greater_than: minRtt expected a number greater than 0 but got 0
+FAIL WebTransport client should throw an error when stats are requested for a failed connection assert_equals: expected (number) 11 but got (undefined) undefined
+FAIL WebTransport client should be able to handle multiple concurrent stats requests assert_greater_than: minRtt expected a number greater than 0 but got 0
+FAIL WebTransport client should be able to handle multiple sequential stats requests assert_greater_than: minRtt expected a number greater than 0 but got 0
+FAIL WebTransport client should be able to provide droppedIncoming values for datagrams assert_greater_than: expected a number greater than 0 but got 0
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/streams-close.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/streams-close.https.any-expected.txt
@@ -1,14 +1,12 @@
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT Close outgoing stream / bidi-1 Test timed out
-NOTRUN Close outgoing stream / bidi-2
-NOTRUN Close outgoing stream / uni
-NOTRUN Abort client-created bidirectional stream
-NOTRUN Abort server-initiated bidirectional stream
-NOTRUN Abort unidirectional stream with WebTransportError
-NOTRUN Close and abort unidirectional stream
-NOTRUN Abort unidirectional stream with default error code
-NOTRUN STOP_SENDING coming from server
-NOTRUN RESET_STREAM coming from server
+PASS Close outgoing stream / bidi-1
+PASS Close outgoing stream / bidi-2
+PASS Close outgoing stream / uni
+PASS Abort client-created bidirectional stream
+PASS Abort server-initiated bidirectional stream
+PASS Abort unidirectional stream with WebTransportError
+FAIL Close and abort unidirectional stream assert_unreached: Should have rejected: close_promise Reached unreachable code
+PASS Abort unidirectional stream with default error code
+PASS STOP_SENDING coming from server
+PASS RESET_STREAM coming from server
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/streams-close.https.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/streams-close.https.any.serviceworker-expected.txt
@@ -1,14 +1,12 @@
 
-Harness Error (TIMEOUT), message = null
-
-FAIL Close outgoing stream / bidi-1 promise_test: Unhandled rejection with value: null
-TIMEOUT Close outgoing stream / bidi-2 Test timed out
-NOTRUN Close outgoing stream / uni
-NOTRUN Abort client-created bidirectional stream
-NOTRUN Abort server-initiated bidirectional stream
-NOTRUN Abort unidirectional stream with WebTransportError
-NOTRUN Close and abort unidirectional stream
-NOTRUN Abort unidirectional stream with default error code
-NOTRUN STOP_SENDING coming from server
-NOTRUN RESET_STREAM coming from server
+PASS Close outgoing stream / bidi-1
+PASS Close outgoing stream / bidi-2
+PASS Close outgoing stream / uni
+PASS Abort client-created bidirectional stream
+PASS Abort server-initiated bidirectional stream
+PASS Abort unidirectional stream with WebTransportError
+FAIL Close and abort unidirectional stream assert_unreached: Should have rejected: close_promise Reached unreachable code
+PASS Abort unidirectional stream with default error code
+PASS STOP_SENDING coming from server
+PASS RESET_STREAM coming from server
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/streams-close.https.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/streams-close.https.any.sharedworker-expected.txt
@@ -1,14 +1,12 @@
 
-Harness Error (TIMEOUT), message = null
-
-FAIL Close outgoing stream / bidi-1 promise_test: Unhandled rejection with value: null
-TIMEOUT Close outgoing stream / bidi-2 Test timed out
-NOTRUN Close outgoing stream / uni
-NOTRUN Abort client-created bidirectional stream
-NOTRUN Abort server-initiated bidirectional stream
-NOTRUN Abort unidirectional stream with WebTransportError
-NOTRUN Close and abort unidirectional stream
-NOTRUN Abort unidirectional stream with default error code
-NOTRUN STOP_SENDING coming from server
-NOTRUN RESET_STREAM coming from server
+PASS Close outgoing stream / bidi-1
+PASS Close outgoing stream / bidi-2
+PASS Close outgoing stream / uni
+PASS Abort client-created bidirectional stream
+PASS Abort server-initiated bidirectional stream
+PASS Abort unidirectional stream with WebTransportError
+FAIL Close and abort unidirectional stream assert_unreached: Should have rejected: close_promise Reached unreachable code
+PASS Abort unidirectional stream with default error code
+PASS STOP_SENDING coming from server
+PASS RESET_STREAM coming from server
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/streams-close.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/streams-close.https.any.worker-expected.txt
@@ -1,14 +1,12 @@
 
-Harness Error (TIMEOUT), message = null
-
-FAIL Close outgoing stream / bidi-1 promise_test: Unhandled rejection with value: null
-TIMEOUT Close outgoing stream / bidi-2 Test timed out
-NOTRUN Close outgoing stream / uni
-NOTRUN Abort client-created bidirectional stream
-NOTRUN Abort server-initiated bidirectional stream
-NOTRUN Abort unidirectional stream with WebTransportError
-NOTRUN Close and abort unidirectional stream
-NOTRUN Abort unidirectional stream with default error code
-NOTRUN STOP_SENDING coming from server
-NOTRUN RESET_STREAM coming from server
+PASS Close outgoing stream / bidi-1
+PASS Close outgoing stream / bidi-2
+PASS Close outgoing stream / uni
+PASS Abort client-created bidirectional stream
+PASS Abort server-initiated bidirectional stream
+PASS Abort unidirectional stream with WebTransportError
+FAIL Close and abort unidirectional stream assert_unreached: Should have rejected: close_promise Reached unreachable code
+PASS Abort unidirectional stream with default error code
+PASS STOP_SENDING coming from server
+PASS RESET_STREAM coming from server
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/streams-echo.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/streams-echo.https.any-expected.txt
@@ -1,14 +1,14 @@
 
 Harness Error (TIMEOUT), message = null
 
-TIMEOUT WebTransport client should be able to create and handle a bidirectional stream Test timed out
-NOTRUN WebTransport client should be able to create and handle a bidirectional stream without waiting for ready
-NOTRUN WebTransport server should be able to accept and handle a bidirectional stream
-NOTRUN WebTransport client should be able to create, accept, and handle a unidirectional stream
-NOTRUN WebTransport client should be able to create, accept, and handle a unidirectional stream without waiting for ready
-NOTRUN Can read data from a bidirectional stream with BYOB reader
-NOTRUN Can read data from a unidirectional stream with BYOB reader
-NOTRUN Transfer large chunks of data on a bidirectional stream
+PASS WebTransport client should be able to create and handle a bidirectional stream
+PASS WebTransport client should be able to create and handle a bidirectional stream without waiting for ready
+PASS WebTransport server should be able to accept and handle a bidirectional stream
+PASS WebTransport client should be able to create, accept, and handle a unidirectional stream
+PASS WebTransport client should be able to create, accept, and handle a unidirectional stream without waiting for ready
+PASS Can read data from a bidirectional stream with BYOB reader
+PASS Can read data from a unidirectional stream with BYOB reader
+TIMEOUT Transfer large chunks of data on a bidirectional stream Test timed out
 NOTRUN Transfer large chunks of data on a unidirectional stream
 NOTRUN Closing the stream with no data still resolves the read request
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/streams-echo.https.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/streams-echo.https.any.serviceworker-expected.txt
@@ -1,14 +1,14 @@
 
 Harness Error (TIMEOUT), message = null
 
-FAIL WebTransport client should be able to create and handle a bidirectional stream promise_test: Unhandled rejection with value: null
-FAIL WebTransport client should be able to create and handle a bidirectional stream without waiting for ready promise_test: Unhandled rejection with value: object "InvalidStateError: The object is in an invalid state."
-TIMEOUT WebTransport server should be able to accept and handle a bidirectional stream Test timed out
-NOTRUN WebTransport client should be able to create, accept, and handle a unidirectional stream
-NOTRUN WebTransport client should be able to create, accept, and handle a unidirectional stream without waiting for ready
-NOTRUN Can read data from a bidirectional stream with BYOB reader
-NOTRUN Can read data from a unidirectional stream with BYOB reader
-NOTRUN Transfer large chunks of data on a bidirectional stream
+PASS WebTransport client should be able to create and handle a bidirectional stream
+PASS WebTransport client should be able to create and handle a bidirectional stream without waiting for ready
+PASS WebTransport server should be able to accept and handle a bidirectional stream
+PASS WebTransport client should be able to create, accept, and handle a unidirectional stream
+PASS WebTransport client should be able to create, accept, and handle a unidirectional stream without waiting for ready
+PASS Can read data from a bidirectional stream with BYOB reader
+PASS Can read data from a unidirectional stream with BYOB reader
+TIMEOUT Transfer large chunks of data on a bidirectional stream Test timed out
 NOTRUN Transfer large chunks of data on a unidirectional stream
 NOTRUN Closing the stream with no data still resolves the read request
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/streams-echo.https.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/streams-echo.https.any.sharedworker-expected.txt
@@ -1,14 +1,14 @@
 
 Harness Error (TIMEOUT), message = null
 
-FAIL WebTransport client should be able to create and handle a bidirectional stream promise_test: Unhandled rejection with value: null
-FAIL WebTransport client should be able to create and handle a bidirectional stream without waiting for ready promise_test: Unhandled rejection with value: object "InvalidStateError: The object is in an invalid state."
-TIMEOUT WebTransport server should be able to accept and handle a bidirectional stream Test timed out
-NOTRUN WebTransport client should be able to create, accept, and handle a unidirectional stream
-NOTRUN WebTransport client should be able to create, accept, and handle a unidirectional stream without waiting for ready
-NOTRUN Can read data from a bidirectional stream with BYOB reader
-NOTRUN Can read data from a unidirectional stream with BYOB reader
-NOTRUN Transfer large chunks of data on a bidirectional stream
+PASS WebTransport client should be able to create and handle a bidirectional stream
+PASS WebTransport client should be able to create and handle a bidirectional stream without waiting for ready
+PASS WebTransport server should be able to accept and handle a bidirectional stream
+PASS WebTransport client should be able to create, accept, and handle a unidirectional stream
+PASS WebTransport client should be able to create, accept, and handle a unidirectional stream without waiting for ready
+PASS Can read data from a bidirectional stream with BYOB reader
+PASS Can read data from a unidirectional stream with BYOB reader
+TIMEOUT Transfer large chunks of data on a bidirectional stream Test timed out
 NOTRUN Transfer large chunks of data on a unidirectional stream
 NOTRUN Closing the stream with no data still resolves the read request
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/streams-echo.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/streams-echo.https.any.worker-expected.txt
@@ -1,14 +1,14 @@
 
 Harness Error (TIMEOUT), message = null
 
-FAIL WebTransport client should be able to create and handle a bidirectional stream promise_test: Unhandled rejection with value: null
-FAIL WebTransport client should be able to create and handle a bidirectional stream without waiting for ready promise_test: Unhandled rejection with value: object "InvalidStateError: The object is in an invalid state."
-TIMEOUT WebTransport server should be able to accept and handle a bidirectional stream Test timed out
-NOTRUN WebTransport client should be able to create, accept, and handle a unidirectional stream
-NOTRUN WebTransport client should be able to create, accept, and handle a unidirectional stream without waiting for ready
-NOTRUN Can read data from a bidirectional stream with BYOB reader
-NOTRUN Can read data from a unidirectional stream with BYOB reader
-NOTRUN Transfer large chunks of data on a bidirectional stream
+PASS WebTransport client should be able to create and handle a bidirectional stream
+PASS WebTransport client should be able to create and handle a bidirectional stream without waiting for ready
+PASS WebTransport server should be able to accept and handle a bidirectional stream
+PASS WebTransport client should be able to create, accept, and handle a unidirectional stream
+PASS WebTransport client should be able to create, accept, and handle a unidirectional stream without waiting for ready
+PASS Can read data from a bidirectional stream with BYOB reader
+PASS Can read data from a unidirectional stream with BYOB reader
+TIMEOUT Transfer large chunks of data on a bidirectional stream Test timed out
 NOTRUN Transfer large chunks of data on a unidirectional stream
 NOTRUN Closing the stream with no data still resolves the read request
 


### PR DESCRIPTION
#### 94f805315b5636260da031cb63d3a230a79b5cde
<pre>
Update WebTransport wpt test expectations
<a href="https://bugs.webkit.org/show_bug.cgi?id=319823">https://bugs.webkit.org/show_bug.cgi?id=319823</a>
<a href="https://rdar.apple.com/182721000">rdar://182721000</a>

Reviewed by Basuke Suzuki.

Some tests were skipped, and some progressed with 317416@main

* LayoutTests/imported/w3c/web-platform-tests/webtransport/back-forward-cache-with-closed-webtransport-connection.https.window-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/webtransport/back-forward-cache-with-open-webtransport-connection.https.window-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/webtransport/close.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webtransport/close.https.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webtransport/close.https.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webtransport/close.https.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webtransport/datagrams.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webtransport/datagrams.https.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webtransport/datagrams.https.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webtransport/datagrams.https.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webtransport/historical.https.sub.any-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/webtransport/historical.https.sub.any.serviceworker-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/webtransport/historical.https.sub.any.sharedworker-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/webtransport/historical.https.sub.any.worker-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/webtransport/idlharness.https.sub.any-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/webtransport/idlharness.https.sub.any.serviceworker-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/webtransport/idlharness.https.sub.any.sharedworker-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/webtransport/idlharness.https.sub.any.worker-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/webtransport/sendorder.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webtransport/sendorder.https.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webtransport/sendorder.https.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webtransport/sendorder.https.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webtransport/stats.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webtransport/stats.https.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webtransport/stats.https.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webtransport/stats.https.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webtransport/streams-close.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webtransport/streams-close.https.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webtransport/streams-close.https.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webtransport/streams-close.https.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webtransport/streams-echo.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webtransport/streams-echo.https.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webtransport/streams-echo.https.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webtransport/streams-echo.https.any.worker-expected.txt:

Canonical link: <a href="https://commits.webkit.org/317554@main">https://commits.webkit.org/317554@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/37269a279f459f0de5450c89b5cb057e35bd03c3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175641 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/49574 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/43357 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/185233 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/137813 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b0f87da2-a2e2-4025-a896-5ec06bac7958) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50866 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/49256 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/185233 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/137813 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/cd884af7-8c7a-465d-9652-be211a262eba) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178597 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/40198 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/43357 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/185233 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/85cad27f-a1bc-4f66-ae5a-0f5e3a808599) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/38840 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/49256 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/185233 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/43357 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/149259 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/43357 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33703 "Built successfully") | | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/49256 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187653 "Built successfully") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/49241 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/43357 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/145746 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/49921 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/43357 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/145584 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26691 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/49921 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/115942 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/48428 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/43357 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/47830 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/48062 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/47887 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->