### PR TITLE
Rewrite touch event layout tests with EventSender asyncTouch* methods

### DIFF
--- a/LayoutTests/fast/events/touch/basic-multi-touch-events-limited.html
+++ b/LayoutTests/fast/events/touch/basic-multi-touch-events-limited.html
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-<script src="../../../resources/js-test-pre.js"></script>
+<script src="../../../resources/js-test.js"></script>
 <!--
   Touch tests that involve the ontouchstart, ontouchmove, ontouchend or ontouchcancel callbacks
   should be written in an asynchronous fashion so they can be run on mobile platforms like Android.
@@ -28,14 +28,6 @@ function touchEventCallback() {
         verifyTouch(touchEventsReceived++);
     } else {
         debug(event.type);
-    }
-
-    if (window.testRunner && touchEventsReceived == EXPECTED_TOUCH_EVENTS_TOTAL) {
-        // If we've got here, we can safely say we were successfully parsed :) We need to
-        // call the isSucccessfullyParsed function to output the correct TEST COMPLETE
-        // footer message.
-        isSuccessfullyParsed();
-        testRunner.notifyDone();
     }
 }
 
@@ -93,29 +85,33 @@ function verifyTouch(which) {
     }
 }
 
-function multiTouchSequence()
+async function multiTouchSequence()
 {
     eventSender.addTouchPoint(10, 10);
     eventSender.addTouchPoint(20, 30);
-    eventSender.touchStart();
+    await eventSender.asyncTouchStart();
 
     eventSender.updateTouchPoint(0, 15, 15);
     eventSender.updateTouchPoint(1, 25, 35);
-    eventSender.touchMove();
+    await eventSender.asyncTouchMove();
 
     eventSender.releaseTouchPoint(0);
     eventSender.releaseTouchPoint(1);
-    eventSender.touchEnd();
+    await eventSender.asyncTouchEnd();
 }
 
-if (window.eventSender) {
-    description("This tests basic multi touch event support. This is a limited version of test basic-multi-touch-events.html that avoids the situation where one touch point is released while another is maintained.");
+description("This tests basic multi touch event support. This is a limited version of test basic-multi-touch-events.html that avoids the situation where one touch point is released while another is maintained.");
+window.jsTestIsAsync = true;
 
-    lastEvent = null;
-    eventSender.clearTouchPoints();
-    multiTouchSequence();
-} else {
-    debug("This test requires DumpRenderTree.  Tap on the blue rect to log.")
+onload = async () => {
+    if (window.eventSender) {
+        lastEvent = null;
+        eventSender.clearTouchPoints();
+        await multiTouchSequence();
+    } else {
+        debug("This test requires DumpRenderTree.  Tap on the blue rect to log.")
+    }
+    finishJSTest();
 }
 </script>
 </body>

--- a/LayoutTests/fast/events/touch/basic-multi-touch-events.html
+++ b/LayoutTests/fast/events/touch/basic-multi-touch-events.html
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-<script src="../../../resources/js-test-pre.js"></script>
+<script src="../../../resources/js-test.js"></script>
 <!--
   Touch tests that involve the ontouchstart, ontouchmove, ontouchend or ontouchcancel callbacks
   should be written in an asynchronous fashion so they can be run on mobile platforms like Android.
@@ -28,14 +28,6 @@ function touchEventCallback() {
         verifyTouch(touchEventsReceived++);
     } else {
         debug(event.type);
-    }
-
-    if (window.testRunner && touchEventsReceived == EXPECTED_TOUCH_EVENTS_TOTAL) {
-        // If we've got here, we can safely say we were successfully parsed :) We need to
-        // call the isSucccessfullyParsed function to output the correct TEST COMPLETE
-        // footer message.
-        isSuccessfullyParsed();
-        testRunner.notifyDone();
     }
 }
 
@@ -95,36 +87,40 @@ function verifyTouch(which) {
     }
 }
 
-function multiTouchSequence()
+async function multiTouchSequence()
 {
     debug("multi touch sequence");
 
     debug("Two touchpoints pressed");
     eventSender.addTouchPoint(10, 10);
     eventSender.addTouchPoint(20, 30);
-    eventSender.touchStart();
+    await eventSender.asyncTouchStart();
 
     debug("First touchpoint moved");
     eventSender.updateTouchPoint(0, 15, 15);
-    eventSender.touchMove();
+    await eventSender.asyncTouchMove();
 
     debug("First touchpoint is released");
     eventSender.releaseTouchPoint(0);
-    eventSender.touchEnd();
+    await eventSender.asyncTouchEnd();
 
     debug("Last remaining touchpoint is released");
     eventSender.releaseTouchPoint(0);
-    eventSender.touchEnd();
+    await eventSender.asyncTouchEnd();
 }
 
-if (window.eventSender) {
-    description("This tests basic multi touch event support.");
+description("This tests basic multi touch event support.");
+window.jsTestIsAsync = true;
 
-    lastEvent = null;
-    eventSender.clearTouchPoints();
-    multiTouchSequence();
-} else {
-    debug("This test requires DumpRenderTree.  Tap on the blue rect to log.")
+onload = async () => {
+    if (window.eventSender) {
+        lastEvent = null;
+        eventSender.clearTouchPoints();
+        await multiTouchSequence();
+    } else {
+        debug("This test requires DumpRenderTree.  Tap on the blue rect to log.")
+    }
+    finishJSTest();
 }
 </script>
 </body>

--- a/LayoutTests/fast/events/touch/basic-single-touch-events.html
+++ b/LayoutTests/fast/events/touch/basic-single-touch-events.html
@@ -103,53 +103,52 @@ function verifyTouch(which) {
     }
 }
 
-function singleTouchSequence()
+async function singleTouchSequence()
 {
     if (eventSender.setTouchPointRadius)
         eventSender.setTouchPointRadius(10,10);
     eventSender.addTouchPoint(10, 10);
-    eventSender.touchStart();
+    await eventSender.asyncTouchStart();
 
     if (eventSender.setTouchPointRadius)
         eventSender.setTouchPointRadius(12,12);
     eventSender.updateTouchPoint(0, 50, 50);
     eventSender.setTouchModifier("shift", true);
     eventSender.setTouchModifier("alt", true);
-    eventSender.touchMove();
+    await eventSender.asyncTouchMove();
 
     eventSender.setTouchModifier("shift", false);
     eventSender.setTouchModifier("alt", false);
 
     eventSender.releaseTouchPoint(0);
-    eventSender.touchEnd();
+    await eventSender.asyncTouchEnd();
 }
 
-function touchTargets()
+async function touchTargets()
 {
     eventSender.addTouchPoint(20, 20);
-    eventSender.touchStart();
+    await eventSender.asyncTouchStart();
 
     eventSender.updateTouchPoint(0, 1000, 1000);
-    eventSender.touchMove();
+    await eventSender.asyncTouchMove();
 }
 
+description("This tests basic single touch event support.");
+window.jsTestIsAsync = true;
 
-if (window.eventSender) {
-    description("This tests basic single touch event support.");
-    window.jsTestIsAsync = true;
-
-    lastEvent = null;
-    eventSender.clearTouchPoints();
-    singleTouchSequence();
-
-    lastEvent = null;
-    eventSender.clearTouchPoints();
-    touchTargets();
-
-} else {
-    debug("This test requires DumpRenderTree.  Tap on the blue rect to log.")
+onload = async () => {
+    if (window.eventSender) {
+        lastEvent = null;
+        eventSender.clearTouchPoints();
+        await singleTouchSequence();
+    
+        lastEvent = null;
+        eventSender.clearTouchPoints();
+        await touchTargets();
+    } else {
+        debug("This test requires DumpRenderTree.  Tap on the blue rect to log.")
+    }
 }
-
 
 </script>
 </body>

--- a/LayoutTests/fast/events/touch/frame-hover-update.html
+++ b/LayoutTests/fast/events/touch/frame-hover-update.html
@@ -25,7 +25,7 @@
             border: none;
         }
     </style>
-    <script src="../../../resources/js-test-pre.js"></script>
+    <script src="../../../resources/js-test.js"></script>
 </head>
 <body>
     <div id='sandbox'>
@@ -34,9 +34,9 @@
     </div>
 
     <script>
-        var hoveredTop, hoveredIframe1, hoveredIframe2;
+        window.jsTestIsAsync = true;
 
-        function runTest() {
+        async function runTest() {
             if (window.testRunner) {
                 var idoc1 = document.getElementById('iframe1').contentDocument;
                 var idoc2 = document.getElementById('iframe2').contentDocument;
@@ -45,7 +45,7 @@
                 eventSender.clearTouchPoints();
 
                 eventSender.addTouchPoint(50, 50);
-                eventSender.touchStart();
+                await eventSender.asyncTouchStart();
                 hoveredTop = document.querySelectorAll('iframe:hover');
                 hoveredIframe1 = idoc1.querySelectorAll('body:hover');
                 hoveredIframe2 = idoc2.querySelectorAll('body:hover');
@@ -53,10 +53,10 @@
                 shouldBe('hoveredIframe1.length', '1');
                 shouldBe('hoveredIframe2.length', '0');
                 eventSender.releaseTouchPoint(0);
-                eventSender.touchEnd();
+                await eventSender.asyncTouchEnd();
 
                 eventSender.addTouchPoint(150, 50);
-                eventSender.touchStart();
+                await eventSender.asyncTouchStart();
                 hoveredTop = document.querySelectorAll('iframe:hover');
                 hoveredIframe1 = idoc1.querySelectorAll('body:hover');
                 hoveredIframe2 = idoc2.querySelectorAll('body:hover');
@@ -64,10 +64,10 @@
                 shouldBe('hoveredIframe1.length', '0');
                 shouldBe('hoveredIframe2.length', '1');
                 eventSender.releaseTouchPoint(0);
-                eventSender.touchCancel();
+                await eventSender.asyncTouchCancel();
 
                 eventSender.addTouchPoint(250, 50);
-                eventSender.touchStart();
+                await eventSender.asyncTouchStart();
                 hoveredTop = document.querySelectorAll('iframe:hover');
                 hoveredIframe1 = idoc1.querySelectorAll('body:hover');
                 hoveredIframe2 = idoc2.querySelectorAll('body:hover');
@@ -75,7 +75,7 @@
                 shouldBe('hoveredIframe1.length', '0');
                 shouldBe('hoveredIframe2.length', '0');
                 eventSender.addTouchPoint(150, 50);
-                eventSender.touchMove();
+                await eventSender.asyncTouchMove();
                 hoveredTop = document.querySelectorAll('#sandbox:hover');
                 hoveredIframe1 = idoc1.querySelectorAll('body:hover');
                 hoveredIframe2 = idoc2.querySelectorAll('body:hover');
@@ -83,7 +83,7 @@
                 shouldBe('hoveredIframe1.length', '0');
                 shouldBe('hoveredIframe2.length', '0');
                 eventSender.releaseTouchPoint(0);
-                eventSender.touchMove();
+                await eventSender.asyncTouchMove();
                 hoveredTop = document.querySelectorAll('#sandbox:hover');
                 hoveredIframe1 = idoc1.querySelectorAll('body:hover');
                 hoveredIframe2 = idoc2.querySelectorAll('body:hover');
@@ -91,11 +91,13 @@
                 shouldBe('hoveredIframe1.length', '0');
                 shouldBe('hoveredIframe2.length', '0');
                 eventSender.releaseTouchPoint(0);
-                eventSender.touchEnd();
+                await eventSender.asyncTouchEnd();
             }
         }
-        runTest();
+        onload = async () => {
+            await runTest();
+            finishJSTest();
+        };
     </script>
-    <script src="../../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/fast/events/touch/gesture/gesture-tap-active-state.html
+++ b/LayoutTests/fast/events/touch/gesture/gesture-tap-active-state.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html>
-<script src="../../../../resources/js-test-pre.js"></script>
+<script src="../../../../resources/js-test.js"></script>
 <style type="text/css">
 #box {
     background-color: blue;
@@ -40,7 +40,9 @@ function isBoxActive()
 
 description("Tests that tap gesture events set and clear the active state of elements.");
 
-function runTests()
+window.jsTestIsAsync = true;
+
+async function runTests()
 {
     if (!window.eventSender) {
         debug('This test requires DRT.');
@@ -81,26 +83,28 @@ function runTests()
 
     debug("Verify that touchstart doesn't trigger active state");
     eventSender.addTouchPoint(50, 50);
-    eventSender.touchStart();
+    await eventSender.asyncTouchStart();
     shouldBeFalse("isBoxActive()");
     eventSender.releaseTouchPoint(0);
-    eventSender.touchEnd();
+    await eventSender.asyncTouchEnd();
 
     debug("Verify that touchstart/touchend doesn't cancel active");
     eventSender.gestureTapDown(50, 50);
     shouldBeTrue("isBoxActive()");
     eventSender.addTouchPoint(50, 50);
-    eventSender.touchStart();
+    await eventSender.asyncTouchStart();
     shouldBeTrue("isBoxActive()");
     eventSender.releaseTouchPoint(0);
-    eventSender.touchEnd();
+    await eventSender.asyncTouchEnd();
     shouldBeTrue("isBoxActive()");
     eventSender.gestureTap(50, 50);
     shouldBeFalse("isBoxActive()");
 }
 
-runTests();
+onload = async () => {
+    await runTests();
+    finishJSTest();
+};
 </script>
-<script src="../../../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/fast/events/touch/input-touch-target.html
+++ b/LayoutTests/fast/events/touch/input-touch-target.html
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-<script src="../../../resources/js-test-pre.js"></script>
+<script src="../../../resources/js-test.js"></script>
 <!--
   Touch tests that involve the ontouchstart, ontouchmove, ontouchend or ontouchcancel callbacks
   should be written in an asynchronous fashion so they can be run on mobile platforms like Android.
@@ -25,24 +25,29 @@ function touchStartHandler()
     shouldBeEqualToString('event.type', 'touchstart');
     shouldBeEqualToString('event.touches[0].target.id', target.id);
     shouldBeEqualToString('event.touches[0].target.nodeName', 'INPUT');
-
-    successfullyParsed = true;
-    isSuccessfullyParsed();
 }
 
 target.addEventListener("touchstart", touchStartHandler, false);
 
 description("Tests that input elements can receive touch events.");
+window.jsTestIsAsync = true;
 
-if (window.eventSender) {
-    eventSender.clearTouchPoints();
-    eventSender.addTouchPoint(10, 10);
-    eventSender.touchStart();
-    eventSender.touchEnd();
-} else
-    debug('This test requires DRT.');
+async function runTest() {
+    if (window.eventSender) {
+        eventSender.clearTouchPoints();
+        eventSender.addTouchPoint(10, 10);
+        await eventSender.asyncTouchStart();
+        await eventSender.asyncTouchEnd();
+    } else
+        debug('This test requires DRT.');
 
-document.body.removeChild(target);
+    document.body.removeChild(target);
+}
+
+onload = async () => {
+    await runTest();
+    finishJSTest();
+}
 
 var successfullyParsed = true;
 </script>

--- a/LayoutTests/fast/events/touch/multi-touch-grouped-targets.html
+++ b/LayoutTests/fast/events/touch/multi-touch-grouped-targets.html
@@ -78,24 +78,30 @@ description("Tests that the an event is sent for every touch listener, and targe
 window.jsTestIsAsync = true;
 
 
-if (window.eventSender) {
-    eventSender.clearTouchPoints();
-    eventSender.addTouchPoint(50, 150);
-    eventSender.addTouchPoint(50, 250);
-    eventSender.addTouchPoint(50, 150);
-    eventSender.touchStart();
+async function runTest() {
+    if (window.eventSender) {
+        eventSender.clearTouchPoints();
+        eventSender.addTouchPoint(50, 150);
+        eventSender.addTouchPoint(50, 250);
+        eventSender.addTouchPoint(50, 150);
+        await eventSender.asyncTouchStart();
 
-    eventSender.updateTouchPoint(0, 200, 150);
-    eventSender.updateTouchPoint(1, 300, 250);
-    eventSender.updateTouchPoint(2, 400, 150);
-    eventSender.touchMove();
+        eventSender.updateTouchPoint(0, 200, 150);
+        eventSender.updateTouchPoint(1, 300, 250);
+        eventSender.updateTouchPoint(2, 400, 150);
+        await eventSender.asyncTouchMove();
 
-    eventSender.releaseTouchPoint(0);
-    eventSender.releaseTouchPoint(1);
-    eventSender.releaseTouchPoint(2);
-    eventSender.touchEnd();
-} else
-    debug('This test requires DRT.');
+        eventSender.releaseTouchPoint(0);
+        eventSender.releaseTouchPoint(1);
+        eventSender.releaseTouchPoint(2);
+        await eventSender.asyncTouchEnd();
+    } else
+        debug('This test requires DRT.');
+}
+
+onload = async () => {
+    await runTest();
+}
 
 </script>
 </body>

--- a/LayoutTests/fast/events/touch/multi-touch-inside-nested-iframes.html
+++ b/LayoutTests/fast/events/touch/multi-touch-inside-nested-iframes.html
@@ -107,53 +107,53 @@ function onTouch(event, receiver)
     touchEventCount++;
 }
 
-function runTest() {
+async function runTest() {
     if (window.eventSender) {
         eventSender.clearTouchPoints();
         // Touch the center of innter iframe. 50px is offset to outer iframe in main frame,
         // 2px for the iframe borders, 100px to get to centre.
         debug('First touch is on inner iframe.');
         eventSender.addTouchPoint(152, 152);
-        eventSender.touchStart();
+        await eventSender.asyncTouchStart();
         debug('');
 
         debug('Second touch is on outer iframe, nothing should happen.');
         eventSender.addTouchPoint(71, 71);
-        eventSender.touchStart();
+        await eventSender.asyncTouchStart();
         debug('');
 
         debug('Moves the first touch outside inner iframe.');
         eventSender.updateTouchPoint(0, 302, 302);
-        eventSender.touchMove();
+        await eventSender.asyncTouchMove();
         debug('');
 
         debug('Release the first touch.');
         eventSender.releaseTouchPoint(0);
-        eventSender.touchEnd();
+        await eventSender.asyncTouchEnd();
         debug('');
 
         debug('Third touch is on outer iframe, nothing should happen.');
         eventSender.addTouchPoint(81, 81);
-        eventSender.touchStart();
+        await eventSender.asyncTouchStart();
         debug('');
 
         debug('Release all touches on outer iframe, and touch outer iframe again.');
         eventSender.releaseTouchPoint(0);
         eventSender.releaseTouchPoint(1);
-        eventSender.touchEnd();
+        await eventSender.asyncTouchEnd();
         eventSender.addTouchPoint(81, 81);
-        eventSender.touchStart();
+        await eventSender.asyncTouchStart();
         debug('');
 
         debug('Touch inner iframe, this will trigger onTouch as it is inside outer iframe.');
         eventSender.addTouchPoint(152, 152);
-        eventSender.touchStart();
+        await eventSender.asyncTouchStart();
         debug('');
 
         debug('Release all touches.');
         eventSender.releaseTouchPoint(0);
         eventSender.releaseTouchPoint(1);
-        eventSender.touchEnd();
+        await eventSender.asyncTouchEnd();
     } else {
        debug('This test requires DRT.');
     }

--- a/LayoutTests/fast/events/touch/multi-touch-some-without-handlers.html
+++ b/LayoutTests/fast/events/touch/multi-touch-some-without-handlers.html
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-<script src="../../../resources/js-test-pre.js"></script>
+<script src="../../../resources/js-test.js"></script>
 <!--
   Touch tests that involve the ontouchstart, ontouchmove, ontouchend or ontouchcancel callbacks
   should be written in an asynchronous fashion so they can be run on mobile platforms like Android.
@@ -29,15 +29,6 @@ function touchEventCallback() {
         verifyTouch(touchEventsReceived++);
     } else {
         debug(event.type);
-    }
-
-    if (window.testRunner && touchEventsReceived == EXPECTED_TOUCH_EVENTS_TOTAL) {
-        // If we've got here, we can safely say we were successfully parsed :) We need to
-        // call the isSucccessfullyParsed function to output the correct TEST COMPLETE
-        // footer message.
-        successfullyParsed = true;
-        isSuccessfullyParsed();
-        testRunner.notifyDone();
     }
 }
 
@@ -93,7 +84,7 @@ function verifyTouch(which) {
     }
 }
 
-function multiTouchSequence()
+async function multiTouchSequence()
 {
     debug("multi touch sequence");
 
@@ -101,38 +92,40 @@ function multiTouchSequence()
     debug("Two touchpoints, 1 in the target, 1 on the body without a target");
     eventSender.addTouchPoint(10, 10);
     eventSender.addTouchPoint(200, 200)
-    eventSender.touchStart(); // Begin, Begin.
+    await eventSender.asyncTouchStart(); // Begin, Begin.
 
     debug("");
     debug("First touchpoint moved");
     eventSender.markAllTouchesAsStationary();
     eventSender.updateTouchPoint(0, 20, 30);
-    eventSender.touchMove(); // Moved, Stationary.
+    await eventSender.asyncTouchMove(); // Moved, Stationary.
 
     debug("");
     debug("Second touchpoint moved");
     eventSender.markAllTouchesAsStationary();
     eventSender.updateTouchPoint(1, 150, 150);
-    eventSender.touchMove(); // Stationary, Moved.
+    await eventSender.asyncTouchMove(); // Stationary, Moved.
 
     debug("");
     debug("First touchpoint is released");
     eventSender.markAllTouchesAsStationary();
     eventSender.releaseTouchPoint(0);
-    eventSender.touchEnd(); // Ended, Stationary.
+    await eventSender.asyncTouchEnd(); // Ended, Stationary.
 }
 
-if (window.eventSender) {
-    description("This tests multi touch event support where one of the touches has no touch event handler.");
+description("This tests multi touch event support where one of the touches has no touch event handler.");
+window.jsTestIsAsync = true;
 
-    lastEvent = null;
-    eventSender.clearTouchPoints();
-    multiTouchSequence();
-} else {
-    debug("This test requires DumpRenderTree.")
+onload = async () => {
+    if (window.eventSender) {
+        lastEvent = null;
+        eventSender.clearTouchPoints();
+        await multiTouchSequence();
+    } else {
+        debug("This test requires DumpRenderTree.")
+    }
+    finishJSTest();
 }
-
-var successfullyParsed = true;
 </script>
 </body>
 </html>

--- a/LayoutTests/fast/events/touch/ontouchstart-active-selector.html
+++ b/LayoutTests/fast/events/touch/ontouchstart-active-selector.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-<script src="../../../resources/js-test-pre.js"></script>
+<script src="../../../resources/js-test.js"></script>
 <style>
     #touchMe {
         background-color: blue;
@@ -18,32 +18,34 @@
 <body>
 <div id="touchMe" ontouchstart=""></div>
 <script>
-
 description("This tests the :active selector on touchable elements");
+window.jsTestIsAsync = true;
 
-if (!window.eventSender)
-    debug("This test will FAIL outside of DRT, but you can test it manually by touching the blue square below. If it turns red when touched, the test is a PASS.");
+async function runTest() {
+    touchMe = document.getElementById("touchMe");
 
-touchMe = document.getElementById("touchMe");
+    shouldBe("getComputedStyle(touchMe).backgroundColor", "'rgb(0, 0, 255)'");
 
-shouldBe("getComputedStyle(touchMe).backgroundColor", "'rgb(0, 0, 255)'");
+    if (window.eventSender) {
+        eventSender.clearTouchPoints();
+        eventSender.addTouchPoint(touchMe.offsetLeft + 10, touchMe.offsetTop + 10);
+        await eventSender.asyncTouchStart();
+    }
 
-if (window.eventSender) {
-    eventSender.clearTouchPoints();
-    eventSender.addTouchPoint(touchMe.offsetLeft + 10, touchMe.offsetTop + 10);
-    eventSender.touchStart();
+    shouldBe("getComputedStyle(touchMe).backgroundColor", "'rgb(255, 0, 0)'");
+
+    if (window.eventSender) {
+        eventSender.clearTouchPoints();
+        await eventSender.asyncTouchEnd();
+    }
+
+    shouldBe("getComputedStyle(touchMe).backgroundColor", "'rgb(0, 0, 255)'");
 }
 
-shouldBe("getComputedStyle(touchMe).backgroundColor", "'rgb(255, 0, 0)'");
-
-if (window.eventSender) {
-    eventSender.clearTouchPoints();
-    eventSender.touchEnd();
-}
-
-shouldBe("getComputedStyle(touchMe).backgroundColor", "'rgb(0, 0, 255)'");
-
-</script>    
-<script src="../../../resources/js-test-post.js"></script>
+onload = async () => {
+    await runTest();
+    finishJSTest();
+};
+</script>
 </body>
 </html>

--- a/LayoutTests/fast/events/touch/resources/misc-touch-helpers.js
+++ b/LayoutTests/fast/events/touch/resources/misc-touch-helpers.js
@@ -1,16 +1,16 @@
-function tap(x, y) {
+async function tap(x, y) {
     if (!window.eventSender)
         return;
 
     eventSender.addTouchPoint(x, y);
-    eventSender.touchStart();
+    await eventSender.asyncTouchStart();
     eventSender.releaseTouchPoint(0);
-    eventSender.touchEnd();
+    await eventSender.asyncTouchEnd();
 }
 
 function tapSoon(x, y) {
-    setTimeout(function () {
-        tap(x, y);
+    setTimeout(async function () {
+        await tap(x, y);
     }, 10);
 }
 

--- a/LayoutTests/fast/events/touch/resources/send-touch-up.html
+++ b/LayoutTests/fast/events/touch/resources/send-touch-up.html
@@ -14,15 +14,15 @@ function doGC()
         var s = new String("");
 }
 
-function sendTouchUp()
+async function sendTouchUp()
 {
     doGC();
     // This touchend will cause a crash if the bug is present.
     eventSender.releaseTouchPoint(0);
-    eventSender.touchEnd();
+    await eventSender.asyncTouchEnd();
     // This touchstart will finish the test when we don't crash.
     eventSender.addTouchPoint(10,10);
-    eventSender.touchStart();
+    await eventSender.asyncTouchStart();
 }
 
 function finishTest(e)

--- a/LayoutTests/fast/events/touch/resources/touch-stale-node-crash.js
+++ b/LayoutTests/fast/events/touch/resources/touch-stale-node-crash.js
@@ -12,9 +12,11 @@ description("If this test does not crash then you pass!");
 if (window.testRunner)
     testRunner.waitUntilDone();
 
-if (window.eventSender) {
-    eventSender.clearTouchPoints();
-    eventSender.addTouchPoint(50, 150);
-    eventSender.touchStart();
-} else
-    debug('This test requires DRT.');
+onload = async () => {
+    if (window.eventSender) {
+        eventSender.clearTouchPoints();
+        eventSender.addTouchPoint(50, 150);
+        await eventSender.asyncTouchStart();
+    } else
+        debug('This test requires DRT.');
+}

--- a/LayoutTests/fast/events/touch/send-oncancel-event.html
+++ b/LayoutTests/fast/events/touch/send-oncancel-event.html
@@ -32,13 +32,13 @@ function touchcancelHandler() {
 }
     
 
-window.onload = function() {
+window.onload = async function() {
     if (window.eventSender) {
         document.addEventListener("touchcancel", touchcancelHandler, false);
         eventSender.addTouchPoint(touchX, touchY);
-        eventSender.touchStart();
+        await eventSender.asyncTouchStart();
         eventSender.cancelTouchPoint(0);
-        eventSender.touchCancel();
+        await eventSender.asyncTouchCancel();
     } else
         debug("This test requires DumpRenderTree.");
 }

--- a/LayoutTests/fast/events/touch/tap-highlight-color.html
+++ b/LayoutTests/fast/events/touch/tap-highlight-color.html
@@ -46,25 +46,26 @@ div.addEventListener("touchstart", onTouchStart, false);
 div.addEventListener("touchend", onTouchEnd, false);
 document.body.insertBefore(div, document.body.firstChild);
 
-function touchTargets()
+async function touchTargets()
 {
     eventSender.clearTouchPoints();
     eventSender.addTouchPoint(20, 20);
-    eventSender.touchStart();
+    await eventSender.asyncTouchStart();
     eventSender.updateTouchPoint(0, 50, 50);
-    eventSender.touchMove();
+    await eventSender.asyncTouchMove();
     eventSender.releaseTouchPoint(0);
-    eventSender.touchEnd();
+    await eventSender.asyncTouchEnd();
 }
 
+description("Check tap highlight color in touch event");
+window.jsTestIsAsync = true;
 
-if (window.eventSender && eventSender.clearTouchPoints) {
-    description("Check tap highlight color in touch event");
-    window.jsTestIsAsync = true;
-
-    touchTargets();
-} else {
-    debug("This test requires DumpRenderTree && WebKit built with ENABLE(TOUCH_EVENT).")
+onload = async () => {
+    if (window.eventSender && eventSender.clearTouchPoints) {
+        await touchTargets();
+    } else {
+        debug("This test requires DumpRenderTree && WebKit built with ENABLE(TOUCH_EVENT).")
+    }
 }
 </script>
 </body>

--- a/LayoutTests/fast/events/touch/touch-active-state.html
+++ b/LayoutTests/fast/events/touch/touch-active-state.html
@@ -27,12 +27,12 @@ function testComplete(event)
     finishJSTest();
 }
 
-function runTest()
+async function runTest()
 {
     if (window.eventSender) {
         // Touch the center of the div.
         eventSender.addTouchPoint(50, 50);
-        eventSender.touchStart();
+        await eventSender.asyncTouchStart();
     } else
         debug('This test requires DRT.');
 }

--- a/LayoutTests/fast/events/touch/touch-before-pressing-spin-button.html
+++ b/LayoutTests/fast/events/touch/touch-before-pressing-spin-button.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-<script src="../../../resources/js-test-pre.js"></script>
+<script src="../../../resources/js-test.js"></script>
 <style type="text/css">
 #box {
     background-color:blue;
@@ -15,19 +15,28 @@
 <div><input type="number" id="number" value="1"></div>
 <script>
 description('Test if a spin-button works correctly after touch events.');
-if (window.eventSender) {
-    eventSender.addTouchPoint(50, 50);
-    eventSender.touchStart();
+window.jsTestIsAsync = true;
 
-    var numberInput = document.getElementById('number');
-    eventSender.mouseMoveTo(numberInput.offsetLeft + numberInput.offsetWidth - 10, numberInput.offsetTop + numberInput.offsetHeight / 4);
-    eventSender.mouseDown();
-    eventSender.mouseUp();
-    shouldBe('numberInput.value', '"2"');
-} else {
-    debug('Needs eventSender.');
+var numberInput = document.getElementById('number');
+
+async function runTest() {
+    if (window.eventSender) {
+        eventSender.addTouchPoint(50, 50);
+        await eventSender.asyncTouchStart();
+
+        eventSender.mouseMoveTo(numberInput.offsetLeft + numberInput.offsetWidth - 10, numberInput.offsetTop + numberInput.offsetHeight / 4);
+        eventSender.mouseDown();
+        eventSender.mouseUp();
+        shouldBe('numberInput.value', '"2"');
+    } else {
+        debug('Needs eventSender.');
+    }
 }
+
+onload = async () => {
+    await runTest();
+    finishJSTest();
+};
 </script>
-<script src="../../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/fast/events/touch/touch-event-frames.html
+++ b/LayoutTests/fast/events/touch/touch-event-frames.html
@@ -106,29 +106,29 @@ function verifyTouch(which) {
     }
 }
 
-function sendTouchSequence()
+async function sendTouchSequence()
 {
     eventSender.mouseMoveTo(22, 25);
     eventSender.mouseDown();
     eventSender.mouseUp();
 
     eventSender.addTouchPoint(22, 25);
-    eventSender.touchStart();
+    await eventSender.asyncTouchStart();
 
     eventSender.releaseTouchPoint(0);
-    eventSender.touchEnd();
+    await eventSender.asyncTouchEnd();
 }
 
+description("This tests pageX and pageY coordinates on touch events and touches.");
+window.jsTestIsAsync = true;
 
-if (window.eventSender) {
-    description("This tests pageX and pageY coordinates on touch events and touches.");
-    window.jsTestIsAsync = true;
-
-    lastEvent = null;
-    sendTouchSequence();
-
-} else {
-    debug("This test requires DumpRenderTree.  Tap on the blue rect to log.")
+onload = async () => {
+    if (window.eventSender) {
+        lastEvent = null;
+        await sendTouchSequence();
+    } else {
+        debug("This test requires DumpRenderTree.  Tap on the blue rect to log.")
+    }
 }
 
 

--- a/LayoutTests/fast/events/touch/touch-event-pageXY.html
+++ b/LayoutTests/fast/events/touch/touch-event-pageXY.html
@@ -101,34 +101,34 @@ function verifyTouch(which) {
     }
 }
 
-function sendTouchSequence()
+async function sendTouchSequence()
 {
     eventSender.addTouchPoint(8, 12);
-    eventSender.touchStart();
+    await eventSender.asyncTouchStart();
 
     debug('move');
     eventSender.updateTouchPoint(0, 10, 15);
-    eventSender.touchMove();
+    await eventSender.asyncTouchMove();
 
     debug('add second touch');
     eventSender.addTouchPoint(40, 45);
-    eventSender.touchStart();
+    await eventSender.asyncTouchStart();
 
     debug('end');
     eventSender.releaseTouchPoint(0);
-    eventSender.touchEnd();
+    await eventSender.asyncTouchEnd();
 }
 
+description("This tests pageX and pageY coordinates on touch events and touches.");
+window.jsTestIsAsync = true;
 
-if (window.eventSender) {
-    description("This tests pageX and pageY coordinates on touch events and touches.");
-    window.jsTestIsAsync = true;
-
-    lastEvent = null;
-    sendTouchSequence();
-
-} else {
-    debug("This test requires DumpRenderTree.  Tap on the blue rect to log.")
+onload = async () => {
+    if (window.eventSender) {
+        lastEvent = null;
+        await sendTouchSequence();
+    } else {
+        debug("This test requires DumpRenderTree.  Tap on the blue rect to log.")
+    }
 }
 
 

--- a/LayoutTests/fast/events/touch/touch-inside-iframe-scrolled.html
+++ b/LayoutTests/fast/events/touch/touch-inside-iframe-scrolled.html
@@ -28,13 +28,13 @@ document.addEventListener('touchstart', function(event) {
   parent.testComplete(false, event);
 }, false);
 
-function runTest() {
+async function runTest() {
     if (window.eventSender) {
         // Touch the center of the div in the iframe.
         // 100px is offset to iframe in main frame,
         // 2px for the iframe border, 50px to get to centre of the div.
         eventSender.addTouchPoint(152, 152);
-        eventSender.touchStart();
+        await eventSender.asyncTouchStart();
     } else {
        debug('This test requires DRT.');
     }

--- a/LayoutTests/fast/events/touch/touch-inside-iframe.html
+++ b/LayoutTests/fast/events/touch/touch-inside-iframe.html
@@ -18,13 +18,13 @@ function testComplete(event)
     finishJSTest();
 }
 
-function runTest() {
+async function runTest() {
     if (window.eventSender) {
         // Touch the center of the div in the iframe.
         // 100px is offset to iframe in main frame,
         // 2px for the iframe border, 50px to get to centre of the div.
         eventSender.addTouchPoint(152, 152);
-        eventSender.touchStart();
+        await eventSender.asyncTouchStart();
     } else {
        debug('This test requires DRT.');
     }

--- a/LayoutTests/fast/events/touch/touch-scaled-scrolled.html
+++ b/LayoutTests/fast/events/touch/touch-scaled-scrolled.html
@@ -23,7 +23,7 @@ async function runTest() {
     if (window.eventSender) {
         eventSender.clearTouchPoints();
         eventSender.addTouchPoint(30, 70);
-        eventSender.touchStart();
+        await eventSender.asyncTouchStart();
     } else
         debug("This test requires DumpRenderTree.");
 }

--- a/LayoutTests/fast/events/touch/touch-target-limited.html
+++ b/LayoutTests/fast/events/touch/touch-target-limited.html
@@ -93,33 +93,39 @@ description("Tests that the target of touches match the element where the event 
 window.jsTestIsAsync = true;
 
 
-if (window.eventSender) {
-    eventSender.clearTouchPoints();
-    eventSender.addTouchPoint(50, 150);
-    eventSender.addTouchPoint(50, 250);
-    eventSender.touchStart();
+async function runTest() {
+    if (window.eventSender) {
+        eventSender.clearTouchPoints();
+        eventSender.addTouchPoint(50, 150);
+        eventSender.addTouchPoint(50, 250);
+        await eventSender.asyncTouchStart();
 
-    eventSender.updateTouchPoint(0, 50, 250);
-    eventSender.updateTouchPoint(1, 50, 150);
-    eventSender.touchMove();
+        eventSender.updateTouchPoint(0, 50, 250);
+        eventSender.updateTouchPoint(1, 50, 150);
+        await eventSender.asyncTouchMove();
 
-    eventSender.updateTouchPoint(0, 1000, 1000);
-    eventSender.updateTouchPoint(1, 1000, 1000);
-    eventSender.touchMove();
+        eventSender.updateTouchPoint(0, 1000, 1000);
+        eventSender.updateTouchPoint(1, 1000, 1000);
+        await eventSender.asyncTouchMove();
 
-    eventSender.releaseTouchPoint(0);
-    eventSender.releaseTouchPoint(1);
-    eventSender.touchEnd();
+        eventSender.releaseTouchPoint(0);
+        eventSender.releaseTouchPoint(1);
+        await eventSender.asyncTouchEnd();
 
-    eventSender.addTouchPoint(50, 250);
-    eventSender.addTouchPoint(50, 150);
-    eventSender.touchStart();
+        eventSender.addTouchPoint(50, 250);
+        eventSender.addTouchPoint(50, 150);
+        await eventSender.asyncTouchStart();
 
-    eventSender.updateTouchPoint(0, 500, 500);
-    eventSender.updateTouchPoint(1, 500, 500);
-    eventSender.touchMove();
-} else
-    debug('This test requires DRT.');
+        eventSender.updateTouchPoint(0, 500, 500);
+        eventSender.updateTouchPoint(1, 500, 500);
+        await eventSender.asyncTouchMove();
+    } else
+        debug('This test requires DRT.');
+}
+
+onload = async () => {
+    await runTest();
+}
 
 </script>
 </body>

--- a/LayoutTests/fast/events/touch/touch-target.html
+++ b/LayoutTests/fast/events/touch/touch-target.html
@@ -54,8 +54,6 @@ function declareTouchStart()
     }
 }
 
-var totalTouchMoveCount = 0;
-
 function declareTouchMove(div_id)
 {
     var touchMoveCount = 0;
@@ -75,11 +73,6 @@ function declareTouchMove(div_id)
         }
         shouldBe('event.targetTouches.length', '1');
         ++touchMoveCount;
-
-        if (++totalTouchMoveCount == 6)
-        {
-            finishJSTest();
-        }
     }
 }
 
@@ -92,33 +85,39 @@ div2.addEventListener("touchmove", declareTouchMove(), false);
 description("Tests that the target of touches match the element where the event originated, not where the touch is currently occurring.");
 window.jsTestIsAsync = true;
 
+async function runTest() {
+    if (window.eventSender) {
+        eventSender.clearTouchPoints();
+        eventSender.addTouchPoint(50, 150);
+        eventSender.addTouchPoint(50, 250);
+        await eventSender.asyncTouchStart();
 
-if (window.eventSender) {
-    eventSender.clearTouchPoints();
-    eventSender.addTouchPoint(50, 150);
-    eventSender.addTouchPoint(50, 250);
-    eventSender.touchStart();
+        eventSender.updateTouchPoint(0, 50, 250);
+        eventSender.updateTouchPoint(1, 50, 150);
+        await eventSender.asyncTouchMove();
 
-    eventSender.updateTouchPoint(0, 50, 250);
-    eventSender.updateTouchPoint(1, 50, 150);
-    eventSender.touchMove();
+        eventSender.updateTouchPoint(0, 1000, 1000);
+        eventSender.updateTouchPoint(1, 1000, 1000);
+        await eventSender.asyncTouchMove();
 
-    eventSender.updateTouchPoint(0, 1000, 1000);
-    eventSender.updateTouchPoint(1, 1000, 1000);
-    eventSender.touchMove();
+        eventSender.releaseTouchPoint(0);
+        await eventSender.asyncTouchEnd();
 
-    eventSender.releaseTouchPoint(0);
-    eventSender.touchEnd();
+        eventSender.addTouchPoint(50,150);
+        await eventSender.asyncTouchStart();
 
-    eventSender.addTouchPoint(50,150);
-    eventSender.touchStart();
+        eventSender.updateTouchPoint(0, 500, 500);
+        eventSender.updateTouchPoint(1, 500, 500);
+        await eventSender.asyncTouchMove();
 
-    eventSender.updateTouchPoint(0, 500, 500);
-    eventSender.updateTouchPoint(1, 500, 500);
-    eventSender.touchMove();
-} else
-    debug('This test requires DRT.');
+    } else
+        debug('This test requires DRT.');
+}
 
+onload = async () => {
+    await runTest();
+    finishJSTest();
+}
 </script>
 </body>
 </html>

--- a/LayoutTests/fast/events/touch/zoomed-touch-event-pageXY.html
+++ b/LayoutTests/fast/events/touch/zoomed-touch-event-pageXY.html
@@ -31,14 +31,6 @@ function touchEventCallback() {
     } else {
         debug(event.type);
     }
-
-    if (window.testRunner && touchEventsReceived == EXPECTED_TOUCH_EVENTS_TOTAL) {
-        // If we've got here, we can safely say we were successfully parsed :) We need to
-        // call the isSucccessfullyParsed function to output the correct TEST COMPLETE
-        // footer message.
-        successfullyParsed = true;
-        finishJSTest();
-    }
 }
 
 div.addEventListener("touchstart", touchEventCallback, false);
@@ -102,37 +94,39 @@ function verifyTouch(which) {
     }
 }
 
-function sendTouchSequence()
+async function sendTouchSequence()
 {
     eventSender.addTouchPoint(8*2, 12*2);
-    eventSender.touchStart();
+    await eventSender.asyncTouchStart();
 
     debug('move');
     eventSender.updateTouchPoint(0, 10*2, 15*2);
-    eventSender.touchMove();
+    await eventSender.asyncTouchMove();
 
     debug('add second touch');
     eventSender.addTouchPoint(40*2, 45*2);
-    eventSender.touchStart();
+    await eventSender.asyncTouchStart();
 
     debug('end');
     eventSender.releaseTouchPoint(0);
-    eventSender.touchEnd();
+    await eventSender.asyncTouchEnd();
+
+    finishJSTest();
 }
 
+description("This tests pageX and pageY coordinates on touch events and touches when zoomed to 2x scale.");
+window.jsTestIsAsync = true;
 
-if (window.eventSender) {
-    description("This tests pageX and pageY coordinates on touch events and touches when zoomed to 2x scale.");
-    window.jsTestIsAsync = true;
-
-    // Give some time for the viewport scale to set in.
-    setTimeout(function() {
-        lastEvent = null;
-        sendTouchSequence();
-    }, 100);
-
-} else {
-    debug("This test requires DumpRenderTree.  Tap on the blue rect to log.")
+onload = () => {
+    if (window.eventSender) {
+        // Give some time for the viewport scale to set in.
+        setTimeout(async function() {
+            lastEvent = null;
+            await sendTouchSequence();
+        }, 100);
+    } else {
+        debug("This test requires DumpRenderTree.  Tap on the blue rect to log.")
+    }
 }
 </script>
 </body>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -4616,7 +4616,7 @@ webkit.org/b/278719 fast/events/touch/gesture/touch-gesture-scroll-iframe-editab
 webkit.org/b/278719 fast/events/touch/gesture/touch-gesture-scroll-page-not-propagated.html [ Failure ]
 webkit.org/b/278719 fast/events/touch/gesture/touch-gesture-scroll-page-propagated.html [ Failure ]
 webkit.org/b/278719 fast/events/touch/gesture/touch-gesture-scroll-sideways.html [ Failure ]
-webkit.org/b/278719 fast/events/touch/multi-touch-some-without-handlers.html [ Failure ]
+webkit.org/b/278719 fast/events/touch/multi-touch-some-without-handlers.html [ Timeout ]
 webkit.org/b/278719 fast/events/touch/ontouchstart-active-selector.html [ Failure ]
 webkit.org/b/278719 fast/events/touch/page-scaled-touch-gesture-click.html [ Timeout ]
 webkit.org/b/278719 fast/events/touch/scroll-without-mouse-lacks-mousemove-events.html [ Failure ]

--- a/LayoutTests/platform/wpe/TestExpectations
+++ b/LayoutTests/platform/wpe/TestExpectations
@@ -887,7 +887,6 @@ fast/events/mouse-cursor-pseudo-elements.html [ Failure Pass ]
 
 webkit.org/b/278719 fast/events/touch/touch-event-frames.html [ Failure ]
 webkit.org/b/278719 fast/events/touch/frame-hover-update.html [ Failure ]
-webkit.org/b/278719 fast/events/touch/multi-touch-some-without-handlers.html [ Failure ]
 webkit.org/b/278719 fast/events/touch/ontouchstart-active-selector.html [ Failure  ]
 webkit.org/b/278719 fast/events/touch/send-oncancel-event.html [ Pass ]
 webkit.org/b/278719 fast/events/touch/touch-event-pageXY.html [ Failure ]


### PR DESCRIPTION
#### 5ca0a73ea682c8afaa5bfedbc4ba00fd845c1c52
<pre>
Rewrite touch event layout tests with EventSender asyncTouch* methods
<a href="https://bugs.webkit.org/show_bug.cgi?id=319874">https://bugs.webkit.org/show_bug.cgi?id=319874</a>

Reviewed by Carlos Alberto Lopez Perez.

317140@main added EventSender.asyncTouch* methods. Rewrote all remaining touch
event layout tests with them.

* LayoutTests/fast/events/touch/basic-multi-touch-events-limited.html:
* LayoutTests/fast/events/touch/basic-multi-touch-events.html:
* LayoutTests/fast/events/touch/basic-single-touch-events.html:
* LayoutTests/fast/events/touch/frame-hover-update.html:
* LayoutTests/fast/events/touch/gesture/gesture-tap-active-state.html:
* LayoutTests/fast/events/touch/input-touch-target.html:
* LayoutTests/fast/events/touch/multi-touch-grouped-targets.html:
* LayoutTests/fast/events/touch/multi-touch-inside-nested-iframes.html:
* LayoutTests/fast/events/touch/multi-touch-some-without-handlers.html:
* LayoutTests/fast/events/touch/ontouchstart-active-selector.html:
* LayoutTests/fast/events/touch/resources/misc-touch-helpers.js:
* LayoutTests/fast/events/touch/send-oncancel-event.html:
* LayoutTests/fast/events/touch/tap-highlight-color.html:
* LayoutTests/fast/events/touch/touch-active-state.html:
* LayoutTests/fast/events/touch/touch-before-pressing-spin-button.html:
* LayoutTests/fast/events/touch/touch-event-frames.html:
* LayoutTests/fast/events/touch/touch-event-pageXY.html:
* LayoutTests/fast/events/touch/touch-inside-iframe-scrolled.html:
* LayoutTests/fast/events/touch/touch-inside-iframe.html:
* LayoutTests/fast/events/touch/touch-scaled-scrolled.html:
* LayoutTests/fast/events/touch/touch-target-limited.html:
* LayoutTests/fast/events/touch/touch-target.html:
* LayoutTests/fast/events/touch/zoomed-touch-event-pageXY.html:
* LayoutTests/fast/events/touch/resources/send-touch-up.html:
* LayoutTests/fast/events/touch/resources/touch-stale-node-crash.js:
* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/wpe/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/318371@main">https://commits.webkit.org/318371@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0980bce8657acf0fe53f6a6a3833dde1f742fbaa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178077 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52015 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45810 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187690 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/141324 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53309 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51724 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138808 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/141324 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181034 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42357 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159565 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119264 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41023 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39375 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151423 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39063 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36148 "Built successfully") | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43618 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190117 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51683 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/159091 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147955 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52365 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35688 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147727 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27011 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42438 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119102 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50883 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14035 "") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50268 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50508 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50330 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->