### PR TITLE
Support external and data: URL marker references on SVG elements

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -2533,7 +2533,6 @@ imported/w3c/web-platform-tests/svg/animations/cyclic-syncbase-events.html [ Ski
 imported/w3c/web-platform-tests/svg/painting/marker-orient-001.svg [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/svg/painting/mask-containing-image-with-clip-path.svg [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/svg/painting/reftests/gradient-external-reference.svg [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/svg/painting/reftests/marker-external-reference.svg [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/svg/painting/reftests/non-scaling-stroke-003.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/svg/painting/reftests/paint-context-004.svg [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/svg/painting/reftests/paint-context-006.svg [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/painting/reftests/marker-data-uri-reference-expected.svg
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/painting/reftests/marker-data-uri-reference-expected.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+  <rect width="100" height="100" fill="green"/>
+</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/painting/reftests/marker-data-uri-reference.svg
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/painting/reftests/marker-data-uri-reference.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:h="http://www.w3.org/1999/xhtml">
+  <title>data: URL reference for marker</title>
+  <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/painting.html#VertexMarkerProperties"/>
+  <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/linking.html#URLReference"/>
+  <h:link rel="match" href="../../pservers/reftests/reference/green-100x100.svg"/>
+
+  <path d="M25,25h50v50h-50" fill="none" stroke="red" stroke-width="5"
+        marker-start="url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjxtYXJrZXIgaWQ9ImdyZWVuTWFya2VyT3JpZW50MCIgb3JpZW50PSIwIiBtYXJrZXJXaWR0aD0iMTAiIG1hcmtlckhlaWdodD0iMTAiIHJlZlg9IjUiIHJlZlk9IjUiPjxyZWN0IHdpZHRoPSIxMCIgaGVpZ2h0PSIxMCIgZmlsbD0iZ3JlZW4iLz48L21hcmtlcj48L3N2Zz4=#greenMarkerOrient0)"
+        marker-mid="url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjxtYXJrZXIgaWQ9ImdyZWVuTWFya2VyT3JpZW50MCIgb3JpZW50PSIwIiBtYXJrZXJXaWR0aD0iMTAiIG1hcmtlckhlaWdodD0iMTAiIHJlZlg9IjUiIHJlZlk9IjUiPjxyZWN0IHdpZHRoPSIxMCIgaGVpZ2h0PSIxMCIgZmlsbD0iZ3JlZW4iLz48L21hcmtlcj48L3N2Zz4=#greenMarkerOrient0)"
+        marker-end="url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjxtYXJrZXIgaWQ9ImdyZWVuTWFya2VyT3JpZW50MCIgb3JpZW50PSIwIiBtYXJrZXJXaWR0aD0iMTAiIG1hcmtlckhlaWdodD0iMTAiIHJlZlg9IjUiIHJlZlk9IjUiPjxyZWN0IHdpZHRoPSIxMCIgaGVpZ2h0PSIxMCIgZmlsbD0iZ3JlZW4iLz48L21hcmtlcj48L3N2Zz4=#greenMarkerOrient0)"/>
+</svg>

--- a/Source/WebCore/rendering/svg/legacy/SVGResources.cpp
+++ b/Source/WebCore/rendering/svg/legacy/SVGResources.cpp
@@ -316,6 +316,16 @@ std::unique_ptr<SVGResources> SVGResources::buildCachedResources(const RenderEle
 
     if (markerTags().contains(tagName) && style.hasMarkers()) {
         auto buildCachedMarkerResource = [&](const Style::SVGMarkerResource& markerResource, bool (SVGResources::*setMarker)(LegacyRenderSVGResourceMarker*)) {
+            if (auto markerURL = markerResource.tryURL()) {
+                if (auto externalDocument = externalSVGResourceDocument(document, markerURL->resolved)) {
+                    if (RefPtr resolvedDocument = *externalDocument) {
+                        auto markerId = markerURL->resolved.fragmentIdentifier().toAtomString();
+                        if (auto* marker = getRenderSVGResourceById<LegacyRenderSVGResourceMarker>(*resolvedDocument, markerId))
+                            (ensureResources(foundResources).*setMarker)(marker);
+                    }
+                    return;
+                }
+            }
             auto markerId = SVGURIReference::fragmentIdentifierFromIRIString(markerResource, document);
             if (auto* marker = getRenderSVGResourceById<LegacyRenderSVGResourceMarker>(treeScope, markerId))
                 (ensureResources(foundResources).*setMarker)(marker);

--- a/Source/WebCore/style/StylePendingResources.cpp
+++ b/Source/WebCore/style/StylePendingResources.cpp
@@ -45,6 +45,7 @@
 #include "StyleFilter.h"
 #include "StyleFilterReference.h"
 #include "StyleImage.h"
+#include "StyleSVGMarkerResource.h"
 
 namespace WebCore {
 namespace Style {
@@ -113,6 +114,12 @@ static void loadPendingExternalSVGPaint(Document& document, const Style::SVGPain
         loadExternalSVGResource(document, url->resolved);
 }
 
+static void loadPendingExternalSVGMarker(Document& document, const Style::SVGMarkerResource& marker)
+{
+    if (auto url = marker.tryURL())
+        loadExternalSVGResource(document, url->resolved);
+}
+
 void loadPendingResources(Style::ComputedStyle& style, Document& document, const Element* element)
 {
     for (auto& backgroundLayer : style.backgroundLayers().usedValues())
@@ -156,6 +163,10 @@ void loadPendingResources(Style::ComputedStyle& style, Document& document, const
     if (document.settings().svgExternalResourcesEnabled() && element && is<SVGElement>(*element)) {
         loadPendingExternalSVGPaint(document, style.fill());
         loadPendingExternalSVGPaint(document, style.stroke());
+
+        loadPendingExternalSVGMarker(document, style.markerStart());
+        loadPendingExternalSVGMarker(document, style.markerMid());
+        loadPendingExternalSVGMarker(document, style.markerEnd());
 
         if (style.filter().size() == 1) {
             WTF::switchOn(style.filter().first(),


### PR DESCRIPTION
#### 09684fda800063d733730312e56fdd98f5c9d04c
<pre>
Support external and data: URL marker references on SVG elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=44144">https://bugs.webkit.org/show_bug.cgi?id=44144</a>
<a href="https://rdar.apple.com/181437589">rdar://181437589</a>

Reviewed by Simon Fraser.

marker-start, marker-mid, and marker-end now resolve &lt;marker&gt; elements
referenced by an external file or a data: URL.

* LayoutTests/imported/w3c/web-platform-tests/svg/painting/reftests/marker-data-uri-reference-expected.svg: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/painting/reftests/marker-data-uri-reference.svg: Added.
* LayoutTests/TestExpectations:
* Source/WebCore/rendering/svg/legacy/SVGResources.cpp:
(WebCore::SVGResources::buildCachedResources):
* Source/WebCore/style/StylePendingResources.cpp:
(WebCore::Style::loadPendingExternalSVGMarker):
(WebCore::Style::loadPendingResources):

Canonical link: <a href="https://commits.webkit.org/317614@main">https://commits.webkit.org/317614@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/990c36aeca9b2d0932e74e2ca8e4eeb1de12db26

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175744 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49677 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43460 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185337 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/137925 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b2492e8b-ce3e-41b4-aace-80b3f9baea8f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/177607 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50969 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49359 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136841 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/137925 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2b04c1e3-6fbc-4037-ad63-c57bf1abf829) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178700 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40300 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157613 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117319 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/596fbaaa-bd6b-4882-9f48-ba01c2f8be4d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38942 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37320 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149361 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37105 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33806 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41370 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41526 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187758 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49344 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/157164 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145833 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39249 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50024 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33729 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145675 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40465 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122220 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/116045 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48531 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12083 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47933 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48165 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47990 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->