### PR TITLE
Rename WebTransportDatagramDuplexStream.incomingHighWaterMark and outgoingHighWaterMark

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/interfaces/webtransport.idl
+++ b/LayoutTests/imported/w3c/web-platform-tests/interfaces/webtransport.idl
@@ -18,8 +18,8 @@ interface WebTransportDatagramDuplexStream {
   readonly attribute unsigned long maxDatagramSize;
   attribute unrestricted double? incomingMaxAge;
   attribute unrestricted double? outgoingMaxAge;
-  attribute unrestricted double incomingHighWaterMark;
-  attribute unrestricted double outgoingHighWaterMark;
+  attribute unsigned long incomingMaxBufferedDatagrams;
+  attribute unsigned long outgoingMaxBufferedDatagrams;
 };
 
 [Exposed=(Window,Worker), SecureContext]

--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/datagrams.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/datagrams.https.any-expected.txt
@@ -7,7 +7,7 @@ FAIL Transfer max-size datagram promise_test: Unhandled rejection with value: ob
 FAIL Fail to transfer max-size+1 datagram, handle PMTUD increases promise_test: Unhandled rejection with value: object "NetworkError:  A network error occurred."
 PASS Sending and receiving datagrams is ready to use before session is established
 FAIL Datagram's outgoingMaxBufferedDatagrams correctly regulates written datagrams assert_true: expected true got false
-FAIL Datagrams read is less than or equal to the incomingMaxBufferedDatagrams assert_less_than_equal: expected a number less than or equal to 5 but got 48
+PASS Datagrams read is less than or equal to the incomingMaxBufferedDatagrams
 PASS Datagram MaxAge getters/setters work correctly
-FAIL Datagram MaxBufferedDatagrams getters/setters work correctly assert_greater_than_equal: expected a number but got a "undefined"
+PASS Datagram MaxBufferedDatagrams getters/setters work correctly
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/datagrams.https.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/datagrams.https.any.serviceworker-expected.txt
@@ -7,7 +7,7 @@ FAIL Transfer max-size datagram promise_test: Unhandled rejection with value: ob
 FAIL Fail to transfer max-size+1 datagram, handle PMTUD increases promise_test: Unhandled rejection with value: object "NetworkError:  A network error occurred."
 PASS Sending and receiving datagrams is ready to use before session is established
 FAIL Datagram's outgoingMaxBufferedDatagrams correctly regulates written datagrams assert_true: expected true got false
-FAIL Datagrams read is less than or equal to the incomingMaxBufferedDatagrams assert_less_than_equal: expected a number less than or equal to 5 but got 42
+PASS Datagrams read is less than or equal to the incomingMaxBufferedDatagrams
 PASS Datagram MaxAge getters/setters work correctly
-FAIL Datagram MaxBufferedDatagrams getters/setters work correctly assert_greater_than_equal: expected a number but got a "undefined"
+PASS Datagram MaxBufferedDatagrams getters/setters work correctly
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/datagrams.https.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/datagrams.https.any.sharedworker-expected.txt
@@ -7,7 +7,7 @@ FAIL Transfer max-size datagram promise_test: Unhandled rejection with value: ob
 FAIL Fail to transfer max-size+1 datagram, handle PMTUD increases promise_test: Unhandled rejection with value: object "NetworkError:  A network error occurred."
 PASS Sending and receiving datagrams is ready to use before session is established
 FAIL Datagram's outgoingMaxBufferedDatagrams correctly regulates written datagrams assert_true: expected true got false
-FAIL Datagrams read is less than or equal to the incomingMaxBufferedDatagrams assert_less_than_equal: expected a number less than or equal to 5 but got 46
+PASS Datagrams read is less than or equal to the incomingMaxBufferedDatagrams
 PASS Datagram MaxAge getters/setters work correctly
-FAIL Datagram MaxBufferedDatagrams getters/setters work correctly assert_greater_than_equal: expected a number but got a "undefined"
+PASS Datagram MaxBufferedDatagrams getters/setters work correctly
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/datagrams.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/datagrams.https.any.worker-expected.txt
@@ -7,7 +7,7 @@ FAIL Transfer max-size datagram promise_test: Unhandled rejection with value: ob
 FAIL Fail to transfer max-size+1 datagram, handle PMTUD increases promise_test: Unhandled rejection with value: object "NetworkError:  A network error occurred."
 PASS Sending and receiving datagrams is ready to use before session is established
 FAIL Datagram's outgoingMaxBufferedDatagrams correctly regulates written datagrams assert_true: expected true got false
-FAIL Datagrams read is less than or equal to the incomingMaxBufferedDatagrams assert_less_than_equal: expected a number less than or equal to 5 but got 47
+PASS Datagrams read is less than or equal to the incomingMaxBufferedDatagrams
 PASS Datagram MaxAge getters/setters work correctly
-FAIL Datagram MaxBufferedDatagrams getters/setters work correctly assert_greater_than_equal: expected a number but got a "undefined"
+PASS Datagram MaxBufferedDatagrams getters/setters work correctly
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/historical.https.sub.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/historical.https.sub.any-expected.txt
@@ -1,5 +1,5 @@
 
 PASS WebTransportDatagramDuplexStream#writable is removed
-FAIL WebTransportDatagramDuplexStream#incomingHighWaterMark is removed assert_false: expected false got true
-FAIL WebTransportDatagramDuplexStream#outgoingHighWaterMark is removed assert_false: expected false got true
+PASS WebTransportDatagramDuplexStream#incomingHighWaterMark is removed
+PASS WebTransportDatagramDuplexStream#outgoingHighWaterMark is removed
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/historical.https.sub.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/historical.https.sub.any.serviceworker-expected.txt
@@ -1,5 +1,5 @@
 
 PASS WebTransportDatagramDuplexStream#writable is removed
-FAIL WebTransportDatagramDuplexStream#incomingHighWaterMark is removed assert_false: expected false got true
-FAIL WebTransportDatagramDuplexStream#outgoingHighWaterMark is removed assert_false: expected false got true
+PASS WebTransportDatagramDuplexStream#incomingHighWaterMark is removed
+PASS WebTransportDatagramDuplexStream#outgoingHighWaterMark is removed
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/historical.https.sub.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/historical.https.sub.any.sharedworker-expected.txt
@@ -1,5 +1,5 @@
 
 PASS WebTransportDatagramDuplexStream#writable is removed
-FAIL WebTransportDatagramDuplexStream#incomingHighWaterMark is removed assert_false: expected false got true
-FAIL WebTransportDatagramDuplexStream#outgoingHighWaterMark is removed assert_false: expected false got true
+PASS WebTransportDatagramDuplexStream#incomingHighWaterMark is removed
+PASS WebTransportDatagramDuplexStream#outgoingHighWaterMark is removed
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/historical.https.sub.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/historical.https.sub.any.worker-expected.txt
@@ -1,5 +1,5 @@
 
 PASS WebTransportDatagramDuplexStream#writable is removed
-FAIL WebTransportDatagramDuplexStream#incomingHighWaterMark is removed assert_false: expected false got true
-FAIL WebTransportDatagramDuplexStream#outgoingHighWaterMark is removed assert_false: expected false got true
+PASS WebTransportDatagramDuplexStream#incomingHighWaterMark is removed
+PASS WebTransportDatagramDuplexStream#outgoingHighWaterMark is removed
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/idlharness.https.sub.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/idlharness.https.sub.any-expected.txt
@@ -22,8 +22,8 @@ PASS WebTransportDatagramDuplexStream interface: attribute readable
 PASS WebTransportDatagramDuplexStream interface: attribute maxDatagramSize
 PASS WebTransportDatagramDuplexStream interface: attribute incomingMaxAge
 PASS WebTransportDatagramDuplexStream interface: attribute outgoingMaxAge
-PASS WebTransportDatagramDuplexStream interface: attribute incomingHighWaterMark
-PASS WebTransportDatagramDuplexStream interface: attribute outgoingHighWaterMark
+PASS WebTransportDatagramDuplexStream interface: attribute incomingMaxBufferedDatagrams
+PASS WebTransportDatagramDuplexStream interface: attribute outgoingMaxBufferedDatagrams
 PASS WebTransport interface: existence and properties of interface object
 PASS WebTransport interface object length
 PASS WebTransport interface object name

--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/idlharness.https.sub.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/idlharness.https.sub.any.serviceworker-expected.txt
@@ -22,8 +22,8 @@ PASS WebTransportDatagramDuplexStream interface: attribute readable
 PASS WebTransportDatagramDuplexStream interface: attribute maxDatagramSize
 PASS WebTransportDatagramDuplexStream interface: attribute incomingMaxAge
 PASS WebTransportDatagramDuplexStream interface: attribute outgoingMaxAge
-PASS WebTransportDatagramDuplexStream interface: attribute incomingHighWaterMark
-PASS WebTransportDatagramDuplexStream interface: attribute outgoingHighWaterMark
+PASS WebTransportDatagramDuplexStream interface: attribute incomingMaxBufferedDatagrams
+PASS WebTransportDatagramDuplexStream interface: attribute outgoingMaxBufferedDatagrams
 PASS WebTransport interface: existence and properties of interface object
 PASS WebTransport interface object length
 PASS WebTransport interface object name

--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/idlharness.https.sub.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/idlharness.https.sub.any.sharedworker-expected.txt
@@ -22,8 +22,8 @@ PASS WebTransportDatagramDuplexStream interface: attribute readable
 PASS WebTransportDatagramDuplexStream interface: attribute maxDatagramSize
 PASS WebTransportDatagramDuplexStream interface: attribute incomingMaxAge
 PASS WebTransportDatagramDuplexStream interface: attribute outgoingMaxAge
-PASS WebTransportDatagramDuplexStream interface: attribute incomingHighWaterMark
-PASS WebTransportDatagramDuplexStream interface: attribute outgoingHighWaterMark
+PASS WebTransportDatagramDuplexStream interface: attribute incomingMaxBufferedDatagrams
+PASS WebTransportDatagramDuplexStream interface: attribute outgoingMaxBufferedDatagrams
 PASS WebTransport interface: existence and properties of interface object
 PASS WebTransport interface object length
 PASS WebTransport interface object name

--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/idlharness.https.sub.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/idlharness.https.sub.any.worker-expected.txt
@@ -22,8 +22,8 @@ PASS WebTransportDatagramDuplexStream interface: attribute readable
 PASS WebTransportDatagramDuplexStream interface: attribute maxDatagramSize
 PASS WebTransportDatagramDuplexStream interface: attribute incomingMaxAge
 PASS WebTransportDatagramDuplexStream interface: attribute outgoingMaxAge
-PASS WebTransportDatagramDuplexStream interface: attribute incomingHighWaterMark
-PASS WebTransportDatagramDuplexStream interface: attribute outgoingHighWaterMark
+PASS WebTransportDatagramDuplexStream interface: attribute incomingMaxBufferedDatagrams
+PASS WebTransportDatagramDuplexStream interface: attribute outgoingMaxBufferedDatagrams
 PASS WebTransport interface: existence and properties of interface object
 PASS WebTransport interface object length
 PASS WebTransport interface object name

--- a/Source/WebCore/Modules/webtransport/WebTransportDatagramDuplexStream.cpp
+++ b/Source/WebCore/Modules/webtransport/WebTransportDatagramDuplexStream.cpp
@@ -97,30 +97,24 @@ ExceptionOr<void> WebTransportDatagramDuplexStream::setOutgoingMaxAge(std::optio
     return { };
 }
 
-ExceptionOr<void> WebTransportDatagramDuplexStream::setIncomingHighWaterMark(double mark)
+void WebTransportDatagramDuplexStream::setIncomingMaxBufferedDatagrams(uint32_t value)
 {
-    // https://www.w3.org/TR/webtransport/#dom-webtransportdatagramduplexstream-incominghighwatermark
-    if (std::isnan(mark) || mark < 0)
-        return Exception { ExceptionCode::RangeError };
-    if (mark < 1)
-        mark = 1;
-    m_incomingHighWaterMark = mark;
+    // https://www.w3.org/TR/webtransport/#dom-webtransportdatagramduplexstream-incomingmaxbuffereddatagrams
+    if (value < 1)
+        value = 1;
+    m_incomingMaxBufferedDatagrams = value;
     if (RefPtr session = this->session())
-        session->datagramIncomingHighWaterMarkUpdated(m_incomingHighWaterMark);
-    return { };
+        session->incomingMaxBufferedDatagramsUpdated(m_incomingMaxBufferedDatagrams);
 }
 
-ExceptionOr<void> WebTransportDatagramDuplexStream::setOutgoingHighWaterMark(double mark)
+void WebTransportDatagramDuplexStream::setOutgoingMaxBufferedDatagrams(uint32_t value)
 {
-    // https://www.w3.org/TR/webtransport/#dom-webtransportdatagramduplexstream-outgoinghighwatermark
-    if (std::isnan(mark) || mark < 0)
-        return Exception { ExceptionCode::RangeError };
-    if (mark < 1)
-        mark = 1;
-    m_outgoingHighWaterMark = mark;
+    // https://www.w3.org/TR/webtransport/#dom-webtransportdatagramduplexstream-outgoingmaxbuffereddatagrams
+    if (value < 1)
+        value = 1;
+    m_outgoingMaxBufferedDatagrams = value;
     if (RefPtr session = this->session())
-        session->datagramOutgoingHighWaterMarkUpdated(m_outgoingHighWaterMark);
-    return { };
+        session->outgoingMaxBufferedDatagramsUpdated(m_outgoingMaxBufferedDatagrams);
 }
 
 }

--- a/Source/WebCore/Modules/webtransport/WebTransportDatagramDuplexStream.h
+++ b/Source/WebCore/Modules/webtransport/WebTransportDatagramDuplexStream.h
@@ -54,12 +54,12 @@ public:
     unsigned maxDatagramSize() const { return std::numeric_limits<uint16_t>::max(); }
     std::optional<double> incomingMaxAge() const { return m_incomingMaxAge; }
     std::optional<double> outgoingMaxAge() const { return m_outgoingMaxAge; }
-    double incomingHighWaterMark() const { return m_incomingHighWaterMark; }
-    double outgoingHighWaterMark() const { return m_outgoingHighWaterMark; }
+    uint32_t incomingMaxBufferedDatagrams() const { return m_incomingMaxBufferedDatagrams; }
+    uint32_t outgoingMaxBufferedDatagrams() const { return m_outgoingMaxBufferedDatagrams; }
     ExceptionOr<void> setIncomingMaxAge(std::optional<double>);
     ExceptionOr<void> setOutgoingMaxAge(std::optional<double>);
-    ExceptionOr<void> setIncomingHighWaterMark(double);
-    ExceptionOr<void> setOutgoingHighWaterMark(double);
+    void setIncomingMaxBufferedDatagrams(uint32_t);
+    void setOutgoingMaxBufferedDatagrams(uint32_t);
 
     void attachTo(WebTransport&);
 
@@ -69,8 +69,8 @@ private:
     RefPtr<WebTransportSession> session();
 
     const Ref<ReadableStream> m_readable;
-    double m_incomingHighWaterMark { 1 };
-    double m_outgoingHighWaterMark { 1 };
+    uint32_t m_incomingMaxBufferedDatagrams { std::numeric_limits<uint32_t>::max() };
+    uint32_t m_outgoingMaxBufferedDatagrams { std::numeric_limits<uint32_t>::max() };
     std::optional<double> m_incomingMaxAge;
     std::optional<double> m_outgoingMaxAge;
     ThreadSafeWeakPtr<WebTransport> m_transport;

--- a/Source/WebCore/Modules/webtransport/WebTransportDatagramDuplexStream.idl
+++ b/Source/WebCore/Modules/webtransport/WebTransportDatagramDuplexStream.idl
@@ -34,6 +34,6 @@
     readonly attribute unsigned long maxDatagramSize;
     attribute unrestricted double? incomingMaxAge;
     attribute unrestricted double? outgoingMaxAge;
-    attribute unrestricted double incomingHighWaterMark;
-    attribute unrestricted double outgoingHighWaterMark;
+    attribute unsigned long incomingMaxBufferedDatagrams;
+    attribute unsigned long outgoingMaxBufferedDatagrams;
 };

--- a/Source/WebCore/Modules/webtransport/WebTransportSession.h
+++ b/Source/WebCore/Modules/webtransport/WebTransportSession.h
@@ -75,8 +75,8 @@ public:
     virtual void terminate(WebTransportSessionErrorCode, CString&&) = 0;
     virtual void datagramIncomingMaxAgeUpdated(std::optional<double>) = 0;
     virtual void datagramOutgoingMaxAgeUpdated(std::optional<double>) = 0;
-    virtual void datagramIncomingHighWaterMarkUpdated(double) = 0;
-    virtual void datagramOutgoingHighWaterMarkUpdated(double) = 0;
+    virtual void incomingMaxBufferedDatagramsUpdated(uint32_t) = 0;
+    virtual void outgoingMaxBufferedDatagramsUpdated(uint32_t) = 0;
 };
 
 }

--- a/Source/WebCore/Modules/webtransport/WorkerWebTransportSession.cpp
+++ b/Source/WebCore/Modules/webtransport/WorkerWebTransportSession.cpp
@@ -270,20 +270,20 @@ void WorkerWebTransportSession::datagramOutgoingMaxAgeUpdated(std::optional<doub
         ASSERT_NOT_REACHED_WITH_MESSAGE("Session should be set up before use then never removed.");
 }
 
-void WorkerWebTransportSession::datagramIncomingHighWaterMarkUpdated(double watermark)
+void WorkerWebTransportSession::incomingMaxBufferedDatagramsUpdated(uint32_t value)
 {
     ASSERT(!RunLoop::isMain());
     if (RefPtr session = m_session)
-        session->datagramIncomingHighWaterMarkUpdated(watermark);
+        session->incomingMaxBufferedDatagramsUpdated(value);
     else
         ASSERT_NOT_REACHED_WITH_MESSAGE("Session should be set up before use then never removed.");
 }
 
-void WorkerWebTransportSession::datagramOutgoingHighWaterMarkUpdated(double watermark)
+void WorkerWebTransportSession::outgoingMaxBufferedDatagramsUpdated(uint32_t value)
 {
     ASSERT(!RunLoop::isMain());
     if (RefPtr session = m_session)
-        session->datagramOutgoingHighWaterMarkUpdated(watermark);
+        session->outgoingMaxBufferedDatagramsUpdated(value);
     else
         ASSERT_NOT_REACHED_WITH_MESSAGE("Session should be set up before use then never removed.");
 }

--- a/Source/WebCore/Modules/webtransport/WorkerWebTransportSession.h
+++ b/Source/WebCore/Modules/webtransport/WorkerWebTransportSession.h
@@ -69,8 +69,8 @@ private:
     void terminate(WebTransportSessionErrorCode, CString&&) final;
     void datagramIncomingMaxAgeUpdated(std::optional<double>) final;
     void datagramOutgoingMaxAgeUpdated(std::optional<double>) final;
-    void datagramIncomingHighWaterMarkUpdated(double) final;
-    void datagramOutgoingHighWaterMarkUpdated(double) final;
+    void incomingMaxBufferedDatagramsUpdated(uint32_t) final;
+    void outgoingMaxBufferedDatagramsUpdated(uint32_t) final;
 
     const ScriptExecutionContextIdentifier m_contextID;
     ThreadSafeWeakPtr<WebTransportSessionClient> m_client;

--- a/Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.cpp
+++ b/Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.cpp
@@ -154,12 +154,12 @@ void NetworkTransportSession::datagramOutgoingMaxAgeUpdated(std::optional<double
     // FIXME: Use this value.
 }
 
-void NetworkTransportSession::datagramIncomingHighWaterMarkUpdated(double)
+void NetworkTransportSession::incomingMaxBufferedDatagramsUpdated(uint32_t)
 {
     // FIXME: Use this value.
 }
 
-void NetworkTransportSession::datagramOutgoingHighWaterMarkUpdated(double)
+void NetworkTransportSession::outgoingMaxBufferedDatagramsUpdated(uint32_t)
 {
     // FIXME: Use this value.
 }

--- a/Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.h
+++ b/Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.h
@@ -90,8 +90,8 @@ public:
     void terminate(WebCore::WebTransportSessionErrorCode, CString&&);
     void NODELETE datagramIncomingMaxAgeUpdated(std::optional<double>);
     void NODELETE datagramOutgoingMaxAgeUpdated(std::optional<double>);
-    void NODELETE datagramIncomingHighWaterMarkUpdated(double);
-    void NODELETE datagramOutgoingHighWaterMarkUpdated(double);
+    void NODELETE incomingMaxBufferedDatagramsUpdated(uint32_t);
+    void NODELETE outgoingMaxBufferedDatagramsUpdated(uint32_t);
 
     void receiveDatagram(std::span<const uint8_t>, bool, std::optional<WebCore::Exception>&&);
     void streamReceiveBytes(WebCore::WebTransportStreamIdentifier, std::span<const uint8_t>, bool, std::optional<WebCore::Exception>&&);

--- a/Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.messages.in
+++ b/Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.messages.in
@@ -40,6 +40,6 @@ messages -> NetworkTransportSession {
     Terminate(uint32_t code, CString reason)
     DatagramIncomingMaxAgeUpdated(std::optional<double> maxAge)
     DatagramOutgoingMaxAgeUpdated(std::optional<double> maxAge)
-    DatagramIncomingHighWaterMarkUpdated(double watermark)
-    DatagramOutgoingHighWaterMarkUpdated(double watermark)
+    IncomingMaxBufferedDatagramsUpdated(uint32_t value)
+    OutgoingMaxBufferedDatagramsUpdated(uint32_t value)
 }

--- a/Source/WebKit/WebProcess/Network/WebTransportSession.cpp
+++ b/Source/WebKit/WebProcess/Network/WebTransportSession.cpp
@@ -245,14 +245,14 @@ void WebTransportSession::datagramOutgoingMaxAgeUpdated(std::optional<double> ma
     send(Messages::NetworkTransportSession::DatagramOutgoingMaxAgeUpdated(maxAge));
 }
 
-void WebTransportSession::datagramIncomingHighWaterMarkUpdated(double watermark)
+void WebTransportSession::incomingMaxBufferedDatagramsUpdated(uint32_t value)
 {
-    send(Messages::NetworkTransportSession::DatagramIncomingHighWaterMarkUpdated(watermark));
+    send(Messages::NetworkTransportSession::IncomingMaxBufferedDatagramsUpdated(value));
 }
 
-void WebTransportSession::datagramOutgoingHighWaterMarkUpdated(double watermark)
+void WebTransportSession::outgoingMaxBufferedDatagramsUpdated(uint32_t value)
 {
-    send(Messages::NetworkTransportSession::DatagramOutgoingHighWaterMarkUpdated(watermark));
+    send(Messages::NetworkTransportSession::OutgoingMaxBufferedDatagramsUpdated(value));
 }
 
 }

--- a/Source/WebKit/WebProcess/Network/WebTransportSession.h
+++ b/Source/WebKit/WebProcess/Network/WebTransportSession.h
@@ -101,8 +101,8 @@ private:
     void terminate(WebCore::WebTransportSessionErrorCode, CString&&) final;
     void datagramIncomingMaxAgeUpdated(std::optional<double>) final;
     void datagramOutgoingMaxAgeUpdated(std::optional<double>) final;
-    void datagramIncomingHighWaterMarkUpdated(double) final;
-    void datagramOutgoingHighWaterMarkUpdated(double) final;
+    void incomingMaxBufferedDatagramsUpdated(uint32_t) final;
+    void outgoingMaxBufferedDatagramsUpdated(uint32_t) final;
 
     // MessageSender
     IPC::Connection* messageSenderConnection() const final;


### PR DESCRIPTION
#### 2db431710a39c040770bd2617eaef61f471fa864
<pre>
Rename WebTransportDatagramDuplexStream.incomingHighWaterMark and outgoingHighWaterMark
<a href="https://bugs.webkit.org/show_bug.cgi?id=319839">https://bugs.webkit.org/show_bug.cgi?id=319839</a>
<a href="https://rdar.apple.com/182736574">rdar://182736574</a>

Reviewed by Basuke Suzuki.

They&apos;ve been renamed to incomingMaxBufferedDatagrams and outgoingMaxBufferedDatagrams.

* LayoutTests/imported/w3c/web-platform-tests/interfaces/webtransport.idl:
* LayoutTests/imported/w3c/web-platform-tests/webtransport/datagrams.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webtransport/datagrams.https.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webtransport/datagrams.https.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webtransport/datagrams.https.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webtransport/historical.https.sub.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webtransport/historical.https.sub.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webtransport/historical.https.sub.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webtransport/historical.https.sub.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webtransport/idlharness.https.sub.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webtransport/idlharness.https.sub.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webtransport/idlharness.https.sub.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webtransport/idlharness.https.sub.any.worker-expected.txt:
* Source/WebCore/Modules/webtransport/WebTransportDatagramDuplexStream.cpp:
(WebCore::WebTransportDatagramDuplexStream::setIncomingMaxBufferedDatagrams):
(WebCore::WebTransportDatagramDuplexStream::setOutgoingMaxBufferedDatagrams):
(WebCore::WebTransportDatagramDuplexStream::setIncomingHighWaterMark): Deleted.
(WebCore::WebTransportDatagramDuplexStream::setOutgoingHighWaterMark): Deleted.
* Source/WebCore/Modules/webtransport/WebTransportDatagramDuplexStream.h:
(WebCore::WebTransportDatagramDuplexStream::incomingMaxBufferedDatagrams const):
(WebCore::WebTransportDatagramDuplexStream::outgoingMaxBufferedDatagrams const):
(WebCore::WebTransportDatagramDuplexStream::incomingHighWaterMark const): Deleted.
(WebCore::WebTransportDatagramDuplexStream::outgoingHighWaterMark const): Deleted.
* Source/WebCore/Modules/webtransport/WebTransportDatagramDuplexStream.idl:
* Source/WebCore/Modules/webtransport/WebTransportSession.h:
* Source/WebCore/Modules/webtransport/WorkerWebTransportSession.cpp:
(WebCore::WorkerWebTransportSession::incomingMaxBufferedDatagramsUpdated):
(WebCore::WorkerWebTransportSession::outgoingMaxBufferedDatagramsUpdated):
(WebCore::WorkerWebTransportSession::datagramIncomingHighWaterMarkUpdated): Deleted.
(WebCore::WorkerWebTransportSession::datagramOutgoingHighWaterMarkUpdated): Deleted.
* Source/WebCore/Modules/webtransport/WorkerWebTransportSession.h:
* Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.cpp:
(WebKit::NetworkTransportSession::incomingMaxBufferedDatagramsUpdated):
(WebKit::NetworkTransportSession::outgoingMaxBufferedDatagramsUpdated):
(WebKit::NetworkTransportSession::datagramIncomingHighWaterMarkUpdated): Deleted.
(WebKit::NetworkTransportSession::datagramOutgoingHighWaterMarkUpdated): Deleted.
* Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.h:
* Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.messages.in:
* Source/WebKit/WebProcess/Network/WebTransportSession.cpp:
(WebKit::WebTransportSession::incomingMaxBufferedDatagramsUpdated):
(WebKit::WebTransportSession::outgoingMaxBufferedDatagramsUpdated):
(WebKit::WebTransportSession::datagramIncomingHighWaterMarkUpdated): Deleted.
(WebKit::WebTransportSession::datagramOutgoingHighWaterMarkUpdated): Deleted.
* Source/WebKit/WebProcess/Network/WebTransportSession.h:

Canonical link: <a href="https://commits.webkit.org/317578@main">https://commits.webkit.org/317578@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/29387eeaf9c2d9a1d56ae3a777c3723684a7c5bc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175663 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49596 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43379 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185255 "") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/137841 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/87c0c08d-bc7b-4242-b455-531d41f2a9c7) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/177526 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50888 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49278 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/185255 "") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/137841 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fff8ea0f-b14a-47f6-98f0-8de772e0a563) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178619 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40218 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157552 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/185255 "") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6298efd9-8f1a-425a-92b0-6268752bb01c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38860 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37245 "Passed tests") | [❌ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/5/builds/185255 "") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149279 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37044 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33725 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41287 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41451 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187677 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49263 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145764 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49943 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/33668 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145602 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26699 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40416 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122138 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115964 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48450 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12022 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47852 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48084 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47909 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->