### PR TITLE
[Site Isolation] Clicking main frame content does not blur focused element in cross-origin frame

### DIFF
--- a/Source/WebCore/page/FocusController.cpp
+++ b/Source/WebCore/page/FocusController.cpp
@@ -1172,6 +1172,13 @@ bool FocusController::setFocusedElement(Element* element, Frame* newFocusedFrame
     
     RefPtr oldFocusedElement = oldDocument ? oldDocument->focusedElement() : nullptr;
     Ref page = m_page.get();
+
+    // When clearing focus while the focused element lives in another process (the focused frame is
+    // remote), clearing focus locally does nothing to the remote document. Broadcast the change so the
+    // remote frame's process clears its own focused element.
+    if (!element && broadcast == BroadcastFocusedElement::Yes && newLocalFocusedFrame && is<RemoteFrame>(m_focusedFrame.get()))
+        page->chrome().focusedElementChanged(nullptr, newLocalFocusedFrame.get(), options, BroadcastFocusedElement::Yes);
+
     if (oldFocusedElement == element) {
         if (element) {
             page->chrome().client().elementDidRefocus(*element, options);

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
@@ -2719,6 +2719,35 @@ TEST(SiteIsolation, HandleAcceptedCandidateInCrossOriginIframe)
         Util::runFor(10_ms);
     }
 }
+
+TEST(SiteIsolation, ClickingMainFrameContentBlursFocusedElementInCrossOriginIframe)
+{
+    HTTPServer server({
+        { "/mainframe"_s, { "<div id='other' style='height: 300px'>other content</div><iframe id='iframe' src='https://domain2.com/subframe'></iframe>"_s } },
+        { "/subframe"_s, { "<body><input id='input'></body>"_s } }
+    }, HTTPServer::Protocol::HttpsProxy);
+    auto [webView, navigationDelegate] = siteIsolatedViewAndDelegate(server, CGRectMake(0, 0, 800, 600));
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://domain1.com/mainframe"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    RetainPtr childFrame = [webView firstChildFrame];
+
+    // Focus the input in the cross-origin iframe. Element::focus() is a no-op for cross-origin
+    // non-main-frame iframes without a user gesture, so use the user-gesture variant, then wait for
+    // the focused-frame state to propagate so the main frame's process knows focus lives in the child.
+    [webView objectByEvaluatingJavaScriptWithUserGesture:@"document.getElementById('input').focus()" inFrame:childFrame];
+    while (![webView firstChildFrame]._isFocused || [webView mainFrame].info._isFocused)
+        Util::spinRunLoop();
+    EXPECT_WK_STREQ("input", [webView stringByEvaluatingJavaScript:@"document.activeElement.id" inFrame:childFrame]);
+
+    [webView sendClickAtPoint:NSMakePoint(400, 570)];
+    [webView waitForPendingMouseEvents];
+
+    int attempts = 0;
+    while ("input"_s == String([webView stringByEvaluatingJavaScript:@"document.activeElement.id" inFrame:childFrame]) && attempts++ < 100)
+        Util::runFor(10_ms);
+    EXPECT_WK_STREQ("", [webView stringByEvaluatingJavaScript:@"document.activeElement.id" inFrame:childFrame]);
+}
 #endif
 
 TEST(SiteIsolation, SetFocusedFrame)


### PR DESCRIPTION
#### 602204153ef9822cbf41183a7858d80ece7cde6e
<pre>
[Site Isolation] Clicking main frame content does not blur focused element in cross-origin frame
<a href="https://bugs.webkit.org/show_bug.cgi?id=319885">https://bugs.webkit.org/show_bug.cgi?id=319885</a>
<a href="https://rdar.apple.com/182789879">rdar://182789879</a>

Reviewed by NOBODY (OOPS!).

When focus is cleared in a web process the focused element is only blurred if the focused frame is
local to that process. With site isolation the focused element can live in a different, and therefore
`localFocusedFrame()` returns null, the local document has nothing to clear, and no blur is ever
delivered to the remote frame.

Fix this by propagating the clear across processes; when focus is being cleared while the focused frame
is remote, broadcast the change so the remote frame&apos;s process receives `ElementWasFocusedInAnotherProcess`
and blurs its own focused element.

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm

* Source/WebCore/page/FocusController.cpp:
(WebCore::FocusController::setFocusedElement):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm:
(TestWebKitAPI::TEST(SiteIsolation, ClickingMainFrameContentBlursFocusedElementInCrossOriginIframe)):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/602204153ef9822cbf41183a7858d80ece7cde6e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175818 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49751 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43535 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185411 "Built successfully") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/138003 "Failed to checkout and rebase branch from PR 69845") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/177681 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51043 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49433 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136907 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/138003 "Failed to checkout and rebase branch from PR 69845") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5e23e99d-fb74-4b32-811f-4cd99772f2e2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178774 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40363 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157680 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117386 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2d517fa5-2080-4ccd-9148-2a5563f6f0a1) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39005 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37388 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149424 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37172 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33881 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41448 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41594 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187832 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49418 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145901 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50098 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33796 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145742 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40531 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122294 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/116125 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48605 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12152 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48007 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48239 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48064 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->