### PR TITLE
[Loading] Enforce CORS for app custom schemes using document provenance

### DIFF
--- a/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h
+++ b/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h
@@ -147,6 +147,7 @@ enum class SDKAlignedBehavior {
     ScrollPocketInFullscreen,
     IgnorePageLocationDuringHardPocketEligibilityCheck,
     AdjustColorExtensionsForHorizontalBannerViewOverlays,
+    CustomSchemeCORSEnforcement,
 
     NumberOfBehaviors
 };

--- a/Source/WebCore/loader/DocumentThreadableLoader.cpp
+++ b/Source/WebCore/loader/DocumentThreadableLoader.cpp
@@ -673,7 +673,7 @@ void DocumentThreadableLoader::loadRequest(ResourceRequest&& request, SecurityCh
         return;
     }
 
-    if (!shouldPerformSecurityChecks()) {
+    if (!shouldPerformSecurityChecks() || LegacySchemeRegistry::schemeIsHandledBySchemeHandler(requestURL.protocol())) {
         // FIXME: FrameLoader::loadSynchronously() does not tell us whether a redirect happened or not, so we guess by comparing the
         // request and response URLs. This isn't a perfect test though, since a server can serve a redirect to the same URL that was
         // requested. Also comparing the request and response URLs as strings will fail if the requestURL still has its credentials.

--- a/Source/WebCore/loader/cache/CachedResourceLoader.cpp
+++ b/Source/WebCore/loader/cache/CachedResourceLoader.cpp
@@ -103,6 +103,10 @@
 #include "CachedApplicationManifest.h"
 #endif
 
+#if PLATFORM(COCOA)
+#include <wtf/cocoa/RuntimeApplicationChecksCocoa.h>
+#endif
+
 #if PLATFORM(IOS_FAMILY)
 #import <pal/system/ios/Device.h>
 #endif
@@ -611,6 +615,12 @@ bool CachedResourceLoader::canRequest(CachedResource::Type type, const URL& url,
             return false;
         }
 
+        if (isNoCorsCrossOriginRequestToURLSchemeHandler(type, url, options)) {
+            CACHEDRESOURCELOADER_RELEASE_LOG("canRequest: cross-origin no-cors subresource load to URL scheme handler is not allowed");
+            printAccessDeniedMessage(url);
+            return false;
+        }
+
         bool shouldReportViolationAsConsoleMessage = forPreload == ForPreload::No || isLinkPreload;
         if (!allowedByContentSecurityPolicy(type, url, options, ContentSecurityPolicy::RedirectResponseReceived::No, { }, shouldReportViolationAsConsoleMessage))
             return false;
@@ -653,6 +663,12 @@ bool CachedResourceLoader::canRequestAfterRedirection(CachedResource::Type type,
 
         if (options.mode == FetchOptions::Mode::SameOrigin && !protect(document->securityOrigin())->canRequest(url, OriginAccessPatternsForWebProcess::singleton())) {
             CACHEDRESOURCELOADER_RELEASE_LOG("canRequestAfterRedirection: URL was not allowed by SecurityOrigin::canRequest");
+            printAccessDeniedMessage(url);
+            return false;
+        }
+
+        if (isNoCorsCrossOriginRequestToURLSchemeHandler(type, url, options)) {
+            CACHEDRESOURCELOADER_RELEASE_LOG("canRequestAfterRedirection: cross-origin no-cors redirect to URL scheme handler is not allowed");
             printAccessDeniedMessage(url);
             return false;
         }
@@ -865,6 +881,64 @@ bool CachedResourceLoader::canRequestInContentDispositionAttachmentSandbox(Cache
     auto message = makeString("Unsafe attempt to load URL "_s, url.stringCenterEllipsizedToLength(), " from document with Content-Disposition: attachment at URL "_s, document->url().stringCenterEllipsizedToLength(), '.');
     document->addConsoleMessage(MessageSource::Security, MessageLevel::Error, message);
     return false;
+}
+
+bool CachedResourceLoader::isNoCorsCrossOriginRequestToURLSchemeHandler(CachedResource::Type type, const URL& url, const ResourceLoaderOptions& options) const
+{
+    RefPtr document = m_document;
+    if (!document)
+        return false;
+
+#if PLATFORM(COCOA)
+    // Compatibility safety net layered on top of the provenance checks below: apps linked before this
+    // enforcement shipped keep the historical permissive behavior.
+    if (!linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior::CustomSchemeCORSEnforcement))
+        return false;
+#endif
+
+    if (type == CachedResource::Type::MainResource)
+        return false;
+
+    if (options.mode != FetchOptions::Mode::NoCors)
+        return false;
+
+    auto protocol = url.protocol();
+    if (!LegacySchemeRegistry::schemeIsHandledBySchemeHandler(protocol))
+        return false;
+
+    // http(s) URLs handled by a WKURLSchemeHandler follow the regular web fetch rules, not this block.
+    if (url.protocolIsInHTTPFamily())
+        return false;
+
+    if (LegacySchemeRegistry::isBuiltInWebKitHandledScheme(protocol))
+        return false;
+
+    // An app controls all loading within its own custom scheme, even across hosts, so only a differing
+    // scheme is subject to this block.
+    Ref origin = document->securityOrigin();
+    auto originProtocol = origin->protocol();
+    if (equalIgnoringASCIICase(originProtocol, protocol))
+        return false;
+
+    // App-controlled content is exempt: a substitute-data document (loadData:/loadHTMLString:, including with
+    // an http(s) baseURL), a file: origin, an app-registered custom scheme, or an opaque origin (loadData:
+    // without a baseURL, or a data: subframe of app content). The frame-tree check below scopes opaque frames
+    // to app-content trees; http(s) is never a scheme handler, so network content only qualifies via substitute data.
+    bool originIsAppProvidedScheme = LegacySchemeRegistry::schemeIsHandledBySchemeHandler(originProtocol)
+        && !LegacySchemeRegistry::isBuiltInWebKitHandledScheme(originProtocol);
+    bool isSubstituteDataDocument = document->loader() && document->loader()->substituteData().isValid();
+    if (origin->isOpaque() || originProtocol == "file"_s || originIsAppProvidedScheme || isSubstituteDataDocument) {
+        if (RefPtr frame = document->frame()) {
+            if (!frame->tree().parent() && !frame->opener() && document->sandboxFlags().isEmpty())
+                return false;
+
+            Ref topFrame = frame->tree().top();
+            if (equalIgnoringASCIICase(topFrame->frameURLProtocol(), protocol))
+                return false;
+        }
+    }
+
+    return !origin->canRequest(url, OriginAccessPatternsForWebProcess::singleton());
 }
 
 bool CachedResourceLoader::shouldContinueAfterNotifyingLoadedFromMemoryCache(const CachedResourceRequest& request, CachedResource& resource, ResourceError& error)

--- a/Source/WebCore/loader/cache/CachedResourceLoader.h
+++ b/Source/WebCore/loader/cache/CachedResourceLoader.h
@@ -213,6 +213,7 @@ private:
 
     bool canRequestAfterRedirection(CachedResource::Type, const URL&, const ResourceLoaderOptions&, const URL& preRedirectURL) const;
     bool canRequestInContentDispositionAttachmentSandbox(CachedResource::Type, const URL&) const;
+    bool isNoCorsCrossOriginRequestToURLSchemeHandler(CachedResource::Type, const URL&, const ResourceLoaderOptions&) const;
 
     MemoryCompactRobinHoodHashSet<URL> m_validatedURLs;
     MemoryCompactRobinHoodHashSet<URL> m_cachedSVGImagesURLs;

--- a/Source/WebCore/platform/LegacySchemeRegistry.cpp
+++ b/Source/WebCore/platform/LegacySchemeRegistry.cpp
@@ -261,6 +261,13 @@ bool LegacySchemeRegistry::schemeIsHandledBySchemeHandler(StringView scheme)
     return schemesHandledBySchemeHandler().contains<StringViewHashTranslator>(scheme);
 }
 
+bool LegacySchemeRegistry::isBuiltInWebKitHandledScheme(StringView scheme)
+{
+    // These schemes are exempt from the generic cross-origin no-cors block applied to
+    // WKURLSchemeHandler supported schemes.
+    return scheme == "webkit-extension"_s;
+}
+
 static URLSchemesMap& NODELETE schemesAllowingDatabaseAccessInPrivateBrowsing()
 {
     ASSERT(isMainThread());
@@ -450,15 +457,16 @@ bool LegacySchemeRegistry::allowsDatabaseAccessInPrivateBrowsing(const String& s
     return !scheme.isNull() && schemesAllowingDatabaseAccessInPrivateBrowsing().contains(scheme);
 }
 
-void LegacySchemeRegistry::registerURLSchemeAsCORSEnabled(const String& scheme)
+LegacySchemeRegistry::SchemeRegisteredForTheFirstTime LegacySchemeRegistry::registerURLSchemeAsCORSEnabled(const String& scheme)
 {
     if (scheme == "about"_s)
-        return;
+        return SchemeRegisteredForTheFirstTime::No;
 
     ASSERT(!isInNetworkProcess());
     if (scheme.isNull())
-        return;
-    CORSEnabledSchemes().add(scheme);
+        return SchemeRegisteredForTheFirstTime::No;
+
+    return CORSEnabledSchemes().add(scheme).isNewEntry ? SchemeRegisteredForTheFirstTime::Yes : SchemeRegisteredForTheFirstTime::No;
 }
 
 bool LegacySchemeRegistry::shouldTreatURLSchemeAsCORSEnabled(StringView scheme)

--- a/Source/WebCore/platform/LegacySchemeRegistry.h
+++ b/Source/WebCore/platform/LegacySchemeRegistry.h
@@ -79,12 +79,14 @@ public:
     static bool allowsDatabaseAccessInPrivateBrowsing(const String& scheme);
 
     // Allow non-HTTP schemes to be registered to allow CORS requests.
-    WEBCORE_EXPORT static void registerURLSchemeAsCORSEnabled(const String& scheme);
+    enum class SchemeRegisteredForTheFirstTime : bool { No, Yes };
+    WEBCORE_EXPORT static SchemeRegisteredForTheFirstTime registerURLSchemeAsCORSEnabled(const String& scheme);
     WEBCORE_EXPORT static bool shouldTreatURLSchemeAsCORSEnabled(StringView scheme);
     WEBCORE_EXPORT static Vector<String> allURLSchemesRegisteredAsCORSEnabled();
 
     WEBCORE_EXPORT static void registerURLSchemeAsHandledBySchemeHandler(const String&);
     WEBCORE_EXPORT static bool schemeIsHandledBySchemeHandler(StringView);
+    WEBCORE_EXPORT static bool isBuiltInWebKitHandledScheme(StringView);
 
     // Allow resources from some schemes to load on a page, regardless of its
     // Content Security Policy.

--- a/Source/WebKit/NetworkProcess/NetworkProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.h
@@ -609,7 +609,6 @@ private:
 #if ENABLE(ALL_LEGACY_REGISTERED_SPECIAL_URL_SCHEMES)
     void registerURLSchemeAsNoAccess(const String&) const;
 #endif
-    void registerURLSchemeAsCORSEnabled(const String&) const;
 
 #if USE(RUNNINGBOARD)
     void setIsHoldingLockedFiles(bool);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -8837,8 +8837,10 @@ void WebPage::stopAllURLSchemeTasks()
 void WebPage::registerURLSchemeHandler(WebURLSchemeHandlerIdentifier handlerIdentifier, const String& scheme)
 {
     WEBPAGE_RELEASE_LOG(Process, "registerURLSchemeHandler: Registered handler %" PRIu64 " for the '%s' scheme", handlerIdentifier.toUInt64(), scheme.utf8().data());
+
     WebCore::LegacySchemeRegistry::registerURLSchemeAsHandledBySchemeHandler(scheme);
-    WebCore::LegacySchemeRegistry::registerURLSchemeAsCORSEnabled(scheme);
+    WebProcess::singleton().registerURLSchemeAsCORSEnabled(scheme);
+
     auto schemeResult = m_schemeToURLSchemeHandlerProxyMap.add(scheme, WebURLSchemeHandlerProxy::create(*this, handlerIdentifier));
     m_identifierToURLSchemeHandlerProxyMap.add(handlerIdentifier, Ref { schemeResult.iterator->value }.get());
 }

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -958,7 +958,8 @@ void WebProcess::registerURLSchemeAsDisplayIsolated(const String& urlScheme) con
 
 void WebProcess::registerURLSchemeAsCORSEnabled(const String& urlScheme)
 {
-    LegacySchemeRegistry::registerURLSchemeAsCORSEnabled(urlScheme);
+    if (LegacySchemeRegistry::registerURLSchemeAsCORSEnabled(urlScheme) == LegacySchemeRegistry::SchemeRegisteredForTheFirstTime::No)
+        return;
     ensureNetworkProcessConnection().connection().send(Messages::NetworkConnectionToWebProcess::RegisterURLSchemesAsCORSEnabled({ urlScheme }), 0);
 }
 

--- a/Source/WebKit/WebProcess/WebProcess.h
+++ b/Source/WebKit/WebProcess/WebProcess.h
@@ -553,6 +553,8 @@ public:
     void remoteAudioSessionConfigurationChanged(const RemoteAudioSessionConfiguration&);
 #endif
 
+    void registerURLSchemeAsCORSEnabled(const String&);
+
 private:
     WebProcess();
     ~WebProcess();
@@ -594,7 +596,6 @@ private:
     void registerURLSchemeAsNoAccess(const String&) const;
 #endif
     void registerURLSchemeAsDisplayIsolated(const String&) const;
-    void registerURLSchemeAsCORSEnabled(const String&);
     void registerURLSchemeAsAlwaysRevalidated(const String&) const;
     void registerURLSchemeAsCachePartitioned(const String&) const;
     void registerURLSchemeAsCanDisplayOnlyIfCanRequest(const String&) const;

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/CreateWebArchive.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/CreateWebArchive.mm
@@ -34,13 +34,8 @@
 #import "Helpers/cocoa/TestNavigationDelegate.h"
 #import "TestURLSchemeHandler.h"
 #import "Helpers/cocoa/TestWKWebView.h"
-#import <UniformTypeIdentifiers/UniformTypeIdentifiers.h>
 #import <WebKit/_WKArchiveConfiguration.h>
 #import <WebKit/_WKArchiveExclusionRule.h>
-
-#if PLATFORM(IOS_FAMILY)
-#import <MobileCoreServices/MobileCoreServices.h>
-#endif
 
 namespace TestWebKitAPI {
 
@@ -114,7 +109,7 @@ TEST(WebArchive, CreateCustomScheme)
     done = false;
 
     [webView performAfterReceivingMessage:@"done" action:[&] { done = true; }];
-    [webView loadData:archiveData.get() MIMEType:UTTypeArchive.identifier characterEncodingName:@"utf-8" baseURL:[NSURL URLWithString:@"about:blank"]];
+    [webView loadData:archiveData.get() MIMEType:@"application/x-webarchive" characterEncodingName:@"utf-8" baseURL:[NSURL URLWithString:@"about:blank"]];
 
     Util::run(&done);
     done = false;

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKURLSchemeHandler-1.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKURLSchemeHandler-1.mm
@@ -183,10 +183,10 @@ TEST(URLSchemeHandler, BasicWithHTTPS)
 {
     using namespace TestWebKitAPI;
 
-    done = false;
-
+    // Verify a custom scheme handler can serve a main resource that loads an HTTPS subresource
+    // through a configured HTTPS proxy.
     HTTPServer httpsServer({
-        { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, schemeHandlerMainBytes } },
+        { "/data.txt"_s, { { { "Content-Type"_s, "text/plain"_s } }, "ok"_s } },
     }, HTTPServer::Protocol::HttpsProxy);
 
     RetainPtr storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
@@ -198,24 +198,39 @@ TEST(URLSchemeHandler, BasicWithHTTPS)
     RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
     [configuration setWebsiteDataStore:dataStore.get()];
 
-    RetainPtr<SchemeHandler> handler = adoptNS([[SchemeHandler alloc] initWithData:schemeHandlerMainBytesData().get() mimeType:@"text/html"]);
-    [configuration setURLSchemeHandler:handler.get() forURLScheme:@"testing"];
+    RetainPtr startedURLs = adoptNS([[NSMutableArray alloc] init]);
+    RetainPtr schemeHandler = adoptNS([TestURLSchemeHandler new]);
+    [schemeHandler setStartURLSchemeTaskHandler:^(WKWebView *, id<WKURLSchemeTask> task) {
+        [startedURLs addObject:task.request.URL];
+        if (![task.request.URL.absoluteString isEqualToString:@"testing:main"])
+            return;
+        NSData *html = [@"<html><script>"
+            "fetch('https://site1.example/data.txt', { mode: 'no-cors' })"
+            ".then(() => window.webkit.messageHandlers.testHandler.postMessage('done'))"
+            ".catch(e => window.webkit.messageHandlers.testHandler.postMessage('error:' + e));"
+            "</script></html>" dataUsingEncoding:NSUTF8StringEncoding];
+        RetainPtr response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:@"text/html" expectedContentLength:html.length textEncodingName:nil]);
+        [task didReceiveResponse:response.get()];
+        [task didReceiveData:html];
+        [task didFinish];
+    }];
+    [configuration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"testing"];
 
     RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     [webView setNavigationDelegate:delegate.get()];
-
     delegate.get().didReceiveAuthenticationChallenge = ^(WKWebView *, NSURLAuthenticationChallenge *challenge, void (^completionHandler)(NSURLSessionAuthChallengeDisposition, NSURLCredential *)) {
         completionHandler(NSURLSessionAuthChallengeUseCredential, [NSURLCredential credentialForTrust:challenge.protectionSpace.serverTrust]);
     };
 
-    NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"https://site1.example/"]];
-    [webView loadRequest:request];
+    static bool done = false;
+    [webView performAfterReceivingMessage:@"done" action:[&] { done = true; }];
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"testing:main"]]];
     Util::run(&done);
 
-    EXPECT_EQ([handler.get().startedURLs count], 1u);
-    EXPECT_TRUE([[handler.get().startedURLs objectAtIndex:0] isEqual:[NSURL URLWithString:@"testing:image"]]);
-    EXPECT_EQ([handler.get().stoppedURLs count], 0u);
+    EXPECT_EQ([startedURLs count], 1u);
+    EXPECT_TRUE([[startedURLs objectAtIndex:0] isEqual:[NSURL URLWithString:@"testing:main"]]);
+    EXPECT_EQ(httpsServer.totalRequests(), 1u);
 }
 
 TEST(URLSchemeHandler, BasicWithAsyncPolicyDelegate)
@@ -1113,7 +1128,7 @@ TEST(URLSchemeHandler, DisableCORSCanvas)
         NSString *mimeType = nil;
         if ([task.request.URL.path isEqualToString:@"/main.html"]) {
             mimeType = @"text/html";
-            response = [@"<canvas id='canvas'></canvas><img src='cors://host2/image.png' onload='imageloaded()' id='img'></img><script>"
+            response = [@"<canvas id='canvas'></canvas><img src='cors://host2/image.png' onload='imageloaded()' onerror=\"fetch('corsfailure')\" id='img'></img><script>"
                 "function imageloaded() {"
                     "let canvas = document.getElementById('canvas');"
                     "let context = canvas.getContext('2d');"
@@ -1850,4 +1865,361 @@ TEST(URLSchemeHandler, Redirect301FromHTTPToHandledScheme)
 TEST(URLSchemeHandler, Redirect302FromHTTPToHandledScheme)
 {
     runRedirectToHandledSchemeTest(302);
+}
+
+static void respondForCrossOriginTest(id<WKURLSchemeTask> task)
+{
+    NSURL *url = task.request.URL;
+    NSString *mimeType = @"text/plain";
+    NSString *body = @"";
+
+    if ([url.path isEqualToString:@"/page.html"]) {
+        mimeType = @"text/html";
+        body = @"<!doctype html><html><head><script>"
+            "let results = {};"
+            "function report() {"
+            "if ('script' in results && 'fetch' in results)"
+            "alert('script=' + results.script + '|fetch=' + results.fetch);"
+            "}"
+            "window.addEventListener('load', () => {"
+            "const s = document.createElement('script');"
+            "s.src = '/config';"
+            "s.onload = () => { results.script = 'executed:' + (window.LEAKED_CONFIG || 'unset'); report(); };"
+            "s.onerror = () => { results.script = 'blocked'; report(); };"
+            "document.head.appendChild(s);"
+            "fetch('/data', { mode: 'no-cors' })"
+            ".then(() => { results.fetch = 'ok'; report(); })"
+            ".catch(() => { results.fetch = 'blocked'; report(); });"
+            "});"
+            "</script></head><body>page</body></html>";
+    } else if ([url.path isEqualToString:@"/config"]) {
+        mimeType = @"application/javascript";
+        body = @"window.LEAKED_CONFIG = 'secret-value';";
+    } else if ([url.path isEqualToString:@"/data"]) {
+        mimeType = @"application/json";
+        body = @"{\"secret\":\"secret-value\"}";
+    }
+
+    NSData *data = [body dataUsingEncoding:NSUTF8StringEncoding];
+    RetainPtr response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:url statusCode:200 HTTPVersion:@"HTTP/1.1" headerFields:@{ @"Content-Type": mimeType }]);
+    [task didReceiveResponse:response.get()];
+    [task didReceiveData:data];
+    [task didFinish];
+}
+
+// Same-scheme no-cors subresources: ALLOWED.
+TEST(URLSchemeHandler, SameSchemeSubresourcesAllowed)
+{
+    RetainPtr receivedPaths = adoptNS([[NSMutableArray alloc] init]);
+    RetainPtr schemeHandler = adoptNS([TestURLSchemeHandler new]);
+    [schemeHandler setStartURLSchemeTaskHandler:^(WKWebView *, id<WKURLSchemeTask> task) {
+        [receivedPaths addObject:task.request.URL.path];
+        respondForCrossOriginTest(task);
+    }];
+
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    [configuration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"myapp"];
+
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"myapp://host.test/page.html"]]];
+
+    EXPECT_WK_STREQ([webView _test_waitForAlert], "script=executed:secret-value|fetch=ok");
+    EXPECT_TRUE([receivedPaths containsObject:@"/config"]);
+    EXPECT_TRUE([receivedPaths containsObject:@"/data"]);
+}
+
+// Network http(s) page → app custom scheme via no-cors <script src> / fetch: BLOCKED.
+TEST(URLSchemeHandler, CrossOriginNoCorsSubresourcesBlocked)
+{
+    TestWebKitAPI::HTTPServer server({
+        { "/attack.html"_s, { { { "Content-Type"_s, "text/html"_s } },
+            "<!doctype html><html><head><script>"
+            "let results = {};"
+            "function report() {"
+            "if ('script' in results && 'fetch' in results)"
+            "alert('script=' + results.script + '|fetch=' + results.fetch);"
+            "}"
+            "window.addEventListener('load', () => {"
+            "const s = document.createElement('script');"
+            "s.src = 'myapp://host.test/config';"
+            "s.onload = () => { results.script = 'executed:' + (window.LEAKED_CONFIG || 'unset'); report(); };"
+            "s.onerror = () => { results.script = 'blocked'; report(); };"
+            "document.head.appendChild(s);"
+            "fetch('myapp://host.test/data', { mode: 'no-cors' })"
+            ".then(() => { results.fetch = 'ok'; report(); })"
+            ".catch(() => { results.fetch = 'blocked'; report(); });"
+            "});"
+            "</script></head><body>attack</body></html>"_s } }
+    });
+
+    RetainPtr receivedPaths = adoptNS([[NSMutableArray alloc] init]);
+    RetainPtr schemeHandler = adoptNS([TestURLSchemeHandler new]);
+    [schemeHandler setStartURLSchemeTaskHandler:^(WKWebView *, id<WKURLSchemeTask> task) {
+        [receivedPaths addObject:task.request.URL.path];
+        respondForCrossOriginTest(task);
+    }];
+
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    [configuration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"myapp"];
+
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    [webView loadRequest:server.request("/attack.html"_s)];
+
+    EXPECT_WK_STREQ([webView _test_waitForAlert], "script=blocked|fetch=blocked");
+    EXPECT_FALSE([receivedPaths containsObject:@"/config"]);
+    EXPECT_FALSE([receivedPaths containsObject:@"/data"]);
+}
+
+// file: (app-loaded) document → app custom scheme: ALLOWED.
+TEST(URLSchemeHandler, LoadFileURLNoCorsSubresourceAllowed)
+{
+    NSString *tempDir = [NSTemporaryDirectory() stringByAppendingPathComponent:@"WKURLSchemeHandlerLoadFileURLTest"];
+    [[NSFileManager defaultManager] removeItemAtPath:tempDir error:nil];
+    [[NSFileManager defaultManager] createDirectoryAtPath:tempDir withIntermediateDirectories:YES attributes:nil error:nil];
+
+    NSString *htmlPath = [tempDir stringByAppendingPathComponent:@"page.html"];
+    NSString *html = @"<!doctype html><html><head><script>"
+        "let results = {};"
+        "function report() {"
+        "if ('script' in results && 'fetch' in results)"
+        "alert('script=' + results.script + '|fetch=' + results.fetch);"
+        "}"
+        "window.addEventListener('load', () => {"
+        "const s = document.createElement('script');"
+        "s.src = 'myapp://host.test/config';"
+        "s.onload = () => { results.script = 'executed:' + (window.LEAKED_CONFIG || 'unset'); report(); };"
+        "s.onerror = () => { results.script = 'blocked'; report(); };"
+        "document.head.appendChild(s);"
+        "fetch('myapp://host.test/data', { mode: 'no-cors' })"
+        ".then(() => { results.fetch = 'ok'; report(); })"
+        ".catch(() => { results.fetch = 'blocked'; report(); });"
+        "});"
+        "</script></head><body>page</body></html>";
+    [html writeToFile:htmlPath atomically:YES encoding:NSUTF8StringEncoding error:nil];
+
+    RetainPtr receivedPaths = adoptNS([[NSMutableArray alloc] init]);
+    RetainPtr schemeHandler = adoptNS([TestURLSchemeHandler new]);
+    [schemeHandler setStartURLSchemeTaskHandler:^(WKWebView *, id<WKURLSchemeTask> task) {
+        [receivedPaths addObject:task.request.URL.path];
+        respondForCrossOriginTest(task);
+    }];
+
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    [configuration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"myapp"];
+
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+
+    NSURL *fileURL = [NSURL fileURLWithPath:htmlPath];
+    [webView loadFileURL:fileURL allowingReadAccessToURL:fileURL.URLByDeletingLastPathComponent];
+
+    EXPECT_WK_STREQ([webView _test_waitForAlert], "script=executed:secret-value|fetch=ok");
+    EXPECT_TRUE([receivedPaths containsObject:@"/config"]);
+    EXPECT_TRUE([receivedPaths containsObject:@"/data"]);
+
+    [[NSFileManager defaultManager] removeItemAtPath:tempDir error:nil];
+}
+
+// App custom scheme A → different app custom scheme B (no-cors): ALLOWED.
+TEST(URLSchemeHandler, LoadCustomSchemeNoCorsCrossSchemeSubresourceAllowed)
+{
+    RetainPtr receivedPaths = adoptNS([[NSMutableArray alloc] init]);
+    RetainPtr documentSchemeHandler = adoptNS([TestURLSchemeHandler new]);
+    [documentSchemeHandler setStartURLSchemeTaskHandler:^(WKWebView *, id<WKURLSchemeTask> task) {
+        [receivedPaths addObject:task.request.URL.path];
+        NSURL *url = task.request.URL;
+        // Reference the other app scheme (bookimg://) absolutely so the subresource loads are cross-scheme.
+        NSString *html = @"<!doctype html><html><head><script>"
+            "let results = {};"
+            "function report() {"
+            "if ('script' in results && 'fetch' in results)"
+            "alert('script=' + results.script + '|fetch=' + results.fetch);"
+            "}"
+            "window.addEventListener('load', () => {"
+            "const s = document.createElement('script');"
+            "s.src = 'bookimg://host.test/config';"
+            "s.onload = () => { results.script = 'executed:' + (window.LEAKED_CONFIG || 'unset'); report(); };"
+            "s.onerror = () => { results.script = 'blocked'; report(); };"
+            "document.head.appendChild(s);"
+            "fetch('bookimg://host.test/data', { mode: 'no-cors' })"
+            ".then(() => { results.fetch = 'ok'; report(); })"
+            ".catch(() => { results.fetch = 'blocked'; report(); });"
+            "});"
+            "</script></head><body>page</body></html>";
+        NSData *data = [html dataUsingEncoding:NSUTF8StringEncoding];
+        RetainPtr response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:url statusCode:200 HTTPVersion:@"HTTP/1.1" headerFields:@{ @"Content-Type": @"text/html" }]);
+        [task didReceiveResponse:response.get()];
+        [task didReceiveData:data];
+        [task didFinish];
+    }];
+    RetainPtr subresourceSchemeHandler = adoptNS([TestURLSchemeHandler new]);
+    [subresourceSchemeHandler setStartURLSchemeTaskHandler:^(WKWebView *, id<WKURLSchemeTask> task) {
+        [receivedPaths addObject:task.request.URL.path];
+        respondForCrossOriginTest(task);
+    }];
+
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    [configuration setURLSchemeHandler:documentSchemeHandler.get() forURLScheme:@"bookapp"];
+    [configuration setURLSchemeHandler:subresourceSchemeHandler.get() forURLScheme:@"bookimg"];
+
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"bookapp://host.test/page.html"]]];
+
+    EXPECT_WK_STREQ([webView _test_waitForAlert], "script=executed:secret-value|fetch=ok");
+    EXPECT_TRUE([receivedPaths containsObject:@"/config"]);
+    EXPECT_TRUE([receivedPaths containsObject:@"/data"]);
+}
+
+// loadHTMLString: with an http(s) baseURL (substitute data) → app custom scheme: ALLOWED.
+TEST(URLSchemeHandler, HttpBaseURLAppLoadedDocumentCustomSchemeAllowed)
+{
+    RetainPtr receivedPaths = adoptNS([[NSMutableArray alloc] init]);
+    RetainPtr schemeHandler = adoptNS([TestURLSchemeHandler new]);
+    [schemeHandler setStartURLSchemeTaskHandler:^(WKWebView *, id<WKURLSchemeTask> task) {
+        [receivedPaths addObject:task.request.URL.path];
+        respondForCrossOriginTest(task);
+    }];
+
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    [configuration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"myapp"];
+
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+
+    // Reference the app custom scheme (myapp://) absolutely so the subresource loads are cross-scheme
+    // relative to the http(s) document origin.
+    NSString *html = @"<!doctype html><html><head><script>"
+        "let results = {};"
+        "function report() {"
+        "if ('script' in results && 'fetch' in results)"
+        "alert('script=' + results.script + '|fetch=' + results.fetch);"
+        "}"
+        "window.addEventListener('load', () => {"
+        "const s = document.createElement('script');"
+        "s.src = 'myapp://host.test/config';"
+        "s.onload = () => { results.script = 'executed:' + (window.LEAKED_CONFIG || 'unset'); report(); };"
+        "s.onerror = () => { results.script = 'blocked'; report(); };"
+        "document.head.appendChild(s);"
+        "fetch('myapp://host.test/data', { mode: 'no-cors' })"
+        ".then(() => { results.fetch = 'ok'; report(); })"
+        ".catch(() => { results.fetch = 'blocked'; report(); });"
+        "});"
+        "</script></head><body>page</body></html>";
+    [webView loadHTMLString:html baseURL:[NSURL URLWithString:@"http://www.example.com/embeds/index.html"]];
+
+    EXPECT_WK_STREQ([webView _test_waitForAlert], "script=executed:secret-value|fetch=ok");
+    EXPECT_TRUE([receivedPaths containsObject:@"/config"]);
+    EXPECT_TRUE([receivedPaths containsObject:@"/data"]);
+}
+
+// loadHTMLString: with no baseURL (opaque origin, substitute data) → app custom scheme: ALLOWED.
+TEST(URLSchemeHandler, OpaqueOriginAppLoadedDocumentCustomSchemeAllowed)
+{
+    RetainPtr receivedPaths = adoptNS([[NSMutableArray alloc] init]);
+    RetainPtr schemeHandler = adoptNS([TestURLSchemeHandler new]);
+    [schemeHandler setStartURLSchemeTaskHandler:^(WKWebView *, id<WKURLSchemeTask> task) {
+        [receivedPaths addObject:task.request.URL.path];
+        respondForCrossOriginTest(task);
+    }];
+
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    [configuration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"myapp"];
+
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+
+    NSString *html = @"<!doctype html><html><head><script>"
+        "let results = {};"
+        "function report() {"
+        "if ('script' in results && 'fetch' in results)"
+        "alert('script=' + results.script + '|fetch=' + results.fetch);"
+        "}"
+        "window.addEventListener('load', () => {"
+        "const s = document.createElement('script');"
+        "s.src = 'myapp://host.test/config';"
+        "s.onload = () => { results.script = 'executed:' + (window.LEAKED_CONFIG || 'unset'); report(); };"
+        "s.onerror = () => { results.script = 'blocked'; report(); };"
+        "document.head.appendChild(s);"
+        "fetch('myapp://host.test/data', { mode: 'no-cors' })"
+        ".then(() => { results.fetch = 'ok'; report(); })"
+        ".catch(() => { results.fetch = 'blocked'; report(); });"
+        "});"
+        "</script></head><body>page</body></html>";
+    [webView loadHTMLString:html baseURL:nil];
+
+    EXPECT_WK_STREQ([webView _test_waitForAlert], "script=executed:secret-value|fetch=ok");
+    EXPECT_TRUE([receivedPaths containsObject:@"/config"]);
+    EXPECT_TRUE([receivedPaths containsObject:@"/data"]);
+}
+
+// Cross-origin iframe reading an app custom scheme (XHR sync/async, fetch): BLOCKED without CORS headers,
+// ALLOWED with Access-Control-Allow-Origin.
+TEST(URLSchemeHandler, CrossOriginIframeCORSEnforcementForCustomScheme)
+{
+    TestWebKitAPI::HTTPServer attackerServer({
+        { "/attack.html"_s, { { { "Content-Type"_s, "text/html"_s } },
+            "<!doctype html><html><head><script>"
+            "let results = {};"
+            "const keys = ['xhr-sync-deny', 'xhr-sync-allow', 'xhr-async-deny', 'xhr-async-allow', 'fetch-deny', 'fetch-allow'];"
+            "function report() {"
+            "if (keys.every(k => k in results))"
+            "parent.postMessage(keys.map(k => k + '=' + results[k]).join('|'), '*');"
+            "}"
+            "function runSyncXhr(path, key) {"
+            "try {"
+            "const xhr = new XMLHttpRequest();"
+            "xhr.open('GET', 'myapp://host.test' + path, false);"
+            "xhr.send();"
+            "results[key] = xhr.responseText || 'empty';"
+            "} catch (e) { results[key] = 'blocked'; }"
+            "report();"
+            "}"
+            "function runAsyncXhr(path, key) {"
+            "const xhr = new XMLHttpRequest();"
+            "xhr.open('GET', 'myapp://host.test' + path, true);"
+            "xhr.onload = () => { results[key] = xhr.responseText || 'empty'; report(); };"
+            "xhr.onerror = () => { results[key] = 'blocked'; report(); };"
+            "xhr.send();"
+            "}"
+            "function runFetch(path, key) {"
+            "fetch('myapp://host.test' + path)"
+            ".then(r => r.text())"
+            ".then(t => { results[key] = t || 'empty'; report(); })"
+            ".catch(() => { results[key] = 'blocked'; report(); });"
+            "}"
+            "window.addEventListener('load', () => {"
+            "runSyncXhr('/secret-deny', 'xhr-sync-deny');"
+            "runSyncXhr('/secret-allow', 'xhr-sync-allow');"
+            "runAsyncXhr('/secret-deny', 'xhr-async-deny');"
+            "runAsyncXhr('/secret-allow', 'xhr-async-allow');"
+            "runFetch('/secret-deny', 'fetch-deny');"
+            "runFetch('/secret-allow', 'fetch-allow');"
+            "});"
+            "</script></head><body>attack</body></html>"_s } }
+    });
+
+    TestWebKitAPI::HTTPServer trustedServer({ });
+    trustedServer.addResponse("/parent.html"_s, { { { "Content-Type"_s, "text/html"_s } },
+        makeString("<!doctype html><html><head><script>"
+        "window.addEventListener('message', e => alert(e.data));"
+        "</script></head><body><iframe src='http://127.0.0.1:"_s, attackerServer.port(), "/attack.html'></iframe></body></html>"_s) });
+
+    RetainPtr schemeHandler = adoptNS([TestURLSchemeHandler new]);
+    [schemeHandler setStartURLSchemeTaskHandler:^(WKWebView *, id<WKURLSchemeTask> task) {
+        NSString *path = task.request.URL.path;
+        NSDictionary *headers = [path isEqualToString:@"/secret-allow"]
+            ? @{ @"Content-Type": @"text/plain", @"Access-Control-Allow-Origin": @"*" }
+            : @{ @"Content-Type": @"text/plain" };
+
+        RetainPtr response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:task.request.URL statusCode:200 HTTPVersion:@"HTTP/1.1" headerFields:headers]);
+        [task didReceiveResponse:response.get()];
+        NSString *body = [path isEqualToString:@"/secret-allow"] ? @"allow-body" : @"deny-body";
+        [task didReceiveData:[body dataUsingEncoding:NSUTF8StringEncoding]];
+        [task didFinish];
+    }];
+
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    [configuration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"myapp"];
+
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    [webView loadRequest:trustedServer.request("/parent.html"_s)];
+
+    EXPECT_WK_STREQ([webView _test_waitForAlert], "xhr-sync-deny=blocked|xhr-sync-allow=allow-body|xhr-async-deny=blocked|xhr-async-allow=allow-body|fetch-deny=blocked|fetch-allow=allow-body");
 }

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebsitePolicies.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebsitePolicies.mm
@@ -1964,45 +1964,20 @@ TEST(WebpagePreferences, HttpPageContentBlockers)
     };
 
     TestWebKitAPI::HTTPServer server({
-        { "/index.html"_s, { 
+        { "/index.html"_s, {
             R"INDEX(<script>
                 window.results = [];
                 window.addEventListener('message', function(event) {
                     window.results.push(event.data);
                     alert();
                 });
+                window.results.push(window.location.href);
             </script>
-            <script src='test:///script.js'></script>
             <iframe src='/subframe.html'></iframe>)INDEX"_s } },
-        { "/subframe.html"_s, { "<script src='test:///script_subframe.js'></script>"_s } },
+        { "/subframe.html"_s, { "<script>window.parent.postMessage(window.location.href, '*');</script>"_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    RetainPtr handler = adoptNS([TestURLSchemeHandler new]);
-    [handler setStartURLSchemeTaskHandler:^(WKWebView *, id<WKURLSchemeTask> task) {
-        NSString *path = task.request.URL.path;
-        NSString *type = nil;
-        NSString *result = nil;
-        if ([path hasSuffix:@"script.js"]) {
-            result = @"window.results.push(window.location.href);";
-            type = @"text/javascript";
-        } else if ([path hasSuffix:@"script_subframe.js"]) {
-            result = @"window.parent.postMessage(window.location.href, '*');";
-            type = @"text/javascript";
-        }
-
-        if (!result) {
-            [task didFailWithError:[NSError errorWithDomain:@"TestWebKitAPI" code:1 userInfo:nil]];
-            return;
-        }
-
-        RetainPtr response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:type expectedContentLength:[result length] textEncodingName:nil]);
-        [task didReceiveResponse:response.get()];
-        [task didReceiveData:[result dataUsingEncoding:NSUTF8StringEncoding]];
-        [task didFinish];
-    }];
-
     RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    [configuration setURLSchemeHandler:handler.get() forURLScheme:@"test"];
 
     doneCompiling = false;
     NSString* contentBlocker = @"[{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\".*\",\"resource-type\":[\"script\"]}}]";


### PR DESCRIPTION
#### d3a9d92553bf47c02cadf7c4ab7ef878c9af1058
<pre>
[Loading] Enforce CORS for app custom schemes using document provenance
<a href="https://bugs.webkit.org/show_bug.cgi?id=319871">https://bugs.webkit.org/show_bug.cgi?id=319871</a>
<a href="https://rdar.apple.com/174287004">rdar://174287004</a>

Reviewed by NOBODY (OOPS!).

WebKit automatically enables CORS for WKURLSchemeHandler custom schemes but did not validate CORS
response headers for them, and did not consistently apply cross-origin checks to no-cors subresource
loads to those schemes. Enforce CORS for app-provided custom schemes, using a discriminator based on
document provenance.

The network process is now informed of the CORS-enabled custom scheme registrations so it validates
response headers, and no-cors cross-scheme subresource loads to a scheme handler are blocked in the
web process.

The app-content carve-out keys on the requesting document&apos;s provenance rather than on the origin&apos;s
scheme, which is ambiguous: an http(s) origin can be either untrusted network content or app content
loaded via -loadData:/-loadHTMLString: with an http(s) baseURL. A substitute-data document is
app-supplied regardless of its origin scheme, alongside the file: and app-custom-scheme signals.
http(s) is never a scheme handler, so network-fetched content only reaches the carve-out via
substitute data and untrusted content stays blocked.

A linked-on-or-after gate (SDKAlignedBehavior::CustomSchemeCORSEnforcement) keeps the historical
permissive behavior for apps linked before this shipped, as a compatibility net on top of the
provenance rule. The version mapping lives in the internal additions.

Tests: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKURLSchemeHandler-1.mm
       Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebsitePolicies.mm
       Tools/TestWebKitAPI/Tests/WebKit/WKWebView/CreateWebArchive.mm

* Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h:
* Source/WebCore/loader/DocumentThreadableLoader.cpp:
(WebCore::DocumentThreadableLoader::loadRequest):
* Source/WebCore/loader/cache/CachedResourceLoader.cpp:
(WebCore::CachedResourceLoader::canRequest):
(WebCore::CachedResourceLoader::canRequestAfterRedirection const):
(WebCore::CachedResourceLoader::isNoCorsCrossOriginRequestToURLSchemeHandler const):
* Source/WebCore/loader/cache/CachedResourceLoader.h:
* Source/WebCore/platform/LegacySchemeRegistry.cpp:
(WebCore::LegacySchemeRegistry::isBuiltInWebKitHandledScheme):
(WebCore::LegacySchemeRegistry::registerURLSchemeAsCORSEnabled):
* Source/WebCore/platform/LegacySchemeRegistry.h:
* Source/WebKit/NetworkProcess/NetworkProcess.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::registerURLSchemeHandler):
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::WebProcess::registerURLSchemeAsCORSEnabled):
* Source/WebKit/WebProcess/WebProcess.h:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/CreateWebArchive.mm:
(TestWebKitAPI::TEST(WebArchive, CreateCustomScheme)):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKURLSchemeHandler-1.mm:
(respondForCrossOriginTest):
(TEST(URLSchemeHandler, BasicWithHTTPS)):
(TEST(URLSchemeHandler, SameSchemeSubresourcesAllowed)):
(TEST(URLSchemeHandler, CrossOriginNoCorsSubresourcesBlocked)):
(TEST(URLSchemeHandler, LoadFileURLNoCorsSubresourceAllowed)):
(TEST(URLSchemeHandler, LoadCustomSchemeNoCorsCrossSchemeSubresourceAllowed)):
(TEST(URLSchemeHandler, HttpBaseURLAppLoadedDocumentCustomSchemeAllowed)):
(TEST(URLSchemeHandler, OpaqueOriginAppLoadedDocumentCustomSchemeAllowed)):
(TEST(URLSchemeHandler, CrossOriginIframeCORSEnforcementForCustomScheme)):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebsitePolicies.mm:
(TEST(WebpagePreferences, HttpPageContentBlockers)):

Co-Authored-By: Basuke Suzuki &lt;basuke@apple.com&gt;
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d3a9d92553bf47c02cadf7c4ab7ef878c9af1058

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175885 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49818 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43602 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185478 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/138084 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/98c47a00-8ecb-4d6e-b98a-2aef27bc089c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/177748 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51110 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49500 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136969 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/138084 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/645e2448-f474-4477-8fe9-2ab1eec4c891) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178841 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40428 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157745 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117448 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9959aae6-43be-42a9-b1b5-f948e8c23b5f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39070 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37451 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/6254 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149489 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37237 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33948 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/37149 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41518 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41657 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187899 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49485 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145961 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50165 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33861 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145802 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40595 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122361 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/116223 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48672 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12217 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48074 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48306 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48131 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->