### PR TITLE
corner-shape: add superellipse tests

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-superellipse-concave-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-superellipse-concave-expected.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<head>
+<title>CSS Borders and Box Decorations 4: per-corner concave 'corner-shape' superellipse values — reference</title>
+<style>
+    .target { position: relative; background: red; width: 100px; height: 100px; box-sizing: border-box;
+        clip-path: path("M 75.000 0.000 C 75.000 7.326 75.379 14.511 80.434 19.566 C 85.489 24.621 92.674 25.000 100.000 25.000 L 100.000 75.000 C 83.369 75.000 79.456 74.694 77.075 77.075 C 74.694 79.456 75.000 83.369 75.000 100.000 L 25.000 100.000 C 25.000 75.747 25.081 75.620 24.731 75.269 C 24.380 74.919 24.253 75.000 0.000 75.000 L 0.000 25.000 C 1.535 25.000 7.947 22.680 15.314 15.314 C 22.680 7.947 25.000 1.535 25.000 0.000 Z"); }
+    .clip { position: absolute; inset: 5px; overflow: hidden; }
+    .shape { position: absolute; inset: -5px; background: green; clip-path: path("M 70.000 0.000 C 70.000 8.791 70.454 17.414 76.520 23.480 C 82.586 29.546 91.209 30.000 100.000 30.000 L 100.000 70.000 C 80.043 70.000 75.347 69.633 72.490 72.490 C 69.633 75.347 70.000 80.043 70.000 100.000 L 30.000 100.000 C 30.000 70.896 30.097 70.744 29.677 70.323 C 29.256 69.903 29.104 70.000 0.000 70.000 L 1.584 29.742 C 3.314 29.742 10.536 27.129 18.832 18.832 C 27.129 10.536 29.742 3.314 29.742 1.584 Z"); }
+</style>
+</head>
+<div class=target><div class=clip><div class=shape></div></div></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-superellipse-concave-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-superellipse-concave-ref.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<head>
+<title>CSS Borders and Box Decorations 4: per-corner concave 'corner-shape' superellipse values — reference</title>
+<style>
+    .target { position: relative; background: red; width: 100px; height: 100px; box-sizing: border-box;
+        clip-path: path("M 75.000 0.000 C 75.000 7.326 75.379 14.511 80.434 19.566 C 85.489 24.621 92.674 25.000 100.000 25.000 L 100.000 75.000 C 83.369 75.000 79.456 74.694 77.075 77.075 C 74.694 79.456 75.000 83.369 75.000 100.000 L 25.000 100.000 C 25.000 75.747 25.081 75.620 24.731 75.269 C 24.380 74.919 24.253 75.000 0.000 75.000 L 0.000 25.000 C 1.535 25.000 7.947 22.680 15.314 15.314 C 22.680 7.947 25.000 1.535 25.000 0.000 Z"); }
+    .clip { position: absolute; inset: 5px; overflow: hidden; }
+    .shape { position: absolute; inset: -5px; background: green; clip-path: path("M 70.000 0.000 C 70.000 8.791 70.454 17.414 76.520 23.480 C 82.586 29.546 91.209 30.000 100.000 30.000 L 100.000 70.000 C 80.043 70.000 75.347 69.633 72.490 72.490 C 69.633 75.347 70.000 80.043 70.000 100.000 L 30.000 100.000 C 30.000 70.896 30.097 70.744 29.677 70.323 C 29.256 69.903 29.104 70.000 0.000 70.000 L 1.584 29.742 C 3.314 29.742 10.536 27.129 18.832 18.832 C 27.129 10.536 29.742 3.314 29.742 1.584 Z"); }
+</style>
+</head>
+<div class=target><div class=clip><div class=shape></div></div></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-superellipse-concave.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-superellipse-concave.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<head>
+<title>CSS Borders and Box Decorations 4: per-corner concave 'corner-shape' superellipse values</title>
+<link rel="help" href="https://drafts.csswg.org/css-borders-4/#corner-shaping">
+<link rel="match" href="corner-shape-superellipse-concave-ref.html">
+<meta name="fuzzy" content="maxDifference=0-70; totalPixels=0-347"/>
+<style>
+    .target {
+        background: green;
+        width: 100px;
+        height: 100px;
+        border-radius: 25px;
+        box-sizing: border-box;
+        border: 5px solid red;
+        corner-shape: superellipse(-0.5) superellipse(-1.5) superellipse(-3) superellipse(-6);
+    }
+</style>
+</head>
+<div class=target></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-superellipse-convex-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-superellipse-convex-expected.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<head>
+<title>CSS Borders and Box Decorations 4: per-corner convex 'corner-shape' superellipse values — reference</title>
+<style>
+    .target { position: relative; background: red; width: 100px; height: 100px; box-sizing: border-box;
+        clip-path: path("M 75.000 0.000 C 82.326 0.000 89.511 0.379 94.566 5.434 C 99.621 10.489 100.000 17.674 100.000 25.000 L 100.000 75.000 C 100.000 91.631 100.306 95.544 97.925 97.925 C 95.544 100.306 91.631 100.000 75.000 100.000 L 25.000 100.000 C 0.747 100.000 0.620 100.081 0.269 99.731 C -0.081 99.380 0.000 99.253 0.000 75.000 L 0.000 25.000 C 0.000 23.465 2.320 17.053 9.686 9.686 C 17.053 2.320 23.465 0.000 25.000 0.000 Z"); }
+    .clip { position: absolute; inset: 5px; overflow: hidden; }
+    .shape { position: absolute; inset: -5px; background: green; clip-path: path("M 74.533 4.978 C 80.537 4.978 86.426 5.288 90.569 9.431 C 94.712 13.574 95.022 19.463 95.022 25.467 L 95.022 74.533 C 95.022 88.163 95.273 91.370 93.321 93.321 C 91.370 95.273 88.163 95.022 74.533 95.022 L 25.467 95.022 C 5.590 95.022 5.486 95.088 5.199 94.801 C 4.912 94.514 4.978 94.410 4.978 74.533 L 4.675 26.773 C 4.675 25.416 6.726 19.748 13.237 13.237 C 19.748 6.726 25.416 4.675 26.773 4.675 Z"); }
+</style>
+</head>
+<div class=target><div class=clip><div class=shape></div></div></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-superellipse-convex-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-superellipse-convex-ref.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<head>
+<title>CSS Borders and Box Decorations 4: per-corner convex 'corner-shape' superellipse values — reference</title>
+<style>
+    .target { position: relative; background: red; width: 100px; height: 100px; box-sizing: border-box;
+        clip-path: path("M 75.000 0.000 C 82.326 0.000 89.511 0.379 94.566 5.434 C 99.621 10.489 100.000 17.674 100.000 25.000 L 100.000 75.000 C 100.000 91.631 100.306 95.544 97.925 97.925 C 95.544 100.306 91.631 100.000 75.000 100.000 L 25.000 100.000 C 0.747 100.000 0.620 100.081 0.269 99.731 C -0.081 99.380 0.000 99.253 0.000 75.000 L 0.000 25.000 C 0.000 23.465 2.320 17.053 9.686 9.686 C 17.053 2.320 23.465 0.000 25.000 0.000 Z"); }
+    .clip { position: absolute; inset: 5px; overflow: hidden; }
+    .shape { position: absolute; inset: -5px; background: green; clip-path: path("M 74.533 4.978 C 80.537 4.978 86.426 5.288 90.569 9.431 C 94.712 13.574 95.022 19.463 95.022 25.467 L 95.022 74.533 C 95.022 88.163 95.273 91.370 93.321 93.321 C 91.370 95.273 88.163 95.022 74.533 95.022 L 25.467 95.022 C 5.590 95.022 5.486 95.088 5.199 94.801 C 4.912 94.514 4.978 94.410 4.978 74.533 L 4.675 26.773 C 4.675 25.416 6.726 19.748 13.237 13.237 C 19.748 6.726 25.416 4.675 26.773 4.675 Z"); }
+</style>
+</head>
+<div class=target><div class=clip><div class=shape></div></div></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-superellipse-convex.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-superellipse-convex.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<head>
+<title>CSS Borders and Box Decorations 4: per-corner convex 'corner-shape' superellipse values</title>
+<link rel="help" href="https://drafts.csswg.org/css-borders-4/#corner-shaping">
+<link rel="match" href="corner-shape-superellipse-convex-ref.html">
+<meta name="fuzzy" content="maxDifference=0-70; totalPixels=0-271"/>
+<style>
+    .target {
+        background: green;
+        width: 100px;
+        height: 100px;
+        border-radius: 25px;
+        box-sizing: border-box;
+        border: 5px solid red;
+        corner-shape: superellipse(0.5) superellipse(1.5) superellipse(3) superellipse(6);
+    }
+</style>
+</head>
+<div class=target></div>


### PR DESCRIPTION
#### dc26ca7e33a50fde3fef1bc661f332faa1b5e2fc
<pre>
corner-shape: add superellipse tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=319426">https://bugs.webkit.org/show_bug.cgi?id=319426</a>
<a href="https://rdar.apple.com/182247714">rdar://182247714</a>

Reviewed by Simon Fraser.

Adds new wpt tests for various corner-shape superellipse values testing
convex and concaveborders

* LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-superellipse-concave-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-superellipse-concave-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-superellipse-concave.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-superellipse-convex-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-superellipse-convex-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-superellipse-convex.html: Added.

Canonical link: <a href="https://commits.webkit.org/317794@main">https://commits.webkit.org/317794@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b016be47731226cca6bbaccedf2d14ac6e431dba

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175879 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49812 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43596 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185472 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/138075 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51104 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49494 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136962 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/138075 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178835 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40424 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157739 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117441 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39066 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37447 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149485 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37231 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33942 "Built successfully") | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41653 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187893 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49479 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/157290 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145954 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39377 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50159 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33855 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145795 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40591 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/116217 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48666 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12211 "") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48068 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48300 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48125 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->