### PR TITLE
[Web Inspector] [Site Isolation] Deliver DOM custom-element and pseudo-element events to Frame Targets

### DIFF
--- a/LayoutTests/http/tests/site-isolation/inspector/dom/custom-elements-and-pseudo-elements-frame-target-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/inspector/dom/custom-elements-and-pseudo-elements-frame-target-expected.txt
@@ -1,0 +1,59 @@
+Tests that a cross-origin iframe's FrameDOMAgent dispatches DOM.customElementStateChanged, DOM.pseudoElementAdded, and DOM.pseudoElementRemoved to its Frame Target under Site Isolation, including multiple, repeated, and interleaved events.
+
+
+
+== Running test suite: SiteIsolation.DOM.FrameDOMAgent.CustomAndPseudoElements
+-- Running test case: Setup
+PASS: Cross-origin iframe should be its own Frame Target.
+PASS: Frame target should have a document.
+PASS: Should find #host in the frame document.
+PASS: #host should start with no pseudo elements.
+
+-- Running test case: CustomElementStateChanged.TwoInSequence
+PASS: Should find <my-widget>.
+PASS: Should find <my-gadget>.
+PASS: <my-widget> should start 'waiting'.
+PASS: <my-gadget> should start 'waiting'.
+PASS: <my-widget> should receive at least one customElementStateChanged event.
+PASS: <my-gadget> should receive at least one customElementStateChanged event.
+PASS: No customElementStateChanged event should target an unrelated node.
+PASS: <my-widget> should become 'custom'.
+PASS: <my-gadget> should become 'custom'.
+
+-- Running test case: PseudoElements.BothCoexist
+PASS: Exactly two pseudoElementAdded events should arrive for #host.
+PASS: Each inserted node should be a pseudo element.
+PASS: Each inserted node should be a pseudo element.
+PASS: #host should track two pseudo elements.
+PASS: #host should track exactly ::before and ::after.
+PASS: #host should have a ::before node.
+PASS: #host should have an ::after node.
+PASS: ::before node should be typed Before.
+PASS: ::after node should be typed After.
+
+-- Running test case: PseudoElements.RemoveOneLeavesOther
+PASS: Precondition: ::before present.
+PASS: Precondition: ::after present.
+PASS: Exactly one pseudoElementRemoved event should fire.
+PASS: The removed node should be the ::before node, not ::after.
+PASS: #host should now track one pseudo element.
+PASS: Only ::after should remain.
+PASS: The surviving ::after should be the same node instance.
+PASS: ::before should be gone.
+
+-- Running test case: PseudoElements.RemoveRemaining
+PASS: Exactly one pseudoElementRemoved event should fire.
+PASS: #host should have no pseudo elements.
+PASS: pseudoElements map should be empty.
+
+-- Running test case: PseudoElements.AddRemoveReAddNoStaleNode
+PASS: First ::before should be present.
+PASS: ::before should be cleared after removal.
+PASS: The first ::before node should be marked destroyed.
+PASS: Second ::before should be present.
+PASS: Re-added ::before must be a fresh node, not the destroyed one.
+PASS: Re-added ::before should not be destroyed.
+PASS: #host should track exactly one pseudo element after re-add.
+PASS: The Before map entry should point at the fresh node.
+PASS: #host should end with no pseudo elements.
+

--- a/LayoutTests/http/tests/site-isolation/inspector/dom/custom-elements-and-pseudo-elements-frame-target.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/dom/custom-elements-and-pseudo-elements-frame-target.html
@@ -1,0 +1,238 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<script src="../../../inspector/resources/inspector-test.js"></script>
+<script src="../debugger/resources/site-isolation-debugger-test-utilities.js"></script>
+<script>
+function test() {
+    let suite = InspectorTest.createAsyncSuite("SiteIsolation.DOM.FrameDOMAgent.CustomAndPseudoElements");
+
+    let frameTarget = null;
+    let frameDoc = null;
+    let hostNode = null;
+
+    const Before = WI.DOMNode.PseudoElementType.Before;
+    const After = WI.DOMNode.PseudoElementType.After;
+
+    // Evaluate an expression inside the cross-origin frame's own process/execution context.
+    async function evaluateInFrame(expression) {
+        await frameTarget.RuntimeAgent.evaluate.invoke({expression, objectGroup: "test"});
+    }
+
+    // Resolve an element in the frame document via a live backend querySelector. The frame target
+    // returns a frame-local nodeId; nodeForIdInFrameTarget scopes it and hands back the cached
+    // DOMNode instance (the same one the DOMManager event handlers mutate).
+    async function querySelectorInFrame(selector) {
+        let rawId = await frameDoc.querySelector(selector);
+        if (!rawId)
+            return null;
+        return WI.domManager.nodeForIdInFrameTarget(rawId, frameTarget);
+    }
+
+    // Only consider events whose node belongs to our frame target (ignore any page-target churn).
+    function belongsToFrame(data) {
+        return !data.node || data.node.owningTarget === frameTarget;
+    }
+
+    // Collect every matching DOMManager event into a growing array until stop() is called.
+    // Returned so a single mutation that fires multiple events can be asserted on as a set,
+    // which is exactly what surfaces back-to-back / duplicate / wrong-node bugs.
+    function collectDOMManagerEvents(eventType, filter) {
+        let collected = [];
+        let listener = (event) => {
+            if (!belongsToFrame(event.data))
+                return;
+            if (filter && !filter(event.data))
+                return;
+            collected.push(event.data);
+        };
+        WI.domManager.addEventListener(eventType, listener);
+        return {
+            events: collected,
+            stop() { WI.domManager.removeEventListener(eventType, listener); },
+        };
+    }
+
+    // Poll until predicate() is true or we give up (keeps the test from hanging forever if an
+    // expected event never arrives — it fails an assertion instead of timing out at 10s).
+    async function waitUntil(predicate, description, maxAttempts = 50) {
+        for (let i = 0; i < maxAttempts; ++i) {
+            if (predicate())
+                return true;
+            await new Promise((resolve) => setTimeout(resolve, 10));
+        }
+        InspectorTest.expectThat(predicate(), "TIMED OUT waiting for: " + description);
+        return predicate();
+    }
+
+    function pseudoNames(node) {
+        return Array.from(node.pseudoElements().keys()).sort().join(",");
+    }
+
+    suite.addTestCase({
+        name: "Setup",
+        description: "Find the cross-origin frame target and obtain its FrameDOMAgent document + #host.",
+        async test() {
+            frameTarget = await frameTargetForURLContaining("custom-elements-and-pseudo-elements-frame.html");
+            InspectorTest.expectThat(frameTarget instanceof WI.FrameTarget, "Cross-origin iframe should be its own Frame Target.");
+
+            frameDoc = WI.domManager.frameTargetDocumentForTarget(frameTarget);
+            if (!frameDoc) {
+                let docEvent = await WI.domManager.awaitEvent(WI.DOMManager.Event.FrameDocumentAvailable);
+                frameDoc = docEvent.data.document;
+            }
+            InspectorTest.expectNotNull(frameDoc, "Frame target should have a document.");
+
+            hostNode = await querySelectorInFrame("#host");
+            InspectorTest.expectNotNull(hostNode, "Should find #host in the frame document.");
+            InspectorTest.expectThat(!hostNode.hasPseudoElements(), "#host should start with no pseudo elements.");
+        }
+    });
+
+    suite.addTestCase({
+        name: "CustomElementStateChanged.TwoInSequence",
+        description: "Two separate custom elements upgraded back-to-back should each fire customElementStateChanged. WebKit's upgrade path transitions each element FailedOrPrecustomized -> Custom (JSCustomElementInterface::upgradeElement), so each element emits two state-change events; this verifies both elements' events arrive, target the correct node, and end in Custom without cross-contamination.",
+        async test() {
+            let widget = await querySelectorInFrame("#widget");
+            let gadget = await querySelectorInFrame("#gadget");
+            InspectorTest.expectNotNull(widget, "Should find <my-widget>.");
+            InspectorTest.expectNotNull(gadget, "Should find <my-gadget>.");
+            InspectorTest.expectEqual(widget.customElementState(), WI.DOMNode.CustomElementState.Waiting, "<my-widget> should start 'waiting'.");
+            InspectorTest.expectEqual(gadget.customElementState(), WI.DOMNode.CustomElementState.Waiting, "<my-gadget> should start 'waiting'.");
+
+            let collector = collectDOMManagerEvents(WI.DOMManager.Event.CustomElementStateChanged);
+
+            // Fire both upgrades back-to-back in a single frame turn (no await between them).
+            // Each element transitions through a transient failed/precustomized state before
+            // becoming Custom, so wait for both elements to reach their terminal Custom state
+            // rather than a fixed event count.
+            await evaluateInFrame("defineWidget(); defineGadget();");
+            await waitUntil(() => widget.customElementState() === WI.DOMNode.CustomElementState.Custom && gadget.customElementState() === WI.DOMNode.CustomElementState.Custom, "both custom elements to reach 'custom'");
+            collector.stop();
+
+            let widgetEvents = collector.events.filter((d) => d.node === widget);
+            let gadgetEvents = collector.events.filter((d) => d.node === gadget);
+            let strayEvents = collector.events.filter((d) => d.node !== widget && d.node !== gadget);
+
+            InspectorTest.expectThat(widgetEvents.length >= 1, "<my-widget> should receive at least one customElementStateChanged event.");
+            InspectorTest.expectThat(gadgetEvents.length >= 1, "<my-gadget> should receive at least one customElementStateChanged event.");
+            InspectorTest.expectEqual(strayEvents.length, 0, "No customElementStateChanged event should target an unrelated node.");
+            InspectorTest.expectEqual(widget.customElementState(), WI.DOMNode.CustomElementState.Custom, "<my-widget> should become 'custom'.");
+            InspectorTest.expectEqual(gadget.customElementState(), WI.DOMNode.CustomElementState.Custom, "<my-gadget> should become 'custom'.");
+        }
+    });
+
+    suite.addTestCase({
+        name: "PseudoElements.BothCoexist",
+        description: "Adding ::before then ::after should fire two pseudoElementAdded events and track both types simultaneously without clobbering.",
+        async test() {
+            let collector = collectDOMManagerEvents(WI.DOMManager.Event.NodeInserted, (data) => data.parent === hostNode);
+
+            // Two separate mutations, each creating exactly one pseudo element; collect both.
+            await evaluateInFrame("addHostClass('b')");
+            await evaluateInFrame("addHostClass('a')");
+            await waitUntil(() => collector.events.length >= 2, "two pseudoElementAdded events");
+            collector.stop();
+
+            InspectorTest.expectEqual(collector.events.length, 2, "Exactly two pseudoElementAdded events should arrive for #host.");
+            for (let {node} of collector.events)
+                InspectorTest.expectThat(node.isPseudoElement(), "Each inserted node should be a pseudo element.");
+
+            InspectorTest.expectEqual(hostNode.pseudoElements().size, 2, "#host should track two pseudo elements.");
+            InspectorTest.expectEqual(pseudoNames(hostNode), "after,before", "#host should track exactly ::before and ::after.");
+            InspectorTest.expectNotNull(hostNode.beforePseudoElement(), "#host should have a ::before node.");
+            InspectorTest.expectNotNull(hostNode.afterPseudoElement(), "#host should have an ::after node.");
+            InspectorTest.expectEqual(hostNode.beforePseudoElement().pseudoType(), Before, "::before node should be typed Before.");
+            InspectorTest.expectEqual(hostNode.afterPseudoElement().pseudoType(), After, "::after node should be typed After.");
+        }
+    });
+
+    suite.addTestCase({
+        name: "PseudoElements.RemoveOneLeavesOther",
+        description: "Removing only ::before should remove exactly that node and leave the ::after node intact (same instance).",
+        async test() {
+            let beforeNode = hostNode.beforePseudoElement();
+            let afterNode = hostNode.afterPseudoElement();
+            InspectorTest.expectNotNull(beforeNode, "Precondition: ::before present.");
+            InspectorTest.expectNotNull(afterNode, "Precondition: ::after present.");
+
+            let removed = null;
+            let collector = collectDOMManagerEvents(WI.DOMManager.Event.NodeRemoved, (data) => data.node.isPseudoElement());
+
+            await evaluateInFrame("removeHostClass('b')"); // removes ::before, keeps ::after
+            await waitUntil(() => collector.events.length >= 1, "one pseudoElementRemoved event");
+            collector.stop();
+            removed = collector.events.length ? collector.events[0].node : null;
+
+            InspectorTest.expectEqual(collector.events.length, 1, "Exactly one pseudoElementRemoved event should fire.");
+            InspectorTest.expectThat(removed === beforeNode, "The removed node should be the ::before node, not ::after.");
+            InspectorTest.expectEqual(hostNode.pseudoElements().size, 1, "#host should now track one pseudo element.");
+            InspectorTest.expectEqual(pseudoNames(hostNode), "after", "Only ::after should remain.");
+            InspectorTest.expectThat(hostNode.afterPseudoElement() === afterNode, "The surviving ::after should be the same node instance.");
+            InspectorTest.expectThat(!hostNode.beforePseudoElement(), "::before should be gone.");
+        }
+    });
+
+    suite.addTestCase({
+        name: "PseudoElements.RemoveRemaining",
+        description: "Removing ::after should leave #host with no pseudo elements.",
+        async test() {
+            let collector = collectDOMManagerEvents(WI.DOMManager.Event.NodeRemoved, (data) => data.node.isPseudoElement());
+
+            await evaluateInFrame("removeHostClass('a')");
+            await waitUntil(() => collector.events.length >= 1, "one pseudoElementRemoved event");
+            collector.stop();
+
+            InspectorTest.expectEqual(collector.events.length, 1, "Exactly one pseudoElementRemoved event should fire.");
+            InspectorTest.expectThat(!hostNode.hasPseudoElements(), "#host should have no pseudo elements.");
+            InspectorTest.expectEqual(hostNode.pseudoElements().size, 0, "pseudoElements map should be empty.");
+        }
+    });
+
+    suite.addTestCase({
+        name: "PseudoElements.AddRemoveReAddNoStaleNode",
+        description: "Add ::before, remove it, then add ::before again. The re-added node must be a fresh instance and the old node must be destroyed (no stale-node leak / duplicate-key overwrite).",
+        async test() {
+            // Add ::before (first instance).
+            let add1 = collectDOMManagerEvents(WI.DOMManager.Event.NodeInserted, (data) => data.parent === hostNode);
+            await evaluateInFrame("addHostClass('b')");
+            await waitUntil(() => add1.events.length >= 1, "first ::before add");
+            add1.stop();
+            let firstBefore = hostNode.beforePseudoElement();
+            InspectorTest.expectNotNull(firstBefore, "First ::before should be present.");
+
+            // Remove it.
+            let rem = collectDOMManagerEvents(WI.DOMManager.Event.NodeRemoved, (data) => data.node === firstBefore);
+            await evaluateInFrame("removeHostClass('b')");
+            await waitUntil(() => rem.events.length >= 1, "::before removal");
+            rem.stop();
+            InspectorTest.expectThat(!hostNode.beforePseudoElement(), "::before should be cleared after removal.");
+            InspectorTest.expectThat(firstBefore.destroyed, "The first ::before node should be marked destroyed.");
+
+            // Add ::before again (second instance).
+            let add2 = collectDOMManagerEvents(WI.DOMManager.Event.NodeInserted, (data) => data.parent === hostNode);
+            await evaluateInFrame("addHostClass('b')");
+            await waitUntil(() => add2.events.length >= 1, "second ::before add");
+            add2.stop();
+            let secondBefore = hostNode.beforePseudoElement();
+
+            InspectorTest.expectNotNull(secondBefore, "Second ::before should be present.");
+            InspectorTest.expectThat(secondBefore !== firstBefore, "Re-added ::before must be a fresh node, not the destroyed one.");
+            InspectorTest.expectThat(!secondBefore.destroyed, "Re-added ::before should not be destroyed.");
+            InspectorTest.expectEqual(hostNode.pseudoElements().size, 1, "#host should track exactly one pseudo element after re-add.");
+            InspectorTest.expectThat(hostNode.pseudoElements().get(Before) === secondBefore, "The Before map entry should point at the fresh node.");
+
+            // Cleanup so the suite ends in a known state.
+            let cleanup = collectDOMManagerEvents(WI.DOMManager.Event.NodeRemoved, (data) => data.node === secondBefore);
+            await evaluateInFrame("removeHostClass('b')");
+            await waitUntil(() => cleanup.events.length >= 1, "cleanup removal");
+            cleanup.stop();
+            InspectorTest.expectThat(!hostNode.hasPseudoElements(), "#host should end with no pseudo elements.");
+        }
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+<body onload="runTest()">
+<p>Tests that a cross-origin iframe's FrameDOMAgent dispatches DOM.customElementStateChanged, DOM.pseudoElementAdded, and DOM.pseudoElementRemoved to its Frame Target under Site Isolation, including multiple, repeated, and interleaved events.</p>
+<iframe src="http://localhost:8000/site-isolation/inspector/dom/resources/custom-elements-and-pseudo-elements-frame.html"></iframe>
+</body>

--- a/LayoutTests/http/tests/site-isolation/inspector/dom/resources/custom-elements-and-pseudo-elements-frame.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/dom/resources/custom-elements-and-pseudo-elements-frame.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Cross-Origin Custom &amp; Pseudo Element Frame</title>
+    <style>
+    /* Independent toggles: class "b" -> ::before, class "a" -> ::after. Combining them
+       ("b a") yields both pseudo elements at once, so the inspector test can drive one,
+       the other, or both, and exercise targeted removal. */
+    .b::before { content: "before"; }
+    .a::after { content: "after"; }
+    </style>
+</head>
+<body>
+    <!-- Two independent undefined custom elements. Each starts as an upgrade candidate
+         ("waiting") and is upgraded to "custom" when its define function runs. Having two
+         lets the test upgrade them back-to-back and confirm two customElementStateChanged
+         events don't cross-contaminate. -->
+    <my-widget id="widget">upgrade me</my-widget>
+    <my-gadget id="gadget">upgrade me too</my-gadget>
+
+    <!-- A plain element whose ::before / ::after pseudo elements are toggled by
+         adding/removing classes, driving pseudoElementAdded / pseudoElementRemoved. -->
+    <div id="host">host element</div>
+
+    <script>
+    // Exposed so the inspector test can trigger custom element upgrades at controlled times
+    // (after it has begun observing DOM.customElementStateChanged).
+    function defineWidget() {
+        customElements.define("my-widget", class extends HTMLElement { });
+    }
+    function defineGadget() {
+        customElements.define("my-gadget", class extends HTMLElement { });
+    }
+
+    // Independent pseudo-element control on #host via incremental class add/remove, so each
+    // call creates/destroys exactly one pseudo element (matching how WebKit's style recalc
+    // preserves an unchanged pseudo element across an unrelated class change).
+    function addHostClass(name) {
+        document.getElementById("host").classList.add(name);
+    }
+    function removeHostClass(name) {
+        document.getElementById("host").classList.remove(name);
+    }
+    </script>
+</body>
+</html>

--- a/Source/JavaScriptCore/inspector/protocol/DOM.json
+++ b/Source/JavaScriptCore/inspector/protocol/DOM.json
@@ -934,7 +934,7 @@
         {
             "name": "customElementStateChanged",
             "description": "Called when the custom element state is changed.",
-            "targetTypes": ["page"],
+            "targetTypes": ["frame", "page"],
             "parameters": [
                 { "name": "nodeId", "$ref": "NodeId", "description": "Element id." },
                 { "name": "customElementState", "$ref": "CustomElementState", "description": "Custom element state." }
@@ -943,7 +943,7 @@
         {
             "name": "pseudoElementAdded",
             "description": "Called when a pseudo element is added to an element.",
-            "targetTypes": ["page"],
+            "targetTypes": ["frame", "page"],
             "parameters": [
                 { "name": "parentId", "$ref": "NodeId", "description": "Pseudo element's parent element id." },
                 { "name": "pseudoElement", "$ref": "Node", "description": "The added pseudo element." }
@@ -952,7 +952,7 @@
         {
             "name": "pseudoElementRemoved",
             "description": "Called when a pseudo element is removed from an element.",
-            "targetTypes": ["page"],
+            "targetTypes": ["frame", "page"],
             "parameters": [
                 { "name": "parentId", "$ref": "NodeId", "description": "Pseudo element's parent element id." },
                 { "name": "pseudoElementId", "$ref": "NodeId", "description": "The removed pseudo element id." }

--- a/Source/WebCore/inspector/InspectorInstrumentation.cpp
+++ b/Source/WebCore/inspector/InspectorInstrumentation.cpp
@@ -360,18 +360,30 @@ void InspectorInstrumentation::didChangeAssignedNodesImpl(InstrumentingAgents& i
 
 void InspectorInstrumentation::didChangeCustomElementStateImpl(InstrumentingAgents& instrumentingAgents, Element& element)
 {
+    if (RefPtr frame = element.document().frame()) {
+        if (CheckedPtr frameDOMAgent = frame->inspectorController().instrumentingAgents().persistentFrameDOMAgent())
+            frameDOMAgent->didChangeCustomElementState(element);
+    }
     if (CheckedPtr domAgent = instrumentingAgents.persistentDOMAgent())
         domAgent->didChangeCustomElementState(element);
 }
 
 void InspectorInstrumentation::pseudoElementCreatedImpl(InstrumentingAgents& instrumentingAgents, PseudoElement& pseudoElement)
 {
+    if (RefPtr frame = pseudoElement.document().frame()) {
+        if (CheckedPtr frameDOMAgent = frame->inspectorController().instrumentingAgents().persistentFrameDOMAgent())
+            frameDOMAgent->pseudoElementCreated(pseudoElement);
+    }
     if (CheckedPtr domAgent = instrumentingAgents.persistentDOMAgent())
         domAgent->pseudoElementCreated(pseudoElement);
 }
 
 void InspectorInstrumentation::pseudoElementDestroyedImpl(InstrumentingAgents& instrumentingAgents, PseudoElement& pseudoElement)
 {
+    if (RefPtr frame = pseudoElement.document().frame()) {
+        if (CheckedPtr frameDOMAgent = frame->inspectorController().instrumentingAgents().persistentFrameDOMAgent())
+            frameDOMAgent->pseudoElementDestroyed(pseudoElement);
+    }
     if (CheckedPtr domAgent = instrumentingAgents.persistentDOMAgent())
         domAgent->pseudoElementDestroyed(pseudoElement);
     if (auto* layerTreeAgent = instrumentingAgents.enabledLayerTreeAgent())

--- a/Source/WebInspectorUI/UserInterface/Controllers/DOMManager.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/DOMManager.js
@@ -483,6 +483,51 @@ WI.DOMManager = class DOMManager extends WI.Object
         this.dispatchEventToListeners(WI.DOMManager.Event.NodeRemoved, {node});
     }
 
+    _frameTargetCustomElementStateChanged(target, nodeId, newState)
+    {
+        let scopedId = target.identifier + ":" + nodeId;
+        let node = this._idToDOMNode[scopedId];
+        if (!node)
+            return;
+
+        node._customElementState = newState;
+        this.dispatchEventToListeners(WI.DOMManager.Event.CustomElementStateChanged, {node});
+    }
+
+    _frameTargetPseudoElementAdded(target, parentId, pseudoElement)
+    {
+        let scopedParentId = target.identifier + ":" + parentId;
+        let parent = this._idToDOMNode[scopedParentId];
+        if (!parent)
+            return;
+
+        let node = new WI.DOMNode(this, parent.ownerDocument, false, pseudoElement, {frameTarget: target});
+        node.parentNode = parent;
+        this._idToDOMNode[node.id] = node;
+        console.assert(!parent.pseudoElements().get(node.pseudoType()));
+        parent.pseudoElements().set(node.pseudoType(), node);
+        this.dispatchEventToListeners(WI.DOMManager.Event.NodeInserted, {node, parent});
+    }
+
+    _frameTargetPseudoElementRemoved(target, parentId, pseudoElementId)
+    {
+        let scopedParentId = target.identifier + ":" + parentId;
+        let scopedPseudoElementId = target.identifier + ":" + pseudoElementId;
+        let pseudoElement = this._idToDOMNode[scopedPseudoElementId];
+        if (!pseudoElement)
+            return;
+
+        let parent = pseudoElement.parentNode;
+        console.assert(parent);
+        console.assert(parent.id === scopedParentId);
+        if (!parent)
+            return;
+
+        parent._removeChild(pseudoElement);
+        this._frameTargetUnbind(pseudoElement);
+        this.dispatchEventToListeners(WI.DOMManager.Event.NodeRemoved, {node: pseudoElement, parent});
+    }
+
     transitionPageTarget()
     {
         this._documentUpdated();

--- a/Source/WebInspectorUI/UserInterface/Protocol/DOMObserver.js
+++ b/Source/WebInspectorUI/UserInterface/Protocol/DOMObserver.js
@@ -144,22 +144,28 @@ WI.DOMObserver = class DOMObserver extends InspectorBackend.Dispatcher
 
     customElementStateChanged(nodeId, customElementState)
     {
-        if (this._target instanceof WI.FrameTarget)
-            return; // FIXME: <https://webkit.org/b/298980> Route to frame-target handler.
+        if (this._target instanceof WI.FrameTarget) {
+            WI.domManager._frameTargetCustomElementStateChanged(this._target, nodeId, customElementState);
+            return;
+        }
         WI.domManager._customElementStateChanged(nodeId, customElementState);
     }
 
     pseudoElementAdded(parentNodeId, pseudoElement)
     {
-        if (this._target instanceof WI.FrameTarget)
-            return; // FIXME: <https://webkit.org/b/298980> Route to frame-target handler.
+        if (this._target instanceof WI.FrameTarget) {
+            WI.domManager._frameTargetPseudoElementAdded(this._target, parentNodeId, pseudoElement);
+            return;
+        }
         WI.domManager._pseudoElementAdded(parentNodeId, pseudoElement);
     }
 
     pseudoElementRemoved(parentNodeId, pseudoElementId)
     {
-        if (this._target instanceof WI.FrameTarget)
-            return; // FIXME: <https://webkit.org/b/298980> Route to frame-target handler.
+        if (this._target instanceof WI.FrameTarget) {
+            WI.domManager._frameTargetPseudoElementRemoved(this._target, parentNodeId, pseudoElementId);
+            return;
+        }
         WI.domManager._pseudoElementRemoved(parentNodeId, pseudoElementId);
     }
 


### PR DESCRIPTION
#### c432535e2dd2f474007a2398f0156106eb87ed0e
<pre>
[Web Inspector] [Site Isolation] Deliver DOM custom-element and pseudo-element events to Frame Targets
<a href="https://bugs.webkit.org/show_bug.cgi?id=NNNNNN">https://bugs.webkit.org/show_bug.cgi?id=NNNNNN</a>
<a href="https://rdar.apple.com/179176056">rdar://179176056</a>

Reviewed by Qianlang Chen.

Web Inspector&apos;s Elements tree for an out-of-process iframe went
stale on these lifecycle changes:

- DOM.customElementStateChanged
- DOM.pseudoElementAdded
- DOM.pseudoElementRemoved

They were stubbed off at every layer for the frame target: the protocol declared
them &quot;page&quot;-only, InspectorInstrumentation routed them only to the page-level
persistentDOMAgent(), and the frontend DOMObserver early-returned with a FIXME
for FrameTarget. FrameDOMAgent already had complete, correct implementations of
all three methods, so this is a pure wiring change, not a new feature.

This adds the missing routing following the existing convention used by
didInsertDOMNode / didModifyDOMAttr (notify the frame&apos;s own FrameDOMAgent, then
the page agent), declares the events for the frame target, and adds the
scoped-id frontend handlers so the iframe&apos;s Elements tree stays live.

The added layout test deliberately covers multiple, repeated, and interleaved
scenarios rather than a single event per type, since these handlers manage
per-node and per-pseudo-type state: two custom elements upgraded back-to-back
(no cross-contamination), ::before and ::after coexisting, targeted single-pseudo
removal leaving the sibling intact, and an add/remove/re-add cycle guarding
against stale-node leaks. It also documents that one upgrade legitimately emits
two transitions (FailedOrPrecustomized then Custom), which the frame target
relays just like the page target.

Test: http/tests/site-isolation/inspector/dom/custom-elements-and-pseudo-elements-frame-target.html

* LayoutTests/http/tests/site-isolation/inspector/dom/custom-elements-and-pseudo-elements-frame-target-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/inspector/dom/custom-elements-and-pseudo-elements-frame-target.html: Added.
* LayoutTests/http/tests/site-isolation/inspector/dom/resources/custom-elements-and-pseudo-elements-frame.html: Added.
* Source/JavaScriptCore/inspector/protocol/DOM.json:
* Source/WebCore/inspector/InspectorInstrumentation.cpp:
(WebCore::InspectorInstrumentation::didChangeCustomElementStateImpl):
(WebCore::InspectorInstrumentation::pseudoElementCreatedImpl):
(WebCore::InspectorInstrumentation::pseudoElementDestroyedImpl):
* Source/WebInspectorUI/UserInterface/Controllers/DOMManager.js:
(WI.DOMManager.prototype._frameTargetCustomElementStateChanged):
(WI.DOMManager.prototype._frameTargetPseudoElementAdded):
(WI.DOMManager.prototype._frameTargetPseudoElementRemoved):
* Source/WebInspectorUI/UserInterface/Protocol/DOMObserver.js:
(WI.DOMObserver.prototype.customElementStateChanged):
(WI.DOMObserver.prototype.pseudoElementAdded):
(WI.DOMObserver.prototype.pseudoElementRemoved):

Canonical link: <a href="https://commits.webkit.org/317699@main">https://commits.webkit.org/317699@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d5209dba0215d09b83e3f7c684ad7ec209b8eb59

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175740 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49673 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43456 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185333 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/137921 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/177603 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50965 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49355 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136838 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/137921 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178696 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40292 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157607 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117316 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e12540cf-fe21-44bd-aebc-f43604c876a6) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38934 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37317 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/6116 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149353 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37099 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33802 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/37004 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41386 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41523 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187754 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49340 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/157158 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145829 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39304 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50020 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33723 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145671 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40459 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122216 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/116041 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48527 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12077 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47929 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48161 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47986 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->