### PR TITLE
TileController's visible size is not constricted to its parent

### DIFF
--- a/LayoutTests/http/tests/site-isolation/iframe-transform-2d-rotate-expected.html
+++ b/LayoutTests/http/tests/site-isolation/iframe-transform-2d-rotate-expected.html
@@ -1,0 +1,13 @@
+<script>
+if (window.testRunner)
+    testRunner.waitUntilDone();
+onmessage = (event) => {
+    if (window.testRunner && event.data == "onload")
+        setTimeout(() => testRunner.notifyDone(), 100);
+};
+</script>
+<body style="margin:0;background:blue">
+<iframe src="http://localhost:8000/site-isolation/resources/green-background.html" frameborder=0
+    style="position:absolute; border:0; left:180px; top:120px; width:200px; height:150px;
+           transform:rotate(35deg); transform-origin:0 0"></iframe>
+</body>

--- a/LayoutTests/http/tests/site-isolation/iframe-transform-2d-rotate.html
+++ b/LayoutTests/http/tests/site-isolation/iframe-transform-2d-rotate.html
@@ -1,0 +1,19 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<!-- An out-of-process iframe rotated in 2D must render its full content. rotate() makes
+     visibleRectOfChild's axis-aligned box larger than the frame, so the projection back
+     into child coordinates must not clip the rotated content (coverage clamp correctness). -->
+<head><meta name="fuzzy" content="maxDifference=0-255; totalPixels=0-2000"/>
+<script>
+if (window.testRunner)
+    testRunner.waitUntilDone();
+onmessage = (event) => {
+    if (window.testRunner && event.data == "onload")
+        setTimeout(() => testRunner.notifyDone(), 100);
+};
+</script>
+</head>
+<body style="margin:0;background:blue">
+<iframe src="http://localhost:8000/site-isolation/resources/green-background.html" frameborder=0
+    style="position:absolute; border:0; left:180px; top:120px; width:200px; height:150px;
+           transform:rotate(35deg); transform-origin:0 0"></iframe>
+</body>

--- a/LayoutTests/http/tests/site-isolation/iframe-transform-2d-translate-expected.html
+++ b/LayoutTests/http/tests/site-isolation/iframe-transform-2d-translate-expected.html
@@ -1,0 +1,13 @@
+<script>
+if (window.testRunner)
+    testRunner.waitUntilDone();
+onmessage = (event) => {
+    if (window.testRunner && event.data == "onload")
+        setTimeout(() => testRunner.notifyDone(), 100);
+};
+</script>
+<body style="margin:0;background:blue">
+<iframe src="http://localhost:8000/site-isolation/resources/green-background.html" frameborder=0
+    style="position:absolute; border:0; left:0; top:0; width:200px; height:150px;
+           transform:translate(220px,180px); transform-origin:0 0"></iframe>
+</body>

--- a/LayoutTests/http/tests/site-isolation/iframe-transform-2d-translate.html
+++ b/LayoutTests/http/tests/site-isolation/iframe-transform-2d-translate.html
@@ -1,0 +1,19 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<!-- An out-of-process iframe with a 2D translate must render its full content: the
+     coverage clamp projects the embedder-visible rect back into child coordinates,
+     and a pure translation is exactly the term that was mishandled for offset frames. -->
+<head><meta name="fuzzy" content="maxDifference=112; totalPixels=900"/>
+<script>
+if (window.testRunner)
+    testRunner.waitUntilDone();
+onmessage = (event) => {
+    if (window.testRunner && event.data == "onload")
+        setTimeout(() => testRunner.notifyDone(), 100);
+};
+</script>
+</head>
+<body style="margin:0;background:blue">
+<iframe src="http://localhost:8000/site-isolation/resources/green-background.html" frameborder=0
+    style="position:absolute; border:0; left:0; top:0; width:200px; height:150px;
+           transform:translate(220px,180px); transform-origin:0 0"></iframe>
+</body>

--- a/LayoutTests/http/tests/site-isolation/iframe-transform-3d-rotate-expected.html
+++ b/LayoutTests/http/tests/site-isolation/iframe-transform-3d-rotate-expected.html
@@ -1,0 +1,13 @@
+<script>
+if (window.testRunner)
+    testRunner.waitUntilDone();
+onmessage = (event) => {
+    if (window.testRunner && event.data == "onload")
+        setTimeout(() => testRunner.notifyDone(), 100);
+};
+</script>
+<body style="margin:0;background:blue">
+<iframe src="http://localhost:8000/site-isolation/resources/green-background.html" frameborder=0
+    style="position:absolute; border:0; left:200px; top:100px; width:200px; height:150px;
+           transform:perspective(700px) rotateY(40deg); transform-origin:0 0"></iframe>
+</body>

--- a/LayoutTests/http/tests/site-isolation/iframe-transform-3d-rotate.html
+++ b/LayoutTests/http/tests/site-isolation/iframe-transform-3d-rotate.html
@@ -1,0 +1,20 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<!-- An out-of-process iframe with a 3D perspective transform must render its full content.
+     TransformationMatrix::mapRect maps the four corners through the perspective divide; the
+     coverage clamp must still cover the projected quad (with the empty-projection correctness
+     floor backing the whole frame if the projection is degenerate). -->
+<head><meta name="fuzzy" content="maxDifference=0-255; totalPixels=0-2000"/>
+<script>
+if (window.testRunner)
+    testRunner.waitUntilDone();
+onmessage = (event) => {
+    if (window.testRunner && event.data == "onload")
+        setTimeout(() => testRunner.notifyDone(), 100);
+};
+</script>
+</head>
+<body style="margin:0;background:blue">
+<iframe src="http://localhost:8000/site-isolation/resources/green-background.html" frameborder=0
+    style="position:absolute; border:0; left:200px; top:100px; width:200px; height:150px;
+           transform:perspective(700px) rotateY(40deg); transform-origin:0 0"></iframe>
+</body>

--- a/Source/WebCore/page/LocalFrameView.h
+++ b/Source/WebCore/page/LocalFrameView.h
@@ -689,6 +689,11 @@ public:
     WEBCORE_EXPORT void setViewExposedRect(std::optional<FloatRect>);
     std::optional<FloatRect> viewExposedRect() const { return m_viewExposedRect; }
 
+    // Set once the main WCP has supplied this iframe root's exposed content rect via childrenFrameLayoutInfo,
+    // so a compositing flush that precedes the first sync doesn't clamp coverage to a stale/empty rect.
+    void setHasSetExposedContentRectFromEmbedder() { m_hasSetExposedContentRectFromEmbedder = true; }
+    bool hasEverSetExposedContentRectFromEmbedder() const { return m_hasSetExposedContentRectFromEmbedder; }
+
     void updateSnapOffsets() final;
     bool isScrollSnapInProgress() const final;
 
@@ -1040,6 +1045,7 @@ private:
     std::optional<LayoutRect> m_visualViewportOverrideRect; // Used when the iOS keyboard is showing.
 
     std::optional<FloatRect> m_viewExposedRect;
+    bool m_hasSetExposedContentRectFromEmbedder { false };
 
     OptionSet<PaintBehavior> m_paintBehavior;
 

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -2224,8 +2224,22 @@ void Page::syncLocalFrameInfoToRemote()
 
         HashMap<FrameIdentifier, Ref<RemoteFrameLayoutInfo>> childrenFrameLayoutInfo;
         for (RefPtr child = frame.tree().firstChild(); child; child = child->tree().nextSibling()) {
+            auto childVisibleRect = frameView->visibleRectOfChild(*child.get());
+
+            // Clamp the child's visible rect to the portion of the page actually on-screen, so an offscreen
+            // iframe commits ~0 tiles — matching the single-tiled-backing coverage decision the page makes
+            // with site isolation off. visibleRectOfChild() clips through the compositor tree but not the
+            // top-level viewport, so a fully-below-fold iframe can still return a non-empty box; intersect
+            // it here with the parent's exposed viewport.
+#if PLATFORM(IOS_FAMILY)
+            if (childVisibleRect && frame.settings().siteIsolationEnabled()) {
+                auto viewport = LayoutRect { frameView->exposedContentRect() };
+                childVisibleRect->intersect(viewport);
+            }
+#endif
+
             childrenFrameLayoutInfo.add(child->frameID(), RemoteFrameLayoutInfo::create(
-                frameView->visibleRectOfChild(*child.get()),
+                childVisibleRect,
                 frameView->childFrameOwnerToRootContentTransform(*child),
                 frameView->absoluteToChildFrameOwnerLocalTransform(*child),
                 frame.usedZoomForChild(*child),

--- a/Source/WebCore/page/RemoteFrameLayoutInfo.cpp
+++ b/Source/WebCore/page/RemoteFrameLayoutInfo.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "RemoteFrameLayoutInfo.h"
 
+#include "FloatRect.h"
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
@@ -45,6 +46,23 @@ RemoteFrameLayoutInfo::RemoteFrameLayoutInfo(std::optional<LayoutRect> visibleRe
     , m_contentBoxLocation(contentBoxLocation)
     , m_ownerElementAppearance(ownerElementAppearance)
 {
+}
+
+std::optional<FloatRect> RemoteFrameLayoutInfo::projectVisibleRectToChildContent() const
+{
+    if (!m_visibleRectInParent)
+        return std::nullopt;
+
+    ASSERT(m_absoluteToChildFrameOwnerLocalTransform.isAffine());
+    // Inverse of LocalFrameView::visibleRectOfChild(): visibleRectInParent is in the parent document's
+    // coordinates. Map it into the iframe owner element's local space, subtract the owner content-box
+    // offset so the rect is relative to the iframe content origin, and undo the owner's used CSS zoom so
+    // the result is in the child frame's unzoomed root-content coordinates (its RenderView space).
+    auto ownerLocal = m_absoluteToChildFrameOwnerLocalTransform.mapRect(FloatRect { *m_visibleRectInParent });
+    ownerLocal.moveBy(-FloatPoint { m_contentBoxLocation });
+    if (m_usedZoom > 0)
+        ownerLocal.scale(1.0f / m_usedZoom);
+    return ownerLocal;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/page/RemoteFrameLayoutInfo.h
+++ b/Source/WebCore/page/RemoteFrameLayoutInfo.h
@@ -57,6 +57,10 @@ public:
     LayoutPoint contentBoxLocation() const { return m_contentBoxLocation; }
     OptionSet<FrameOwnerElementAppearance> ownerElementAppearance() const { return m_ownerElementAppearance; }
 
+    // Inverse of LocalFrameView::visibleRectOfChild - iframes use this to clamp its
+    // tiled-backing coverage to the embedder-visible region (setExposedContentRect).
+    WEBCORE_EXPORT std::optional<FloatRect> projectVisibleRectToChildContent() const;
+
 private:
     RemoteFrameLayoutInfo(std::optional<LayoutRect>, TransformationMatrix, TransformationMatrix, float, LayoutPoint, OptionSet<FrameOwnerElementAppearance>);
 

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -1306,10 +1306,16 @@ void WebFrame::updateLocalFrameRect(WebCore::LocalFrame& localFrame, WebCore::In
     }
 
 #if PLATFORM(IOS_FAMILY)
-    // FIXME: This ensures cross-site iframe render correctly;
-    // it should be removed after rdar://122429810 is fixed.
-    frameView->setExposedContentRect(FloatRect { { }, frameView->size() });
+    // The iframe root's unobscured content size is its natural frame size: it drives the scrolling
+    // tree's scrollable-area size and CSS viewport units, so it must never be clamped to the visible
+    // region (doing so collapses an off-screen frame's scrolling node to 0x0).
     frameView->setUnobscuredContentSize(frameView->size());
+    // Tile coverage (exposedContentRect) is normally driven by the embedder-visible rect in
+    // WebPage::updateExposedRectFromParent, so a below-fold frame commits ~0 tiles. Until that
+    // path has supplied a rect at least once, back the whole frame so nothing blanks if the first
+    // compositor flush precedes the first childrenFrameLayoutInfo sync (see rdar://122429810 history).
+    if (!frameView->hasEverSetExposedContentRectFromEmbedder())
+        frameView->setExposedContentRect(FloatRect { { }, frameView->size() });
 #endif
 
     if (!rectChanged)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -1432,6 +1432,10 @@ void WebPage::frameTreeSyncDataChangedInAnotherProcess(FrameIdentifier frameID, 
 
             break;
 
+        case FrameTreeSyncDataType::ChildrenFrameLayoutInfo:
+            updateExposedRectFromParent(*coreFrame);
+            break;
+
         default:
             break;
         }
@@ -1447,8 +1451,76 @@ void WebPage::allFrameTreeSyncDataChangedInAnotherProcess(FrameIdentifier frameI
         return;
 
     RefPtr coreFrame = frame->coreFrame();
-    if (coreFrame)
+    if (coreFrame) {
         coreFrame->updateFrameTreeSyncData(WTF::move(data));
+        updateExposedRectFromParent(*coreFrame);
+    }
+}
+
+void WebPage::updateExposedRectFromParent(WebCore::Frame& parentCoreFrame)
+{
+    // FIXME: https://bugs.webkit.org/show_bug.cgi?id=320601 - Align iOS and macOS behavior regarding m_exposedContentRect
+#if PLATFORM(IOS_FAMILY)
+    // When a RemoteFrame parent broadcasts childrenFrameLayoutInfo, each entry carries the child's visible
+    // rect in the parent (already clamped to the top-level viewport on the sender side).
+    // Project that rect into the child's own root-content coords and use it as the frame's exposedContentRect,
+    // so its tiled backing covers only the on-screen portion, matching the rect with site isolation off.
+    if (!m_page || !m_page->settings().siteIsolationEnabled())
+        return;
+
+    auto& childrenInfo = parentCoreFrame.frameTreeSyncData().childrenFrameLayoutInfo;
+    if (childrenInfo.isEmpty())
+        return;
+
+    bool needsRenderingUpdate = false;
+    for (RefPtr child = parentCoreFrame.tree().firstChild(); child; child = child->tree().nextSibling()) {
+        RefPtr localChild = dynamicDowncast<LocalFrame>(child.get());
+        if (!localChild)
+            continue;
+        RefPtr childView = localChild->view();
+        if (!childView)
+            continue;
+        auto it = childrenInfo.find(localChild->frameID());
+        if (it == childrenInfo.end())
+            continue;
+
+        // Project the parent-supplied visible rect into this child's root-content coordinates. A missing
+        // rect (fully below the fold / clipped out) maps to an empty rect so all tiles can be released.
+        Ref layoutInfo = it->value;
+        auto visibleRectInParent = layoutInfo->visibleRectInParent();
+        bool visibleRectInParentIsEmpty = !visibleRectInParent || visibleRectInParent->isEmpty();
+        auto projected = layoutInfo->projectVisibleRectToChildContent().value_or(FloatRect { });
+        projected.intersect(FloatRect { { }, childView->size() });
+
+        // If the main WCP says this frame is visible but the projection is empty, fallback to the full
+        // rect until we get updated geometry from the main WCP
+        if (!visibleRectInParentIsEmpty && projected.isEmpty())
+            projected = FloatRect { { }, childView->size() };
+
+        // This runs once per parent rendering update, so only touch the frame (and schedule a rendering
+        // update) when the coverage rect actually changes — or the first time the embedder supplies a rect,
+        // which flips WebFrame's full-size fallback off. This keeps steady-state (no scroll/resize)
+        // broadcasts from scheduling redundant rendering updates.
+        // exposedContentRect tracks the main WCP visible region, while unobscured content size stays at
+        // the child view's size (setUnobscuredContentSize is itself a no-op when unchanged).
+        if (childView->exposedContentRect() != projected) {
+            childView->setExposedContentRect(projected);
+            needsRenderingUpdate = true;
+        }
+        childView->setUnobscuredContentSize(childView->size());
+        if (!childView->hasEverSetExposedContentRectFromEmbedder()) {
+            childView->setHasSetExposedContentRectFromEmbedder();
+            needsRenderingUpdate = true;
+        }
+    }
+
+    if (needsRenderingUpdate) {
+        if (RefPtr drawingArea = this->drawingArea())
+            drawingArea->triggerRenderingUpdate();
+    }
+#else
+    UNUSED_PARAM(parentCoreFrame);
+#endif
 }
 
 void WebPage::updateUserActivationState(const Vector<FrameIdentifier>& frameIDs, MonotonicTime activationTime)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -867,6 +867,10 @@ public:
     void frameTreeSyncDataChangedInAnotherProcess(WebCore::FrameIdentifier, const WebCore::FrameTreeSyncSerializationData&);
     void allFrameTreeSyncDataChangedInAnotherProcess(WebCore::FrameIdentifier, Ref<WebCore::FrameTreeSyncData>&&);
 
+    // Clamps local iframe-root children's exposedContentRect to the embedder-visible rect carried in
+    // the parent's childrenFrameLayoutInfo.
+    void updateExposedRectFromParent(WebCore::Frame& parentCoreFrame);
+
     void updateUserActivationState(const Vector<WebCore::FrameIdentifier>&, MonotonicTime);
     void consumeUserActivations(const Vector<WebCore::FrameIdentifier>&);
 


### PR DESCRIPTION
#### 88d15b836df1c203053e3cff296dd35b2f1a25f5
<pre>
TileController&apos;s visible size is not constricted to its parent
<a href="https://bugs.webkit.org/show_bug.cgi?id=319838">https://bugs.webkit.org/show_bug.cgi?id=319838</a>
<a href="https://rdar.apple.com/181089113">rdar://181089113</a>

Reviewed by Alex Christensen.

An out of process iframe gets its own TileController, but previously
we were not clipping the child iframe&apos;s visibleRect to that of its
parent.

This occurs when site isolation is disabled since its all in the same
process.

No new IPC messages needed since we were already sending the needed
information across processes, we just didn&apos;t use it to constrain the
overdraw rect of the child iframes.

This reclaims ~100% of the IOSurface memory increase in plum4 testing.

Tests: http/tests/site-isolation/iframe-transform-2d-rotate.html
       http/tests/site-isolation/iframe-transform-2d-translate.html
       http/tests/site-isolation/iframe-transform-3d-rotate.html

* LayoutTests/http/tests/site-isolation/iframe-transform-2d-rotate-expected.html: Added.
* LayoutTests/http/tests/site-isolation/iframe-transform-2d-rotate.html: Added.
* LayoutTests/http/tests/site-isolation/iframe-transform-2d-translate-expected.html: Added.
* LayoutTests/http/tests/site-isolation/iframe-transform-2d-translate.html: Added.
* LayoutTests/http/tests/site-isolation/iframe-transform-3d-rotate-expected.html: Added.
* LayoutTests/http/tests/site-isolation/iframe-transform-3d-rotate.html: Added.
* Source/WebCore/page/LocalFrameView.h:
* Source/WebCore/page/Page.cpp:
(WebCore::Page::syncLocalFrameInfoToRemote):
* Source/WebCore/page/RemoteFrameLayoutInfo.cpp:
(WebCore::RemoteFrameLayoutInfo::projectVisibleRectToChildContent const):
* Source/WebCore/page/RemoteFrameLayoutInfo.h:
* Source/WebKit/WebProcess/WebPage/WebFrame.cpp:
(WebKit::WebFrame::updateLocalFrameRect):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::frameTreeSyncDataChangedInAnotherProcess):
(WebKit::WebPage::allFrameTreeSyncDataChangedInAnotherProcess):
(WebKit::WebPage::updateExposedRectFromParent):
* Source/WebKit/WebProcess/WebPage/WebPage.h:

Canonical link: <a href="https://commits.webkit.org/318269@main">https://commits.webkit.org/318269@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/72eb7efb7bf6c140e8aba20b12a39875dd6bf4af

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177773 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51711 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45505 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187382 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/141020 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5c081e6b-63a1-4a7c-8173-d9719eda2e06) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179636 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53003 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51420 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138574 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/141020 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/51595975-fd9d-491c-a4d7-92d1d5a01a74) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180729 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42099 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159317 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119037 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/55308f83-521a-43f9-ac23-0611de28b86b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40761 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39118 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151167 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38813 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35844 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/43496 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43353 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189810 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51378 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/158849 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147687 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39677 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52060 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/35442 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147472 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42188 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124275 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118741 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50568 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13790 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49964 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50204 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50026 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->