### PR TITLE
[ANGLE] Skip ANGLE test suite failing/crashing tests

### DIFF
--- a/Source/ThirdParty/ANGLE/src/tests/angle_end2end_tests_expectations.txt
+++ b/Source/ThirdParty/ANGLE/src/tests/angle_end2end_tests_expectations.txt
@@ -2896,6 +2896,53 @@
 // webkit.org/b/317381
 0 METAL : HardenedContextTest.RenderingFeedbackLoopWithStencilOnlyANGLE/* = SKIP
 
+// webkit.org/b/319849
+0 METAL : ClipDistanceAPPLETest.OneClipDistance/* = SKIP
+0 METAL : ClipDistanceAPPLETest.ToggleOneClipDistance/* = SKIP
+0 METAL : ClipDistanceAPPLETest.EachClipDistance/* = SKIP
+0 METAL : ClipDistanceAPPLETest.ThreeClipDistancesRedeclared/* = SKIP
+0 METAL : ClipCullDistanceTest.SizedArrayLength/* = SKIP
+0 METAL : ClipCullDistanceTest.OneClipDistance/* = SKIP
+0 METAL : ClipCullDistanceTest.EachClipDistance/* = SKIP
+0 METAL : ClipCullDistanceTest.ThreeClipDistancesRedeclared/* = SKIP
+0 METAL : GLSLConstantFoldingTest.RadiansInfinity/* = SKIP
+0 METAL : GLSLConstantFoldingTest.DegreesInfinity/* = SKIP
+0 METAL : GLSLConstantFoldingTest.SinhInfinity/* = SKIP
+0 METAL : GLSLConstantFoldingTest.SinhNegativeInfinity/* = SKIP
+0 METAL : GLSLConstantFoldingTest.CoshInfinity/* = SKIP
+0 METAL : GLSLConstantFoldingTest.CoshNegativeInfinity/* = SKIP
+0 METAL : GLSLConstantFoldingTest.AsinhInfinity/* = SKIP
+0 METAL : GLSLConstantFoldingTest.AsinhNegativeInfinity/* = SKIP
+0 METAL : GLSLConstantFoldingTest.AcoshInfinity/* = SKIP
+0 METAL : GLSLConstantFoldingTest.ExpInfinity/* = SKIP
+0 METAL : GLSLConstantFoldingTest.LogInfinity/* = SKIP
+0 METAL : GLSLConstantFoldingTest.Exp2Infinity/* = SKIP
+0 METAL : GLSLConstantFoldingTest.Log2Infinity/* = SKIP
+0 METAL : GLSLConstantFoldingTest.SqrtInfinity/* = SKIP
+0 METAL : GLSLConstantFoldingTest.LengthInfinity/* = SKIP
+0 METAL : GLSLConstantFoldingTest.DotInfinity/* = SKIP
+0 METAL : GLSLConstantFoldingTest.DotInfinity2/* = SKIP
+0 METAL : GLSLConstantFoldingTest.InfinityMinusFinite/* = SKIP
+0 METAL : GLSLConstantFoldingTest.MinusInfinityPlusFinite/* = SKIP
+0 METAL : GLSLConstantFoldingTest.InfinityMultipliedByFinite/* = SKIP
+0 METAL : GLSLConstantFoldingTest.InfinityMultipliedByInfinity/* = SKIP
+0 METAL : GLSLConstantFoldingTest.InfinityMultipliedByNegativeInfinity/* = SKIP
+0 METAL : GLSLConstantFoldingTest.DivideByNegativeZero/* = SKIP
+0 METAL : GLSLConstantFoldingTest.InfinityDividedByZero/* = SKIP
+0 METAL : GLSLConstantFoldingTest.MinusInfinityDividedByZero/* = SKIP
+0 METAL : GLSLConstantFoldingTest.InfinityMinusInfinity/* = SKIP
+0 METAL : GLSLConstantFoldingTest.InfinityPlusNegativeInfinity/* = SKIP
+0 METAL : GLSLConstantFoldingTest.InfinityMultipliedByZero/* = SKIP
+0 METAL : GLSLConstantFoldingTest.InfinityDividedByInfinity/* = SKIP
+0 METAL : GLSLConstantFoldingTest.ZeroDividedByZero/* = SKIP
+0 METAL : GLSLConstantFoldingTest.FloatOverflowAdd/* = SKIP
+0 METAL : GLSLConstantFoldingTest.FloatOverflowSubtract/* = SKIP
+0 METAL : GLSLConstantFoldingTest.FloatOverflowMultiply/* = SKIP
+0 METAL : GLSLConstantFoldingTest.FloatOverflowDivide/* = SKIP
+0 METAL : GLSLTest.InactiveVaryingInVertexActiveInFragment/* = SKIP
+0 METAL : PixelLocalStorageTest.DrawCommandValidation/* = SKIP
+0 METAL : TransformFeedbackTest.InactiveStructureVarying/* = SKIP
+
 // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 // Slow tests, should appear last in this file
 // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!

--- a/Source/ThirdParty/ANGLE/src/tests/deqp_support/deqp_gles2_test_expectations.txt
+++ b/Source/ThirdParty/ANGLE/src/tests/deqp_support/deqp_gles2_test_expectations.txt
@@ -502,3 +502,6 @@
 356399840 WGPU : dEQP-GLES2.functional.uniform_api.value.*.render.* = FAIL
 356399840 WGPU : dEQP-GLES2.functional.uniform_api.random.* = FAIL
 392542001 WGPU : dEQP-GLES2.functional.vertex_arrays.multiple_attributes* = FAIL
+
+// webkit.org/b/319849
+0 METAL : dEQP-GLES2.functional.shaders.linkage.varying* = SKIP

--- a/Source/ThirdParty/ANGLE/src/tests/deqp_support/deqp_gles3_test_expectations.txt
+++ b/Source/ThirdParty/ANGLE/src/tests/deqp_support/deqp_gles3_test_expectations.txt
@@ -996,3 +996,12 @@
 349994211 IR D3D11 NVIDIA : dEQP-GLES3.functional.shaders.switch.default_label_static_* = SKIP
 349994211 IR D3D11 NVIDIA : dEQP-GLES3.functional.shaders.switch.default_not_last_static_* = SKIP
 349994211 IR D3D11 NVIDIA : dEQP-GLES3.functional.shaders.switch.if_in_switch_static_* = SKIP
+
+// webkit.org/b/319849
+0 METAL : dEQP-GLES3.functional.shaders.builtin_functions.common.isinf.* = SKIP
+0 METAL : dEQP-GLES3.functional.shaders.builtin_functions.common.isnan.* = SKIP
+0 METAL : dEQP-GLES3.functional.shaders.builtin_functions.precision.* = SKIP
+0 METAL : dEQP-GLES3.functional.shaders.linkage.varying.rules.* = SKIP
+0 METAL : dEQP-GLES3.functional.shaders.metamorphic.bubblesort_flag.variant_* = SKIP
+0 METAL : dEQP-GLES3.functional.shaders.metamorphic.synthetic.variant_* = SKIP
+0 METAL : dEQP-GLES3.functional.shaders.operator.geometric.faceforward.mediump_vec2_vertex = SKIP

--- a/Source/ThirdParty/ANGLE/src/tests/gl_tests/FramebufferTest.cpp
+++ b/Source/ThirdParty/ANGLE/src/tests/gl_tests/FramebufferTest.cpp
@@ -9937,4 +9937,5 @@ ANGLE_INSTANTIATE_TEST_ES3_AND(
     ES3_OPENGLES().enable(Feature::ReattachFboDepthStencilOnReallocation),
     ES3_OPENGLES().disable(Feature::ReattachFboDepthStencilOnReallocation));
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(FramebufferTest_ES31_MSAA);
 ANGLE_INSTANTIATE_TEST_ES31(FramebufferTest_ES31_MSAA);


### PR DESCRIPTION
#### 786ab29f8f885275f20d5a00371838357e825b02
<pre>
[ANGLE] Skip ANGLE test suite failing/crashing tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=319849">https://bugs.webkit.org/show_bug.cgi?id=319849</a>
<a href="https://rdar.apple.com/182745738">rdar://182745738</a>

Reviewed by Dan Glastonbury.

Test cleanup for ANGLE test suites. Skip all tests for now that
currently fail or crash (in many cases due to a Metal validation
failure).

* Source/ThirdParty/ANGLE/src/tests/angle_end2end_tests_expectations.txt:
* Source/ThirdParty/ANGLE/src/tests/deqp_support/deqp_gles2_test_expectations.txt:
* Source/ThirdParty/ANGLE/src/tests/deqp_support/deqp_gles3_test_expectations.txt:
* Source/ThirdParty/ANGLE/src/tests/gl_tests/FramebufferTest.cpp:

Canonical link: <a href="https://commits.webkit.org/317604@main">https://commits.webkit.org/317604@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7e280976052ee2cb8b7c0ece4c21d0a4b68cf4fd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175785 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49718 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43502 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185378 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/137968 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/86121d39-ef32-4bcc-8c90-4b4e895f2dd9) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51010 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49400 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136874 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/137968 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/52adf3d2-cd88-4cff-b39c-687d7d174b30) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178741 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40329 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/157646 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117353 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/dcb881c3-b5c9-4d25-9d3d-b3e5ac528928) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38971 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/37354 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149390 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37138 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33847 "Built successfully") | | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/41560 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187799 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49385 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145868 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39244 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50065 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/33762 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145709 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40497 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/116087 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48572 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12116 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47974 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48206 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48031 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->