### PR TITLE
[JSC] Avoid zero-filling and `gcSafeMemcpy` in `tryCreateObjectViaCloning`

### DIFF
--- a/JSTests/microbenchmarks/object-spread-small-clone.js
+++ b/JSTests/microbenchmarks/object-spread-small-clone.js
@@ -1,0 +1,10 @@
+(function() {
+    var obj = { a: 1, b: 2, c: 3, d: 4, e: 5 };
+    var acc = 0;
+
+    for (var i = 0; i < 1e6; i++)
+        acc += ({ ...obj }).a;
+
+    if (acc !== 1e6)
+        throw new Error("Bad assertion!");
+})();

--- a/Source/JavaScriptCore/runtime/JSObject.h
+++ b/Source/JavaScriptCore/runtime/JSObject.h
@@ -940,6 +940,7 @@ public:
 
     static JSFinalObject* create(VM&, Structure*);
     static JSFinalObject* createWithButterfly(VM&, Structure*, Butterfly*);
+    static JSFinalObject* createWithButterflyCopyingInlineStorage(VM&, Structure*, Butterfly*, const WriteBarrierBase<Unknown>* inlineStorageSource);
     inline static Structure* createStructure(VM&, JSGlobalObject*, JSValue, unsigned);
 
     static JSFinalObject* createDefaultEmptyObject(JSGlobalObject*);
@@ -956,6 +957,16 @@ private:
     {
         // We do not need to use gcSafeMemcpy since this object is not exposed yet.
         memset(inlineStorageUnsafe(), 0, inlineCapacity * sizeof(EncodedJSValue));
+    }
+
+    // Initializes the inline storage by copying from |inlineStorageSource| instead of zero-filling.
+    explicit JSFinalObject(VM& vm, Structure* structure, Butterfly* butterfly, size_t inlineCapacity, const WriteBarrierBase<Unknown>* inlineStorageSource)
+        : JSObjectWithButterfly(vm, structure, butterfly)
+    {
+        auto* destination = reinterpret_cast<EncodedJSValue*>(inlineStorageUnsafe());
+        auto* source = reinterpret_cast<const EncodedJSValue*>(inlineStorageSource);
+        for (size_t i = 0; i < inlineCapacity; ++i)
+            destination[i] = source[i];
     }
 
     explicit JSFinalObject(CreatingWellDefinedBuiltinCellTag, StructureID structureID)
@@ -984,6 +995,14 @@ inline JSFinalObject* JSFinalObject::createWithButterfly(VM& vm, Structure* stru
         NotNull,
         allocateCell<JSFinalObject>(vm, allocationSize(inlineCapacity))
     ) JSFinalObject(vm, structure, butterfly, inlineCapacity);
+    finalObject->finishCreation(vm);
+    return finalObject;
+}
+
+inline JSFinalObject* JSFinalObject::createWithButterflyCopyingInlineStorage(VM& vm, Structure* structure, Butterfly* butterfly, const WriteBarrierBase<Unknown>* inlineStorageSource)
+{
+    size_t inlineCapacity = structure->inlineCapacity();
+    JSFinalObject* finalObject = new (NotNull, allocateCell<JSFinalObject>(vm, allocationSize(inlineCapacity))) JSFinalObject(vm, structure, butterfly, inlineCapacity, inlineStorageSource);
     finalObject->finishCreation(vm);
     return finalObject;
 }

--- a/Source/JavaScriptCore/runtime/ObjectConstructorInlines.h
+++ b/Source/JavaScriptCore/runtime/ObjectConstructorInlines.h
@@ -270,21 +270,15 @@ ALWAYS_INLINE JSObject* tryCreateObjectViaCloning(VM& vm, JSGlobalObject* global
 
     dataLogLnIf(verbose, "Use fast cloning!");
 
+    unsigned propertyCapacity = source->butterfly() ? sourceStructure->outOfLineCapacity() : 0;
+    if (!propertyCapacity)
+        return JSFinalObject::createWithButterflyCopyingInlineStorage(vm, sourceStructure, nullptr, source->inlineStorage());
+
     DeferGC deferGC(vm);
-
-    unsigned propertyCapacity = sourceStructure->outOfLineCapacity();
-    Butterfly* newButterfly = nullptr;
-    if (propertyCapacity) {
-        newButterfly = Butterfly::createUninitialized(vm, nullptr, 0, propertyCapacity, /* hasIndexingHeader */ false, 0);
-        // memcpy is fine since newButterfly is not tied to any object yet.
-        memcpy(newButterfly->propertyStorage() - propertyCapacity, source->butterfly()->propertyStorage() - propertyCapacity, propertyCapacity * sizeof(EncodedJSValue));
-    }
-    JSFinalObject* target = JSFinalObject::createWithButterfly(vm, sourceStructure, newButterfly);
-    if (sourceStructure->inlineCapacity() > 0)
-        gcSafeMemcpy(target->inlineStorage(), source->inlineStorage(), sourceStructure->inlineCapacity() * sizeof(EncodedJSValue));
-    vm.writeBarrier(target);
-
-    return target;
+    Butterfly* newButterfly = Butterfly::createUninitialized(vm, nullptr, 0, propertyCapacity, /* hasIndexingHeader */ false, 0);
+    // memcpy is fine since newButterfly is not tied to any object yet.
+    memcpy(newButterfly->propertyStorage() - propertyCapacity, source->butterfly()->propertyStorage() - propertyCapacity, propertyCapacity * sizeof(EncodedJSValue));
+    return JSFinalObject::createWithButterflyCopyingInlineStorage(vm, sourceStructure, newButterfly, source->inlineStorage());
 }
 
 ALWAYS_INLINE bool objectAssignFast(JSGlobalObject* globalObject, JSFinalObject* target, JSObject* source, Vector<UniquedStringImpl*, 8>& properties, MarkedArgumentBuffer& values)


### PR DESCRIPTION
#### 8339909e6ce15eb0070e5ec79871bff7e7c76148
<pre>
[JSC] Avoid zero-filling and `gcSafeMemcpy` in `tryCreateObjectViaCloning`
<a href="https://bugs.webkit.org/show_bug.cgi?id=319850">https://bugs.webkit.org/show_bug.cgi?id=319850</a>

Reviewed by Yusuke Suzuki.

tryCreateObjectViaCloning, which implements the fast path of object spread `{ ...source }`,
was creating a JSFinalObject via createWithButterfly, which zero-fills the inline storage in
its constructor, and then copying source&apos;s inline storage over it with gcSafeMemcpy. Since the
zero-filled values are always overwritten by source&apos;s values, that memset is pure waste.

This patch adds a JSFinalObject constructor (and createWithButterflyCopyingInlineStorage)
which initializes the inline storage by copying from another object&apos;s inline storage instead
of zero-filling it. Because the new object is not exposed to anyone until this function
returns, the copy does not need to be gcSafeMemcpy either. Also, DeferGC and the out-of-line
capacity computation are now only performed when source actually has out-of-line properties.

                                             Baseline                  Patched

    object-spread-small-clone            11.7545+-0.1951     ^      9.9040+-0.2022        ^ definitely 1.1868x faster
    clone-objects-via-spread-first       17.8918+-0.1675           17.5364+-0.3234          might be 1.0203x faster
    clone-objects-via-spread             16.5543+-0.2060           16.3735+-0.1780          might be 1.0110x faster

Test: JSTests/microbenchmarks/object-spread-small-clone.js

* JSTests/microbenchmarks/object-spread-small-clone.js: Added.
* Source/JavaScriptCore/runtime/JSObject.h:
(JSC::JSFinalObject::createWithButterflyCopyingInlineStorage):
* Source/JavaScriptCore/runtime/ObjectConstructorInlines.h:
(JSC::tryCreateObjectViaCloning):

Canonical link: <a href="https://commits.webkit.org/317659@main">https://commits.webkit.org/317659@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0382ed63b825362b6c496b0910aafe3150f1d268

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175796 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49729 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43513 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185389 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/137979 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51021 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49411 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136898 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/137979 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178752 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40347 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157665 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117377 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38989 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37367 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/6174 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149408 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37157 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33858 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/37060 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41425 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41573 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187810 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49396 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145880 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39278 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50076 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33781 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145722 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40513 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122272 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/116098 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48583 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12136 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47985 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48217 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48042 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->