### PR TITLE
Add OpenID4VP presentation protocols behind an off-by-default flag

### DIFF
--- a/LayoutTests/http/wpt/identity/digital-credential-openid4vp-disabled-by-default.https-expected.txt
+++ b/LayoutTests/http/wpt/identity/digital-credential-openid4vp-disabled-by-default.https-expected.txt
@@ -1,0 +1,6 @@
+
+PASS "org-iso-mdoc" is allowed regardless of the OpenID4VP setting
+PASS "openid4vp-v1-unsigned" is not allowed when the OpenID4VP setting is disabled
+PASS "openid4vp-v1-signed" is not allowed when the OpenID4VP setting is disabled
+PASS "openid4vp-v1-multisigned" is not allowed when the OpenID4VP setting is disabled
+

--- a/LayoutTests/http/wpt/identity/digital-credential-openid4vp-disabled-by-default.https.html
+++ b/LayoutTests/http/wpt/identity/digital-credential-openid4vp-disabled-by-default.https.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<meta charset="utf-8" />
+<title>DigitalCredential.userAgentAllowsProtocol() does not advertise OpenID4VP while the setting is disabled.</title>
+<link rel="help" href="https://w3c-fedid.github.io/digital-credentials/" />
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body></body>
+<script>
+    // With DigitalCredentialsOpenID4VPEnabled at its default (disabled), the OpenID4VP
+    // protocols must not be advertised as supported, since the request pipeline for them
+    // is not yet in place. The mdoc protocol is unaffected by the setting.
+
+    test(() => {
+        assert_true(DigitalCredential.userAgentAllowsProtocol("org-iso-mdoc"));
+    }, `"org-iso-mdoc" is allowed regardless of the OpenID4VP setting`);
+
+    const openID4VPProtocols = [
+        "openid4vp-v1-unsigned",
+        "openid4vp-v1-signed",
+        "openid4vp-v1-multisigned",
+    ];
+
+    for (const protocol of openID4VPProtocols) {
+        test(() => {
+            assert_false(DigitalCredential.userAgentAllowsProtocol(protocol));
+        }, `"${protocol}" is not allowed when the OpenID4VP setting is disabled`);
+    }
+</script>

--- a/LayoutTests/http/wpt/identity/digital-credential-openid4vp-user-agent-allows-protocol.https-expected.txt
+++ b/LayoutTests/http/wpt/identity/digital-credential-openid4vp-user-agent-allows-protocol.https-expected.txt
@@ -1,0 +1,17 @@
+
+PASS "org-iso-mdoc" is an allowed protocol
+PASS "openid4vp-v1-unsigned" is an allowed protocol
+PASS "openid4vp-v1-signed" is an allowed protocol
+PASS "openid4vp-v1-multisigned" is an allowed protocol
+PASS "" is not an allowed protocol
+PASS " " is not an allowed protocol
+PASS "openid4vp" is not an allowed protocol
+PASS "openid4vp-v1" is not an allowed protocol
+PASS "openid4vp-v1-" is not an allowed protocol
+PASS "openid4vp-v1-unsigned " is not an allowed protocol
+PASS " openid4vp-v1-unsigned" is not an allowed protocol
+PASS "openid4vp-v1-unsigned-extra" is not an allowed protocol
+PASS "openid4vp-v2-unsigned" is not an allowed protocol
+PASS "OPENID4VP-V1-UNSIGNED" is not an allowed protocol
+PASS "org-iso-mdoc-extra" is not an allowed protocol
+

--- a/LayoutTests/http/wpt/identity/digital-credential-openid4vp-user-agent-allows-protocol.https.html
+++ b/LayoutTests/http/wpt/identity/digital-credential-openid4vp-user-agent-allows-protocol.https.html
@@ -1,0 +1,46 @@
+<!-- webkit-test-runner [ DigitalCredentialsOpenID4VPEnabled=true ] -->
+<!DOCTYPE html>
+<meta charset="utf-8" />
+<title>DigitalCredential.userAgentAllowsProtocol() recognizes the supported presentation protocols.</title>
+<link rel="help" href="https://w3c-fedid.github.io/digital-credentials/" />
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body></body>
+<script>
+    // Protocol identifiers defined by the W3C Digital Credentials specification
+    // that this user agent recognizes.
+    const allowedProtocols = [
+        "org-iso-mdoc",
+        "openid4vp-v1-unsigned",
+        "openid4vp-v1-signed",
+        "openid4vp-v1-multisigned",
+    ];
+
+    for (const protocol of allowedProtocols) {
+        test(() => {
+            assert_true(DigitalCredential.userAgentAllowsProtocol(protocol));
+        }, `"${protocol}" is an allowed protocol`);
+    }
+
+    // Matching is exact and case-sensitive: near-misses of the OpenID4VP
+    // identifiers, as well as empty and whitespace-padded strings, are rejected.
+    const disallowedProtocols = [
+        "",
+        " ",
+        "openid4vp",
+        "openid4vp-v1",
+        "openid4vp-v1-",
+        "openid4vp-v1-unsigned ",
+        " openid4vp-v1-unsigned",
+        "openid4vp-v1-unsigned-extra",
+        "openid4vp-v2-unsigned",
+        "OPENID4VP-V1-UNSIGNED",
+        "org-iso-mdoc-extra",
+    ];
+
+    for (const protocol of disallowedProtocols) {
+        test(() => {
+            assert_false(DigitalCredential.userAgentAllowsProtocol(protocol));
+        }, `"${protocol}" is not an allowed protocol`);
+    }
+</script>

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -2707,6 +2707,22 @@ DigitalCredentialsEnabled:
   disableInLockdownMode: true
   richJavaScript: true
 
+DigitalCredentialsOpenID4VPEnabled:
+  type: bool
+  status: internal
+  category: dom
+  humanReadableName: "OpenID4VP for Digital Credentials API"
+  humanReadableDescription: "Enable the OpenID4VP presentation protocols for the Digital Credentials API"
+  condition: ENABLE(WEB_AUTHN)
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+  disableInLockdownMode: true
+
 DirectoryUploadEnabled:
   type: bool
   status: embedder

--- a/Source/WebCore/Modules/identity/DigitalCredential.cpp
+++ b/Source/WebCore/Modules/identity/DigitalCredential.cpp
@@ -45,6 +45,7 @@
 #include "LocalFrame.h"
 #include "MediationRequirement.h"
 #include "PermissionsPolicy.h"
+#include "Settings.h"
 #include "VisibilityState.h"
 #include <JavaScriptCore/ConsoleTypes.h>
 #include <JavaScriptCore/JSONObject.h>
@@ -68,6 +69,23 @@ DigitalCredential::DigitalCredential(JSC::Strong<JSC::JSObject>&& data, DigitalC
     , m_protocol(protocol)
     , m_data(WTF::move(data))
 {
+}
+
+bool DigitalCredential::userAgentAllowsProtocol(const Document& document, const String& protocol)
+{
+    if (protocol == "org-iso-mdoc"_s)
+        return true;
+
+    // The OpenID4VP protocols are gated behind an off-by-default setting while their request
+    // validation and wallet plumbing are still under development, so that the API does not
+    // advertise support for a protocol it cannot yet fulfill.
+    if (document.settings().digitalCredentialsOpenID4VPEnabled()) {
+        return protocol == "openid4vp-v1-unsigned"_s
+            || protocol == "openid4vp-v1-signed"_s
+            || protocol == "openid4vp-v1-multisigned"_s;
+    }
+
+    return false;
 }
 
 static std::optional<DigitalCredentialPresentationProtocol> convertProtocolString(const String& protocolString)

--- a/Source/WebCore/Modules/identity/DigitalCredential.h
+++ b/Source/WebCore/Modules/identity/DigitalCredential.h
@@ -65,10 +65,7 @@ public:
 
     static void discoverFromExternalSource(const Document&, CredentialPromise&&, CredentialRequestOptions&&);
 
-    static bool userAgentAllowsProtocol(const String& protocol)
-    {
-        return protocol == "org-iso-mdoc"_s;
-    }
+    static bool userAgentAllowsProtocol(const Document&, const String& protocol);
 
 private:
     DigitalCredential(JSC::Strong<JSC::JSObject>&&, DigitalCredentialPresentationProtocol);

--- a/Source/WebCore/Modules/identity/DigitalCredential.idl
+++ b/Source/WebCore/Modules/identity/DigitalCredential.idl
@@ -31,6 +31,6 @@
 ] interface DigitalCredential : BasicCredential {
     [SameObject] readonly attribute object data;
     readonly attribute DigitalCredentialPresentationProtocol protocol;
-    static boolean userAgentAllowsProtocol(DOMString protocol);
+    [CallWith=CurrentDocument] static boolean userAgentAllowsProtocol(DOMString protocol);
     [Default] object toJSON();
 };

--- a/Source/WebCore/Modules/identity/DigitalCredentialPresentationProtocol.h
+++ b/Source/WebCore/Modules/identity/DigitalCredentialPresentationProtocol.h
@@ -29,6 +29,9 @@ namespace WebCore {
 
 enum class DigitalCredentialPresentationProtocol : uint8_t {
     OrgIsoMdoc,
+    Openid4vpV1Unsigned,
+    Openid4vpV1Signed,
+    Openid4vpV1Multisigned,
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/identity/DigitalCredentialPresentationProtocol.idl
+++ b/Source/WebCore/Modules/identity/DigitalCredentialPresentationProtocol.idl
@@ -25,4 +25,7 @@
 
 enum DigitalCredentialPresentationProtocol {
     "org-iso-mdoc",
+    "openid4vp-v1-unsigned",
+    "openid4vp-v1-signed",
+    "openid4vp-v1-multisigned",
 };

--- a/Source/WebKit/Shared/WebCoreArgumentCodersAuth.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCodersAuth.serialization.in
@@ -364,7 +364,10 @@ struct WebCore::DigitalCredentialsResponseData {
 };
 
 [Nested] enum class WebCore::DigitalCredentialPresentationProtocol : uint8_t {
-    OrgIsoMdoc
+    OrgIsoMdoc,
+    Openid4vpV1Unsigned,
+    Openid4vpV1Signed,
+    Openid4vpV1Multisigned
 };
 
 #endif // ENABLE(WEB_AUTHN)


### PR DESCRIPTION
#### 0179ac8fd6ef82163e4a08d41735ff8d0b0e85cd
<pre>
Add OpenID4VP presentation protocols behind an off-by-default flag
<a href="https://bugs.webkit.org/show_bug.cgi?id=319841">https://bugs.webkit.org/show_bug.cgi?id=319841</a>
<a href="https://rdar.apple.com/182739442">rdar://182739442</a>

Reviewed by Abrar Rahman Protyasha.

Add the three OpenID4VP protocol identifiers defined by the W3C Digital
Credentials specification -- &quot;openid4vp-v1-unsigned&quot;,
&quot;openid4vp-v1-signed&quot;, and &quot;openid4vp-v1-multisigned&quot; -- alongside the
existing &quot;org-iso-mdoc&quot; protocol.  This is the first step toward
supporting OpenID4VP presentation requests; request validation and
wallet plumbing follow in later changes.

`DigitalCredentialsEnabled` is a stable, entitlement-gated preference
that is on by default in browsers, so advertising these protocols
unconditionally would make `userAgentAllowsProtocol()` report support
that the engine cannot yet fulfill (a request using one of them would
still be filtered out).  Introduce a separate off-by-default setting,
`DigitalCredentialsOpenID4VPEnabled` (internal), to gate the OpenID4VP
behavior while it is under development.

Extend the `DigitalCredentialPresentationProtocol` enum, the matching
IDL enum, and the IPC serialization list, kept in the same order since
the IDL enum&apos;s generated string mapping is indexed by the C++ enum
value.  `userAgentAllowsProtocol()` now receives the current document
(`CallWith=CurrentDocument`) and allows the OpenID4VP identifiers only
when the new setting is enabled; &quot;org-iso-mdoc&quot; is unaffected.

Request conversion in `convertProtocolString()` and
`jsToCredentialRequest()` is deliberately left to a follow-up: mapping
these identifiers there has no observable effect until the OpenID4VP
request structures and validation exist.

Tests: http/wpt/identity/digital-credential-openid4vp-user-agent-allows-protocol.https.html
       http/wpt/identity/digital-credential-openid4vp-disabled-by-default.https.html

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/Modules/identity/DigitalCredential.cpp:
(WebCore::DigitalCredential::userAgentAllowsProtocol):
* Source/WebCore/Modules/identity/DigitalCredential.h:
* Source/WebCore/Modules/identity/DigitalCredential.idl:
* Source/WebCore/Modules/identity/DigitalCredentialPresentationProtocol.h:
* Source/WebCore/Modules/identity/DigitalCredentialPresentationProtocol.idl:
* Source/WebKit/Shared/WebCoreArgumentCodersAuth.serialization.in:
* LayoutTests/http/wpt/identity/digital-credential-openid4vp-disabled-by-default.https.html: Added.
* LayoutTests/http/wpt/identity/digital-credential-openid4vp-disabled-by-default.https-expected.txt: Added.
* LayoutTests/http/wpt/identity/digital-credential-openid4vp-user-agent-allows-protocol.https.html: Added.
* LayoutTests/http/wpt/identity/digital-credential-openid4vp-user-agent-allows-protocol.https-expected.txt: Added.

Canonical link: <a href="https://commits.webkit.org/317599@main">https://commits.webkit.org/317599@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8945582a8215d5a83591951982807e62222fa389

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175675 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49608 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43391 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185267 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/137853 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/177538 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50900 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49290 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136791 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/137853 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/18db2ba5-9d76-48ae-8e80-5ba97204dc8c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178631 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40232 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157564 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117269 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7d92c04d-654f-4a09-ae46-6222c649633d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38874 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37258 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/6073 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149293 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37056 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33737 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/36939 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41299 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41464 "Found 1 new test failure: http/wpt/background-fetch/change-documents-in-progress-event.window.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187689 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49275 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/157115 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145771 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39240 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49955 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33680 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145610 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40422 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122150 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115976 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48462 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12034 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47864 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48096 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47921 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->