### PR TITLE
Web Inspector: [SI] route shadowRootPushed/Popped to per-frame FrameDOMAgent

### DIFF
--- a/LayoutTests/http/tests/site-isolation/inspector/dom/resources/shadow-root-child-frame.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/dom/resources/shadow-root-child-frame.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Cross-Origin Shadow DOM Child Frame</title>
+</head>
+<body>
+    <div id="child-host" data-role="child-host"></div>
+    <script>
+    // Embed a grandchild iframe back on the original host so main(A) -> child(B) ->
+    // grandchild(A): the grandchild shares the main frame's process, giving two distinct
+    // frame targets (child and grandchild) whose FrameDOMAgents mint node ids from
+    // independent counters and can therefore collide numerically.
+    let grandchildHost = location.hostname === "localhost" ? "127.0.0.1" : "localhost";
+    let iframe = document.createElement("iframe");
+    iframe.name = "grandchild-frame";
+    iframe.src = `http://${grandchildHost}:8000/site-isolation/inspector/dom/resources/shadow-root-grandchild-frame.html`;
+    document.body.appendChild(iframe);
+
+    function attachShadowToChildHost() {
+        document.getElementById("child-host").attachShadow({mode: "open"});
+        return true;
+    }
+    </script>
+</body>
+</html>

--- a/LayoutTests/http/tests/site-isolation/inspector/dom/resources/shadow-root-frame.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/dom/resources/shadow-root-frame.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Cross-Origin Shadow DOM Frame</title>
+</head>
+<body>
+    <div id="container" class="main-content" data-role="frame-root">
+        <div id="host"></div>
+    </div>
+    <script>
+    // Attach an open shadow root to #host and return true. Called after the frontend has
+    // expanded #host so that DOM.shadowRootPushed can be matched to a known host node.
+    function attachShadowToHost() {
+        let host = document.getElementById("host");
+        let root = host.attachShadow({mode: "open"});
+        root.innerHTML = "<span id='shadow-child'>shadow content</span>";
+        return true;
+    }
+    </script>
+</body>
+</html>

--- a/LayoutTests/http/tests/site-isolation/inspector/dom/resources/shadow-root-grandchild-frame.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/dom/resources/shadow-root-grandchild-frame.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Cross-Origin Shadow DOM Grandchild Frame</title>
+</head>
+<body>
+    <div id="grandchild-host" data-role="grandchild-host"></div>
+    <script>
+    function attachShadowToGrandchildHost() {
+        document.getElementById("grandchild-host").attachShadow({mode: "open"});
+        return true;
+    }
+    </script>
+</body>
+</html>

--- a/LayoutTests/http/tests/site-isolation/inspector/dom/shadow-root-cross-frame-isolation-frame-target-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/inspector/dom/shadow-root-cross-frame-isolation-frame-target-expected.txt
@@ -1,0 +1,21 @@
+Test that shadow roots pushed from two distinct cross-origin frame targets stay isolated under site isolation, even with colliding raw node ids.
+
+
+
+== Running test suite: SiteIsolation.DOM.FrameDOMAgent.ShadowRootCrossFrameIsolation
+-- Running test case: Setup
+PASS: Should find the child frame target (host B).
+PASS: Should find the grandchild frame target (host A).
+PASS: Child and grandchild should be distinct targets.
+
+-- Running test case: SiteIsolation.DOM.ShadowRootCrossFrameIsolation.DistinctScopedNodes
+PASS: Should find #child-host in the child frame.
+PASS: Should find #grandchild-host in the grandchild frame.
+PASS: Child shadow root should be owned by the child target.
+PASS: Grandchild shadow root should be owned by the grandchild target.
+PASS: The two shadow roots must be distinct WI.DOMNode instances.
+PASS: The two shadow roots must have distinct scoped ids.
+PASS: Child shadow root should resolve on the child target by its raw id.
+PASS: Grandchild shadow root should resolve on the grandchild target by its raw id.
+PASS: Child's raw id must not resolve to the child's node on the grandchild target.
+

--- a/LayoutTests/http/tests/site-isolation/inspector/dom/shadow-root-cross-frame-isolation-frame-target.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/dom/shadow-root-cross-frame-isolation-frame-target.html
@@ -1,0 +1,97 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<script src="../../../inspector/resources/inspector-test.js"></script>
+<script src="../debugger/resources/site-isolation-debugger-test-utilities.js"></script>
+<script>
+function test() {
+    let suite = InspectorTest.createAsyncSuite("SiteIsolation.DOM.FrameDOMAgent.ShadowRootCrossFrameIsolation");
+
+    // main(A) -> child(B) -> grandchild(A). Each frame's FrameDOMAgent mints node ids from its
+    // own counter, so the two frames can hand out the same raw NodeId; `target.identifier + ":" + id`
+    // scoping keeps the frontend from confusing them. This test guards that scoping.
+    let childTarget = null;
+    let grandchildTarget = null;
+
+    async function frameTargetForURLContainingWhenReady(substring, maxAttempts = 50) {
+        for (let attempt = 0; attempt < maxAttempts; ++attempt) {
+            let target = await frameTargetForURLContaining(substring);
+            if (target && WI.domManager.frameTargetDocumentForTarget(target))
+                return target;
+            await new Promise((resolve) => setTimeout(resolve, 100));
+        }
+        return null;
+    }
+
+    async function expandToHost(target, role) {
+        let doc = WI.domManager.frameTargetDocumentForTarget(target);
+        let htmlNode = doc.children.find((child) => child.nodeName() === "HTML");
+        await new Promise((resolve) => htmlNode.getChildNodes(resolve));
+        let bodyNode = htmlNode.children.find((child) => child.nodeName() === "BODY");
+        await new Promise((resolve) => bodyNode.getChildNodes(resolve));
+        return bodyNode.children.find((child) => child.getAttribute("data-role") === role);
+    }
+
+    function awaitShadowRootPushedOn(target) {
+        return new Promise((resolve) => {
+            WI.domManager.addEventListener(WI.DOMManager.Event.NodeInserted, function listener(event) {
+                let node = event.data.node;
+                if (!node || node.owningTarget !== target || !node.isShadowRoot())
+                    return;
+                WI.domManager.removeEventListener(WI.DOMManager.Event.NodeInserted, listener, null);
+                resolve(event.data);
+            });
+        });
+    }
+
+    suite.addTestCase({
+        name: "Setup",
+        description: "Find the child (B) and grandchild (A) frame targets.",
+        async test() {
+            childTarget = await frameTargetForURLContainingWhenReady("shadow-root-child-frame.html");
+            grandchildTarget = await frameTargetForURLContainingWhenReady("shadow-root-grandchild-frame.html");
+
+            InspectorTest.expectNotNull(childTarget, "Should find the child frame target (host B).");
+            InspectorTest.expectNotNull(grandchildTarget, "Should find the grandchild frame target (host A).");
+            InspectorTest.expectThat(childTarget !== grandchildTarget, "Child and grandchild should be distinct targets.");
+        }
+    });
+
+    suite.addTestCase({
+        name: "SiteIsolation.DOM.ShadowRootCrossFrameIsolation.DistinctScopedNodes",
+        description: "Each frame pushing a shadow root produces a distinct scoped WI.DOMNode, even with colliding raw node ids.",
+        async test() {
+            let childHost = await expandToHost(childTarget, "child-host");
+            let grandchildHost = await expandToHost(grandchildTarget, "grandchild-host");
+            InspectorTest.expectNotNull(childHost, "Should find #child-host in the child frame.");
+            InspectorTest.expectNotNull(grandchildHost, "Should find #grandchild-host in the grandchild frame.");
+
+            let childPushPromise = awaitShadowRootPushedOn(childTarget);
+            let grandchildPushPromise = awaitShadowRootPushedOn(grandchildTarget);
+
+            childTarget.RuntimeAgent.evaluate.invoke({expression: "attachShadowToChildHost()", objectGroup: "test"});
+            grandchildTarget.RuntimeAgent.evaluate.invoke({expression: "attachShadowToGrandchildHost()", objectGroup: "test"});
+
+            let childShadow = (await childPushPromise).node;
+            let grandchildShadow = (await grandchildPushPromise).node;
+
+            InspectorTest.expectEqual(childShadow.owningTarget, childTarget, "Child shadow root should be owned by the child target.");
+            InspectorTest.expectEqual(grandchildShadow.owningTarget, grandchildTarget, "Grandchild shadow root should be owned by the grandchild target.");
+            InspectorTest.expectThat(childShadow !== grandchildShadow, "The two shadow roots must be distinct WI.DOMNode instances.");
+            InspectorTest.expectThat(childShadow.id !== grandchildShadow.id, "The two shadow roots must have distinct scoped ids.");
+
+            // The cross-target lookup below is the real guard: it only bites when the two frames'
+            // raw ids collide, but holds either way, so the expected output stays stable.
+            InspectorTest.expectEqual(WI.domManager.nodeForIdInFrameTarget(childShadow._rawNodeId, childTarget), childShadow, "Child shadow root should resolve on the child target by its raw id.");
+            InspectorTest.expectEqual(WI.domManager.nodeForIdInFrameTarget(grandchildShadow._rawNodeId, grandchildTarget), grandchildShadow, "Grandchild shadow root should resolve on the grandchild target by its raw id.");
+            InspectorTest.expectThat(WI.domManager.nodeForIdInFrameTarget(childShadow._rawNodeId, grandchildTarget) !== childShadow, "Child's raw id must not resolve to the child's node on the grandchild target.");
+        }
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+
+<body onload="runTest()">
+<p>Test that shadow roots pushed from two distinct cross-origin frame targets stay isolated under site isolation, even with colliding raw node ids.</p>
+<iframe src="http://127.0.0.1:8000/site-isolation/inspector/dom/resources/shadow-root-child-frame.html"></iframe>
+</body>
+</html>

--- a/LayoutTests/http/tests/site-isolation/inspector/dom/shadow-root-pushed-frame-target-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/inspector/dom/shadow-root-pushed-frame-target-expected.txt
@@ -1,0 +1,19 @@
+Test that shadow root push events from a cross-origin iframe are routed to the frame target under site isolation.
+
+
+
+== Running test suite: SiteIsolation.DOM.FrameDOMAgent.ShadowRoot
+-- Running test case: Setup
+PASS: Should find a cross-origin frame target.
+PASS: Frame target should have a document.
+PASS: Should find #container.
+PASS: Should find #host.
+PASS: #host should be owned by the frame target.
+
+-- Running test case: SiteIsolation.DOM.ShadowRoot.Pushed
+PASS: Shadow root's parent should be #host.
+PASS: Inserted node should be a shadow root.
+PASS: Shadow root should be open.
+PASS: Shadow root should be owned by the frame target, not the main page.
+PASS: Shadow root should be reachable via its scoped id on the frame target.
+

--- a/LayoutTests/http/tests/site-isolation/inspector/dom/shadow-root-pushed-frame-target.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/dom/shadow-root-pushed-frame-target.html
@@ -1,0 +1,89 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<script src="../../../inspector/resources/inspector-test.js"></script>
+<script src="../debugger/resources/site-isolation-debugger-test-utilities.js"></script>
+<script>
+function test() {
+    let suite = InspectorTest.createAsyncSuite("SiteIsolation.DOM.FrameDOMAgent.ShadowRoot");
+
+    let frameTarget = null;
+    let frameDoc = null;
+    let hostNode = null;
+
+    function evaluateInFrame(expression) {
+        return frameTarget.RuntimeAgent.evaluate.invoke({expression, objectGroup: "test"});
+    }
+
+    // NodeInserted is manager-wide and also fires for the page target, so filter by owningTarget
+    // rather than taking the first event.
+    function awaitFrameTargetNodeInserted(predicate) {
+        return new Promise((resolve) => {
+            WI.domManager.addEventListener(WI.DOMManager.Event.NodeInserted, function listener(event) {
+                let node = event.data.node;
+                if (!node || node.owningTarget !== frameTarget || !predicate(node, event.data))
+                    return;
+                WI.domManager.removeEventListener(WI.DOMManager.Event.NodeInserted, listener, null);
+                resolve(event.data);
+            });
+        });
+    }
+
+    suite.addTestCase({
+        name: "Setup",
+        description: "Find the cross-origin frame target and expand down to the shadow host.",
+        async test() {
+            let frameTargets = WI.targets.filter((t) => t.type === WI.TargetType.Frame);
+            let urlTargetMap = await fetchDocumentURLsForTargets(frameTargets);
+            let mainFrameTarget = urlTargetMap.get(WI.networkManager.mainFrame.url);
+            frameTarget = frameTargets.find((t) => t !== mainFrameTarget);
+
+            InspectorTest.expectNotNull(frameTarget, "Should find a cross-origin frame target.");
+
+            frameDoc = WI.domManager.frameTargetDocumentForTarget(frameTarget);
+            InspectorTest.expectNotNull(frameDoc, "Frame target should have a document.");
+
+            let htmlNode = frameDoc.children.find((child) => child.nodeName() === "HTML");
+            await new Promise((resolve) => htmlNode.getChildNodes(resolve));
+
+            let bodyNode = htmlNode.children.find((child) => child.nodeName() === "BODY");
+            await new Promise((resolve) => bodyNode.getChildNodes(resolve));
+
+            let containerNode = bodyNode.children.find((child) => child.getAttribute("id") === "container");
+            InspectorTest.expectNotNull(containerNode, "Should find #container.");
+            await new Promise((resolve) => containerNode.getChildNodes(resolve));
+
+            hostNode = containerNode.children.find((child) => child.getAttribute("id") === "host");
+            InspectorTest.expectNotNull(hostNode, "Should find #host.");
+            InspectorTest.expectEqual(hostNode.owningTarget, frameTarget, "#host should be owned by the frame target.");
+        }
+    });
+
+    suite.addTestCase({
+        name: "SiteIsolation.DOM.ShadowRoot.Pushed",
+        description: "Attaching a shadow root in a cross-origin frame should fire shadowRootPushed on the frame target.",
+        async test() {
+            let eventPromise = awaitFrameTargetNodeInserted((node) => node.isShadowRoot());
+            evaluateInFrame("attachShadowToHost()");
+
+            let {node, parent} = await eventPromise;
+            InspectorTest.expectEqual(parent, hostNode, "Shadow root's parent should be #host.");
+            InspectorTest.expectThat(node.isShadowRoot(), "Inserted node should be a shadow root.");
+            InspectorTest.expectEqual(node.shadowRootType(), WI.DOMNode.ShadowRootType.Open, "Shadow root should be open.");
+            InspectorTest.expectEqual(node.owningTarget, frameTarget, "Shadow root should be owned by the frame target, not the main page.");
+            InspectorTest.expectEqual(WI.domManager.nodeForIdInFrameTarget(node._rawNodeId, frameTarget), node, "Shadow root should be reachable via its scoped id on the frame target.");
+        }
+    });
+
+    // No shadowRootPopped case: author shadow roots have no scriptable detach, so willPopShadowRoot
+    // only fires when the host is destroyed — and removing the host first unbinds the root
+    // (FrameDOMAgent::unbind), leaving boundNodeId 0 so the backend suppresses the event. The
+    // frontend routing is wired regardless; it just can't be triggered deterministically here.
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+
+<body onload="runTest()">
+<p>Test that shadow root push events from a cross-origin iframe are routed to the frame target under site isolation.</p>
+<iframe src="http://localhost:8000/site-isolation/inspector/dom/resources/shadow-root-frame.html"></iframe>
+</body>
+</html>

--- a/Source/JavaScriptCore/inspector/protocol/DOM.json
+++ b/Source/JavaScriptCore/inspector/protocol/DOM.json
@@ -916,7 +916,7 @@
         {
             "name": "shadowRootPushed",
             "description": "Called when shadow root is pushed into the element.",
-            "targetTypes": ["page"],
+            "targetTypes": ["frame", "page"],
             "parameters": [
                 { "name": "hostId", "$ref": "NodeId", "description": "Host element id." },
                 { "name": "root", "$ref": "Node", "description": "Shadow root." }
@@ -925,7 +925,7 @@
         {
             "name": "shadowRootPopped",
             "description": "Called when shadow root is popped from the element.",
-            "targetTypes": ["page"],
+            "targetTypes": ["frame", "page"],
             "parameters": [
                 { "name": "hostId", "$ref": "NodeId", "description": "Host element id." },
                 { "name": "rootId", "$ref": "NodeId", "description": "Shadow root id." }

--- a/Source/WebCore/inspector/InspectorInstrumentation.cpp
+++ b/Source/WebCore/inspector/InspectorInstrumentation.cpp
@@ -328,12 +328,20 @@ void InspectorInstrumentation::activeStyleSheetsUpdatedImpl(InstrumentingAgents&
 
 void InspectorInstrumentation::didPushShadowRootImpl(InstrumentingAgents& instrumentingAgents, Element& host, ShadowRoot& root)
 {
+    if (RefPtr frame = host.document().frame()) {
+        if (CheckedPtr frameDOMAgent = frame->inspectorController().instrumentingAgents().persistentFrameDOMAgent())
+            frameDOMAgent->didPushShadowRoot(host, root);
+    }
     if (CheckedPtr domAgent = instrumentingAgents.persistentDOMAgent())
         domAgent->didPushShadowRoot(host, root);
 }
 
 void InspectorInstrumentation::willPopShadowRootImpl(InstrumentingAgents& instrumentingAgents, Element& host, ShadowRoot& root)
 {
+    if (RefPtr frame = host.document().frame()) {
+        if (CheckedPtr frameDOMAgent = frame->inspectorController().instrumentingAgents().persistentFrameDOMAgent())
+            frameDOMAgent->willPopShadowRoot(host, root);
+    }
     if (CheckedPtr domAgent = instrumentingAgents.persistentDOMAgent())
         domAgent->willPopShadowRoot(host, root);
 }

--- a/Source/WebInspectorUI/UserInterface/Controllers/DOMManager.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/DOMManager.js
@@ -440,6 +440,37 @@ WI.DOMManager = class DOMManager extends WI.Object
         this.dispatchEventToListeners(WI.DOMManager.Event.NodeRemoved, {node, parent});
     }
 
+    _frameTargetShadowRootPushed(target, hostId, payload)
+    {
+        let scopedHostId = target.identifier + ":" + hostId;
+        let host = this._idToDOMNode[scopedHostId];
+        if (!host)
+            return;
+
+        // Insert as a child with no previous sibling, mirroring the page path's
+        // `_childNodeInserted(hostId, 0, root)`; `_insertChild` scopes the node to this target.
+        let node = host._insertChild(null, payload);
+        this._idToDOMNode[node.id] = node;
+        this.dispatchEventToListeners(WI.DOMManager.Event.NodeInserted, {node, parent: host});
+
+        // A shadow subtree may contain an iframe element.
+        this._trySpliceUnsplicedFrameDocuments();
+    }
+
+    _frameTargetShadowRootPopped(target, hostId, rootId)
+    {
+        let scopedHostId = target.identifier + ":" + hostId;
+        let scopedRootId = target.identifier + ":" + rootId;
+        let host = this._idToDOMNode[scopedHostId];
+        let root = this._idToDOMNode[scopedRootId];
+        if (!host || !root)
+            return;
+
+        host._removeChild(root);
+        this._frameTargetUnbind(root);
+        this.dispatchEventToListeners(WI.DOMManager.Event.NodeRemoved, {node: root, parent: host});
+    }
+
     _frameTargetWillDestroyDOMNode(target, nodeId)
     {
         let scopedId = target.identifier + ":" + nodeId;

--- a/Source/WebInspectorUI/UserInterface/Protocol/DOMObserver.js
+++ b/Source/WebInspectorUI/UserInterface/Protocol/DOMObserver.js
@@ -126,15 +126,19 @@ WI.DOMObserver = class DOMObserver extends InspectorBackend.Dispatcher
 
     shadowRootPushed(hostId, root)
     {
-        if (this._target instanceof WI.FrameTarget)
-            return; // FIXME: <https://webkit.org/b/298980> Route to frame-target handler.
+        if (this._target instanceof WI.FrameTarget) {
+            WI.domManager._frameTargetShadowRootPushed(this._target, hostId, root);
+            return;
+        }
         WI.domManager._childNodeInserted(hostId, 0, root);
     }
 
     shadowRootPopped(hostId, rootId)
     {
-        if (this._target instanceof WI.FrameTarget)
-            return; // FIXME: <https://webkit.org/b/298980> Route to frame-target handler.
+        if (this._target instanceof WI.FrameTarget) {
+            WI.domManager._frameTargetShadowRootPopped(this._target, hostId, rootId);
+            return;
+        }
         WI.domManager._childNodeRemoved(hostId, rootId);
     }
 


### PR DESCRIPTION
#### 034bf10318cda0200ec8efc019bca8c0202da9e8
<pre>
Web Inspector: [SI] route shadowRootPushed/Popped to per-frame FrameDOMAgent
<a href="https://bugs.webkit.org/show_bug.cgi?id=X">https://bugs.webkit.org/show_bug.cgi?id=X</a>
<a href="https://rdar.apple.com/179248483">rdar://179248483</a>

Reviewed by Qianlang Chen.

Under Site Isolation a cross-origin iframe&apos;s DOM lives in a separate
WebProcess with its own FrameDOMAgent. The DOM.shadowRootPushed and
shadowRootPopped events are fired through InstrumentingAgents, which only
notified the page-level agent, so attaching a shadow root inside a cross-
origin iframe reached no agent for that frame -- and even when it did, the
frontend dropped it for a FrameTarget. The shadow root never appeared in the
Elements tree.

didPushShadowRootImpl and willPopShadowRootImpl now resolve the host&apos;s frame
and notify that frame&apos;s persistentFrameDOMAgent before falling through to the
page agent, matching the branch already used by the sibling per-node hooks
(didModifyDOMAttr, didInsertDOMNode). The main frame has no
persistentFrameDOMAgent and the page agent&apos;s boundNodeId() guard suppresses
subframe hosts, so there is no double-fire. DOM.json widens both events&apos;
targetTypes from [&quot;page&quot;] to [&quot;frame&quot;,&quot;page&quot;] so the generated dispatcher
accepts them from a FrameTarget; FrameDOMAgent already implemented
didPushShadowRoot/willPopShadowRoot.

On the frontend, DOMObserver replaces the two FrameTarget FIXME early-returns
with _frameTargetShadowRootPushed/_frameTargetShadowRootPopped, modeled on
_frameTargetChildNodeInserted/Removed. They scope the shadow-root WI.DOMNode
to the owning frame target (target.identifier + &quot;:&quot; + nodeId) so colliding
raw NodeIds across frames stay distinct.

shadowRootPopped is wired but has no end-to-end test: author shadow roots have
no scriptable detach, so willPopShadowRoot only fires on host destruction, and
removing the host first unbinds the root (FrameDOMAgent::unbind), leaving
boundNodeId 0 so the backend suppresses the event.

Tests: http/tests/site-isolation/inspector/dom/shadow-root-cross-frame-isolation-frame-target.html
       http/tests/site-isolation/inspector/dom/shadow-root-pushed-frame-target.html

* LayoutTests/http/tests/site-isolation/inspector/dom/resources/shadow-root-child-frame.html: Added.
* LayoutTests/http/tests/site-isolation/inspector/dom/resources/shadow-root-frame.html: Added.
* LayoutTests/http/tests/site-isolation/inspector/dom/resources/shadow-root-grandchild-frame.html: Added.
* LayoutTests/http/tests/site-isolation/inspector/dom/shadow-root-cross-frame-isolation-frame-target-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/inspector/dom/shadow-root-cross-frame-isolation-frame-target.html: Added.
* LayoutTests/http/tests/site-isolation/inspector/dom/shadow-root-pushed-frame-target-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/inspector/dom/shadow-root-pushed-frame-target.html: Added.
* Source/JavaScriptCore/inspector/protocol/DOM.json:
* Source/WebCore/inspector/InspectorInstrumentation.cpp:
(WebCore::InspectorInstrumentation::didPushShadowRootImpl):
(WebCore::InspectorInstrumentation::willPopShadowRootImpl):
* Source/WebInspectorUI/UserInterface/Controllers/DOMManager.js:
(WI.DOMManager.prototype._frameTargetShadowRootPushed):
(WI.DOMManager.prototype._frameTargetShadowRootPopped):
* Source/WebInspectorUI/UserInterface/Protocol/DOMObserver.js:
(WI.DOMObserver.prototype.shadowRootPushed):
(WI.DOMObserver.prototype.shadowRootPopped):

Canonical link: <a href="https://commits.webkit.org/317697@main">https://commits.webkit.org/317697@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f6f0c3d4f420da8a84439d81c600f21ebaf0ab4f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175767 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49700 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43484 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185360 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/137950 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/177630 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50992 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49382 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136862 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/137950 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a79dcd6b-d17e-46a8-bae6-2b76e015f54a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178723 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40318 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157636 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117341 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/814a1103-87a6-4f63-9257-5f34f82c9bc3) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38960 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37339 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/6145 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149379 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37128 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33829 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/37031 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41394 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41545 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187781 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49367 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/157187 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145853 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39303 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50047 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33752 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145694 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40485 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122243 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/116069 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48554 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12106 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47956 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48188 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48013 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->