### PR TITLE
Widen IPAddressSpace to distinguish loopback from other local addresses

### DIFF
--- a/Source/WebCore/Modules/fetch/FetchRequest.cpp
+++ b/Source/WebCore/Modules/fetch/FetchRequest.cpp
@@ -140,8 +140,9 @@ static IPAddressSpace updateTargetAddressSpaceIfNeeded(IPAddressSpace currentAdd
     if (host.isEmpty())
         return currentAddressSpace;
 
-    if (WebCore::isLocalIPAddressSpace(url))
-        return IPAddressSpace::Local;
+    auto addressSpace = WebCore::determineIPAddressSpace(url);
+    if (addressSpace != IPAddressSpace::Public)
+        return addressSpace;
 
     if (host.endsWithIgnoringASCIICase(".local"_s))
         return IPAddressSpace::Local;

--- a/Source/WebCore/Modules/fetch/IPAddressSpace.cpp
+++ b/Source/WebCore/Modules/fetch/IPAddressSpace.cpp
@@ -36,27 +36,22 @@
 
 namespace WebCore {
 
-IPAddressSpace determineIPAddressSpace(const URL& url)
+static IPAddressSpace classifyHost(String host)
 {
-    // Defined in https://wicg.github.io/local-network-access/#ip-address-space-section
-    String host = url.host().toString();
-    host = makeStringByReplacingAll(host, '[', ""_s);
-    host = makeStringByReplacingAll(host, ']', ""_s);
-
     if (!URL::hostIsIPAddress(host))
         return IPAddressSpace::Public;
 
     // Handle IPv6 addresses (check for colon to distinguish from IPv4)
     if (host.contains(':')) {
-        // ::1/128 - IPv6 Local - loopback
+        // ::1/128 - IPv6 Loopback
         if (host == "::1")
-            return IPAddressSpace::Local;
+            return IPAddressSpace::Loopback;
 
-        // fc00::/7 - Unique Loopback - local
+        // fc00::/7 - Unique Local - local
         if (host.startsWith("fc"_s) || host.startsWith("fd"_s))
             return IPAddressSpace::Local;
 
-        // fe80::/10 - Link-Loopback Unicast - local
+        // fe80::/10 - Link-Local Unicast - local
         if (host.startsWith("fe8"_s) || host.startsWith("fe9"_s) || host.startsWith("fea"_s) || host.startsWith("feb"_s))
             return IPAddressSpace::Local;
         // ::ffff: - IPv4 Mapped IPv6 Addresses - format for parsing by IPv4 Algorithm.
@@ -104,9 +99,9 @@ IPAddressSpace determineIPAddressSpace(const URL& url)
 
         // Check IPv4 address blocks according to spec table:
 
-        // 127.0.0.0/8 - IPv4 Loopback - loopback
+        // 127.0.0.0/8 - IPv4 Loopback
         if (parts[0] == 127)
-            return IPAddressSpace::Local;
+            return IPAddressSpace::Loopback;
 
         // 10.0.0.0/8 - Local Use - local
         if (parts[0] == 10)
@@ -137,9 +132,14 @@ IPAddressSpace determineIPAddressSpace(const URL& url)
     return IPAddressSpace::Public;
 }
 
-bool isLocalIPAddressSpace(const URL& url)
+IPAddressSpace determineIPAddressSpace(const URL& url)
 {
-    return determineIPAddressSpace(url) == IPAddressSpace::Local;
+    // Defined in https://wicg.github.io/local-network-access/#ip-address-space-section
+    StringView host = url.host();
+    if (host.startsWith('[') && host.endsWith(']'))
+        host = host.substring(1, host.length() - 2);
+
+    return classifyHost(host.toString());
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/fetch/IPAddressSpace.h
+++ b/Source/WebCore/Modules/fetch/IPAddressSpace.h
@@ -27,14 +27,30 @@
 
 namespace WebCore {
 
-enum class IPAddressSpace : bool {
+enum class IPAddressSpace : uint8_t {
     Public,
-    Local
+    Local,
+    Loopback
 };
 
-WEBCORE_EXPORT IPAddressSpace determineIPAddressSpace(const WTF::URL&);
+constexpr uint8_t publicnessRank(IPAddressSpace space)
+{
+    switch (space) {
+    case IPAddressSpace::Loopback:
+        return 0;
+    case IPAddressSpace::Local:
+        return 1;
+    case IPAddressSpace::Public:
+        return 2;
+    }
+    return 2;
+}
 
-WEBCORE_EXPORT bool isLocalIPAddressSpace(IPAddressSpace);
-WEBCORE_EXPORT bool isLocalIPAddressSpace(const WTF::URL&);
+inline bool isLessPublicThan(IPAddressSpace a, IPAddressSpace b)
+{
+    return publicnessRank(a) < publicnessRank(b);
+}
+
+WEBCORE_EXPORT IPAddressSpace determineIPAddressSpace(const WTF::URL&);
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/fetch/IPAddressSpace.idl
+++ b/Source/WebCore/Modules/fetch/IPAddressSpace.idl
@@ -23,4 +23,6 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
  
- enum IPAddressSpace { "public", "local" };
+[
+    ExportMacro=WEBCORE_EXPORT
+] enum IPAddressSpace { "public", "local", "loopback" };

--- a/Source/WebCore/platform/network/ResourceRequestBase.h
+++ b/Source/WebCore/platform/network/ResourceRequestBase.h
@@ -41,7 +41,7 @@
 
 namespace WebCore {
 
-enum class IPAddressSpace : bool;
+enum class IPAddressSpace : uint8_t;
 
 enum class ResourceRequestCachePolicy : uint8_t {
     UseProtocolCachePolicy, // normal load, equivalent to fetch "default" cache mode.

--- a/Source/WebCore/platform/network/ResourceResponseBase.h
+++ b/Source/WebCore/platform/network/ResourceResponseBase.h
@@ -63,8 +63,8 @@ enum class WasPrivateRelayed : bool { No, Yes };
 static constexpr unsigned bitWidthOfWasPrivateRelayed = 1;
 static_assert(static_cast<unsigned>(WasPrivateRelayed::Yes) <= ((1U << bitWidthOfWasPrivateRelayed) - 1));
 
-static constexpr unsigned bitWidthOfIPAddressSpace = 1;
-static_assert(static_cast<unsigned>(IPAddressSpace::Local) <= ((1U << bitWidthOfIPAddressSpace) - 1));
+static constexpr unsigned bitWidthOfIPAddressSpace = 2;
+static_assert(((1U << bitWidthOfIPAddressSpace) - 1) >= static_cast<unsigned>(IPAddressSpace::Loopback));
 
 enum class ResourceResponseBaseType : uint8_t { Basic, Cors, Default, Error, Opaque, Opaqueredirect };
 enum class ResourceResponseBaseTainting : uint8_t { Basic, Cors, Opaque, Opaqueredirect };

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -32,7 +32,13 @@ enum class WebCore::ContactProperty : uint8_t {
 
 header: <WebCore/IDBResultData.h>
 
-enum class WebCore::IPAddressSpace : bool;
+header: <WebCore/IPAddressSpace.h>
+
+enum class WebCore::IPAddressSpace : uint8_t {
+    Public,
+    Local,
+    Loopback
+};
 
 enum class WebCore::NotificationEventType : bool;
 

--- a/Tools/TestWebKitAPI/Tests/WebCore/IPAddressSpaceTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/IPAddressSpaceTests.cpp
@@ -33,10 +33,10 @@ namespace TestWebKitAPI {
 // Test IPv4 loopback addresses (127.0.0.0/8)
 TEST(IPAddressSpace, IPv4Loopback)
 {
-    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://127.0.0.1/"_s)), WebCore::IPAddressSpace::Local);
-    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://127.0.0.2/"_s)), WebCore::IPAddressSpace::Local);
-    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://127.255.255.255/"_s)), WebCore::IPAddressSpace::Local);
-    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("https://127.1.2.3:8080/"_s)), WebCore::IPAddressSpace::Local);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://127.0.0.1/"_s)), WebCore::IPAddressSpace::Loopback);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://127.0.0.2/"_s)), WebCore::IPAddressSpace::Loopback);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://127.255.255.255/"_s)), WebCore::IPAddressSpace::Loopback);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("https://127.1.2.3:8080/"_s)), WebCore::IPAddressSpace::Loopback);
 }
 
 // Test IPv4 private address ranges
@@ -115,8 +115,8 @@ TEST(IPAddressSpace, IPv4PublicAddresses)
 // Test IPv6 loopback (::1/128)
 TEST(IPAddressSpace, IPv6Loopback)
 {
-    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://[::1]/"_s)), WebCore::IPAddressSpace::Local);
-    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("https://[::1]:8080/"_s)), WebCore::IPAddressSpace::Local);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://[::1]/"_s)), WebCore::IPAddressSpace::Loopback);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("https://[::1]:8080/"_s)), WebCore::IPAddressSpace::Loopback);
 }
 
 // Test IPv6 Unique Local addresses (fc00::/7)
@@ -150,7 +150,8 @@ TEST(IPAddressSpace, IPv6LinkLocal)
 TEST(IPAddressSpace, IPv6MappedIPv4DottedDecimal)
 {
     // Local IPv4 addresses mapped to IPv6
-    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://[::ffff:127.0.0.1]/"_s)), WebCore::IPAddressSpace::Local);
+    // ::ffff:127.0.0.1 maps to a loopback address, so it's classified as ::Loopback, not ::Local.
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://[::ffff:127.0.0.1]/"_s)), WebCore::IPAddressSpace::Loopback);
     EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://[::ffff:10.0.0.1]/"_s)), WebCore::IPAddressSpace::Local);
     EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://[::ffff:192.168.1.1]/"_s)), WebCore::IPAddressSpace::Local);
     EXPECT_EQ(WebCore::determineIPAddressSpace(URL("https://[::ffff:172.16.0.1]:443/"_s)), WebCore::IPAddressSpace::Local);
@@ -219,15 +220,13 @@ TEST(IPAddressSpace, EdgeCasesAndMalformed)
 // Test the utility functions
 TEST(IPAddressSpace, UtilityFunctions)
 {
-    // Test isLocalIPAddressSpace(const URL&)
-    EXPECT_TRUE(WebCore::isLocalIPAddressSpace(URL("http://127.0.0.1/"_s)));
-    EXPECT_TRUE(WebCore::isLocalIPAddressSpace(URL("http://192.168.1.1/"_s)));
-    EXPECT_TRUE(WebCore::isLocalIPAddressSpace(URL("http://[::1]/"_s)));
-    EXPECT_TRUE(WebCore::isLocalIPAddressSpace(URL("http://[fc00::1]/"_s)));
-
-    EXPECT_FALSE(WebCore::isLocalIPAddressSpace(URL("http://8.8.8.8/"_s)));
-    EXPECT_FALSE(WebCore::isLocalIPAddressSpace(URL("https://www.example.com/"_s)));
-    EXPECT_FALSE(WebCore::isLocalIPAddressSpace(URL("http://[2001:db8::1]/"_s)));
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://127.0.0.1/"_s)), WebCore::IPAddressSpace::Loopback);
+    EXPECT_TRUE(WebCore::isLessPublicThan(WebCore::IPAddressSpace::Loopback, WebCore::IPAddressSpace::Local));
+    EXPECT_TRUE(WebCore::isLessPublicThan(WebCore::IPAddressSpace::Loopback, WebCore::IPAddressSpace::Public));
+    EXPECT_TRUE(WebCore::isLessPublicThan(WebCore::IPAddressSpace::Local, WebCore::IPAddressSpace::Public));
+    EXPECT_FALSE(WebCore::isLessPublicThan(WebCore::IPAddressSpace::Public, WebCore::IPAddressSpace::Local));
+    EXPECT_FALSE(WebCore::isLessPublicThan(WebCore::IPAddressSpace::Local, WebCore::IPAddressSpace::Loopback));
+    EXPECT_FALSE(WebCore::isLessPublicThan(WebCore::IPAddressSpace::Public, WebCore::IPAddressSpace::Public));
 }
 
 // Test different URL schemes
@@ -254,9 +253,9 @@ TEST(IPAddressSpace, DifferentURLSchemes)
 TEST(IPAddressSpace, URLsWithPorts)
 {
     // Local addresses with various ports
-    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://127.0.0.1:8080/"_s)), WebCore::IPAddressSpace::Local);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://127.0.0.1:8080/"_s)), WebCore::IPAddressSpace::Loopback);
     EXPECT_EQ(WebCore::determineIPAddressSpace(URL("https://192.168.1.1:443/"_s)), WebCore::IPAddressSpace::Local);
-    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://[::1]:3000/"_s)), WebCore::IPAddressSpace::Local);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://[::1]:3000/"_s)), WebCore::IPAddressSpace::Loopback);
     EXPECT_EQ(WebCore::determineIPAddressSpace(URL("https://[fc00::1]:8443/"_s)), WebCore::IPAddressSpace::Local);
 
     // Public addresses with ports

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebViewServerTrustKVC.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebViewServerTrustKVC.mm
@@ -25,6 +25,7 @@
 
 #import "config.h"
 
+#import "Helpers/PlatformUtilities.h"
 #import "Helpers/Test.h"
 #import "Helpers/cocoa/HTTPServer.h"
 #import "Helpers/cocoa/TestNavigationDelegate.h"


### PR DESCRIPTION
#### dd2e06452ff034b6715f831b5320a08b207b6f9c
<pre>
Widen IPAddressSpace to distinguish loopback from other local addresses
<a href="https://bugs.webkit.org/show_bug.cgi?id=319853">https://bugs.webkit.org/show_bug.cgi?id=319853</a>
<a href="https://rdar.apple.com/182752197">rdar://182752197</a>

Reviewed by Alex Christensen.

Splits IPAddressSpace&apos;s Local value into Local and Loopback, so
127.0.0.0/8 and ::1 are distinguishable from other private address
space. This is prep work for the Local Network Access enforcement
path (meta bug 250607), which needs to treat loopback more
permissively than general local-network access.

Also removes isLocalIPAddressSpace(const URL&amp;), whose only call site
now needs the full three-way classification instead of a boolean, and
fixes an unrelated missing #import in WKWebViewServerTrustKVC.mm found
while working on this stack.

* Source/WebCore/Modules/fetch/FetchRequest.cpp:
(WebCore::updateTargetAddressSpaceIfNeeded):
* Source/WebCore/Modules/fetch/IPAddressSpace.cpp:
(WebCore::classifyHost):
(WebCore::determineIPAddressSpace):
* Source/WebCore/Modules/fetch/IPAddressSpace.h:
(WebCore::publicnessRank):
(WebCore::isLessPublicThan):
* Source/WebCore/Modules/fetch/IPAddressSpace.idl:
* Source/WebCore/platform/network/ResourceRequestBase.h:
* Source/WebCore/platform/network/ResourceResponseBase.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Tools/TestWebKitAPI/Tests/WebCore/IPAddressSpaceTests.cpp:
(TestWebKitAPI::TEST(IPAddressSpace, IPv4Loopback)):
(TestWebKitAPI::TEST(IPAddressSpace, IPv6Loopback)):
(TestWebKitAPI::TEST(IPAddressSpace, IPv6MappedIPv4DottedDecimal)):
(TestWebKitAPI::TEST(IPAddressSpace, UtilityFunctions)):
(TestWebKitAPI::TEST(IPAddressSpace, URLsWithPorts)):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebViewServerTrustKVC.mm:

Canonical link: <a href="https://commits.webkit.org/317664@main">https://commits.webkit.org/317664@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/58c914618b7bccc137b4016cf0246dbf8c062b29

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175926 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49859 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43643 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185519 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/138128 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/177789 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51151 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49541 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/137013 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/138128 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178882 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40468 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/157780 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/117492 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39110 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/37489 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149529 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37272 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33989 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41559 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/41695 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187940 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49526 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146001 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39281 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50206 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/33897 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145840 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40631 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/122402 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/116275 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48713 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12253 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48115 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48347 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48172 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->