### PR TITLE
[GTK][Skia] ShareableBitmap::paint ignores CompositeOperator::Copy

### DIFF
--- a/Source/WebCore/platform/graphics/skia/ShareableBitmapSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/ShareableBitmapSkia.cpp
@@ -95,7 +95,10 @@ void ShareableBitmap::paint(GraphicsContext& context, float scaleFactor, const I
     FloatRect scaledDestRect(dstPoint, srcRect.size());
     scaledDestRect.scale(scaleFactor);
     auto image = createPlatformImage(BackingStoreCopy::DontCopyBackingStore);
-    context.platformContext()->drawImageRect(image.get(), scaledSrcRect, scaledDestRect, { }, nullptr, { });
+    SkPaint paint;
+    if (context.compositeMode().operation == CompositeOperator::Copy)
+        paint.setBlendMode(SkBlendMode::kSrc);
+    context.platformContext()->drawImageRect(image.get(), scaledSrcRect, scaledDestRect, { }, &paint, { });
 }
 
 RefPtr<Image> ShareableBitmap::createImage()


### PR DESCRIPTION
#### 645ce1764ad44d709b8ddfdcfd564fd06d1d8dc6
<pre>
[GTK][Skia] ShareableBitmap::paint ignores CompositeOperator::Copy
<a href="https://bugs.webkit.org/show_bug.cgi?id=319864">https://bugs.webkit.org/show_bug.cgi?id=319864</a>

Reviewed by Carlos Garcia Campos.

BackingStore::incorporateUpdate sets CompositeOperator::Copy on the
GraphicsContext before painting update rects into the persistent backing
store, so that transparent webviews overwrite the previous frame instead of
blending over it. The Skia ShareableBitmap::paint implementation calls the
raw SkCanvas with a null SkPaint, which defaults to SrcOver and silently
discards the requested operator.

On a transparent webview every partial update therefore blends over the
previous frame&apos;s pixels: opaque content that shrinks or moves leaves
permanent trails, and semi-transparent content accumulates opacity on every
repaint, until the backing store is reallocated. Map CompositeOperator::Copy
to SkBlendMode::kSrc; all other callers keep the default SrcOver.

* Source/WebCore/platform/graphics/skia/ShareableBitmapSkia.cpp:
(WebCore::ShareableBitmap::paint): Honor CompositeOperator::Copy.

Canonical link: <a href="https://commits.webkit.org/317608@main">https://commits.webkit.org/317608@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f9e8ad7559ee3741e39cec60282113a9df19e795

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175752 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49685 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43468 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185345 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/137935 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/177615 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50977 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49367 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136848 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/137935 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178708 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40303 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157621 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117326 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38945 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37329 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149364 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37113 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33814 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41378 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41535 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187766 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49352 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145841 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50032 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33737 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145683 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26711 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40474 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122228 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/116053 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48539 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12091 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47941 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48173 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47998 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->