### PR TITLE
[AppKit Gestures] Add test coverage for DOM dblclick and smart magnification support

### DIFF
--- a/Tools/TestWebKitAPI/Helpers/cocoa/JavaScriptMessages.swift
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/JavaScriptMessages.swift
@@ -256,4 +256,75 @@ extension JavaScriptMessages {
     }
 }
 
+extension JavaScriptMessages {
+    /// Installs listeners on an element that record every received event into a log.
+    ///
+    /// Use `EventLog` to read the recorded events back.
+    public struct InstallEventLog: WebPage.JavaScriptExpression {
+        // Protocol conformance.
+        // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
+        public typealias Output = Void
+
+        // Protocol conformance.
+        // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
+        public static var expression: String {
+            """
+            window.eventLog = [];
+            const target = document.getElementById(elementID);
+            for (const type of eventTypes)
+                target.addEventListener(type, event => window.eventLog.push({ "type": event.type, "detail": event.detail }));
+            """
+        }
+
+        private let elementID: String
+        private let eventTypes: [String]
+
+        /// Creates an expression that records the given event types fired on an element.
+        ///
+        /// - Parameters:
+        ///   - elementID: The `id` attribute of the element to observe.
+        ///   - eventTypes: The event types to record.
+        public init(in elementID: String, for eventTypes: [DOMEventType]) {
+            self.elementID = elementID
+            self.eventTypes = eventTypes.map(\.rawValue)
+        }
+
+        // Protocol conformance.
+        // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
+        public func encoded() -> [String: Any?] {
+            [
+                "elementID": elementID,
+                "eventTypes": eventTypes,
+            ]
+        }
+    }
+}
+
+extension JavaScriptMessages {
+    /// Reads the events recorded by `InstallEventLog`.
+    public struct EventLog: WebPage.JavaScriptExpression {
+        // Protocol conformance.
+        // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
+        public typealias Output = [DOMEvent]
+
+        // Protocol conformance.
+        // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
+        public static var expression: String {
+            """
+            return window.eventLog ?? [];
+            """
+        }
+
+        /// Creates a new `EventLog`.
+        public init() {
+        }
+
+        // Protocol conformance.
+        // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
+        public func encoded() -> [String: Any?] {
+            [:]
+        }
+    }
+}
+
 #endif // ENABLE_SWIFTUI

--- a/Tools/TestWebKitAPI/Helpers/cocoa/JavaScriptTypes.swift
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/JavaScriptTypes.swift
@@ -242,4 +242,60 @@ extension CGPoint {
     }
 }
 
+// MARK: DOMEvent
+
+/// A DOM event type, matching the string value of `Event.type` (e.g. `click`, `dblclick`).
+public enum DOMEventType: String, Hashable, Sendable {
+    /// The `click` event.
+    case click
+
+    /// The `dblclick` event.
+    case dblclick
+
+    /// The `pointerdown` event.
+    case pointerdown
+
+    /// The `pointerup` event.
+    case pointerup
+
+    /// The `mousedown` event.
+    case mousedown
+
+    /// The `mouseup` event.
+    case mouseup
+}
+
+/// A DOM UI event observed on an element.
+public struct DOMEvent: Hashable, Sendable {
+    /// The type of the event.
+    public let type: DOMEventType
+
+    /// The event's `detail` value, or `nil` for events that do not carry one; for click events this is the click count.
+    public let detail: Int?
+
+    /// Creates a new `DOMEvent`.
+    ///
+    /// - Parameters:
+    ///   - type: The type of the event.
+    ///   - detail: The event's `detail` value, or `nil` if it does not have one.
+    public init(type: DOMEventType, detail: Int?) {
+        self.type = type
+        self.detail = detail
+    }
+}
+
+extension DOMEvent: WebPage.JavaScriptDecodable {
+    // Protocol conformance.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
+    public init?(decodedRepresentation: [String: Any?]) {
+        guard let type = decodedRepresentation["type"] as? String,
+            let eventType = DOMEventType(rawValue: type)
+        else {
+            return nil
+        }
+
+        self = .init(type: eventType, detail: decodedRepresentation["detail"] as? Int)
+    }
+}
+
 #endif // ENABLE_SWIFTUI

--- a/Tools/TestWebKitAPI/Helpers/cocoa/WebPage+JavaScriptExpression.swift
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/WebPage+JavaScriptExpression.swift
@@ -129,6 +129,47 @@ extension WebPage {
         return decodedResult
     }
 
+    /// Evaluates the provided JavaScript expression whose result is an array of decodable values.
+    ///
+    /// - Parameter expression: The expression to evaluate.
+    /// - Returns: The result of evaluating the expression.
+    /// - Throws: An error if the JavaScript evaluation or decoding fails.
+    public func callJavaScript<Expression, Element>(
+        _ expression: Expression
+    ) async throws(JavaScriptEvaluationError) -> [Element]
+    where Expression: JavaScriptExpression, Expression.Output == [Element], Element: JavaScriptDecodable {
+        let arguments = expression.encoded() as [String: Any]
+        let result: Any?
+        do {
+            result = try await self.callJavaScript(Expression.expression, arguments: arguments)
+        } catch {
+            throw .scriptError(underlyingError: error)
+        }
+
+        guard let result else {
+            throw .noResult
+        }
+
+        guard let array = result as? [Any] else {
+            throw .mismatchedType(expected: [Any].self, actual: type(of: result))
+        }
+
+        var decodedElements: [Element] = []
+        for element in array {
+            guard let dictionary = element as? [String: Any?] else {
+                throw .mismatchedType(expected: [String: Any?].self, actual: type(of: element))
+            }
+
+            guard let decodedElement = Element(decodedRepresentation: dictionary) else {
+                throw .decodingFailure("failed to decode array element")
+            }
+
+            decodedElements.append(decodedElement)
+        }
+
+        return decodedElements
+    }
+
     /// Executes the specified string as an async JavaScript function.
     ///
     /// - Parameters:

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -180,6 +180,7 @@
 			);
 			script = (
 				"\"${SCRIPT_INPUT_FILE_0}\"",
+				"",
 			);
 		};
 /* End PBXBuildRule section */
@@ -550,6 +551,7 @@
 			membershipExceptions = (
 				"WebKit/WebPage/AppKit Gesture Tests/AppKitGesturesTestsSupport.swift",
 				"WebKit/WebPage/AppKit Gesture Tests/BasicAppKitGesturesTests.swift",
+				"WebKit/WebPage/AppKit Gesture Tests/DoubleClickGesturesTests.swift",
 				"WebKit/WebPage/AppKit Gesture Tests/EmbeddedAppKitGesturesTests.swift",
 				WebKit/WebPage/EditingFontSizeTests.swift,
 				WebKit/WebPage/JavaScriptExpressionTests.swift,
@@ -1331,6 +1333,7 @@
 			membershipExceptions = (
 				"WebKit/WebPage/AppKit Gesture Tests/AppKitGesturesTestsSupport.swift",
 				"WebKit/WebPage/AppKit Gesture Tests/BasicAppKitGesturesTests.swift",
+				"WebKit/WebPage/AppKit Gesture Tests/DoubleClickGesturesTests.swift",
 				"WebKit/WebPage/AppKit Gesture Tests/EmbeddedAppKitGesturesTests.swift",
 				WebKit/WebPage/EditingFontSizeTests.swift,
 				WebKit/WebPage/JavaScriptExpressionTests.swift,

--- a/Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/AppKitGesturesTestsSupport.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/AppKitGesturesTestsSupport.swift
@@ -154,4 +154,19 @@ extension AppKitGestureTestSuite {
     }
 }
 
+extension AppKitGestureTestSuite {
+    // Loads a single `#div` containing `Self.text`, optionally editable or with click/dblclick listeners attached.
+    func loadHTML(contentEditable: Bool = false, clickHandler: Bool = false, dblclickHandler: Bool = false) async throws {
+        let contentEditableMarkup = contentEditable ? "contenteditable" : ""
+        let clickHandlerMarkup = clickHandler ? "onclick='void(0)'" : ""
+        let dblclickHandlerMarkup = dblclickHandler ? "ondblclick='void(0)'" : ""
+
+        let html = """
+            <div \(contentEditableMarkup) \(clickHandlerMarkup) \(dblclickHandlerMarkup) id="div" style="font-size: 30px;">\(Self.text)</div>
+            """
+
+        try await page.load(html: html).wait()
+    }
+}
+
 #endif // HAVE_APPKIT_GESTURES_SUPPORT

--- a/Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/BasicAppKitGesturesTests.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/BasicAppKitGesturesTests.swift
@@ -76,17 +76,9 @@ extension AppKitGesturesTests.Basic {
     func singleClickFiresPointerMouseAndClickEvents(contentEditable: Bool) async throws {
         try await loadHTML(contentEditable: contentEditable)
 
-        let expectedEvents = ["pointerdown", "mousedown", "pointerup", "mouseup", "click"]
+        let expectedEvents: [DOMEventType] = [.pointerdown, .mousedown, .pointerup, .mouseup, .click]
 
-        try await page.callJavaScript(arguments: ["events": expectedEvents]) {
-            """
-            window.eventLog = [];
-            const target = document.getElementById("div");
-            for (const eventType of events) {
-                target.addEventListener(eventType, e => window.eventLog.push(e.type));
-            }
-            """
-        }
+        try await page.callJavaScript(JavaScriptMessages.InstallEventLog(in: "div", for: expectedEvents))
 
         if contentEditable {
             // FIXME: <rdar://177201499> This workaround establishes a selection first so that the synthetic click does not change insertion point.
@@ -103,14 +95,10 @@ extension AppKitGesturesTests.Basic {
         await page.waitForPendingMouseEvents()
         await page.waitForNextPresentationUpdate()
 
-        let eventLog = try await page.callJavaScript(returning: [String].self) {
-            """
-            return window.eventLog;
-            """
-        }
+        let eventLog = try await page.callJavaScript(JavaScriptMessages.EventLog())
 
         for eventType in expectedEvents {
-            #expect(eventLog.contains(eventType))
+            #expect(eventLog.contains { $0.type == eventType })
         }
     }
 
@@ -756,6 +744,52 @@ extension AppKitGesturesTests.Basic {
     }
 
     @Test
+    func clickAfterScrollStillProducesClick() async throws {
+        let html = """
+            <body style="margin: 0;">
+                <div id="content"
+                     onclick="window.clicks = (window.clicks || 0) + 1;"
+                     style="height: 4000px; font-size: 30px;
+                            background: repeating-linear-gradient(to bottom, #eee 0 40px, #fff 40px 80px);">
+                    scroll, then click
+                </div>
+            </body>
+            """
+        try await page.load(html: html).wait()
+        await page.waitForNextPresentationUpdate()
+
+        let center = screenBounds(ofPointInWindowCoordinates: window.frame.center)
+
+        await recap.play { composer in
+            composer._wk_drag(
+                withStart: center,
+                end: CGPoint(x: center.x, y: center.y - 200),
+                duration: .seconds(0.5),
+                release: false
+            )
+            composer.advanceTime(0.5)
+            composer._wk_mouseUp()
+        }
+        await page.waitForNextPresentationUpdate()
+
+        let scrollPosition = try await page.callJavaScript(JavaScriptMessages.ScrollPosition())
+        #expect(scrollPosition.y > 0)
+
+        try await Task.sleep(for: .seconds(1.5))
+
+        await recap.play { composer in
+            composer._wk_click(at: center, for: .seconds(0.1))
+        }
+        await page.waitForPendingMouseEvents()
+        await page.waitForNextPresentationUpdate()
+
+        let clicks = try await page.callJavaScript(returning: Int.self) {
+            "return window.clicks || 0;"
+        }
+        #expect(clicks >= 1)
+    }
+
+    @Test
     func clickingOnSelectControlsKeepsMenuOpen() async throws {
         let html = """
             <select name="pets" id="select">
@@ -822,7 +856,10 @@ extension AppKitGesturesTests.Basic {
 
         await page.waitForNextPresentationUpdate()
 
-        try await page.callJavaScript(arguments: ["elementID": "custom-slider"], script: styleAdjustmentForCustomWidgetScript)
+        try await page.callJavaScript(
+            arguments: ["elementID": "custom-slider", "interactive": false],
+            script: styleAdjustmentForCustomWidgetScript
+        )
         await page.waitForNextPresentationUpdate()
 
         let sliderBounds = try await page.callJavaScript(JavaScriptMessages.BoundingClientRect(elementID: elementID))
@@ -1210,17 +1247,6 @@ extension CGPoint {
 }
 
 extension AppKitGesturesTests.Basic {
-    private func loadHTML(contentEditable: Bool = false, clickHandler: Bool = false) async throws {
-        let contentEditableMarkup = contentEditable ? "contenteditable" : ""
-        let clickHandlerMarkup = clickHandler ? "onclick='void(0)'" : ""
-
-        let html = """
-            <div \(contentEditableMarkup) \(clickHandlerMarkup) id="div" style="font-size: 30px;">\(Self.text)</div>
-            """
-
-        try await page.load(html: html).wait()
-    }
-
     private func loadScrollableText() async throws {
         let lines = (0..<100)
             .reversed()

--- a/Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/DoubleClickGesturesTests.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/DoubleClickGesturesTests.swift
@@ -1,0 +1,294 @@
+// Copyright (C) 2026 Apple Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+
+#if HAVE_APPKIT_GESTURES_SUPPORT
+
+import Foundation
+import struct Foundation.URL
+@_spi(WebKitAdditions_Testing) @_spi(Testing) import WebKit
+import SwiftUI
+import struct Swift.String
+import struct _Concurrency.Task
+private import struct TestWebKitAPILibrary.DOMRect
+import Testing
+private import TestWebKitAPILibrary
+private import Recap
+private import AppKit_Private.NSMenu_Private
+
+extension AppKitGesturesTests {
+    @MainActor
+    @Suite(.serialized, .timeLimit(.minutes(1)))
+    struct DoubleClick: AppKitGestureTestSuite {
+        static let text = "Here's to the crazy ones."
+
+        let recap = Recap.shared
+
+        let page: WebPage = {
+            var configuration = WebPage.Configuration()
+            configuration.requiresUserActionForEditingControlsManager = true
+            return WebPage(configuration: configuration)
+        }()
+
+        let window: NSWindow
+
+        init() async throws {
+            let contentSize = NSSize(width: 800, height: 600)
+
+            self.window = NSWindow(size: contentSize) { [page] in
+                WebView(page)
+                    .webViewBackForwardNavigationGestures(.enabled)
+            }
+
+            self.window.setFrameOrigin(.zero)
+            NSApp.activate(ignoringOtherApps: true)
+            self.window.makeKeyAndOrderFront(nil)
+
+            await NSApp.waitForActivation()
+        }
+    }
+}
+
+extension AppKitGesturesTests.DoubleClick {
+    // MARK: - DOM dblclick / detail==2 coverage
+
+    @Test
+    func doubleClickWithListenerFiresDblclick() async throws {
+        try await loadHTML(dblclickHandler: true)
+        try await page.callJavaScript(JavaScriptMessages.InstallEventLog(in: "div", for: [.click, .dblclick]))
+
+        let crazyBounds = try await screenBoundsOfText("crazy")
+
+        await recap.play { composer in
+            composer._wk_click(at: crazyBounds.center, for: .seconds(0.1))
+            composer.advanceTime(0.1)
+            composer._wk_click(at: crazyBounds.center, for: .seconds(0.1))
+        }
+        await page.waitForPendingMouseEvents()
+        await page.waitForNextPresentationUpdate()
+
+        #expect(try await page.callJavaScript(JavaScriptMessages.EventLog()).contains(.init(type: .dblclick, detail: 2)))
+    }
+
+    @Test
+    func doubleClickReportsDetailTwo() async throws {
+        try await loadHTML(dblclickHandler: true)
+        try await page.callJavaScript(JavaScriptMessages.InstallEventLog(in: "div", for: [.click, .dblclick]))
+
+        let crazyBounds = try await screenBoundsOfText("crazy")
+
+        await recap.play { composer in
+            composer._wk_click(at: crazyBounds.center, for: .seconds(0.1))
+            composer.advanceTime(0.1)
+            composer._wk_click(at: crazyBounds.center, for: .seconds(0.1))
+        }
+        await page.waitForPendingMouseEvents()
+        await page.waitForNextPresentationUpdate()
+
+        #expect(try await page.callJavaScript(JavaScriptMessages.EventLog()).contains(.init(type: .click, detail: 2)))
+    }
+
+    @Test
+    func doubleClickWithListenerFiresDblclickAndSelectsWord() async throws {
+        // A dblclick listener and a word selection coexist (only smart magnification
+        // could suppress the selection, and this content is not zoomable).
+        try await loadHTML(dblclickHandler: true)
+        try await page.callJavaScript(JavaScriptMessages.InstallEventLog(in: "div", for: [.click, .dblclick]))
+
+        let crazyRange = try #require(Self.text.utf16Range(of: "crazy"))
+        let crazySelection = JavaScriptSelection.range(
+            base: .init(in: "div", at: crazyRange.lowerBound),
+            extent: .init(in: "div", at: crazyRange.upperBound)
+        )
+
+        let crazyBounds = try await screenBoundsOfText("crazy")
+        try await page.callJavaScript(JavaScriptMessages.SetSelection(in: "div", offset: 0))
+        await page.waitForNextPresentationUpdate()
+
+        await recap.play { composer in
+            composer._wk_click(at: crazyBounds.center, for: .seconds(0.1))
+            composer.advanceTime(0.1)
+            composer._wk_click(at: crazyBounds.center, for: .seconds(0.1))
+        }
+        await page.waitForNextPresentationUpdate()
+
+        #expect(try await page.callJavaScript(JavaScriptMessages.EventLog()).contains(.init(type: .dblclick, detail: 2)))
+        #expect(try await page.callJavaScript(JavaScriptMessages.GetSelection()) == crazySelection)
+    }
+
+    @Test(arguments: [true, false])
+    func doubleClickWithListenerFiresDblclickRegardlessOfEditability(contentEditable: Bool) async throws {
+        try await loadHTML(contentEditable: contentEditable, dblclickHandler: true)
+        try await page.callJavaScript(JavaScriptMessages.InstallEventLog(in: "div", for: [.click, .dblclick]))
+
+        if contentEditable {
+            // Establish a selection first so the synthetic click does not just move the insertion point.
+            try await page.callJavaScript(JavaScriptMessages.SetSelection(in: "div", offset: 0))
+            await page.waitForNextPresentationUpdate()
+        }
+
+        let crazyBounds = try await screenBoundsOfText("crazy")
+
+        await recap.play { composer in
+            composer._wk_click(at: crazyBounds.center, for: .seconds(0.1))
+            composer.advanceTime(0.1)
+            composer._wk_click(at: crazyBounds.center, for: .seconds(0.1))
+        }
+        await page.waitForPendingMouseEvents()
+        await page.waitForNextPresentationUpdate()
+
+        #expect(try await page.callJavaScript(JavaScriptMessages.EventLog()).contains(.init(type: .dblclick, detail: 2)))
+    }
+
+    @Test
+    func singleClickReportsDetailOne() async throws {
+        try await loadHTML()
+        try await page.callJavaScript(JavaScriptMessages.InstallEventLog(in: "div", for: [.click, .dblclick]))
+
+        let toBounds = try await screenBoundsOfText("to")
+
+        await recap.play { composer in
+            composer._wk_click(at: toBounds.center, for: .seconds(0.05))
+        }
+        await page.waitForPendingMouseEvents()
+        await page.waitForNextPresentationUpdate()
+
+        let eventLog = try await page.callJavaScript(JavaScriptMessages.EventLog())
+        #expect(eventLog.contains(.init(type: .click, detail: 1)))
+        #expect(!eventLog.contains { $0.type == .dblclick })
+    }
+
+    @Test
+    func clickingTwoDifferentWordsDoesNotFireDblclick() async throws {
+        // Two clicks far apart in space are two single clicks, disambiguated by location — not a double click.
+        try await loadHTML(dblclickHandler: true)
+        try await page.callJavaScript(JavaScriptMessages.InstallEventLog(in: "div", for: [.click, .dblclick]))
+
+        let toBounds = try await screenBoundsOfText("to")
+        let onesBounds = try await screenBoundsOfText("ones")
+
+        await recap.play { composer in
+            composer._wk_click(at: toBounds.center, for: .seconds(0.1))
+            composer.advanceTime(0.1)
+            composer._wk_click(at: onesBounds.center, for: .seconds(0.1))
+        }
+        await page.waitForPendingMouseEvents()
+        await page.waitForNextPresentationUpdate()
+
+        let eventLog = try await page.callJavaScript(JavaScriptMessages.EventLog())
+        #expect(!eventLog.contains { $0.type == .dblclick })
+    }
+
+    // MARK: - Smart magnification
+
+    @Test
+    func smartMagnificationGestureOnZoomableColumnDoesNotSelectWord() async throws {
+        try await loadZoomableHTML()
+
+        let crazyRange = try #require(Self.text.utf16Range(of: "crazy"))
+        let crazySelection = JavaScriptSelection.range(
+            base: .init(in: "div", at: crazyRange.lowerBound),
+            extent: .init(in: "div", at: crazyRange.upperBound)
+        )
+
+        let crazyBounds = try await screenBoundsOfText("crazy")
+        try await page.callJavaScript(JavaScriptMessages.SetSelection(in: "div", offset: 0))
+        await page.waitForNextPresentationUpdate()
+
+        await recap.play { composer in
+            composer._wk_click(at: crazyBounds.center, for: .seconds(0.1))
+            composer.advanceTime(0.1)
+            composer._wk_click(at: crazyBounds.center, for: .seconds(0.1))
+        }
+        await page.waitForNextPresentationUpdate()
+
+        #expect(try await page.callJavaScript(JavaScriptMessages.GetSelection()) != crazySelection)
+    }
+
+    @Test(arguments: [false, true])
+    func styleAdjustmentCanBlockSmartMagnification(interactive: Bool) async throws {
+        try await loadZoomableHTML()
+        try await page.callJavaScript(
+            arguments: ["elementID": "div", "interactive": interactive],
+            script: styleAdjustmentForCustomWidgetScript
+        )
+
+        let crazyRange = try #require(Self.text.utf16Range(of: "crazy"))
+        let crazySelection = JavaScriptSelection.range(
+            base: .init(in: "div", at: crazyRange.lowerBound),
+            extent: .init(in: "div", at: crazyRange.upperBound)
+        )
+
+        let crazyBounds = try await screenBoundsOfText("crazy")
+        try await page.callJavaScript(JavaScriptMessages.SetSelection(in: "div", offset: 0))
+        await page.waitForNextPresentationUpdate()
+
+        await recap.play { composer in
+            composer._wk_click(at: crazyBounds.center, for: .seconds(0.1))
+            composer.advanceTime(0.1)
+            composer._wk_click(at: crazyBounds.center, for: .seconds(0.1))
+        }
+        await page.waitForNextPresentationUpdate()
+
+        #expect(try await page.callJavaScript(JavaScriptMessages.GetSelection()) == crazySelection)
+    }
+
+    @Test
+    func doubleClickZoomableColumnWithListenerSelectsWordAndFiresDblclick() async throws {
+        // A dblclick listener suppresses smart magnification, so
+        // the dblclick fires AND the word is selected (no zoom).
+        try await loadZoomableHTML(dblclickHandler: true)
+        try await page.callJavaScript(JavaScriptMessages.InstallEventLog(in: "div", for: [.click, .dblclick]))
+
+        let crazyRange = try #require(Self.text.utf16Range(of: "crazy"))
+        let crazySelection = JavaScriptSelection.range(
+            base: .init(in: "div", at: crazyRange.lowerBound),
+            extent: .init(in: "div", at: crazyRange.upperBound)
+        )
+
+        let crazyBounds = try await screenBoundsOfText("crazy")
+        try await page.callJavaScript(JavaScriptMessages.SetSelection(in: "div", offset: 0))
+        await page.waitForNextPresentationUpdate()
+
+        await recap.play { composer in
+            composer._wk_click(at: crazyBounds.center, for: .seconds(0.1))
+            composer.advanceTime(0.1)
+            composer._wk_click(at: crazyBounds.center, for: .seconds(0.1))
+        }
+        await page.waitForNextPresentationUpdate()
+
+        #expect(try await page.callJavaScript(JavaScriptMessages.EventLog()).contains(.init(type: .dblclick, detail: 2)))
+        #expect(try await page.callJavaScript(JavaScriptMessages.GetSelection()) == crazySelection)
+    }
+
+    private func loadZoomableHTML(dblclickHandler: Bool = false) async throws {
+        let dblclickHandlerMarkup = dblclickHandler ? "ondblclick='void(0)'" : ""
+
+        let html = """
+            <div \(dblclickHandlerMarkup) id="div" style="width: 160px; font-size: 30px;">\(Self.text)</div>
+            """
+
+        try await page.load(html: html).wait()
+    }
+}
+
+#endif


### PR DESCRIPTION
#### 5352ff234d70513cf8bdaa6266b68fd6c1459492
<pre>
[AppKit Gestures] Add test coverage for DOM dblclick and smart magnification support
<a href="https://bugs.webkit.org/show_bug.cgi?id=319835">https://bugs.webkit.org/show_bug.cgi?id=319835</a>
<a href="https://rdar.apple.com/182734321">rdar://182734321</a>

Reviewed by Richard Robinson.

This patch provides testing coverage for the titled interaction support
that we are bringing up in webkit.org/b/319832.

For organization purposes, we introduce a new subsuite `DoubleClick`.

Furthermore, we add reusable JavaScript event-log helpers
(InstallEventLog/EventLog + DOMEvent) and migrate the AppKit gesture
tests onto them.

Tests:
  AppKitGesturesTests.clickAfterScrollStillProducesClick
  AppKitGesturesTests.doubleClickWithListenerFiresDblclick
  AppKitGesturesTests.doubleClickReportsDetailTwo
  AppKitGesturesTests.doubleClickWithListenerFiresDblclickAndSelectsWord
  AppKitGesturesTests.doubleClickWithListenerFiresDblclickRegardlessOfEditability
  AppKitGesturesTests.singleClickReportsDetailOne
  AppKitGesturesTests.clickingTwoDifferentWordsDoesNotFireDblclick
  AppKitGesturesTests.smartMagnificationGestureOnZoomableColumnDoesNotSelectWord
  AppKitGesturesTests.styleAdjustmentCanBlockSmartMagnification
  AppKitGesturesTests.doubleClickZoomableColumnWithListenerSelectsWordAndFiresDblclick

Canonical link: <a href="https://commits.webkit.org/317607@main">https://commits.webkit.org/317607@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0b2a185d74fd465e349d2a7eca60b83cde6d9993

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175804 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49737 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43521 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185397 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/137987 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/04109639-23c0-41a0-a0d1-8f166c069662) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/177667 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51029 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49419 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136889 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/137987 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178760 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40349 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157662 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117368 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1f4ba96a-d5c5-41bc-8a84-702240dc2a8b) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/38991 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/37372 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149410 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37154 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33867 "Built successfully") | | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/41578 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187818 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49404 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145887 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50084 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/33778 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145728 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26710 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40516 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/116107 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48591 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12133 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47993 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48225 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48050 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->