### PR TITLE
[webkitscmpy] Changes to tests shouldn't be considered "Gardening"

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/classify_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/classify_unittest.py
@@ -27,6 +27,24 @@ from webkitcorepy import OutputCapture, Terminal, testing
 from webkitscmpy import program, mocks, Commit, CommitClassifier, Contributor
 
 
+def repository_commit_classes():
+    path = os.path.dirname(os.path.abspath(__file__))
+    while path != os.path.dirname(path):
+        candidate = os.path.join(path, 'metadata', 'commit_classes.json')
+        if os.path.isfile(candidate):
+            return candidate
+        path = os.path.dirname(path)
+    return None
+
+
+class MockClassifyRepository(object):
+    def __init__(self, files_changed):
+        self._files_changed = files_changed
+
+    def files_changed(self, argument=None):
+        return self._files_changed
+
+
 class TestClassify(testing.PathTestCase):
     basepath = 'mock/repository'
 
@@ -173,3 +191,45 @@ class TestClassify(testing.PathTestCase):
                     'Reviewed by NOBODY (OOPS!)\n\n'
                     'cherry-pick: 2.3@branch-b (790725a6d79e)\n',
         )))
+
+    def classify_against_repository_classes(self, message, files_changed):
+        path = repository_commit_classes()
+        if not path:
+            self.skipTest('Cannot find metadata/commit_classes.json to classify against')
+        with open(path) as file:
+            classifier = CommitClassifier.load(file)
+        commit = Commit(
+            revision=10,
+            hash='898d20c0b1efc7b717173804676349f079df3b7e',
+            identifier='6@main',
+            timestamp=int(time.time()),
+            author=Contributor.Encoder().default(Contributor.from_scm_log('Author: jbedard@apple.com <jbedard@apple.com>')),
+            message=message,
+        )
+        klass = classifier.classify(commit, repository=MockClassifyRepository(files_changed))
+        return klass.name if klass else None
+
+    def test_gardening_excludes_test_source(self):
+        self.assertEqual('Tools', self.classify_against_repository_classes(
+            'NEW TEST(316388@main): [macOS iOS debug]: http/tests/ipc/foo.html is constant failure\n\nUnreviewed.\n',
+            [
+                'LayoutTests/http/tests/ipc/foo.html',
+                'LayoutTests/platform/ios/TestExpectations',
+                'LayoutTests/platform/mac-wk2/TestExpectations',
+            ],
+        ))
+
+    def test_gardening_expectations_only(self):
+        self.assertEqual('Gardening', self.classify_against_repository_classes(
+            'foo.html is a constant failure\n\nUnreviewed.\n',
+            ['LayoutTests/platform/ios/TestExpectations'],
+        ))
+
+    def test_gardening_rebaseline_only(self):
+        self.assertEqual('Gardening', self.classify_against_repository_classes(
+            'REBASELINE foo after 316378@main\n\nUnreviewed.\n',
+            [
+                'LayoutTests/fast/foo-expected.txt',
+                'LayoutTests/platform/mac/fast/foo-expected.png',
+            ],
+        ))

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/pull_request_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/pull_request_unittest.py
@@ -1472,6 +1472,47 @@ No pre-PR checks to run""")
             ],
         )
 
+    def test_github_bugzilla_gardening_with_test_fix(self):
+        with OutputCapture(level=logging.INFO) as captured, mocks.remote.GitHub(projects=bmocks.PROJECTS) as remote, bmocks.Bugzilla(
+            self.BUGZILLA.split('://')[-1],
+            projects=bmocks.PROJECTS, issues=bmocks.ISSUES,
+            environment=Environment(
+                BUGS_EXAMPLE_COM_USERNAME='tcontributor@example.com',
+                BUGS_EXAMPLE_COM_PASSWORD='password',
+            )), patch(
+                'webkitbugspy.Tracker._trackers', [bugzilla.Tracker(self.BUGZILLA)],
+        ), mocks.local.Git(
+            self.path, remote='https://{}'.format(remote.remote),
+            remotes=dict(fork='https://{}/Contributor/WebKit'.format(remote.hosts[0])),
+        ) as repo, mocks.local.Svn():
+
+            repo.commits['eng/pr-branch'] = [
+                repo.commits[repo.default_branch][-1],
+                Commit(
+                    hash='06de5d56554e693db72313f4ca1fb969c30b8ccb',
+                    branch='eng/pr-branch',
+                    author=dict(name='Tim Contributor', emails=['tcontributor@example.com']),
+                    identifier="5.1@eng/pr-branch",
+                    timestamp=int(time.time()),
+                    message='[GARDENING] Existing commit\nbugs.example.com/show_bug.cgi?id=1'
+                )
+            ]
+            repo.head = repo.commits['eng/pr-branch'][-1]
+            self.assertEqual(0, program.main(
+                args=('pull-request', '-v', '--no-history'),
+                path=self.path,
+                classifier=CommitClassifier([CommitClassifier.CommitClass(
+                    name='Gardening',
+                    headers=[{'value': 'GARDENING', 'ratio': 85}],
+                    paths=['LayoutTests/TestExpectations', 'LayoutTests/.+-expected(-mismatch)?\\.'],
+                )]),
+            ))
+
+            self.assertEqual(
+                Tracker.instance().issue(1).comments[-1].content,
+                'Pull request: https://github.example.com/WebKit/WebKit/pull/1',
+            )
+
     def test_github_branch_secondary_redacted(self):
         with OutputCapture(level=logging.INFO) as captured, mocks.remote.GitHub(projects=bmocks.PROJECTS) as remote, bmocks.Bugzilla(
             self.BUGZILLA.split('://')[-1],

--- a/metadata/commit_classes.json
+++ b/metadata/commit_classes.json
@@ -39,9 +39,11 @@
 			{"value": "unreviewed test gardening"}
 		],
 		"paths": [
-			"LayoutTests/",
-			"Tools/TestWebKitAPI",
-			"TestExpectations/apitests"
+			"LayoutTests/TestExpectations",
+			"LayoutTests/platform/.+/TestExpectations",
+			"LayoutTests/.+-expected(-mismatch)?\\.",
+			"TestExpectations/apitests",
+			"Tools/TestWebKitAPI/.+/TestExpectations"
 		]
 	},
 	{


### PR DESCRIPTION
#### b560bf8e54109b9e46d737bf1c4b0d90324f6401
<pre>
[webkitscmpy] Changes to tests shouldn&apos;t be considered &quot;Gardening&quot;
<a href="https://bugs.webkit.org/show_bug.cgi?id=319847">https://bugs.webkit.org/show_bug.cgi?id=319847</a>
<a href="https://rdar.apple.com/182469134">rdar://182469134</a>

Reviewed by Aakash Jain.

The &quot;Gardening&quot; commit class matched any change whose files were all located in LayoutTests,
so a PR that fixed test code would be classified as &quot;Gardening&quot;, resulting in git-webkit
commenting as much in the associated bugzilla. Beyond potential confusion, it could also result
in silently skipping bug assignment and reopening.

* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/classify_unittest.py:
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/pull_request_unittest.py:
* metadata/commit_classes.json: Narrow the Gardening paths so a gardening change may only
touch test expectations and baseline/result files, never a test driver. A change that edits
an actual test now falls through to the Tools class and is handled like any other pull request.
Pure skip and rebaseline changes continue to be classified as Gardening.

Canonical link: <a href="https://commits.webkit.org/317644@main">https://commits.webkit.org/317644@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ee8618266d90fc8cafcaa0db446e852c6ff4355d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175698 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49631 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/43414 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/185290 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/137876 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/177561 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50923 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49313 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/185290 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/137876 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178654 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/40252 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/43414 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/185290 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a321c411-2294-4d3a-8016-be08fb1245c9) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/175021 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/38894 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/37275 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/185290 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/43414 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/149313 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/43414 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33760 "Built successfully") | | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/41481 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187712 "Built successfully") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/175101 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49298 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/43414 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/145789 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/49978 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/43414 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/145629 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26726 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/49978 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115999 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48485 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/43414 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47887 "Built successfully") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/48119 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/47944 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->