### PR TITLE
NetworkConnectionToWebProcess::takeAllMessagesForPort terminates WebContent on a benign message-port race

### DIFF
--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
@@ -1842,9 +1842,21 @@ void NetworkConnectionToWebProcess::takeAllMessagesForPort(const MessagePortIden
 {
     CheckedRef registry = m_networkProcess->messagePortChannelRegistry();
     RefPtr channel = registry->existingChannelContainingPort(port);
-    MESSAGE_CHECK_COMPLETION(channel, callback({ }, std::nullopt));
-    // A WebContent process may only receive messages for ports entangled to it.
-    MESSAGE_CHECK_COMPLETION(channel->processForPort(port) == m_webProcessIdentifier, callback({ }, std::nullopt));
+
+    // The channel may have been closed, or the port may have been disentangled (e.g. mid-transfer to
+    // another process), concurrently with this request. This commonly happens while a worker process is
+    // being torn down and relaunched, when a takeAllMessagesForPort() may have already been dispatched
+    // from a worker thread. Such races are benign, so return no messages rather than treating the
+    // message as invalid and terminating the sending WebContent process.
+    std::optional<WebCore::ProcessIdentifier> entangledProcess;
+    if (channel)
+        entangledProcess = channel->processForPort(port);
+    if (!entangledProcess)
+        return callback({ }, std::nullopt);
+
+    // A WebContent process may only receive messages for ports entangled to it. A request for a port
+    // currently entangled to a *different* process indicates a misbehaving process and is treated as invalid.
+    MESSAGE_CHECK_COMPLETION(*entangledProcess == m_webProcessIdentifier, callback({ }, std::nullopt));
 
     registry->takeAllMessagesForPort(port, [this, protectedThis = Ref { *this }, callback = WTF::move(callback)](Vector<MessageWithMessagePorts>&& messages, CompletionHandler<void()>&& deliveryCallback) mutable {
         // Now that the receiving process has been authenticated and is about to take possession,


### PR DESCRIPTION
#### 1c2e7ba25b95c9835fdbd67878c189d7906c713a
<pre>
NetworkConnectionToWebProcess::takeAllMessagesForPort terminates WebContent on a benign message-port race
<a href="https://bugs.webkit.org/show_bug.cgi?id=319881">https://bugs.webkit.org/show_bug.cgi?id=319881</a>
<a href="https://rdar.apple.com/182244946">rdar://182244946</a>

Reviewed by Brady Eidson.

A WebContent process asks the network process for the messages queued on one of its
MessagePorts via NetworkConnectionToWebProcess::takeAllMessagesForPort(). That request
can race with the port&apos;s channel being destroyed, or with the port being disentangled /
transferred to another process: existingChannelContainingPort() returns null once the
channel is gone, and MessagePortChannel::processForPort() returns std::nullopt while a
port is mid-transfer or closed.

Both of these are benign races, not misbehaving WebContent processes, yet the handler
treated them as invalid messages via MESSAGE_CHECK_COMPLETION(). Note that
MESSAGE_CHECK_COMPLETION() still calls markCurrentlyDispatchedMessageAsInvalid(), so it
requests termination of the sender; the completion handler only avoids leaving the reply
hanging. This is easy to hit while a SharedWorker&apos;s context process is being torn down and
relaunched, since a takeAllMessagesForPort() may already have been dispatched from a worker
thread (see the existing comments in MessagePort::messageAvailable() and
WebMessagePortChannelProvider::takeAllMessagesForPort()). When it happens repeatedly, the
network process terminates each new WebContent process, the worker relaunches (its clients
still need it), and the loop spins fast enough that the UI process accumulates IPC::Connection
port rights until it is killed for Mach port exhaustion.

Only take messages when the port is currently entangled to the requesting process. When the
channel is missing or the port is not entangled to anyone, gracefully return no messages
instead of terminating the sender; the queued messages remain in the channel and are
delivered once the port is re-entangled to its owner. Keep the terminating check strictly for
a request for a port entangled to a *different* process, which is the only genuine violation.

No new tests, I have tried writing one but wasn&apos;t successful. This is likely very timing
dependent.

* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp:
(WebKit::NetworkConnectionToWebProcess::takeAllMessagesForPort):

Canonical link: <a href="https://commits.webkit.org/317668@main">https://commits.webkit.org/317668@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b6408be16fac9708abf73e9b79f1678f63a14bc8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175812 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49745 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43529 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185405 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/137995 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c33263e8-5d18-47e9-8b50-19129b1ef35b) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51037 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49427 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136900 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/137995 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ec0f8b28-3845-4604-b39a-9d8ad2068f2a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178768 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40358 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157675 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117379 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6dd2031d-b906-481b-b95f-8a4aa97daa18) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39000 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37382 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149419 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37167 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33875 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41442 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41588 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187826 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49412 "Built successfully") | | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145894 "Found 1 new test failure: compositing/color-matching/image-color-matching.html (failure)") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39287 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50092 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33791 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/bfcache/abort.tentative.https.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145735 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40526 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122288 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/116116 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48599 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12147 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48001 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48233 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48058 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->