### PR TITLE
[WebTransport] Make WebTransportSendStream.sendOrder and WebTransportSendStreamOptions non-nullable to match spec

### DIFF
--- a/Source/WebCore/Modules/webtransport/WebTransportSendStream.h
+++ b/Source/WebCore/Modules/webtransport/WebTransportSendStream.h
@@ -48,8 +48,8 @@ public:
     void getStats(ScriptExecutionContext&, Ref<DeferredPromise>&&);
     WebTransportSendGroup* NODELETE sendGroup();
     ExceptionOr<void> setSendGroup(WebTransportSendGroup*);
-    std::optional<int64_t> sendOrder() { return m_sendOrder; }
-    void setSendOrder(std::optional<int64_t> order) { m_sendOrder = order; }
+    int64_t sendOrder() { return m_sendOrder; }
+    void setSendOrder(int64_t order) { m_sendOrder = order; }
 private:
     WebTransportSendStream(WebTransportStreamIdentifier, WebTransport&, Ref<InternalWritableStream>&&);
 
@@ -58,7 +58,7 @@ private:
     const WebTransportStreamIdentifier m_identifier;
     const ThreadSafeWeakPtr<WebTransport> m_transport;
     RefPtr<WebTransportSendGroup> m_sendGroup;
-    std::optional<int64_t> m_sendOrder;
+    int64_t m_sendOrder { 0 };
 };
 
 }

--- a/Source/WebCore/Modules/webtransport/WebTransportSendStream.idl
+++ b/Source/WebCore/Modules/webtransport/WebTransportSendStream.idl
@@ -30,6 +30,6 @@
     Transferable
 ] interface WebTransportSendStream : WritableStream {
     attribute WebTransportSendGroup? sendGroup;
-    attribute long long? sendOrder;
+    attribute long long sendOrder;
     [CallWith=CurrentScriptExecutionContext] Promise<WebTransportSendStreamStats> getStats();
 };

--- a/Source/WebCore/Modules/webtransport/WebTransportSendStreamOptions.h
+++ b/Source/WebCore/Modules/webtransport/WebTransportSendStreamOptions.h
@@ -25,10 +25,11 @@
 
 #pragma once
 
+#include "WebTransportSendOptions.h"
+
 namespace WebCore {
 
-struct WebTransportSendStreamOptions {
-    std::optional<int64_t> sendOrder;
+struct WebTransportSendStreamOptions : WebTransportSendOptions {
 };
 
 }

--- a/Source/WebCore/Modules/webtransport/WebTransportSendStreamOptions.idl
+++ b/Source/WebCore/Modules/webtransport/WebTransportSendStreamOptions.idl
@@ -24,12 +24,9 @@
  */
 
 // https://w3c.github.io/webtransport/#dictdef-webtransportsendstreamoptions
-// FIXME: `WebTransportSendStreamOptions` should have a parent dictionary `WebTransportSendOptions`.
 [
     EnabledBySetting=WebTransportEnabled,
-] dictionary WebTransportSendStreamOptions {
-    // FIXME: `sendOrder` should be in parent dictionary `WebTransportSendOptions`.
-    long long? sendOrder = null;
+] dictionary WebTransportSendStreamOptions : WebTransportSendOptions {
     // FIXME: Add support for `waitUntilAvailable`.
     // boolean waitUntilAvailable = false;
 };


### PR DESCRIPTION
#### 8e0a1f8b1e39496c4678521c1edf0410b90ab455
<pre>
[WebTransport] Make WebTransportSendStream.sendOrder and WebTransportSendStreamOptions non-nullable to match spec
<a href="https://bugs.webkit.org/show_bug.cgi?id=310559">https://bugs.webkit.org/show_bug.cgi?id=310559</a>
<a href="https://rdar.apple.com/182738080">rdar://182738080</a>

Reviewed by Alex Christensen.

Per the WebTransport spec change (w3c/webtransport commit 37d1d28), sendOrder is
non-nullable (defaulting to 0) and WebTransportSendStreamOptions inherits from
WebTransportSendOptions. WebTransportSendOptions and WebTransportDatagramsWritable already
used the non-nullable form; this brings the remaining two declarations into line:

- WebTransportSendStream.sendOrder becomes `long long` instead of `long long?`, so assigning
  null coerces to 0 per the WebIDL rules rather than being retained as null.
- WebTransportSendStreamOptions now inherits WebTransportSendOptions instead of declaring its
  own nullable sendOrder, which also gives it the inherited sendGroup member.

This covers the IDL/attribute nullability conformance only. Actual sendOrder backend plumbing
is tracked separately in <a href="https://rdar.apple.com/161685860">rdar://161685860</a>, so the sendorder.https.any.* WPT tests remain
skipped.

No new tests (IDL conformance; existing sendorder WPT tests remain skipped pending backend
support).

* Source/WebCore/Modules/webtransport/WebTransportSendStream.h:
(WebCore::WebTransportSendStream::sendOrder):
(WebCore::WebTransportSendStream::setSendOrder):
* Source/WebCore/Modules/webtransport/WebTransportSendStream.idl:
* Source/WebCore/Modules/webtransport/WebTransportSendStreamOptions.h:
* Source/WebCore/Modules/webtransport/WebTransportSendStreamOptions.idl:

Canonical link: <a href="https://commits.webkit.org/317583@main">https://commits.webkit.org/317583@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/846baf6f1486df88d9e51f842e7b1b7363ae4534

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175690 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49623 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43406 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185282 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/137868 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/40fb6ef2-0248-474a-bac0-0ecb52b59914) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/177553 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50915 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49305 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136799 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/137868 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178646 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40245 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157567 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117277 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/94cc39e7-897e-4899-ba5a-6901c6477075) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38887 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/37268 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149306 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37059 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33752 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41314 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/41474 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187704 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49290 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145783 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39229 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49970 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/33683 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145623 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40429 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122166 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115991 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48477 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12037 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47879 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48111 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47936 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->