### PR TITLE
[JSC][Temporal][Intl.Era] Implement intl-era-monthcode

### DIFF
--- a/JSTests/stress/intl-datetimeformat.js
+++ b/JSTests/stress/intl-datetimeformat.js
@@ -8,6 +8,15 @@ function shouldBeOneOf(actual, expectedArray) {
         throw new Error('bad value: ' + actual + ' expected values: ' + expectedArray);
 }
 
+const icuVersion = $vm.icuVersion();
+function shouldBeOneOfForICUVersion(minimumVersion, actual, expectedArray) {
+    if (icuVersion < minimumVersion)
+        return;
+
+    if (!expectedArray.some((value) => value === actual))
+        throw new Error('bad value: ' + actual + ' expected values: ' + expectedArray);
+}
+
 function shouldNotThrow(func) {
     func();
 }
@@ -305,7 +314,7 @@ shouldBe(Intl.DateTimeFormat('en-u-ca-ethiopic').resolvedOptions().calendar, 'et
 shouldBe(Intl.DateTimeFormat('ar-SA-u-ca-gregory').resolvedOptions().calendar, 'gregory');
 shouldBe(Intl.DateTimeFormat('en-u-ca-hebrew').resolvedOptions().calendar, 'hebrew');
 shouldBe(Intl.DateTimeFormat('en-u-ca-indian').resolvedOptions().calendar, 'indian');
-shouldBe(Intl.DateTimeFormat('en-u-ca-islamic').resolvedOptions().calendar, 'islamic');
+shouldBe(Intl.DateTimeFormat('en-u-ca-islamic').resolvedOptions().calendar, 'islamic-tbla');
 shouldBe(Intl.DateTimeFormat('en-u-ca-islamicc').resolvedOptions().calendar, 'islamic-civil');
 shouldBe(Intl.DateTimeFormat('en-u-ca-ISO8601').resolvedOptions().calendar, 'iso8601');
 shouldBe(Intl.DateTimeFormat('en-u-ca-japanese').resolvedOptions().calendar, 'japanese');
@@ -315,7 +324,7 @@ shouldBe(Intl.DateTimeFormat('en-u-ca-ethiopic-amete-alem').resolvedOptions().ca
 shouldBe(Intl.DateTimeFormat('en-u-ca-islamic-umalqura').resolvedOptions().calendar, 'islamic-umalqura');
 shouldBe(Intl.DateTimeFormat('en-u-ca-islamic-tbla').resolvedOptions().calendar, 'islamic-tbla');
 shouldBe(Intl.DateTimeFormat('en-u-ca-islamic-civil').resolvedOptions().calendar, 'islamic-civil');
-shouldBe(Intl.DateTimeFormat('en-u-ca-islamic-rgsa').resolvedOptions().calendar, 'islamic-rgsa');
+shouldBe(Intl.DateTimeFormat('en-u-ca-islamic-rgsa').resolvedOptions().calendar, 'gregory');
 
 // Calendar-sensitive format().
 shouldBe(Intl.DateTimeFormat('en-u-ca-buddhist', { timeZone: 'America/Los_Angeles' }).format(1451099872641), '12/25/2558 BE');
@@ -337,7 +346,89 @@ shouldBeOneOf(Intl.DateTimeFormat('en-u-ca-ethiopic-amete-alem', { timeZone: 'Am
 shouldBe(Intl.DateTimeFormat('en-u-ca-islamic-umalqura', { timeZone: 'America/Los_Angeles' }).format(1451099872641), '3/14/1437 AH');
 shouldBe(Intl.DateTimeFormat('en-u-ca-islamic-tbla', { timeZone: 'America/Los_Angeles' }).format(1451099872641), '3/14/1437 AH');
 shouldBe(Intl.DateTimeFormat('en-u-ca-islamic-civil', { timeZone: 'America/Los_Angeles' }).format(1451099872641), '3/13/1437 AH');
-shouldBe(Intl.DateTimeFormat('en-u-ca-islamic-rgsa', { timeZone: 'America/Los_Angeles' }).format(1451099872641), '3/14/1437 AH');
+shouldBe(Intl.DateTimeFormat('en-u-ca-islamic-rgsa', { timeZone: 'America/Los_Angeles' }).format(1451099872641), '12/25/2015');
+
+{
+    const opts = { year: 'numeric', era: 'long', timeZone: 'UTC' };
+    // islamic-civil/islamic-umalqura epoch is ISO 622-07-19T07:52:58.000Z; islamic-tbla's is one
+    // day earlier. A date in February 622 is before both real epochs but was previously missed by
+    // an overly early hardcoded threshold, so it incorrectly reported "Anno Hegirae".
+    shouldBeOneOf(Intl.DateTimeFormat('en-u-ca-islamic-civil', opts).format(Date.UTC(622, 1, 1)), ['Before Hijra 0', '0 Before Hijra']);
+    // ICU < 78 has no distinct long-form "Anno Hegirae" era string for islamic-civil in this locale and falls back to the short form ("AH").
+    shouldBeOneOfForICUVersion(78, Intl.DateTimeFormat('en-u-ca-islamic-civil', opts).format(Date.UTC(650, 0, 1)), ['Anno Hegirae 29', '29 Anno Hegirae']);
+    shouldBeOneOf(Intl.DateTimeFormat('en-u-ca-islamic-tbla', opts).format(Date.UTC(622, 1, 1)), ['Before Hijra 0', '0 Before Hijra']);
+    shouldBeOneOf(Intl.DateTimeFormat('en-u-ca-islamic-umalqura', opts).format(Date.UTC(622, 1, 1)), ['Before Hijra 0', '0 Before Hijra']);
+    // coptic AM epoch is ISO 284-08-29T07:52:58.000Z.
+    shouldBeOneOf(Intl.DateTimeFormat('en-u-ca-coptic', opts).format(Date.UTC(200, 0, 1)), ['Anno Martyrum 85', '85 Anno Martyrum']);
+    // ICU < 78 has no distinct long-form "Anno Martyrum" era string for coptic in this locale and falls back to the generic "ERA1" placeholder.
+    shouldBeOneOfForICUVersion(78, Intl.DateTimeFormat('en-u-ca-coptic', opts).format(Date.UTC(400, 0, 1)), ['Anno Martyrum 116', '116 Anno Martyrum']);
+}
+
+// The pre-Hijra/pre-AM era-text override must only apply when era was actually requested.
+{
+    const noEraOpts = { month: 'long', day: 'numeric', timeZone: 'UTC' };
+    const civilNoEra = Intl.DateTimeFormat('en-u-ca-islamic-civil', noEraOpts).format(Date.UTC(622, 1, 1));
+    if (civilNoEra.includes('Hijra'))
+        throw new Error(`islamic-civil pre-epoch format() with no era option must not include era text, got: ${civilNoEra}`);
+    const copticNoEra = Intl.DateTimeFormat('en-u-ca-coptic', noEraOpts).format(Date.UTC(200, 0, 1));
+    if (copticNoEra.includes('Martyrum'))
+        throw new Error(`coptic pre-epoch format() with no era option must not include era text, got: ${copticNoEra}`);
+}
+
+{
+    const pre = Date.UTC(622, 1, 1); // islamic-civil pre-Hijra
+    const base = { year: 'numeric', month: 'long', day: 'numeric', timeZone: 'UTC' };
+
+    // Width ignored: long/short/narrow all produce the same text.
+    for (const width of ['long', 'short', 'narrow']) {
+        const eraPart = Intl.DateTimeFormat('en-u-ca-islamic-civil', { ...base, era: width }).formatToParts(pre).find(p => p.type === 'era');
+        shouldBe(eraPart && eraPart.value, 'Before Hijra');
+    }
+
+    // Locale ignored: ja gets the English text glued onto Japanese-formatted output.
+    const ja = Intl.DateTimeFormat('ja-u-ca-islamic-civil', { ...base, era: 'long' }).format(pre);
+    if (!ja.includes('Before Hijra'))
+        throw new Error(`islamic-civil pre-epoch ja locale expected (incorrect) "Before Hijra", got: ${ja}`);
+
+    // Pattern position ignored: ja's real era position is first (see the post-epoch date, which
+    // ICU formats natively), but the override always appends last instead.
+    const postParts = Intl.DateTimeFormat('ja-u-ca-coptic', { ...base, era: 'long' }).formatToParts(Date.UTC(400, 0, 1)).map(p => p.type);
+    shouldBe(postParts[0], 'era');
+
+    // ICU4C-WORKAROUND: rdar://183226206 - below ICU 78, the coptic calendar emits a native
+    // era field even for pre-AM dates (ICU 78+ emits none there), so the override replaces
+    // that field in place instead of appending a new part. Only verifying current (78+)
+    // behavior here; not pinning down the old-ICU shape.
+    const preParts = Intl.DateTimeFormat('ja-u-ca-coptic', { ...base, era: 'long' }).formatToParts(Date.UTC(200, 0, 1)).map(p => p.type);
+    if (icuVersion >= 78)
+        shouldBe(preParts[preParts.length - 1], 'era');
+}
+
+// FIXME: rdar://182953351 (icu-issues/05) - formatRange/formatRangeToParts don't apply the
+// pre-Hijra/pre-AM override at all, unlike format()/formatToParts. Wait for ICU to select the
+// right era natively rather than threading this through more call sites; flip to `if (true)`
+// once fixed.
+if (false) {
+    const rangeOpts = { year: 'numeric', month: 'long', day: 'numeric', era: 'long', timeZone: 'UTC' };
+
+    const civilRange = Intl.DateTimeFormat('en-u-ca-islamic-civil', rangeOpts).formatRange(Date.UTC(622, 1, 1), Date.UTC(622, 1, 2));
+    if (civilRange.includes('Anno Hegirae') || !civilRange.includes('Before Hijra'))
+        throw new Error(`islamic-civil pre-epoch formatRange must say "Before Hijra", got: ${civilRange}`);
+
+    const civilPartsEra = Intl.DateTimeFormat('en-u-ca-islamic-civil', rangeOpts)
+        .formatRangeToParts(Date.UTC(622, 1, 1), Date.UTC(622, 1, 1))
+        .filter(p => p.type === 'era');
+    shouldBe(civilPartsEra.length, 1, "islamic-civil pre-epoch formatRangeToParts must include exactly one era part");
+    if (civilPartsEra.length)
+        shouldBe(civilPartsEra[0].value, 'Before Hijra', "islamic-civil pre-epoch formatRangeToParts era value (currently shows raw ICU text)");
+
+    const copticPartsEra = Intl.DateTimeFormat('en-u-ca-coptic', rangeOpts)
+        .formatRangeToParts(Date.UTC(200, 0, 1), Date.UTC(200, 0, 1))
+        .filter(p => p.type === 'era');
+    shouldBe(copticPartsEra.length, 1, "coptic pre-AM formatRangeToParts must include exactly one era part (currently emits none)");
+    if (copticPartsEra.length)
+        shouldBe(copticPartsEra[0].value, 'Anno Martyrum', "coptic pre-AM formatRangeToParts era value");
+}
 
 shouldBe(Intl.DateTimeFormat('en', { numberingSystem: 'gujr' }).resolvedOptions().numberingSystem, 'gujr');
 shouldBe(Intl.DateTimeFormat('en-u-nu-bogus').resolvedOptions().locale, 'en');

--- a/JSTests/stress/temporal-calendar-canonical-set.js
+++ b/JSTests/stress/temporal-calendar-canonical-set.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useTemporal=1", "--useIntlEraMonthcode=1")
+//@ requireOptions("--useTemporal=1")
 
 // Regression for proposal-intl-era-monthcode Phase 0.
 

--- a/JSTests/stress/temporal-calendar-icu-bridge-non-iso.js
+++ b/JSTests/stress/temporal-calendar-icu-bridge-non-iso.js
@@ -440,3 +440,19 @@ for (const [calendar, startFields, endFields, expectedMonths] of [
     shouldBe(reverse.toString(), `-P${expectedMonths}M`, `${calendar} wide reverse month difference`);
     shouldBe(start.until(end, {largestUnit:"years"}).toString(), "P500000Y", `${calendar} wide year difference`);
 }
+
+// Extreme .add({years}) that fits int32 but drives ucal_add(UCAL_EXTENDED_YEAR) far enough that
+// epochMs can exceed int64_t's range; must throw RangeError, not crash or produce a wrong date.
+for (const calendar of ["chinese", "dangi", "hebrew"]) {
+    const start = calendar === "hebrew"
+        ? Temporal.PlainDate.from({year:5760, monthCode:"M01", day:1, calendar})
+        : Temporal.PlainDate.from({year:2000, monthCode:"M01", day:1, calendar});
+    shouldThrow(() => start.add({years: 2147483637}), RangeError, `${calendar} add extreme years (just under INT32_MAX)`);
+    shouldThrow(() => start.add({years: 2147483647}), RangeError, `${calendar} add extreme years (exactly INT32_MAX)`);
+    shouldThrow(() => start.subtract({years: 2147483637}), RangeError, `${calendar} subtract extreme years`);
+}
+
+// Hebrew has no extreme-year ISO-fallback (unlike chinese/dangi), so a huge year reaches
+// construction directly.
+shouldThrow(() => Temporal.PlainDate.from({year: 2147483637, monthCode: "M01", day: 1, calendar: "hebrew"}), RangeError, "hebrew extreme positive year construction");
+shouldThrow(() => Temporal.PlainDate.from({year: -2147483637, monthCode: "M01", day: 1, calendar: "hebrew"}), RangeError, "hebrew extreme negative year construction");

--- a/JSTests/stress/temporal-era-aliases.js
+++ b/JSTests/stress/temporal-era-aliases.js
@@ -1,0 +1,41 @@
+//@ requireOptions("--useTemporal=1")
+
+function shouldBe(actual, expected, label) {
+    if (actual !== expected)
+        throw new Error(`${label}: expected ${expected}, got ${actual}`);
+}
+
+function shouldThrow(fn, label) {
+    let threw = false;
+    try { fn(); }
+    catch (e) { threw = e instanceof RangeError; }
+    shouldBe(threw, true, label);
+}
+
+// gregory/japanese: ad -> ce, bc -> bce (case-insensitive).
+{
+    const ad = Temporal.PlainDate.from({ calendar: "gregory", era: "ad", eraYear: 2024, year: 2024, month: 1, day: 1 });
+    shouldBe(ad.era, "ce", "gregory ad -> ce");
+    shouldBe(ad.eraYear, 2024, "gregory ad eraYear");
+    const bc = Temporal.PlainDate.from({ calendar: "gregory", era: "bc", eraYear: 44, year: -43, month: 3, day: 15 });
+    shouldBe(bc.era, "bce", "gregory bc -> bce");
+    shouldBe(bc.eraYear, 44, "gregory bc eraYear");
+    const jad = Temporal.PlainDate.from({ calendar: "japanese", era: "ad", eraYear: 1, month: 1, day: 1 });
+    shouldBe(jad.era, "ce", "japanese ad -> ce");
+    const upper = Temporal.PlainDate.from({ calendar: "gregory", era: "AD", eraYear: 1, year: 1, month: 1, day: 1 });
+    shouldBe(upper.era, "ce", "AD (upper) -> ce");
+}
+
+// Non-alias calendars still reject "ad"/"bc".
+for (const cal of ["ethiopic", "buddhist", "hebrew", "islamic-civil", "persian", "roc"]) {
+    shouldThrow(() => Temporal.PlainDate.from({ calendar: cal, era: "ad", eraYear: 1, month: 1, day: 1 }), `${cal} rejects ad`);
+    shouldThrow(() => Temporal.PlainDate.from({ calendar: cal, era: "bc", eraYear: 1, month: 1, day: 1 }), `${cal} rejects bc`);
+}
+
+// Canonical form still works.
+{
+    const ce = Temporal.PlainDate.from({ calendar: "gregory", era: "ce", eraYear: 2024, year: 2024, month: 1, day: 1 });
+    shouldBe(ce.era, "ce", "gregory ce -> ce");
+    const bce = Temporal.PlainDate.from({ calendar: "gregory", era: "bce", eraYear: 44, year: -43, month: 3, day: 15 });
+    shouldBe(bce.era, "bce", "gregory bce -> bce");
+}

--- a/JSTests/stress/temporal-era-boundaries.js
+++ b/JSTests/stress/temporal-era-boundaries.js
@@ -1,0 +1,58 @@
+//@ requireOptions("--useTemporal=1")
+
+function shouldBe(actual, expected, label) {
+    if (actual !== expected)
+        throw new Error(`${label}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+}
+
+function assertPD(d, year, month, day, era, eraYear, label) {
+    shouldBe(d.year, year, `${label} year`);
+    shouldBe(d.month, month, `${label} month`);
+    shouldBe(d.day, day, `${label} day`);
+    shouldBe(d.era, era, `${label} era`);
+    shouldBe(d.eraYear, eraYear, `${label} eraYear`);
+}
+
+// gregory / roc / islamic-civil / ethiopic: non-positive eraYear remaps to opposite era.
+{
+    const d = Temporal.PlainDate.from({ calendar: "gregory", era: "ce", eraYear: 0, monthCode: "M01", day: 1 });
+    assertPD(d, 0, 1, 1, "bce", 1, "gregory ce 0 -> bce 1");
+    const d2 = Temporal.PlainDate.from({ calendar: "gregory", era: "bce", eraYear: -1, monthCode: "M01", day: 1 });
+    assertPD(d2, 2, 1, 1, "ce", 2, "gregory bce -1 -> ce 2");
+    const d3 = Temporal.PlainDate.from({ calendar: "roc", era: "roc", eraYear: 0, monthCode: "M01", day: 1 });
+    assertPD(d3, 0, 1, 1, "broc", 1, "roc roc 0 -> broc 1");
+    const d4 = Temporal.PlainDate.from({ calendar: "islamic-civil", era: "ah", eraYear: 0, monthCode: "M01", day: 1 });
+    assertPD(d4, 0, 1, 1, "bh", 1, "islamic-civil ah 0 -> bh 1");
+    const d5 = Temporal.PlainDate.from({ calendar: "ethiopic", era: "am", eraYear: 0, monthCode: "M01", day: 1 });
+    assertPD(d5, 0, 1, 1, "aa", 5500, "ethiopic am 0 -> aa 5500");
+    const d6 = Temporal.PlainDate.from({ calendar: "ethiopic", era: "aa", eraYear: 0, monthCode: "M01", day: 1 });
+    assertPD(d6, -5500, 1, 1, "aa", 0, "ethiopic aa 0 (not remapped)");
+}
+
+// Single-era calendars: negative eraYear NOT remapped.
+for (const [cal, era] of [["buddhist","be"], ["coptic","am"], ["ethioaa","aa"], ["hebrew","am"], ["indian","shaka"], ["persian","ap"]]) {
+    for (const y of [-1, 0, 1]) {
+        const d = Temporal.PlainDate.from({ calendar: cal, era, eraYear: y, monthCode: "M01", day: 1 });
+        shouldBe(d.era, era, `${cal} ${era} ${y} era`);
+        shouldBe(d.eraYear, y, `${cal} ${era} ${y} eraYear`);
+    }
+}
+
+// Japanese dated era boundaries + pre-Gregorian meiji fallback.
+{
+    const d = Temporal.PlainDate.from({ calendar: "japanese", era: "reiwa", eraYear: 1, monthCode: "M04", day: 30 });
+    assertPD(d, 2019, 4, 30, "heisei", 31, "reiwa 1 before start -> heisei 31");
+    const d2 = Temporal.PlainDate.from({ calendar: "japanese", era: "heisei", eraYear: 31, monthCode: "M05", day: 1 });
+    assertPD(d2, 2019, 5, 1, "reiwa", 1, "heisei 31 on reiwa start -> reiwa 1");
+    const d3 = Temporal.PlainDate.from({ calendar: "japanese", era: "meiji", eraYear: 5, monthCode: "M12", day: 31 });
+    assertPD(d3, 1872, 12, 31, "ce", 1872, "meiji 5 (pre-1873) -> ce 1872");
+    const d4 = Temporal.PlainDate.from({ calendar: "japanese", era: "ce", eraYear: 1873, monthCode: "M01", day: 1 });
+    assertPD(d4, 1873, 1, 1, "meiji", 6, "ce 1873 -> meiji 6");
+}
+
+// Case-insensitive alias canonicalizes then remaps.
+{
+    const d = Temporal.PlainDate.from({ calendar: "gregory", era: "AD", eraYear: 0, monthCode: "M01", day: 1 });
+    assertPD(d, 0, 1, 1, "bce", 1, "AD 0 -> bce 1");
+}
+

--- a/JSTests/stress/temporal-extreme-proleptic.js
+++ b/JSTests/stress/temporal-extreme-proleptic.js
@@ -1,0 +1,39 @@
+//@ requireOptions("--useTemporal=1")
+
+function shouldBe(actual, expected, label) {
+    if (actual !== expected)
+        throw new Error(`${label}: expected ${expected}, got ${actual}`);
+}
+
+// Buddhist: BE = ISO + 543, both directions across the representable range.
+{
+    // Minimum ISO year -271821 → BE -271278.
+    const min = Temporal.PlainDate.from({ calendar: "buddhist", year: -271278, era: "be", eraYear: -271278, month: 4, monthCode: "M04", day: 19 });
+    shouldBe(min.year, -271278, "buddhist min year");
+    shouldBe(min.eraYear, -271278, "buddhist min eraYear");
+    shouldBe(min.era, "be", "buddhist min era");
+    // Maximum ISO year 275760 → BE 276303.
+    const max = Temporal.PlainDate.from({ calendar: "buddhist", year: 276303, era: "be", eraYear: 276303, month: 9, monthCode: "M09", day: 13 });
+    shouldBe(max.year, 276303, "buddhist max year");
+    shouldBe(max.eraYear, 276303, "buddhist max eraYear");
+}
+
+// ROC: ISO 1912 = ROC 1; era boundary at ISO 1912.
+{
+    const min = Temporal.PlainDate.from({ calendar: "roc", year: -273732, era: "broc", eraYear: 273733, month: 4, monthCode: "M04", day: 19 });
+    shouldBe(min.year, -273732, "roc min year");
+    shouldBe(min.eraYear, 273733, "roc min eraYear");
+    shouldBe(min.era, "broc", "roc min era");
+    const max = Temporal.PlainDate.from({ calendar: "roc", year: 273849, era: "roc", eraYear: 273849, month: 9, monthCode: "M09", day: 13 });
+    shouldBe(max.year, 273849, "roc max year");
+    shouldBe(max.eraYear, 273849, "roc max eraYear");
+    shouldBe(max.era, "roc", "roc max era");
+}
+
+// Japanese: pre-meiji reports ce/bce; ISO year direct.
+{
+    const bceExtreme = Temporal.PlainDate.from({ calendar: "japanese", year: -271821, era: "bce", eraYear: 271822, month: 4, monthCode: "M04", day: 19 });
+    shouldBe(bceExtreme.year, -271821, "japanese bce extreme year");
+    shouldBe(bceExtreme.eraYear, 271822, "japanese bce extreme eraYear");
+    shouldBe(bceExtreme.era, "bce", "japanese bce extreme era");
+}

--- a/JSTests/stress/temporal-hebrew-year0-kislev.js
+++ b/JSTests/stress/temporal-hebrew-year0-kislev.js
@@ -1,0 +1,106 @@
+//@ requireOptions("--useTemporal=1")
+
+function shouldBe(actual, expected, label) {
+    if (actual !== expected)
+        throw new Error(`${label}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+}
+
+const kislev30 = Temporal.PlainDate.from({calendar: "hebrew", year: 0, monthCode: "M03", day: 30});
+shouldBe(kislev30.day, 30, "y0 Kislev D30 .day");
+shouldBe(kislev30.monthCode, "M03", "y0 Kislev D30 .monthCode");
+shouldBe(kislev30.year, 0, "y0 Kislev D30 .year");
+
+// day <= daysInMonth is a Temporal invariant. Pre-fix: daysInMonth=29.
+shouldBe(kislev30.daysInMonth, 30, "y0 Kislev D30 .daysInMonth (pre-fix: 29)");
+if (!(kislev30.day <= kislev30.daysInMonth))
+    throw new Error("Invariant day <= daysInMonth violated");
+
+// y0 is Regular leap (384 days) per icu4x, not Deficient leap (383).
+const tishri1 = Temporal.PlainDate.from({calendar: "hebrew", year: 0, monthCode: "M01", day: 1});
+shouldBe(tishri1.daysInYear, 384, "y0 .daysInYear (pre-fix: 383)");
+shouldBe(tishri1.inLeapYear, true, "y0 .inLeapYear");
+shouldBe(tishri1.monthsInYear, 13, "y0 .monthsInYear");
+
+// PlainDateTime and PlainYearMonth share the accessor implementations.
+const pdt = Temporal.PlainDateTime.from({calendar: "hebrew", year: 0, monthCode: "M03", day: 30});
+shouldBe(pdt.daysInMonth, 30, "PDT y0 Kislev D30 .daysInMonth");
+shouldBe(pdt.daysInYear, 384, "PDT y0 .daysInYear");
+
+const pym = Temporal.PlainYearMonth.from({calendar: "hebrew", year: 0, monthCode: "M03"});
+shouldBe(pym.daysInMonth, 30, "PYM y0 Kislev .daysInMonth");
+shouldBe(pym.daysInYear, 384, "PYM y0 .daysInYear");
+
+// .add({months:1}) from Kislev D30 must land on Tevet (M04), not Shevat (M05).
+// Pre-fix: origMonthCode snapshot read ICU's "M04" (Tevet slot) and ucal_add advanced from
+// Tevet to Shevat, dropping a month.
+const plusOne = kislev30.add({months: 1});
+shouldBe(plusOne.monthCode, "M04", "y0 Kislev D30 + 1mo .monthCode (pre-fix: M05)");
+shouldBe(plusOne.year, 0, "y0 Kislev D30 + 1mo .year stays 0");
+// Tevet has 29 days per both ICU and icu4x; day 30 constrains to 29.
+shouldBe(plusOne.day, 29, "y0 Kislev D30 + 1mo .day (Tevet has 29)");
+
+// .add({years:1}) from Kislev D30 preserves monthCode M03 in the target year.
+const plusOneYear = kislev30.add({years: 1});
+shouldBe(plusOneYear.year, 1, "y0 Kislev D30 + 1y .year");
+shouldBe(plusOneYear.monthCode, "M03", "y0 Kislev D30 + 1y .monthCode (pre-fix: M04)");
+
+// .subtract({months:1}) from Kislev D30 = Cheshvan (M02).
+const minusOne = kislev30.subtract({months: 1});
+shouldBe(minusOne.monthCode, "M02", "y0 Kislev D30 - 1mo .monthCode");
+
+// Sanity: y0 M03 D29 (non-fabricated Kislev) is unaffected — normal ICU path.
+const kislev29 = Temporal.PlainDate.from({calendar: "hebrew", year: 0, monthCode: "M03", day: 29});
+shouldBe(kislev29.day, 29, "y0 Kislev D29 .day");
+shouldBe(kislev29.monthCode, "M03", "y0 Kislev D29 .monthCode");
+shouldBe(kislev29.add({months: 1}).monthCode, "M04", "y0 Kislev D29 + 1mo .monthCode");
+shouldBe(kislev29.add({months: 1}).day, 29, "y0 Kislev D29 + 1mo .day");
+
+// Sanity: post-y0 (year 1) Hebrew years are unaffected by the workaround.
+const y1kislev = Temporal.PlainDate.from({calendar: "hebrew", year: 1, monthCode: "M03", day: 1});
+shouldBe(y1kislev.daysInYear >= 353 && y1kislev.daysInYear <= 385, true, "y1 daysInYear in valid range");
+
+// Ordinal-month and monthCode input must agree on whether y0 Kislev day 30 exists: the maxDay
+// override is keyed on calendar position (year 0, Kislev), not on which field selected the month.
+{
+    const viaMonthCode = Temporal.PlainDate.from({calendar: "hebrew", year: 0, monthCode: "M03", day: 30});
+    const viaOrdinal = Temporal.PlainDate.from({calendar: "hebrew", year: 0, month: 3, day: 30}, {overflow: "constrain"});
+    shouldBe(viaOrdinal.day, viaMonthCode.day, "y0 ordinal month=3 day=30 must agree with monthCode M03 day=30");
+
+    let threw = false;
+    try {
+        Temporal.PlainDate.from({calendar: "hebrew", year: 0, month: 3, day: 30}, {overflow: "reject"});
+    } catch (e) {
+        threw = e instanceof RangeError;
+    }
+    shouldBe(threw, false, "y0 ordinal month=3 day=30 overflow:reject must not throw");
+}
+
+// FIXME: rdar://182958553 (icu-issues/01) - the Kislev D30 fabrication only relabels the single
+// Tevet D1 slot, so it doesn't shift the rest of the year. Wait for ICU's classification to
+// match icu4x rather than growing more relabeling logic; flip to `if (true)` once fixed.
+if (false) {
+    // The last day of the year must have dayOfYear === daysInYear.
+    {
+        const elul29 = Temporal.PlainDate.from({calendar: "hebrew", year: 0, monthCode: "M12", day: 29});
+        shouldBe(elul29.daysInYear, elul29.dayOfYear, "y0 last day (Elul 29): dayOfYear must equal daysInYear (currently 383 vs 384)");
+    }
+
+    // "Tevet D1" is currently unreachable: monthCode input collapses it to Kislev D30, and
+    // arithmetic (+1 day from Kislev D30) skips straight to Tevet D2.
+    {
+        const requestedTevet1 = Temporal.PlainDate.from({calendar: "hebrew", year: 0, monthCode: "M04", day: 1});
+        shouldBe(requestedTevet1.monthCode, "M04", "y0 requested Tevet D1 .monthCode (currently collapses to M03)");
+        shouldBe(requestedTevet1.day, 1, "y0 requested Tevet D1 .day (currently collapses to 30)");
+
+        const dayAfterKislev30 = kislev30.add({days: 1});
+        shouldBe(dayAfterKislev30.monthCode, "M04", "y0 Kislev D30 + 1 day .monthCode");
+        shouldBe(dayAfterKislev30.day, 1, "y0 Kislev D30 + 1 day .day (currently skips to 2)");
+    }
+
+    // PlainYearMonth and PlainDate must agree on Tevet's daysInMonth in y0.
+    {
+        const pymTevet = Temporal.PlainYearMonth.from({calendar: "hebrew", year: 0, monthCode: "M04"});
+        const pdTevet = Temporal.PlainDate.from({calendar: "hebrew", year: 0, monthCode: "M04", day: 15});
+        shouldBe(pymTevet.daysInMonth, pdTevet.daysInMonth, "y0 Tevet .daysInMonth must agree between PlainYearMonth (currently 30) and PlainDate (29)");
+    }
+}

--- a/JSTests/stress/temporal-lunisolar-and-wrappers.js
+++ b/JSTests/stress/temporal-lunisolar-and-wrappers.js
@@ -1,0 +1,92 @@
+//@ requireOptions("--useTemporal=1")
+
+function shouldBe(actual, expected, label) {
+    if (actual !== expected)
+        throw new Error(`${label}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+}
+
+const icuVersion = $vm.icuVersion();
+
+// dayOfYear returns calendar-native day (chinese year starts different day than ISO).
+{
+    const chinese1969 = Temporal.PlainDate.from({ year: 1969, month: 1, day: 1, calendar: "chinese" });
+    shouldBe(chinese1969.dayOfYear, 1, "chinese year 1969 M01 D01 -> dayOfYear=1");
+    const pdt = Temporal.PlainDateTime.from({ year: 1969, month: 1, day: 1, hour: 12, calendar: "chinese" });
+    shouldBe(pdt.dayOfYear, 1, "PDT chinese year 1969 M01 D01 -> dayOfYear=1");
+    const zdt = Temporal.ZonedDateTime.from({ year: 1969, month: 1, day: 1, hour: 12, timeZone: "UTC", calendar: "chinese" });
+    shouldBe(zdt.dayOfYear, 1, "ZDT chinese year 1969 M01 D01 -> dayOfYear=1");
+}
+
+// hebrew M13 and non-M05L leap month codes are invalid.
+for (const cal of ["hebrew"]) {
+    for (const mc of ["M13", "M01L", "M03L", "M06L", "M12L"]) {
+        let threw = false;
+        try { Temporal.PlainDate.from({ year: 5779, monthCode: mc, day: 1, calendar: cal }); }
+        catch (e) { threw = e instanceof RangeError; }
+        shouldBe(threw, true, `${cal} ${mc} -> RangeError`);
+    }
+    // M05L (Adar I) is valid in hebrew leap years.
+    const validAdarI = Temporal.PlainDate.from({ year: 5779, monthCode: "M05L", day: 1, calendar: "hebrew" });
+    shouldBe(validAdarI.monthCode, "M05L", "hebrew year 5779 M05L is valid");
+}
+
+// lunisolar leap-month year addition constrains monthCode to base month.
+{
+    // Chinese 1938 M07L D30. Chinese 1939 has no M07L, so +1y constrains to M07 D29 (M07 has 29 days in 1939).
+    const start = Temporal.PlainDate.from({ year: 1938, monthCode: "M07L", day: 30, calendar: "chinese" });
+    const plusOne = start.add(new Temporal.Duration(1));
+    shouldBe(plusOne.monthCode, "M07", "chinese M07L +1y constrains to M07 in non-leap year");
+    shouldBe(plusOne.day, 29, "chinese M07 D30 constrains to D29 (M07 chinese 1939 = 29 days)");
+}
+
+// lunisolar month/monthCode conflict check.
+{
+    // In chinese 2020 (has M04L), monthCode M05 is not at ordinal 12. Conflict.
+    let threw = false;
+    try { Temporal.PlainDate.from({ calendar: "chinese", year: 2020, monthCode: "M05", month: 12, day: 1 }); }
+    catch (e) { threw = e instanceof RangeError; }
+    shouldBe(threw, true, "chinese M05/month=12 conflict -> RangeError");
+    // Correct ordinal works. ICU < 78 places 2020's leap month after M06 instead of M04
+    // (verified wrong against icu4x's china_data.rs, which gives M04L; rdar://182753821),
+    // making M05 ordinal 5 there instead of 6, so the call below throws — skip entirely
+    // on affected ICU versions rather than just the assertion.
+    if (icuVersion >= 78) {
+        const ok = Temporal.PlainDate.from({ calendar: "chinese", year: 2020, monthCode: "M05", month: 6, day: 1 });
+        shouldBe(ok.monthCode, "M05", "chinese M05/month=6 accepted");
+    }
+}
+
+// PMD leap-month with year-from-options-bag falls back to reference year.
+{
+    // Chinese year 1651 has M01L (ICU4C). PMD should carry the reference year (1972), not 1651.
+    const pd = Temporal.PlainDate.from({ calendar: "chinese", year: 1651, monthCode: "M01L", day: 29 });
+    if (pd.monthCode === "M01L" && pd.day === 29) {
+        const pmd = Temporal.PlainMonthDay.from({ calendar: "chinese", year: 1651, monthCode: "M01L", day: 29 });
+        const pmdYear = Number(pmd.toString().split("-")[0]);
+        shouldBe(pmdYear, 1972, "PMD chinese M01L D29 uses reference year 1972");
+    }
+}
+
+// with() on hebrew year that doesn't have same leap distribution — monthCode preserved,
+// month adjusts to new year's ordinal.
+{
+    const start = new Temporal.PlainDate(2024, 8, 8, "hebrew"); // hebrew 5784
+    const changed = start.with({ year: 5783 });
+    shouldBe(changed.year, 5783, "hebrew with year=5783");
+    shouldBe(changed.monthCode, "M11", "hebrew monthCode M11 preserved");
+    // The ordinal adjusts to match the new year's leap-month layout.
+    shouldBe(typeof changed.month, "number", "month is numeric");
+}
+
+// REGRESSION: at extreme chinese/dangi years (beyond the ±10000 astronomical-reliability
+// threshold), construction clamps to a representable ISO date without throwing, but reading
+// any field back off the constructed object throws instead of returning the clamped values.
+for (const cal of ["chinese", "dangi"]) {
+    for (const year of [100000, -100000]) {
+        const pd = Temporal.PlainDate.from({ calendar: cal, year, month: 1, day: 1 });
+        shouldBe(typeof pd.year, "number", `${cal} year=${year} .year must not throw`);
+        shouldBe(typeof pd.month, "number", `${cal} year=${year} .month must not throw`);
+        shouldBe(typeof pd.day, "number", `${cal} year=${year} .day must not throw`);
+        shouldBe(typeof pd.monthCode, "string", `${cal} year=${year} .monthCode must not throw`);
+    }
+}

--- a/JSTests/stress/temporal-nonISO-arithmetic.js
+++ b/JSTests/stress/temporal-nonISO-arithmetic.js
@@ -1,0 +1,61 @@
+//@ requireOptions("--useTemporal=1")
+
+function shouldBe(actual, expected, label) {
+    if (actual !== expected)
+        throw new Error(`${label}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+}
+
+function assertPD(d, year, month, day, era, eraYear, label) {
+    shouldBe(d.year, year, `${label} year`);
+    shouldBe(d.month, month, `${label} month`);
+    shouldBe(d.day, day, `${label} day`);
+    shouldBe(d.era, era, `${label} era`);
+    shouldBe(d.eraYear, eraYear, `${label} eraYear`);
+}
+
+// Non-Gregorian-structured calendars: add-year preserves calendar month/day (not ISO month/day).
+{
+    // Coptic M02 always has 30 days; adding 1 year to M02 D29 stays D29.
+    const d = Temporal.PlainDate.from({ year: 1747, monthCode: "M02", day: 29, calendar: "coptic" });
+    assertPD(d.add(new Temporal.Duration(1)), 1748, 2, 29, "am", 1748, "coptic add 1y preserves M02 D29");
+    // Ethiopic same shape (13 months).
+    const e = Temporal.PlainDate.from({ year: 2016, monthCode: "M13", day: 5, calendar: "ethiopic" });
+    assertPD(e.add(new Temporal.Duration(1)), 2017, 13, 5, "am", 2017, "ethiopic add 1y preserves M13 D5");
+}
+
+// Islamic-civil add years/months preserves calendar frame.
+{
+    const d = Temporal.PlainDate.from({ year: 1443, monthCode: "M02", day: 29, calendar: "islamic-civil" });
+    const added = d.add(new Temporal.Duration(0, 1));
+    shouldBe(added.year, 1443, "islamic-civil add 1 month year");
+    shouldBe(added.month, 3, "islamic-civil add 1 month month");
+}
+
+// Persian: 30-day month (Mordad) + 1 year stays 30-day.
+{
+    const d = Temporal.PlainDate.from({ year: 1400, monthCode: "M05", day: 30, calendar: "persian" });
+    assertPD(d.add(new Temporal.Duration(1)), 1401, 5, 30, "ap", 1401, "persian add 1y preserves M05 D30");
+}
+
+// Gregorian-structured calendars (buddhist/roc/japanese) treat calendar year proleptically.
+{
+    // Buddhist BE 2125 M10 D04 = ISO 1582-10-04 (proleptic Gregorian, not Julian).
+    const d = Temporal.PlainDate.from({ year: 2125, monthCode: "M10", day: 4, calendar: "buddhist" });
+    assertPD(d.add(new Temporal.Duration(0, 0, 0, 3)), 2125, 10, 7, "be", 2125, "buddhist proleptic add 3 days");
+    // ROC year=-329 (BROC 330) = ISO 1582; same +3 days = day 7.
+    const r = Temporal.PlainDate.from({ year: -329, monthCode: "M10", day: 4, calendar: "roc" });
+    assertPD(r.add(new Temporal.Duration(0, 0, 0, 3)), -329, 10, 7, "broc", 330, "roc proleptic add 3 days");
+    // Japanese year=1582 = ISO 1582.
+    const j = Temporal.PlainDate.from({ year: 1582, monthCode: "M10", day: 4, calendar: "japanese" });
+    assertPD(j.add(new Temporal.Duration(0, 0, 0, 3)), 1582, 10, 7, "ce", 1582, "japanese proleptic add 3 days");
+}
+
+// until in non-Gregorian-structured calendar produces calendar-frame duration.
+{
+    const a = Temporal.PlainDate.from({ year: 1747, monthCode: "M02", day: 1, calendar: "coptic" });
+    const b = Temporal.PlainDate.from({ year: 1748, monthCode: "M02", day: 1, calendar: "coptic" });
+    const dur = a.until(b, { largestUnit: "years" });
+    shouldBe(dur.years, 1, "coptic until: years");
+    shouldBe(dur.months, 0, "coptic until: months");
+    shouldBe(dur.days, 0, "coptic until: days");
+}

--- a/JSTests/stress/temporal-nonISO-with.js
+++ b/JSTests/stress/temporal-nonISO-with.js
@@ -1,0 +1,46 @@
+//@ requireOptions("--useTemporal=1")
+
+function shouldBe(actual, expected, label) {
+    if (actual !== expected)
+        throw new Error(`${label}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+}
+
+// Buddhist: batched fields.year must be BE year (not Gregorian), else with() double-shifts.
+{
+    const d = Temporal.PlainDate.from({ year: 2543, monthCode: "M01", day: 1, calendar: "buddhist" });
+    shouldBe(d.year, 2543, "buddhist year");
+    const withDay = d.with({ day: 15 });
+    shouldBe(withDay.year, 2543, "buddhist with day preserves year");
+    shouldBe(withDay.eraYear, 2543, "buddhist with day preserves eraYear");
+    shouldBe(withDay.day, 15, "buddhist with day");
+}
+
+// ROC: with should preserve calendar year.
+{
+    const d = Temporal.PlainDate.from({ year: 113, monthCode: "M06", day: 15, calendar: "roc" });
+    shouldBe(d.year, 113, "roc year");
+    const withMonth = d.with({ month: 1 });
+    shouldBe(withMonth.year, 113, "roc with month preserves year");
+    shouldBe(withMonth.month, 1, "roc with month");
+}
+
+// Coptic: with a different day preserves M13 (13-month calendar).
+{
+    const d = Temporal.PlainDate.from({ year: 1741, monthCode: "M13", day: 3, calendar: "coptic" });
+    shouldBe(d.month, 13, "coptic M13");
+    const withDay = d.with({ day: 5 });
+    shouldBe(withDay.year, 1741, "coptic with day preserves year");
+    shouldBe(withDay.month, 13, "coptic with day preserves M13");
+    shouldBe(withDay.day, 5, "coptic with day");
+}
+
+// Islamic-civil: with year advances era correctly.
+{
+    const d = Temporal.PlainDate.from({ year: 1445, monthCode: "M06", day: 15, calendar: "islamic-civil" });
+    const withYear = d.with({ year: 1446 });
+    shouldBe(withYear.year, 1446, "islamic-civil with year");
+    shouldBe(withYear.month, 6, "islamic-civil with year preserves month");
+    shouldBe(withYear.day, 15, "islamic-civil with year preserves day");
+    shouldBe(withYear.era, "ah", "islamic-civil era");
+    shouldBe(withYear.eraYear, 1446, "islamic-civil eraYear");
+}

--- a/JSTests/stress/temporal-nonisoresolvefields-monthcode-validation.js
+++ b/JSTests/stress/temporal-nonisoresolvefields-monthcode-validation.js
@@ -1,0 +1,52 @@
+//@ requireOptions("--useTemporal=1")
+
+function shouldThrow(fn, ErrCtor, label) {
+    let threw;
+    try { fn(); } catch (e) { threw = e.constructor; }
+    if (threw !== ErrCtor)
+        throw new Error(`${label}: expected ${ErrCtor.name}, got ${threw ? threw.name : "no throw"}`);
+}
+
+// Hebrew: only M05L is valid.
+for (const mc of ["M01L", "M02L", "M03L", "M04L", "M06L", "M07L", "M08L", "M09L", "M10L", "M11L", "M12L"]) {
+    shouldThrow(() => Temporal.PlainDate.from({ calendar: "hebrew", year: 5784, monthCode: mc, day: 1 }),
+        RangeError, `hebrew PD ${mc}`);
+    shouldThrow(() => Temporal.PlainYearMonth.from({ calendar: "hebrew", year: 5784, monthCode: mc }),
+        RangeError, `hebrew PYM ${mc}`);
+    shouldThrow(() => Temporal.PlainMonthDay.from({ calendar: "hebrew", monthCode: mc, day: 1 }),
+        RangeError, `hebrew PMD ${mc}`);
+}
+
+// Chinese/Dangi: M01L..M12L only, no M13.
+for (const cal of ["chinese", "dangi"]) {
+    shouldThrow(() => Temporal.PlainDate.from({ calendar: cal, year: 2024, monthCode: "M13", day: 1 }),
+        RangeError, `${cal} M13`);
+    shouldThrow(() => Temporal.PlainDate.from({ calendar: cal, year: 2024, monthCode: "M13L", day: 1 }),
+        RangeError, `${cal} M13L`);
+}
+
+// Solar calendars: no leap monthCodes.
+for (const cal of ["gregory", "buddhist", "indian", "japanese", "persian", "roc"]) {
+    shouldThrow(() => Temporal.PlainDate.from({ calendar: cal, year: 2024, monthCode: "M05L", day: 1 }),
+        RangeError, `${cal} M05L`);
+}
+
+// Coptic/Ethiopic/Ethioaa: M13 valid; MnnL and M14+ invalid.
+for (const cal of ["coptic", "ethiopic", "ethioaa"]) {
+    Temporal.PlainDate.from({ calendar: cal, year: 1740, monthCode: "M13", day: 1 });
+    shouldThrow(() => Temporal.PlainDate.from({ calendar: cal, year: 1740, monthCode: "M14", day: 1 }),
+        RangeError, `${cal} M14`);
+    shouldThrow(() => Temporal.PlainDate.from({ calendar: cal, year: 1740, monthCode: "M05L", day: 1 }),
+        RangeError, `${cal} M05L`);
+    shouldThrow(() => Temporal.PlainDate.from({ calendar: cal, year: 1740, monthCode: "M13L", day: 1 }),
+        RangeError, `${cal} M13L`);
+}
+
+// Chinese 2020 (no M02L, ~skip-backward~ → M02, ordinal 2).
+Temporal.PlainDate.from({ calendar: "chinese", year: 2020, month: 2, monthCode: "M02L", day: 1 });
+shouldThrow(() => Temporal.PlainDate.from({ calendar: "chinese", year: 2020, month: 3, monthCode: "M02L", day: 1 }),
+    RangeError, "chinese 2020 M02L constrain->M02 vs m=3");
+// Hebrew 5783 (non-leap, ~skip-forward~ → M06, ordinal 6).
+Temporal.PlainDate.from({ calendar: "hebrew", year: 5783, month: 6, monthCode: "M05L", day: 1 });
+shouldThrow(() => Temporal.PlainDate.from({ calendar: "hebrew", year: 5783, month: 5, monthCode: "M05L", day: 1 }),
+    RangeError, "hebrew 5783 M05L constrain->M06 vs m=5");

--- a/JSTests/stress/temporal-resolvefields-error-ordering.js
+++ b/JSTests/stress/temporal-resolvefields-error-ordering.js
@@ -1,0 +1,51 @@
+//@ requireOptions("--useTemporal=1")
+
+function shouldThrow(fn, ErrCtor, label) {
+    let threw;
+    try { fn(); } catch (e) { threw = e.constructor; }
+    if (threw !== ErrCtor)
+        throw new Error(`${label}: expected ${ErrCtor.name}, got ${threw ? threw.name : "no throw"}`);
+}
+
+// PlainDate.from: TypeError before RangeError.
+{
+    shouldThrow(() => Temporal.PlainDate.from({ calendar: "gregory", monthCode: "M05", month: 6, day: 1 }),
+        TypeError, "PD gregory missing year -> TypeError before conflict");
+    shouldThrow(() => Temporal.PlainDate.from({ calendar: "gregory", year: 2020, day: 32 }),
+        TypeError, "PD gregory missing month -> TypeError");
+    shouldThrow(() => Temporal.PlainDate.from({ calendar: "gregory", year: 2020, monthCode: "M05", month: 6 }),
+        TypeError, "PD gregory missing day -> TypeError");
+    // era without eraYear -> TypeError.
+    shouldThrow(() => Temporal.PlainDate.from({ calendar: "gregory", era: "ce", monthCode: "M05", month: 6, day: 1 }),
+        TypeError, "PD gregory era without eraYear -> TypeError");
+    // Range check still fires after all types valid.
+    shouldThrow(() => Temporal.PlainDate.from({ calendar: "gregory", year: 2020, monthCode: "M05", month: 6, day: 1 }),
+        RangeError, "PD gregory month/monthCode conflict -> RangeError");
+}
+
+// PlainYearMonth.from: TypeError before RangeError.
+{
+    shouldThrow(() => Temporal.PlainYearMonth.from({ calendar: "gregory", monthCode: "M05", month: 6 }),
+        TypeError, "PYM gregory missing year -> TypeError");
+    shouldThrow(() => Temporal.PlainYearMonth.from({ calendar: "gregory", year: 2020 }),
+        TypeError, "PYM gregory missing month -> TypeError");
+    shouldThrow(() => Temporal.PlainYearMonth.from({ calendar: "gregory", year: 2020, monthCode: "M05", month: 6 }),
+        RangeError, "PYM gregory month/monthCode conflict -> RangeError");
+}
+
+// PlainMonthDay.from: month+monthCode requires year for calendar-year disambiguation.
+{
+    shouldThrow(() => Temporal.PlainMonthDay.from({ calendar: "gregory", monthCode: "M04", month: 5, day: 1 }),
+        TypeError, "PMD gregory month+monthCode without year -> TypeError");
+    shouldThrow(() => Temporal.PlainMonthDay.from({ calendar: "gregory", year: 2020, day: 15 }),
+        TypeError, "PMD gregory missing month/monthCode -> TypeError");
+}
+
+// ZonedDateTime.with: era without eraYear -> TypeError.
+{
+    const z = Temporal.ZonedDateTime.from({ calendar: "gregory", timeZone: "UTC", year: 2020, month: 5, day: 15, hour: 12 });
+    shouldThrow(() => z.with({ era: "ce", monthCode: "M05", month: 6 }),
+        TypeError, "ZDT.with era without eraYear -> TypeError");
+    shouldThrow(() => z.with({ monthCode: "M05", month: 6 }),
+        RangeError, "ZDT.with month/monthCode conflict -> RangeError");
+}

--- a/JSTests/test262/config.yaml
+++ b/JSTests/test262/config.yaml
@@ -4,7 +4,6 @@ flags:
   SharedArrayBuffer: useSharedArrayBuffer
   Atomics: useSharedArrayBuffer
   Temporal: useTemporal
-  Intl.Era-monthcode: useIntlEraMonthcode
   ShadowRealm: useShadowRealm
   json-parse-with-source: useJSONSourceTextAccess
   iterator-sequencing: useIteratorSequencing
@@ -17,7 +16,6 @@ skip:
     - FinalizationRegistry.prototype.cleanupSome
     - decorators
     - source-phase-imports
-    - Intl.Era-monthcode
     - await-dictionary
     - import-bytes
     - immutable-arraybuffer

--- a/Source/JavaScriptCore/API/tests/TemporalCoreTest.cpp
+++ b/Source/JavaScriptCore/API/tests/TemporalCoreTest.cpp
@@ -2705,90 +2705,98 @@ static void testCalendarFieldsFunctions()
     TCHECK_TRUE(!rDW6.has_value() && rDW6.error().kind == TemporalErrorKind::RangeError, "plainDateWith: inconsistent year+era+eraYear -> RangeError");
 }
 
-static void testCalendarDateFromFields()
+static void testNonISOCalendarDateToISO()
 {
     using MC = ParsedMonthCode;
     auto id = calendarIDFromString;
 
-    // --- Non-lunisolar: year + month + day ---
-    // Gregory year->ISO
-    auto r = calendarDateFromFields(id("gregory"_s), 2024, 3, 15, std::nullopt, std::nullopt, std::nullopt, TemporalOverflow::Reject);
+    auto fromEra = [&](CalendarID calendarId, StringView era, int32_t eraYear, uint8_t month, uint8_t day, std::optional<MC> monthCode, TemporalOverflow overflow) {
+        CalendarFieldsIn fields;
+        fields.era = era.toString();
+        fields.eraYear = eraYear;
+        fields.month = month;
+        fields.day = day;
+        fields.monthCode = monthCode;
+        return dateFromFields(calendarId, fields, overflow);
+    };
+
+    // --- Non-lunisolar: year + month + day (direct call) ---
+    auto r = nonISOCalendarDateToISO(id("gregory"_s), 2024, 3, 15, std::nullopt, TemporalOverflow::Reject);
     TCHECK_TRUE(r.has_value() && r->year() == 2024 && r->month() == 3 && r->day() == 15, "gregory: year+month+day");
 
-    // --- Era + eraYear ---
-    // Gregory ce era — year=nullopt: no user-provided year, consistency check skipped
-    auto rEra = calendarDateFromFields(id("gregory"_s), std::nullopt, 3, 15, StringView("ce"_s), 2024, std::nullopt, TemporalOverflow::Reject);
-    TCHECK_TRUE(rEra.has_value() && rEra->year() == 2024 && rEra->month() == 3 && rEra->day() == 15, "gregory: ce+eraYear");
+    // --- Era + eraYear (via dateFromFields — nonISOResolveFields collapses era into year) ---
+    auto rEra = fromEra(id("gregory"_s), "ce"_s, 2024, 3, 15, std::nullopt, TemporalOverflow::Reject);
+    TCHECK_TRUE(rEra.has_value() && rEra->isoDate.year() == 2024 && rEra->isoDate.month() == 3 && rEra->isoDate.day() == 15, "gregory: ce+eraYear");
 
-    // Gregory bce era: eraYear 1 = ISO year 0 — year=nullopt (user didn't provide year)
-    auto rBce = calendarDateFromFields(id("gregory"_s), std::nullopt, 1, 1, StringView("bce"_s), 1, std::nullopt, TemporalOverflow::Reject);
-    TCHECK_TRUE(rBce.has_value() && !rBce->year(), "gregory: bce eraYear 1 = ISO 0");
+    // Gregory bce era: eraYear 1 = ISO year 0.
+    auto rBce = fromEra(id("gregory"_s), "bce"_s, 1, 1, 1, std::nullopt, TemporalOverflow::Reject);
+    TCHECK_TRUE(rBce.has_value() && !rBce->isoDate.year(), "gregory: bce eraYear 1 = ISO 0");
 
-    // Japanese: modern era (reiwa year 6 = 2024) — year=nullopt
-    auto rJp = calendarDateFromFields(id("japanese"_s), std::nullopt, 1, 1, StringView("reiwa"_s), 6, std::nullopt, TemporalOverflow::Reject);
-    TCHECK_TRUE(rJp.has_value() && rJp->year() == 2024, "japanese: reiwa 6 = 2024");
+    // Japanese: modern era (reiwa year 6 = 2024).
+    auto rJp = fromEra(id("japanese"_s), "reiwa"_s, 6, 1, 1, std::nullopt, TemporalOverflow::Reject);
+    TCHECK_TRUE(rJp.has_value() && rJp->isoDate.year() == 2024, "japanese: reiwa 6 = 2024");
 
-    // Japanese: pre-1868 "ce" era bypasses ICU — year=nullopt
-    auto rJpCe = calendarDateFromFields(id("japanese"_s), std::nullopt, 6, 15, StringView("ce"_s), 1600, std::nullopt, TemporalOverflow::Reject);
-    TCHECK_TRUE(rJpCe.has_value() && rJpCe->year() == 1600 && rJpCe->month() == 6 && rJpCe->day() == 15, "japanese: ce 1600 bypass");
+    // Japanese: pre-1868 "ce" era bypasses ICU.
+    auto rJpCe = fromEra(id("japanese"_s), "ce"_s, 1600, 6, 15, std::nullopt, TemporalOverflow::Reject);
+    TCHECK_TRUE(rJpCe.has_value() && rJpCe->isoDate.year() == 1600 && rJpCe->isoDate.month() == 6 && rJpCe->isoDate.day() == 15, "japanese: ce 1600 bypass");
 
-    // ROC: positive year (roc era)
-    auto rRoc = calendarDateFromFields(id("roc"_s), 113, 1, 1, std::nullopt, std::nullopt, std::nullopt, TemporalOverflow::Reject);
+    // ROC: positive year (roc era).
+    auto rRoc = nonISOCalendarDateToISO(id("roc"_s), 113, 1, 1, std::nullopt, TemporalOverflow::Reject);
     TCHECK_TRUE(rRoc.has_value() && rRoc->year() == 2024, "roc: year 113 = 2024");
 
-    // ROC: year 0 -> broc era (ISO 1911)
-    auto rRocBroc = calendarDateFromFields(id("roc"_s), 0, 1, 1, std::nullopt, std::nullopt, std::nullopt, TemporalOverflow::Reject);
+    // ROC: year 0 -> broc era (ISO 1911).
+    auto rRocBroc = nonISOCalendarDateToISO(id("roc"_s), 0, 1, 1, std::nullopt, TemporalOverflow::Reject);
     TCHECK_TRUE(rRocBroc.has_value() && rRocBroc->year() == 1911, "roc: year 0 = ISO 1911");
 
     // --- Month code: non-lunisolar ---
-    // Gregory M03 = March
-    auto rMc = calendarDateFromFields(id("gregory"_s), 2024, 0, 15, std::nullopt, std::nullopt, MC { 3, false }, TemporalOverflow::Reject);
+    // Gregory M03 = March.
+    auto rMc = nonISOCalendarDateToISO(id("gregory"_s), 2024, 0, 15, MC { 3, false }, TemporalOverflow::Reject);
     TCHECK_TRUE(rMc.has_value() && rMc->month() == 3 && rMc->day() == 15, "gregory: monthCode M03");
 
     // --- Month code: Hebrew leap month ---
-    // Hebrew 5784 is a leap year; M05L = Adar I
-    auto rHebLeap = calendarDateFromFields(id("hebrew"_s), 5784, 0, 1, std::nullopt, std::nullopt, MC { 5, true }, TemporalOverflow::Reject);
+    // Hebrew 5784 is a leap year; M05L = Adar I.
+    auto rHebLeap = nonISOCalendarDateToISO(id("hebrew"_s), 5784, 0, 1, MC { 5, true }, TemporalOverflow::Reject);
     TCHECK_TRUE(rHebLeap.has_value(), "hebrew: M05L in leap year 5784");
 
-    // Hebrew 5783 is NOT a leap year; M05L constrain -> same month
-    auto rHebConstrain = calendarDateFromFields(id("hebrew"_s), 5783, 0, 1, std::nullopt, std::nullopt, MC { 5, true }, TemporalOverflow::Constrain);
+    // Hebrew 5783 is NOT a leap year; M05L constrain -> same month.
+    auto rHebConstrain = nonISOCalendarDateToISO(id("hebrew"_s), 5783, 0, 1, MC { 5, true }, TemporalOverflow::Constrain);
     TCHECK_TRUE(rHebConstrain.has_value(), "hebrew: M05L constrain in non-leap year 5783");
 
-    // Hebrew 5783 non-leap + M05L reject -> error
-    auto rHebReject = calendarDateFromFields(id("hebrew"_s), 5783, 0, 1, std::nullopt, std::nullopt, MC { 5, true }, TemporalOverflow::Reject);
+    // Hebrew 5783 non-leap + M05L reject -> error.
+    auto rHebReject = nonISOCalendarDateToISO(id("hebrew"_s), 5783, 0, 1, MC { 5, true }, TemporalOverflow::Reject);
     TCHECK_TRUE(!rHebReject.has_value(), "hebrew: M05L reject in non-leap year");
 
     // --- Overflow: constrain ---
-    // Gregory: day 32 in January -> day 31
-    auto rConstrain = calendarDateFromFields(id("gregory"_s), 2024, 1, 32, std::nullopt, std::nullopt, std::nullopt, TemporalOverflow::Constrain);
+    // Gregory: day 32 in January -> day 31.
+    auto rConstrain = nonISOCalendarDateToISO(id("gregory"_s), 2024, 1, 32, std::nullopt, TemporalOverflow::Constrain);
     TCHECK_TRUE(rConstrain.has_value() && rConstrain->day() == 31, "gregory: day 32 constrain -> 31");
 
-    // Gregory: day 32 in January reject -> error
-    auto rReject = calendarDateFromFields(id("gregory"_s), 2024, 1, 32, std::nullopt, std::nullopt, std::nullopt, TemporalOverflow::Reject);
+    // Gregory: day 32 in January reject -> error.
+    auto rReject = nonISOCalendarDateToISO(id("gregory"_s), 2024, 1, 32, std::nullopt, TemporalOverflow::Reject);
     TCHECK_TRUE(!rReject.has_value(), "gregory: day 32 reject -> error");
 
-    // --- Invalid era ---
-    auto rBadEra = calendarDateFromFields(id("gregory"_s), 0, 1, 1, StringView("invalid"_s), 2024, std::nullopt, TemporalOverflow::Reject);
-    TCHECK_TRUE(!rBadEra.has_value(), "gregory: invalid era -> error");
+    // --- Invalid era (via dateFromFields — era validity is enforced in nonISOResolveFields) ---
+    auto rBadEra = fromEra(id("gregory"_s), "invalid"_s, 2024, 1, 1, std::nullopt, TemporalOverflow::Reject);
+    TCHECK_TRUE(!rBadEra.has_value() && rBadEra.error().kind == TemporalErrorKind::RangeError, "gregory: invalid era -> RangeError");
 
     // Buddhist: user's `year` is BE (= Gregorian + 543).
-    auto rBud = calendarDateFromFields(id("buddhist"_s), 2567, 1, 1, std::nullopt, std::nullopt, std::nullopt, TemporalOverflow::Reject);
+    auto rBud = nonISOCalendarDateToISO(id("buddhist"_s), 2567, 1, 1, std::nullopt, TemporalOverflow::Reject);
     TCHECK_TRUE(rBud.has_value() && rBud->year() == 2024, "buddhist: BE 2567 -> ISO 2024");
-    auto rBudEra = calendarDateFromFields(id("buddhist"_s), std::nullopt, 1, 1, StringView("be"_s), 2567, std::nullopt, TemporalOverflow::Reject);
-    TCHECK_TRUE(rBudEra.has_value() && rBudEra->year() == 2024, "buddhist: era be, eraYear=2567 -> ISO 2024");
+    auto rBudEra = fromEra(id("buddhist"_s), "be"_s, 2567, 1, 1, std::nullopt, TemporalOverflow::Reject);
+    TCHECK_TRUE(rBudEra.has_value() && rBudEra->isoDate.year() == 2024, "buddhist: era be, eraYear=2567 -> ISO 2024");
     // Reference-year path: BE 2515 = Gregorian 1972 leap; Feb 29 must succeed.
-    auto rBudRef = calendarDateFromFields(id("buddhist"_s), 2515, 2, 29, std::nullopt, std::nullopt, std::nullopt, TemporalOverflow::Reject);
+    auto rBudRef = nonISOCalendarDateToISO(id("buddhist"_s), 2515, 2, 29, std::nullopt, TemporalOverflow::Reject);
     TCHECK_TRUE(rBudRef.has_value() && rBudRef->year() == 1972 && rBudRef->day() == 29u, "buddhist: BE 2515 Feb 29 -> ISO 1972-02-29");
 
-    // Coptic am era: era 1 (AM), not era 0. AM 1740 M01 D01 = ISO 2023-09-12.
-    auto rCop = calendarDateFromFields(id("coptic"_s), std::nullopt, 1, 1, StringView("am"_s), 1740, std::nullopt, TemporalOverflow::Reject);
-    TCHECK_TRUE(rCop.has_value() && rCop->year() == 2023 && rCop->month() == 9u && rCop->day() == 12u, "coptic: am 1740 M01 D01 -> ISO 2023-09-12");
-    auto rCopY = calendarDateFromFields(id("coptic"_s), 1740, 1, 1, std::nullopt, std::nullopt, std::nullopt, TemporalOverflow::Reject);
+    // Coptic am era: AM 1740 M01 D01 = ISO 2023-09-12.
+    auto rCop = fromEra(id("coptic"_s), "am"_s, 1740, 1, 1, std::nullopt, TemporalOverflow::Reject);
+    TCHECK_TRUE(rCop.has_value() && rCop->isoDate.year() == 2023 && rCop->isoDate.month() == 9u && rCop->isoDate.day() == 12u, "coptic: am 1740 M01 D01 -> ISO 2023-09-12");
+    auto rCopY = nonISOCalendarDateToISO(id("coptic"_s), 1740, 1, 1, std::nullopt, TemporalOverflow::Reject);
     TCHECK_TRUE(rCopY.has_value() && rCopY->year() == 2023, "coptic: year=1740 -> ISO 2023 (era-free)");
 
     // Ethiopic am era: same fix as Coptic. AM 2016 M01 D01 = ISO 2023-09-12.
-    auto rEth = calendarDateFromFields(id("ethiopic"_s), std::nullopt, 1, 1, StringView("am"_s), 2016, std::nullopt, TemporalOverflow::Reject);
-    TCHECK_TRUE(rEth.has_value() && rEth->year() == 2023, "ethiopic: am 2016 -> ISO 2023");
+    auto rEth = fromEra(id("ethiopic"_s), "am"_s, 2016, 1, 1, std::nullopt, TemporalOverflow::Reject);
+    TCHECK_TRUE(rEth.has_value() && rEth->isoDate.year() == 2023, "ethiopic: am 2016 -> ISO 2023");
 }
 
 static void testIsBuiltinCalendar()
@@ -2885,7 +2893,7 @@ static void testCalendarICUNonISO()
     TCHECK_EQ(*rPY, 1399, "persian: Nowruz 1399");
 
     // Islamic calendar: 2020-04-24 = 1 Ramadan 1441
-    auto rIM = calendarMonth(calendarIDFromString("islamic"_s), { 2020, 4, 24 });
+    auto rIM = calendarMonth(calendarIDFromString("islamic-tbla"_s), { 2020, 4, 24 });
     TCHECK_TRUE(rIM.has_value(), "islamic: month ok");
     TCHECK_EQ(*rIM, 9u, "islamic: Ramadan = month 9");
 
@@ -3834,7 +3842,7 @@ static void runStressTests()
     testCalendarInLeapYearISO(); // ISO leap year
     testCalendarISO8601Fields(); // ISO field accessors
     testCalendarICUNonISO(); // Non-ISO calendars (hebrew, chinese, japanese, persian)
-    testCalendarDateFromFields(); // calendarDateFromFields: era, monthCode, overflow, ROC, Japanese, Buddhist, Coptic, Ethiopic
+    testNonISOCalendarDateToISO(); // nonISOCalendarDateToISO: era, monthCode, overflow, ROC, Japanese, Buddhist, Coptic, Ethiopic
     testIsBuiltinCalendar(); // Canonical Temporal calendar set + legacy aliases
     testCalendarFieldsFunctions(); // yearMonthFromFields, monthDayFromFields, differenceYearMonth, plainYearMonthAdd, etc.
 

--- a/Source/JavaScriptCore/runtime/IntlDateTimeFormat.cpp
+++ b/Source/JavaScriptCore/runtime/IntlDateTimeFormat.cpp
@@ -819,13 +819,15 @@ void IntlDateTimeFormat::initializeDateTimeFormat(JSGlobalObject* globalObject, 
             // Handling "islamicc" candidate for backward compatibility.
             if (calendar == "islamicc"_s)
                 calendar = "islamic-civil"_s;
-            if (Options::useIntlEraMonthcode()) {
-                // https://tc39.es/proposal-intl-era-monthcode/#sec-createdatetimeformat step 9
-                if (calendar == "islamic"_s)
-                    calendar = "islamic-tbla"_s;
-                if (!intlAvailableCalendarIndex().contains(calendar))
-                    calendar = defaultCalendarForLocale(resolved.dataLocale);
-            }
+            // https://tc39.es/proposal-intl-era-monthcode/#sec-createdatetimeformat step 9
+            if (calendar == "islamic"_s)
+                calendar = "islamic-tbla"_s;
+            // Not a numbered CreateDateTimeFormat step; the spec's [[ca]] slot still permits
+            // calendars outside AvailableCalendars() here. Per TG2's resolution closing
+            // AvailableCalendars() and ignoring unsupported "ca" values like "islamic-rgsa"
+            // (https://github.com/tc39/ecma402/blob/main/meetings/notes-2026-01-08.md#intl-era-month-code-99), fall back instead.
+            if (!intlAvailableCalendarIndex().contains(calendar))
+                calendar = defaultCalendarForLocale(resolved.dataLocale);
         }
         impl->m_calendar = WTF::move(calendar);
     }
@@ -1392,6 +1394,80 @@ static void NODELETE replaceNarrowNoBreakSpaceOrThinSpaceWithNormalSpace(Contain
     }
 }
 
+// ICU4C-WORKAROUND: rdar://182953351 - Islamic calendars never expose a second era
+// (architecturally locked to one); Coptic has a second era but never selects it.
+// Substitute CLDR's "Before Hijra"/"Anno Martyrum" text ourselves. islamic-tbla's
+// epoch differs from civil/umalqura's by a day, hence the separate branch.
+// FIXME: doesn't cover formatRange()/formatRangeToParts(); wait for ICU
+// to fix era selection natively rather than extending this further.
+static ASCIILiteral proposalEraOverrideString(const String& calendar, double epochMs)
+{
+    if (calendar == "islamic-civil"_s || calendar == "islamic-umalqura"_s) {
+        constexpr double islamicEpoch = -42521558822000.0; // ISO 622-07-19T07:52:58.000Z
+        if (epochMs < islamicEpoch)
+            return "Before Hijra"_s;
+        return { };
+    }
+    if (calendar == "islamic-tbla"_s) {
+        constexpr double islamicTblaEpoch = -42521645222000.0; // ISO 622-07-18T07:52:58.000Z
+        if (epochMs < islamicTblaEpoch)
+            return "Before Hijra"_s;
+        return { };
+    }
+    if (calendar == "coptic"_s) {
+        constexpr double copticEpoch = -53184182822000.0; // ISO 284-08-29T07:52:58.000Z
+        if (epochMs < copticEpoch)
+            return "Anno Martyrum"_s;
+        return { };
+    }
+    return { };
+}
+
+// ICU4C-WORKAROUND: rdar://182953351 - see proposalEraOverrideString. Shared by both format() overloads.
+static JSValue formatWithEraOverride(JSGlobalObject* globalObject, UDateFormat* format, double value, ASCIILiteral eraOverride)
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    UErrorCode fieldsStatus = U_ZERO_ERROR;
+    auto fields = std::unique_ptr<UFieldPositionIterator, UFieldPositionIteratorDeleter>(ufieldpositer_open(&fieldsStatus));
+    if (U_FAILURE(fieldsStatus)) [[unlikely]]
+        return throwTypeError(globalObject, scope, "failed to open field position iterator"_s);
+    Vector<char16_t, 32> result;
+    fieldsStatus = callBufferProducingFunction(udat_formatForFields, format, value, result, fields.get());
+    if (U_FAILURE(fieldsStatus)) [[unlikely]]
+        return throwTypeError(globalObject, scope, "failed to format date value"_s);
+    replaceNarrowNoBreakSpaceOrThinSpaceWithNormalSpace(result);
+    // Splice: replace the era field's substring with override, or append if missing.
+    int32_t eraBegin = -1, eraEnd = -1;
+    int32_t beginIndex = 0, endIndex = 0;
+    while (true) {
+        auto fieldType = ufieldpositer_next(fields.get(), &beginIndex, &endIndex);
+        if (fieldType < 0)
+            break;
+        if (fieldType == UDAT_ERA_FIELD) {
+            eraBegin = beginIndex;
+            eraEnd = endIndex;
+            break;
+        }
+    }
+    StringBuilder builder;
+    if (eraBegin >= 0) {
+        builder.append(StringView(result.span()).substring(0, eraBegin));
+        builder.append(String(eraOverride));
+        builder.append(StringView(result.span()).substring(eraEnd, result.size() - eraEnd));
+    } else {
+        // ICU can already leave a trailing space where the empty era slot would go;
+        // only add our own separator if one isn't already there.
+        StringView resultView(result.span());
+        builder.append(resultView);
+        if (resultView.isEmpty() || !WTF::isUnicodeWhitespace(resultView[resultView.length() - 1]))
+            builder.append(' ');
+        builder.append(String(eraOverride));
+    }
+    return jsString(vm, builder.toString());
+}
+
 // https://tc39.es/proposal-temporal/#sec-formatdatetime
 JSValue IntlDateTimeFormat::format(JSGlobalObject* globalObject, double value) const
 {
@@ -1403,9 +1479,14 @@ JSValue IntlDateTimeFormat::format(JSGlobalObject* globalObject, double value) c
     if (!std::isfinite(value))
         return throwRangeError(globalObject, scope, "date value is not finite in DateTimeFormat format()"_s);
 
+    // ICU4C-WORKAROUND: rdar://182953351 - see proposalEraOverrideString; only when era requested.
+    auto eraOverride = m_impl->m_era != Era::None ? proposalEraOverrideString(m_impl->m_calendar, value) : ASCIILiteral { };
+    if (!eraOverride.isNull())
+        RELEASE_AND_RETURN(scope, formatWithEraOverride(globalObject, m_impl->m_dateFormat.get(), value, eraOverride));
+
     Vector<char16_t, 32> result;
     auto status = callBufferProducingFunction(udat_format, m_impl->m_dateFormat.get(), value, result, nullptr);
-    if (U_FAILURE(status))
+    if (U_FAILURE(status)) [[unlikely]]
         return throwTypeError(globalObject, scope, "failed to format date value"_s);
     replaceNarrowNoBreakSpaceOrThinSpaceWithNormalSpace(result);
 
@@ -1475,7 +1556,7 @@ static ASCIILiteral partTypeString(UDateFormatField field)
     return "unknown"_s;
 }
 
-static JSValue buildFormattedDateTimeParts(JSGlobalObject* globalObject, UDateFormat* format, double value, JSString* sourceType)
+static JSValue buildFormattedDateTimeParts(JSGlobalObject* globalObject, UDateFormat* format, double value, JSString* sourceType, ASCIILiteral eraOverride = { })
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
@@ -1505,6 +1586,7 @@ static JSValue buildFormattedDateTimeParts(JSGlobalObject* globalObject, UDateFo
     int32_t previousEndIndex = 0;
     int32_t beginIndex = 0;
     int32_t endIndex = 0;
+    bool sawEra = false;
     while (previousEndIndex < resultLength) {
         auto fieldType = ufieldpositer_next(fields.get(), &beginIndex, &endIndex);
         if (fieldType < 0)
@@ -1522,10 +1604,31 @@ static JSValue buildFormattedDateTimeParts(JSGlobalObject* globalObject, UDateFo
 
         if (fieldType >= 0) {
             auto type = jsNontrivialString(vm, partTypeString(UDateFormatField(fieldType)));
-            auto value = jsString(vm, resultStringView.substring(beginIndex, endIndex - beginIndex));
+            JSString* valueStr;
+            {
+                // ICU4C-WORKAROUND: rdar://182953351 - replace era field text with override for islamic-* pre-Hijra / coptic pre-AM.
+                if (!eraOverride.isNull() && fieldType == UDAT_ERA_FIELD) {
+                    valueStr = jsNontrivialString(vm, String(eraOverride));
+                    sawEra = true;
+                } else
+                    valueStr = jsString(vm, resultStringView.substring(beginIndex, endIndex - beginIndex));
+            }
             JSObject* part = sourceType
-                ? createIntlPartObjectWithSource(globalObject, type, value, sourceType)
-                : createIntlPartObject(globalObject, type, value);
+                ? createIntlPartObjectWithSource(globalObject, type, valueStr, sourceType)
+                : createIntlPartObject(globalObject, type, valueStr);
+            parts->putDirectIndex(globalObject, parts->length(), part);
+            RETURN_IF_EXCEPTION(scope, { });
+        }
+    }
+
+    {
+        // ICU4C-WORKAROUND: rdar://182953351 - append era override as a distinct part when ICU emitted no era field (coptic pre-AM).
+        if (!eraOverride.isNull() && !sawEra) {
+            auto type = jsNontrivialString(vm, "era"_s);
+            auto valueStr = jsNontrivialString(vm, String(eraOverride));
+            JSObject* part = sourceType
+                ? createIntlPartObjectWithSource(globalObject, type, valueStr, sourceType)
+                : createIntlPartObject(globalObject, type, valueStr);
             parts->putDirectIndex(globalObject, parts->length(), part);
             RETURN_IF_EXCEPTION(scope, { });
         }
@@ -2402,9 +2505,14 @@ JSValue IntlDateTimeFormat::format(JSGlobalObject* globalObject, JSValue x) cons
     if (!tempFormat) [[unlikely]]
         return throwTypeError(globalObject, scope, "DateTimeFormat has no fields applicable to this Temporal type"_s);
 
+    // ICU4C-WORKAROUND: rdar://182953351 - see proposalEraOverrideString; only when era requested.
+    auto eraOverride = m_impl->m_era != Era::None ? proposalEraOverrideString(m_impl->m_calendar, record.value) : ASCIILiteral { };
+    if (!eraOverride.isNull())
+        RELEASE_AND_RETURN(scope, formatWithEraOverride(globalObject, tempFormat, record.value, eraOverride));
+
     Vector<char16_t, 32> result;
     auto fmtStatus = callBufferProducingFunction(udat_format, tempFormat, record.value, result, nullptr);
-    if (U_FAILURE(fmtStatus))
+    if (U_FAILURE(fmtStatus)) [[unlikely]]
         return throwTypeError(globalObject, scope, "failed to format date value"_s);
     replaceNarrowNoBreakSpaceOrThinSpaceWithNormalSpace(result);
     return jsString(vm, String(WTF::move(result)));
@@ -2431,7 +2539,9 @@ JSValue IntlDateTimeFormat::formatToParts(JSGlobalObject* globalObject, JSValue 
             return throwTypeError(globalObject, scope, "DateTimeFormat has no fields applicable to this Temporal type"_s);
     }
 
-    RELEASE_AND_RETURN(scope, buildFormattedDateTimeParts(globalObject, fmt, record.value, nullptr));
+    // ICU4C-WORKAROUND: rdar://182953351 - see proposalEraOverrideString; only when era requested.
+    auto eraOverride = m_impl->m_era != Era::None ? proposalEraOverrideString(m_impl->m_calendar, record.value) : ASCIILiteral { };
+    RELEASE_AND_RETURN(scope, buildFormattedDateTimeParts(globalObject, fmt, record.value, nullptr, eraOverride));
 }
 
 std::unique_ptr<UDateIntervalFormat, UDateIntervalFormatDeleter>

--- a/Source/JavaScriptCore/runtime/IntlObject.cpp
+++ b/Source/JavaScriptCore/runtime/IntlObject.cpp
@@ -1720,42 +1720,17 @@ const Vector<String>& intlAvailableCalendars()
         };
         availableCalendars.construct();
 
-        if (Options::useIntlEraMonthcode()) {
-            // https://tc39.es/proposal-intl-era-monthcode/#sup-availablecalendars
-            // proposal-intl-era-monthcode "Calendar Type" table.
-            static constexpr ASCIILiteral canonicalCalendars[] {
-                "buddhist"_s, "chinese"_s, "coptic"_s, "dangi"_s, "ethioaa"_s,
-                "ethiopic"_s, "gregory"_s, "hebrew"_s, "indian"_s,
-                "islamic-civil"_s, "islamic-tbla"_s, "islamic-umalqura"_s,
-                "iso8601"_s, "japanese"_s, "persian"_s, "roc"_s,
-            };
-            for (auto id : canonicalCalendars) {
-                String s(id);
-                availableCalendars->append(createImmortalThreadSafeString(WTF::move(s)));
-            }
-        } else {
-            // Pre-proposal (default): use ICU4C's keyword-set enumeration.
-            UErrorCode status = U_ZERO_ERROR;
-            auto enumeration = std::unique_ptr<UEnumeration, ICUDeleter<uenum_close>>(ucal_getKeywordValuesForLocale("calendars", "und", false, &status));
-            ASSERT(U_SUCCESS(status));
-
-            int32_t count = uenum_count(enumeration.get(), &status);
-            ASSERT(U_SUCCESS(status));
-
-            for (int32_t i = 0; i < count; ++i) {
-                int32_t length = 0;
-                const char* pointer = uenum_next(enumeration.get(), &length, &status);
-                ASSERT(U_SUCCESS(status));
-                String calendar(unsafeMakeSpan(pointer, static_cast<size_t>(length)));
-                if (auto mapped = mapICUCalendarKeywordToBCP47(calendar))
-                    calendar = WTF::move(mapped.value());
-
-                // Skip if the obtained calendar code is not meeting Unicode Locale Identifier's `type` definition
-                // as whole ECMAScript's i18n is relying on Unicode Local Identifiers.
-                if (!isUnicodeLocaleIdentifierType(calendar))
-                    continue;
-                availableCalendars->append(createImmortalThreadSafeString(WTF::move(calendar)));
-            }
+        // https://tc39.es/proposal-intl-era-monthcode/#sup-availablecalendars
+        // proposal-intl-era-monthcode "Calendar Type" table.
+#define CANONICAL_CALENDAR_STRING(name, str) str,
+        static constexpr ASCIILiteral canonicalCalendars[] {
+            FOR_EACH_CACHED_CALENDAR_ID(CANONICAL_CALENDAR_STRING)
+            "iso8601"_s,
+        };
+#undef CANONICAL_CALENDAR_STRING
+        for (auto id : canonicalCalendars) {
+            String s(id);
+            availableCalendars->append(createImmortalThreadSafeString(WTF::move(s)));
         }
 
         // The AvailableCalendars abstract operation returns a List, ordered as if an Array of the same
@@ -1822,8 +1797,7 @@ CalendarID iso8601CalendarIDSlow()
                     return; \
                 } \
             } \
-            if (!Options::useIntlEraMonthcode()) \
-                RELEASE_ASSERT_NOT_REACHED(); \
+            RELEASE_ASSERT_NOT_REACHED(); \
         }); \
         return name##CalendarIDStorage; \
     }

--- a/Source/JavaScriptCore/runtime/IntlObject.h
+++ b/Source/JavaScriptCore/runtime/IntlObject.h
@@ -129,9 +129,7 @@ inline CalendarID iso8601CalendarID()
     macro(gregory, "gregory"_s) \
     macro(hebrew, "hebrew"_s) \
     macro(indian, "indian"_s) \
-    macro(islamic, "islamic"_s) \
     macro(islamicCivil, "islamic-civil"_s) \
-    macro(islamicRgsa, "islamic-rgsa"_s) \
     macro(islamicTbla, "islamic-tbla"_s) \
     macro(islamicUmalqura, "islamic-umalqura"_s) \
     macro(japanese, "japanese"_s) \

--- a/Source/JavaScriptCore/runtime/TemporalCalendar.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalCalendar.cpp
@@ -159,11 +159,6 @@ TemporalCore::CalendarFieldsIn readCalendarFieldsFromObject(JSGlobalObject* glob
             }
             fields.eraYear = clampTo<int32_t>(ey);
         }
-        // era and eraYear must be provided together or not at all.
-        if (fields.era.has_value() != fields.eraYear.has_value()) [[unlikely]] {
-            throwTypeError(globalObject, scope, "era and eraYear must both be present or both absent"_s);
-            return fields;
-        }
     }
 
     // month
@@ -279,11 +274,6 @@ ZonedDateTimeFields readZonedDateTimeFieldsFromObject(JSGlobalObject* globalObje
             }
             result.dateFields.eraYear = clampTo<int32_t>(ey);
             result.anyFieldSet = true;
-        }
-        // CalendarResolveFields requires era and eraYear to be present together or both absent.
-        if (result.dateFields.era.has_value() != result.dateFields.eraYear.has_value()) [[unlikely]] {
-            throwTypeError(globalObject, scope, "era and eraYear must both be present or both absent"_s);
-            return result;
         }
     }
 
@@ -459,9 +449,7 @@ ISO8601::PlainDate isoDateFromFields(JSGlobalObject* globalObject, TemporalDateF
     ASSERT(day > 0);
 
     if (calendarId != iso8601CalendarID()) {
-        auto result = TemporalCore::calendarDateFromFields(
-            calendarId, std::optional<int32_t>(year), static_cast<uint8_t>(month), static_cast<uint8_t>(day),
-            std::nullopt, std::nullopt, monthCode, overflow);
+        auto result = TemporalCore::nonISOCalendarDateToISO(calendarId, std::optional<int32_t>(year), static_cast<uint8_t>(month), static_cast<uint8_t>(day), monthCode, overflow);
         if (!result) [[unlikely]] {
             throwRangeError(globalObject, scope, String(result.error().message));
             return { };

--- a/Source/JavaScriptCore/runtime/TemporalPlainDatePrototype.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainDatePrototype.cpp
@@ -710,13 +710,10 @@ JSC_DEFINE_CUSTOM_GETTER(temporalPlainDatePrototypeGetterDayOfYear, (JSGlobalObj
     if (!plainDate) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Temporal.PlainDate.prototype.dayOfYear called on value that's not a PlainDate"_s);
 
-    if (!TemporalCore::calendarIsISO(plainDate->calendarID())) {
-        auto result = TemporalCore::calendarDayOfYear(plainDate->calendarID(), plainDate->plainDate());
-        if (!result) [[unlikely]]
-            return throwVMRangeError(globalObject, scope, result.error().message);
-        return JSValue::encode(jsNumber(*result));
-    }
-    return JSValue::encode(jsNumber(plainDate->dayOfYear()));
+    auto result = TemporalCore::calendarDayOfYear(plainDate->calendarID(), plainDate->plainDate());
+    if (!result) [[unlikely]]
+        return throwVMRangeError(globalObject, scope, String(result.error().message));
+    return JSValue::encode(jsNumber(*result));
 }
 
 // https://tc39.es/proposal-temporal/#sec-get-temporal.plaindate.prototype.weekofyear

--- a/Source/JavaScriptCore/runtime/TemporalPlainDateTimePrototype.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainDateTimePrototype.cpp
@@ -303,8 +303,6 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainDateTimePrototypeFuncWith, (JSGlobalObject
             partialDate.eraYear = clampTo<int32_t>(ey);
             anyFieldSet = true;
         }
-        if (partialDate.era.has_value() != partialDate.eraYear.has_value()) [[unlikely]]
-            return throwVMTypeError(globalObject, scope, "era and eraYear must both be present or both absent"_s);
     }
 
     // hour, microsecond, millisecond, minute
@@ -844,13 +842,10 @@ JSC_DEFINE_CUSTOM_GETTER(temporalPlainDateTimePrototypeGetterDayOfYear, (JSGloba
     if (!plainDateTime) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Temporal.PlainDateTime.prototype.dayOfYear called on value that's not a PlainDateTime"_s);
 
-    if (!TemporalCore::calendarIsISO(plainDateTime->calendarID())) {
-        auto result = TemporalCore::calendarDayOfYear(plainDateTime->calendarID(), plainDateTime->plainDate());
-        if (!result) [[unlikely]]
-            return throwVMRangeError(globalObject, scope, result.error().message);
-        return JSValue::encode(jsNumber(*result));
-    }
-    return JSValue::encode(jsNumber(plainDateTime->dayOfYear()));
+    auto result = TemporalCore::calendarDayOfYear(plainDateTime->calendarID(), plainDateTime->plainDate());
+    if (!result) [[unlikely]]
+        return throwVMRangeError(globalObject, scope, String(result.error().message));
+    return JSValue::encode(jsNumber(*result));
 }
 
 // https://tc39.es/proposal-temporal/#sec-get-temporal.plaindatetime.prototype.weekofyear

--- a/Source/JavaScriptCore/runtime/TemporalPlainMonthDayPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainMonthDayPrototype.cpp
@@ -329,8 +329,6 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainMonthDayPrototypeFuncToPlainDate, (JSGloba
                 return throwVMRangeError(globalObject, scope, "eraYear must be finite"_s);
             merged.eraYear = clampTo<int32_t>(ey);
         }
-        if (merged.era.has_value() != merged.eraYear.has_value()) [[unlikely]]
-            return throwVMTypeError(globalObject, scope, "era and eraYear must both be present or both absent"_s);
     }
     JSValue yearProp = item->get(globalObject, vm.propertyNames->year);
     RETURN_IF_EXCEPTION(scope, { });

--- a/Source/JavaScriptCore/runtime/TemporalZonedDateTimePrototype.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalZonedDateTimePrototype.cpp
@@ -1423,13 +1423,10 @@ JSC_DEFINE_CUSTOM_GETTER(temporalZonedDateTimePrototypeGetterDayOfYear, (JSGloba
     auto [date, time] = zdt->getLocalDateTime(globalObject);
     RETURN_IF_EXCEPTION(scope, { });
     // Step 4: Return 𝔽(CalendarISOToDate(calendar, isoDateTime.[[ISODate]]).[[DayOfYear]]).
-    if (!TemporalCore::calendarIsISO(zdt->calendarID())) {
-        auto result = TemporalCore::calendarDayOfYear(zdt->calendarID(), date);
-        if (!result) [[unlikely]]
-            return throwVMRangeError(globalObject, scope, result.error().message);
-        return JSValue::encode(jsNumber(*result));
-    }
-    return JSValue::encode(jsNumber(ISO8601::dayOfYear(date)));
+    auto result = TemporalCore::calendarDayOfYear(zdt->calendarID(), date);
+    if (!result) [[unlikely]]
+        return throwVMRangeError(globalObject, scope, String(result.error().message));
+    return JSValue::encode(jsNumber(*result));
 }
 
 // https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.weekofyear

--- a/Source/JavaScriptCore/runtime/temporal/core/CalendarFields.cpp
+++ b/Source/JavaScriptCore/runtime/temporal/core/CalendarFields.cpp
@@ -153,6 +153,109 @@ static TemporalResult<ResolvedISOFields> resolveISOFields(const CalendarFieldsIn
     return ResolvedISOFields { year, static_cast<uint8_t>(month), day };
 }
 
+// https://tc39.es/proposal-intl-era-monthcode/#sup-temporal-nonisoresolvefields
+TemporalResult<void> nonISOResolveFields(CalendarID calendarId, CalendarFieldsIn& fields, ResolveType type)
+{
+    ASSERT(!calendarIsISO(calendarId));
+
+    // Steps 1-4: needsYear.
+    bool needsYear = type == ResolveType::Date
+        || type == ResolveType::YearMonth
+        || !fields.monthCode
+        || fields.month.has_value();
+    bool needsOrdinalMonth = fields.year.has_value() || fields.eraYear.has_value();
+    // Steps 8-9: needsDay.
+    bool needsDay = type == ResolveType::Date || type == ResolveType::MonthDay;
+
+    bool hasEras = calendarHasEras(calendarId);
+    bool hasEraYearPair = fields.era.has_value() && fields.eraYear.has_value();
+
+    // Step 10: needsYear + year unset → require era+eraYear on an era-supporting calendar.
+    if (needsYear && !fields.year) {
+        if (!hasEras || !fields.era || !fields.eraYear) [[unlikely]]
+            return makeUnexpected(typeError("year property must be present"_s));
+    }
+    if (hasEras && fields.era.has_value() != fields.eraYear.has_value()) [[unlikely]]
+        return makeUnexpected(typeError("era and eraYear must both be present or both absent"_s));
+    // Step 12: needsDay + day unset.
+    if (needsDay && !fields.day) [[unlikely]]
+        return makeUnexpected(typeError("day property must be present"_s));
+    // Step 13: month and monthCode both unset.
+    if (!fields.month && !fields.monthCode) [[unlikely]]
+        return makeUnexpected(typeError("month or monthCode property must be present"_s));
+
+    // MonthDay-only checks not in the spec emu-alg: NonISOMonthDayToISOReferenceDate needs a
+    // year to resolve leap-month layout, so demand monthCode + (year OR era+eraYear).
+    if (type == ResolveType::MonthDay && !fields.monthCode && !fields.year && !hasEraYearPair) [[unlikely]]
+        return makeUnexpected(typeError("monthCode is required for non-ISO calendar MonthDay"_s));
+    if (type == ResolveType::MonthDay && fields.month && fields.monthCode && !fields.year && !hasEraYearPair) [[unlikely]]
+        return makeUnexpected(typeError("year is required when both month and monthCode are given"_s));
+
+    auto rangeCheck = checkYearRange(fields);
+    if (!rangeCheck) [[unlikely]]
+        return makeUnexpected(rangeCheck.error());
+
+    // Step 14: CalendarDateArithmeticYearForEraYear = canonicalize + non-positive remap + math;
+    //          then reconcile with fields.year and store the arithmetic year.
+    if (hasEras && fields.era && fields.eraYear) {
+        if (auto canonical = canonicalizeEraInCalendar(calendarId, StringView(*fields.era)))
+            fields.era = String(*canonical);
+        if (auto remapped = remapNonPositiveEraYear(calendarId, StringView(*fields.era), *fields.eraYear)) {
+            fields.era = String(remapped->first);
+            fields.eraYear = remapped->second;
+        }
+        auto arithmeticYear = calendarDateArithmeticYearForEraYear(calendarId, StringView(*fields.era), *fields.eraYear);
+        if (!arithmeticYear) [[unlikely]]
+            return makeUnexpected(rangeError("era is not valid for this calendar"_s));
+        if (fields.year && *fields.year != *arithmeticYear) [[unlikely]]
+            return makeUnexpected(rangeError("year is inconsistent with era and eraYear"_s));
+        fields.year = *arithmeticYear;
+    }
+    // Steps 15-17: erase era + eraYear.
+    fields.era = std::nullopt;
+    fields.eraYear = std::nullopt;
+
+    // Step 18: monthCode validation + resolve fields.[[Month]] from monthCode ordinal.
+    if (fields.monthCode) {
+        auto& mc = *fields.monthCode;
+        // Step 18.a: IsValidMonthCodeForCalendar.
+        if (!isValidMonthCodeForCalendar(calendarId, mc)) [[unlikely]]
+            return makeUnexpected(rangeError("monthCode is not valid for this calendar"_s));
+
+        // Step 18.b — if year is set, derive MonthCodeToOrdinal and set fields.[[Month]].
+        if (fields.year) {
+            std::optional<uint8_t> ordinal;
+            if (!calendarIsLunisolar(calendarId))
+                ordinal = static_cast<uint8_t>(mc.monthNumber);
+            else {
+                // ~constrain~ is spec-pinned here → can't throw, .value() safe.
+                auto constrained = yearContainsMonthCode(calendarId, *fields.year, mc)
+                    ? mc
+                    : constrainMonthCode(calendarId, *fields.year, mc, TemporalOverflow::Constrain).value();
+                // Step 18.b.ii: MonthCodeToOrdinal (precondition guaranteed by constrain above).
+                ordinal = static_cast<uint8_t>(monthCodeOrdinalInYear(calendarId, constrained, *fields.year));
+            }
+            if (ordinal) {
+                // Step 18.b.iii: consistency.
+                if (fields.month && clampTo<uint8_t>(*fields.month) != *ordinal) [[unlikely]]
+                    return makeUnexpected(rangeError("month does not match monthCode"_s));
+                // Step 18.b.iv: Set fields.[[Month]] to month.
+                fields.month = *ordinal;
+            }
+        }
+    }
+
+    // Steps 19-22: postconditions.
+    ASSERT(!fields.era && !fields.eraYear);
+    ASSERT(!needsYear || fields.year.has_value());
+    // Assertion 21 (needsOrdinalMonth → month set) may be relaxed when the lunisolar ICU
+    // ordinal probe fails; downstream nonISOCalendarDateToISO re-derives via the monthCode.
+    ASSERT_UNUSED(needsOrdinalMonth, !needsOrdinalMonth || fields.month.has_value() || fields.monthCode.has_value());
+    ASSERT(!needsDay || fields.day.has_value());
+
+    return { };
+}
+
 // CalendarDateFromFields — temporal_rs: Calendar::date_from_fields (src/builtins/core/calendar.rs)
 // https://tc39.es/proposal-temporal/#sec-temporal-calendardatefromfields
 // Implements steps 1-4; PrepareCalendarFields done by JS-layer caller.
@@ -160,8 +263,8 @@ TemporalResult<ResolvedCalendarDate> dateFromFields(CalendarID calendarId, const
 {
     bool isISO = calendarIsISO(calendarId);
 
-    // Steps 1-2: CalendarResolveFields + CalendarDateToISO — fused into resolveISOFields (ISO path).
     if (isISO) {
+        // Step 1 (ISO): CalendarResolveFields + Step 2 CalendarDateToISO — fused into resolveISOFields.
         auto resolved = resolveISOFields(fields, overflow, ISOResolveType::Date);
         if (!resolved)
             return makeUnexpected(resolved.error());
@@ -175,44 +278,21 @@ TemporalResult<ResolvedCalendarDate> dateFromFields(CalendarID calendarId, const
         return ResolvedCalendarDate { isoDate, iso8601CalendarID() };
     }
 
-    // Steps 1-2 (non-ISO): CalendarResolveFields + CalendarDateToISO via ICU bridge.
-    auto rangeCheck = checkYearRange(fields);
-    if (!rangeCheck)
-        return makeUnexpected(rangeCheck.error());
-
-    // Non-lunisolar calendars have no leap months — reject leap month codes.
-    if (fields.monthCode && fields.monthCode->isLeapMonth && !calendarIsLunisolar(calendarId))
-        return makeUnexpected(rangeError("Leap month codes are not valid for this calendar"_s));
-
-    // Reject month/monthCode conflicts on non-ISO non-lunisolar calendars. Lunisolar
-    // (chinese/dangi/hebrew) is skipped because a leap slot pushes ordinals up (Chinese M02L has
-    // ord=3), making numeric comparison meaningless.
-    if (fields.month && fields.monthCode && !calendarIsLunisolar(calendarId)) {
-        uint8_t codeMonth = static_cast<uint8_t>(fields.monthCode->monthNumber);
-        if (clampTo<uint8_t>(*fields.month) != codeMonth)
-            return makeUnexpected(rangeError("month does not match monthCode"_s));
-    }
-
-    bool hasEraYear = fields.era.has_value() && fields.eraYear.has_value();
-    if (!fields.year && !hasEraYear)
-        return makeUnexpected(typeError("year property must be present"_s));
-    if (!fields.day)
-        return makeUnexpected(typeError("day property must be present"_s));
-    if (!fields.month && !fields.monthCode)
-        return makeUnexpected(typeError("month or monthCode property must be present"_s));
+    // Step 1 (non-ISO): CalendarResolveFields → nonISOResolveFields.
+    CalendarFieldsIn resolved = fields;
+    if (auto validated = nonISOResolveFields(calendarId, resolved, ResolveType::Date); !validated)
+        return makeUnexpected(validated.error());
 
     // Resolve month from month/monthCode
     uint8_t month = 1;
-    if (fields.month)
-        month = clampTo<uint8_t>(*fields.month);
-    else if (fields.monthCode)
-        month = static_cast<uint8_t>(fields.monthCode->monthNumber);
+    if (resolved.month)
+        month = clampTo<uint8_t>(*resolved.month);
+    else if (resolved.monthCode)
+        month = static_cast<uint8_t>(resolved.monthCode->monthNumber);
 
-    std::optional<StringView> era;
-    if (fields.era)
-        era = StringView(*fields.era);
-
-    auto result = calendarDateFromFields(calendarId, fields.year, month, *fields.day, era, fields.eraYear, fields.monthCode, overflow);
+    // nonISOResolveFields has already derived the arithmetic year and erased era/eraYear.
+    // Step 2 (non-ISO): CalendarDateToISO → nonISOCalendarDateToISO.
+    auto result = nonISOCalendarDateToISO(calendarId, resolved.year, month, *resolved.day, resolved.monthCode, overflow);
     if (!result)
         return makeUnexpected(result.error());
     if (auto consistencyCheck = checkLunisolarMonthConsistency(calendarId, fields, *result); !consistencyCheck)
@@ -228,12 +308,11 @@ TemporalResult<ResolvedCalendarDate> dateFromFields(CalendarID calendarId, const
 
 // CalendarYearMonthFromFields — temporal_rs: Calendar::year_month_from_fields (src/builtins/core/calendar.rs)
 // https://tc39.es/proposal-temporal/#sec-temporal-calendaryearmonthfromfields
-// Implements steps 1-5; PrepareCalendarFields done by JS-layer caller.
 TemporalResult<ResolvedCalendarDate> yearMonthFromFields(CalendarID calendarId, const CalendarFieldsIn& fields, TemporalOverflow overflow)
 {
     bool isISO = calendarIsISO(calendarId);
 
-    // Steps 1-3: set [[Day]]=1 + CalendarResolveFields + CalendarDateToISO — fused into resolveISOFields.
+    // Steps 1-2 (ISO): set [[Day]]=1 + CalendarResolveFields + Step 3 CalendarDateToISO — fused into resolveISOFields.
     if (isISO) {
         auto resolved = resolveISOFields(fields, overflow, ISOResolveType::YearMonth);
         if (!resolved)
@@ -248,41 +327,20 @@ TemporalResult<ResolvedCalendarDate> yearMonthFromFields(CalendarID calendarId, 
         return ResolvedCalendarDate { isoDate, iso8601CalendarID() };
     }
 
-    // Steps 1-3 (non-ISO): set [[Day]]=1 + CalendarResolveFields + CalendarDateToISO via ICU bridge.
-    auto rangeCheck = checkYearRange(fields);
-    if (!rangeCheck)
-        return makeUnexpected(rangeCheck.error());
-
-    // Non-lunisolar calendars have no leap months — reject leap month codes.
-    if (fields.monthCode && fields.monthCode->isLeapMonth && !calendarIsLunisolar(calendarId))
-        return makeUnexpected(rangeError("Leap month codes are not valid for this calendar"_s));
-
-    // Reject month/monthCode conflicts on non-ISO non-lunisolar calendars. Lunisolar
-    // (chinese/dangi/hebrew) is skipped because a leap slot pushes ordinals up (Chinese M02L has
-    // ord=3), making numeric comparison meaningless.
-    if (fields.month && fields.monthCode && !calendarIsLunisolar(calendarId)) {
-        uint8_t codeMonth = static_cast<uint8_t>(fields.monthCode->monthNumber);
-        if (clampTo<uint8_t>(*fields.month) != codeMonth)
-            return makeUnexpected(rangeError("month does not match monthCode"_s));
-    }
-
-    bool hasEraYear = fields.era.has_value() && fields.eraYear.has_value();
-    if (!fields.year && !hasEraYear)
-        return makeUnexpected(typeError("year property must be present"_s));
-    if (!fields.month && !fields.monthCode)
-        return makeUnexpected(typeError("month or monthCode property must be present"_s));
+    // Steps 1-2 (non-ISO): set [[Day]]=1 + CalendarResolveFields → nonISOResolveFields.
+    CalendarFieldsIn resolved = fields;
+    if (auto validated = nonISOResolveFields(calendarId, resolved, ResolveType::YearMonth); !validated)
+        return makeUnexpected(validated.error());
 
     uint8_t month = 1;
-    if (fields.month)
-        month = clampTo<uint8_t>(*fields.month);
-    else if (fields.monthCode)
-        month = static_cast<uint8_t>(fields.monthCode->monthNumber);
+    if (resolved.month)
+        month = clampTo<uint8_t>(*resolved.month);
+    else if (resolved.monthCode)
+        month = static_cast<uint8_t>(resolved.monthCode->monthNumber);
 
-    std::optional<StringView> era;
-    if (fields.era)
-        era = StringView(*fields.era);
-
-    auto result = calendarDateFromFields(calendarId, fields.year, month, 1, era, fields.eraYear, fields.monthCode, overflow);
+    // nonISOResolveFields has already derived the arithmetic year and erased era/eraYear.
+    // Step 3 (non-ISO): CalendarDateToISO → nonISOCalendarDateToISO.
+    auto result = nonISOCalendarDateToISO(calendarId, resolved.year, month, 1, resolved.monthCode, overflow);
     if (!result)
         return makeUnexpected(result.error());
     if (auto consistencyCheck = checkLunisolarMonthConsistency(calendarId, fields, *result); !consistencyCheck)
@@ -298,7 +356,6 @@ TemporalResult<ResolvedCalendarDate> yearMonthFromFields(CalendarID calendarId, 
 
 // CalendarMonthDayFromFields — temporal_rs: Calendar::month_day_from_fields (src/builtins/core/calendar.rs)
 // https://tc39.es/proposal-temporal/#sec-temporal-calendarmonthdayfromfields
-// Implements steps 1-4; PrepareCalendarFields done by JS-layer caller.
 TemporalResult<ResolvedCalendarDate> monthDayFromFields(CalendarID calendarId, const CalendarFieldsIn& fields, TemporalOverflow overflow)
 {
     bool isISO = calendarIsISO(calendarId);
@@ -337,35 +394,22 @@ TemporalResult<ResolvedCalendarDate> monthDayFromFields(CalendarID calendarId, c
     }
 
     // Steps 1-2 (non-ISO): CalendarResolveFields + CalendarMonthDayToISOReferenceDate via ICU bridge.
-    if (!fields.day)
-        return makeUnexpected(typeError("day property must be present"_s));
-    if (fields.month && !fields.year && !(fields.era && fields.eraYear))
-        return makeUnexpected(typeError("year is required with month for non-ISO calendar MonthDay"_s));
-    if (!fields.month && !fields.monthCode)
-        return makeUnexpected(typeError("month or monthCode is required for non-ISO calendar MonthDay"_s));
-    auto rangeCheck = checkYearRange(fields);
-    if (!rangeCheck)
-        return makeUnexpected(rangeCheck.error());
-
-    if (fields.monthCode && fields.monthCode->isLeapMonth && !calendarIsLunisolar(calendarId))
-        return makeUnexpected(rangeError("Leap month codes are not valid for this calendar"_s));
-    if (fields.month && fields.monthCode && !calendarIsLunisolar(calendarId)) {
-        uint8_t codeMonth = static_cast<uint8_t>(fields.monthCode->monthNumber);
-        if (clampTo<uint8_t>(*fields.month) != codeMonth)
-            return makeUnexpected(rangeError("month does not match monthCode"_s));
-    }
+    CalendarFieldsIn resolved = fields;
+    if (auto validated = nonISOResolveFields(calendarId, resolved, ResolveType::MonthDay); !validated)
+        return makeUnexpected(validated.error());
 
     uint8_t month = 1;
-    if (fields.month)
-        month = clampTo<uint8_t>(*fields.month);
-    else if (fields.monthCode)
-        month = static_cast<uint8_t>(fields.monthCode->monthNumber);
+    if (resolved.month)
+        month = clampTo<uint8_t>(*resolved.month);
+    else if (resolved.monthCode)
+        month = static_cast<uint8_t>(resolved.monthCode->monthNumber);
 
-    // Reference year for ICU. Unset on the era+eraYear path (ICU uses UCAL_ERA+UCAL_YEAR).
+    // Reference year for ICU: the arithmetic year resolved from either a plain year or
+    // era+eraYear (nonISOResolveFields already collapsed era+eraYear into resolved.year).
     std::optional<int32_t> localYear;
     bool usedRegularMonthFallback = false;
-    if (fields.year)
-        localYear = *fields.year;
+    if (resolved.year)
+        localYear = *resolved.year;
     else if (fields.monthCode) {
         auto refYear = ecmaReferenceYear(calendarId, fields.monthCode->monthNumber, fields.monthCode->isLeapMonth, fields.day ? *fields.day : 1);
         if (!refYear) {
@@ -386,32 +430,27 @@ TemporalResult<ResolvedCalendarDate> monthDayFromFields(CalendarID calendarId, c
             localYear = *refYear;
     }
 
-    std::optional<StringView> era;
-    if (fields.era)
-        era = StringView(*fields.era);
-
     // When using the regular-month fallback, use a non-leap monthCode so ICU doesn't
     // look for a leap month in the reference year.
     std::optional<ParsedMonthCode> regularMonthCode;
-    const std::optional<ParsedMonthCode>* effectiveMonthCode = &fields.monthCode;
-    if (usedRegularMonthFallback && fields.monthCode) {
-        regularMonthCode = ParsedMonthCode { fields.monthCode->monthNumber, false };
+    const std::optional<ParsedMonthCode>* effectiveMonthCode = &resolved.monthCode;
+    if (usedRegularMonthFallback && resolved.monthCode) {
+        regularMonthCode = ParsedMonthCode { resolved.monthCode->monthNumber, /* isLeapMonth */ false };
         effectiveMonthCode = &regularMonthCode;
     }
 
-    // Era+eraYear path: ICU ignores the year param (uses UCAL_ERA+UCAL_YEAR instead), so pass
-    // fields.year (optional) to enable the year-consistency check in calendarDateFromFields.
-    // Non-era path: pass the computed reference year for correct ICU month resolution.
-    std::optional<int32_t> yearArg = (era && fields.eraYear) ? fields.year : localYear;
-    auto result = calendarDateFromFields(calendarId, yearArg, month, *fields.day, era, fields.eraYear, *effectiveMonthCode, overflow);
+    // nonISOResolveFields has already derived the arithmetic year and erased era/eraYear;
+    // pass the computed reference year for correct ICU month resolution.
+    auto result = nonISOCalendarDateToISO(calendarId, localYear, month, *resolved.day, *effectiveMonthCode, overflow);
     if (!result)
         return makeUnexpected(result.error());
     if (auto consistencyCheck = checkLunisolarMonthConsistency(calendarId, fields, *result); !consistencyCheck)
         return makeUnexpected(consistencyCheck.error());
 
-    // For MonthDay with year provided: validate ISO range, then re-resolve with
-    // reference year to get canonical reference ISO date per spec.
-    if (fields.year || (fields.era && fields.eraYear)) {
+    // For MonthDay with a user-provided year (either directly or via era+eraYear, which
+    // nonISOResolveFields has already collapsed into fields.year): validate ISO range, then
+    // re-resolve with the reference year to get the canonical reference ISO date per spec.
+    if (resolved.year) {
         if (!ISO8601::isYearWithinLimits(result->year()))
             return makeUnexpected(rangeError("Date is not within representable range"_s));
 
@@ -438,7 +477,7 @@ TemporalResult<ResolvedCalendarDate> monthDayFromFields(CalendarID calendarId, c
                     }
                 } else
                     refYear = *refYearOr;
-                auto refResult = calendarDateFromFields(calendarId, std::optional<int32_t>(refYear), resolvedFields->month, resolvedFields->day, std::nullopt, std::nullopt, effectiveRefMonthCode, TemporalOverflow::Constrain);
+                auto refResult = nonISOCalendarDateToISO(calendarId, std::optional<int32_t>(refYear), resolvedFields->month, resolvedFields->day, effectiveRefMonthCode, TemporalOverflow::Constrain);
                 if (refResult)
                     return ResolvedCalendarDate { *refResult, calendarId };
             }
@@ -566,10 +605,15 @@ TemporalResult<ResolvedCalendarDate> plainDateWith(CalendarID calendarId, const 
     if (!keysToIgnoreYear && !merged.year)
         merged.year = std::optional<int32_t>(calFields->year);
 
-    // Keep an inherited month as monthCode only, so it can be constrained in a different year.
+    // month: user's value if provided; suppress base month when monthCode is provided (they're mutually exclusive).
+    // Also drop base's month for lunisolar calendars when the user changes year (or era) — the ordinal shifts
+    // between years with different leap-month layouts and monthCode alone is the correct calendar-native identifier.
+    // Keep an inherited month as monthCode only (not raw month) so it can be constrained in a different year.
+    bool lunisolarYearChange = calendarIsLunisolar(calendarId)
+        && (partialFields.year.has_value() || partialFields.era.has_value() || partialFields.eraYear.has_value());
     if (partialFields.month.has_value())
         merged.month = *partialFields.month;
-    else if (!partialFields.monthCode.has_value() && calFields->monthCode.isEmpty())
+    else if (!partialFields.monthCode.has_value() && calFields->monthCode.isEmpty() && !lunisolarYearChange)
         merged.month = static_cast<uint32_t>(calFields->month);
     merged.day = partialFields.day.has_value() ? *partialFields.day : calFields->day;
 

--- a/Source/JavaScriptCore/runtime/temporal/core/CalendarFields.h
+++ b/Source/JavaScriptCore/runtime/temporal/core/CalendarFields.h
@@ -68,6 +68,9 @@ struct ResolvedCalendarDate {
     CalendarID calendarId { 0 };
 };
 
+enum class ResolveType : uint8_t { Date, YearMonth, MonthDay };
+JS_EXPORT_PRIVATE TemporalResult<void> nonISOResolveFields(CalendarID, CalendarFieldsIn&, ResolveType);
+
 JS_EXPORT_PRIVATE TemporalResult<ResolvedCalendarDate> dateFromFields(CalendarID, const CalendarFieldsIn&, TemporalOverflow);
 
 JS_EXPORT_PRIVATE TemporalResult<ResolvedCalendarDate> yearMonthFromFields(CalendarID, const CalendarFieldsIn&, TemporalOverflow);

--- a/Source/JavaScriptCore/runtime/temporal/core/CalendarICUBridge.cpp
+++ b/Source/JavaScriptCore/runtime/temporal/core/CalendarICUBridge.cpp
@@ -95,19 +95,36 @@ public:
 };
 WTF_MAKE_TZONE_ALLOCATED_IMPL(CalendarCacheEntry);
 
+static bool calendarIsIslamic(CalendarID id)
+{
+    return id == islamicCivilCalendarID() || id == islamicTblaCalendarID() || id == islamicUmalquraCalendarID();
+}
+
+static bool calendarIsGregorianStructured(CalendarID id)
+{
+    return id == buddhistCalendarID() || id == rocCalendarID() || id == japaneseCalendarID();
+}
+
+static bool calendarUsesISODateArithmetic(CalendarID id)
+{
+    return calendarIsISO(id) || id == gregoryCalendarID() || calendarIsGregorianStructured(id);
+}
+
 // Japanese/ROC/Buddhist derive from Gregorian and reject ucal_setGregorianChange
 // (U_UNSUPPORTED_ERROR), so Gregorian-arithmetic accessors route through gregory
 // to get proleptic Gregorian. Calendar-native year and era fields are handled
 // separately.
 static CalendarID gregorianArithmeticCalendarFor(CalendarID calendarId)
 {
-    if (calendarId == japaneseCalendarID() || calendarId == rocCalendarID() || calendarId == buddhistCalendarID())
+    if (calendarIsGregorianStructured(calendarId))
         return gregoryCalendarID();
     return calendarId;
 }
 
+// https://tc39.es/proposal-intl-era-monthcode/#table-epoch-years
 static constexpr int32_t rocCalendarYearOffset = 1911;
-static constexpr int32_t buddhistCalendarYearOffset = 543;
+static constexpr int32_t buddhistCalendarYearOffset = -543;
+static constexpr int32_t indianCalendarYearOffset = 78;
 
 struct GregorianArithmeticYearFields {
     int32_t year;
@@ -119,7 +136,7 @@ static GregorianArithmeticYearFields gregorianArithmeticYearFieldsFor(CalendarID
 {
     ASSERT(calendarId == rocCalendarID() || calendarId == buddhistCalendarID());
     if (calendarId == buddhistCalendarID()) {
-        int32_t year = isoYear + buddhistCalendarYearOffset;
+        int32_t year = isoYear - buddhistCalendarYearOffset;
         return { year, "be"_s, year };
     }
 
@@ -178,7 +195,7 @@ int32_t lunarCalendarExtendedYearFor1972(CalendarID calendarId)
     // ISO 1972-02-15 00:00:00 UTC = 66,960,000,000 ms from Unix epoch (1970-01-01).
     static constexpr double iso1972Feb15EpochMs = 66960000000.0;
     value = withCalendar(calendarId, [&](UCalendar* cal) -> int32_t {
-        if (!cal)
+        if (!cal) [[unlikely]]
             return 1972; // fallback: assume ISO-proleptic
         UErrorCode status = U_ZERO_ERROR;
         ucal_setMillis(cal, iso1972Feb15EpochMs, &status);
@@ -219,7 +236,7 @@ static std::optional<ISO8601::PlainDate> isoDateFromCalendarChecked(UCalendar* c
     double epochMs = ucal_getMillis(cal, &status);
     if (U_FAILURE(status)) [[unlikely]]
         return std::nullopt;
-    WTF::Int64Milliseconds msWT(static_cast<int64_t>(epochMs));
+    WTF::Int64Milliseconds msWT(ISO8601::Duration::doubleToInt64Saturating(epochMs));
     int32_t days = WTF::msToDays(msWT);
     auto [year, month, day] = WTF::yearMonthDayFromDays(days);
     if (!ISO8601::isYearWithinLimits(year)) [[unlikely]]
@@ -227,104 +244,225 @@ static std::optional<ISO8601::PlainDate> isoDateFromCalendarChecked(UCalendar* c
     return ISO8601::PlainDate(year, static_cast<uint8_t>(month + 1), static_cast<uint8_t>(day));
 }
 
-// Japanese era table — start years are historically fixed calendar facts.
+template<typename F>
+static auto withCalendarSetToDate(CalendarID calendarId, const ISO8601::PlainDate& isoDate, F&& body) -> decltype(body(static_cast<UCalendar*>(nullptr)))
+{
+    return withCalendar(calendarId, [&](UCalendar* cal) -> decltype(body(cal)) {
+        if (!cal) [[unlikely]]
+            return makeUnexpected(rangeError(icuOpenCalendarFailed));
+        if (!setCalendarToISODate(cal, isoDate)) [[unlikely]]
+            return makeUnexpected(rangeError(icuSetCalendarFailed));
+        return body(cal);
+    });
+}
+
+static TemporalResult<int32_t> readICUField(UCalendar* cal, UCalendarDateFields field)
+{
+    UErrorCode status = U_ZERO_ERROR;
+    int32_t result = ucal_get(cal, field, &status);
+    if (U_FAILURE(status)) [[unlikely]]
+        return makeUnexpected(rangeError(icuReadCalendarFailed));
+    return result;
+}
+
+static TemporalResult<int32_t> readICUFieldLimit(UCalendar* cal, UCalendarDateFields field, UCalendarLimitType limitType)
+{
+    UErrorCode status = U_ZERO_ERROR;
+    int32_t result = ucal_getLimit(cal, field, limitType, &status);
+    if (U_FAILURE(status)) [[unlikely]]
+        return makeUnexpected(rangeError(icuReadCalendarFailed));
+    return result;
+}
+
+static bool resetCalendarToMonthStart(UCalendar* cal)
+{
+    UErrorCode status = U_ZERO_ERROR;
+    ucal_set(cal, UCAL_MONTH, 0);
+    ucal_set(cal, UCAL_IS_LEAP_MONTH, 0);
+    ucal_set(cal, UCAL_DAY_OF_MONTH, 1);
+    ucal_getMillis(cal, &status);
+    return U_SUCCESS(status);
+}
+
+// ICU4C-WORKAROUND: rdar://182952830 - after ucal_add(MONTH) with no other field read
+// in between, ucal_getLimit(DAY_OF_MONTH, ACTUAL_MAXIMUM) can return the previous month's
+// value. The getMillis+setMillis roundtrip (same value, re-written) forces re-resolution.
+static bool forceICUFieldReresolution(UCalendar* cal)
+{
+    UErrorCode status = U_ZERO_ERROR;
+    double epochMs = ucal_getMillis(cal, &status);
+    if (U_FAILURE(status)) [[unlikely]]
+        return false;
+    ucal_setMillis(cal, epochMs, &status);
+    return U_SUCCESS(status);
+}
+
+static TemporalResult<void> validateRejectMode(UCalendar*, CalendarID, std::optional<ParsedMonthCode>, uint8_t day);
+
+// https://tc39.es/proposal-intl-era-monthcode/#sec-temporal-calendarintegerstoiso
+static TemporalResult<ISO8601::PlainDate> calendarIntegersToISO(UCalendar* cal, CalendarID calendarId, std::optional<ParsedMonthCode> monthCode, uint8_t day, TemporalOverflow overflow)
+{
+    // Step 1: on Reject, verify cursor-resolved fields match the user-requested triple.
+    if (overflow == TemporalOverflow::Reject) {
+        if (auto r = validateRejectMode(cal, calendarId, monthCode, day); !r) [[unlikely]]
+            return makeUnexpected(r.error());
+    }
+    // Step 2: read UCAL_MILLIS + decompose to ISO Y/M/D.
+    UErrorCode status = U_ZERO_ERROR;
+    double epochMs = ucal_getMillis(cal, &status);
+    if (U_FAILURE(status)) [[unlikely]]
+        return makeUnexpected(rangeError(icuReadCalendarFailed));
+    WTF::Int64Milliseconds msWT(ISO8601::Duration::doubleToInt64Saturating(epochMs));
+    int32_t days = WTF::msToDays(msWT);
+    auto [year, month, dom] = WTF::yearMonthDayFromDays(days);
+    if (!ISO8601::isYearWithinLimits(year)) [[unlikely]] // not in spec; defensive PlainDate-range guard.
+        return makeUnexpected(rangeError("Resolved calendar date is outside representable range"_s));
+    // Step 3 (NOTE): no known calendars have ambiguous mappings.
+    // Step 4: return isoDate.
+    return ISO8601::PlainDate(year, static_cast<uint8_t>(month + 1), static_cast<uint8_t>(dom));
+}
+
+// Arithmetic year → ISO year for buddhist/roc/japanese. Bypasses ICU (Julian shift + range wrap).
+static int32_t gregorianStructuredCalendarISOYear(CalendarID calendarId, int32_t year)
+{
+    if (calendarId == buddhistCalendarID())
+        return year + buddhistCalendarYearOffset;
+    if (calendarId == rocCalendarID())
+        return year + rocCalendarYearOffset;
+    ASSERT(calendarId == japaneseCalendarID());
+    return year;
+}
+
+// Japanese era table. https://tc39.es/proposal-intl-era-monthcode/#table-eras
 // icu4x: components/calendar/src/cal/japanese.rs Japanese::eras()
 // https://github.com/tc39/proposal-intl-era-monthcode/issues/86
-static constexpr int32_t japaneseCalendarGregorianTransitionYear = 1873;
-
+// ICU4C exposes UCAL_ERA as an integer index only; we keep the mapping to canonical codes locally.
+// startYear/Month/Day = earliest ISO date this era is emitted on; epochYear = era-year origin (differs only for meiji).
 struct JapaneseEra {
     int32_t startYear;
+    uint8_t startMonth;
+    uint8_t startDay;
+    int32_t epochYear;
     ASCIILiteral name;
 };
 static constexpr auto japaneseEras = WTF::toArray<JapaneseEra>({
-    { 2019, "reiwa"_s },
-    { 1989, "heisei"_s },
-    { 1926, "showa"_s },
-    { 1912, "taisho"_s },
-    { 1868, "meiji"_s },
+    { 2019, 5, 1, 2019, "reiwa"_s },
+    { 1989, 1, 8, 1989, "heisei"_s },
+    { 1926, 12, 25, 1926, "showa"_s },
+    { 1912, 7, 30, 1912, "taisho"_s },
+    // Meiji: historical epoch 1868-10-23; Japan adopted Gregorian on 1873-01-01.
+    // Emit only for ISO ≥ 1873; era-year counting still uses 1868 (Meiji 6 = ISO 1873).
+    // https://github.com/tc39/proposal-intl-era-monthcode/issues/86
+    { 1873, 1, 1, 1868, "meiji"_s },
 });
 
-// japaneseEraStartYear — no spec AO, no ICU4X equivalent (ICU4X keys on EraStartDate directly).
-// Bridges ICU4C's UCAL_ERA integer to a Gregorian start year for lookup in japaneseEras[].
-static std::optional<int32_t> japaneseEraStartYear(int32_t icuEraCode)
+// https://tc39.es/proposal-intl-era-monthcode/#table-eras
+enum class EraKind : uint8_t { Epoch, Negative, Offset };
+struct EraRow {
+    CalendarID calendar;
+    ASCIILiteral era;
+    ASCIILiteral alias;
+    EraKind kind;
+    int32_t offset;
+};
+static const Vector<EraRow>& eraTable()
 {
-    return withCalendar(japaneseCalendarID(), [&](UCalendar* cal) -> std::optional<int32_t> {
-        if (!cal)
-            return std::nullopt;
-        UErrorCode status = U_ZERO_ERROR;
-        ucal_set(cal, UCAL_ERA, icuEraCode);
-        ucal_set(cal, UCAL_YEAR, 2);
-        // YEAR=2: YEAR=1/January doesn't exist for eras starting mid-year (e.g. Showa on Dec 25).
-        ucal_set(cal, UCAL_MONTH, UCAL_JANUARY);
-        ucal_set(cal, UCAL_DAY_OF_MONTH, 1);
-        int32_t extYear = ucal_get(cal, UCAL_EXTENDED_YEAR, &status);
-        if (U_FAILURE(status)) [[unlikely]]
-            return std::nullopt;
-        return extYear - 1; // EXTENDED_YEAR of YEAR=2/Jan 1 is eraStartYear+1.
+    static LazyNeverDestroyed<Vector<EraRow>> table;
+    static std::once_flag initializeOnce;
+    std::call_once(initializeOnce, [] {
+        table.construct();
+        table->append({ buddhistCalendarID(), "be"_s, { }, EraKind::Epoch, 0 });
+        table->append({ copticCalendarID(), "am"_s, { }, EraKind::Epoch, 0 });
+        table->append({ ethioaaCalendarID(), "aa"_s, { }, EraKind::Epoch, 0 });
+        table->append({ ethiopicCalendarID(), "am"_s, { }, EraKind::Epoch, 0 });
+        table->append({ ethiopicCalendarID(), "aa"_s, { }, EraKind::Offset, -5499 });
+        table->append({ gregoryCalendarID(), "ce"_s, "ad"_s, EraKind::Epoch, 0 });
+        table->append({ gregoryCalendarID(), "bce"_s, "bc"_s, EraKind::Negative, 0 });
+        table->append({ hebrewCalendarID(), "am"_s, { }, EraKind::Epoch, 0 });
+        table->append({ indianCalendarID(), "shaka"_s, { }, EraKind::Epoch, 0 });
+        for (auto cal : { islamicCivilCalendarID(), islamicTblaCalendarID(), islamicUmalquraCalendarID() }) {
+            table->append({ cal, "ah"_s, { }, EraKind::Epoch, 0 });
+            table->append({ cal, "bh"_s, { }, EraKind::Negative, 0 });
+        }
+        // japanese: modern era rows + legacy ce/bce (for ISO ≤ 1872, per spec).
+        table->append({ japaneseCalendarID(), "ce"_s, "ad"_s, EraKind::Epoch, 0 });
+        table->append({ japaneseCalendarID(), "bce"_s, "bc"_s, EraKind::Negative, 0 });
+        for (auto& e : japaneseEras)
+            table->append({ japaneseCalendarID(), e.name, { }, EraKind::Offset, e.epochYear });
+        table->append({ persianCalendarID(), "ap"_s, { }, EraKind::Epoch, 0 });
+        table->append({ rocCalendarID(), "roc"_s, { }, EraKind::Epoch, 0 });
+        table->append({ rocCalendarID(), "broc"_s, { }, EraKind::Negative, 0 });
     });
+    return table.get();
 }
 
-// japaneseEraCode — inverse of japaneseEraStartYear: derives the ICU era integer from a known era start year.
-static std::optional<int32_t> japaneseEraCode(int32_t startYear)
+static const JapaneseEra* japaneseEraForDate(const ISO8601::PlainDate& isoDate)
 {
-    return withCalendar(japaneseCalendarID(), [&](UCalendar* cal) -> std::optional<int32_t> {
-        if (!cal)
-            return std::nullopt;
-        UErrorCode status = U_ZERO_ERROR;
-        ucal_set(cal, UCAL_EXTENDED_YEAR, startYear + 1); // startYear+1/Jan 1 is always within the era.
-        ucal_set(cal, UCAL_MONTH, UCAL_JANUARY);
-        ucal_set(cal, UCAL_DAY_OF_MONTH, 1);
-        int32_t eraCode = ucal_get(cal, UCAL_ERA, &status);
-        if (U_FAILURE(status)) [[unlikely]]
-            return std::nullopt;
-        return eraCode;
-    });
+    int32_t y = isoDate.year();
+    uint8_t m = isoDate.month();
+    uint8_t d = isoDate.day();
+    for (auto& e : japaneseEras) {
+        if (y > e.startYear
+            || (y == e.startYear && m > e.startMonth)
+            || (y == e.startYear && m == e.startMonth && d >= e.startDay))
+            return &e;
+    }
+    return nullptr;
 }
 
-// mapICUEraToTemporalEra — ICU4C has no locale-independent era identifier API (UDAT_ERA_NAMES is locale-dependent).
-// For non-Japanese calendars, era indices are 0/1 and fixed by the calendar system — hardcoded string mapping suffices.
-// For Japanese, era indices grow as new eras are added; japaneseEraStartYear derives the name via ICU4C dynamically.
-// Era strings match icu4x era_year_from_extended (gregorian.rs, japanese.rs, coptic.rs, ethiopian.rs, hebrew.rs, persian.rs, indian.rs, roc.rs).
-static std::optional<String> mapICUEraToTemporalEra(CalendarID calendarId, int32_t icuEra)
+struct EraAndYear {
+    std::optional<String> era;
+    std::optional<int32_t> eraYear;
+};
+
+static std::optional<EraAndYear> emitEraProleptic(CalendarID calendarId, const ISO8601::PlainDate& isoDate)
+{
+    if (calendarId == japaneseCalendarID()) {
+        if (auto* era = japaneseEraForDate(isoDate))
+            return EraAndYear { String(era->name), isoDate.year() - era->epochYear + 1 };
+        return EraAndYear { isoDate.year() > 0 ? String("ce"_s) : String("bce"_s),
+            isoDate.year() > 0 ? isoDate.year() : (1 - isoDate.year()) };
+    }
+    if (calendarId == buddhistCalendarID() || calendarId == rocCalendarID()) {
+        auto fields = gregorianArithmeticYearFieldsFor(calendarId, isoDate.year());
+        return EraAndYear { String(fields.era), fields.eraYear };
+    }
+    return std::nullopt;
+}
+
+static EraAndYear emitEraFromICU(CalendarID calendarId, int32_t icuEra, int32_t ucalYear, int32_t extendedYear)
 {
     if (!calendarHasEras(calendarId))
-        return std::nullopt;
-
-    if (calendarId == gregoryCalendarID())
-        return !icuEra ? "bce"_s : "ce"_s;
-    if (calendarId == buddhistCalendarID())
-        return "be"_s;
-    if (calendarId == japaneseCalendarID()) {
-        auto startYear = japaneseEraStartYear(icuEra);
-        if (!startYear) [[unlikely]]
-            return std::nullopt;
-        for (auto& e : japaneseEras) {
-            if (*startYear == e.startYear)
-                return String(e.name);
-        }
-        return *startYear > 0 ? "ce"_s : "bce"_s;
+        return { std::nullopt, std::nullopt };
+    // https://tc39.es/proposal-intl-era-monthcode/#table-eras: pre-epoch eras derived from extended year.
+    if (extendedYear <= 0) {
+        if (calendarIsIslamic(calendarId))
+            return { String("bh"_s), 1 - extendedYear };
     }
-    if (calendarId == rocCalendarID())
-        return !icuEra ? "broc"_s : "roc"_s;
-    if (calendarId == copticCalendarID())
-        return "am"_s;
     if (calendarId == ethiopicCalendarID())
-        return !icuEra ? "aa"_s : "am"_s;
-    if (calendarId == ethioaaCalendarID())
-        return "aa"_s;
-    if (calendarId == hebrewCalendarID())
-        return "am"_s;
-    if (calendarId == indianCalendarID())
-        return "shaka"_s;
-    if (calendarId == persianCalendarID())
-        return "ap"_s;
-    if (calendarIsIslamic(calendarId))
-        return "ah"_s;
-    return std::nullopt;
+        return { !icuEra ? String("aa"_s) : String("am"_s), ucalYear };
+    // Coptic is proposal single-era "am"; ICU wraps UCAL_YEAR to positive for pre-AM, so use extendedYear.
+    if (calendarId == copticCalendarID())
+        return { String("am"_s), extendedYear };
+    // Gregorian is the only remaining calendar where UCAL_ERA (0=bce, 1=ce) picks between two rows.
+    // Single-era calendars (hebrew/indian/persian/ethioaa, plus islamic when extendedYear > 0) return their Epoch row.
+    for (const auto& r : eraTable()) {
+        if (r.calendar != calendarId)
+            continue;
+        if (calendarId == gregoryCalendarID()) {
+            if (!icuEra && r.kind == EraKind::Negative)
+                return { String(r.era), ucalYear };
+            if (icuEra && r.kind == EraKind::Epoch)
+                return { String(r.era), ucalYear };
+        } else if (r.kind == EraKind::Epoch)
+            return { String(r.era), ucalYear };
+    }
+    return { std::nullopt, std::nullopt };
 }
 
 // getMonthCode — internal: returns monthCode string from ICU calendar state (e.g. "M05L" for Hebrew Adar I).
 // Read-only: does not modify cal.
+// https://tc39.es/proposal-intl-era-monthcode/#table-additional-month-codes
 // icu4x: components/calendar/src/cal/hebrew.rs (Hebrew special case)
 // icu4x: components/calendar/src/cal/chinese_based.rs (Chinese/Dangi IS_LEAP_MONTH)
 static std::optional<String> getMonthCode(UCalendar* cal, CalendarID calendarId, UErrorCode& status)
@@ -334,21 +472,15 @@ static std::optional<String> getMonthCode(UCalendar* cal, CalendarID calendarId,
         return std::nullopt;
 
     if (calendarId == hebrewCalendarID()) {
-        // ICU4C Hebrew never sets IS_LEAP_MONTH=1. Instead, leap years have 13 slots
-        // (maxMonth=12, UCAL_MONTH 0-12) and non-leap years have 12 slots (maxMonth=11).
-        // Leap year slot 5 = Adar I (M05L); non-leap slot 5 = Adar (M06).
-        int32_t maxMonth = ucal_getLimit(cal, UCAL_MONTH, UCAL_ACTUAL_MAXIMUM, &status);
-        if (U_FAILURE(status)) [[unlikely]]
-            return std::nullopt;
-        bool isLeapYear = (maxMonth == 12);
-        if (isLeapYear && ucalMonth == 5)
-            return String("M05L"_s);
-        int32_t codeNum;
-        if (isLeapYear && ucalMonth >= 6)
-            codeNum = ucalMonth; // leap post-Adar-I: M06-M12 for slots 6-12
-        else
-            codeNum = ucalMonth + 1; // non-leap all slots, or leap slots 0-4: M01-M05
-        return makeString("M"_s, codeNum < 10 ? "0"_s : ""_s, codeNum);
+        // Hebrew never sets UCAL_IS_LEAP_MONTH (by design -- Adar I/II are distinct slots).
+        // Slot 5 only occurs in leap years, so reaching it here already implies leap.
+        if (ucalMonth >= 6) {
+            int32_t codeNum = ucalMonth;
+            return makeString("M"_s, codeNum < 10 ? "0"_s : ""_s, codeNum);
+        }
+        if (ucalMonth < 5)
+            return makeString("M0"_s, ucalMonth + 1);
+        return String("M05L"_s);
     }
 
     // Chinese/Dangi: IS_LEAP_MONTH distinguishes leap months on the same UCAL_MONTH slot.
@@ -378,13 +510,8 @@ static bool addUTCCalendarDays(UCalendar* cal, int32_t days, UErrorCode& status)
 
 static bool setCalendarToLunisolarYearStart(UCalendar* cal, CalendarID calendarId, std::optional<int32_t> year, UErrorCode& status)
 {
-    if (calendarId != chineseCalendarID() && calendarId != dangiCalendarID()) {
-        ucal_set(cal, UCAL_MONTH, 0);
-        ucal_set(cal, UCAL_IS_LEAP_MONTH, 0);
-        ucal_set(cal, UCAL_DAY_OF_MONTH, 1);
-        ucal_getMillis(cal, &status);
-        return U_SUCCESS(status);
-    }
+    if (calendarId != chineseCalendarID() && calendarId != dangiCalendarID())
+        return resetCalendarToMonthStart(cal);
     if (year && !ISO8601::isYearWithinLimits(*year)) [[unlikely]]
         return false;
     if (year && !setCalendarToISODate(cal, ISO8601::PlainDate(*year, 7, 1))) [[unlikely]]
@@ -410,8 +537,10 @@ static bool setCalendarToLunisolarYearStart(UCalendar* cal, CalendarID calendarI
 static std::optional<std::pair<double, double>> lunisolarYearAnchor(UCalendar* cal, CalendarID calendarId, UErrorCode& status)
 {
     double targetMs = ucal_getMillis(cal, &status);
+    if (U_FAILURE(status)) [[unlikely]]
+        return std::nullopt;
     auto targetISODate = isoDateFromCalendarChecked(cal);
-    if (U_FAILURE(status) || !targetISODate) [[unlikely]]
+    if (!targetISODate) [[unlikely]]
         return std::nullopt;
     CheckedInt32 anchorYear = targetISODate->year();
     if (!setCalendarToLunisolarYearStart(cal, calendarId, anchorYear.value(), status)) [[unlikely]]
@@ -422,6 +551,17 @@ static std::optional<std::pair<double, double>> lunisolarYearAnchor(UCalendar* c
     return std::pair { targetMs, yearStartMs };
 }
 
+static std::optional<bool> isChineseLeapYear(UCalendar* cal, const std::pair<double, double>& anchor, UErrorCode& status)
+{
+    ucal_setMillis(cal, anchor.first, &status);
+    if (U_FAILURE(status)) [[unlikely]]
+        return std::nullopt;
+    int32_t daysInYear = ucal_getLimit(cal, UCAL_DAY_OF_YEAR, UCAL_ACTUAL_MAXIMUM, &status);
+    if (U_FAILURE(status)) [[unlikely]]
+        return std::nullopt;
+    return daysInYear > 360;
+}
+
 enum class LunisolarMonthAdvanceResult : uint8_t {
     Advanced,
     Error,
@@ -429,8 +569,12 @@ enum class LunisolarMonthAdvanceResult : uint8_t {
 
 static LunisolarMonthAdvanceResult advanceToNextLunisolarMonth(UCalendar* cal, CalendarID calendarId, UErrorCode& status)
 {
-    if (calendarId != chineseCalendarID() && calendarId != dangiCalendarID())
-        return ucal_add(cal, UCAL_MONTH, 1, &status), U_SUCCESS(status) ? LunisolarMonthAdvanceResult::Advanced : LunisolarMonthAdvanceResult::Error;
+    if (calendarId != chineseCalendarID() && calendarId != dangiCalendarID()) {
+        ucal_add(cal, UCAL_MONTH, 1, &status);
+        if (U_FAILURE(status)) [[unlikely]]
+            return LunisolarMonthAdvanceResult::Error;
+        return forceICUFieldReresolution(cal) ? LunisolarMonthAdvanceResult::Advanced : LunisolarMonthAdvanceResult::Error;
+    }
 
     auto currentMonthCode = getMonthCode(cal, calendarId, status);
     if (!currentMonthCode) [[unlikely]]
@@ -455,7 +599,7 @@ static std::optional<int32_t> stableLunisolarYear(UCalendar* cal, CalendarID cal
     ucal_setMillis(cal, anchor->first, &status);
     if (U_FAILURE(status)) [[unlikely]]
         return std::nullopt;
-    WTF::Int64Milliseconds msWT(static_cast<int64_t>(anchor->second));
+    WTF::Int64Milliseconds msWT(ISO8601::Duration::doubleToInt64Saturating(anchor->second));
     auto [year, month, day] = WTF::yearMonthDayFromDays(WTF::msToDays(msWT));
     CheckedInt32 relatedYear = year;
     relatedYear += static_cast<int32_t>(month + 1 > 7 || (month + 1 == 7 && day > 1)) - static_cast<int32_t>(anchor->second > anchor->first);
@@ -497,7 +641,7 @@ static std::optional<int32_t> actualLunisolarMonthLength(UCalendar* cal, Calenda
     }
 
     auto advanceResult = advanceToNextLunisolarMonth(cal, calendarId, status);
-    if (advanceResult == LunisolarMonthAdvanceResult::Error) {
+    if (advanceResult == LunisolarMonthAdvanceResult::Error) [[unlikely]] {
         restoreCalendar();
         return std::nullopt;
     }
@@ -516,6 +660,43 @@ static bool addLunisolarCalendarDays(UCalendar* cal, CalendarID calendarId, int3
     if (calendarId == chineseCalendarID() || calendarId == dangiCalendarID())
         return addUTCCalendarDays(cal, days, status);
     return ucal_add(cal, UCAL_DAY_OF_MONTH, days, &status), U_SUCCESS(status);
+}
+
+// ICU4C-WORKAROUND: rdar://182958553 - Hebrew y0: ICU says Kislev=29 days (Deficient leap);
+// icu4x says 30 (Regular). Forces maxDay=30 on input; relabels ICU's M04 D1 as M03 D30 on output.
+// FIXME: only relabels the single Tevet D1 slot; doesn't shift the rest of the year, so
+// dayOfYear under-counts from there on (see temporal-hebrew-year0-kislev.js skipped block).
+// Wait for ICU to fix the classification rather than patching further (icu-issues/01).
+static bool isHebrewYear0(UCalendar* cal, CalendarID calendarId)
+{
+    if (calendarId != hebrewCalendarID())
+        return false;
+    UErrorCode status = U_ZERO_ERROR;
+    int32_t year = ucal_get(cal, UCAL_EXTENDED_YEAR, &status);
+    return !U_FAILURE(status) && !year;
+}
+static bool isHebrewYear0ExtraKislevDay(UCalendar* cal, CalendarID calendarId)
+{
+    if (!isHebrewYear0(cal, calendarId))
+        return false;
+    UErrorCode status = U_ZERO_ERROR;
+    int32_t day = ucal_get(cal, UCAL_DAY_OF_MONTH, &status);
+    if (U_FAILURE(status) || day != 1) [[unlikely]]
+        return false;
+    int32_t ucalMonth = ucal_get(cal, UCAL_MONTH, &status);
+    if (U_FAILURE(status)) [[unlikely]]
+        return false;
+    return ucalMonth == 3; // Tevet slot in Hebrew (0-indexed): Tishri=0, Cheshvan=1, Kislev=2, Tevet=3.
+}
+static bool isHebrewYear0Kislev(UCalendar* cal, CalendarID calendarId)
+{
+    if (!isHebrewYear0(cal, calendarId))
+        return false;
+    UErrorCode status = U_ZERO_ERROR;
+    int32_t ucalMonth = ucal_get(cal, UCAL_MONTH, &status);
+    if (U_FAILURE(status)) [[unlikely]]
+        return false;
+    return ucalMonth == 2; // Kislev slot.
 }
 
 // computeOrdinalMonth — internal: returns 1-based ordinal month position in year, counting leap months for lunisolar
@@ -555,6 +736,8 @@ static std::optional<uint8_t> computeOrdinalMonth(UCalendar* cal, CalendarID cal
         ucal_add(cal, UCAL_MONTH, 1, &status);
         if (U_FAILURE(status)) [[unlikely]]
             return std::nullopt;
+        if (!forceICUFieldReresolution(cal)) [[unlikely]]
+            return std::nullopt;
         ordinal++;
     }
 
@@ -576,12 +759,11 @@ static std::optional<uint8_t> computeFieldResolutionOrdinalMonth(UCalendar* cal,
         return std::nullopt;
 
     if (anchor->second > anchor->first) {
-        ucal_setMillis(cal, anchor->first, &status);
-        int32_t daysInYear = ucal_getLimit(cal, UCAL_DAY_OF_YEAR, UCAL_ACTUAL_MAXIMUM, &status);
-        if (U_FAILURE(status)) [[unlikely]]
+        auto isLeapYear = isChineseLeapYear(cal, *anchor, status);
+        if (!isLeapYear) [[unlikely]]
             return std::nullopt;
         uint8_t ordinal = parsedTargetCode->monthNumber + parsedTargetCode->isLeapMonth;
-        if (daysInYear > 360 && !parsedTargetCode->isLeapMonth) {
+        if (*isLeapYear && !parsedTargetCode->isLeapMonth) {
             bool leapFollows = false;
             for (uint8_t i = 0; i < 13; ++i) {
                 if (advanceToNextLunisolarMonth(cal, calendarId, status) != LunisolarMonthAdvanceResult::Advanced) [[unlikely]]
@@ -610,57 +792,130 @@ static std::optional<uint8_t> computeFieldResolutionOrdinalMonth(UCalendar* cal,
     return std::nullopt;
 }
 
-// mapTemporalEraToICUEra — ICU4C has no set-by-era-name API; ucal_set only accepts UCAL_ERA as integer.
-// For non-Japanese calendars, era indices are 0/1 and fixed by the calendar system — hardcoded mapping suffices.
-// For Japanese, japaneseEraCode derives the integer via ICU4C dynamically using the era's historically-fixed start year.
-// Era strings match icu4x extended_year_from_era_year_unchecked (gregorian.rs, japanese.rs, coptic.rs, ethiopian.rs, hebrew.rs, persian.rs, indian.rs, roc.rs).
-static std::optional<int32_t> mapTemporalEraToICUEra(CalendarID calendarId, StringView era)
+// https://tc39.es/proposal-intl-era-monthcode/#sec-temporal-canonicalizeeraincalendar
+std::optional<ASCIILiteral> canonicalizeEraInCalendar(CalendarID calendarId, StringView era)
 {
-    if (calendarId == gregoryCalendarID()) {
-        if (era == "bce"_s)
-            return 0;
-        if (era == "ce"_s)
-            return 1;
-        return std::nullopt;
+    // Step 1: walk table-eras; return canonical name for input matching canonical or alias.
+    for (const auto& r : eraTable()) {
+        if (r.calendar != calendarId)
+            continue;
+        if (equalIgnoringASCIICase(era, StringView(r.era)))
+            return r.era;
+        if (!r.alias.isNull() && equalIgnoringASCIICase(era, StringView(r.alias)))
+            return r.era;
     }
-    if (calendarId == buddhistCalendarID())
-        return era == "be"_s ? std::optional<int32_t>(0) : std::nullopt;
-    if (calendarId == japaneseCalendarID()) {
-        for (auto& e : japaneseEras) {
-            if (era == StringView(e.name))
-                return japaneseEraCode(e.startYear);
-        }
-        if (era == "ce"_s)
-            return 0;
-        return std::nullopt;
-    }
-    if (calendarId == rocCalendarID()) {
-        if (era == "broc"_s)
-            return 0;
-        if (era == "roc"_s)
-            return 1;
-        return std::nullopt;
-    }
-    if (calendarId == copticCalendarID())
-        return era == "am"_s ? std::optional<int32_t>(1) : std::nullopt;
-    if (calendarId == ethiopicCalendarID()) {
-        if (era == "aa"_s)
-            return 0;
-        if (era == "am"_s)
-            return 1;
-        return std::nullopt;
-    }
-    if (calendarId == ethioaaCalendarID())
-        return era == "aa"_s ? std::optional<int32_t>(0) : std::nullopt;
-    if (calendarId == hebrewCalendarID())
-        return era == "am"_s ? std::optional<int32_t>(0) : std::nullopt;
-    if (calendarId == indianCalendarID())
-        return era == "shaka"_s ? std::optional<int32_t>(0) : std::nullopt;
-    if (calendarId == persianCalendarID())
-        return era == "ap"_s ? std::optional<int32_t>(0) : std::nullopt;
-    if (calendarIsIslamic(calendarId))
-        return era == "ah"_s ? std::optional<int32_t>(0) : std::nullopt;
+    // Steps 2-3: unknown era in a known calendar → undefined; unknown calendar → implementation-defined (both nullopt).
     return std::nullopt;
+}
+
+// Swap negative eraYear to the calendar's complement era: Epoch↔Negative gives 1-eraYear;
+// Epoch→Offset (ethiopic am→aa) gives eraYear + 1 - offset. Returns nullopt for positive
+// eraYear or single-era calendars.
+std::optional<std::pair<ASCIILiteral, int32_t>> remapNonPositiveEraYear(CalendarID calendarId, StringView era, int32_t eraYear)
+{
+    if (eraYear > 0)
+        return std::nullopt;
+    const EraRow* inputRow = nullptr;
+    for (const auto& r : eraTable()) {
+        if (r.calendar == calendarId && StringView(r.era) == era) {
+            inputRow = &r;
+            break;
+        }
+    }
+    if (!inputRow)
+        return std::nullopt;
+    // Epoch ↔ Negative complement: swap era, year → 1 - eraYear (gregory ce↔bce, roc↔broc, islamic ah↔bh, japanese ce↔bce).
+    if (inputRow->kind == EraKind::Epoch || inputRow->kind == EraKind::Negative) {
+        EraKind wantedKind = inputRow->kind == EraKind::Epoch ? EraKind::Negative : EraKind::Epoch;
+        for (const auto& r : eraTable()) {
+            if (r.calendar == calendarId && r.kind == wantedKind)
+                return std::make_pair(r.era, 1 - eraYear);
+        }
+    }
+    // Epoch → Offset (ethiopic am → aa): shift eraYear into the Offset era's counting.
+    if (inputRow->kind == EraKind::Epoch && calendarId == ethiopicCalendarID()) {
+        for (const auto& r : eraTable()) {
+            if (r.calendar == calendarId && r.kind == EraKind::Offset)
+                return std::make_pair(r.era, eraYear + 1 - r.offset);
+        }
+    }
+    return std::nullopt;
+}
+
+// https://tc39.es/proposal-intl-era-monthcode/#sec-temporal-calendardatearithmeticyearforerayear
+std::optional<int32_t> calendarDateArithmeticYearForEraYear(CalendarID calendarId, StringView era, int32_t eraYear)
+{
+    // Step 1: canonicalize (idempotent — caller may have canonicalized already).
+    auto canonicalOpt = canonicalizeEraInCalendar(calendarId, era);
+    StringView eraToMatch = canonicalOpt ? StringView(*canonicalOpt) : era;
+    // Steps 4-6: find matching row.
+    for (const auto& r : eraTable()) {
+        if (r.calendar != calendarId || StringView(r.era) != eraToMatch)
+            continue;
+        // Steps 7-11: eraKind-driven arithmetic.
+        switch (r.kind) {
+        case EraKind::Epoch:
+            return eraYear; // step 7
+        case EraKind::Negative:
+            return 1 - eraYear; // step 8
+        case EraKind::Offset:
+            return r.offset + eraYear - 1; // step 11
+        }
+    }
+    // Step 3: unknown (calendar, era) pair → implementation-defined (nullopt).
+    return std::nullopt;
+}
+
+// ICU4C-WORKAROUND: rdar://182960658 - IndianCalendar's ucal_setMillis/ucal_get round-trip
+// produces an off-by-one day at extreme Saka years (mechanism unconfirmed -- not the JS
+// Date range boundary). Local arithmetic ported from icu4x components/calendar/src/cal/indian.rs.
+static uint8_t indianSakaDaysInMonth(int32_t sakaYear, uint8_t month)
+{
+    if (month == 1)
+        return WTF::isLeapYear(sakaYear + indianCalendarYearOffset) ? 31 : 30;
+    return month <= 6 ? 31 : 30;
+}
+static std::optional<ISO8601::PlainDate> indianSakaToISO(int32_t sakaYear, uint8_t month, uint8_t day)
+{
+    if (month < 1 || month > 12 || day < 1)
+        return std::nullopt;
+    uint8_t monthLen = indianSakaDaysInMonth(sakaYear, month);
+    if (day > monthLen)
+        return std::nullopt;
+    bool isLeap = WTF::isLeapYear(sakaYear + indianCalendarYearOffset);
+    uint32_t sakaDayOfYear = day;
+    for (uint8_t m = 1; m < month; m++)
+        sakaDayOfYear += indianSakaDaysInMonth(sakaYear, m);
+    // ISO day-of-year = sakaDayOfYear + 80 (Chaitra 1 = ISO day 81: 31+28+22 non-leap or 31+29+21 leap).
+    int32_t isoYear = sakaYear + indianCalendarYearOffset;
+    uint32_t isoDayOfYear = sakaDayOfYear + 80;
+    uint32_t daysInISOYear = isLeap ? 366 : 365;
+    if (isoDayOfYear > daysInISOYear) {
+        isoYear++;
+        isoDayOfYear -= daysInISOYear;
+    }
+    // Convert (isoYear, isoDayOfYear) -> (isoYear, isoMonth, isoDay).
+    static constexpr std::array<uint16_t, 13> offsets { 0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334, 365 };
+    static constexpr std::array<uint16_t, 13> offsetsLeap { 0, 31, 60, 91, 121, 152, 182, 213, 244, 274, 305, 335, 366 };
+    bool isoIsLeap = WTF::isLeapYear(isoYear);
+    const auto& off = isoIsLeap ? offsetsLeap : offsets;
+    uint8_t isoMonth = 12;
+    for (uint8_t m = 1; m <= 12; m++) {
+        if (isoDayOfYear <= off[m]) {
+            isoMonth = m;
+            break;
+        }
+    }
+    uint8_t isoDay = static_cast<uint8_t>(isoDayOfYear - off[isoMonth - 1]);
+    return ISO8601::PlainDate(isoYear, isoMonth, isoDay);
+}
+
+// Design choice, not an ICU4C workaround: beyond icu4x's WELL_BEHAVED_ASTRONOMICAL_RANGE
+// (±10000 years), chinese/dangi astronomical output isn't trustworthy. Every getter below
+// falls back to ISO fields here, matching nonISOCalendarDateToISO's construction-side fallback.
+static bool calendarUsesISOFallbackForExtremeYear(CalendarID calendarId, int32_t isoYear)
+{
+    return (calendarId == chineseCalendarID() || calendarId == dangiCalendarID()) && std::abs(isoYear) > 10000;
 }
 
 // isoToCalendarFields — no single temporal_rs equivalent; aggregates Calendar::year/month/month_code/day/era.
@@ -678,6 +933,15 @@ TemporalResult<CalendarFields> isoToCalendarFields(CalendarID calendarId, const 
         return fields;
     }
 
+    if (calendarUsesISOFallbackForExtremeYear(calendarId, isoDate.year())) {
+        CalendarFields fields;
+        fields.year = isoDate.year();
+        fields.month = isoDate.month();
+        fields.day = isoDate.day();
+        fields.monthCode = ISO8601::monthCode(isoDate.month());
+        return fields;
+    }
+
     struct RawFields {
         int32_t extendedYear { 0 };
         int32_t ucalEra { 0 };
@@ -688,27 +952,33 @@ TemporalResult<CalendarFields> isoToCalendarFields(CalendarID calendarId, const 
         bool hasEra { false };
     };
 
-    auto rawOrError = withCalendar(calendarId, [&](UCalendar* cal) -> TemporalResult<RawFields> {
-        if (!cal) [[unlikely]]
-            return makeUnexpected(rangeError(icuOpenCalendarFailed));
-        if (!setCalendarToISODate(cal, isoDate)) [[unlikely]]
-            return makeUnexpected(rangeError(icuSetCalendarFailed));
-
-        UErrorCode status = U_ZERO_ERROR;
+    auto rawOrError = withCalendarSetToDate(calendarId, isoDate, [&](UCalendar* cal) -> TemporalResult<RawFields> {
         RawFields raw;
-        auto stableYear = calendarId == chineseCalendarID() || calendarId == dangiCalendarID() ? stableLunisolarYear(cal, calendarId, status) : std::nullopt;
-        raw.extendedYear = stableYear ? *stableYear : ucal_get(cal, UCAL_EXTENDED_YEAR, &status);
-        if (U_FAILURE(status) || ((calendarId == chineseCalendarID() || calendarId == dangiCalendarID()) && !stableYear)) [[unlikely]]
-            return makeUnexpected(rangeError(icuReadCalendarFailed));
-        raw.ucalEra = ucal_get(cal, UCAL_ERA, &status);
-        if (U_FAILURE(status)) [[unlikely]]
-            return makeUnexpected(rangeError(icuReadCalendarFailed));
-        raw.ucalYear = ucal_get(cal, UCAL_YEAR, &status);
-        if (U_FAILURE(status)) [[unlikely]]
-            return makeUnexpected(rangeError(icuReadCalendarFailed));
-        raw.day = ucal_get(cal, UCAL_DAY_OF_MONTH, &status);
-        if (U_FAILURE(status)) [[unlikely]]
-            return makeUnexpected(rangeError(icuReadCalendarFailed));
+        bool isChineseBased = calendarId == chineseCalendarID() || calendarId == dangiCalendarID();
+        if (isChineseBased) {
+            UErrorCode status = U_ZERO_ERROR;
+            auto stableYear = stableLunisolarYear(cal, calendarId, status);
+            if (U_FAILURE(status) || !stableYear) [[unlikely]]
+                return makeUnexpected(rangeError(icuReadCalendarFailed));
+            raw.extendedYear = *stableYear;
+        } else {
+            auto extendedYear = readICUField(cal, UCAL_EXTENDED_YEAR);
+            if (!extendedYear) [[unlikely]]
+                return makeUnexpected(extendedYear.error());
+            raw.extendedYear = *extendedYear;
+        }
+        auto ucalEra = readICUField(cal, UCAL_ERA);
+        if (!ucalEra) [[unlikely]]
+            return makeUnexpected(ucalEra.error());
+        raw.ucalEra = *ucalEra;
+        auto ucalYear = readICUField(cal, UCAL_YEAR);
+        if (!ucalYear) [[unlikely]]
+            return makeUnexpected(ucalYear.error());
+        raw.ucalYear = *ucalYear;
+        auto day = readICUField(cal, UCAL_DAY_OF_MONTH);
+        if (!day) [[unlikely]]
+            return makeUnexpected(day.error());
+        raw.day = *day;
         raw.monthCode = getMonthCode(cal, calendarId);
         if (!raw.monthCode) [[unlikely]]
             return makeUnexpected(rangeError(icuReadCalendarFailed));
@@ -716,10 +986,20 @@ TemporalResult<CalendarFields> isoToCalendarFields(CalendarID calendarId, const 
         raw.ordinalMonth = computeFieldResolutionOrdinalMonth(cal, calendarId);
         if (!raw.ordinalMonth) [[unlikely]]
             return makeUnexpected(rangeError(icuReadCalendarFailed));
+        {
+            // ICU4C-WORKAROUND: rdar://182958553 - re-label y0 M04 D1 as y0 M03 D30.
+            if (!setCalendarToISODate(cal, isoDate)) [[unlikely]]
+                return makeUnexpected(rangeError(icuSetCalendarFailed));
+            if (isHebrewYear0ExtraKislevDay(cal, calendarId)) {
+                raw.day = 30;
+                raw.ordinalMonth = 3;
+                raw.monthCode = String("M03"_s);
+            }
+        }
         return raw;
     });
 
-    if (!rawOrError)
+    if (!rawOrError) [[unlikely]]
         return makeUnexpected(rawOrError.error());
     auto& raw = *rawOrError;
 
@@ -744,17 +1024,9 @@ TemporalResult<CalendarFields> isoToCalendarFields(CalendarID calendarId, const 
     fields.isLeapMonth = fields.monthCode.endsWith("L"_s);
 
     if (raw.hasEra) {
-        // mapICUEraToTemporalEra for Japanese calls japaneseEraStartYear which uses withCalendar
-        // on the same calendarId — safe because the outer lock was released above.
-        fields.era = mapICUEraToTemporalEra(calendarId, raw.ucalEra);
-        fields.eraYear = raw.ucalYear;
-        if (calendarId == japaneseCalendarID()) {
-            if (isoDate.year() < japaneseCalendarGregorianTransitionYear) {
-                fields.era = isoDate.year() > 0 ? "ce"_s : "bce"_s;
-                fields.eraYear = isoDate.year() > 0 ? isoDate.year() : (1 - isoDate.year());
-            } else if (fields.era && *fields.era == "ce"_s)
-                fields.eraYear = isoDate.year();
-        }
+        auto emitted = emitEraProleptic(calendarId, isoDate).value_or(emitEraFromICU(calendarId, raw.ucalEra, raw.ucalYear, raw.extendedYear));
+        fields.era = emitted.era;
+        fields.eraYear = emitted.eraYear;
     }
 
     return fields;
@@ -774,6 +1046,8 @@ TemporalResult<int32_t> calendarYear(CalendarID calendarId, const ISO8601::Plain
         return isoDate.year();
     if (calendarId == rocCalendarID() || calendarId == buddhistCalendarID())
         return gregorianArithmeticYearFieldsFor(calendarId, isoDate.year()).year;
+    if (calendarUsesISOFallbackForExtremeYear(calendarId, isoDate.year()))
+        return isoDate.year();
     return withCalendar(calendarId, [&](UCalendar* cal) -> TemporalResult<int32_t> {
         if (!cal) [[unlikely]]
             return makeUnexpected(rangeError(icuOpenCalendarFailed));
@@ -809,17 +1083,16 @@ TemporalResult<int32_t> calendarYear(CalendarID calendarId, const ISO8601::Plain
 //   2. (non-ISO) NonISOCalendarISOToDate — implementation-defined.
 TemporalResult<uint8_t> calendarMonth(CalendarID calendarId, const ISO8601::PlainDate& isoDate)
 {
-    // 1. Return the ordinal month (1-based position in year, counting leap months) of isoDate in calendarId.
-
-    // Japanese uses proleptic Gregorian for its date fields, so the month is always the ISO month.
-    if (calendarId == japaneseCalendarID())
+    if (calendarIsGregorianStructured(calendarId))
         return isoDate.month();
-
-    return withCalendar(gregorianArithmeticCalendarFor(calendarId), [&](UCalendar* cal) -> TemporalResult<uint8_t> {
-        if (!cal) [[unlikely]]
-            return makeUnexpected(rangeError(icuOpenCalendarFailed));
-        if (!setCalendarToISODate(cal, isoDate)) [[unlikely]]
-            return makeUnexpected(rangeError(icuSetCalendarFailed));
+    if (calendarUsesISOFallbackForExtremeYear(calendarId, isoDate.year()))
+        return isoDate.month();
+    return withCalendarSetToDate(calendarId, isoDate, [&](UCalendar* cal) -> TemporalResult<uint8_t> {
+        {
+            // ICU4C-WORKAROUND: rdar://182958553 - re-label y0 M04 as ordinal 3.
+            if (isHebrewYear0ExtraKislevDay(cal, calendarId))
+                return static_cast<uint8_t>(3);
+        }
         auto ordinal = computeFieldResolutionOrdinalMonth(cal, calendarId);
         if (!ordinal) [[unlikely]]
             return makeUnexpected(rangeError(icuReadCalendarFailed));
@@ -835,17 +1108,16 @@ TemporalResult<uint8_t> calendarMonth(CalendarID calendarId, const ISO8601::Plai
 //   2. (non-ISO) NonISOCalendarISOToDate — implementation-defined.
 TemporalResult<String> calendarMonthCode(CalendarID calendarId, const ISO8601::PlainDate& isoDate)
 {
-    // 1. Return the month code string (e.g. "M01", "M05L") of isoDate in calendarId.
-
-    // Japanese uses proleptic Gregorian for its date fields, so the month code is always the ISO month code.
-    if (calendarId == japaneseCalendarID())
+    if (calendarIsGregorianStructured(calendarId))
         return ISO8601::monthCode(isoDate.month());
-
-    return withCalendar(gregorianArithmeticCalendarFor(calendarId), [&](UCalendar* cal) -> TemporalResult<String> {
-        if (!cal) [[unlikely]]
-            return makeUnexpected(rangeError(icuOpenCalendarFailed));
-        if (!setCalendarToISODate(cal, isoDate)) [[unlikely]]
-            return makeUnexpected(rangeError(icuSetCalendarFailed));
+    if (calendarUsesISOFallbackForExtremeYear(calendarId, isoDate.year()))
+        return ISO8601::monthCode(isoDate.month());
+    return withCalendarSetToDate(calendarId, isoDate, [&](UCalendar* cal) -> TemporalResult<String> {
+        {
+            // ICU4C-WORKAROUND: rdar://182958553 - re-label y0 M04 as monthCode M03.
+            if (isHebrewYear0ExtraKislevDay(cal, calendarId))
+                return String("M03"_s);
+        }
         auto code = getMonthCode(cal, calendarId);
         if (!code) [[unlikely]]
             return makeUnexpected(rangeError(icuReadCalendarFailed));
@@ -861,37 +1133,32 @@ TemporalResult<String> calendarMonthCode(CalendarID calendarId, const ISO8601::P
 //   2. (non-ISO) NonISOCalendarISOToDate — implementation-defined.
 TemporalResult<uint8_t> calendarDay(CalendarID calendarId, const ISO8601::PlainDate& isoDate)
 {
-    // 1. Return the day-of-month of isoDate in calendarId.
-
-    // Japanese uses proleptic Gregorian for its date fields, so the day is always the ISO day.
-    if (calendarId == japaneseCalendarID())
+    if (calendarIsGregorianStructured(calendarId))
         return isoDate.day();
-
-    return withCalendar(gregorianArithmeticCalendarFor(calendarId), [&](UCalendar* cal) -> TemporalResult<uint8_t> {
-        if (!cal) [[unlikely]]
-            return makeUnexpected(rangeError(icuOpenCalendarFailed));
-        if (!setCalendarToISODate(cal, isoDate)) [[unlikely]]
-            return makeUnexpected(rangeError(icuSetCalendarFailed));
-        UErrorCode status = U_ZERO_ERROR;
-        int32_t day = ucal_get(cal, UCAL_DAY_OF_MONTH, &status);
-        if (U_FAILURE(status)) [[unlikely]]
-            return makeUnexpected(rangeError(icuReadCalendarFailed));
-        return static_cast<uint8_t>(day);
+    if (calendarUsesISOFallbackForExtremeYear(calendarId, isoDate.year()))
+        return isoDate.day();
+    return withCalendarSetToDate(calendarId, isoDate, [&](UCalendar* cal) -> TemporalResult<uint8_t> {
+        {
+            // ICU4C-WORKAROUND: rdar://182958553 - Kislev has 30 days in y0 per icu4x.
+            if (isHebrewYear0ExtraKislevDay(cal, calendarId))
+                return static_cast<uint8_t>(30);
+        }
+        auto day = readICUField(cal, UCAL_DAY_OF_MONTH);
+        if (!day) [[unlikely]]
+            return makeUnexpected(day.error());
+        return static_cast<uint8_t>(*day);
     });
 }
 
-TemporalResult<uint16_t> calendarDayOfYear(CalendarID calendarId, const ISO8601::PlainDate& isoDate)
+// calendarDayOfYear — 1-based day within the calendar's year (ISO's if calendarUsesISODateArithmetic).
+TemporalResult<int32_t> calendarDayOfYear(CalendarID calendarId, const ISO8601::PlainDate& isoDate)
 {
-    return withCalendar(gregorianArithmeticCalendarFor(calendarId), [&](UCalendar* cal) -> TemporalResult<uint16_t> {
-        if (!cal) [[unlikely]]
-            return makeUnexpected(rangeError(icuOpenCalendarFailed));
-        if (!setCalendarToISODate(cal, isoDate)) [[unlikely]]
-            return makeUnexpected(rangeError(icuSetCalendarFailed));
-        UErrorCode status = U_ZERO_ERROR;
-        int32_t dayOfYear = ucal_get(cal, UCAL_DAY_OF_YEAR, &status);
-        if (U_FAILURE(status)) [[unlikely]]
-            return makeUnexpected(rangeError(icuReadCalendarFailed));
-        return static_cast<uint16_t>(dayOfYear);
+    if (calendarUsesISODateArithmetic(calendarId))
+        return static_cast<int32_t>(ISO8601::dayOfYear(isoDate));
+    if (calendarUsesISOFallbackForExtremeYear(calendarId, isoDate.year()))
+        return static_cast<int32_t>(ISO8601::dayOfYear(isoDate));
+    return withCalendarSetToDate(calendarId, isoDate, [](UCalendar* cal) {
+        return readICUField(cal, UCAL_DAY_OF_YEAR);
     });
 }
 
@@ -903,31 +1170,22 @@ TemporalResult<uint16_t> calendarDayOfYear(CalendarID calendarId, const ISO8601:
 //   2. (non-ISO) NonISOCalendarISOToDate — implementation-defined.
 TemporalResult<std::optional<String>> calendarEra(CalendarID calendarId, const ISO8601::PlainDate& isoDate)
 {
-    // 1. If calendarId has no eras, return undefined.
     if (!calendarHasEras(calendarId))
         return std::optional<String>(std::nullopt);
-    if (calendarId == rocCalendarID() || calendarId == buddhistCalendarID())
-        return std::optional<String>(String(gregorianArithmeticYearFieldsFor(calendarId, isoDate.year()).era));
-    // 2. Return the era string for isoDate in calendarId (e.g. "ce", "bce", "reiwa").
-    // NOTE: Japanese dates before 1873 use "ce"/"bce" per spec, not ICU era names.
-    if (calendarId == japaneseCalendarID() && isoDate.year() < japaneseCalendarGregorianTransitionYear)
-        return std::optional<String>(isoDate.year() > 0 ? String("ce"_s) : String("bce"_s));
-    // Read UCAL_ERA inside the lock, then map to era string outside (mapICUEraToTemporalEra
-    // for Japanese calls japaneseEraStartYear which needs its own withCalendar call).
-    auto icuEraOrError = withCalendar(calendarId, [&](UCalendar* cal) -> TemporalResult<int32_t> {
-        if (!cal) [[unlikely]]
-            return makeUnexpected(rangeError(icuOpenCalendarFailed));
-        if (!setCalendarToISODate(cal, isoDate)) [[unlikely]]
-            return makeUnexpected(rangeError(icuSetCalendarFailed));
-        UErrorCode status = U_ZERO_ERROR;
-        int32_t icuEra = ucal_get(cal, UCAL_ERA, &status);
-        if (U_FAILURE(status)) [[unlikely]]
-            return makeUnexpected(rangeError(icuReadCalendarFailed));
-        return icuEra;
+    if (auto proleptic = emitEraProleptic(calendarId, isoDate))
+        return proleptic->era;
+    return withCalendarSetToDate(calendarId, isoDate, [&](UCalendar* cal) -> TemporalResult<std::optional<String>> {
+        auto icuEra = readICUField(cal, UCAL_ERA);
+        if (!icuEra) [[unlikely]]
+            return makeUnexpected(icuEra.error());
+        auto ucalYear = readICUField(cal, UCAL_YEAR);
+        if (!ucalYear) [[unlikely]]
+            return makeUnexpected(ucalYear.error());
+        auto extendedYear = readICUField(cal, UCAL_EXTENDED_YEAR);
+        if (!extendedYear) [[unlikely]]
+            return makeUnexpected(extendedYear.error());
+        return emitEraFromICU(calendarId, *icuEra, *ucalYear, *extendedYear).era;
     });
-    if (!icuEraOrError)
-        return makeUnexpected(icuEraOrError.error());
-    return mapICUEraToTemporalEra(calendarId, *icuEraOrError);
 }
 
 // calendarEraYear — temporal_rs: Calendar::era_year (src/builtins/core/calendar.rs)
@@ -938,47 +1196,22 @@ TemporalResult<std::optional<String>> calendarEra(CalendarID calendarId, const I
 //   2. (non-ISO) NonISOCalendarISOToDate — implementation-defined.
 TemporalResult<std::optional<int32_t>> calendarEraYear(CalendarID calendarId, const ISO8601::PlainDate& isoDate)
 {
-    // 1. If calendarId has no eras, return undefined.
     if (!calendarHasEras(calendarId))
         return std::optional<int32_t>(std::nullopt);
-    if (calendarId == rocCalendarID() || calendarId == buddhistCalendarID())
-        return std::optional<int32_t>(gregorianArithmeticYearFieldsFor(calendarId, isoDate.year()).eraYear);
-    // 2. Return the era year (year within the current era) of isoDate in calendarId.
-    // NOTE: Japanese "ce"/"bce" fallback: eraYear is the Gregorian year.
-    if (calendarId == japaneseCalendarID() && isoDate.year() < japaneseCalendarGregorianTransitionYear)
-        return std::optional<int32_t>(isoDate.year() > 0 ? isoDate.year() : (1 - isoDate.year()));
-
-    struct RawEraYear {
-        int32_t eraYear { 0 };
-        int32_t icuEra { 0 };
-    };
-    auto rawOrError = withCalendar(calendarId, [&](UCalendar* cal) -> TemporalResult<RawEraYear> {
-        if (!cal) [[unlikely]]
-            return makeUnexpected(rangeError(icuOpenCalendarFailed));
-        if (!setCalendarToISODate(cal, isoDate)) [[unlikely]]
-            return makeUnexpected(rangeError(icuSetCalendarFailed));
-        UErrorCode status = U_ZERO_ERROR;
-        RawEraYear raw;
-        raw.eraYear = ucal_get(cal, UCAL_YEAR, &status);
-        if (U_FAILURE(status)) [[unlikely]]
-            return makeUnexpected(rangeError(icuReadCalendarFailed));
-        raw.icuEra = ucal_get(cal, UCAL_ERA, &status);
-        if (U_FAILURE(status)) [[unlikely]]
-            return makeUnexpected(rangeError(icuReadCalendarFailed));
-        return raw;
+    if (auto proleptic = emitEraProleptic(calendarId, isoDate))
+        return proleptic->eraYear;
+    return withCalendarSetToDate(calendarId, isoDate, [&](UCalendar* cal) -> TemporalResult<std::optional<int32_t>> {
+        auto icuEra = readICUField(cal, UCAL_ERA);
+        if (!icuEra) [[unlikely]]
+            return makeUnexpected(icuEra.error());
+        auto ucalYear = readICUField(cal, UCAL_YEAR);
+        if (!ucalYear) [[unlikely]]
+            return makeUnexpected(ucalYear.error());
+        auto extendedYear = readICUField(cal, UCAL_EXTENDED_YEAR);
+        if (!extendedYear) [[unlikely]]
+            return makeUnexpected(extendedYear.error());
+        return emitEraFromICU(calendarId, *icuEra, *ucalYear, *extendedYear).eraYear;
     });
-    if (!rawOrError)
-        return makeUnexpected(rawOrError.error());
-
-    int32_t eraYear = rawOrError->eraYear;
-    if (calendarId == japaneseCalendarID()) {
-        // isoDate.year() >= 1873 here (earlier case handled above).
-        // mapICUEraToTemporalEra calls japaneseEraStartYear which uses its own withCalendar.
-        auto era = mapICUEraToTemporalEra(calendarId, rawOrError->icuEra);
-        if (era && *era == "ce"_s)
-            eraYear = isoDate.year();
-    }
-    return std::optional<int32_t>(eraYear);
 }
 
 // calendarDaysInMonth — temporal_rs: Calendar::days_in_month (src/builtins/core/calendar.rs)
@@ -990,22 +1223,19 @@ TemporalResult<std::optional<int32_t>> calendarEraYear(CalendarID calendarId, co
 TemporalResult<int32_t> calendarDaysInMonth(CalendarID calendarId, const ISO8601::PlainDate& isoDate)
 {
     // 1. Return the number of days in the month containing isoDate in calendarId.
-    return withCalendar(gregorianArithmeticCalendarFor(calendarId), [&](UCalendar* cal) -> TemporalResult<int32_t> {
-        if (!cal) [[unlikely]]
-            return makeUnexpected(rangeError(icuOpenCalendarFailed));
-        if (!setCalendarToISODate(cal, isoDate)) [[unlikely]]
-            return makeUnexpected(rangeError(icuSetCalendarFailed));
-        UErrorCode status = U_ZERO_ERROR;
+    if (calendarUsesISOFallbackForExtremeYear(calendarId, isoDate.year()))
+        return ISO8601::daysInMonth(isoDate.year(), isoDate.month());
+    return withCalendarSetToDate(gregorianArithmeticCalendarFor(calendarId), isoDate, [&](UCalendar* cal) -> TemporalResult<int32_t> {
+        // ICU4C-WORKAROUND: rdar://182958553 - ICU says 29 (Deficient leap); icu4x says 30.
+        if (isHebrewYear0Kislev(cal, calendarId) || isHebrewYear0ExtraKislevDay(cal, calendarId))
+            return 30;
         if (calendarId == chineseCalendarID() || calendarId == dangiCalendarID()) {
             auto result = actualLunisolarMonthLength(cal, calendarId);
             if (!result) [[unlikely]]
                 return makeUnexpected(rangeError(icuReadCalendarFailed));
             return *result;
         }
-        auto result = ucal_getLimit(cal, UCAL_DAY_OF_MONTH, UCAL_ACTUAL_MAXIMUM, &status);
-        if (U_FAILURE(status)) [[unlikely]]
-            return makeUnexpected(rangeError(icuReadCalendarFailed));
-        return result;
+        return readICUFieldLimit(cal, UCAL_DAY_OF_MONTH, UCAL_ACTUAL_MAXIMUM);
     });
 }
 
@@ -1018,17 +1248,45 @@ TemporalResult<int32_t> calendarDaysInMonth(CalendarID calendarId, const ISO8601
 TemporalResult<int32_t> calendarDaysInYear(CalendarID calendarId, const ISO8601::PlainDate& isoDate)
 {
     // 1. Return the number of days in the year containing isoDate in calendarId.
-    return withCalendar(gregorianArithmeticCalendarFor(calendarId), [&](UCalendar* cal) -> TemporalResult<int32_t> {
-        if (!cal) [[unlikely]]
-            return makeUnexpected(rangeError(icuOpenCalendarFailed));
-        if (!setCalendarToISODate(cal, isoDate)) [[unlikely]]
-            return makeUnexpected(rangeError(icuSetCalendarFailed));
-        UErrorCode status = U_ZERO_ERROR;
-        int32_t result = ucal_getLimit(cal, UCAL_DAY_OF_YEAR, UCAL_ACTUAL_MAXIMUM, &status);
-        if (U_FAILURE(status)) [[unlikely]]
-            return makeUnexpected(rangeError(icuReadCalendarFailed));
-        return result;
+    if (calendarUsesISOFallbackForExtremeYear(calendarId, isoDate.year()))
+        return WTF::daysInYear(isoDate.year());
+    return withCalendarSetToDate(gregorianArithmeticCalendarFor(calendarId), isoDate, [&](UCalendar* cal) -> TemporalResult<int32_t> {
+        // ICU4C-WORKAROUND: rdar://182958553 - Hebrew y0 is Regular leap per icu4x (384), not Deficient leap (383).
+        if (calendarId == hebrewCalendarID()) {
+            UErrorCode s = U_ZERO_ERROR;
+            int32_t y = ucal_get(cal, UCAL_EXTENDED_YEAR, &s);
+            if (!U_FAILURE(s) && !y)
+                return 384;
+        }
+        return readICUFieldLimit(cal, UCAL_DAY_OF_YEAR, UCAL_ACTUAL_MAXIMUM);
     });
+}
+
+static TemporalResult<int32_t> walkLunisolarMonthsFromYearStart(UCalendar* cal, CalendarID calendarId, ASCIILiteral failureMessage)
+{
+    UErrorCode status = U_ZERO_ERROR;
+    bool isChineseBased = calendarId == chineseCalendarID() || calendarId == dangiCalendarID();
+    int32_t savedYear = isChineseBased ? 0 : ucal_get(cal, UCAL_EXTENDED_YEAR, &status);
+    if (U_FAILURE(status)) [[unlikely]]
+        return makeUnexpected(rangeError(icuReadCalendarFailed));
+    int32_t count = 1;
+    bool reachedNextYear = false;
+    for (int i = 0; i < 14; i++) {
+        if (advanceToNextLunisolarMonth(cal, calendarId, status) != LunisolarMonthAdvanceResult::Advanced) [[unlikely]]
+            return makeUnexpected(rangeError(failureMessage));
+        int32_t curYear = isChineseBased ? savedYear : ucal_get(cal, UCAL_EXTENDED_YEAR, &status);
+        auto monthCode = isChineseBased ? getMonthCode(cal, calendarId) : std::optional<String> { };
+        if (U_FAILURE(status) || (isChineseBased && !monthCode)) [[unlikely]]
+            return makeUnexpected(rangeError(icuReadCalendarFailed));
+        if ((isChineseBased && *monthCode == "M01"_s) || (!isChineseBased && curYear != savedYear)) {
+            reachedNextYear = true;
+            break;
+        }
+        count++;
+    }
+    if (!reachedNextYear || count > 13) [[unlikely]]
+        return makeUnexpected(rangeError(failureMessage));
+    return count;
 }
 
 // calendarMonthsInYear — temporal_rs: Calendar::months_in_year (src/builtins/core/calendar.rs)
@@ -1041,59 +1299,32 @@ TemporalResult<int32_t> calendarMonthsInYear(CalendarID calendarId, const ISO860
 {
     // 1. Return the number of months in the year containing isoDate in calendarId.
     // NOTE: Lunisolar calendars may have 12 or 13 months; requires walking all months.
-    return withCalendar(calendarId, [&](UCalendar* cal) -> TemporalResult<int32_t> {
-        if (!cal) [[unlikely]]
-            return makeUnexpected(rangeError(icuOpenCalendarFailed));
-        if (!setCalendarToISODate(cal, isoDate)) [[unlikely]]
-            return makeUnexpected(rangeError(icuSetCalendarFailed));
-        UErrorCode status = U_ZERO_ERROR;
-
+    if (calendarUsesISOFallbackForExtremeYear(calendarId, isoDate.year()))
+        return 12;
+    return withCalendarSetToDate(calendarId, isoDate, [&](UCalendar* cal) -> TemporalResult<int32_t> {
         if (calendarIsLunisolar(calendarId)) {
             // For lunisolar calendars, count months by walking from month 1 to end of year.
             // cal is local; mutating it has no observable effect outside this function.
+            UErrorCode status = U_ZERO_ERROR;
             bool isChineseBased = calendarId == chineseCalendarID() || calendarId == dangiCalendarID();
-            int32_t savedYear = isChineseBased ? 0 : ucal_get(cal, UCAL_EXTENDED_YEAR, &status);
-            if (U_FAILURE(status)) [[unlikely]]
-                return makeUnexpected(rangeError(icuReadCalendarFailed));
             if (isChineseBased) {
                 auto anchor = lunisolarYearAnchor(cal, calendarId, status);
                 if (!anchor) [[unlikely]]
                     return makeUnexpected(rangeError(icuCalendarArithmeticFailed));
                 if (anchor->second > anchor->first) {
-                    ucal_setMillis(cal, anchor->first, &status);
-                    int32_t daysInYear = ucal_getLimit(cal, UCAL_DAY_OF_YEAR, UCAL_ACTUAL_MAXIMUM, &status);
-                    if (U_FAILURE(status)) [[unlikely]]
+                    auto isLeapYear = isChineseLeapYear(cal, *anchor, status);
+                    if (!isLeapYear) [[unlikely]]
                         return makeUnexpected(rangeError(icuReadCalendarFailed));
-                    return daysInYear > 360 ? 13 : 12;
+                    return *isLeapYear ? 13 : 12;
                 }
             } else if (!setCalendarToLunisolarYearStart(cal, calendarId, std::nullopt, status)) [[unlikely]]
                 return makeUnexpected(rangeError(icuCalendarArithmeticFailed));
-            int32_t count = 1;
-            bool reachedNextYear = false;
-            for (int i = 0; i < 14; i++) {
-                if (advanceToNextLunisolarMonth(cal, calendarId, status) != LunisolarMonthAdvanceResult::Advanced) [[unlikely]]
-                    return makeUnexpected(rangeError(icuCalendarArithmeticFailed));
-                int32_t curYear = isChineseBased ? savedYear : ucal_get(cal, UCAL_EXTENDED_YEAR, &status);
-                if (U_FAILURE(status)) [[unlikely]]
-                    return makeUnexpected(rangeError(icuReadCalendarFailed));
-                auto monthCode = isChineseBased ? getMonthCode(cal, calendarId) : std::optional<String> { };
-                if (isChineseBased && !monthCode) [[unlikely]]
-                    return makeUnexpected(rangeError(icuReadCalendarFailed));
-                if ((isChineseBased && *monthCode == "M01"_s) || (!isChineseBased && curYear != savedYear)) {
-                    reachedNextYear = true;
-                    break;
-                }
-                count++;
-            }
-            if (!reachedNextYear || count > 13) [[unlikely]]
-                return makeUnexpected(rangeError(icuCalendarArithmeticFailed));
-            return count;
+            return walkLunisolarMonthsFromYearStart(cal, calendarId, icuCalendarArithmeticFailed);
         }
-
-        int32_t result = ucal_getLimit(cal, UCAL_MONTH, UCAL_ACTUAL_MAXIMUM, &status) + 1;
-        if (U_FAILURE(status)) [[unlikely]]
-            return makeUnexpected(rangeError(icuReadCalendarFailed));
-        return result;
+        auto result = readICUFieldLimit(cal, UCAL_MONTH, UCAL_ACTUAL_MAXIMUM);
+        if (!result) [[unlikely]]
+            return makeUnexpected(result.error());
+        return *result + 1;
     });
 }
 
@@ -1114,19 +1345,14 @@ TemporalResult<bool> calendarInLeapYear(CalendarID calendarId, const ISO8601::Pl
             return makeUnexpected(months.error());
         return *months > 12;
     }
-    return withCalendar(gregorianArithmeticCalendarFor(calendarId), [&](UCalendar* cal) -> TemporalResult<bool> {
-        if (!cal) [[unlikely]]
-            return makeUnexpected(rangeError(icuOpenCalendarFailed));
-        if (!setCalendarToISODate(cal, isoDate)) [[unlikely]]
-            return makeUnexpected(rangeError(icuSetCalendarFailed));
-        UErrorCode status = U_ZERO_ERROR;
-        int32_t actualMax = ucal_getLimit(cal, UCAL_DAY_OF_YEAR, UCAL_ACTUAL_MAXIMUM, &status);
-        if (U_FAILURE(status)) [[unlikely]]
-            return makeUnexpected(rangeError(icuReadCalendarFailed));
-        int32_t leastMax = ucal_getLimit(cal, UCAL_DAY_OF_YEAR, UCAL_LEAST_MAXIMUM, &status);
-        if (U_FAILURE(status)) [[unlikely]]
-            return makeUnexpected(rangeError(icuReadCalendarFailed));
-        return actualMax > leastMax;
+    return withCalendarSetToDate(gregorianArithmeticCalendarFor(calendarId), isoDate, [](UCalendar* cal) -> TemporalResult<bool> {
+        auto actualMax = readICUFieldLimit(cal, UCAL_DAY_OF_YEAR, UCAL_ACTUAL_MAXIMUM);
+        if (!actualMax) [[unlikely]]
+            return makeUnexpected(actualMax.error());
+        auto leastMax = readICUFieldLimit(cal, UCAL_DAY_OF_YEAR, UCAL_LEAST_MAXIMUM);
+        if (!leastMax) [[unlikely]]
+            return makeUnexpected(leastMax.error());
+        return *actualMax > *leastMax;
     });
 }
 
@@ -1146,11 +1372,7 @@ static std::optional<int> setCalendarToMonthCode(UCalendar* cal, CalendarID cale
         int32_t savedYear = ucal_get(cal, UCAL_EXTENDED_YEAR, &status);
         if (U_FAILURE(status)) [[unlikely]]
             return std::nullopt;
-        ucal_set(cal, UCAL_MONTH, 0);
-        ucal_set(cal, UCAL_IS_LEAP_MONTH, 0);
-        ucal_set(cal, UCAL_DAY_OF_MONTH, 1);
-        ucal_getMillis(cal, &status);
-        if (U_FAILURE(status)) [[unlikely]]
+        if (!resetCalendarToMonthStart(cal)) [[unlikely]]
             return std::nullopt;
 
         for (int i = 0; i < 15; i++) {
@@ -1161,6 +1383,8 @@ static std::optional<int> setCalendarToMonthCode(UCalendar* cal, CalendarID cale
                 return 1; // exact match
             ucal_add(cal, UCAL_MONTH, 1, &status);
             if (U_FAILURE(status)) [[unlikely]]
+                return std::nullopt;
+            if (!forceICUFieldReresolution(cal)) [[unlikely]]
                 return std::nullopt;
             int32_t curYear = ucal_get(cal, UCAL_EXTENDED_YEAR, &status);
             if (U_FAILURE(status)) [[unlikely]]
@@ -1182,10 +1406,9 @@ static std::optional<int> setCalendarToMonthCode(UCalendar* cal, CalendarID cale
     int32_t savedYear = ucal_get(cal, UCAL_EXTENDED_YEAR, &status);
     if (U_FAILURE(status)) [[unlikely]]
         return std::nullopt;
-    ucal_set(cal, UCAL_MONTH, 0);
-    ucal_set(cal, UCAL_IS_LEAP_MONTH, 0);
-    ucal_set(cal, UCAL_DAY_OF_MONTH, 1);
-    ucal_getMillis(cal, &status);
+    if (!resetCalendarToMonthStart(cal)) [[unlikely]]
+        return std::nullopt;
+    double previousMonthStartMs = ucal_getMillis(cal, &status);
     if (U_FAILURE(status)) [[unlikely]]
         return std::nullopt;
 
@@ -1197,23 +1420,25 @@ static std::optional<int> setCalendarToMonthCode(UCalendar* cal, CalendarID cale
             return 1; // exact match
         // If we've walked past the target monthCode lexicographically, the requested code
         // (a leap month) doesn't exist in this year — constrain to the base month by
-        // reverting one step (Chinese/Dangi convention, matches temporal_rs).
+        // reverting to the previous position (Chinese/Dangi convention, matches temporal_rs).
         // Without this early-stop, walking to year-end would incorrectly land on M12.
         if (codePointCompare(*curCode, monthCode) > 0) {
-            ucal_add(cal, UCAL_MONTH, -1, &status);
+            ucal_setMillis(cal, previousMonthStartMs, &status);
             if (U_FAILURE(status)) [[unlikely]]
                 return std::nullopt;
             return 0; // constrained to base month
         }
-        ucal_add(cal, UCAL_MONTH, 1, &status);
+        previousMonthStartMs = ucal_getMillis(cal, &status);
         if (U_FAILURE(status)) [[unlikely]]
+            return std::nullopt;
+        if (advanceToNextLunisolarMonth(cal, calendarId, status) != LunisolarMonthAdvanceResult::Advanced) [[unlikely]]
             return std::nullopt;
         int32_t curYear = ucal_get(cal, UCAL_EXTENDED_YEAR, &status);
         if (U_FAILURE(status)) [[unlikely]]
             return std::nullopt;
         if (curYear != savedYear) {
             // Month code sorts after every month in the year (e.g., "M99") — constrain to last month.
-            ucal_add(cal, UCAL_MONTH, -1, &status);
+            ucal_setMillis(cal, previousMonthStartMs, &status);
             if (U_FAILURE(status)) [[unlikely]]
                 return std::nullopt;
             return 0; // constrained
@@ -1257,22 +1482,27 @@ static UCalendarDateFields calendarArithmeticYearField(CalendarID calendarId)
     return calendarId == ethioaaCalendarID() ? UCAL_YEAR : UCAL_EXTENDED_YEAR;
 }
 
+// Chinese/Dangi: UCAL_EXTENDED_YEAR's epoch differs across ICU versions, so position via ISO date instead.
+static bool positionCalendarToYearStart(UCalendar* cal, CalendarID calendarId, int32_t year, UErrorCode& status)
+{
+    if (calendarId == chineseCalendarID() || calendarId == dangiCalendarID())
+        return setCalendarToLunisolarYearStart(cal, calendarId, year, status);
+    auto yearField = calendarArithmeticYearField(calendarId);
+    if (yearField == UCAL_YEAR)
+        ucal_set(cal, UCAL_ERA, 0);
+    ucal_set(cal, yearField, year);
+    return resetCalendarToMonthStart(cal);
+}
+
 // resolveMonthCodeToOrdinal — internal: resolves a monthCode to its 1-based ordinal position in the given year
 static int32_t resolveMonthCodeToOrdinal(CalendarID calendarId, const String& monthCode, int32_t year)
 {
     return withCalendar(calendarId, [&](UCalendar* cal) -> int32_t {
-        if (!cal)
+        if (!cal) [[unlikely]]
             return 1;
         UErrorCode status = U_ZERO_ERROR;
         auto yearField = calendarArithmeticYearField(calendarId);
-        if (yearField == UCAL_YEAR)
-            ucal_set(cal, UCAL_ERA, 0);
-        ucal_set(cal, yearField, year);
-        ucal_set(cal, UCAL_MONTH, 0);
-        ucal_set(cal, UCAL_IS_LEAP_MONTH, 0);
-        ucal_set(cal, UCAL_DAY_OF_MONTH, 1);
-        ucal_getMillis(cal, &status);
-        if (U_FAILURE(status)) [[unlikely]]
+        if (!positionCalendarToYearStart(cal, calendarId, year, status)) [[unlikely]]
             return 1;
 
         int32_t savedYear = ucal_get(cal, yearField, &status);
@@ -1297,6 +1527,8 @@ static int32_t resolveMonthCodeToOrdinal(CalendarID calendarId, const String& mo
             ucal_add(cal, UCAL_MONTH, 1, &status);
             if (U_FAILURE(status)) [[unlikely]]
                 return lastOrdinal;
+            if (!forceICUFieldReresolution(cal)) [[unlikely]]
+                return lastOrdinal;
             int32_t curYear = ucal_get(cal, yearField, &status);
             if (U_FAILURE(status)) [[unlikely]]
                 return lastOrdinal;
@@ -1304,6 +1536,119 @@ static int32_t resolveMonthCodeToOrdinal(CalendarID calendarId, const String& mo
                 return lastOrdinal;
         }
         return lastOrdinal;
+    });
+}
+
+// https://tc39.es/proposal-intl-era-monthcode/#sec-temporal-isvalidmonthcodeforcalendar
+bool isValidMonthCodeForCalendar(CalendarID calendarId, ParsedMonthCode monthCode)
+{
+    uint8_t number = monthCode.monthNumber;
+    bool isLeap = monthCode.isLeapMonth;
+    // Steps 1-2: commonMonthCodes = «M01..M12». If contains monthCode → return true.
+    if (!isLeap && number >= 1 && number <= 12)
+        return true;
+    // Step 3: if calendar is in table-additional-month-codes, check its "Additional Month Codes" list.
+    if (calendarId == chineseCalendarID() || calendarId == dangiCalendarID())
+        return isLeap && number >= 1 && number <= 12; // «M01L..M12L»
+    if (calendarId == copticCalendarID() || calendarId == ethiopicCalendarID() || calendarId == ethioaaCalendarID())
+        return !isLeap && number == 13; // «M13»
+    if (calendarId == hebrewCalendarID())
+        return isLeap && number == 5; // «M05L»
+    // Step 4: calendar in table-calendar-types but not in table-additional-month-codes.
+    // (buddhist / gregory / indian / islamic-* / japanese / persian / roc / iso8601)
+    // Step 5 (implementation-defined for unknown calendars): the same `return false` also
+    // satisfies step 5 if JSC ever adds a calendar not in the spec's table-calendar-types.
+    return false;
+}
+
+// https://tc39.es/proposal-intl-era-monthcode/#sec-temporal-yearcontainsmonthcode
+static bool yearContainsMonthCodeInternal(UCalendar* cal, CalendarID calendarId, int32_t year, ParsedMonthCode monthCode)
+{
+    // Step 1: Assert IsValidMonthCodeForCalendar.
+    ASSERT(isValidMonthCodeForCalendar(calendarId, monthCode));
+    // Step 2: non-leap monthCodes always exist in every year.
+    if (!monthCode.isLeapMonth)
+        return true;
+    // Step 3 (calendar-dependent): leap month exists iff ICU can position on the exact monthCode.
+    UErrorCode status = U_ZERO_ERROR;
+    if (!positionCalendarToYearStart(cal, calendarId, year, status)) [[unlikely]]
+        return false;
+    String mcStr = makeString("M"_s, monthCode.monthNumber < 10 ? "0"_s : ""_s, monthCode.monthNumber, "L"_s);
+    auto probe = setCalendarToMonthCode(cal, calendarId, mcStr);
+    return probe && *probe == 1;
+}
+
+// Public wrapper: opens ICU via withCalendar for one-shot callers.
+bool yearContainsMonthCode(CalendarID calendarId, int32_t year, ParsedMonthCode monthCode)
+{
+    return withCalendar(calendarId, [&](UCalendar* cal) -> bool {
+        return cal && yearContainsMonthCodeInternal(cal, calendarId, year, monthCode);
+    });
+}
+
+// https://tc39.es/proposal-intl-era-monthcode/#sec-temporal-constrainmonthcode
+static TemporalResult<ParsedMonthCode> constrainMonthCodeGivenContainment(CalendarID calendarId, ParsedMonthCode monthCode, bool contained, TemporalOverflow overflow)
+{
+    // Step 2: If YearContainsMonthCode, return monthCode.
+    if (contained)
+        return monthCode;
+    // Step 3: If overflow is ~reject~, throw RangeError.
+    if (overflow == TemporalOverflow::Reject)
+        return makeUnexpected(rangeError("monthCode does not exist in this calendar year"_s));
+    // Step 4: Assert calendar is in table-additional-month-codes with a leap-transformation column.
+    ASSERT(calendarId == chineseCalendarID() || calendarId == dangiCalendarID() || calendarId == hebrewCalendarID());
+    // Steps 5-7: chinese/dangi row → ~skip-backward~ → CreateMonthCode(monthNumber, false).
+    if (calendarId == chineseCalendarID() || calendarId == dangiCalendarID())
+        return ParsedMonthCode { monthCode.monthNumber, false };
+    // Step 8: hebrew row → ~skip-forward~ → assert "M05L" (8.a), return "M06" (8.b).
+    ASSERT(monthCode.monthNumber == 5 && monthCode.isLeapMonth);
+    return ParsedMonthCode { 6, false };
+}
+TemporalResult<ParsedMonthCode> constrainMonthCode(CalendarID calendarId, int32_t year, ParsedMonthCode monthCode, TemporalOverflow overflow)
+{
+    // Step 1: Assert IsValidMonthCodeForCalendar.
+    ASSERT(isValidMonthCodeForCalendar(calendarId, monthCode));
+    // Steps 2-8: delegate to algorithm extract with cursor-computed containment.
+    return constrainMonthCodeGivenContainment(calendarId, monthCode, yearContainsMonthCode(calendarId, year, monthCode), overflow);
+}
+static TemporalResult<ParsedMonthCode> constrainMonthCodeInternal(UCalendar* cal, CalendarID calendarId, ParsedMonthCode monthCode, TemporalOverflow overflow)
+{
+    // Step 1: Assert IsValidMonthCodeForCalendar.
+    ASSERT(isValidMonthCodeForCalendar(calendarId, monthCode));
+    UErrorCode status = U_ZERO_ERROR;
+    int32_t year = ucal_get(cal, UCAL_EXTENDED_YEAR, &status);
+    if (U_FAILURE(status)) [[unlikely]]
+        return makeUnexpected(rangeError(icuReadCalendarFailed));
+    // Steps 2-8: delegate to algorithm extract with cursor-computed containment.
+    return constrainMonthCodeGivenContainment(calendarId, monthCode, yearContainsMonthCodeInternal(cal, calendarId, year, monthCode), overflow);
+}
+
+// https://tc39.es/proposal-intl-era-monthcode/#sec-temporal-monthcodetoordinal
+int32_t monthCodeOrdinalInYear(CalendarID calendarId, ParsedMonthCode monthCode, int32_t year)
+{
+    ASSERT(isValidMonthCodeForCalendar(calendarId, monthCode));
+    ASSERT(yearContainsMonthCode(calendarId, year, monthCode));
+
+    // Step 6 (extended to non-table calendars): no leap months -> ordinal == monthNumber.
+    if (!calendarIsLunisolar(calendarId))
+        return monthCode.monthNumber;
+
+    // Steps 2-4 init + steps 8-9 loop: M01, M01L, M02, M02L, ..., M12, M12L.
+    return withCalendar(calendarId, [&](UCalendar* cal) -> int32_t {
+        if (!cal) [[unlikely]]
+            return monthCode.monthNumber; // fallback: ignore leap-month index shift
+        int32_t monthsBefore = 0;
+        for (uint8_t number = 1; number <= 12; number++) {
+            for (bool isLeap : { false, true }) {
+                ParsedMonthCode candidate { number, isLeap };
+                if (isValidMonthCodeForCalendar(calendarId, candidate)
+                    && yearContainsMonthCodeInternal(cal, calendarId, year, candidate))
+                    monthsBefore++; // Step 9.b
+                if (number == monthCode.monthNumber && isLeap == monthCode.isLeapMonth) // Step 9.c
+                    return monthsBefore;
+            }
+        }
+        RELEASE_ASSERT_NOT_REACHED(); // Precondition ensures target is visited.
     });
 }
 
@@ -1366,6 +1711,35 @@ static std::optional<FixedSolarYearMonth> balanceFixedSolarYearMonth(int32_t sou
     return FixedSolarYearMonth { expectedYear, expectedMonth };
 }
 
+static std::optional<bool> verifyAndCorrectFixedSolarDay(UCalendar* cal, UCalendarDateFields yearField, int32_t expectedYear, int32_t expectedMonth, int32_t expectedDay)
+{
+    UErrorCode status = U_ZERO_ERROR;
+    int32_t actualYear = ucal_get(cal, yearField, &status);
+    if (U_FAILURE(status)) [[unlikely]]
+        return std::nullopt;
+    int32_t actualMonth = ucal_get(cal, UCAL_MONTH, &status);
+    if (U_FAILURE(status)) [[unlikely]]
+        return std::nullopt;
+    int32_t actualDay = ucal_get(cal, UCAL_DAY_OF_MONTH, &status);
+    if (U_FAILURE(status)) [[unlikely]]
+        return std::nullopt;
+    if (actualYear == expectedYear && actualMonth == expectedMonth && std::abs(actualDay - expectedDay) == 1) {
+        ucal_add(cal, UCAL_DAY_OF_MONTH, expectedDay - actualDay, &status);
+        if (U_FAILURE(status)) [[unlikely]]
+            return std::nullopt;
+        actualYear = ucal_get(cal, yearField, &status);
+        if (U_FAILURE(status)) [[unlikely]]
+            return std::nullopt;
+        actualMonth = ucal_get(cal, UCAL_MONTH, &status);
+        if (U_FAILURE(status)) [[unlikely]]
+            return std::nullopt;
+        actualDay = ucal_get(cal, UCAL_DAY_OF_MONTH, &status);
+        if (U_FAILURE(status)) [[unlikely]]
+            return std::nullopt;
+    }
+    return actualYear == expectedYear && actualMonth == expectedMonth && actualDay == expectedDay;
+}
+
 // Clear and construct an exact native year/month at day 1. Noon preserves Temporal's partial-day
 // endpoints. At ICU's extreme millisecond boundary, directly set fields can resolve one day off;
 // correct only that rounding after the expected year/month resolve, then verify every field.
@@ -1384,22 +1758,7 @@ static std::optional<bool> setFixedSolarCalendarToYearMonth(UCalendar* cal, Cale
     ucal_getMillis(cal, &status);
     if (U_FAILURE(status)) [[unlikely]]
         return std::nullopt;
-    int32_t actualYear = ucal_get(cal, yearField, &status);
-    int32_t actualMonth = ucal_get(cal, UCAL_MONTH, &status);
-    int32_t actualDay = ucal_get(cal, UCAL_DAY_OF_MONTH, &status);
-    if (U_FAILURE(status)) [[unlikely]]
-        return std::nullopt;
-    if (actualYear == expected.year && actualMonth == expected.month && std::abs(actualDay - 1) == 1) {
-        ucal_add(cal, UCAL_DAY_OF_MONTH, 1 - actualDay, &status);
-        if (U_FAILURE(status)) [[unlikely]]
-            return std::nullopt;
-        actualYear = ucal_get(cal, yearField, &status);
-        actualMonth = ucal_get(cal, UCAL_MONTH, &status);
-        actualDay = ucal_get(cal, UCAL_DAY_OF_MONTH, &status);
-        if (U_FAILURE(status)) [[unlikely]]
-            return std::nullopt;
-    }
-    return actualYear == expected.year && actualMonth == expected.month && actualDay == 1;
+    return verifyAndCorrectFixedSolarDay(cal, yearField, expected.year, expected.month, 1);
 }
 
 static TemporalResult<ISO8601::PlainDate> fixedSolarDateAdd(CalendarID calendarId, const ISO8601::PlainDate& isoDate, const ISO8601::Duration& duration, TemporalOverflow overflow)
@@ -1413,7 +1772,11 @@ static TemporalResult<ISO8601::PlainDate> fixedSolarDateAdd(CalendarID calendarI
         UErrorCode status = U_ZERO_ERROR;
         auto yearField = calendarArithmeticYearField(calendarId);
         int32_t sourceYear = ucal_get(cal, yearField, &status);
+        if (U_FAILURE(status)) [[unlikely]]
+            return makeUnexpected(rangeError(icuReadCalendarFailed));
         int32_t sourceMonth = ucal_get(cal, UCAL_MONTH, &status);
+        if (U_FAILURE(status)) [[unlikely]]
+            return makeUnexpected(rangeError(icuReadCalendarFailed));
         int32_t sourceDay = ucal_get(cal, UCAL_DAY_OF_MONTH, &status);
         if (U_FAILURE(status)) [[unlikely]]
             return makeUnexpected(rangeError(icuReadCalendarFailed));
@@ -1437,25 +1800,13 @@ static TemporalResult<ISO8601::PlainDate> fixedSolarDateAdd(CalendarID calendarI
         ucal_getMillis(cal, &status);
         if (U_FAILURE(status)) [[unlikely]]
             return makeUnexpected(rangeError(icuCalendarArithmeticFailed));
-        int32_t actualYear = ucal_get(cal, yearField, &status);
-        int32_t actualMonth = ucal_get(cal, UCAL_MONTH, &status);
-        int32_t actualDay = ucal_get(cal, UCAL_DAY_OF_MONTH, &status);
-        if (U_FAILURE(status)) [[unlikely]]
-            return makeUnexpected(rangeError(icuReadCalendarFailed));
         // At ICU's extreme millisecond boundary, resolving a directly set day can round to
         // the adjacent day even though that native day is representable. Correct only the day
         // after the expected year/month have resolved exactly, then verify all fields again.
-        if (actualYear == expected->year && actualMonth == expected->month && std::abs(actualDay - regulatedDay) == 1) {
-            ucal_add(cal, UCAL_DAY_OF_MONTH, regulatedDay - actualDay, &status);
-            if (U_FAILURE(status)) [[unlikely]]
-                return makeUnexpected(rangeError(icuCalendarArithmeticFailed));
-            actualYear = ucal_get(cal, yearField, &status);
-            actualMonth = ucal_get(cal, UCAL_MONTH, &status);
-            actualDay = ucal_get(cal, UCAL_DAY_OF_MONTH, &status);
-            if (U_FAILURE(status)) [[unlikely]]
-                return makeUnexpected(rangeError(icuReadCalendarFailed));
-        }
-        if (actualYear != expected->year || actualMonth != expected->month || actualDay != regulatedDay) [[unlikely]]
+        auto constructedRegulatedDay = verifyAndCorrectFixedSolarDay(cal, yearField, expected->year, expected->month, regulatedDay);
+        if (!constructedRegulatedDay) [[unlikely]]
+            return makeUnexpected(rangeError(icuCalendarArithmeticFailed));
+        if (!*constructedRegulatedDay) [[unlikely]]
             return makeUnexpected(rangeError("Result of calendar date addition is outside representable range"_s));
 
         auto baseline = isoDateFromCalendarChecked(cal);
@@ -1463,7 +1814,7 @@ static TemporalResult<ISO8601::PlainDate> fixedSolarDateAdd(CalendarID calendarI
             return makeUnexpected(rangeError("Result of calendar date addition is outside representable range"_s));
         return *baseline;
     });
-    if (!baselineOrError)
+    if (!baselineOrError) [[unlikely]]
         return makeUnexpected(baselineOrError.error());
 
     ISO8601::Duration remaining;
@@ -1476,26 +1827,19 @@ static TemporalResult<ISO8601::PlainDate> fixedSolarDateAdd(CalendarID calendarI
 //   temporal_rs delegates to icu4x: AnyCalendar::add -> ArithmeticDate::added (components/calendar/src/calendar_arithmetic.rs)
 //   ICU4C has no equivalent: we use ucal_add(UCAL_EXTENDED_YEAR/UCAL_MONTH) with month-code re-resolution for lunisolar.
 // https://tc39.es/proposal-temporal/#sec-temporal-calendardateadd
-// CalendarDateAdd steps:
-//   1. If iso8601 -> isoDateAdd (BalanceISOYearMonth + RegulateISODate + AddDaysToISODate). (our steps 1–2)
-//   2. (else) NonISODateAdd — implementation-defined. (our steps 3–9)
-//   3. If ISODateWithinLimits(result) is false, throw RangeError. (checked after conversion)
-//   4. Return result.
 TemporalResult<ISO8601::PlainDate> calendarDateAdd(CalendarID calendarId, const ISO8601::PlainDate& isoDate, const ISO8601::Duration& duration, TemporalOverflow overflow)
 {
-    // 1. If there are no year or month components, day/week addition is calendar-independent; use isoDateAdd.
-    // NOTE: ICU's Chinese/Dangi approximation gives wrong results for far-future dates (year > ~2100).
+    // Step 1: iso8601 → BalanceISOYearMonth + RegulateISODate + AddDaysToISODate.
+    if (calendarUsesISODateArithmetic(calendarId))
+        return isoDateAdd(isoDate, duration, overflow);
+    // Fast path: day/week-only durations are calendar-independent.
     if (!duration.years() && !duration.months())
         return isoDateAdd(isoDate, duration, overflow);
-    // 2. Fixed solar calendars construct the exact expected native fields directly.
+    // Fixed solar calendars construct the exact expected native fields directly.
     if (calendarIsNonISOSolar(calendarId))
         return fixedSolarDateAdd(calendarId, isoDate, duration, overflow);
-    // 3. Gregorian-derived calendars use ISO proleptic-Gregorian arithmetic.
-    // NOTE: ICU's gregory uses Julian arithmetic before 1582; keep the ISO path for Gregorian-derived calendars.
-    if (!calendarIsLunisolar(calendarId))
-        return isoDateAdd(isoDate, duration, overflow);
-    // 4. Let totalDays be duration.[[Days]] + 7 × duration.[[Weeks]].
-    // NOTE: ucal_add takes int32_t; any component outside int32_t exceeds Temporal's representable range.
+
+    // ucal_add takes int32_t; larger components exceed Temporal's representable range.
     auto fitsInt32 = [](int64_t v) -> bool {
         return v >= INT32_MIN && v <= INT32_MAX;
     };
@@ -1503,46 +1847,58 @@ TemporalResult<ISO8601::PlainDate> calendarDateAdd(CalendarID calendarId, const 
     if (!fitsInt32(duration.years()) || !fitsInt32(duration.months()) || !fitsInt32(totalDays64)) [[unlikely]]
         return makeUnexpected(rangeError("duration is out of the representable range"_s));
 
+    // Step 2: non-ISO → NonISODateAdd. https://tc39.es/proposal-intl-era-monthcode/#sup-temporal-nonisodateadd
     return withCalendar(calendarId, [&](UCalendar* cal) -> TemporalResult<ISO8601::PlainDate> {
         if (!cal) [[unlikely]]
             return makeUnexpected(rangeError(icuOpenCalendarFailed));
-
-        // 4. Open ICU calendar for calendarId. (done by withCalendar above)
-        // 5. Set ICU calendar to isoDate.
         if (!setCalendarToISODate(cal, isoDate)) [[unlikely]]
             return makeUnexpected(rangeError(icuSetCalendarFailed));
 
-        // 6. Let origMonthCode and origDay be the source month code and day (preserved across year addition per icu4x).
+        // ICU4C-WORKAROUND: rdar://182958553 - y0 Kislev D30 sits at ICU's Tevet D1; step back
+        // one day so ucal_add(MONTH) advances from Kislev, and treat the snapshot as M03 D30.
+        bool hebrewY0Kislev = isHebrewYear0ExtraKislevDay(cal, calendarId);
+        if (hebrewY0Kislev) {
+            UErrorCode s = U_ZERO_ERROR;
+            ucal_add(cal, UCAL_DAY_OF_MONTH, -1, &s);
+            if (U_FAILURE(s)) [[unlikely]]
+                return makeUnexpected(rangeError(icuCalendarArithmeticFailed));
+        }
+
+        // Snapshot source monthCode + day; icu4x preserves both across year-add.
         UErrorCode status = U_ZERO_ERROR;
         auto origMonthCodeOpt = getMonthCode(cal, calendarId);
         if (!origMonthCodeOpt) [[unlikely]]
             return makeUnexpected(rangeError(icuReadCalendarFailed));
-        String origMonthCode = WTF::move(*origMonthCodeOpt);
-        int32_t originalDay = ucal_get(cal, UCAL_DAY_OF_MONTH, &status);
-        if (U_FAILURE(status)) [[unlikely]]
+        String origMonthCode = hebrewY0Kislev ? String("M03"_s) : WTF::move(*origMonthCodeOpt);
+        int32_t originalDay = hebrewY0Kislev ? 30 : ucal_get(cal, UCAL_DAY_OF_MONTH, &status);
+        if (!hebrewY0Kislev && U_FAILURE(status)) [[unlikely]]
             return makeUnexpected(rangeError(icuReadCalendarFailed));
-        // 7. If duration.[[Years]] ≠ 0, add years and re-resolve the original month code in the new year.
+
+        // Add years. Lunisolar: re-resolve original monthCode in the new year (= ConstrainMonthCode).
         if (duration.years()) {
             ucal_add(cal, UCAL_EXTENDED_YEAR, clampTo<int32_t>(duration.years()), &status);
             if (U_FAILURE(status)) [[unlikely]]
                 return makeUnexpected(rangeError(icuCalendarArithmeticFailed));
-            auto foundState = setCalendarToMonthCode(cal, calendarId, origMonthCode);
-            if (!foundState) [[unlikely]]
-                return makeUnexpected(rangeError("Failed to resolve month code after year addition"_s));
-            //    a. If overflow is ~reject~ and month code doesn't exist in new year, throw RangeError.
-            if (!foundState.value() && overflow == TemporalOverflow::Reject) [[unlikely]]
-                return makeUnexpected(rangeError("month code does not exist in the target year (overflow: reject)"_s));
+            if (calendarIsLunisolar(calendarId)) {
+                auto foundState = setCalendarToMonthCode(cal, calendarId, origMonthCode);
+                if (!foundState) [[unlikely]]
+                    return makeUnexpected(rangeError("Failed to resolve month code after year addition"_s));
+                if (!foundState.value() && overflow == TemporalOverflow::Reject) [[unlikely]]
+                    return makeUnexpected(rangeError("month code does not exist in the target year (overflow: reject)"_s));
+            }
         }
 
-        // 8. If duration.[[Months]] ≠ 0, add months.
+        // Add months. ICU balances year rollover implicitly.
         if (duration.months()) {
             ucal_add(cal, UCAL_MONTH, clampTo<int32_t>(duration.months()), &status);
             if (U_FAILURE(status)) [[unlikely]]
                 return makeUnexpected(rangeError(icuCalendarArithmeticFailed));
+            if (!forceICUFieldReresolution(cal)) [[unlikely]]
+                return makeUnexpected(rangeError(icuCalendarArithmeticFailed));
         }
-        // 9. Clamp or reject the day to the new month's maximum.
-        // NOTE: ucal_add already clamps for constrain. For reject, check if day was reduced.
-        // Do NOT use ucal_set(DAY_OF_MONTH) after ucal_add — causes ICU state corruption on lunisolar calendars.
+
+        // Regulate day to the new month's max. ucal_add already clamps on constrain; for reject,
+        // detect and throw. Do NOT ucal_set(DAY_OF_MONTH) after ucal_add — corrupts lunisolar cursor.
         int32_t maxDay = ucal_getLimit(cal, UCAL_DAY_OF_MONTH, UCAL_ACTUAL_MAXIMUM, &status);
         if (U_FAILURE(status)) [[unlikely]]
             return makeUnexpected(rangeError(icuReadCalendarFailed));
@@ -1551,7 +1907,6 @@ TemporalResult<ISO8601::PlainDate> calendarDateAdd(CalendarID calendarId, const 
         int32_t curDay = ucal_get(cal, UCAL_DAY_OF_MONTH, &status);
         if (U_FAILURE(status)) [[unlikely]]
             return makeUnexpected(rangeError(icuReadCalendarFailed));
-
         if (curDay != originalDay && originalDay <= maxDay) {
             ucal_add(cal, UCAL_DAY_OF_MONTH, originalDay - curDay, &status);
             if (U_FAILURE(status)) [[unlikely]]
@@ -1565,8 +1920,7 @@ TemporalResult<ISO8601::PlainDate> calendarDateAdd(CalendarID calendarId, const 
             }
         }
 
-        // 10. Add totalDays.
-        // 11. If result is outside representable range, throw RangeError.
+        // Add totalDays (= days + 7 * weeks).
         int32_t totalDays = static_cast<int32_t>(totalDays64);
         if (totalDays) {
             ucal_add(cal, UCAL_DAY_OF_MONTH, totalDays, &status);
@@ -1574,10 +1928,10 @@ TemporalResult<ISO8601::PlainDate> calendarDateAdd(CalendarID calendarId, const 
                 return makeUnexpected(rangeError(icuCalendarArithmeticFailed));
         }
 
-        // 12. Return result.
-        auto result = isoDateFromCalendarChecked(cal);
+        // Read result + range check (skip Reject re-validation: cursor is valid by construction).
+        auto result = calendarIntegersToISO(cal, calendarId, std::nullopt, 0, TemporalOverflow::Constrain);
         if (!result) [[unlikely]]
-            return makeUnexpected(rangeError("Result of calendar date addition is outside representable range"_s));
+            return makeUnexpected(result.error());
         return *result;
     });
 }
@@ -1598,6 +1952,8 @@ static std::optional<bool> surpassesMonths(
     if (calendarIsNonISOSolar(calendarId)) {
         auto yearField = calendarArithmeticYearField(calendarId);
         int32_t sourceYear = ucal_get(trialCal, yearField, &status);
+        if (U_FAILURE(status)) [[unlikely]]
+            return std::nullopt;
         int32_t sourceMonth = ucal_get(trialCal, UCAL_MONTH, &status);
         if (U_FAILURE(status)) [[unlikely]]
             return std::nullopt;
@@ -1605,7 +1961,7 @@ static std::optional<bool> surpassesMonths(
         if (!expected)
             return true;
         auto advancedExactly = setFixedSolarCalendarToYearMonth(trialCal, calendarId, *expected);
-        if (!advancedExactly)
+        if (!advancedExactly) [[unlikely]]
             return std::nullopt;
         if (!*advancedExactly)
             return true;
@@ -1631,12 +1987,12 @@ static std::optional<bool> surpassesMonths(
 
     // Phase 2: constrain source monthCode to year y0, compare ordinally.
     // trialCal is at the trial position, so its ordinal month equals resolveMonthCodeToOrdinal(calendarId, trialMonthCode, trialYear).
-    // Read it directly. computeOrdinalMonth mutates trialCal (walks from year-start for lunisolar). save+restore epoch ms preserves
-    // the trial position for the next loop iteration.
+    // Read it directly. computeFieldResolutionOrdinalMonth mutates trialCal (walks from year-start
+    // for lunisolar). save+restore epoch ms preserves the trial position for the next loop iteration.
     double savedMs = ucal_getMillis(trialCal, &status);
     if (U_FAILURE(status)) [[unlikely]]
         return std::nullopt;
-    auto trialOrdinal = computeOrdinalMonth(trialCal, calendarId);
+    auto trialOrdinal = computeFieldResolutionOrdinalMonth(trialCal, calendarId);
     UErrorCode restoreStatus = U_ZERO_ERROR;
     ucal_setMillis(trialCal, savedMs, &restoreStatus);
     if (!trialOrdinal || U_FAILURE(restoreStatus)) [[unlikely]]
@@ -1667,100 +2023,76 @@ static std::optional<bool> setMonths(UCalendar* cal, int32_t sourceDay)
 //   temporal_rs delegates to icu4x: AnyCalendar::until -> ArithmeticDate::until + SurpassesChecker (components/calendar/src/calendar_arithmetic.rs)
 //   ICU4C has no equivalent: fixed-solar calendars balance native fields directly; lunisolar calendars walk months with ucal_add.
 // https://tc39.es/proposal-temporal/#sec-temporal-calendardateuntil
-// CalendarDateUntil steps:
-//   1. Let sign be CompareISODate(one, two). (our step 4)
-//   2. If sign = 0, return ZeroDateDuration(). (our step 4)
-//   3. If iso8601 -> diffISODate (ISODateSurpasses algorithm). (our steps 1–2)
-//   4. Return NonISODateUntil — implementation-defined. (our steps 3–8)
 TemporalResult<ISO8601::Duration> calendarDateUntil(CalendarID calendarId, const ISO8601::PlainDate& one, const ISO8601::PlainDate& two, TemporalUnit largestUnit)
 {
-    // CalendarDateUntil takes "largestUnit: a date unit" — spec guarantees Year/Month/Week/Day only.
     ASSERT(largestUnit == TemporalUnit::Year || largestUnit == TemporalUnit::Month || largestUnit == TemporalUnit::Week || largestUnit == TemporalUnit::Day);
 
-    // 1. If calendarId is neither fixed solar nor lunisolar, use ISO proleptic-Gregorian arithmetic.
-    // NOTE: ICU's 'gregory' uses Julian before 1582, causing field mismatches; always route through ISO.
-    if (!calendarIsNonISOSolar(calendarId) && !calendarIsLunisolar(calendarId))
+    // Step 3 (iso8601 inline algorithm): ISODateSurpasses-based diff.
+    if (calendarUsesISODateArithmetic(calendarId))
         return diffISODate(one, two, largestUnit);
-    // 2. If largestUnit is ~day~ or ~week~, use pure ISO day count (calendar-independent).
-    // NOTE: ICU Chinese/Dangi epoch ms is approximate for dates beyond ~year 2100; pure ISO is exact.
+    // Fast path: day/week diff is calendar-independent regardless of largestUnit.
     if (largestUnit == TemporalUnit::Day || largestUnit == TemporalUnit::Week)
         return diffISODate(one, two, largestUnit);
 
-    // 3. Read target (two) fields — separate withCalendar call for minimal lock scope.
-    struct TargetFields {
+    // Step 4 (non-ISO tail return): `Return NonISODateUntil(calendar, one, two, largestUnit)`.
+    // https://tc39.es/proposal-intl-era-monthcode/#sup-temporal-nonisodateuntil
+
+    // Snapshot source (one) and target (two) fields — separate withCalendar calls for minimal lock scope.
+    struct DateSnapshot {
         double epochMs { 0 };
         int32_t year { 0 };
         String monthCode;
         int32_t day { 0 };
         int32_t ordinalMonth { 0 };
     };
-    auto targetOrError = withCalendar(calendarId, [&](UCalendar* cal) -> TemporalResult<TargetFields> {
-        if (!cal) [[unlikely]]
-            return makeUnexpected(rangeError(icuOpenCalendarFailed));
-        if (!setCalendarToISODate(cal, two)) [[unlikely]]
-            return makeUnexpected(rangeError(icuSetCalendarFailed));
-        UErrorCode status = U_ZERO_ERROR;
-        TargetFields t;
-        t.epochMs = ucal_getMillis(cal, &status);
-        if (U_FAILURE(status)) [[unlikely]]
-            return makeUnexpected(rangeError(icuReadCalendarFailed));
-        t.year = ucal_get(cal, calendarArithmeticYearField(calendarId), &status);
-        if (U_FAILURE(status)) [[unlikely]]
-            return makeUnexpected(rangeError(icuReadCalendarFailed));
-        auto monthCodeOpt = getMonthCode(cal, calendarId);
-        if (!monthCodeOpt) [[unlikely]]
-            return makeUnexpected(rangeError(icuReadCalendarFailed));
-        t.monthCode = WTF::move(*monthCodeOpt);
-        t.day = ucal_get(cal, UCAL_DAY_OF_MONTH, &status);
-        if (U_FAILURE(status)) [[unlikely]]
-            return makeUnexpected(rangeError(icuReadCalendarFailed));
-        auto ordinalMonthOpt = computeOrdinalMonth(cal, calendarId);
-        if (!ordinalMonthOpt) [[unlikely]]
-            return makeUnexpected(rangeError(icuReadCalendarFailed));
-        t.ordinalMonth = *ordinalMonthOpt;
-        return t;
-    });
-    if (!targetOrError)
+    auto snapshotFields = [&](const ISO8601::PlainDate& date) -> TemporalResult<DateSnapshot> {
+        return withCalendar(calendarId, [&](UCalendar* cal) -> TemporalResult<DateSnapshot> {
+            if (!cal) [[unlikely]]
+                return makeUnexpected(rangeError(icuOpenCalendarFailed));
+            if (!setCalendarToISODate(cal, date)) [[unlikely]]
+                return makeUnexpected(rangeError(icuSetCalendarFailed));
+            UErrorCode status = U_ZERO_ERROR;
+            DateSnapshot snapshot;
+            snapshot.epochMs = ucal_getMillis(cal, &status);
+            if (U_FAILURE(status)) [[unlikely]]
+                return makeUnexpected(rangeError(icuReadCalendarFailed));
+            // ICU4C-WORKAROUND: rdar://182958553 - relabel ICU's Tevet D1 as Kislev D30 for diff snapshots.
+            bool hebrewY0Kislev = isHebrewYear0ExtraKislevDay(cal, calendarId);
+            snapshot.year = ucal_get(cal, calendarArithmeticYearField(calendarId), &status);
+            if (U_FAILURE(status)) [[unlikely]]
+                return makeUnexpected(rangeError(icuReadCalendarFailed));
+            if (hebrewY0Kislev) {
+                snapshot.monthCode = String("M03"_s);
+                snapshot.day = 30;
+                snapshot.ordinalMonth = 3;
+                return snapshot;
+            }
+            auto monthCodeOpt = getMonthCode(cal, calendarId);
+            if (!monthCodeOpt) [[unlikely]]
+                return makeUnexpected(rangeError(icuReadCalendarFailed));
+            snapshot.monthCode = WTF::move(*monthCodeOpt);
+            snapshot.day = ucal_get(cal, UCAL_DAY_OF_MONTH, &status);
+            if (U_FAILURE(status)) [[unlikely]]
+                return makeUnexpected(rangeError(icuReadCalendarFailed));
+            auto ordinalMonthOpt = computeFieldResolutionOrdinalMonth(cal, calendarId);
+            if (!ordinalMonthOpt) [[unlikely]]
+                return makeUnexpected(rangeError(icuReadCalendarFailed));
+            snapshot.ordinalMonth = *ordinalMonthOpt;
+            return snapshot;
+        });
+    };
+    auto targetOrError = snapshotFields(two);
+    if (!targetOrError) [[unlikely]]
         return makeUnexpected(targetOrError.error());
     auto& target = *targetOrError;
 
-    // 4. Read source (one) fields — separate withCalendar call for minimal lock scope.
-    struct SourceFields {
-        double epochMs { 0 };
-        int32_t year { 0 };
-        String monthCode;
-        int32_t ordinalMonth { 0 };
-        int32_t day { 0 };
-    };
-    auto sourceOrError = withCalendar(calendarId, [&](UCalendar* cal) -> TemporalResult<SourceFields> {
-        if (!cal) [[unlikely]]
-            return makeUnexpected(rangeError(icuOpenCalendarFailed));
-        if (!setCalendarToISODate(cal, one)) [[unlikely]]
-            return makeUnexpected(rangeError(icuSetCalendarFailed));
-        UErrorCode status = U_ZERO_ERROR;
-        SourceFields s;
-        s.epochMs = ucal_getMillis(cal, &status);
-        if (U_FAILURE(status)) [[unlikely]]
-            return makeUnexpected(rangeError(icuReadCalendarFailed));
-        s.year = ucal_get(cal, calendarArithmeticYearField(calendarId), &status);
-        if (U_FAILURE(status)) [[unlikely]]
-            return makeUnexpected(rangeError(icuReadCalendarFailed));
-        auto monthCodeOpt = getMonthCode(cal, calendarId);
-        if (!monthCodeOpt) [[unlikely]]
-            return makeUnexpected(rangeError(icuReadCalendarFailed));
-        s.monthCode = WTF::move(*monthCodeOpt);
-        s.ordinalMonth = ucal_get(cal, UCAL_MONTH, &status) + 1;
-        s.day = ucal_get(cal, UCAL_DAY_OF_MONTH, &status);
-        if (U_FAILURE(status)) [[unlikely]]
-            return makeUnexpected(rangeError(icuReadCalendarFailed));
-        return s;
-    });
-    if (!sourceOrError)
+    auto sourceOrError = snapshotFields(one);
+    if (!sourceOrError) [[unlikely]]
         return makeUnexpected(sourceOrError.error());
     auto& source = *sourceOrError;
 
-    // 5. Let sign be +1 if one < two, -1 if one > two, 0 if equal. Return zero duration if sign = 0.
-    //    (Source/target calendar fields already read above.)
+    // CalendarDateUntil Steps 1-2 (deferred from the top): sign compute + zero-return.
+    // +1 (one < two), -1 (one > two), 0 (equal → zero duration).
     int32_t sign;
     if (source.epochMs < target.epochMs)
         sign = 1;
@@ -1790,18 +2122,17 @@ TemporalResult<ISO8601::Duration> calendarDateUntil(CalendarID calendarId, const
         return ISO8601::Duration { 0, months, 0, remainder.days(), 0, 0, 0, 0, Int128(0), Int128(0) };
     }
 
-    // NOTE: min_years fast-forward: pre-guess year delta that doesn't surpass (icu4x optimization).
+    // icu4x optimization: pre-guess year delta that doesn't surpass, to skip ahead in the loop.
     int32_t yearDiff = target.year - source.year;
     int32_t minYears = !yearDiff ? 0 : yearDiff - sign;
 
-    // 6. largestUnit is ~year~ or ~month~: count years (if any) using nonISODateSurpasses,
-    //    then run the month loop on the shared cached calendar.
+    // largestUnit is Year or Month (Day/Week short-circuited above).
     ASSERT(largestUnit == TemporalUnit::Year || largestUnit == TemporalUnit::Month);
 
     int32_t years = 0;
     int32_t months = 0;
 
-    //    a. If largestUnit is ~year~: count full years using nonISODateSurpasses fast-forward.
+    // Count full years by fast-forward + surpass probe.
     if (largestUnit == TemporalUnit::Year) {
         int64_t candidateYears = minYears ? minYears : sign;
         auto yearDoesNotSurpass = [&] {
@@ -1813,7 +2144,7 @@ TemporalResult<ISO8601::Duration> calendarDateUntil(CalendarID calendarId, const
         }
     }
 
-    //    b. Compute the month-loop start: (one + years) via calendarDateAdd (preserves month code).
+    // Month-loop start: (one + years) via calendarDateAdd (preserves monthCode).
     ISO8601::PlainDate monthLoopStart = one;
     if (years) {
         ISO8601::Duration yearDur;
@@ -1824,7 +2155,7 @@ TemporalResult<ISO8601::Duration> calendarDateUntil(CalendarID calendarId, const
         monthLoopStart = *advanced;
     }
 
-    //    c. Month iteration on the cached calendar.
+    // Month iteration on the cached calendar.
     return withCalendar(calendarId, [&](UCalendar* cal) -> TemporalResult<ISO8601::Duration> {
         if (!cal) [[unlikely]]
             return makeUnexpected(rangeError(icuOpenCalendarFailed));
@@ -1863,6 +2194,8 @@ TemporalResult<ISO8601::Duration> calendarDateUntil(CalendarID calendarId, const
         if (months) {
             if (calendarIsNonISOSolar(calendarId)) {
                 int32_t sourceYear = ucal_get(cal, calendarArithmeticYearField(calendarId), &status);
+                if (U_FAILURE(status)) [[unlikely]]
+                    return makeUnexpected(rangeError(icuReadCalendarFailed));
                 int32_t sourceMonth = ucal_get(cal, UCAL_MONTH, &status);
                 if (U_FAILURE(status)) [[unlikely]]
                     return makeUnexpected(rangeError(icuReadCalendarFailed));
@@ -1876,21 +2209,22 @@ TemporalResult<ISO8601::Duration> calendarDateUntil(CalendarID calendarId, const
                 ucal_add(cal, UCAL_MONTH, months, &status);
                 if (U_FAILURE(status)) [[unlikely]]
                     return makeUnexpected(rangeError(icuCalendarArithmeticFailed));
+                if (!forceICUFieldReresolution(cal)) [[unlikely]]
+                    return makeUnexpected(rangeError(icuCalendarArithmeticFailed));
             }
         }
-        //    e. Apply regulated day = min(sourceDay, end_of_month) via setMonths.
+        // Regulated day = min(sourceDay, end_of_month).
         if (!setMonths(cal, source.day)) [[unlikely]]
             return makeUnexpected(rangeError(icuCalendarArithmeticFailed));
 
-        // 7. Compute remaining days from the epoch ms difference between cal and two.
-        const double msPerDay = 86'400'000.0; // nsPerDay / nsPerMillisecond
-        // 8. Return Duration { years, months, weeks, days }.
+        // Days: derived from epoch-ms delta between cal (source + years + months) and target.
+        const double msPerDay = 86'400'000.0;
         double finalMs1 = ucal_getMillis(cal, &status);
         if (U_FAILURE(status)) [[unlikely]]
             return makeUnexpected(rangeError(icuCalendarArithmeticFailed));
         double daysDiff = std::trunc((target.epochMs - finalMs1) / msPerDay);
 
-        //    f. If largestUnit is ~month~, clear years (months were counted from one + years=0).
+        // If largestUnit is Month, clear years (months were counted from one + years=0).
         int32_t resultYears = (largestUnit == TemporalUnit::Month) ? 0 : years;
 
         return ISO8601::Duration {
@@ -2111,122 +2445,205 @@ Expected<int32_t, EcmaReferenceYearError> ecmaReferenceYear(CalendarID calendarI
     return 1972;
 }
 
-// calendarDateFromFields — temporal_rs: Calendar::date_from_fields (src/builtins/core/calendar.rs)
-//   temporal_rs delegates to icu4x: ArithmeticDate::from_fields (components/calendar/src/calendar_arithmetic.rs)
-//   ICU4C has no equivalent: we implement the same field-resolution logic using ucal_set + ucal_get.
-// https://tc39.es/proposal-temporal/#sec-temporal-calendardatefromfields
-// CalendarDateFromFields steps 1-4 (CalendarResolveFields is done by the JS-layer caller):
-//   1. (Resolved by caller.)
-//   2. Let result be ? CalendarDateToISO(calendar, fields, overflow).
-//      -> iso8601: handled by the JS layer before reaching here.
-//      -> non-ISO: implementation-defined (NonISOCalendarDateToISO); no concrete spec steps.
-//   3. Date-producing callers enforce ISODateWithinLimits; partial callers enforce their own limits.
-//   4. Return result.
-TemporalResult<ISO8601::PlainDate> calendarDateFromFields(CalendarID calendarId, std::optional<int32_t> year, uint8_t month, uint8_t day, std::optional<StringView> era, std::optional<int32_t> eraYear, std::optional<ParsedMonthCode> monthCode, TemporalOverflow overflow)
+// Sets ICU4C's UCAL_ERA/UCAL_YEAR/UCAL_EXTENDED_YEAR depending on which field the calendar
+// treats as authoritative for arithmetic year. ROC/Buddhist/Ethioaa need UCAL_ERA+UCAL_YEAR;
+// everything else takes the extended year directly.
+static void setICUCalendarYear(UCalendar* cal, CalendarID calendarId, std::optional<int32_t> year)
 {
-    bool tookEraPath = false;
-    if (era && eraYear) {
-        tookEraPath = true;
-        if (calendarId == japaneseCalendarID()) {
-            // Named-era arithmetic year is era start year + eraYear - 1.
-            CheckedInt32 checkedISOYear = *eraYear;
-            if (*era == "bce"_s)
-                checkedISOYear = 1 - checkedISOYear;
-            else if (*era != "ce"_s) {
-                const JapaneseEra* japaneseEra = nullptr;
-                for (auto& candidate : japaneseEras) {
-                    if (*era == StringView(candidate.name)) {
-                        japaneseEra = &candidate;
-                        break;
-                    }
+    if (calendarId == rocCalendarID()) {
+        // ROC: year > 0 → roc era (1); year <= 0 → broc era (0) with eraYear = 1 - year.
+        int32_t y = year.value_or(0);
+        if (y <= 0) {
+            ucal_set(cal, UCAL_ERA, 0); // broc
+            ucal_set(cal, UCAL_YEAR, 1 - y);
+        } else {
+            ucal_set(cal, UCAL_ERA, 1); // roc
+            ucal_set(cal, UCAL_YEAR, y);
+        }
+        return;
+    }
+    if (calendarId == buddhistCalendarID() || calendarId == ethioaaCalendarID()) {
+        // These one-era calendars use calendar-native UCAL_YEAR for arithmetic.
+        ucal_set(cal, UCAL_ERA, 0);
+        ucal_set(cal, UCAL_YEAR, year.value_or(0));
+        return;
+    }
+    ucal_set(cal, UCAL_EXTENDED_YEAR, year.value_or(0));
+}
+
+static TemporalResult<void> positionCursorAtConstrainedMonthCode(UCalendar* cal, CalendarID calendarId, const ParsedMonthCode& monthCode, TemporalOverflow overflow)
+{
+    if (!isValidMonthCodeForCalendar(calendarId, monthCode)) [[unlikely]]
+        return makeUnexpected(rangeError("monthCode is not valid for this calendar"_s));
+
+    auto constrained = constrainMonthCodeInternal(cal, calendarId, monthCode, overflow);
+    if (!constrained) [[unlikely]]
+        return makeUnexpected(constrained.error());
+
+    // Position the cursor at the constrained monthCode.
+    UErrorCode status = U_ZERO_ERROR;
+    if (calendarIsLunisolar(calendarId)) {
+        String targetCode = makeString("M"_s, constrained->monthNumber < 10 ? "0"_s : ""_s,
+            constrained->monthNumber, constrained->isLeapMonth ? "L"_s : ""_s);
+        auto probe = setCalendarToMonthCode(cal, calendarId, targetCode);
+        if (!probe) [[unlikely]]
+            return makeUnexpected(rangeError(icuCalendarArithmeticFailed));
+        return { };
+    }
+    // Non-lunisolar: direct set (M13 for coptic/ethiopic/ethioaa; M01..M12 otherwise).
+    ucal_set(cal, UCAL_MONTH, constrained->monthNumber - 1);
+    if (constrained->isLeapMonth)
+        ucal_set(cal, UCAL_IS_LEAP_MONTH, 1);
+    ucal_set(cal, UCAL_DAY_OF_MONTH, 1);
+    ucal_getMillis(cal, &status);
+    if (U_FAILURE(status)) [[unlikely]]
+        return makeUnexpected(rangeError(icuCalendarArithmeticFailed));
+    return { };
+}
+
+// Detects implicit clamps when overflow=Reject (ICU helpers above always constrain).
+static TemporalResult<void> validateRejectMode(UCalendar* cal, CalendarID calendarId, std::optional<ParsedMonthCode> monthCode, uint8_t day)
+{
+    UErrorCode status = U_ZERO_ERROR;
+    int32_t resolvedDay = ucal_get(cal, UCAL_DAY_OF_MONTH, &status);
+    if (U_FAILURE(status)) [[unlikely]]
+        return makeUnexpected(rangeError("Failed to resolve calendar date"_s));
+    if (!monthCode)
+        return { };
+
+    if (calendarIsLunisolar(calendarId)) {
+        // Lunisolar: ICU slot numbers != monthCode numbers (e.g. Hebrew M05L at slot 5
+        // gives UCAL_MONTH+1=6, and ICU4C never sets IS_LEAP_MONTH). constrainMonthCode
+        // already positioned the calendar at the target month; verify only the day.
+        // ICU4C-WORKAROUND: rdar://182958553 - y0 Kislev D30 rolls to ICU's M04 D1 (see maxDay override).
+        bool hebrewYear0KislevD30 = calendarId == hebrewCalendarID()
+            && monthCode->monthNumber == 3 && !monthCode->isLeapMonth && day == 30 && isHebrewYear0ExtraKislevDay(cal, calendarId);
+        if (!hebrewYear0KislevD30 && resolvedDay != static_cast<int32_t>(day)) [[unlikely]]
+            return makeUnexpected(rangeError("Day is out of range for the given month in this calendar"_s));
+        return { };
+    }
+
+    int32_t resolvedMonth = ucal_get(cal, UCAL_MONTH, &status) + 1;
+    if (U_FAILURE(status)) [[unlikely]]
+        return makeUnexpected(rangeError(icuReadCalendarFailed));
+    int32_t resolvedLeap = ucal_get(cal, UCAL_IS_LEAP_MONTH, &status);
+    if (U_FAILURE(status)) [[unlikely]]
+        return makeUnexpected(rangeError(icuReadCalendarFailed));
+    bool leapMismatch = monthCode->isLeapMonth && !resolvedLeap;
+    if (resolvedDay != static_cast<int32_t>(day) || resolvedMonth != static_cast<int32_t>(monthCode->monthNumber) || leapMismatch) [[unlikely]]
+        return makeUnexpected(rangeError("Day is out of range for the given month in this calendar"_s));
+    return { };
+}
+
+// https://tc39.es/proposal-intl-era-monthcode/#sup-temporal-nonisocalendardatetoiso
+TemporalResult<ISO8601::PlainDate> nonISOCalendarDateToISO(CalendarID calendarId, std::optional<int32_t> year, uint8_t month, uint8_t day, std::optional<ParsedMonthCode> monthCode, TemporalOverflow overflow)
+{
+    if (year && calendarUsesISOFallbackForExtremeYear(calendarId, *year)) {
+        if (*year < ISO8601::minYear || *year > ISO8601::maxYear) [[unlikely]]
+            return ISO8601::PlainDate { ISO8601::outOfRangeYear, 1, 1 };
+        int32_t isoYear = *year;
+        if (month > 12) {
+            if (overflow == TemporalOverflow::Reject) [[unlikely]]
+                return makeUnexpected(rangeError("month is out of range"_s));
+        }
+        uint8_t isoMonth = std::clamp<uint8_t>(month, 1, 12);
+        uint8_t maxDay = ISO8601::daysInMonth(isoYear, isoMonth);
+        if (day > maxDay) {
+            if (overflow == TemporalOverflow::Reject) [[unlikely]]
+                return makeUnexpected(rangeError("Day is out of range for the given month"_s));
+        }
+        uint8_t isoDay = std::clamp<uint8_t>(day, 1, maxDay);
+        return ISO8601::PlainDate(isoYear, isoMonth, isoDay);
+    }
+
+    {
+        // ICU4C-WORKAROUND: rdar://182960658 - IndianCalendar clamped arithmetic (see helper).
+        if (calendarId == indianCalendarID() && year) {
+            uint8_t sakaMonth;
+            if (monthCode) {
+                if (monthCode->isLeapMonth) [[unlikely]]
+                    return makeUnexpected(rangeError("Leap month codes are not valid for this calendar"_s));
+                if (monthCode->monthNumber > 12) [[unlikely]]
+                    return makeUnexpected(rangeError("month is out of range"_s));
+                sakaMonth = static_cast<uint8_t>(monthCode->monthNumber);
+            } else {
+                if (month > 12) {
+                    if (overflow == TemporalOverflow::Reject) [[unlikely]]
+                        return makeUnexpected(rangeError("month is out of range"_s));
                 }
-                if (!japaneseEra) [[unlikely]]
-                    return makeUnexpected(rangeError("era is not valid for this calendar"_s));
-                checkedISOYear += japaneseEra->startYear;
-                checkedISOYear -= 1;
+                sakaMonth = std::clamp<uint8_t>(month, 1, 12);
             }
-            if (checkedISOYear.hasOverflowed() || !ISO8601::isYearWithinLimits(checkedISOYear.value())) [[unlikely]]
+            uint8_t monthLen = indianSakaDaysInMonth(*year, sakaMonth);
+            uint8_t sakaDay = day;
+            if (day > monthLen) {
+                if (overflow == TemporalOverflow::Reject) [[unlikely]]
+                    return makeUnexpected(rangeError("Day is out of range for the given month"_s));
+                sakaDay = monthLen;
+            }
+            auto isoDate = indianSakaToISO(*year, sakaMonth, sakaDay);
+            if (!isoDate) [[unlikely]]
                 return makeUnexpected(rangeError("Resolved calendar date is outside representable range"_s));
-            int32_t isoYear = checkedISOYear.value();
-            if (year && *year != isoYear) [[unlikely]]
-                return makeUnexpected(rangeError("year is inconsistent with era and eraYear"_s));
-            return calendarDateFromFields(gregoryCalendarID(), isoYear, month, day, std::nullopt, std::nullopt, monthCode, overflow);
+            if (!ISO8601::isYearWithinLimits(isoDate->year())) [[unlikely]]
+                return makeUnexpected(rangeError("Resolved calendar date is outside representable range"_s));
+            return *isoDate;
         }
     }
 
-    // A Japanese extended year is an ISO year. Resolve year-only input through the
-    // proleptic-Gregorian calendar so getters can be fed back through from() or with().
-    if (calendarId == japaneseCalendarID() && !tookEraPath)
-        return calendarDateFromFields(gregorianArithmeticCalendarFor(calendarId), year, month, day, std::nullopt, std::nullopt, monthCode, overflow);
-
-    std::optional<int32_t> icuEraCode;
-    if (tookEraPath && era) {
-        icuEraCode = mapTemporalEraToICUEra(calendarId, *era);
-        if (!icuEraCode) [[unlikely]]
-            return makeUnexpected(rangeError("era is not valid for this calendar"_s));
-    }
-
-    if (calendarId == rocCalendarID() || calendarId == buddhistCalendarID()) {
-        CheckedInt32 checkedCalendarYear = year.value_or(0);
-        if (tookEraPath) {
-            checkedCalendarYear = *eraYear;
-            if (calendarId == rocCalendarID() && !*icuEraCode) {
-                checkedCalendarYear = 1;
-                checkedCalendarYear -= *eraYear;
-            }
-            if (checkedCalendarYear.hasOverflowed()) [[unlikely]]
+    {
+        // ICU4C-WORKAROUND: rdar://182963532 - ucal_setGregorianChange returns U_UNSUPPORTED_ERROR
+        // for buddhist/roc/japanese derived calendars; can't set proleptic mode via API, so bypass ICU for pre-1582.
+        if (calendarIsGregorianStructured(calendarId)) {
+            if (monthCode && monthCode->monthNumber > 12) [[unlikely]]
+                return makeUnexpected(rangeError("month is out of range"_s));
+            ASSERT(year);
+            int32_t isoYear = gregorianStructuredCalendarISOYear(calendarId, *year);
+            if (!ISO8601::isYearWithinLimits(isoYear)) [[unlikely]]
                 return makeUnexpected(rangeError("Resolved calendar date is outside representable range"_s));
-            if (year && *year != checkedCalendarYear.value()) [[unlikely]]
-                return makeUnexpected(rangeError("year is inconsistent with era and eraYear"_s));
+            uint8_t resolvedMonth = month;
+            if (month > 12) {
+                if (overflow == TemporalOverflow::Reject) [[unlikely]]
+                    return makeUnexpected(rangeError("month is out of range for this calendar"_s));
+                resolvedMonth = 12;
+            }
+            uint8_t resolvedDay = day;
+            uint8_t daysInMo = ISO8601::daysInMonth(isoYear, resolvedMonth);
+            if (day > daysInMo) {
+                if (overflow == TemporalOverflow::Reject) [[unlikely]]
+                    return makeUnexpected(rangeError("Day is out of range for the given month"_s));
+                resolvedDay = daysInMo;
+            }
+            return ISO8601::PlainDate(isoYear, resolvedMonth, resolvedDay);
         }
-
-        CheckedInt32 checkedISOYear = checkedCalendarYear;
-        if (calendarId == rocCalendarID())
-            checkedISOYear += rocCalendarYearOffset;
-        else
-            checkedISOYear -= buddhistCalendarYearOffset;
-        if (checkedISOYear.hasOverflowed() || !ISO8601::isYearWithinLimits(checkedISOYear.value())) [[unlikely]]
-            return makeUnexpected(rangeError("Resolved calendar date is outside representable range"_s));
-        return calendarDateFromFields(gregoryCalendarID(), checkedISOYear.value(), month, day, std::nullopt, std::nullopt, monthCode, overflow);
     }
+
+    // Step 1: Year/Month/Day asserted by caller (month=0 permitted only when monthCode supplied).
+    ASSERT(day >= 1);
+    ASSERT(monthCode || month >= 1);
 
     return withCalendar(calendarId, [&](UCalendar* cal) -> TemporalResult<ISO8601::PlainDate> {
         if (!cal) [[unlikely]]
             return makeUnexpected(rangeError(icuOpenCalendarFailed));
-
         UErrorCode status = U_ZERO_ERROR;
 
-        if (tookEraPath) {
-            // Gregorian-derived calendars returned through arithmetic paths above.
-            if (!icuEraCode) [[unlikely]]
-                return makeUnexpected(rangeError("era is not valid for this calendar"_s));
-            ucal_set(cal, UCAL_ERA, *icuEraCode);
-            ucal_set(cal, UCAL_YEAR, *eraYear);
-        } else if (calendarId == ethioaaCalendarID()) {
-            // Ethioaa uses calendar-native UCAL_YEAR for arithmetic.
-            ucal_set(cal, UCAL_ERA, 0);
-            ucal_set(cal, UCAL_YEAR, year.value_or(0));
-        } else
-            ucal_set(cal, UCAL_EXTENDED_YEAR, year.value_or(0));
+        setICUCalendarYear(cal, calendarId, year);
 
         bool isChineseBased = calendarId == chineseCalendarID() || calendarId == dangiCalendarID();
         if (monthCode) {
-            // Month codes > M13 are always invalid. M13 is only valid for Coptic/Ethiopian.
-            if (monthCode->monthNumber > 13) [[unlikely]]
-                return makeUnexpected(rangeError("month is out of range"_s));
-            if (monthCode->monthNumber == 13 && calendarId != copticCalendarID() && calendarId != ethiopicCalendarID() && calendarId != ethioaaCalendarID()) [[unlikely]]
-                return makeUnexpected(rangeError("month is out of range"_s));
-
+            // Step 2: ConstrainMonthCode + position ICU cursor for downstream day/millis reads.
             if (calendarIsLunisolar(calendarId)) {
                 // Lunisolar: walk months from start of year to find target monthCode.
                 // ICU4X uses precomputed year.packed.leap_month() for O(1) lookup; ICU4C
                 // doesn't expose this data, so we walk. The walk is correct and safe.
+                if (!isValidMonthCodeForCalendar(calendarId, *monthCode)) [[unlikely]]
+                    return makeUnexpected(rangeError("monthCode is not valid for this calendar"_s));
                 if (!setCalendarToLunisolarYearStart(cal, calendarId, year, status)) [[unlikely]]
                     return makeUnexpected(rangeError(icuCalendarArithmeticFailed));
 
                 String targetCode = makeString("M"_s, monthCode->monthNumber < 10 ? "0"_s : ""_s,
                     monthCode->monthNumber, monthCode->isLeapMonth ? "L"_s : ""_s);
                 int32_t savedYear = isChineseBased ? 0 : ucal_get(cal, UCAL_EXTENDED_YEAR, &status);
+                if (U_FAILURE(status)) [[unlikely]]
+                    return makeUnexpected(rangeError(icuReadCalendarFailed));
                 double previousMonthMs = ucal_getMillis(cal, &status);
                 if (U_FAILURE(status)) [[unlikely]]
                     return makeUnexpected(rangeError(icuReadCalendarFailed));
@@ -2260,7 +2677,7 @@ TemporalResult<ISO8601::PlainDate> calendarDateFromFields(CalendarID calendarId,
                     if (U_FAILURE(status)) [[unlikely]]
                         return makeUnexpected(rangeError(icuReadCalendarFailed));
                     auto advanceResult = advanceToNextLunisolarMonth(cal, calendarId, status);
-                    if (advanceResult == LunisolarMonthAdvanceResult::Error)
+                    if (advanceResult == LunisolarMonthAdvanceResult::Error) [[unlikely]]
                         return makeUnexpected(rangeError(U_FAILURE(status) ? icuReadCalendarFailed : icuCalendarArithmeticFailed));
                     int32_t curYear = isChineseBased ? savedYear : ucal_get(cal, UCAL_EXTENDED_YEAR, &status);
                     auto nextCode = isChineseBased ? getMonthCode(cal, calendarId) : std::optional<String> { };
@@ -2274,186 +2691,110 @@ TemporalResult<ISO8601::PlainDate> calendarDateFromFields(CalendarID calendarId,
                     }
                 }
                 if (!found && overflow == TemporalOverflow::Reject) [[unlikely]]
-                    return makeUnexpected(rangeError("monthCode does not exist in this calendar year"_s)); // Clamp day via ucal_add.
-                auto maxDayOrError = actualLunisolarMonthLength(cal, calendarId);
-                if (!maxDayOrError) [[unlikely]]
-                    return makeUnexpected(rangeError(icuReadCalendarFailed));
-                int32_t maxDay = *maxDayOrError;
-                uint8_t clampedDay = day;
-                if (day > maxDay) {
-                    if (overflow == TemporalOverflow::Reject) [[unlikely]]
-                        return makeUnexpected(rangeError("Day is out of range for the given month in this calendar"_s));
-                    clampedDay = static_cast<uint8_t>(maxDay);
-                }
-                if (clampedDay > 1) {
-                    if (!addLunisolarCalendarDays(cal, calendarId, clampedDay - 1, status)) [[unlikely]]
-                        return makeUnexpected(rangeError(icuCalendarArithmeticFailed));
-                }
-            } else if (calendarId == hebrewCalendarID()) [[unlikely]] {
-                // Hebrew non-lunisolar path — shouldn't reach here since Hebrew IS lunisolar.
-                ASSERT_NOT_REACHED();
-                return makeUnexpected(rangeError("unexpected hebrew non-lunisolar path"_s));
+                    return makeUnexpected(rangeError("monthCode does not exist in this calendar year"_s));
             } else {
                 // Non-lunisolar with monthCode (Gregorian-based calendars).
-                // Set month with day=1 first to avoid ICU normalizing out-of-range day.
-                ucal_set(cal, UCAL_MONTH, monthCode->monthNumber - 1);
-                if (monthCode->isLeapMonth)
-                    ucal_set(cal, UCAL_IS_LEAP_MONTH, 1);
-                ucal_set(cal, UCAL_DAY_OF_MONTH, 1);
-                ucal_getMillis(cal, &status); // force resolution of year+month
-                if (U_FAILURE(status)) [[unlikely]]
-                    return makeUnexpected(rangeError(icuCalendarArithmeticFailed));
-
-                // Now check maxDay for the resolved month.
-                int32_t maxDay = ucal_getLimit(cal, UCAL_DAY_OF_MONTH, UCAL_ACTUAL_MAXIMUM, &status);
+                if (auto r = positionCursorAtConstrainedMonthCode(cal, calendarId, *monthCode, overflow); !r)
+                    return makeUnexpected(r.error());
+            }
+        } else {
+            // Step 3: CalendarMonthsInYear.
+            uint8_t resolvedMonth;
+            if (calendarIsLunisolar(calendarId)) {
+                // For lunisolar calendars, 'month' is the ordinal month (1-indexed).
+                // Count monthsInYear using a separate calendar to avoid state corruption.
+                if (!setCalendarToLunisolarYearStart(cal, calendarId, year, status)) [[unlikely]]
+                    return makeUnexpected(rangeError("Failed to resolve lunisolar calendar"_s));
+                // Count months in year by walking cal forward, then reset to year start.
+                double calMs = ucal_getMillis(cal, &status);
                 if (U_FAILURE(status)) [[unlikely]]
                     return makeUnexpected(rangeError(icuReadCalendarFailed));
-                if (day > maxDay) {
+                auto monthsInYearOrError = walkLunisolarMonthsFromYearStart(cal, calendarId, "Failed to resolve lunisolar calendar"_s);
+                if (!monthsInYearOrError) [[unlikely]]
+                    return makeUnexpected(monthsInYearOrError.error());
+                int32_t monthsInYear = *monthsInYearOrError;
+                // Reset to year start before advancing to target month.
+                ucal_setMillis(cal, calMs, &status);
+                if (U_FAILURE(status)) [[unlikely]]
+                    return makeUnexpected(rangeError(icuSetCalendarFailed));
+
+                // Clamp or reject month against monthsInYear.
+                resolvedMonth = month;
+                if (month > monthsInYear) {
                     if (overflow == TemporalOverflow::Reject) [[unlikely]]
-                        return makeUnexpected(rangeError("Day is out of range for the given month in this calendar"_s));
-                    ucal_set(cal, UCAL_DAY_OF_MONTH, maxDay);
-                } else if (day > 1)
-                    ucal_set(cal, UCAL_DAY_OF_MONTH, day);
-            }
-        } else if (calendarIsLunisolar(calendarId)) {
-            // For lunisolar calendars, 'month' is the ordinal month (1-indexed).
-            // Count monthsInYear using a separate calendar to avoid state corruption.
-            if (!setCalendarToLunisolarYearStart(cal, calendarId, year, status)) [[unlikely]]
-                return makeUnexpected(rangeError("Failed to resolve lunisolar calendar"_s));
-            // Count months in year by walking cal forward, then reset to year start.
-            double calMs = ucal_getMillis(cal, &status);
-            if (U_FAILURE(status)) [[unlikely]]
-                return makeUnexpected(rangeError(icuReadCalendarFailed));
-            int32_t savedYear = isChineseBased ? 0 : ucal_get(cal, UCAL_EXTENDED_YEAR, &status);
-            if (U_FAILURE(status)) [[unlikely]]
-                return makeUnexpected(rangeError(icuReadCalendarFailed));
-            int32_t monthsInYear = 1;
-            bool reachedNextYear = false;
-            for (int i = 0; i < 14; i++) {
-                if (advanceToNextLunisolarMonth(cal, calendarId, status) != LunisolarMonthAdvanceResult::Advanced) [[unlikely]]
-                    return makeUnexpected(rangeError(icuCalendarArithmeticFailed));
-                int32_t curYear = isChineseBased ? savedYear : ucal_get(cal, UCAL_EXTENDED_YEAR, &status);
-                auto nextCode = isChineseBased ? getMonthCode(cal, calendarId) : std::optional<String> { };
-                if (U_FAILURE(status) || (isChineseBased && !nextCode)) [[unlikely]]
-                    return makeUnexpected(rangeError(icuReadCalendarFailed));
-                if ((isChineseBased && *nextCode == "M01"_s) || (!isChineseBased && curYear != savedYear)) {
-                    reachedNextYear = true;
-                    break;
+                        return makeUnexpected(rangeError("month is out of range for this calendar year"_s));
+                    resolvedMonth = static_cast<uint8_t>(monthsInYear);
                 }
-                monthsInYear++;
-            }
-            if (!reachedNextYear || monthsInYear > 13) [[unlikely]]
-                return makeUnexpected(rangeError("Failed to resolve lunisolar calendar"_s));
-            // Reset to year start before advancing to target month.
-            ucal_setMillis(cal, calMs, &status);
-            if (U_FAILURE(status)) [[unlikely]]
-                return makeUnexpected(rangeError(icuSetCalendarFailed));
 
-            // Clamp or reject month against monthsInYear.
-            uint8_t resolvedMonth = month;
-            if (month > monthsInYear) {
-                if (overflow == TemporalOverflow::Reject) [[unlikely]]
-                    return makeUnexpected(rangeError("month is out of range for this calendar year"_s));
-                resolvedMonth = static_cast<uint8_t>(monthsInYear);
-            }
+                // Advance the original calendar to the target month.
+                for (uint8_t ordinal = 1; ordinal < resolvedMonth; ++ordinal) {
+                    auto advanceResult = advanceToNextLunisolarMonth(cal, calendarId, status);
+                    if (advanceResult == LunisolarMonthAdvanceResult::Error) [[unlikely]]
+                        return makeUnexpected(rangeError(U_FAILURE(status) ? icuReadCalendarFailed : icuCalendarArithmeticFailed));
+                }
+            } else {
+                // CalendarMonthsInYear: cursor is already at year start, so read [[MonthsInYear]]
+                // straight off ICU instead of round-tripping through an ISO date.
+                int32_t monthsInYear = ucal_getLimit(cal, UCAL_MONTH, UCAL_ACTUAL_MAXIMUM, &status) + 1;
+                if (U_FAILURE(status)) [[unlikely]]
+                    return makeUnexpected(rangeError(icuReadCalendarFailed));
 
-            // Advance the original calendar to the target month.
-            for (uint8_t ordinal = 1; ordinal < resolvedMonth; ++ordinal) {
-                auto advanceResult = advanceToNextLunisolarMonth(cal, calendarId, status);
-                if (advanceResult == LunisolarMonthAdvanceResult::Error) [[unlikely]]
-                    return makeUnexpected(rangeError(U_FAILURE(status) ? icuReadCalendarFailed : icuCalendarArithmeticFailed));
-            }
+                // Steps 4-5: clamp month to monthsInYear (reject on out-of-range).
+                if (month > monthsInYear) {
+                    if (overflow == TemporalOverflow::Reject) [[unlikely]]
+                        return makeUnexpected(rangeError("month is out of range for this calendar year"_s));
+                    resolvedMonth = static_cast<uint8_t>(monthsInYear);
+                } else
+                    resolvedMonth = month;
 
-            // Clamp day to daysInMonth if constrain.
+                ucal_set(cal, UCAL_MONTH, resolvedMonth - 1);
+                ucal_set(cal, UCAL_DAY_OF_MONTH, 1);
+            }
+        }
+
+        // Step 6: CalendarDaysInMonth.
+        int32_t maxDay;
+        if (calendarIsLunisolar(calendarId)) {
             auto maxDayOrError = actualLunisolarMonthLength(cal, calendarId);
             if (!maxDayOrError) [[unlikely]]
                 return makeUnexpected(rangeError(icuReadCalendarFailed));
-            int32_t maxDay = *maxDayOrError;
-            uint8_t resolvedDay = day;
-            if (day > maxDay) {
-                if (overflow == TemporalOverflow::Reject) [[unlikely]]
-                    return makeUnexpected(rangeError("Day is out of range for the given month in this calendar"_s));
-                resolvedDay = static_cast<uint8_t>(maxDay);
-            }
-            // Advance from day 1 to preserve the resolved month position.
+            maxDay = *maxDayOrError;
+        } else {
+            // CalendarDaysInMonth: cursor is already at the target month, so read [[DaysInMonth]]
+            // straight off ICU instead of round-tripping through an ISO date.
+            maxDay = ucal_getLimit(cal, UCAL_DAY_OF_MONTH, UCAL_ACTUAL_MAXIMUM, &status);
+            if (U_FAILURE(status)) [[unlikely]]
+                return makeUnexpected(rangeError(icuReadCalendarFailed));
+        }
+
+        {
+            // ICU4C-WORKAROUND: rdar://182958553 - force maxDay = 30 for Hebrew y0 Kislev.
+            if (isHebrewYear0Kislev(cal, calendarId))
+                maxDay = 30;
+        }
+
+        // Steps 7-8: clamp day to daysInMonth (reject on out-of-range).
+        uint8_t resolvedDay;
+        if (day > maxDay) {
+            if (overflow == TemporalOverflow::Reject) [[unlikely]]
+                return makeUnexpected(rangeError("Day is out of range for the given month in this calendar"_s));
+            resolvedDay = static_cast<uint8_t>(maxDay);
+        } else
+            resolvedDay = day;
+
+        // Advance cursor to resolvedDay.
+        if (calendarIsLunisolar(calendarId)) {
             if (resolvedDay > 1) {
                 if (!addLunisolarCalendarDays(cal, calendarId, resolvedDay - 1, status)) [[unlikely]]
                     return makeUnexpected(rangeError(icuCalendarArithmeticFailed));
             }
-        } else {
-            // Non-lunisolar: clamp month to calendar max.
-            int32_t maxMonth = ucal_getLimit(cal, UCAL_MONTH, UCAL_ACTUAL_MAXIMUM, &status) + 1;
-            if (U_FAILURE(status)) [[unlikely]]
-                return makeUnexpected(rangeError(icuReadCalendarFailed));
-            uint8_t resolvedMonth = month;
-            if (month > maxMonth) {
-                if (overflow == TemporalOverflow::Reject) [[unlikely]]
-                    return makeUnexpected(rangeError("month is out of range for this calendar"_s));
-                resolvedMonth = static_cast<uint8_t>(maxMonth);
-            }
-            ucal_set(cal, UCAL_MONTH, resolvedMonth - 1); // Resolve to get actual max day for this month.
-            ucal_set(cal, UCAL_DAY_OF_MONTH, 1);
-            int32_t maxDay = ucal_getLimit(cal, UCAL_DAY_OF_MONTH, UCAL_ACTUAL_MAXIMUM, &status);
-            if (U_FAILURE(status)) [[unlikely]]
-                return makeUnexpected(rangeError(icuReadCalendarFailed));
-            uint8_t resolvedDay = day;
-            if (day > maxDay) {
-                if (overflow == TemporalOverflow::Reject) [[unlikely]]
-                    return makeUnexpected(rangeError("Day is out of range for the given month in this calendar"_s));
-                resolvedDay = static_cast<uint8_t>(maxDay);
-            }
+        } else
             ucal_set(cal, UCAL_DAY_OF_MONTH, resolvedDay);
-        }
 
-        if (overflow == TemporalOverflow::Reject) {
-            int32_t resolvedDay = ucal_get(cal, UCAL_DAY_OF_MONTH, &status);
-            if (U_FAILURE(status)) [[unlikely]]
-                return makeUnexpected(rangeError("Failed to resolve calendar date"_s));
-            if (monthCode) {
-                if (calendarIsLunisolar(calendarId)) {
-                    // For lunisolar calendars, ICU slot numbers != monthCode numbers (e.g. Hebrew
-                    // M05L at slot 5 gives UCAL_MONTH+1=6, and ICU4C never sets IS_LEAP_MONTH).
-                    // Use getMonthCode to verify the actual month — the walk already positioned
-                    // the calendar at the target month, so we only need to verify the day.
-                    if (resolvedDay != static_cast<int32_t>(day)) [[unlikely]]
-                        return makeUnexpected(rangeError("Day is out of range for the given month in this calendar"_s));
-                } else {
-                    int32_t resolvedMonth = ucal_get(cal, UCAL_MONTH, &status) + 1;
-                    if (U_FAILURE(status)) [[unlikely]]
-                        return makeUnexpected(rangeError(icuReadCalendarFailed));
-                    int32_t resolvedLeap = ucal_get(cal, UCAL_IS_LEAP_MONTH, &status);
-                    if (U_FAILURE(status)) [[unlikely]]
-                        return makeUnexpected(rangeError(icuReadCalendarFailed));
-                    bool leapMismatch = monthCode->isLeapMonth && !resolvedLeap;
-                    if (resolvedDay != static_cast<int32_t>(day) || resolvedMonth != static_cast<int32_t>(monthCode->monthNumber) || leapMismatch) [[unlikely]]
-                        return makeUnexpected(rangeError("Day is out of range for the given month in this calendar"_s));
-                }
-            }
-        }
-
-        // For constrain with a leap monthCode that doesn't exist: ICU silently drops the leap
-        // flag and lands on the non-leap version of the month, which is the correct constrain
-        // behavior. No explicit fallback is needed.
-
-        auto resolved = isoDateFromCalendarChecked(cal);
+        // Step 9: CalendarIntegersToISO (runs step-1 Reject-mode validity check internally).
+        auto resolved = calendarIntegersToISO(cal, calendarId, monthCode, day, overflow);
         if (!resolved) [[unlikely]]
-            return makeUnexpected(rangeError("Resolved calendar date is outside representable range"_s));
-
-        // NonISOResolveFields: when era+eraYear and year are all non-unset, they must identify
-        // the same year. year == nullopt means the caller did not have a user-provided year.
-        if (tookEraPath && year) {
-            // Re-use cal (we hold the lock): set it to resolved and read back calendar year.
-            if (!setCalendarToISODate(cal, *resolved)) [[unlikely]]
-                return makeUnexpected(rangeError(icuSetCalendarFailed));
-            UErrorCode yearStatus = U_ZERO_ERROR;
-            int32_t resolvedYear;
-            if (calendarId == ethioaaCalendarID())
-                resolvedYear = ucal_get(cal, UCAL_YEAR, &yearStatus);
-            else
-                resolvedYear = ucal_get(cal, UCAL_EXTENDED_YEAR, &yearStatus);
-            if (!U_FAILURE(yearStatus) && resolvedYear != *year) [[unlikely]]
-                return makeUnexpected(rangeError("year is inconsistent with era and eraYear"_s));
-        }
+            return makeUnexpected(resolved.error());
 
         return *resolved;
     });

--- a/Source/JavaScriptCore/runtime/temporal/core/CalendarICUBridge.h
+++ b/Source/JavaScriptCore/runtime/temporal/core/CalendarICUBridge.h
@@ -59,13 +59,13 @@ inline StringView calendarIDToString(CalendarID id) { return intlAvailableCalend
 inline bool calendarIsISO(CalendarID id) { return id == iso8601CalendarID(); }
 
 // calendarHasEras — true for calendars that expose era/eraYear fields in Temporal.
-// Covers the 15 spec-defined era-bearing calendars; unknown future calendars default to false.
+// Covers the 13 spec-defined era-bearing calendars; unknown future calendars default to false.
 inline bool calendarHasEras(CalendarID id)
 {
     return id == buddhistCalendarID() || id == copticCalendarID() || id == ethioaaCalendarID()
         || id == ethiopicCalendarID() || id == gregoryCalendarID() || id == hebrewCalendarID()
-        || id == indianCalendarID() || id == islamicCalendarID() || id == islamicCivilCalendarID()
-        || id == islamicRgsaCalendarID() || id == islamicTblaCalendarID() || id == islamicUmalquraCalendarID()
+        || id == indianCalendarID() || id == islamicCivilCalendarID()
+        || id == islamicTblaCalendarID() || id == islamicUmalquraCalendarID()
         || id == japaneseCalendarID() || id == persianCalendarID() || id == rocCalendarID();
 }
 
@@ -74,13 +74,6 @@ inline bool calendarHasEras(CalendarID id)
 inline bool calendarIsLunisolar(CalendarID id)
 {
     return id == chineseCalendarID() || id == dangiCalendarID() || id == hebrewCalendarID();
-}
-
-// Returns true for any Islamic calendar variant.
-inline bool calendarIsIslamic(CalendarID id)
-{
-    return id == islamicCalendarID() || id == islamicCivilCalendarID() || id == islamicRgsaCalendarID()
-        || id == islamicTblaCalendarID() || id == islamicUmalquraCalendarID();
 }
 
 TemporalResult<CalendarFields> isoToCalendarFields(CalendarID, const ISO8601::PlainDate& isoDate);
@@ -93,7 +86,15 @@ JS_EXPORT_PRIVATE TemporalResult<String> calendarMonthCode(CalendarID, const ISO
 
 JS_EXPORT_PRIVATE TemporalResult<uint8_t> calendarDay(CalendarID, const ISO8601::PlainDate& isoDate);
 
-JS_EXPORT_PRIVATE TemporalResult<uint16_t> calendarDayOfYear(CalendarID, const ISO8601::PlainDate& isoDate);
+JS_EXPORT_PRIVATE TemporalResult<int32_t> calendarDayOfYear(CalendarID, const ISO8601::PlainDate& isoDate);
+
+JS_EXPORT_PRIVATE bool isValidMonthCodeForCalendar(CalendarID, ParsedMonthCode);
+
+JS_EXPORT_PRIVATE bool yearContainsMonthCode(CalendarID, int32_t year, ParsedMonthCode);
+
+JS_EXPORT_PRIVATE TemporalResult<ParsedMonthCode> constrainMonthCode(CalendarID, int32_t year, ParsedMonthCode, TemporalOverflow);
+
+JS_EXPORT_PRIVATE int32_t monthCodeOrdinalInYear(CalendarID, ParsedMonthCode, int32_t year);
 
 JS_EXPORT_PRIVATE TemporalResult<std::optional<String>> calendarEra(CalendarID, const ISO8601::PlainDate& isoDate);
 
@@ -126,7 +127,13 @@ Expected<int32_t, EcmaReferenceYearError> ecmaReferenceYear(CalendarID, uint8_t 
 
 JS_EXPORT_PRIVATE int32_t lunarCalendarExtendedYearFor1972(CalendarID);
 
-JS_EXPORT_PRIVATE TemporalResult<ISO8601::PlainDate> calendarDateFromFields(CalendarID, std::optional<int32_t> year, uint8_t month, uint8_t day, std::optional<StringView> era, std::optional<int32_t> eraYear, std::optional<ParsedMonthCode>, TemporalOverflow);
+JS_EXPORT_PRIVATE std::optional<ASCIILiteral> canonicalizeEraInCalendar(CalendarID, StringView era);
+
+JS_EXPORT_PRIVATE std::optional<std::pair<ASCIILiteral, int32_t>> remapNonPositiveEraYear(CalendarID, StringView era, int32_t eraYear);
+
+JS_EXPORT_PRIVATE std::optional<int32_t> calendarDateArithmeticYearForEraYear(CalendarID, StringView era, int32_t eraYear);
+
+JS_EXPORT_PRIVATE TemporalResult<ISO8601::PlainDate> nonISOCalendarDateToISO(CalendarID, std::optional<int32_t> year, uint8_t month, uint8_t day, std::optional<ParsedMonthCode>, TemporalOverflow);
 
 } // namespace TemporalCore
 } // namespace JSC

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -4561,19 +4561,6 @@ InterruptVideoOnPageVisibilityChangeEnabled:
     WebCore:
       default: false
 
-IntlEraMonthcodeEnabled:
-  type: bool
-  status: testable
-  category: javascript
-  humanReadableName: "Intl Era and Month Code"
-  humanReadableDescription: "Enable Intl.Era-monthcode proposal."
-  webcoreBinding: none
-  jscOptionName: useIntlEraMonthcode
-  sharedPreferenceForWebProcess: true
-  defaultValue:
-    WebKit:
-      default: false
-
 InvisibleAutoplayNotPermitted:
   type: bool
   status: embedder


### PR DESCRIPTION
#### 99473681ff5ee5bc7d666904274b1491a81c5196
<pre>
[JSC][Temporal][Intl.Era] Implement intl-era-monthcode
<a href="https://bugs.webkit.org/show_bug.cgi?id=319855">https://bugs.webkit.org/show_bug.cgi?id=319855</a>
<a href="https://rdar.apple.com/182753821">rdar://182753821</a>

Reviewed by Yusuke Suzuki.

Implement the Stage 4 proposal-intl-era-monthcode[1] end-to-end and drop the
useIntlEraMonthcode transition flag.

CalendarICUBridge is consolidated around the intl-era spec ops. A canonical
eraTable() replaces per-calendar if-ladders in CanonicalizeEraInCalendar,
CalendarDateArithmeticYearForEraYear, and RemapNonPositiveEraYear.

New IsValidMonthCodeForCalendar, YearContainsMonthCode, ConstrainMonthCode
(with ~constrain~/~reject~ overflow), and MonthCodeOrdinalInYear share
algorithms via cursor-taking Internal variants to avoid withCalendar
cache-lock re-entry.

Era emission is unified via emitEraProleptic and
emitEraFromICU. Calendar-category predicates and ICU boilerplate helpers
replace repeated inline patterns.

Audited 7 distinct calendar-behavior clusters in CalendarICUBridge.cpp and
IntlDateTimeFormat.cpp against standalone ICU repros and icu4x/temporal_rs
cross-checks. 6 of the 7 trace to a confirmed, filable ICU4C calendar-data
bug; the 7th (Hebrew never setting UCAL_IS_LEAP_MONTH) is confirmed
intentional API design, not a bug, and needs no radar. Of the 6 confirmed
bugs, 5 are tagged ICU4C-WORKAROUND in code and are pure stopgaps that fully
disappear once ICU ships a fix; the 6th (Chinese/Dangi, <a href="https://rdar.apple.com/182965648">rdar://182965648</a>) is
deliberately left untagged as a workaround, since its ±10000-year ISO
fallback is a permanent design choice independent of that specific bug (see
below).

- <a href="https://rdar.apple.com/182952830">rdar://182952830</a> (stale ucal_getLimit after ucal_add(MONTH, -1)),
  <a href="https://rdar.apple.com/182960658">rdar://182960658</a> (Indian/Saka extreme-year round-trip), and
  <a href="https://rdar.apple.com/182963532">rdar://182963532</a> (Buddhist/ROC/Japanese pre-1582 Julian arithmetic)
  already had correct, complete workarounds; no changes needed. All three
  fully disappear once ICU fixes the underlying behavior.

- <a href="https://rdar.apple.com/182965648">rdar://182965648</a> (Chinese/Dangi: ucal_getMillis succeeds but the paired
  ucal_get(UCAL_EXTENDED_YEAR) fails at extreme years) was only handled on
  the construction side (NonISOCalendarDateToISO). Every calendar field
  accessor (year, month, day, monthCode, dayOfYear, daysInMonth, daysInYear,
  monthsInYear) is now fixed to fall back to the ISO calendar&apos;s own fields
  beyond the same ±10000 threshold, instead of throwing (RangeError: Failed
  to read calendar fields from ICU) or silently returning stale, incorrect
  values. Unlike the other five, this fallback does NOT go away once ICU
  fixes the ucal_getMillis/ucal_get inconsistency: the ±10000 threshold
  matches icu4x&apos;s own WELL_BEHAVED_ASTRONOMICAL_RANGE and is required by
  test262 extreme-dates.js regardless of that specific ICU bug, since
  Chinese/Dangi astronomical calculations are unreliable that far out on
  any implementation.

- <a href="https://rdar.apple.com/182953351">rdar://182953351</a> (Islamic calendar era architecturally locked at 0, no
  pre-Hijra era; Coptic never emits its second era for pre-AM dates) is
  partially fixed: the era-text override now only fires when the caller
  actually requested an era field (it previously spliced era text into
  format()/formatToParts() output unconditionally). formatRange() and
  formatRangeToParts() still don&apos;t apply the override at all; fixing that
  properly needs per-endpoint override text (a range whose ends fall on
  opposite sides of the era boundary can&apos;t be expressed with one override
  string), which is complexity not worth adding to a workaround that fully
  disappears once ICU selects the correct era natively.

- <a href="https://rdar.apple.com/182958553">rdar://182958553</a> (Hebrew calendar year 0 classified &quot;Deficient&quot; leap year
  instead of &quot;Regular&quot;, giving Kislev 29 days instead of 30) remains only
  partially addressed: the existing workaround relabels ICU&apos;s single native
  Tevet D1 slot as the fabricated Kislev D30, but never shifts the rest of
  the year by the day it inserts, so dayOfYear under-counts by 1 from Tevet
  D1 onward and the true Tevet D1 is unreachable. A correct fix means
  re-deriving every field for the remainder of year 0, which isn&apos;t worth
  hand-rolling for a workaround that fully disappears once ICU&apos;s
  classification matches icu4x.

The last two are left as FIXMEs with regression tests gated behind
`if (false)` (temporal-hebrew-year0-kislev.js, intl-datetimeformat.js),
to be flipped on once ICU ships the underlying fixes, rather than growing
more workaround logic in this codebase. intl-datetimeformat.js also gained
coverage pinning down the era-text override&apos;s known compatibility boundary
(hardcoded English text, era width ignored, wrong pattern position for
non-English locales) so it stays visible without expanding the override&apos;s
scope.

[1] <a href="https://github.com/tc39/proposal-intl-era-monthcode">https://github.com/tc39/proposal-intl-era-monthcode</a>

Tests: JSTests/stress/intl-datetimeformat.js
       JSTests/stress/temporal-era-aliases.js
       JSTests/stress/temporal-era-boundaries.js
       JSTests/stress/temporal-extreme-proleptic.js
       JSTests/stress/temporal-hebrew-year0-kislev.js
       JSTests/stress/temporal-lunisolar-and-wrappers.js
       JSTests/stress/temporal-nonISO-arithmetic.js
       JSTests/stress/temporal-nonISO-with.js
       JSTests/stress/temporal-nonisoresolvefields-monthcode-validation.js
       JSTests/stress/temporal-resolvefields-error-ordering.js
       Source/JavaScriptCore/API/tests/TemporalCoreTest.cpp

Canonical link: <a href="https://commits.webkit.org/318428@main">https://commits.webkit.org/318428@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/57e40640c932fb02153e7281bf5cd99e6f89526e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178256 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52194 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45989 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187870 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/141504 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4e01ecf9-20ae-421f-af3b-27c41efe0d96) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53488 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51903 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138961 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96475 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fab6ad04-d620-45b8-879e-da1c3a521d5d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181213 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42515 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159724 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119417 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e7df52cb-0826-4913-8299-a0d1b7090679) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41181 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39537 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/1386 "Passed tests") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/8212 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Checked out pull request; Passed JSC tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151581 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39221 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36327 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/39529 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44794 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43780 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190297 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51862 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148111 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52544 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35846 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147884 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27040 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42599 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124808 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119391 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51062 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14196 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50447 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50687 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50509 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->