### PR TITLE
[libpas] Check zeroed and large allocations in IsoHeapChaosTests

### DIFF
--- a/Source/bmalloc/libpas/src/test/IsoHeapChaosTests.cpp
+++ b/Source/bmalloc/libpas/src/test/IsoHeapChaosTests.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2025 Apple Inc. All rights reserved.
+ * Copyright (c) 2019-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -40,6 +40,8 @@
 #include "iso_test_heap_config.h"
 #include "jit_heap.h"
 #include "jit_heap_config.h"
+#include <algorithm>
+#include <functional>
 #include <map>
 #include "minalign32_heap.h"
 #include "minalign32_heap_config.h"
@@ -52,6 +54,8 @@
 #include "pas_epoch.h"
 #include "pas_get_page_base.h"
 #include "pas_heap.h"
+#include "pas_internal_config.h"
+#include "pas_page_malloc.h"
 #include "pas_root.h"
 #include "pas_segregated_page.h"
 #include "pas_thread_local_cache.h"
@@ -75,6 +79,7 @@ constexpr bool verbose = false;
 
 const pas_heap_config* selectedHeapConfig;
 void* (*selectedAllocateCommonPrimitive)(size_t size, pas_allocation_mode allocation_mode);
+void* (*selectedAllocateCommonPrimitiveZeroed)(size_t size, pas_allocation_mode allocation_mode);
 void* (*selectedAllocate)(pas_heap_ref* heapRef, pas_allocation_mode allocation_mode);
 void* (*selectedAllocateArray)(pas_heap_ref* heapRef, size_t count, size_t alignment, pas_allocation_mode allocation_mode);
 void (*selectedShrink)(void* ptr, size_t newSize);
@@ -370,6 +375,89 @@ void enumeratorRecorder(pas_enumerator* enumerator,
     recordedRanges[kind].insert(range);
 }
 
+// Zeroing takes the VA path (madvise(MADV_ZERO)/mmap) at/above this size, memset below; we
+// inject huge allocations past it to exercise that path.
+constexpr size_t vaZeroThreshold = (size_t)1 << PAS_VA_BASED_ZERO_MEMORY_SHIFT;
+constexpr size_t hugeObjectMaxSize = vaZeroThreshold * 16;
+constexpr size_t maxSampledPages = 64;
+
+// Per-sampled-page overlap marker for large objects -- one word, a cheap window. Large-object
+// overlap coverage is loose by design; small objects are stamped in full.
+constexpr size_t sampledStampMarkerBytes = 8;
+
+// ~1/4 of common-primitive allocations are zeroed and born-dirty checked; ~1/250 of those are
+// upsized into the VA regime.
+constexpr unsigned zeroedAllocationRarity = 4;
+constexpr unsigned hugeAllocationRarity = 250;
+
+// In-place Fisher-Yates shuffle using the seeded test RNG.
+template<typename T>
+void seededShuffle(vector<T>& values)
+{
+    for (size_t i = values.size(); i-- > 1;) {
+        size_t j = deterministicRandomNumber(static_cast<unsigned>(i + 1));
+        T temp = values[i];
+        values[i] = values[j];
+        values[j] = temp;
+    }
+}
+
+// A bounded, shuffled subset of a large object's page offsets, rotated by seed so different
+// seeds cover different pages (no permanent blind spot). Shuffling first-faults them out of
+// order, as a hashtable faults its buckets.
+vector<size_t> sampledPageOffsets(size_t size, unsigned seed)
+{
+    size_t pageSize = pas_page_malloc_alignment();
+    size_t numPages = (size + pageSize - 1) / pageSize;
+    size_t numSamples = std::min(numPages, maxSampledPages);
+    size_t base = seed % numPages;
+
+    vector<size_t> offsets;
+    offsets.reserve(numSamples);
+    for (size_t k = 0; k < numSamples; ++k) {
+        size_t page = (k * numPages / numSamples + base) % numPages;
+        offsets.push_back(page * pageSize);
+    }
+    seededShuffle(offsets);
+    return offsets;
+}
+
+// The ranges carrying an object's stamp: the whole buffer when small, else the leading word of
+// each sampled page. Seeded by startValue so a stamp and its later check agree.
+void forEachStampRange(size_t size, uint8_t startValue,
+                       const std::function<void(size_t offset, size_t length)>& func)
+{
+    if (size < vaZeroThreshold) {
+        func(0, size);
+        return;
+    }
+    for (size_t offset : sampledPageOffsets(size, startValue)) {
+        // The last page may hold fewer than sampledStampMarkerBytes bytes.
+        size_t remaining = size - offset;
+        func(offset, std::min(remaining, sampledStampMarkerBytes));
+    }
+}
+
+// The ranges to scan for zero on a fresh allocation: the whole buffer when small, else whole
+// sampled pages, chosen randomly so a large object's covered pages rotate across allocations.
+// Whole pages are affordable -- touching one to check faults it regardless.
+void forEachZeroCheckRange(size_t size,
+                           const std::function<void(size_t offset, size_t length)>& func)
+{
+    if (size < vaZeroThreshold) {
+        func(0, size);
+        return;
+    }
+    size_t pageSize = pas_page_malloc_alignment();
+    for (size_t offset : sampledPageOffsets(size, deterministicRandomNumber(0xffffffff))) {
+        // Yield before a random subset of page faults to vary where migration may occur.
+        if (!deterministicRandomNumber(8))
+            sched_yield();
+        size_t remaining = size - offset;
+        func(offset, std::min(pageSize, remaining));
+    }
+}
+
 unsigned uniformlyRandomUpTo5000()
 {
     return deterministicRandomNumber(5000);
@@ -427,6 +515,38 @@ void testAllocationChaos(unsigned numThreads, unsigned numIsolatedHeaps,
     vector<thread> threads;
     unsigned totalSize;
 
+    // Track only large allocations, and check every allocation for overlap with a tracked one. The
+    // stamp covers small objects in full but only samples large ones, so overlap onto a large object
+    // can otherwise go unnoticed. Called with lock held.
+    map<uintptr_t, size_t> largeLiveRanges;
+    auto recordLiveRange = [&] (void* ptr, size_t size) {
+        // Size 0 owns no bytes, and the allocator may share a sentinel across size-0 requests.
+        if (!size)
+            return;
+        uintptr_t base = reinterpret_cast<uintptr_t>(ptr);
+        auto next = largeLiveRanges.lower_bound(base);
+        auto conflict = largeLiveRanges.end();
+        if (next != largeLiveRanges.end() && next->first < base + size)
+            conflict = next;
+        else if (next != largeLiveRanges.begin()) {
+            auto prev = next;
+            --prev;
+            if (prev->first + prev->second > base)
+                conflict = prev;
+        }
+        if (conflict != largeLiveRanges.end()) {
+            cout << "  double handout: [" << ptr << ", +" << size << ") overlaps live ["
+                 << reinterpret_cast<void*>(conflict->first) << ", +" << conflict->second << ")\n";
+            CHECK(!"allocation overlaps a live allocation");
+        }
+        if (size >= vaZeroThreshold)
+            largeLiveRanges[base] = size;
+    };
+    auto forgetLiveRange = [&] (void* ptr, size_t size) {
+        if (size >= vaZeroThreshold)
+            largeLiveRanges.erase(reinterpret_cast<uintptr_t>(ptr));
+    };
+
     vector<OptionalObject> optionalObjects;
     if (testEnumerator) {
         pas_scavenger_did_start_callback = scavengerDidStart;
@@ -451,8 +571,12 @@ void testAllocationChaos(unsigned numThreads, unsigned numIsolatedHeaps,
             uint8_t startValue = static_cast<uint8_t>(deterministicRandomNumber(255));
 
             auto populateObject = [&] () {
-                for (unsigned i = 0; i < size; ++i)
-                    static_cast<uint8_t*>(ptr)[i] = static_cast<uint8_t>(startValue + i);
+                uint8_t* bytes = static_cast<uint8_t*>(ptr);
+                forEachStampRange(size, startValue,
+                    [&] (size_t offset, size_t length) {
+                        for (size_t k = 0; k < length; ++k)
+                            bytes[offset + k] = static_cast<uint8_t>(startValue + offset + k);
+                    });
             };
 
             if (!testEnumerator)
@@ -470,6 +594,7 @@ void testAllocationChaos(unsigned numThreads, unsigned numIsolatedHeaps,
                     optionalObjects[threadIndex] = OptionalObject();
                 objects.push_back(Object(ptr, size, startValue));
                 totalSize += size;
+                recordLiveRange(ptr, size);
             }
         };
 
@@ -482,14 +607,64 @@ void testAllocationChaos(unsigned numThreads, unsigned numIsolatedHeaps,
                 optionalObjects[threadIndex] = OptionalObject(nullptr, size);
             }
         };
-    
+
+    auto firstNonZeroByte = [] (const void* ptr, size_t size) -> size_t {
+        const uint8_t* bytes = static_cast<const uint8_t*>(ptr);
+        PAS_ASSERT(pas_is_aligned(reinterpret_cast<uintptr_t>(bytes), sizeof(uint64_t)));
+        size_t i = 0;
+        for (; i + sizeof(uint64_t) <= size; i += sizeof(uint64_t)) {
+            if (*reinterpret_cast<const uint64_t*>(bytes + i)) {
+                for (size_t b = i; b < i + sizeof(uint64_t); ++b) {
+                    if (bytes[b])
+                        return b;
+                }
+            }
+        }
+        for (; i < size; ++i) {
+            if (bytes[i])
+                return i;
+        }
+        return size;
+    };
+
+    // Verify a freshly zeroed allocation reads back zero. The buffer is thread-private until
+    // addObject publishes it, so the scan is lock-free; we lock only to report a failure.
+    auto verifyZeroed = [&] (unsigned threadIndex, void* ptr, size_t size) {
+        const uint8_t* bytes = static_cast<const uint8_t*>(ptr);
+        forEachZeroCheckRange(size,
+            [&] (size_t offset, size_t length) {
+                size_t nonZero = firstNonZeroByte(bytes + offset, length);
+                if (nonZero < length) {
+                    lock_guard<mutex> locker(lock);
+                    cout << "  born-dirty: thread=" << threadIndex << " size=" << size
+                         << " offset=" << (offset + nonZero) << " value=0x" << hex
+                         << static_cast<unsigned>(bytes[offset + nonZero]) << dec << "\n";
+                    CHECK(!bytes[offset + nonZero]);
+                }
+            });
+    };
+
     auto allocateSomething = [&] (unsigned threadIndex) {
         unsigned heapIndex = deterministicRandomNumber(static_cast<unsigned>(isolatedHeaps.size() + 1));
         unsigned size = chooseSize();
 
         if (heapIndex == isolatedHeaps.size()) {
+            // A fraction of common-primitive allocations go through the zeroed API (null for
+            // configs without one) for born-dirty checking.
+            bool zeroed = selectedAllocateCommonPrimitiveZeroed && !deterministicRandomNumber(zeroedAllocationRarity);
+            // A rarer fraction are upsized past the VA-zeroing line to reach the large heap.
+            if (zeroed && !deterministicRandomNumber(hugeAllocationRarity)) {
+                size = static_cast<unsigned>(
+                    vaZeroThreshold + deterministicRandomNumber(
+                        static_cast<unsigned>(hugeObjectMaxSize - vaZeroThreshold)));
+            }
             logOptionalObject(threadIndex, size);
-            void* ptr = selectedAllocateCommonPrimitive(size, pas_non_compact_allocation_mode);
+            void* ptr;
+            if (zeroed) {
+                ptr = selectedAllocateCommonPrimitiveZeroed(size, pas_non_compact_allocation_mode);
+                verifyZeroed(threadIndex, ptr, size);
+            } else
+                ptr = selectedAllocateCommonPrimitive(size, pas_non_compact_allocation_mode);
             addObject(threadIndex, ptr, size);
             return;
         }
@@ -517,10 +692,14 @@ void testAllocationChaos(unsigned numThreads, unsigned numIsolatedHeaps,
         Object object;
 
         auto validateObject = [&] () {
-            for (unsigned i = 0; i < object.size; ++i) {
-                CHECK_EQUAL(static_cast<unsigned>(static_cast<uint8_t*>(object.ptr)[i]),
-                            static_cast<unsigned>(static_cast<uint8_t>(object.startValue + i)));
-            }
+            const uint8_t* bytes = static_cast<const uint8_t*>(object.ptr);
+            forEachStampRange(object.size, object.startValue,
+                [&] (size_t offset, size_t length) {
+                    for (size_t k = 0; k < length; ++k) {
+                        CHECK_EQUAL(static_cast<unsigned>(bytes[offset + k]),
+                                    static_cast<unsigned>(static_cast<uint8_t>(object.startValue + offset + k)));
+                    }
+                });
         };
 
         {
@@ -532,6 +711,7 @@ void testAllocationChaos(unsigned numThreads, unsigned numIsolatedHeaps,
             objects[index] = objects.back();
             objects.pop_back();
             totalSize -= object.size;
+            forgetLiveRange(object.ptr, object.size);
 
             if (verbose)
                 cout << "Freeing object " << object.ptr << "\n";
@@ -574,6 +754,7 @@ void testAllocationChaos(unsigned numThreads, unsigned numIsolatedHeaps,
             objects[index] = objects.back();
             objects.pop_back();
             totalSize -= object.size;
+            forgetLiveRange(object.ptr, object.size);
 
             if (verbose)
                 cout << "Shrinking object " << object.ptr << "\n";
@@ -589,6 +770,7 @@ void testAllocationChaos(unsigned numThreads, unsigned numIsolatedHeaps,
         {
             lock_guard<mutex> locker(lock);
             objects.push_back(object);
+            recordLiveRange(object.ptr, object.size);
         }
     };
 
@@ -909,7 +1091,7 @@ void testAllocationChaos(unsigned numThreads, unsigned numIsolatedHeaps,
         cout << "    Test done; did " << numEnumerations << " enumerations.\n";
     
     CHECK_EQUAL(numThreadsStopped, threads.size());
-    
+
     vector<pas_heap*> heaps;
     heaps.push_back(selectedCommonPrimitiveHeap);
     for (pas_heap_ref* heapRef : isolatedHeaps)
@@ -980,6 +1162,7 @@ void addIsoTests()
             [] () {
                 selectedHeapConfig = &iso_heap_config;
                 selectedAllocateCommonPrimitive = iso_try_allocate_common_primitive;
+                selectedAllocateCommonPrimitiveZeroed = iso_try_allocate_common_primitive_zeroed;
                 selectedAllocate = iso_try_allocate;
                 selectedAllocateArray = iso_try_allocate_array_by_count;
                 selectedDeallocate = iso_deallocate;
@@ -1117,6 +1300,7 @@ void addAllTests()
             [] () {
                 selectedHeapConfig = &bmalloc_heap_config;
                 selectedAllocateCommonPrimitive = bmalloc_allocate;
+                selectedAllocateCommonPrimitiveZeroed = bmalloc_allocate_zeroed;
                 selectedAllocate = bmalloc_iso_allocate;
                 selectedAllocateArray = bmalloc_iso_allocate_array_by_count_with_alignment;
                 selectedDeallocate = bmalloc_deallocate;
@@ -1126,6 +1310,18 @@ void addAllTests()
             });
     
         addSpotTests(true);
+
+        {
+            // Also run under aggressive background scavenging, racing decommit against alloc/free.
+            TestScope frequentScavenging(
+                "frequent-scavenging",
+                [] () {
+                    pas_scavenger_period_in_milliseconds = 1.;
+                    pas_scavenger_max_epoch_delta = -1ll * 1000ll * 1000ll;
+                });
+
+            addSpotTests(false);
+        }
     }
 
     {


### PR DESCRIPTION
#### a9c5f5b57b1740de140d8528c98ee8186e024dd8
<pre>
[libpas] Check zeroed and large allocations in IsoHeapChaosTests
<a href="https://bugs.webkit.org/show_bug.cgi?id=319861">https://bugs.webkit.org/show_bug.cgi?id=319861</a>
<a href="https://rdar.apple.com/182760919">rdar://182760919</a>

Reviewed by Marcus Plutowski and Yusuke Suzuki.

testAllocationChaos stamped every object immediately and kept sizes under 1 MB, so
it never verified that a zeroed allocation came back zero and never reached the
large-heap VA-zeroing path. Extend it to cover both, and to catch a double handout
onto a large object:

- Route about one in four common-primitive allocations through the zeroed API and
  verify the buffer reads back zero before stamping it, catching a reused region
  handed back non-zero. Wired for the iso and bmalloc scopes.

- Inject a rare fraction of those allocations into [1 MB, 16 MB] (threshold from
  PAS_VA_BASED_ZERO_MEMORY_SHIFT) to exercise the VA zeroing path concurrently.
  Large objects are sampled -- a leading-word stamp and a whole-page zero scan over
  a bounded, seed-rotated, shuffled set of pages, faulted out of order -- since
  touching every byte over millions of actions is infeasible; smaller objects keep
  the full-buffer path.

- Add a frequent-scavenging variant of the bmalloc scope so decommit races
  alloc/free and large regions are re-zeroed on reuse, and yield before a random
  subset of a large region&apos;s page faults so they can first-fault on different cores.

- Track live large [base, size) ranges and CHECK that no allocation overlaps one.
  The stamp catches overlap onto small objects (stamped in full) but not large ones
  (only sampled); tracking just large ranges keeps this check free.

* Source/bmalloc/libpas/src/test/IsoHeapChaosTests.cpp:
(std::seededShuffle):
(std::sampledPageOffsets):
(std::forEachStampRange):
(std::forEachZeroCheckRange):
(std::testAllocationChaos):
(std::addIsoTests):
(std::addAllTests):

Canonical link: <a href="https://commits.webkit.org/317624@main">https://commits.webkit.org/317624@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/71d9b5babf9b4a1b35db0641991aeeefa86adf38

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175743 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49676 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43459 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185336 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/137924 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f706d29e-00dd-40a6-ac2e-d4055f4ac470) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50968 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49358 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136839 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/137924 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0110dbcf-3622-416e-90db-9ea0a83421ca) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178699 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40293 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157614 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117317 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ab82bce0-7b88-4e42-b5f6-65fa0aa28661) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38935 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37319 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/6123 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149354 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37106 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33805 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/37007 "Built successfully and passed tests") | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41525 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187757 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49343 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145832 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50023 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33730 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145674 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26717 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40462 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/116044 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48530 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12084 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47932 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48164 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47989 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->