### PR TITLE
[JSC] DFG Object.defineProperty descriptor cell confusion (JIT code invalid cell dereference)

### DIFF
--- a/JSTests/stress/object-define-property-fields-merged-non-object-descriptor.js
+++ b/JSTests/stress/object-define-property-fields-merged-non-object-descriptor.js
@@ -1,0 +1,91 @@
+// Regression test for the DFG ObjectDefineProperty descriptor-field fold in
+// DFGConstantFoldingPhase. The fold reads the descriptor's structure via
+// AbstractValue::m_structure and then emits KnownCellUse GetByOffset loads,
+// converting the node into ObjectDefinePropertyFromFields.
+//
+// AbstractValue::m_structure only describes the *cell* portion of a value.
+// When a value merges an object literal (a concrete FinalObject structure)
+// with `undefined` on another path, the merged abstract value keeps the
+// object structure while its type becomes SpecFinalObject | SpecOther — i.e.
+// it is NOT proven to be an object. Emitting KnownCellUse loads (which perform
+// no speculation) on that value would dereference the `undefined` immediate as
+// a cell and crash.
+//
+// The fold must re-emit the ObjectUse speculation the original
+// ObjectDefineProperty node carried, so a non-object descriptor OSR-exits to
+// the runtime (which throws the spec TypeError) instead of crashing. This test
+// exercises exactly that merge: the descriptor is either a full data descriptor
+// or `undefined`. It must not crash; the undefined path must throw TypeError,
+// and the object path must define the property normally.
+
+function shouldBe(actual, expected, msg) {
+    if (actual !== expected)
+        throw new Error((msg || "") + " expected " + expected + " got " + actual);
+}
+
+function shouldThrow(fn, ctor, msg) {
+    let threw = false;
+    try {
+        fn();
+    } catch (e) {
+        threw = true;
+        if (!(e instanceof ctor))
+            throw new Error((msg || "") + " wrong error type: " + e);
+    }
+    if (!threw)
+        throw new Error((msg || "") + " expected throw");
+}
+
+// `descriptor` is a Phi merging a FinalObject literal and `undefined`.
+function defineWithMaybeDescriptor(target, useObject, v) {
+    const descriptor = useObject
+        ? { value: v, writable: true, enumerable: true, configurable: true }
+        : undefined;
+    Object.defineProperty(target, "p", descriptor);
+}
+noInline(defineWithMaybeDescriptor);
+
+for (let i = 0; i < testLoopCount; ++i) {
+    if ((i & 3) === 0) {
+        const o = {};
+        shouldThrow(() => defineWithMaybeDescriptor(o, false, i), TypeError, "undefined descriptor");
+        shouldBe("p" in o, false, "undefined descriptor did not define");
+    } else {
+        const o = {};
+        defineWithMaybeDescriptor(o, true, i);
+        shouldBe(o.p, i, "object descriptor value");
+        const d = Object.getOwnPropertyDescriptor(o, "p");
+        shouldBe(d.writable, true, "object descriptor writable");
+        shouldBe(d.enumerable, true, "object descriptor enumerable");
+        shouldBe(d.configurable, true, "object descriptor configurable");
+    }
+}
+
+// Reproduction shaped like the original report: the descriptor merge happens
+// deep inside a JSON.parse reviver so the crashing frame is reached through the
+// LLInt->baseline->DFG tier-up path.
+let tick = 0;
+
+function pressure(n) {
+    if ((n & 7) !== 0)
+        return;
+
+    let descriptor = (n % 3) === 0
+        ? { value: n, writable: true, enumerable: true, configurable: true }
+        : undefined;
+
+    Object.defineProperty(this, "pressure", descriptor);
+}
+
+function reviver(key, value) {
+    tick++;
+    pressure(tick);
+    return value;
+}
+
+for (let i = 0; i < testLoopCount; ++i) {
+    try {
+        JSON.parse("[0]", reviver);
+    } catch {
+    }
+}

--- a/Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp
@@ -1353,6 +1353,8 @@ private:
                 Edge keyEdge = node->child2();
                 Edge descriptorEdge = node->child3();
 
+                m_insertionSet.insertCheck(m_graph, indexInBlock, node);
+
                 std::array<Edge, Node::numberOfDescriptorSlots> slotEdges;
                 Node* butterfly = nullptr;
                 Node* emptyConstant = nullptr;


### PR DESCRIPTION
#### 10b3c7332780d0ebdd37868da4858fee93593cc4
<pre>
[JSC] DFG Object.defineProperty descriptor cell confusion (JIT code invalid cell dereference)
<a href="https://bugs.webkit.org/show_bug.cgi?id=318139">https://bugs.webkit.org/show_bug.cgi?id=318139</a>
<a href="https://rdar.apple.com/180958800">rdar://180958800</a>

Reviewed by Yijia Huang.

When constant-folding ObjectDefineProperty, we should emit checks
attached in the edges to ensure that these filters work. In this case,
descriptor&apos;s ObjectUse edge filter is missing.

Test: JSTests/stress/object-define-property-fields-merged-non-object-descriptor.js

* JSTests/stress/object-define-property-fields-merged-non-object-descriptor.js: Added.
(shouldBe):
(shouldThrow):
(defineWithMaybeDescriptor):
(pressure):
(reviver):
* Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp:
(JSC::DFG::ConstantFoldingPhase::foldConstants):

Canonical link: <a href="https://commits.webkit.org/317601@main">https://commits.webkit.org/317601@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0000d7acb3a6dcfde9b0021d01cf76c0cb083691

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175710 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49643 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43426 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185302 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/137888 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50935 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49325 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136819 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/137888 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e2bc7150-680f-44f8-8101-eb567f870eac) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178666 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40263 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157585 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117297 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0a5290c2-736e-4f8d-9229-24a3749c22fd) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38905 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37287 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/6094 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149324 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37077 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33772 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/36974 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41334 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/41493 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187724 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49310 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145804 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49990 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/33701 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145646 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26708 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40440 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122186 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/116011 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48497 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12055 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47899 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48131 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47956 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->