### PR TITLE
Support external and data: URL clip-path references on SVG elements

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-url-reference-data-uri-svg-element-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-url-reference-data-uri-svg-element-expected.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<div style="width: 100px; height: 100px; background-color: green; border-radius: 50px;"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-url-reference-data-uri-svg-element.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-url-reference-data-uri-svg-element.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<title>Referencing a &lt;clipPath> element in a data: URL from an SVG element</title>
+<link rel="help" href="http://www.w3.org/TR/css-masking-1/#clipping-paths">
+<link rel="help" href="http://www.w3.org/TR/css-masking-1/#the-clip-path">
+<link rel="match" href="reference/green-circle-100x100.html">
+<meta name="fuzzy" content="0-36; 0-384">
+<svg width="100" height="100">
+  <rect width="100" height="100" fill="green" clip-path="url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjxjbGlwUGF0aCBpZD0iY2lyY2xlQ2xpcCIgY2xpcFBhdGhVbml0cz0ib2JqZWN0Qm91bmRpbmdCb3giPjxjaXJjbGUgY3g9IjAuNSIgY3k9IjAuNSIgcj0iMC41Ii8+PC9jbGlwUGF0aD48L3N2Zz4=#circleClip)"/>
+</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-url-reference-external-svg-element-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-url-reference-external-svg-element-expected.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<div style="width: 100px; height: 100px; background-color: green; border-radius: 50px;"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-url-reference-external-svg-element.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-url-reference-external-svg-element.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<title>Referencing a &lt;clipPath> element in an external resource from an SVG element</title>
+<link rel="help" href="http://www.w3.org/TR/css-masking-1/#clipping-paths">
+<link rel="help" href="http://www.w3.org/TR/css-masking-1/#the-clip-path">
+<link rel="match" href="reference/green-circle-100x100.html">
+<meta name="fuzzy" content="0-36; 0-384">
+<svg width="100" height="100">
+  <rect width="100" height="100" fill="green" clip-path="url(support/resources.svg#circleClip)"/>
+</svg>

--- a/Source/WebCore/rendering/svg/legacy/SVGResources.cpp
+++ b/Source/WebCore/rendering/svg/legacy/SVGResources.cpp
@@ -272,8 +272,14 @@ std::unique_ptr<SVGResources> SVGResources::buildCachedResources(const RenderEle
     if (clipperFilterMaskerTags().contains(tagName)) {
         WTF::switchOn(style.clipPath(),
             [&](const Style::ReferencePath& clipPath) {
-                // FIXME: -webkit-clip-path should support external resources
-                // https://bugs.webkit.org/show_bug.cgi?id=127032
+                if (auto externalDocument = externalSVGResourceDocument(document, clipPath.url().resolved)) {
+                    if (RefPtr resolvedDocument = *externalDocument) {
+                        auto id = clipPath.url().resolved.fragmentIdentifier().toAtomString();
+                        if (auto* clipper = getRenderSVGResourceById<LegacyRenderSVGResourceClipper>(*resolvedDocument, id))
+                            ensureResources(foundResources).setClipper(clipper);
+                    }
+                    return;
+                }
                 if (auto* clipper = getRenderSVGResourceById<LegacyRenderSVGResourceClipper>(treeScope, clipPath.fragment()))
                     ensureResources(foundResources).setClipper(clipper);
                 else

--- a/Source/WebCore/style/StylePendingResources.cpp
+++ b/Source/WebCore/style/StylePendingResources.cpp
@@ -40,6 +40,7 @@
 #include "SVGElement.h"
 #include "SVGURIReference.h"
 #include "Settings.h"
+#include "StyleClipPath.h"
 #include "StyleComputedStyle+GettersInlines.h"
 #include "StyleCursor.h"
 #include "StyleFilter.h"
@@ -120,6 +121,12 @@ static void loadPendingExternalSVGMarker(Document& document, const Style::SVGMar
         loadExternalSVGResource(document, url->resolved);
 }
 
+static void loadPendingExternalSVGClipPath(Document& document, const Style::ClipPath& clipPath)
+{
+    if (auto referencePath = clipPath.tryReference())
+        loadExternalSVGResource(document, referencePath->url().resolved);
+}
+
 void loadPendingResources(Style::ComputedStyle& style, Document& document, const Element* element)
 {
     for (auto& backgroundLayer : style.backgroundLayers().usedValues())
@@ -167,6 +174,8 @@ void loadPendingResources(Style::ComputedStyle& style, Document& document, const
         loadPendingExternalSVGMarker(document, style.markerStart());
         loadPendingExternalSVGMarker(document, style.markerMid());
         loadPendingExternalSVGMarker(document, style.markerEnd());
+
+        loadPendingExternalSVGClipPath(document, style.clipPath());
 
         if (style.filter().size() == 1) {
             WTF::switchOn(style.filter().first(),


### PR DESCRIPTION
#### 89f1efca5390b62f704bbf23fffce8e4188fd4a3
<pre>
Support external and data: URL clip-path references on SVG elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=104442">https://bugs.webkit.org/show_bug.cgi?id=104442</a>
<a href="https://rdar.apple.com/182801442">rdar://182801442</a>

Reviewed by Simon Fraser.

clip-path on an SVG element now resolves a &lt;clipPath&gt; referenced by an
external file or a data: URL.

clip-path on HTML elements goes through a separate path and is a follow-up.

Tests: imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-url-reference-data-uri-svg-element.html
       imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-url-reference-external-svg-element.html

* LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-url-reference-data-uri-svg-element-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-url-reference-data-uri-svg-element.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-url-reference-external-svg-element-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-url-reference-external-svg-element.html: Added.
* Source/WebCore/rendering/svg/legacy/SVGResources.cpp:
(WebCore::SVGResources::buildCachedResources):
* Source/WebCore/style/StylePendingResources.cpp:
(WebCore::Style::loadPendingExternalSVGClipPath):
(WebCore::Style::loadPendingResources):

Canonical link: <a href="https://commits.webkit.org/317649@main">https://commits.webkit.org/317649@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3458f3b672ac3231275aafca22c687ce08c4e5da

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175845 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49778 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43562 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185438 "Build is in progress. Recent messages:Printed configuration; Checked out pull request; Compiled WebKit") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/138036 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1e01875e-e02c-4531-99c0-edcb6e81e155) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/177708 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51070 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49460 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136930 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/138036 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c6211406-63d5-4374-9ec7-d454b31195d9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178801 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40390 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157706 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117409 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/86946fdc-af33-496f-b4bf-01f781a1a88d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39032 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37414 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/5/builds/185438 "Build is in progress. Recent messages:Printed configuration; Checked out pull request; Compiled WebKit") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149451 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37198 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33908 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41478 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41620 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187859 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49445 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/157257 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145923 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39272 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50125 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33822 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145763 "Passed tests") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40558 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; Passed layout tests; Ignored 2 pre-existing failure based on results-db; Uploaded test results") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122321 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/116170 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48632 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12178 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48034 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48266 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48091 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->