### PR TITLE
[white-space-trim] Add to white-space shorthand syntax

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text/parsing/white-space-shorthand-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text/parsing/white-space-shorthand-expected.txt
@@ -44,4 +44,55 @@ PASS e.style['white-space'] = "collapse balance" should not set the property val
 PASS e.style['white-space'] = "balance collapse" should not set the property value
 PASS e.style['white-space'] = "preserve balance" should not set the property value
 PASS e.style['white-space'] = "balance preserve" should not set the property value
+PASS e.style['white-space'] = "discard-before" should set the property value
+PASS Property white-space value 'discard-before'
+PASS e.style['white-space'] = "discard-after" should set the property value
+PASS Property white-space value 'discard-after'
+PASS e.style['white-space'] = "discard-inner" should set the property value
+PASS Property white-space value 'discard-inner'
+PASS e.style['white-space'] = "collapse wrap discard-before" should set the property value
+PASS Property white-space value 'collapse wrap discard-before'
+PASS e.style['white-space'] = "wrap collapse discard-before" should set the property value
+PASS Property white-space value 'wrap collapse discard-before'
+PASS e.style['white-space'] = "discard-before collapse wrap" should set the property value
+PASS Property white-space value 'discard-before collapse wrap'
+PASS e.style['white-space'] = "preserve discard-before" should set the property value
+PASS Property white-space value 'preserve discard-before'
+PASS e.style['white-space'] = "discard-before preserve" should set the property value
+PASS Property white-space value 'discard-before preserve'
+PASS e.style['white-space'] = "nowrap discard-after" should set the property value
+PASS Property white-space value 'nowrap discard-after'
+PASS e.style['white-space'] = "discard-after nowrap" should set the property value
+PASS Property white-space value 'discard-after nowrap'
+PASS e.style['white-space'] = "preserve nowrap discard-inner" should set the property value
+PASS Property white-space value 'preserve nowrap discard-inner'
+PASS e.style['white-space'] = "discard-inner nowrap preserve" should set the property value
+PASS Property white-space value 'discard-inner nowrap preserve'
+PASS e.style['white-space'] = "discard-inner preserve nowrap" should set the property value
+PASS Property white-space value 'discard-inner preserve nowrap'
+PASS e.style['white-space'] = "discard-after discard-before" should set the property value
+PASS Property white-space value 'discard-after discard-before'
+PASS e.style['white-space'] = "collapse wrap discard-after discard-before" should set the property value
+PASS Property white-space value 'collapse wrap discard-after discard-before'
+PASS e.style['white-space'] = "discard-before discard-after discard-inner" should set the property value
+PASS Property white-space value 'discard-before discard-after discard-inner'
+PASS e.style['white-space'] = "discard-inner discard-after discard-before" should set the property value
+PASS Property white-space value 'discard-inner discard-after discard-before'
+PASS e.style['white-space'] = "discard-after discard-inner discard-before" should set the property value
+PASS Property white-space value 'discard-after discard-inner discard-before'
+PASS e.style['white-space'] = "collapse wrap discard-before discard-after discard-inner" should set the property value
+PASS Property white-space value 'collapse wrap discard-before discard-after discard-inner'
+PASS e.style['white-space'] = "discard-inner discard-before discard-after collapse wrap" should set the property value
+PASS Property white-space value 'discard-inner discard-before discard-after collapse wrap'
+PASS e.style['white-space'] = "preserve nowrap discard-inner discard-before discard-after" should set the property value
+PASS Property white-space value 'preserve nowrap discard-inner discard-before discard-after'
+PASS e.style['white-space'] = "discard-after discard-inner discard-before preserve nowrap" should set the property value
+PASS Property white-space value 'discard-after discard-inner discard-before preserve nowrap'
+PASS e.style['white-space'] = "normal discard-before" should not set the property value
+PASS e.style['white-space'] = "discard-before normal" should not set the property value
+PASS e.style['white-space'] = "pre discard-before" should not set the property value
+PASS e.style['white-space'] = "pre-wrap discard-before" should not set the property value
+PASS e.style['white-space'] = "pre-line discard-before" should not set the property value
+PASS e.style['white-space'] = "discard-before discard-before" should not set the property value
+PASS e.style['white-space'] = "discard-before discard-after discard-inner discard-before" should not set the property value
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text/parsing/white-space-shorthand-longhands-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text/parsing/white-space-shorthand-longhands-expected.txt
@@ -1,0 +1,21 @@
+
+PASS white-space: normal
+PASS white-space: pre
+PASS white-space: pre-wrap
+PASS white-space: pre-line
+PASS white-space: nowrap
+PASS white-space: break-spaces
+PASS white-space: collapse
+PASS white-space: preserve
+PASS white-space: preserve-breaks
+PASS white-space: wrap
+PASS white-space: discard-before
+PASS white-space: discard-after
+PASS white-space: discard-inner
+PASS white-space: preserve nowrap discard-inner
+PASS white-space: discard-before discard-after
+PASS white-space: discard-inner discard-after discard-before
+PASS white-space: collapse wrap discard-before discard-after discard-inner
+PASS `white-space` should overwrite a previously set `white-space-trim`
+PASS `white-space-trim` set after `white-space` should not be overwritten
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text/parsing/white-space-shorthand-longhands.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text/parsing/white-space-shorthand-longhands.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<title>CSS Text Module Test: white-space-collapse, text-wrap-mode, and white-space-trim computed values when set via the white-space shorthand</title>
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<link rel="help" href="https://drafts.csswg.org/css-text-4/#propdef-white-space">
+<link rel="help" href="https://drafts.csswg.org/css-text-4/#white-space-collapsing">
+<link rel="help" href="https://drafts.csswg.org/css-text-4/#text-wrap-mode">
+<link rel="help" href="https://drafts.csswg.org/css-text-4/#white-space-trim">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<div id="target"></div>
+<script>
+function test_longhands_from_shorthand(whiteSpace, expected) {
+  test(() => {
+    const target = document.getElementById('target');
+    target.style.whiteSpace = '';
+    target.style.whiteSpace = whiteSpace;
+    const style = getComputedStyle(target);
+    assert_equals(style.whiteSpaceCollapse, expected.whiteSpaceCollapse, 'white-space-collapse');
+    assert_equals(style.textWrapMode, expected.textWrapMode, 'text-wrap-mode');
+    assert_equals(style.whiteSpaceTrim, expected.whiteSpaceTrim, 'white-space-trim');
+  }, `white-space: ${whiteSpace}`);
+}
+
+// The pre-defined single-keyword forms.
+test_longhands_from_shorthand("normal", { whiteSpaceCollapse: "collapse", textWrapMode: "wrap", whiteSpaceTrim: "none" });
+test_longhands_from_shorthand("pre", { whiteSpaceCollapse: "preserve", textWrapMode: "nowrap", whiteSpaceTrim: "none" });
+test_longhands_from_shorthand("pre-wrap", { whiteSpaceCollapse: "preserve", textWrapMode: "wrap", whiteSpaceTrim: "none" });
+test_longhands_from_shorthand("pre-line", { whiteSpaceCollapse: "preserve-breaks", textWrapMode: "wrap", whiteSpaceTrim: "none" });
+test_longhands_from_shorthand("nowrap", { whiteSpaceCollapse: "collapse", textWrapMode: "nowrap", whiteSpaceTrim: "none" });
+test_longhands_from_shorthand("break-spaces", { whiteSpaceCollapse: "break-spaces", textWrapMode: "wrap", whiteSpaceTrim: "none" });
+
+// The multi-value syntax with a single longhand keyword; the other longhands fall back to their initial value.
+test_longhands_from_shorthand("collapse", { whiteSpaceCollapse: "collapse", textWrapMode: "wrap", whiteSpaceTrim: "none" });
+test_longhands_from_shorthand("preserve", { whiteSpaceCollapse: "preserve", textWrapMode: "wrap", whiteSpaceTrim: "none" });
+test_longhands_from_shorthand("preserve-breaks", { whiteSpaceCollapse: "preserve-breaks", textWrapMode: "wrap", whiteSpaceTrim: "none" });
+test_longhands_from_shorthand("wrap", { whiteSpaceCollapse: "collapse", textWrapMode: "wrap", whiteSpaceTrim: "none" });
+test_longhands_from_shorthand("discard-before", { whiteSpaceCollapse: "collapse", textWrapMode: "wrap", whiteSpaceTrim: "discard-before" });
+test_longhands_from_shorthand("discard-after", { whiteSpaceCollapse: "collapse", textWrapMode: "wrap", whiteSpaceTrim: "discard-after" });
+test_longhands_from_shorthand("discard-inner", { whiteSpaceCollapse: "collapse", textWrapMode: "wrap", whiteSpaceTrim: "discard-inner" });
+
+// The multi-value syntax with all three longhands present, in various orders.
+test_longhands_from_shorthand("preserve nowrap discard-inner", { whiteSpaceCollapse: "preserve", textWrapMode: "nowrap", whiteSpaceTrim: "discard-inner" });
+test_longhands_from_shorthand("discard-before discard-after", { whiteSpaceCollapse: "collapse", textWrapMode: "wrap", whiteSpaceTrim: "discard-before discard-after" });
+test_longhands_from_shorthand("discard-inner discard-after discard-before", { whiteSpaceCollapse: "collapse", textWrapMode: "wrap", whiteSpaceTrim: "discard-before discard-after discard-inner" });
+test_longhands_from_shorthand("collapse wrap discard-before discard-after discard-inner", { whiteSpaceCollapse: "collapse", textWrapMode: "wrap", whiteSpaceTrim: "discard-before discard-after discard-inner" });
+
+// Setting the shorthand overwrites previously-set longhand values, including white-space-trim.
+test(() => {
+  const target = document.getElementById('target');
+  target.style.whiteSpace = '';
+  target.style.whiteSpaceTrim = 'discard-inner';
+  target.style.whiteSpace = 'pre';
+  const style = getComputedStyle(target);
+  assert_equals(style.whiteSpaceCollapse, 'preserve');
+  assert_equals(style.textWrapMode, 'nowrap');
+  assert_equals(style.whiteSpaceTrim, 'none');
+}, "`white-space` should overwrite a previously set `white-space-trim`");
+
+// white-space-trim set after the shorthand is not overwritten by it.
+test(() => {
+  const target = document.getElementById('target');
+  target.style.whiteSpace = '';
+  target.style.whiteSpace = 'pre';
+  target.style.whiteSpaceTrim = 'discard-before';
+  const style = getComputedStyle(target);
+  assert_equals(style.whiteSpaceCollapse, 'preserve');
+  assert_equals(style.textWrapMode, 'nowrap');
+  assert_equals(style.whiteSpaceTrim, 'discard-before');
+}, "`white-space-trim` set after `white-space` should not be overwritten");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text/parsing/white-space-shorthand.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text/parsing/white-space-shorthand.html
@@ -46,4 +46,47 @@ test_invalid_value("white-space", "collapse balance");
 test_invalid_value("white-space", "balance collapse");
 test_invalid_value("white-space", "preserve balance");
 test_invalid_value("white-space", "balance preserve");
+
+// white-space-trim as a component of the shorthand.
+test_valid_and_computed_value("white-space", "discard-before", "discard-before");
+test_valid_and_computed_value("white-space", "discard-after", "discard-after");
+test_valid_and_computed_value("white-space", "discard-inner", "discard-inner");
+
+test_valid_and_computed_value("white-space", "collapse wrap discard-before", "discard-before");
+test_valid_and_computed_value("white-space", "wrap collapse discard-before", "discard-before");
+test_valid_and_computed_value("white-space", "discard-before collapse wrap", "discard-before");
+
+test_valid_and_computed_value("white-space", "preserve discard-before", "preserve discard-before");
+test_valid_and_computed_value("white-space", "discard-before preserve", "preserve discard-before");
+
+test_valid_and_computed_value("white-space", "nowrap discard-after", "nowrap discard-after");
+test_valid_and_computed_value("white-space", "discard-after nowrap", "nowrap discard-after");
+
+test_valid_and_computed_value("white-space", "preserve nowrap discard-inner", "preserve nowrap discard-inner");
+test_valid_and_computed_value("white-space", "discard-inner nowrap preserve", "preserve nowrap discard-inner");
+test_valid_and_computed_value("white-space", "discard-inner preserve nowrap", "preserve nowrap discard-inner");
+
+// Multiple white-space-trim keywords are normalized to their canonical grammar order.
+test_valid_and_computed_value("white-space", "discard-after discard-before", "discard-before discard-after");
+test_valid_and_computed_value("white-space", "collapse wrap discard-after discard-before", "discard-before discard-after");
+
+// All three white-space-trim keywords together.
+test_valid_and_computed_value("white-space", "discard-before discard-after discard-inner", "discard-before discard-after discard-inner");
+test_valid_and_computed_value("white-space", "discard-inner discard-after discard-before", "discard-before discard-after discard-inner");
+test_valid_and_computed_value("white-space", "discard-after discard-inner discard-before", "discard-before discard-after discard-inner");
+test_valid_and_computed_value("white-space", "collapse wrap discard-before discard-after discard-inner", "discard-before discard-after discard-inner");
+test_valid_and_computed_value("white-space", "discard-inner discard-before discard-after collapse wrap", "discard-before discard-after discard-inner");
+test_valid_and_computed_value("white-space", "preserve nowrap discard-inner discard-before discard-after", "preserve nowrap discard-before discard-after discard-inner");
+test_valid_and_computed_value("white-space", "discard-after discard-inner discard-before preserve nowrap", "preserve nowrap discard-before discard-after discard-inner");
+
+// The pre-defined single-keyword forms don't combine with white-space-trim.
+test_invalid_value("white-space", "normal discard-before");
+test_invalid_value("white-space", "discard-before normal");
+test_invalid_value("white-space", "pre discard-before");
+test_invalid_value("white-space", "pre-wrap discard-before");
+test_invalid_value("white-space", "pre-line discard-before");
+
+// white-space-trim doesn't accept duplicate keywords.
+test_invalid_value("white-space", "discard-before discard-before");
+test_invalid_value("white-space", "discard-before discard-after discard-inner discard-before");
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text/white-space/white-space-trim-white-space.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text/white-space/white-space-trim-white-space.html
@@ -8,8 +8,8 @@
 <link rel="match" href="reference/white-space-trim-white-space-ref.html">
 <meta name="assert" content="discard-before/discard-after only affect collapsible white space; preserved white space (pre / pre-wrap / break-spaces) is left intact. Collapsibility is determined by the white space's own containing style, not by the box carrying white-space-trim.">
 <style>
-  .db { white-space-trim: discard-before; }
-  .da { white-space-trim: discard-after; }
+  .db { white-space-trim: discard-before !important; }
+  .da { white-space-trim: discard-after !important; }
 </style>
 </head>
 <body>

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -9043,10 +9043,11 @@
             "codegen-properties": {
                 "longhands": [
                     "white-space-collapse",
-                    "text-wrap-mode"
+                    "text-wrap-mode",
+                    "white-space-trim"
                 ],
                 "parser-function": "consumeWhiteSpaceShorthand",
-                "parser-grammar-unused": "normal | pre | pre-wrap | pre-line | [ <'white-space-collapse'> || <'text-wrap-mode'> ]",
+                "parser-grammar-unused": "normal | pre | pre-wrap | pre-line | [ <'white-space-collapse'> || <'text-wrap-mode'> || <'white-space-trim'> ]",
                 "parser-grammar-unused-reason": "Needs support for shorthand grammars."
             },
             "specification": {

--- a/Source/WebCore/css/ShorthandSerializer.cpp
+++ b/Source/WebCore/css/ShorthandSerializer.cpp
@@ -1624,23 +1624,36 @@ String ShorthandSerializer::serializeWhiteSpace() const
     auto whiteSpaceCollapse = longhandValueID(0);
     auto textWrapMode = longhandValueID(1);
 
-    // Convert to backwards-compatible keywords if possible.
-    if (whiteSpaceCollapse == CSSValueCollapse && textWrapMode == CSSValueWrap)
-        return nameString(CSSValueNormal);
-    if (whiteSpaceCollapse == CSSValuePreserve && textWrapMode == CSSValueNowrap)
-        return nameString(CSSValuePre);
-    if (whiteSpaceCollapse == CSSValuePreserve && textWrapMode == CSSValueWrap)
-        return nameString(CSSValuePreWrap);
-    if (whiteSpaceCollapse == CSSValuePreserveBreaks && textWrapMode == CSSValueWrap)
-        return nameString(CSSValuePreLine);
+    if (isLonghandValueNone(2)) {
+        // Convert to backwards-compatible keywords if possible.
+        if (whiteSpaceCollapse == CSSValueCollapse && textWrapMode == CSSValueWrap)
+            return nameString(CSSValueNormal);
+        if (whiteSpaceCollapse == CSSValuePreserve && textWrapMode == CSSValueNowrap)
+            return nameString(CSSValuePre);
+        if (whiteSpaceCollapse == CSSValuePreserve && textWrapMode == CSSValueWrap)
+            return nameString(CSSValuePreWrap);
+        if (whiteSpaceCollapse == CSSValuePreserveBreaks && textWrapMode == CSSValueWrap)
+            return nameString(CSSValuePreLine);
 
+        // Omit default longhand values.
+        if (whiteSpaceCollapse == CSSValueCollapse)
+            return nameString(textWrapMode);
+        if (textWrapMode == CSSValueWrap)
+            return nameString(whiteSpaceCollapse);
+
+        return makeString(nameLiteral(whiteSpaceCollapse), ' ', nameLiteral(textWrapMode));
+    }
+
+    // white-space-trim has a non-initial value, so the backwards-compatible keywords don't apply.
     // Omit default longhand values.
+    if (whiteSpaceCollapse == CSSValueCollapse && textWrapMode == CSSValueWrap)
+        return serializeLonghandValue(2);
     if (whiteSpaceCollapse == CSSValueCollapse)
-        return nameString(textWrapMode);
+        return makeString(nameLiteral(textWrapMode), ' ', serializeLonghandValue(2));
     if (textWrapMode == CSSValueWrap)
-        return nameString(whiteSpaceCollapse);
+        return makeString(nameLiteral(whiteSpaceCollapse), ' ', serializeLonghandValue(2));
 
-    return makeString(nameLiteral(whiteSpaceCollapse), ' ', nameLiteral(textWrapMode));
+    return makeString(nameLiteral(whiteSpaceCollapse), ' ', nameLiteral(textWrapMode), ' ', serializeLonghandValue(2));
 }
 
 String serializeShorthandValue(const CSS::SerializationContext& context, const StyleProperties& properties, CSSPropertyID shorthand)

--- a/Source/WebCore/css/parser/CSSPropertyParserCustom.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserCustom.h
@@ -2023,6 +2023,7 @@ inline bool PropertyParserCustom::consumeWhiteSpaceShorthand(CSSParserTokenRange
 {
     RefPtr<CSSValue> whiteSpaceCollapse;
     RefPtr<CSSValue> textWrapMode;
+    RefPtr<CSSValue> whiteSpaceTrim;
 
     // Single value syntax.
     auto singleValueKeyword = consumeIdentRaw<
@@ -2054,12 +2055,15 @@ inline bool PropertyParserCustom::consumeWhiteSpaceShorthand(CSSParserTokenRange
             ASSERT_NOT_REACHED();
             return false;
         }
+        whiteSpaceTrim = CSSKeywordValue::create(CSSValueNone);
     } else {
         // Multi-value syntax.
-        for (unsigned propertiesParsed = 0; propertiesParsed < 2 && !range.atEnd(); ++propertiesParsed) {
+        for (unsigned propertiesParsed = 0; propertiesParsed < 3 && !range.atEnd(); ++propertiesParsed) {
             if (!whiteSpaceCollapse && (whiteSpaceCollapse = CSSPropertyParsing::consumeWhiteSpaceCollapse(range)))
                 continue;
             if (!textWrapMode && (textWrapMode = CSSPropertyParsing::consumeTextWrapMode(range)))
+                continue;
+            if (!whiteSpaceTrim && state.context.propertySettings.cssWhiteSpaceTrimEnabled && (whiteSpaceTrim = CSSPropertyParsing::consumeWhiteSpaceTrim(range)))
                 continue;
             // If we didn't find at least one match, this is an invalid shorthand and we have to ignore it.
             return false;
@@ -2074,9 +2078,12 @@ inline bool PropertyParserCustom::consumeWhiteSpaceShorthand(CSSParserTokenRange
         whiteSpaceCollapse = CSSKeywordValue::create(CSSValueCollapse);
     if (!textWrapMode)
         textWrapMode = CSSKeywordValue::create(CSSValueWrap);
+    if (!whiteSpaceTrim)
+        whiteSpaceTrim = CSSKeywordValue::create(CSSValueNone);
 
     result.addPropertyForCurrentShorthand(state, CSSPropertyWhiteSpaceCollapse, WTF::move(whiteSpaceCollapse));
     result.addPropertyForCurrentShorthand(state, CSSPropertyTextWrapMode, WTF::move(textWrapMode));
+    result.addPropertyForCurrentShorthand(state, CSSPropertyWhiteSpaceTrim, WTF::move(whiteSpaceTrim));
     return true;
 }
 

--- a/Source/WebCore/editing/EditingStyle.cpp
+++ b/Source/WebCore/editing/EditingStyle.cpp
@@ -115,7 +115,8 @@ static constexpr std::array editingProperties {
     CSSPropertyTextDecorationLine,
     CSSPropertyTextDecorationThickness,
     CSSPropertyTextDecorationStyle,
-    CSSPropertyTextDecorationColor
+    CSSPropertyTextDecorationColor,
+    CSSPropertyWhiteSpaceTrim
 };
 
 static constexpr std::array postLayoutEditingProperties {
@@ -128,7 +129,7 @@ static constexpr std::array postLayoutEditingProperties {
 };
 
 const unsigned numAllEditingProperties = std::size(editingProperties);
-const unsigned numInheritableEditingProperties = numAllEditingProperties - 5;
+const unsigned numInheritableEditingProperties = numAllEditingProperties - 6;
 
 enum class EditingPropertiesToInclude { OnlyInheritableEditingProperties, AllEditingProperties, PostLayoutProperties };
 template <class StyleDeclarationType>
@@ -579,6 +580,8 @@ void EditingStyle::init(Node* initialNode, PropertiesToInclude propertiesToInclu
             mutableStyle->setProperty(CSSPropertyTextDecorationColor, CSSValueCurrentcolor);
             mutableStyle->removeProperty(CSSPropertyWebkitTextDecorationsInEffect);
         }
+        if (RefPtr value = computedStyleAtPosition.propertyValue(CSSPropertyWhiteSpaceTrim))
+            mutableStyle->setProperty(CSSPropertyWhiteSpaceTrim, value->cssText(CSS::defaultSerializationContext()));
     }
 
     if (node && node->computedStyle()) {
@@ -1010,7 +1013,7 @@ bool EditingStyle::conflictsWithInlineStyleOfElement(StyledElement& element, Ref
         auto propertyID = property.id();
 
         // We don't override whitespace property of a tab span because that would collapse the tab into a space.
-        if ((propertyID == CSSPropertyWhiteSpaceCollapse || propertyID == CSSPropertyTextWrapMode) && tabSpanNode(&element))
+        if ((propertyID == CSSPropertyWhiteSpaceCollapse || propertyID == CSSPropertyTextWrapMode || propertyID == CSSPropertyWhiteSpaceTrim) && tabSpanNode(&element))
             continue;
 
         if (propertyID == CSSPropertyWebkitTextDecorationsInEffect && inlineStyle->getPropertyCSSValue(CSSPropertyTextDecorationLine)) {
@@ -1512,9 +1515,13 @@ void EditingStyle::removeStyleInContextNotOverridenByMatchedRules(StyledElement&
         auto textWrapMode = mutableStyle->getPropertyCSSValue(CSSPropertyTextWrapMode);
         auto contextTextWrapMode = computedStyleMutableStyle->getPropertyCSSValue(CSSPropertyTextWrapMode);
 
-        if (whiteSpaceCollapse != contextWhiteSpaceCollapse || textWrapMode != contextTextWrapMode) {
+        auto whiteSpaceTrim = mutableStyle->getPropertyCSSValue(CSSPropertyWhiteSpaceTrim);
+        auto contextWhiteSpaceTrim = computedStyleMutableStyle->getPropertyCSSValue(CSSPropertyWhiteSpaceTrim);
+
+        if (whiteSpaceCollapse != contextWhiteSpaceCollapse || textWrapMode != contextTextWrapMode || whiteSpaceTrim != contextWhiteSpaceTrim) {
             computedStyleMutableStyle->removeProperty(CSSPropertyWhiteSpaceCollapse);
             computedStyleMutableStyle->removeProperty(CSSPropertyTextWrapMode);
+            computedStyleMutableStyle->removeProperty(CSSPropertyWhiteSpaceTrim);
         }
 
         RefPtr<EditingStyle> computedStyleOfElement;
@@ -1958,6 +1965,7 @@ StyleChange::StyleChange(EditingStyle* style, const Position& position)
         if (parentTabSpanNode(positionDeprecatedNode.get()) || tabSpanNode(positionDeprecatedNode.get())) {
             mutableStyle->removeProperty(CSSPropertyWhiteSpaceCollapse);
             mutableStyle->removeProperty(CSSPropertyTextWrapMode);
+            mutableStyle->removeProperty(CSSPropertyWhiteSpaceTrim);
         }
     }
 

--- a/Source/WebCore/style/StyleExtractorCustom.h
+++ b/Source/WebCore/style/StyleExtractorCustom.h
@@ -1307,24 +1307,38 @@ template<> struct PropertyExtractorAdaptor<CSSPropertyWhiteSpace> {
     {
         auto whiteSpaceCollapse = state.style.whiteSpaceCollapse();
         auto textWrapMode = state.style.textWrapMode();
+        auto whiteSpaceTrim = state.style.whiteSpaceTrim();
 
-        // Convert to backwards-compatible keywords if possible.
-        if (whiteSpaceCollapse == WhiteSpaceCollapse::Collapse && textWrapMode == TextWrapMode::Wrap)
-            return functor(CSS::Keyword::Normal { });
-        if (whiteSpaceCollapse == WhiteSpaceCollapse::Preserve && textWrapMode == TextWrapMode::NoWrap)
-            return functor(CSS::Keyword::Pre { });
-        if (whiteSpaceCollapse == WhiteSpaceCollapse::Preserve && textWrapMode == TextWrapMode::Wrap)
-            return functor(CSS::Keyword::PreWrap { });
-        if (whiteSpaceCollapse == WhiteSpaceCollapse::PreserveBreaks && textWrapMode == TextWrapMode::Wrap)
-            return functor(CSS::Keyword::PreLine { });
+        if (whiteSpaceTrim.isNone()) {
+            // Convert to backwards-compatible keywords if possible.
+            if (whiteSpaceCollapse == WhiteSpaceCollapse::Collapse && textWrapMode == TextWrapMode::Wrap)
+                return functor(CSS::Keyword::Normal { });
+            if (whiteSpaceCollapse == WhiteSpaceCollapse::Preserve && textWrapMode == TextWrapMode::NoWrap)
+                return functor(CSS::Keyword::Pre { });
+            if (whiteSpaceCollapse == WhiteSpaceCollapse::Preserve && textWrapMode == TextWrapMode::Wrap)
+                return functor(CSS::Keyword::PreWrap { });
+            if (whiteSpaceCollapse == WhiteSpaceCollapse::PreserveBreaks && textWrapMode == TextWrapMode::Wrap)
+                return functor(CSS::Keyword::PreLine { });
 
+            // Omit default longhand values.
+            if (whiteSpaceCollapse == ComputedStyle::initialWhiteSpaceCollapse())
+                return functor(textWrapMode);
+            if (textWrapMode == ComputedStyle::initialTextWrapMode())
+                return functor(whiteSpaceCollapse);
+
+            return functor(SpaceSeparatedTuple { whiteSpaceCollapse, textWrapMode });
+        }
+
+        // white-space-trim has a non-initial value, so the backwards-compatible keywords don't apply.
         // Omit default longhand values.
+        if (whiteSpaceCollapse == ComputedStyle::initialWhiteSpaceCollapse() && textWrapMode == ComputedStyle::initialTextWrapMode())
+            return functor(whiteSpaceTrim);
         if (whiteSpaceCollapse == ComputedStyle::initialWhiteSpaceCollapse())
-            return functor(textWrapMode);
+            return functor(SpaceSeparatedTuple { textWrapMode, whiteSpaceTrim });
         if (textWrapMode == ComputedStyle::initialTextWrapMode())
-            return functor(whiteSpaceCollapse);
+            return functor(SpaceSeparatedTuple { whiteSpaceCollapse, whiteSpaceTrim });
 
-        return functor(SpaceSeparatedTuple { whiteSpaceCollapse, textWrapMode });
+        return functor(SpaceSeparatedTuple { whiteSpaceCollapse, textWrapMode, whiteSpaceTrim });
     }
 };
 


### PR DESCRIPTION
#### a58ccd8694552211ae08acdf3be50c00e2136cd5
<pre>
[white-space-trim] Add to white-space shorthand syntax
<a href="https://bugs.webkit.org/show_bug.cgi?id=319831">https://bugs.webkit.org/show_bug.cgi?id=319831</a>
<a href="https://rdar.apple.com/182739052">rdar://182739052</a>

Reviewed by NOBODY (OOPS!).

The syntax for the white-space shorthand is:

normal | pre | pre-wrap | pre-line | &lt;&apos;white-space-collapse&apos;&gt; || &lt;&apos;text-wrap-mode&apos;&gt; || &lt;&apos;white-space-trim&apos;&gt;

See: <a href="https://drafts.csswg.org/css-text-4/#white-space-property">https://drafts.csswg.org/css-text-4/#white-space-property</a>

Tests: imported/w3c/web-platform-tests/css/css-text/parsing/white-space-shorthand-longhands.html
       imported/w3c/web-platform-tests/css/css-text/parsing/white-space-shorthand.html

* LayoutTests/imported/w3c/web-platform-tests/css/css-text/parsing/white-space-shorthand-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-text/parsing/white-space-shorthand-longhands-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-text/parsing/white-space-shorthand-longhands.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-text/parsing/white-space-shorthand.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-text/white-space/white-space-trim-white-space.html:
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/css/ShorthandSerializer.cpp:
(WebCore::ShorthandSerializer::serializeWhiteSpace const):
* Source/WebCore/css/parser/CSSPropertyParserCustom.h:
(WebCore::CSS::PropertyParserCustom::consumeWhiteSpaceShorthand):
* Source/WebCore/editing/EditingStyle.cpp:
(WebCore::EditingStyle::init):
(WebCore::EditingStyle::conflictsWithInlineStyleOfElement const):
(WebCore::EditingStyle::removeStyleInContextNotOverridenByMatchedRules):
(WebCore::StyleChange::StyleChange):
* Source/WebCore/style/StyleExtractorCustom.h:
(WebCore::Style::PropertyExtractorAdaptor&lt;CSSPropertyWhiteSpace&gt;::computedValue const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a58ccd8694552211ae08acdf3be50c00e2136cd5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175877 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49810 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43594 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185470 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/138072 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2b6eb0c2-059d-4808-a659-9a21e4e8bc67) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/177740 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51102 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49492 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136955 "Found 13 new test failures: fast/events/input-events-paste-rich-datatransfer.html imported/w3c/web-platform-tests/editing/other/delete-without-unwrapping-first-line-of-child-block.html?method=BackspaceKey&lineBreak=br imported/w3c/web-platform-tests/editing/other/delete-without-unwrapping-first-line-of-child-block.html?method=DeleteKey&lineBreak=br imported/w3c/web-platform-tests/editing/other/delete-without-unwrapping-first-line-of-child-block.html?method=deleteCommand&lineBreak=br imported/w3c/web-platform-tests/editing/other/delete-without-unwrapping-first-line-of-child-block.html?method=forwardDeleteCommand&lineBreak=br imported/w3c/web-platform-tests/editing/other/join-different-white-space-style-left-line-and-right-paragraph.html?method=forwarddelete&left-white-space=nowrap&right-white-space=normal imported/w3c/web-platform-tests/editing/other/join-different-white-space-style-left-line-and-right-paragraph.html?method=forwarddelete&left-white-space=pre&right-white-space=normal imported/w3c/web-platform-tests/editing/other/join-different-white-space-style-left-line-and-right-paragraph.html?method=forwarddelete&left-white-space=pre-line&right-white-space=normal imported/w3c/web-platform-tests/editing/other/join-different-white-space-style-left-line-and-right-paragraph.html?method=forwarddelete&left-white-space=pre-wrap&right-white-space=normal imported/w3c/web-platform-tests/editing/other/join-different-white-space-style-left-line-and-right-paragraph.html?method=select-boundary&left-white-space=nowrap&right-white-space=normal ... (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96224 "4 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8c01d830-352d-425a-9940-8043b6c85e90) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178833 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40419 "Found 1 new test failure: fast/events/input-events-paste-rich-datatransfer.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157735 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117434 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1638f339-1a28-48cd-92e2-6ad10cb12e8f) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39061 "Found 3 new test failures: imported/w3c/web-platform-tests/editing/other/delete-without-unwrapping-first-line-of-child-block.html?method=deleteCommand&lineBreak=br imported/w3c/web-platform-tests/editing/other/delete-without-unwrapping-first-line-of-child-block.html?method=deleteCommand&lineBreak=preformat imported/w3c/web-platform-tests/editing/other/delete-without-unwrapping-first-line-of-child-block.html?method=forwardDeleteCommand&lineBreak=br (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37443 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149480 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37227 "Found 14 new test failures: editing/pasteboard/data-transfer-get-data-on-drop-rich-text.html fast/events/input-events-paste-rich-datatransfer.html imported/w3c/web-platform-tests/editing/other/delete-without-unwrapping-first-line-of-child-block.html?method=BackspaceKey&lineBreak=br imported/w3c/web-platform-tests/editing/other/delete-without-unwrapping-first-line-of-child-block.html?method=DeleteKey&lineBreak=br imported/w3c/web-platform-tests/editing/other/delete-without-unwrapping-first-line-of-child-block.html?method=deleteCommand&lineBreak=br imported/w3c/web-platform-tests/editing/other/delete-without-unwrapping-first-line-of-child-block.html?method=forwardDeleteCommand&lineBreak=br imported/w3c/web-platform-tests/editing/other/join-different-white-space-style-left-line-and-right-paragraph.html?method=forwarddelete&left-white-space=nowrap&right-white-space=normal imported/w3c/web-platform-tests/editing/other/join-different-white-space-style-left-line-and-right-paragraph.html?method=forwarddelete&left-white-space=pre&right-white-space=normal imported/w3c/web-platform-tests/editing/other/join-different-white-space-style-left-line-and-right-paragraph.html?method=forwarddelete&left-white-space=pre-line&right-white-space=normal imported/w3c/web-platform-tests/editing/other/join-different-white-space-style-left-line-and-right-paragraph.html?method=forwarddelete&left-white-space=pre-wrap&right-white-space=normal ... (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33940 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41510 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41649 "Found 15 new test failures: editing/pasteboard/data-transfer-get-data-on-drop-rich-text.html fast/events/input-events-paste-rich-datatransfer.html imported/w3c/web-platform-tests/editing/other/delete-without-unwrapping-first-line-of-child-block.html?method=BackspaceKey&lineBreak=br imported/w3c/web-platform-tests/editing/other/delete-without-unwrapping-first-line-of-child-block.html?method=DeleteKey&lineBreak=br imported/w3c/web-platform-tests/editing/other/delete-without-unwrapping-first-line-of-child-block.html?method=deleteCommand&lineBreak=br imported/w3c/web-platform-tests/editing/other/delete-without-unwrapping-first-line-of-child-block.html?method=forwardDeleteCommand&lineBreak=br imported/w3c/web-platform-tests/editing/other/join-different-white-space-style-left-line-and-right-paragraph.html?method=forwarddelete&left-white-space=nowrap&right-white-space=normal imported/w3c/web-platform-tests/editing/other/join-different-white-space-style-left-line-and-right-paragraph.html?method=forwarddelete&left-white-space=pre&right-white-space=normal imported/w3c/web-platform-tests/editing/other/join-different-white-space-style-left-line-and-right-paragraph.html?method=forwarddelete&left-white-space=pre-line&right-white-space=normal imported/w3c/web-platform-tests/editing/other/join-different-white-space-style-left-line-and-right-paragraph.html?method=forwarddelete&left-white-space=pre-wrap&right-white-space=normal ... (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187891 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49477 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/157286 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145952 "Found 13 new test failures: fast/events/input-events-paste-rich-datatransfer.html imported/w3c/web-platform-tests/editing/other/delete-without-unwrapping-first-line-of-child-block.html?method=BackspaceKey&lineBreak=br imported/w3c/web-platform-tests/editing/other/delete-without-unwrapping-first-line-of-child-block.html?method=DeleteKey&lineBreak=br imported/w3c/web-platform-tests/editing/other/delete-without-unwrapping-first-line-of-child-block.html?method=deleteCommand&lineBreak=br imported/w3c/web-platform-tests/editing/other/delete-without-unwrapping-first-line-of-child-block.html?method=forwardDeleteCommand&lineBreak=br imported/w3c/web-platform-tests/editing/other/join-different-white-space-style-left-line-and-right-paragraph.html?method=forwarddelete&left-white-space=nowrap&right-white-space=normal imported/w3c/web-platform-tests/editing/other/join-different-white-space-style-left-line-and-right-paragraph.html?method=forwarddelete&left-white-space=pre&right-white-space=normal imported/w3c/web-platform-tests/editing/other/join-different-white-space-style-left-line-and-right-paragraph.html?method=forwarddelete&left-white-space=pre-line&right-white-space=normal imported/w3c/web-platform-tests/editing/other/join-different-white-space-style-left-line-and-right-paragraph.html?method=forwarddelete&left-white-space=pre-wrap&right-white-space=normal imported/w3c/web-platform-tests/editing/other/join-different-white-space-style-left-line-and-right-paragraph.html?method=select-boundary&left-white-space=nowrap&right-white-space=normal ... (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50157 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33851 "Found 14 new test failures: editing/pasteboard/data-transfer-get-data-on-drop-rich-text.html fast/events/input-events-paste-rich-datatransfer.html imported/w3c/web-platform-tests/editing/other/delete-without-unwrapping-first-line-of-child-block.html?method=BackspaceKey&lineBreak=br imported/w3c/web-platform-tests/editing/other/delete-without-unwrapping-first-line-of-child-block.html?method=DeleteKey&lineBreak=br imported/w3c/web-platform-tests/editing/other/delete-without-unwrapping-first-line-of-child-block.html?method=deleteCommand&lineBreak=br imported/w3c/web-platform-tests/editing/other/delete-without-unwrapping-first-line-of-child-block.html?method=forwardDeleteCommand&lineBreak=br imported/w3c/web-platform-tests/editing/other/join-different-white-space-style-left-line-and-right-paragraph.html?method=forwarddelete&left-white-space=nowrap&right-white-space=normal imported/w3c/web-platform-tests/editing/other/join-different-white-space-style-left-line-and-right-paragraph.html?method=forwarddelete&left-white-space=pre&right-white-space=normal imported/w3c/web-platform-tests/editing/other/join-different-white-space-style-left-line-and-right-paragraph.html?method=forwarddelete&left-white-space=pre-line&right-white-space=normal imported/w3c/web-platform-tests/editing/other/join-different-white-space-style-left-line-and-right-paragraph.html?method=forwarddelete&left-white-space=pre-wrap&right-white-space=normal ... (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145793 "Found 1 new API test failure: WebKitGTK/TestInspector:/webkit/WebKitWebInspector/default (failure)") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40590 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122353 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/116215 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48664 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12207 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48066 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48298 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48123 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->