### PR TITLE
[JSC][Wasm] Include module name/hash in debugger stack frames

### DIFF
--- a/JSTests/wasm/stress/stack-trace-binary-offset.js
+++ b/JSTests/wasm/stress/stack-trace-binary-offset.js
@@ -1,0 +1,144 @@
+//@ skip if $architecture != "arm64"
+//@ requireOptions("--useExecutableAllocationFuzz=false", "--enableWasmDebugger=true")
+import * as assert from "../assert.js";
+
+// Bug 278991 / 318712: with enableWasmDebugger (IPInt only), Error.stack includes :0xOFF.
+
+function moduleUnreachable() {
+    // (module (func (export "run") unreachable))
+    // FunctionData.start = 0x1f; unreachable at module offset 0x20.
+    return new Uint8Array([
+        0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
+        0x01, 0x04, 0x01, 0x60, 0x00, 0x00,
+        0x03, 0x02, 0x01, 0x00,
+        0x07, 0x07, 0x01, 0x03, 0x72, 0x75, 0x6e, 0x00, 0x00,
+        0x0a, 0x05, 0x01, 0x03, 0x00, 0x00, 0x0b,
+    ]);
+}
+
+function moduleDivZero() {
+    // (module (func (export "run") i32.const 1 i32.const 0 i32.div_s drop))
+    // FunctionData.start = 0x1f; i32.div_s at module offset 0x24.
+    return new Uint8Array([
+        0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
+        0x01, 0x04, 0x01, 0x60, 0x00, 0x00,
+        0x03, 0x02, 0x01, 0x00,
+        0x07, 0x07, 0x01, 0x03, 0x72, 0x75, 0x6e, 0x00, 0x00,
+        0x0a, 0x0a, 0x01, 0x08, 0x00, 0x41, 0x01, 0x41, 0x00, 0x6d, 0x1a, 0x0b,
+    ]);
+}
+
+function moduleImportCall() {
+    // (module (import "e" "f" (func)) (func (export "run") (call 0)))
+    // Defined function body starts at 0x28; call at 0x29.
+    return new Uint8Array([
+        0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
+        0x01, 0x04, 0x01, 0x60, 0x00, 0x00,
+        0x02, 0x07, 0x01, 0x01, 0x65, 0x01, 0x66, 0x00, 0x00,
+        0x03, 0x02, 0x01, 0x00,
+        0x07, 0x07, 0x01, 0x03, 0x72, 0x75, 0x6e, 0x00, 0x01,
+        0x0a, 0x06, 0x01, 0x04, 0x00, 0x10, 0x00, 0x0b,
+    ]);
+}
+
+function moduleOOBLoad() {
+    // (module (memory 0) (func (export "run") i32.const 0 i32.load drop))
+    // FunctionData.start = 0x24; i32.load at module offset 0x27.
+    return new Uint8Array([
+        0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
+        0x01, 0x04, 0x01, 0x60, 0x00, 0x00,
+        0x03, 0x02, 0x01, 0x00,
+        0x05, 0x03, 0x01, 0x00, 0x00,
+        0x07, 0x07, 0x01, 0x03, 0x72, 0x75, 0x6e, 0x00, 0x00,
+        0x0a, 0x0a, 0x01, 0x08, 0x00, 0x41, 0x00, 0x28, 0x02, 0x00, 0x1a, 0x0b,
+    ]);
+}
+
+// Google Maps toy from https://bugs.webkit.org/show_bug.cgi?id=278991#c4
+// Chrome reports wasm-function[0]:0x34 (i32.load).
+function moduleMapsOOB() {
+    const s = "AGFzbQEAAAABBgFgAX8BfwMCAQAFAwEAAQcSAgZtZW1vcnkCAAVkZXJlZgAACgkBBwAgACgCAAsAFQRuYW1lAgMBAAAGCQEABm1lbW9yeQ";
+    const pad = s + "=".repeat((4 - s.length % 4) % 4);
+    return Uint8Array.from(atob(pad), (c) => c.charCodeAt(0));
+}
+
+function firstWasmFrame(stack) {
+    const line = stack.split("\n").find((l) => l.includes("wasm-function["));
+    assert.truthy(line, `expected wasm frame in stack:\n${stack}`);
+    return line;
+}
+
+function assertFrameOffset(stack, index, offset) {
+    const line = firstWasmFrame(stack);
+    const expected = `wasm-function[${index}]:0x${offset.toString(16)}`;
+    assert.truthy(line.includes(expected), `expected ${expected} in:\n${stack}`);
+}
+
+function testUnreachableOffset() {
+    const inst = new WebAssembly.Instance(new WebAssembly.Module(moduleUnreachable()));
+    let stack = null;
+    try {
+        inst.exports.run();
+    } catch (e) {
+        stack = e.stack;
+    }
+    assert.truthy(stack, "should throw");
+    assertFrameOffset(stack, 0, 0x20);
+}
+
+function testDivZeroOffset() {
+    const inst = new WebAssembly.Instance(new WebAssembly.Module(moduleDivZero()));
+    let stack = null;
+    try {
+        inst.exports.run();
+    } catch (e) {
+        stack = e.stack;
+    }
+    assert.truthy(stack, "should throw");
+    assertFrameOffset(stack, 0, 0x24);
+}
+
+function testImportCallOffset() {
+    let stack = null;
+    const inst = new WebAssembly.Instance(new WebAssembly.Module(moduleImportCall()), {
+        e: {
+            f() {
+                stack = new Error().stack;
+            }
+        }
+    });
+    inst.exports.run();
+    assert.truthy(stack, "callback should run");
+    assertFrameOffset(stack, 1, 0x29);
+}
+
+function testOOBLoadOffset() {
+    const inst = new WebAssembly.Instance(new WebAssembly.Module(moduleOOBLoad()));
+    let stack = null;
+    try {
+        inst.exports.run();
+    } catch (e) {
+        stack = e.stack;
+    }
+    assert.truthy(stack, "should throw");
+    assertFrameOffset(stack, 0, 0x27);
+}
+
+function testMapsOOBOffset() {
+    const inst = new WebAssembly.Instance(new WebAssembly.Module(moduleMapsOOB()));
+    let stack = null;
+    try {
+        inst.exports.deref(-1);
+    } catch (e) {
+        stack = e.stack;
+    }
+    assert.truthy(stack, "should throw");
+    assertFrameOffset(stack, 0, 0x34);
+}
+
+testUnreachableOffset();
+testDivZeroOffset();
+testImportCallOffset();
+testOOBLoadOffset();
+testMapsOOBOffset();
+print("stack-trace-binary-offset: ok");

--- a/JSTests/wasm/stress/stack-trace-function-index.js
+++ b/JSTests/wasm/stress/stack-trace-function-index.js
@@ -1,0 +1,70 @@
+//@ skip if $architecture != "arm64"
+//@ requireOptions("--useExecutableAllocationFuzz=false", "--enableWasmDebugger=true")
+import * as assert from "../assert.js";
+
+// Bug 278991 / 318712: with enableWasmDebugger, Error.stack uses wasm-function[index]
+// (debugger forces IPInt so stacks are tier-stable).
+
+function moduleUnreachable() {
+    // (module (func (export "run") unreachable))
+    return new Uint8Array([
+        0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
+        0x01, 0x04, 0x01, 0x60, 0x00, 0x00,
+        0x03, 0x02, 0x01, 0x00,
+        0x07, 0x07, 0x01, 0x03, 0x72, 0x75, 0x6e, 0x00, 0x00,
+        0x0a, 0x05, 0x01, 0x03, 0x00, 0x00, 0x0b,
+    ]);
+}
+
+function moduleWithImportCallback() {
+    // (module
+    //   (import "env" "cb" (func $cb))
+    //   (func (export "run") (call $cb)))
+    return new Uint8Array([
+        0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
+        0x01, 0x04, 0x01, 0x60, 0x00, 0x00,
+        0x02, 0x0a, 0x01, 0x03, 0x65, 0x6e, 0x76, 0x02, 0x63, 0x62, 0x00, 0x00,
+        0x03, 0x02, 0x01, 0x00,
+        0x07, 0x07, 0x01, 0x03, 0x72, 0x75, 0x6e, 0x00, 0x01,
+        0x0a, 0x06, 0x01, 0x04, 0x00, 0x10, 0x00, 0x0b,
+    ]);
+}
+
+function assertHasWasmFunctionIndex(stack, index) {
+    const needle = `wasm-function[${index}]`;
+    assert.truthy(stack.includes(needle), `stack should contain ${needle}, got:\n${stack}`);
+    // Production format is `N@wasm-function[N]`; debugger mode puts the index only in the location.
+    const productionStyle = new RegExp(String.raw`^\d+@wasm-function\[${index}\]`, "m");
+    assert.falsy(productionStyle.test(stack), `debugger mode should not use production N@wasm-function form, got:\n${stack}`);
+}
+
+function testUnreachableHasIndex() {
+    const inst = new WebAssembly.Instance(new WebAssembly.Module(moduleUnreachable()));
+    let stack = null;
+    try {
+        inst.exports.run();
+    } catch (e) {
+        stack = e.stack;
+    }
+    assert.truthy(stack, "should throw");
+    assertHasWasmFunctionIndex(stack, 0);
+}
+
+function testImportCallbackSeesCallerIndex() {
+    let stack = null;
+    const inst = new WebAssembly.Instance(new WebAssembly.Module(moduleWithImportCallback()), {
+        env: {
+            cb() {
+                stack = new Error().stack;
+            }
+        }
+    });
+    inst.exports.run();
+    assert.truthy(stack, "callback should run");
+    // Import is index 0; defined function is index 1.
+    assertHasWasmFunctionIndex(stack, 1);
+}
+
+testUnreachableHasIndex();
+testImportCallbackSeesCallerIndex();
+print("stack-trace-function-index: ok");

--- a/JSTests/wasm/stress/stack-trace-module-name.js
+++ b/JSTests/wasm/stress/stack-trace-module-name.js
@@ -1,0 +1,36 @@
+//@ skip if $architecture != "arm64"
+//@ requireOptions("--useExecutableAllocationFuzz=false", "--enableWasmDebugger=true")
+import * as assert from "../assert.js";
+import { instantiate } from "../wabt-wrapper.js";
+
+
+async function trapStack(moduleName) {
+    const wat = `
+(module $${moduleName}
+  (func (export "run")
+    unreachable
+  )
+)`;
+    const inst = await instantiate(wat, {}, { write_debug_names: true });
+    try {
+        inst.exports.run();
+        throw new Error("expected trap");
+    } catch (e) {
+        assert.eq(e instanceof WebAssembly.RuntimeError, true);
+        return String(e.stack);
+    }
+}
+
+function assertHasModuleFrame(stack, moduleName) {
+    const needle = `${moduleName}:wasm-function[0]`;
+    assert.truthy(stack.includes(needle), `expected ${needle} in:\n${stack}`);
+}
+
+const stackA = await trapStack("modA");
+const stackB = await trapStack("modB");
+assertHasModuleFrame(stackA, "modA");
+assertHasModuleFrame(stackB, "modB");
+assert.eq(stackA.includes("modB:wasm-function"), false);
+assert.eq(stackB.includes("modA:wasm-function"), false);
+
+print("stack-trace-module-name: ok");

--- a/Source/JavaScriptCore/interpreter/Interpreter.cpp
+++ b/Source/JavaScriptCore/interpreter/Interpreter.cpp
@@ -97,6 +97,7 @@
 
 #if ENABLE(WEBASSEMBLY)
 #include "JSWebAssemblyInstance.h"
+#include "WasmCallee.h"
 #include "WasmContext.h"
 #include "WebAssemblyFunction.h"
 #endif
@@ -656,7 +657,17 @@ void Interpreter::getStackTrace(JSCell* owner, Vector<StackFrame>& results, size
                 auto* nativeCallee = visitor->callee().asNativeCallee();
                 switch (nativeCallee->category()) {
                 case NativeCallee::Category::Wasm: {
-                    results.append(StackFrame(visitor->wasmFunctionIndexOrName(), visitor->wasmFunctionIndex()));
+                    std::optional<uint32_t> binaryOffset;
+#if ENABLE(WEBASSEMBLY)
+                    if (Options::enableWasmDebugger()) {
+                        auto* wasmCallee = uncheckedDowncast<Wasm::Callee>(nativeCallee);
+                        if (wasmCallee->compilationMode() == Wasm::CompilationMode::IPIntMode) {
+                            auto& ipintCallee = uncheckedDowncast<Wasm::IPIntCallee>(*wasmCallee);
+                            binaryOffset = ipintCallee.moduleBytecodeOffsetBase() + visitor->wasmCallSiteIndex().bits();
+                        }
+                    }
+#endif
+                    results.append(StackFrame(visitor->wasmFunctionIndexOrName(), visitor->wasmFunctionIndex(), binaryOffset));
                     break;
                 }
                 case NativeCallee::Category::InlineCache: {

--- a/Source/JavaScriptCore/interpreter/StackVisitor.cpp
+++ b/Source/JavaScriptCore/interpreter/StackVisitor.cpp
@@ -32,6 +32,7 @@
 #include "InlineCallFrame.h"
 #include "JSCInlines.h"
 #include "NativeCallee.h"
+#include "Options.h"
 #include "RegisterAtOffsetList.h"
 #include "WasmCallee.h"
 #include "WasmIndexOrName.h"
@@ -386,9 +387,20 @@ String StackVisitor::Frame::functionName() const
     String traceLine;
 
     switch (codeType()) {
-    case CodeType::Wasm:
-        traceLine = makeString(m_wasmFunctionIndexOrName);
+    case CodeType::Wasm: {
+        if (Options::enableWasmDebugger()) {
+            if (m_wasmFunctionIndexOrName.nameSection()) {
+                auto moduleName = m_wasmFunctionIndexOrName.moduleName();
+                if (!moduleName.empty()) {
+                    traceLine = makeString(moduleName, ":wasm-function["_s, m_wasmFunctionIndex, ']');
+                    break;
+                }
+            }
+            traceLine = makeString("wasm-function["_s, m_wasmFunctionIndex, ']');
+        } else
+            traceLine = makeString(m_wasmFunctionIndexOrName);
         break;
+    }
     case CodeType::Eval:
         traceLine = "eval code"_s;
         break;
@@ -429,7 +441,8 @@ String StackVisitor::Frame::sourceURL() const
         traceLine = "[native code]"_s;
         break;
     case CodeType::Wasm:
-        traceLine = "[wasm code]"_s;
+        if (!Options::enableWasmDebugger())
+            traceLine = "[wasm code]"_s;
         break;
     }
     return traceLine.isNull() ? emptyString() : traceLine;

--- a/Source/JavaScriptCore/llint/InPlaceInterpreter.asm
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter.asm
@@ -441,9 +441,7 @@ end
 # Call site tracking
 
 macro saveCallSiteIndex()
-if X86_64
     loadp UnboxedWasmCalleeStackSlot[cfr], ws0
-end
     loadp Wasm::IPIntCallee::m_bytecode[ws0], t0
     negp t0
     addp PC, t0
@@ -515,6 +513,7 @@ end
 #
 # debugger-aware trap. 2 instructions; heavy logic in _wasm_ipint_check_debugger_hook_and_throw_trap due to fixed-size IPInt dispatch slots.
 macro handleDebuggerTrapIfNeededAndThrowWasmTrap(exception)
+    saveCallSiteIndex()
     storei constexpr Wasm::ExceptionType::%exception%, ArgumentCountIncludingThis + PayloadOffset[cfr]
 if ADDRESS64 and (ARM64 or ARM64E)
    # Currently, only ARM64 and ARM64E with ADDRESS64 platforms support the WasmDebugger.
@@ -1298,7 +1297,6 @@ op(wasm_throw_from_slow_path_trampoline, macro ()
     move wasmInstance, a1
     # Slow paths and the throwException macro store the exception code in the ArgumentCountIncludingThis slot
     loadi ArgumentCountIncludingThis + PayloadOffset[cfr], a2
-    storei 0, CallSiteIndex[cfr]
     cCall3(_slow_path_wasm_throw_exception)
     jumpToException()
 end)
@@ -1312,15 +1310,14 @@ op(wasm_unwind_from_slow_path_trampoline, macro()
 
     move cfr, a0
     move wasmInstance, a1
-    storei 0, CallSiteIndex[cfr]
     cCall3(_slow_path_wasm_unwind_exception)
     jumpToException()
 end)
 
 op(wasm_throw_from_fault_handler_trampoline_reg_instance, macro ()
-    # enableWasmDebugger disables BBQ/OMG, so this trampoline is only
-    # reached from IPInt when the debugger is active. The signal handler only patches
-    # the machine PC, so IPInt registers (PC, MC, ws0, cfr) are still live.
+    # Signal handler only patches the machine PC; IPInt registers (PC, MC, ws0, cfr) are still live.
+    # Fast/signaling memory OOB often traps here instead of the software bounds-check path.
+    saveCallSiteIndex()
     # Exception type comes from instance->m_exception; copy to CFR slot for handle_debugger_trap_if_needed.
     loadi JSWebAssemblyInstance::m_exception[wasmInstance], t0
     storei t0, ArgumentCountIncludingThis + PayloadOffset[cfr]
@@ -1335,7 +1332,6 @@ op(wasm_throw_from_fault_handler_trampoline_reg_instance, macro ()
     move a2, a1
     loadi JSWebAssemblyInstance::m_exception[a1], a2
 
-    storei 0, CallSiteIndex[cfr]
     cCall3(_slow_path_wasm_throw_exception)
     jumpToException()
 end)

--- a/Source/JavaScriptCore/runtime/Options.cpp
+++ b/Source/JavaScriptCore/runtime/Options.cpp
@@ -873,6 +873,7 @@ void Options::notifyOptionsChanged()
     if (Options::enableWasmDebugger()) [[unlikely]] {
         Options::useBBQJIT() = false;
         Options::useOMGJIT() = false;
+        Options::useEagerWasmModuleHashing() = true;
     }
 #else
     Options::enableWasmDebugger() = false;

--- a/Source/JavaScriptCore/runtime/StackFrame.cpp
+++ b/Source/JavaScriptCore/runtime/StackFrame.cpp
@@ -31,9 +31,19 @@
 #include "FunctionExecutable.h"
 #include "JSCellInlines.h"
 #include "JSFunctionInlines.h"
+#include "Options.h"
+#include <wtf/HexNumber.h>
 #include <wtf/text/MakeString.h>
 
 namespace JSC {
+
+// Richer Wasm Error.stack (index-stable location, names-section prefix, IPInt :0xOFF)
+// is debugger-only for now so default stacks do not differ by compilation tier.
+// enableWasmDebugger forces IPInt (no BBQ/OMG) on supported platforms.
+static bool useDetailedWasmStackTraces()
+{
+    return Options::enableWasmDebugger();
+}
 
 StackFrame::StackFrame(VM& vm, JSCell* owner, JSCell* callee)
     : m_frameData(JSFrameData {
@@ -73,12 +83,12 @@ StackFrame::StackFrame(VM& vm, JSCell* owner, CodeBlock* codeBlock, BytecodeInde
 }
 
 StackFrame::StackFrame(Wasm::IndexOrName indexOrName)
-    : m_frameData(WasmFrameData { WTF::move(indexOrName), 0 })
+    : m_frameData(WasmFrameData { WTF::move(indexOrName), 0, std::nullopt })
 {
 }
 
-StackFrame::StackFrame(Wasm::IndexOrName indexOrName, size_t functionIndex)
-    : m_frameData(WasmFrameData { WTF::move(indexOrName), functionIndex })
+StackFrame::StackFrame(Wasm::IndexOrName indexOrName, size_t functionIndex, std::optional<uint32_t> binaryOffset)
+    : m_frameData(WasmFrameData { WTF::move(indexOrName), functionIndex, binaryOffset })
 {
 }
 
@@ -154,6 +164,21 @@ static String processSourceURL(VM& vm, const JSC::StackFrame& frame, const Strin
     return emptyString();
 }
 
+static String wasmStackLocation(const WasmFrameData& wasmFrame)
+{
+    String location;
+    if (wasmFrame.functionIndexOrName.nameSection()) {
+        auto moduleName = wasmFrame.functionIndexOrName.moduleName();
+        if (!moduleName.empty())
+            location = makeString(moduleName, ":wasm-function["_s, wasmFrame.functionIndex, ']');
+    }
+    if (location.isNull())
+        location = makeString("wasm-function["_s, wasmFrame.functionIndex, ']');
+    if (useDetailedWasmStackTraces() && wasmFrame.binaryOffset)
+        return makeString(location, ":0x"_s, hex(*wasmFrame.binaryOffset, Lowercase));
+    return location;
+}
+
 String StackFrame::sourceURL(VM& vm, AllowURLOverride allowOverride) const
 {
     return WTF::switchOn(m_frameData,
@@ -170,10 +195,7 @@ String StackFrame::sourceURL(VM& vm, AllowURLOverride allowOverride) const
             return processSourceURL(vm, *this, jsFrame.codeBlock->ownerExecutable()->sourceURL(), allowOverride);
         },
         [](const WasmFrameData& wasmFrame) -> String {
-            auto moduleName = wasmFrame.functionIndexOrName.moduleName();
-            if (moduleName.empty())
-                return makeString("wasm-function["_s, wasmFrame.functionIndex, ']');
-            return makeString(moduleName, ":wasm-function["_s, wasmFrame.functionIndex, ']');
+            return wasmStackLocation(wasmFrame);
         }
     );
 }
@@ -194,10 +216,7 @@ String StackFrame::sourceURLStripped(VM& vm) const
             return processSourceURL(vm, *this, jsFrame.codeBlock->ownerExecutable()->sourceURLStripped());
         },
         [](const WasmFrameData& wasmFrame) -> String {
-            auto moduleName = wasmFrame.functionIndexOrName.moduleName();
-            if (moduleName.empty())
-                return makeString("wasm-function["_s, wasmFrame.functionIndex, ']');
-            return makeString(moduleName, ":wasm-function["_s, wasmFrame.functionIndex, ']');
+            return wasmStackLocation(wasmFrame);
         }
     );
 }
@@ -235,6 +254,14 @@ String StackFrame::functionName(VM& vm) const
             return name;
         },
         [](const WasmFrameData& wasmFrame) -> String {
+            if (useDetailedWasmStackTraces()) {
+                // Location carries wasm-function[index](:0x). Names-section label is only the prefix before '@'.
+                if (wasmFrame.functionIndexOrName.isEmpty() || !wasmFrame.functionIndexOrName.nameSection())
+                    return emptyString();
+                if (!wasmFrame.functionIndexOrName.isIndex())
+                    return WTF::toString(wasmFrame.functionIndexOrName.name()->span());
+                return emptyString();
+            }
             if (wasmFrame.functionIndexOrName.isEmpty() || !wasmFrame.functionIndexOrName.nameSection())
                 return "wasm-stub"_s;
             if (wasmFrame.functionIndexOrName.isIndex())
@@ -264,6 +291,14 @@ String StackFrame::toString(VM& vm) const
 {
     String functionName = this->functionName(vm);
     String sourceURL = this->sourceURLStripped(vm);
+
+    // Debugger mode: omit empty name so the frame is just wasm-function[N]:0xOFF
+    // (e.g. _eggs@wasm-function[21]:0x3b3, or wasm-function[0]:0x20 with no names section).
+    if (useDetailedWasmStackTraces() && std::holds_alternative<WasmFrameData>(m_frameData)) {
+        if (functionName.isEmpty())
+            return sourceURL;
+        return makeString(functionName, '@', sourceURL);
+    }
 
     if (sourceURL.isEmpty() || !hasLineAndColumnInfo())
         return makeString(functionName, '@', sourceURL);

--- a/Source/JavaScriptCore/runtime/StackFrame.h
+++ b/Source/JavaScriptCore/runtime/StackFrame.h
@@ -33,6 +33,7 @@
 #include <JavaScriptCore/WasmIndexOrName.h>
 #include <JavaScriptCore/WriteBarrier.h>
 #include <limits.h>
+#include <optional>
 #include <wtf/Variant.h>
 
 namespace JSC {
@@ -50,6 +51,7 @@ struct JSFrameData {
 struct WasmFrameData {
     Wasm::IndexOrName functionIndexOrName;
     size_t functionIndex { 0 };
+    std::optional<uint32_t> binaryOffset;
 };
 
 enum class AllowURLOverride : bool { No, Yes };
@@ -64,7 +66,7 @@ public:
     StackFrame(VM&, JSCell* owner, CodeBlock*, BytecodeIndex);
     StackFrame(VM&, JSCell* owner, JSCell* callee, bool isAsyncFrame);
     StackFrame(Wasm::IndexOrName);
-    StackFrame(Wasm::IndexOrName, size_t functionIndex);
+    StackFrame(Wasm::IndexOrName, size_t functionIndex, std::optional<uint32_t> binaryOffset = std::nullopt);
     StackFrame() = default;
 
     bool hasLineAndColumnInfo() const

--- a/Source/JavaScriptCore/wasm/WasmCallee.cpp
+++ b/Source/JavaScriptCore/wasm/WasmCallee.cpp
@@ -306,11 +306,12 @@ RestoreFrameCallee& RestoreFrameCallee::singleton()
     return callee.get().get();
 }
 
-IPIntCallee::IPIntCallee(FunctionIPIntMetadataGenerator& generator, FunctionSpaceIndex index, const RTT& signatureRTT, std::pair<const Name*, RefPtr<NameSection>>&& name)
+IPIntCallee::IPIntCallee(FunctionIPIntMetadataGenerator& generator, FunctionSpaceIndex index, const RTT& signatureRTT, std::pair<const Name*, RefPtr<NameSection>>&& name, size_t functionStartInModule)
     : Callee(Wasm::CompilationMode::IPIntMode, index, WTF::move(name))
     , m_functionIndex(generator.m_functionIndex)
     , m_bytecode(generator.m_bytecode.data() + generator.m_bytecodeOffset)
     , m_bytecodeEnd(m_bytecode + (generator.m_bytecode.size() - generator.m_bytecodeOffset - 1))
+    , m_moduleBytecodeOffsetBase(static_cast<uint32_t>(functionStartInModule + generator.m_bytecodeOffset))
     , m_metadata(WTF::move(generator.m_metadata))
     , m_localInitBytecode(WTF::move(generator.m_localInitBytecode))
     , m_signatureRTT(&signatureRTT)

--- a/Source/JavaScriptCore/wasm/WasmCallee.h
+++ b/Source/JavaScriptCore/wasm/WasmCallee.h
@@ -474,9 +474,9 @@ class IPIntCallee final : public Callee {
     friend class JSC::LLIntOffsetsExtractor;
     friend class Callee;
 public:
-    static Ref<IPIntCallee> create(FunctionIPIntMetadataGenerator& generator, FunctionSpaceIndex index, const RTT& signatureRTT, std::pair<const Name*, RefPtr<NameSection>>&& name)
+    static Ref<IPIntCallee> create(FunctionIPIntMetadataGenerator& generator, FunctionSpaceIndex index, const RTT& signatureRTT, std::pair<const Name*, RefPtr<NameSection>>&& name, size_t functionStartInModule)
     {
-        return adoptRef(*new IPIntCallee(generator, index, signatureRTT, WTF::move(name)));
+        return adoptRef(*new IPIntCallee(generator, index, signatureRTT, WTF::move(name), functionStartInModule));
     }
 
     FunctionCodeIndex functionIndex() const { return m_functionIndex; }
@@ -486,6 +486,7 @@ public:
     const uint8_t* bytecode() const { return m_bytecode; }
     const uint8_t* bytecodeEnd() const { return m_bytecodeEnd; }
     const uint8_t* metadata() const LIFETIME_BOUND { return m_metadata.span().data(); }
+    uint32_t moduleBytecodeOffsetBase() const { return m_moduleBytecodeOffsetBase; }
 
     unsigned numLocals() const { return m_numLocals; }
     unsigned localSizeToAlloc() const { return m_localSizeToAlloc; }
@@ -508,7 +509,7 @@ public:
     unsigned computeCodeHashImpl() const;
 
 private:
-    IPIntCallee(FunctionIPIntMetadataGenerator&, FunctionSpaceIndex, const RTT& signatureRTT, std::pair<const Name*, RefPtr<NameSection>>&&);
+    IPIntCallee(FunctionIPIntMetadataGenerator&, FunctionSpaceIndex, const RTT& signatureRTT, std::pair<const Name*, RefPtr<NameSection>>&&, size_t functionStartInModule);
 
     CodePtr<WasmEntryPtrTag> entrypointImpl() const { return m_entrypoint; }
     std::tuple<void*, void*> rangeImpl() const { return { nullptr, nullptr }; };
@@ -519,6 +520,7 @@ private:
 
     const uint8_t* m_bytecode;
     const uint8_t* m_bytecodeEnd;
+    uint32_t m_moduleBytecodeOffsetBase { 0 };
     Vector<uint8_t> m_metadata;
     Vector<uint8_t> m_localInitBytecode;
     RefPtr<const RTT> m_signatureRTT;

--- a/Source/JavaScriptCore/wasm/WasmIPIntPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmIPIntPlan.cpp
@@ -109,7 +109,7 @@ void IPIntPlan::compileFunction(FunctionCodeIndex functionIndex)
     m_wasmInternalFunctions[functionIndex] = WTF::move(*parseAndCompileResult);
 
     {
-        auto callee = IPIntCallee::create(*m_wasmInternalFunctions[functionIndex], functionIndexSpace, signature, { });
+        auto callee = IPIntCallee::create(*m_wasmInternalFunctions[functionIndex], functionIndexSpace, signature, { }, m_moduleInformation->functions[functionIndex].start);
         ASSERT(!callee->entrypoint());
         bool usesSIMD = m_moduleInformation->usesSIMD(functionIndex);
         // Immediately tier up to BBQ for SIMD, if necesary.

--- a/Source/JavaScriptCore/wasm/WasmIndexOrName.cpp
+++ b/Source/JavaScriptCore/wasm/WasmIndexOrName.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "WasmIndexOrName.h"
 
+#include "Options.h"
 #include <wtf/PrintStream.h>
 #include <wtf/text/MakeString.h>
 
@@ -55,6 +56,23 @@ IndexOrName::IndexOrName(Index index, std::pair<const Name*, RefPtr<NameSection>
 
 void IndexOrName::dump(PrintStream& out) const
 {
+    if (Options::enableWasmDebugger()) {
+        if (isEmpty() || !nameSection()) {
+            if (isIndex())
+                out.print("wasm-function["_s, index(), ']');
+            else
+                out.print("wasm-function"_s);
+            return;
+        }
+
+        auto moduleName = nameSection()->moduleName.size() ? nameSection()->moduleName.span() : nameSection()->moduleHash.span();
+        if (isIndex())
+            out.print(moduleName, ":wasm-function["_s, index(), ']');
+        else
+            out.print(moduleName, ":wasm-function["_s, name()->span(), ']');
+        return;
+    }
+
     if (isEmpty() || !nameSection()) {
         out.print("wasm-stub"_s);
         if (isIndex())
@@ -71,6 +89,18 @@ void IndexOrName::dump(PrintStream& out) const
 
 String makeString(const IndexOrName& ion)
 {
+    if (Options::enableWasmDebugger()) {
+        if (ion.isEmpty() || !ion.nameSection()) {
+            if (ion.isIndex())
+                return makeString("wasm-function["_s, ion.index(), ']');
+            return "wasm-function"_s;
+        }
+        auto moduleName = ion.moduleName();
+        if (ion.isIndex())
+            return makeString(moduleName, ":wasm-function["_s, ion.index(), ']');
+        return makeString(moduleName, ":wasm-function["_s, ion.name()->span(), ']');
+    }
+
     if (ion.isEmpty() || !ion.nameSection()) {
         if (ion.isIndex())
             return makeString("wasm-stub["_s, ion.index(), "]"_s);

--- a/Source/JavaScriptCore/wasm/WasmModuleInformation.cpp
+++ b/Source/JavaScriptCore/wasm/WasmModuleInformation.cpp
@@ -30,6 +30,7 @@
 
 #if ENABLE(WEBASSEMBLY)
 
+#include "Options.h"
 #include "WasmNameSection.h"
 
 #if ENABLE(WEBASSEMBLY_DEBUGGER)
@@ -60,6 +61,8 @@ void ModuleInformation::setNameSection(Ref<NameSection>&& section)
     if (m_hasCustomNameSection)
         return;
     m_hasCustomNameSection = true;
+    if (Options::useEagerWasmModuleHashing() && !section->moduleHash.size())
+        section->setHash(std::nullopt);
     m_retiredNameSection = WTF::move(m_nameSection);
     m_nameSection = WTF::move(section);
     m_nameSectionPtr.store(m_nameSection.ptr(), std::memory_order_release);


### PR DESCRIPTION
https://bugs.webkit.org/show_bug.cgi?id=174098

**Depends on** https://github.com/WebKit/WebKit/pull/69646.

#### 9587a4afbae0
<pre>
[JSC][Wasm] Include module name/hash in debugger stack frames
https://bugs.webkit.org/show_bug.cgi?id=174098

Reviewed by NOBODY (OOPS!).

When enableWasmDebugger is on, enable eager Wasm module hashing so
unnamed modules get a content hash in Error.stack, and prefer the
names-section module name when present (module:wasm-function[N][:0xOFF]).
This disambiguates multi-module trap stacks under the debugger.

* Source/JavaScriptCore/runtime/Options.cpp:
* Source/JavaScriptCore/wasm/WasmModuleInformation.cpp:
* JSTests/wasm/stress/stack-trace-module-name.js: Added.
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9587a4afbae0cd88a483b717f879466e03c075a9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175642 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49575 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43358 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185234 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/137814 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50867 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49257 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136770 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96215 "3 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178598 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40204 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157541 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117248 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38846 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37229 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | 
| [❌ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/6050 "Found 145 new JSC stress test failures: wasm.yaml/LayoutTests/imported/w3c/web-platform-tests/wasm/core/js/align.wast.js.wasm-bbq, wasm.yaml/LayoutTests/imported/w3c/web-platform-tests/wasm/core/js/align.wast.js.wasm-bbq-no-consts, wasm.yaml/LayoutTests/imported/w3c/web-platform-tests/wasm/core/js/f32.wast.js.wasm-collect-continuously, wasm.yaml/LayoutTests/imported/w3c/web-platform-tests/wasm/core/js/f32_cmp.wast.js.wasm-collect-continuously, wasm.yaml/LayoutTests/imported/w3c/web-platform-tests/wasm/core/js/f64.wast.js.wasm-collect-continuously, wasm.yaml/LayoutTests/imported/w3c/web-platform-tests/wasm/core/js/memory_trap.wast.js.wasm-bbq, wasm.yaml/LayoutTests/imported/w3c/web-platform-tests/wasm/core/js/memory_trap.wast.js.wasm-bbq-no-consts, wasm.yaml/LayoutTests/imported/w3c/web-platform-tests/wasm/core/js/memory_trap.wast.js.wasm-omg, wasm.yaml/LayoutTests/imported/w3c/web-platform-tests/wasm/core/js/multi-memory/memory_trap0.wast.js.wasm-bbq, wasm.yaml/LayoutTests/imported/w3c/web-platform-tests/wasm/core/js/multi-memory/memory_trap0.wast.js.wasm-bbq-no-consts ... (failure)") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149265 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37033 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33704 "Built successfully") | 
| [❌ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/36906 "Found 191 new JSC stress test failures: wasm.yaml/LayoutTests/imported/w3c/web-platform-tests/wasm/core/js/address.wast.js.wasm-bbq, wasm.yaml/LayoutTests/imported/w3c/web-platform-tests/wasm/core/js/address.wast.js.wasm-bbq-no-consts, wasm.yaml/LayoutTests/imported/w3c/web-platform-tests/wasm/core/js/address.wast.js.wasm-omg, wasm.yaml/LayoutTests/imported/w3c/web-platform-tests/wasm/core/js/align.wast.js.wasm-bbq, wasm.yaml/LayoutTests/imported/w3c/web-platform-tests/wasm/core/js/align.wast.js.wasm-bbq-no-consts, wasm.yaml/LayoutTests/imported/w3c/web-platform-tests/wasm/core/js/imports.wast.js.wasm-bbq, wasm.yaml/LayoutTests/imported/w3c/web-platform-tests/wasm/core/js/imports.wast.js.wasm-bbq-no-consts, wasm.yaml/LayoutTests/imported/w3c/web-platform-tests/wasm/core/js/imports.wast.js.wasm-omg, wasm.yaml/LayoutTests/imported/w3c/web-platform-tests/wasm/core/js/memory_grow.wast.js.wasm-bbq, wasm.yaml/LayoutTests/imported/w3c/web-platform-tests/wasm/core/js/memory_grow.wast.js.wasm-bbq-no-consts ... (failure)") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41266 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41435 "Passed tests") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187659 "") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49242 "Built successfully") | | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/187659 "") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49922 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33657 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/187659 "") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40399 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122117 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/115943 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48429 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12010 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47831 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48063 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47888 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->