### PR TITLE
[JSC] Use cooperative driving in TLA modules

### DIFF
--- a/JSTests/stress/async-iterator-tla-cached-result.js
+++ b/JSTests/stress/async-iterator-tla-cached-result.js
@@ -1,0 +1,67 @@
+// Verifies the per-producer cached iterator-result-object reuse optimization (317587@main) stays
+// correct when the for-await *driver* is a top-level-await (TLA) module. module-fast-drive routes
+// module for-await through the fast consumer path (op_async_iterator_open fast sentinel ->
+// op_async_iterator_next driver branch -> AsyncGeneratorDriverResume with the module record as the
+// driver), so the async generator producer's cached result object is now handed to a module driver.
+// That reuse is only sound while the object cannot be observed; these checks confirm both the
+// non-observable fast path (correct values across many yields) and the observable-`then` fallback
+// (distinct, unmutated results) for the module driver.
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`bad value: expected ${expected} but got ${actual}`);
+}
+
+let error = null;
+let pending = 0;
+
+function track(promise, onValue) {
+    pending++;
+    promise.then((v) => { onValue(v); pending--; }, (e) => { error = e; pending--; });
+}
+
+// Sequence the two scenarios: the fast (no observable then) module must fully settle before the
+// aliasing module installs the global `then` getter, otherwise the fast module's own iterator
+// results would be captured too.
+track(
+    import("./resources/async-iterator-tla-cached-fast.js").then(() => {
+        const r = globalThis.__tlaCachedFast;
+        shouldBe(r.length, 500);
+        for (let i = 0; i < 500; ++i)
+            shouldBe(r[i], i);
+        return import("./resources/async-iterator-tla-cached-aliasing.js");
+    }).then(() => {
+        const { delivered, captured } = globalThis.__tlaCachedAliasing;
+
+        // The module for-await must still deliver the correct values.
+        shouldBe(delivered.join(","), "10,20,30");
+
+        // Every captured iterator result must be a distinct object (no reused/aliased cached object).
+        shouldBe(new Set(captured.map(c => c.result)).size, captured.length);
+
+        // The value observed at capture time must not have been mutated afterwards by reuse.
+        for (const c of captured)
+            shouldBe(c.result.value, c.value);
+
+        // The three value-carrying results must retain 10/20/30.
+        const values = captured.filter(c => c.done === false).map(c => c.value);
+        shouldBe(values.join(","), "10,20,30");
+
+        return import("./resources/async-iterator-tla-cached-mid-lifetime.js");
+    }).then(() => {
+        const { delivered, captured } = globalThis.__tlaCachedMidLifetime;
+
+        // The module for-await must still deliver every value across the watchpoint transition.
+        shouldBe(delivered.join(","), "a,b,c,d");
+
+        // The cached object created while non-observable must not leak once `then` is defined:
+        // every captured result is a distinct object.
+        shouldBe(new Set(captured).size, captured.length);
+    }),
+    () => { });
+
+drainMicrotasks();
+
+if (error)
+    throw error;
+shouldBe(pending, 0);

--- a/JSTests/stress/async-iterator-tla-fast-consumer.js
+++ b/JSTests/stress/async-iterator-tla-fast-consumer.js
@@ -1,0 +1,56 @@
+// Verifies top-level-await (TLA) modules can cooperatively drive a native async generator via the
+// for-await fast consumer path (op_async_iterator_open fast sentinel -> op_async_iterator_next
+// driver branch -> AsyncGeneratorDriverResume with the module record as driver). Before the
+// unification, module for-await always took the generic real-call branch. These checks confirm the
+// fast path at module scope produces correct values/order, does not double-drive completed
+// producers, handles nesting, and propagates producer errors to the module's top-level capability.
+
+function assert(cond, message) {
+    if (!cond)
+        throw new Error("Assertion failed: " + message);
+}
+
+function assertArrayEq(actual, expected, message) {
+    assert(Array.isArray(actual), message + " (not an array: " + actual + ")");
+    assert(actual.length === expected.length, message + "\n  expected: " + expected.join(",") + "\n  got:      " + actual.join(","));
+    for (let i = 0; i < expected.length; i++)
+        assert(actual[i] === expected[i], message + " at [" + i + "]\n  expected: " + expected.join(",") + "\n  got:      " + actual.join(","));
+}
+
+let pending = 0;
+let error = null;
+
+function track(promise, onValue) {
+    pending++;
+    promise.then((v) => { onValue(v); pending--; }, (e) => { error = e; pending--; });
+}
+
+// 1. Basic multi-yield, completed-producer reconsume (no double-drive), and nested TLA for-await.
+track(import("./resources/async-iterator-tla-basic.js"), (ns) => {
+    assertArrayEq(ns.log, ["v1", "v2", "v3", "done", "a10", "done2", "n1a", "n1b", "n2a", "n2b"], "basic TLA fast-consumer log");
+});
+
+// 2. Producer that throws must reject the module's top-level capability.
+pending++;
+import("./resources/async-iterator-tla-error.js").then(
+    () => { error = new Error("error module should have rejected"); pending--; },
+    (e) => { assert(e instanceof Error && e.message === "boom", "producer error propagated, got: " + e); pending--; });
+
+// 3. Fast (pristine async generator) vs generic (tampered %AsyncGeneratorPrototype%.next) at module
+//    scope must be observably identical -- same values, ordering, and microtask tick cadence.
+pending++;
+import("./resources/async-iterator-tla-ruler-fast.js")
+    .then(() => import("./resources/async-iterator-tla-ruler-generic.js"))
+    .then(() => {
+        const fast = globalThis.__tlaRulerFast;
+        const generic = globalThis.__tlaRulerGeneric;
+        assert(typeof fast === "string" && fast.length, "fast ruler log present");
+        assert(fast === generic, "TLA fast vs generic ruler\n  fast:    " + fast + "\n  generic: " + generic);
+        pending--;
+    }, (e) => { error = e; pending--; });
+
+drainMicrotasks();
+
+if (error)
+    throw error;
+assert(pending === 0, "not all TLA module imports settled (pending=" + pending + ")");

--- a/JSTests/stress/resources/async-iterator-tla-basic.js
+++ b/JSTests/stress/resources/async-iterator-tla-basic.js
@@ -1,0 +1,27 @@
+// TLA module: exercises the for-await fast consumer at module top level.
+const log = [];
+
+// Multi-yield over a pristine async generator -> fast cooperative driving (driver = this module record).
+async function* g() { yield 1; yield 2; yield 3; }
+for await (const x of g())
+    log.push("v" + x);
+log.push("done");
+
+// Reconsume an already-exhausted producer: the completed-producer fast path must settle
+// { undefined, true } without enqueuing/double-driving the module.
+async function* g2() { yield 10; }
+const it = g2();
+for await (const x of it)
+    log.push("a" + x);
+for await (const x of it)
+    log.push("b" + x); // producer already completed -> loop body never runs
+log.push("done2");
+
+// Nested top-level for-await: each inner loop re-registers the module as the driver.
+async function* inner(k) { yield k + "a"; yield k + "b"; }
+async function* outer() { yield 1; yield 2; }
+for await (const o of outer())
+    for await (const i of inner(o))
+        log.push("n" + i);
+
+export { log };

--- a/JSTests/stress/resources/async-iterator-tla-cached-aliasing.js
+++ b/JSTests/stress/resources/async-iterator-tla-cached-aliasing.js
@@ -1,0 +1,35 @@
+// TLA module driving an async generator via the for-await fast-consumer path (module record as
+// driver) while Object.prototype.then is defined. Defining `then` fires the promise-then
+// watchpoint, so the settle path reads `.then` on each iterator result -- the result escapes to
+// user code. The driver must therefore NOT hand out a reused/aliased cached object: each delivered
+// result must be a distinct, unmutated { value, done } object (as if freshly created), exactly as
+// required for the async-function/async-generator drivers (JSTests/stress/
+// async-generator-driver-cached-result-not-aliased.js). This exercises that same safety for the
+// module driver.
+const captured = [];
+
+Object.defineProperty(Object.prototype, "then", {
+    configurable: true,
+    get() {
+        if (this && typeof this === "object"
+            && Object.prototype.hasOwnProperty.call(this, "value")
+            && Object.prototype.hasOwnProperty.call(this, "done"))
+            captured.push({ result: this, value: this.value, done: this.done });
+        return undefined;
+    },
+});
+
+const delivered = [];
+async function* g() {
+    yield 10;
+    yield 20;
+    yield 30;
+}
+
+for await (const x of g())
+    delivered.push(x);
+
+delete Object.prototype.then;
+
+globalThis.__tlaCachedAliasing = { delivered, captured };
+export { };

--- a/JSTests/stress/resources/async-iterator-tla-cached-fast.js
+++ b/JSTests/stress/resources/async-iterator-tla-cached-fast.js
@@ -1,0 +1,17 @@
+// TLA module driving a pristine async generator via the for-await fast-consumer path with NO
+// observable `then` (promise-then watchpoint valid). This is the path where the async generator
+// producer reuses its per-generator cached iterator-result object across yields (317587@main),
+// with the module record itself as the driver. Reuse is non-observable here, so we can only assert
+// that many yields are delivered with correct values/order.
+const log = [];
+
+async function* g() {
+    for (let i = 0; i < 500; ++i)
+        yield i;
+}
+
+for await (const x of g())
+    log.push(x);
+
+globalThis.__tlaCachedFast = log;
+export { };

--- a/JSTests/stress/resources/async-iterator-tla-cached-mid-lifetime.js
+++ b/JSTests/stress/resources/async-iterator-tla-cached-mid-lifetime.js
@@ -1,0 +1,37 @@
+// TLA module driver where the promise-then watchpoint is invalidated *mid-drive*: the first yields
+// run on the fast path (the producer's cached iterator-result object is created and reused), then
+// Object.prototype.then is defined partway through the for-await, so subsequent settles take the
+// observable slow path. The driver must not leak the previously-cached object once it becomes
+// observable -- every captured result must be distinct. Mirrors test 3 of
+// JSTests/stress/async-generator-driver-cached-result-not-aliased.js for the module driver.
+const captured = [];
+const delivered = [];
+
+async function* g() {
+    yield "a";
+    yield "b";
+    yield "c";
+    yield "d";
+}
+
+let n = 0;
+for await (const x of g()) {
+    delivered.push(x);
+    if (++n === 2) {
+        Object.defineProperty(Object.prototype, "then", {
+            configurable: true,
+            get() {
+                if (this && typeof this === "object"
+                    && Object.prototype.hasOwnProperty.call(this, "value")
+                    && Object.prototype.hasOwnProperty.call(this, "done"))
+                    captured.push(this);
+                return undefined;
+            },
+        });
+    }
+}
+
+delete Object.prototype.then;
+
+globalThis.__tlaCachedMidLifetime = { delivered, captured };
+export { };

--- a/JSTests/stress/resources/async-iterator-tla-error.js
+++ b/JSTests/stress/resources/async-iterator-tla-error.js
@@ -1,0 +1,8 @@
+// TLA module: a producer that throws mid-iteration must reject this module's top-level capability
+// (the rejection is routed through asyncGeneratorDriverResume -> asyncModuleExecutionResume ->
+// capability->rejectWithCaughtException on the fast path).
+const collected = [];
+async function* g() { yield 1; throw new Error("boom"); }
+for await (const x of g())
+    collected.push(x);
+export { collected }; // unreachable: the throw aborts module evaluation

--- a/JSTests/stress/resources/async-iterator-tla-ruler-fast.js
+++ b/JSTests/stress/resources/async-iterator-tla-ruler-fast.js
@@ -1,0 +1,19 @@
+// TLA module (fast path): a top-level for-await over a pristine async generator, interleaved with a
+// fixed 8-turn microtask "ruler". The interleaving of ruler ticks (Rn) with consumer events makes
+// the per-step microtask cadence observable. Result is compared against the generic-path module.
+const log = [];
+const E = s => log.push(s);
+
+let p = Promise.resolve();
+for (let i = 0; i < 8; i++) {
+    const j = i;
+    p = p.then(() => E("R" + j));
+}
+
+async function* g() { yield 1; yield 2; yield 3; }
+for await (const x of g())
+    E("v" + x);
+E("done");
+
+globalThis.__tlaRulerFast = log.join(",");
+export { };

--- a/JSTests/stress/resources/async-iterator-tla-ruler-generic.js
+++ b/JSTests/stress/resources/async-iterator-tla-ruler-generic.js
@@ -1,0 +1,26 @@
+// TLA module (generic path): identical to async-iterator-tla-ruler-fast.js, but first breaks the
+// pristine-next identity by wrapping %AsyncGeneratorPrototype%.next. This forces op_async_iterator_open
+// to skip the fast sentinel so op_async_iterator_next takes its generic real-call branch, and the
+// module suspends/resumes through the ordinary AsyncModuleExecutionResume promise path. The wrapper
+// forwards synchronously, so any divergence from the fast log is a fast-path-only tick/ordering bug.
+const asyncGenProto = Object.getPrototypeOf(Object.getPrototypeOf((async function* () {})()));
+const origNext = asyncGenProto.next;
+asyncGenProto.next = function (...args) { return origNext.apply(this, args); };
+
+const log = [];
+const E = s => log.push(s);
+
+let p = Promise.resolve();
+for (let i = 0; i < 8; i++) {
+    const j = i;
+    p = p.then(() => E("R" + j));
+}
+
+async function* g() { yield 1; yield 2; yield 3; }
+for await (const x of g())
+    E("v" + x);
+E("done");
+
+asyncGenProto.next = origNext;
+globalThis.__tlaRulerGeneric = log.join(",");
+export { };

--- a/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp
+++ b/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp
@@ -4951,19 +4951,13 @@ void BytecodeGenerator::emitEnumeration(ThrowableExpressionData* node, Expressio
 
         RefPtr<RegisterID> iterator = newTemporary();
         RefPtr<RegisterID> nextMethod = newTemporary();
-        RefPtr<RegisterID> symbolAsyncIterator;
 
-        if (isAsyncFunctionParseMode(parseMode())) {
+        {
             emitExpressionInfo(node->divot(), node->divotStart(), node->divotEnd());
-            symbolAsyncIterator = emitGetById(newTemporary(), subject.get(), propertyNames().asyncIteratorSymbol);
+            RefPtr<RegisterID> symbolAsyncIterator = emitGetById(newTemporary(), subject.get(), propertyNames().asyncIteratorSymbol);
             CallArguments args(*this, nullptr, 0);
             move(args.thisRegister(), subject.get());
             emitAsyncIteratorOpen(iterator.get(), nextMethod.get(), symbolAsyncIterator.get(), args, node);
-        } else {
-            // Module top-level await. `driver` is an AbstractModuleRecord, which AsyncGeneratorDriverResume
-            // cannot drive, so acquire generically -- op_async_iterator_next then always takes its real-call branch.
-            move(iterator.get(), emitGetAsyncIterator(subject.get(), node));
-            emitGetById(nextMethod.get(), iterator.get(), propertyNames().next);
         }
 
         Ref<Label> loopDone = newLabel();

--- a/Source/JavaScriptCore/runtime/JSAsyncGeneratorInlines.h
+++ b/Source/JavaScriptCore/runtime/JSAsyncGeneratorInlines.h
@@ -28,6 +28,7 @@
 #include "JSAsyncFunctionGenerator.h"
 #include "JSAsyncGenerator.h"
 #include "JSInternalFieldObjectImplInlines.h"
+#include "JSModuleRecord.h"
 #include "JSPromise.h"
 #include "JSPromiseReaction.h"
 
@@ -35,7 +36,7 @@ namespace JSC {
 
 ALWAYS_INLINE void JSAsyncGenerator::enqueue(VM& vm, JSValue value, int32_t mode, JSObject* settlementTarget)
 {
-    ASSERT(settlementTarget->inherits<JSPromise>() || settlementTarget->inherits<JSAsyncGenerator>() || settlementTarget->inherits<JSAsyncFunctionGenerator>());
+    ASSERT(settlementTarget->inherits<JSPromise>() || settlementTarget->inherits<JSAsyncGenerator>() || settlementTarget->inherits<JSAsyncFunctionGenerator>() || settlementTarget->inherits<JSModuleRecord>());
     if (isQueueEmpty()) [[likely]] {
         setResumeValue(vm, value);
         setResumeMode(mode);

--- a/Source/JavaScriptCore/runtime/JSMicrotask.cpp
+++ b/Source/JavaScriptCore/runtime/JSMicrotask.cpp
@@ -926,36 +926,48 @@ static void promiseFinallyReactionJob(JSGlobalObject* globalObject, VM& vm, JSPr
     promiseResolveThenableJob(globalObject, resolutionObject, then, resolve, reject, microtaskCallCache);
 }
 
-static void asyncModuleExecutionDone(JSGlobalObject* globalObject, ThrowScope& scope, JSModuleRecord* module, JSValue value, JSPromise::Status status)
+static void asyncModuleExecutionDone(JSGlobalObject* globalObject, JSModuleRecord* module, JSValue value, JSPromise::Status status)
 {
-    scope.release();
-    if (status == JSPromise::Status::Fulfilled)
+    if (status == JSPromise::Status::Fulfilled) {
         module->asyncExecutionFulfilled(globalObject);
-    else {
-        ASSERT(status == JSPromise::Status::Rejected);
-        module->asyncExecutionRejected(globalObject, value);
+        return;
     }
+
+    ASSERT(status == JSPromise::Status::Rejected);
+    module->asyncExecutionRejected(globalObject, value);
 }
 
-static void asyncModuleExecutionResume(JSGlobalObject* globalObject, VM& vm, ThrowScope& scope, JSModuleRecord* module, JSValue resolution, JSPromise::Status status)
+void asyncModuleResolveEvaluation(JSGlobalObject* globalObject, VM& vm, ThrowScope& scope, JSModuleRecord* module, JSValue result)
 {
     auto* capability = module->asyncCapability();
+
+    if (scope.exception()) [[unlikely]] {
+        capability->rejectWithCaughtException(vm, scope);
+        return;
+    }
+
+    if (result == vm.fastAsyncGeneratorSentinel()) {
+        // The module suspended cooperatively driving an async generator, which
+        // already holds this module in its queue as the driver. Do not schedule our own resume.
+        return;
+    }
+
+    if (module->isTopLevelExecutionFinished())
+        capability->resolve(globalObject, vm, result);
+    else
+        JSPromise::resolveWithInternalMicrotaskForAsyncAwait(globalObject, vm, result, InternalMicrotask::AsyncModuleExecutionResume, module);
+}
+
+static void asyncModuleExecutionResume(JSGlobalObject* globalObject, VM& vm, JSModuleRecord* module, JSValue resolution, JSPromise::Status status)
+{
+    auto scope = DECLARE_THROW_SCOPE(vm);
 
     JSValue resumeMode = jsNumber(status == JSPromise::Status::Fulfilled
         ? static_cast<int32_t>(JSGenerator::ResumeMode::NormalMode)
         : static_cast<int32_t>(JSGenerator::ResumeMode::ThrowMode));
 
     JSValue result = module->evaluate(globalObject, resolution, resumeMode);
-
-    if (scope.exception())
-        capability->rejectWithCaughtException(vm, scope);
-    else {
-        JSValue state = module->internalField(AbstractModuleRecord::Field::State).get();
-        if (!state.isNumber() || state.asNumber() == static_cast<int32_t>(JSGenerator::State::Executing))
-            capability->resolve(globalObject, vm, result);
-        else
-            JSPromise::resolveWithInternalMicrotaskForAsyncAwait(globalObject, vm, result, InternalMicrotask::AsyncModuleExecutionResume, module);
-    }
+    asyncModuleResolveEvaluation(globalObject, vm, scope, module, result);
 }
 
 static void moduleRegistryFetchSettled(JSGlobalObject* globalObject, VM& vm, ThrowScope& scope, std::span<const JSValue, maxMicrotaskArguments> arguments, uint8_t payload)
@@ -1715,8 +1727,16 @@ static void asyncGeneratorDriverResume(VM& vm, JSValue context, JSValue resoluti
         return;
     }
 
-    auto* generator = uncheckedDowncast<JSAsyncGenerator>(context);
-    asyncGeneratorBodyCall(generator->realm(), generator, resolution, static_cast<int32_t>(resumeMode), microtaskCallCache);
+    if (auto* generator = dynamicDowncast<JSAsyncGenerator>(context)) {
+        asyncGeneratorBodyCall(generator->realm(), generator, resolution, static_cast<int32_t>(resumeMode), microtaskCallCache);
+        return;
+    }
+
+    // The only remaining for-await driver kind is a top-level-await module. Any other context type
+    // reaching here means a new driver was wired up without a branch above.
+    auto* module = dynamicDowncast<JSModuleRecord>(context);
+    RELEASE_ASSERT(module);
+    asyncModuleExecutionResume(module->realm(), vm, module, resolution, status);
 }
 
 void runInternalMicrotask(JSGlobalObject* globalObject, VM& vm, InternalMicrotask task, uint8_t payload, std::span<const JSValue, maxMicrotaskArguments> arguments, MicrotaskCallCache* microtaskCallCache)
@@ -1956,14 +1976,12 @@ void runInternalMicrotask(JSGlobalObject* globalObject, VM& vm, InternalMicrotas
 
     case InternalMicrotask::AsyncModuleExecutionDone: {
         auto* module = uncheckedDowncast<JSModuleRecord>(arguments[2]);
-        asyncModuleExecutionDone(module->realm(), scope, module, arguments[1], static_cast<JSPromise::Status>(payload));
-        return;
+        RELEASE_AND_RETURN(scope, asyncModuleExecutionDone(module->realm(), module, arguments[1], static_cast<JSPromise::Status>(payload)));
     }
 
     case InternalMicrotask::AsyncModuleExecutionResume: {
         auto* module = uncheckedDowncast<JSModuleRecord>(arguments[2]);
-        asyncModuleExecutionResume(module->realm(), vm, scope, module, arguments[1], static_cast<JSPromise::Status>(payload));
-        return;
+        RELEASE_AND_RETURN(scope, asyncModuleExecutionResume(module->realm(), vm, module, arguments[1], static_cast<JSPromise::Status>(payload)));
     }
 
     case InternalMicrotask::ModuleRegistryFetchSettled: {

--- a/Source/JavaScriptCore/runtime/JSMicrotask.h
+++ b/Source/JavaScriptCore/runtime/JSMicrotask.h
@@ -33,8 +33,12 @@ namespace JSC {
 
 class MicrotaskCallCache;
 class JSAsyncGenerator;
+class JSModuleRecord;
+class ThrowScope;
 
 void runInternalMicrotask(JSGlobalObject*, VM&, InternalMicrotask, uint8_t, std::span<const JSValue, maxMicrotaskArguments>, MicrotaskCallCache* = nullptr);
+
+void asyncModuleResolveEvaluation(JSGlobalObject*, VM&, ThrowScope&, JSModuleRecord*, JSValue result);
 
 // https://tc39.es/ecma262/#sec-asyncgeneratorresume and #sec-asyncgeneratorawaitreturn — used by the C++
 // %AsyncGeneratorPrototype%.return / .throw host functions to drive a non-busy generator.

--- a/Source/JavaScriptCore/runtime/JSModuleRecord.cpp
+++ b/Source/JavaScriptCore/runtime/JSModuleRecord.cpp
@@ -32,6 +32,7 @@
 #include "JSAsyncGeneratorFunction.h"
 #include "JSCInlines.h"
 #include "JSGeneratorFunction.h"
+#include "JSMicrotask.h"
 #include "JSModuleEnvironment.h"
 #include "JSModuleLoader.h"
 #include "JSModuleNamespaceObject.h"
@@ -85,6 +86,12 @@ void JSModuleRecord::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 
 DEFINE_VISIT_CHILDREN(JSModuleRecord);
 
+bool JSModuleRecord::isTopLevelExecutionFinished() const
+{
+    JSValue state = internalField(Field::State).get();
+    return !state.isNumber() || state.asInt32AsAnyInt() == std::to_underlying(State::Executing);
+}
+
 JSValue JSModuleRecord::evaluate(JSGlobalObject* globalObject, JSValue sentValue, JSValue resumeMode)
 {
     if (!m_moduleProgramExecutable) {
@@ -104,7 +111,7 @@ JSValue JSModuleRecord::evaluate(JSGlobalObject* globalObject, JSValue sentValue
     JSValue resultOrAwaitedValue = vm.interpreter.executeModuleProgram(this, executable, globalObject, moduleEnvironment(), sentValue, resumeMode);
     RETURN_IF_EXCEPTION(scope, { });
 
-    if (JSValue state = internalField(Field::State).get(); !state.isNumber() || state.asInt32AsAnyInt() == std::to_underlying(State::Executing))
+    if (isTopLevelExecutionFinished())
         m_moduleProgramExecutable.clear();
 
     RELEASE_AND_RETURN(scope, resultOrAwaitedValue);
@@ -146,12 +153,7 @@ void JSModuleRecord::execute(JSGlobalObject* globalObject, JSPromise* capability
         // 10.b. Perform AsyncBlockStart(capability, module.[[ECMAScriptCode]], moduleContext).
         asyncCapability(vm, capability);
         JSValue result = globalObject->moduleLoader()->evaluate(globalObject, identifierToJSValue(vm, moduleKey()), this, nullptr, jsUndefined(), jsNumber(static_cast<int32_t>(ResumeMode::NormalMode)));
-        if (scope.exception())
-            capability->rejectWithCaughtException(vm, scope);
-        else if (JSValue state = internalField(Field::State).get(); !state.isNumber() || state.asInt32AsAnyInt() == std::to_underlying(State::Executing))
-            capability->resolve(globalObject, vm, result);
-        else
-            JSPromise::resolveWithInternalMicrotaskForAsyncAwait(globalObject, vm, result, InternalMicrotask::AsyncModuleExecutionResume, this);
+        asyncModuleResolveEvaluation(globalObject, vm, scope, this, result);
     }
     // 11. Return unused.
 }

--- a/Source/JavaScriptCore/runtime/JSModuleRecord.h
+++ b/Source/JavaScriptCore/runtime/JSModuleRecord.h
@@ -59,6 +59,8 @@ public:
 
     JS_EXPORT_PRIVATE JSValue evaluate(JSGlobalObject*, JSValue sentValue, JSValue resumeMode);
 
+    bool isTopLevelExecutionFinished() const;
+
     void execute(JSGlobalObject*, JSPromise* = nullptr);
     void executeAsync(JSGlobalObject*);
 


### PR DESCRIPTION
#### 771e7c42bc494b463800e4a87a032b99af72800d
<pre>
[JSC] Use cooperative driving in TLA modules
<a href="https://bugs.webkit.org/show_bug.cgi?id=319867">https://bugs.webkit.org/show_bug.cgi?id=319867</a>
<a href="https://rdar.apple.com/182767755">rdar://182767755</a>

Reviewed by Yijia Huang.

This patch extends support of cooperative driving to cover TLA modules.
The core change is accepting JSModuleRecord as a driver. And the change
is really minimum. The benefit is now bytecode generation becomes
simpler since we can always use the cooperative driving code.

Tests: JSTests/stress/async-iterator-tla-cached-result.js
       JSTests/stress/async-iterator-tla-fast-consumer.js

* JSTests/stress/async-iterator-tla-cached-result.js: Added.
(shouldBe):
(track):
(track.import.string_appeared_here.then):
(then):
* JSTests/stress/async-iterator-tla-fast-consumer.js: Added.
(assert):
(assertArrayEq):
(track):
(import.string_appeared_here.then):
(import.string_appeared_here.then.import.string_appeared_here.then):
* JSTests/stress/resources/async-iterator-tla-basic.js: Added.
(async g):
(async g2):
(async inner):
(async outer):
* JSTests/stress/resources/async-iterator-tla-cached-aliasing.js: Added.
(get if):
* JSTests/stress/resources/async-iterator-tla-cached-fast.js: Added.
(async g):
* JSTests/stress/resources/async-iterator-tla-cached-mid-lifetime.js: Added.
(async g):
(get delete):
* JSTests/stress/resources/async-iterator-tla-error.js: Added.
(async g):
* JSTests/stress/resources/async-iterator-tla-ruler-fast.js: Added.
(async g):
* JSTests/stress/resources/async-iterator-tla-ruler-generic.js: Added.
(const.asyncGenProto.Object.getPrototypeOf.Object.getPrototypeOf):
(asyncGenProto.next):
(async const):
(async g):
* Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp:
(JSC::BytecodeGenerator::emitEnumeration):
* Source/JavaScriptCore/runtime/JSAsyncGeneratorInlines.h:
(JSC::JSAsyncGenerator::enqueue):
* Source/JavaScriptCore/runtime/JSMicrotask.cpp:
(JSC::asyncModuleExecutionDone):
(JSC::asyncModuleResolveEvaluation):
(JSC::asyncModuleExecutionResume):
(JSC::asyncGeneratorDriverResume):
(JSC::runInternalMicrotask):
* Source/JavaScriptCore/runtime/JSMicrotask.h:
* Source/JavaScriptCore/runtime/JSModuleRecord.cpp:
(JSC::JSModuleRecord::isTopLevelExecutionFinished const):
(JSC::JSModuleRecord::evaluate):
(JSC::JSModuleRecord::execute):
* Source/JavaScriptCore/runtime/JSModuleRecord.h:

Canonical link: <a href="https://commits.webkit.org/317629@main">https://commits.webkit.org/317629@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ef7a14f0bc467dd4932d0803df51fa6539e41b58

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175808 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49741 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43525 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185401 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/137991 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/dfca8035-1e39-465e-a3ad-4959ff20c12b) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51033 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49423 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136897 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/137991 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c7985e75-504a-4e52-b981-8f6ea02da62f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178764 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40353 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157670 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117376 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4e80d084-ce39-4c83-a7ed-5ea2e0726e6e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38995 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37379 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/6179 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149414 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37162 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33871 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/37072 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41437 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41585 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187822 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49408 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145891 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50088 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33786 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145732 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26718 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40521 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122284 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/116112 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48595 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12141 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47997 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48229 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48054 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->