### PR TITLE
Implement FetchRequest duplex property

### DIFF
--- a/LayoutTests/http/wpt/fetch/fetch-request-with-stream-body.html
+++ b/LayoutTests/http/wpt/fetch/fetch-request-with-stream-body.html
@@ -24,7 +24,7 @@ promise_test(test => {
         controller.enqueue(new ArrayBuffer(10));
         controller.close();
     }});
-    var request = new Request("", {body: stream, mode:"cors", method: "POST"});
+    var request = new Request("", {body: stream, mode:"cors", method: "POST", duplex : "half"});
     return promise_rejects_dom(test, "NotSupportedError", fetch(request));
 }, "Uploading a readable stream body request is not supported");
     </script>

--- a/LayoutTests/http/wpt/fetch/request-clone-resizable.html
+++ b/LayoutTests/http/wpt/fetch/request-clone-resizable.html
@@ -22,7 +22,7 @@ var clonedRequest = request.clone();
 function testReadableStreamClone(initialBuffer, bufferType)
 {
     promise_test(function(test) {
-        var request = new Request("", {"method" : "POST", "body" : new ReadableStream({start : function(controller) {
+        var request = new Request("", {"method" : "POST", duplex : "half", "body" : new ReadableStream({start : function(controller) {
             controller.enqueue(initialBuffer);
             controller.close();
         }})});

--- a/LayoutTests/http/wpt/fetch/request-clone.html
+++ b/LayoutTests/http/wpt/fetch/request-clone.html
@@ -30,7 +30,7 @@ promise_test(function(test) {
 function testReadableStreamClone(initialBuffer, bufferType)
 {
     promise_test(function(test) {
-        var request = new Request("", {"method" : "POST", "body" : new ReadableStream({start : function(controller) {
+        var request = new Request("", {"method" : "POST", duplex : "half", "body" : new ReadableStream({start : function(controller) {
             controller.enqueue(initialBuffer);
             controller.close();
         }})});

--- a/LayoutTests/http/wpt/fetch/request-stream-empty.html
+++ b/LayoutTests/http/wpt/fetch/request-stream-empty.html
@@ -13,7 +13,7 @@ function createRequestWithEmptyReadableStream()
     var stream = new ReadableStream({start: controller => {
         controller.close();
     }});
-    return new Request("", {body: stream, method: "POST"});
+    return new Request("", {body: stream, duplex : "half", method: "POST"});
 }
 
 function createRequestWithEmptyChunkReadableStream()
@@ -22,7 +22,7 @@ function createRequestWithEmptyChunkReadableStream()
         controller.enqueue(new Uint8Array(0));
         controller.close();
     }});
-    return new Request("", {body: stream, method: "POST"});
+    return new Request("", {body: stream, duplex : "half", method: "POST"});
 }
 
 promise_test(test => {

--- a/LayoutTests/http/wpt/fetch/request-stream-error.html
+++ b/LayoutTests/http/wpt/fetch/request-stream-error.html
@@ -13,7 +13,7 @@ promise_test(test => {
         controller.enqueue("This is not a buffer");
         controller.close();
     }});
-    var request = new Request("", {body: stream, method: "POST"});
+    var request = new Request("", {body: stream, duplex : "half", method: "POST"});
     return promise_rejects_js(test, TypeError, request.text());
 }, "Request body should only contain BufferSource chunks");
     </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/api/idlharness.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/api/idlharness.https.any-expected.txt
@@ -62,7 +62,7 @@ PASS Request interface: attribute keepalive
 FAIL Request interface: attribute isReloadNavigation assert_true: The prototype object must have a property "isReloadNavigation" expected true got false
 FAIL Request interface: attribute isHistoryNavigation assert_true: The prototype object must have a property "isHistoryNavigation" expected true got false
 PASS Request interface: attribute signal
-FAIL Request interface: attribute duplex assert_true: The prototype object must have a property "duplex" expected true got false
+PASS Request interface: attribute duplex
 PASS Request interface: operation clone()
 PASS Request interface: attribute body
 PASS Request interface: attribute bodyUsed
@@ -89,7 +89,7 @@ PASS Request interface: new Request('about:blank') must inherit property "keepal
 FAIL Request interface: new Request('about:blank') must inherit property "isReloadNavigation" with the proper type assert_inherits: property "isReloadNavigation" not found in prototype chain
 FAIL Request interface: new Request('about:blank') must inherit property "isHistoryNavigation" with the proper type assert_inherits: property "isHistoryNavigation" not found in prototype chain
 PASS Request interface: new Request('about:blank') must inherit property "signal" with the proper type
-FAIL Request interface: new Request('about:blank') must inherit property "duplex" with the proper type assert_inherits: property "duplex" not found in prototype chain
+PASS Request interface: new Request('about:blank') must inherit property "duplex" with the proper type
 PASS Request interface: new Request('about:blank') must inherit property "clone()" with the proper type
 PASS Request interface: new Request('about:blank') must inherit property "body" with the proper type
 PASS Request interface: new Request('about:blank') must inherit property "bodyUsed" with the proper type

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/api/idlharness.https.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/api/idlharness.https.any.serviceworker-expected.txt
@@ -62,7 +62,7 @@ PASS Request interface: attribute keepalive
 FAIL Request interface: attribute isReloadNavigation assert_true: The prototype object must have a property "isReloadNavigation" expected true got false
 FAIL Request interface: attribute isHistoryNavigation assert_true: The prototype object must have a property "isHistoryNavigation" expected true got false
 PASS Request interface: attribute signal
-FAIL Request interface: attribute duplex assert_true: The prototype object must have a property "duplex" expected true got false
+PASS Request interface: attribute duplex
 PASS Request interface: operation clone()
 PASS Request interface: attribute body
 PASS Request interface: attribute bodyUsed
@@ -89,7 +89,7 @@ PASS Request interface: new Request('about:blank') must inherit property "keepal
 FAIL Request interface: new Request('about:blank') must inherit property "isReloadNavigation" with the proper type assert_inherits: property "isReloadNavigation" not found in prototype chain
 FAIL Request interface: new Request('about:blank') must inherit property "isHistoryNavigation" with the proper type assert_inherits: property "isHistoryNavigation" not found in prototype chain
 PASS Request interface: new Request('about:blank') must inherit property "signal" with the proper type
-FAIL Request interface: new Request('about:blank') must inherit property "duplex" with the proper type assert_inherits: property "duplex" not found in prototype chain
+PASS Request interface: new Request('about:blank') must inherit property "duplex" with the proper type
 PASS Request interface: new Request('about:blank') must inherit property "clone()" with the proper type
 PASS Request interface: new Request('about:blank') must inherit property "body" with the proper type
 PASS Request interface: new Request('about:blank') must inherit property "bodyUsed" with the proper type

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/api/idlharness.https.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/api/idlharness.https.any.sharedworker-expected.txt
@@ -62,7 +62,7 @@ PASS Request interface: attribute keepalive
 FAIL Request interface: attribute isReloadNavigation assert_true: The prototype object must have a property "isReloadNavigation" expected true got false
 FAIL Request interface: attribute isHistoryNavigation assert_true: The prototype object must have a property "isHistoryNavigation" expected true got false
 PASS Request interface: attribute signal
-FAIL Request interface: attribute duplex assert_true: The prototype object must have a property "duplex" expected true got false
+PASS Request interface: attribute duplex
 PASS Request interface: operation clone()
 PASS Request interface: attribute body
 PASS Request interface: attribute bodyUsed
@@ -89,7 +89,7 @@ PASS Request interface: new Request('about:blank') must inherit property "keepal
 FAIL Request interface: new Request('about:blank') must inherit property "isReloadNavigation" with the proper type assert_inherits: property "isReloadNavigation" not found in prototype chain
 FAIL Request interface: new Request('about:blank') must inherit property "isHistoryNavigation" with the proper type assert_inherits: property "isHistoryNavigation" not found in prototype chain
 PASS Request interface: new Request('about:blank') must inherit property "signal" with the proper type
-FAIL Request interface: new Request('about:blank') must inherit property "duplex" with the proper type assert_inherits: property "duplex" not found in prototype chain
+PASS Request interface: new Request('about:blank') must inherit property "duplex" with the proper type
 PASS Request interface: new Request('about:blank') must inherit property "clone()" with the proper type
 PASS Request interface: new Request('about:blank') must inherit property "body" with the proper type
 PASS Request interface: new Request('about:blank') must inherit property "bodyUsed" with the proper type

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/api/idlharness.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/api/idlharness.https.any.worker-expected.txt
@@ -62,7 +62,7 @@ PASS Request interface: attribute keepalive
 FAIL Request interface: attribute isReloadNavigation assert_true: The prototype object must have a property "isReloadNavigation" expected true got false
 FAIL Request interface: attribute isHistoryNavigation assert_true: The prototype object must have a property "isHistoryNavigation" expected true got false
 PASS Request interface: attribute signal
-FAIL Request interface: attribute duplex assert_true: The prototype object must have a property "duplex" expected true got false
+PASS Request interface: attribute duplex
 PASS Request interface: operation clone()
 PASS Request interface: attribute body
 PASS Request interface: attribute bodyUsed
@@ -89,7 +89,7 @@ PASS Request interface: new Request('about:blank') must inherit property "keepal
 FAIL Request interface: new Request('about:blank') must inherit property "isReloadNavigation" with the proper type assert_inherits: property "isReloadNavigation" not found in prototype chain
 FAIL Request interface: new Request('about:blank') must inherit property "isHistoryNavigation" with the proper type assert_inherits: property "isHistoryNavigation" not found in prototype chain
 PASS Request interface: new Request('about:blank') must inherit property "signal" with the proper type
-FAIL Request interface: new Request('about:blank') must inherit property "duplex" with the proper type assert_inherits: property "duplex" not found in prototype chain
+PASS Request interface: new Request('about:blank') must inherit property "duplex" with the proper type
 PASS Request interface: new Request('about:blank') must inherit property "clone()" with the proper type
 PASS Request interface: new Request('about:blank') must inherit property "body" with the proper type
 PASS Request interface: new Request('about:blank') must inherit property "bodyUsed" with the proper type

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/api/request/request-init-stream.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/api/request/request-init-stream.any-expected.txt
@@ -10,16 +10,16 @@ PASS It is OK to omit .duplex when the body is null.
 PASS It is OK to omit .duplex when the body is a string.
 PASS It is OK to omit .duplex when the body is a Uint8Array.
 PASS It is OK to omit .duplex when the body is a Blob.
-FAIL It is error to omit .duplex when the body is a ReadableStream. assert_throws_js: function "() => new Request("...", { method, body })" did not throw
+PASS It is error to omit .duplex when the body is a ReadableStream.
 PASS It is OK to set .duplex = 'half' when the body is null.
 PASS It is OK to set .duplex = 'half' when the body is a string.
 PASS It is OK to set .duplex = 'half' when the body is a Uint8Array.
 PASS It is OK to set .duplex = 'half' when the body is a Blob.
 PASS It is OK to set .duplex = 'half' when the body is a ReadableStream.
-FAIL It is error to set .duplex = 'full' when the body is null. assert_throws_js: function "() => new Request("...", { method, body, duplex })" did not throw
-FAIL It is error to set .duplex = 'full' when the body is a string. assert_throws_js: function "() => new Request("...", { method, body, duplex })" did not throw
-FAIL It is error to set .duplex = 'full' when the body is a Uint8Array. assert_throws_js: function "() => new Request("...", { method, body, duplex })" did not throw
-FAIL It is error to set .duplex = 'full' when the body is a Blob. assert_throws_js: function "() => new Request("...", { method, body, duplex })" did not throw
-FAIL It is error to set .duplex = 'full' when the body is a ReadableStream. assert_throws_js: function "() => new Request("...", { method, body, duplex })" did not throw
+PASS It is error to set .duplex = 'full' when the body is null.
+PASS It is error to set .duplex = 'full' when the body is a string.
+PASS It is error to set .duplex = 'full' when the body is a Uint8Array.
+PASS It is error to set .duplex = 'full' when the body is a Blob.
+PASS It is error to set .duplex = 'full' when the body is a ReadableStream.
 PASS It is OK to omit duplex when init.body is not given and input.body is given.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/api/request/request-init-stream.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/api/request/request-init-stream.any.serviceworker-expected.txt
@@ -10,16 +10,16 @@ PASS It is OK to omit .duplex when the body is null.
 PASS It is OK to omit .duplex when the body is a string.
 PASS It is OK to omit .duplex when the body is a Uint8Array.
 PASS It is OK to omit .duplex when the body is a Blob.
-FAIL It is error to omit .duplex when the body is a ReadableStream. assert_throws_js: function "() => new Request("...", { method, body })" did not throw
+PASS It is error to omit .duplex when the body is a ReadableStream.
 PASS It is OK to set .duplex = 'half' when the body is null.
 PASS It is OK to set .duplex = 'half' when the body is a string.
 PASS It is OK to set .duplex = 'half' when the body is a Uint8Array.
 PASS It is OK to set .duplex = 'half' when the body is a Blob.
 PASS It is OK to set .duplex = 'half' when the body is a ReadableStream.
-FAIL It is error to set .duplex = 'full' when the body is null. assert_throws_js: function "() => new Request("...", { method, body, duplex })" did not throw
-FAIL It is error to set .duplex = 'full' when the body is a string. assert_throws_js: function "() => new Request("...", { method, body, duplex })" did not throw
-FAIL It is error to set .duplex = 'full' when the body is a Uint8Array. assert_throws_js: function "() => new Request("...", { method, body, duplex })" did not throw
-FAIL It is error to set .duplex = 'full' when the body is a Blob. assert_throws_js: function "() => new Request("...", { method, body, duplex })" did not throw
-FAIL It is error to set .duplex = 'full' when the body is a ReadableStream. assert_throws_js: function "() => new Request("...", { method, body, duplex })" did not throw
+PASS It is error to set .duplex = 'full' when the body is null.
+PASS It is error to set .duplex = 'full' when the body is a string.
+PASS It is error to set .duplex = 'full' when the body is a Uint8Array.
+PASS It is error to set .duplex = 'full' when the body is a Blob.
+PASS It is error to set .duplex = 'full' when the body is a ReadableStream.
 PASS It is OK to omit duplex when init.body is not given and input.body is given.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/api/request/request-init-stream.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/api/request/request-init-stream.any.sharedworker-expected.txt
@@ -10,16 +10,16 @@ PASS It is OK to omit .duplex when the body is null.
 PASS It is OK to omit .duplex when the body is a string.
 PASS It is OK to omit .duplex when the body is a Uint8Array.
 PASS It is OK to omit .duplex when the body is a Blob.
-FAIL It is error to omit .duplex when the body is a ReadableStream. assert_throws_js: function "() => new Request("...", { method, body })" did not throw
+PASS It is error to omit .duplex when the body is a ReadableStream.
 PASS It is OK to set .duplex = 'half' when the body is null.
 PASS It is OK to set .duplex = 'half' when the body is a string.
 PASS It is OK to set .duplex = 'half' when the body is a Uint8Array.
 PASS It is OK to set .duplex = 'half' when the body is a Blob.
 PASS It is OK to set .duplex = 'half' when the body is a ReadableStream.
-FAIL It is error to set .duplex = 'full' when the body is null. assert_throws_js: function "() => new Request("...", { method, body, duplex })" did not throw
-FAIL It is error to set .duplex = 'full' when the body is a string. assert_throws_js: function "() => new Request("...", { method, body, duplex })" did not throw
-FAIL It is error to set .duplex = 'full' when the body is a Uint8Array. assert_throws_js: function "() => new Request("...", { method, body, duplex })" did not throw
-FAIL It is error to set .duplex = 'full' when the body is a Blob. assert_throws_js: function "() => new Request("...", { method, body, duplex })" did not throw
-FAIL It is error to set .duplex = 'full' when the body is a ReadableStream. assert_throws_js: function "() => new Request("...", { method, body, duplex })" did not throw
+PASS It is error to set .duplex = 'full' when the body is null.
+PASS It is error to set .duplex = 'full' when the body is a string.
+PASS It is error to set .duplex = 'full' when the body is a Uint8Array.
+PASS It is error to set .duplex = 'full' when the body is a Blob.
+PASS It is error to set .duplex = 'full' when the body is a ReadableStream.
 PASS It is OK to omit duplex when init.body is not given and input.body is given.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/api/request/request-init-stream.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/api/request/request-init-stream.any.worker-expected.txt
@@ -10,16 +10,16 @@ PASS It is OK to omit .duplex when the body is null.
 PASS It is OK to omit .duplex when the body is a string.
 PASS It is OK to omit .duplex when the body is a Uint8Array.
 PASS It is OK to omit .duplex when the body is a Blob.
-FAIL It is error to omit .duplex when the body is a ReadableStream. assert_throws_js: function "() => new Request("...", { method, body })" did not throw
+PASS It is error to omit .duplex when the body is a ReadableStream.
 PASS It is OK to set .duplex = 'half' when the body is null.
 PASS It is OK to set .duplex = 'half' when the body is a string.
 PASS It is OK to set .duplex = 'half' when the body is a Uint8Array.
 PASS It is OK to set .duplex = 'half' when the body is a Blob.
 PASS It is OK to set .duplex = 'half' when the body is a ReadableStream.
-FAIL It is error to set .duplex = 'full' when the body is null. assert_throws_js: function "() => new Request("...", { method, body, duplex })" did not throw
-FAIL It is error to set .duplex = 'full' when the body is a string. assert_throws_js: function "() => new Request("...", { method, body, duplex })" did not throw
-FAIL It is error to set .duplex = 'full' when the body is a Uint8Array. assert_throws_js: function "() => new Request("...", { method, body, duplex })" did not throw
-FAIL It is error to set .duplex = 'full' when the body is a Blob. assert_throws_js: function "() => new Request("...", { method, body, duplex })" did not throw
-FAIL It is error to set .duplex = 'full' when the body is a ReadableStream. assert_throws_js: function "() => new Request("...", { method, body, duplex })" did not throw
+PASS It is error to set .duplex = 'full' when the body is null.
+PASS It is error to set .duplex = 'full' when the body is a string.
+PASS It is error to set .duplex = 'full' when the body is a Uint8Array.
+PASS It is error to set .duplex = 'full' when the body is a Blob.
+PASS It is error to set .duplex = 'full' when the body is a ReadableStream.
 PASS It is OK to omit duplex when init.body is not given and input.body is given.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/api/request/request-structure.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/api/request/request-structure.any-expected.txt
@@ -18,7 +18,7 @@ PASS Check redirect attribute
 PASS Check integrity attribute
 FAIL Check isReloadNavigation attribute assert_true: request has isReloadNavigation attribute expected true got false
 FAIL Check isHistoryNavigation attribute assert_true: request has isHistoryNavigation attribute expected true got false
-FAIL Check duplex attribute assert_true: request has duplex attribute expected true got false
+PASS Check duplex attribute
 PASS Check bodyUsed attribute
 PASS Request does not expose priority attribute
 PASS Request does not expose internalpriority attribute

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/api/request/request-structure.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/api/request/request-structure.any.serviceworker-expected.txt
@@ -18,7 +18,7 @@ PASS Check redirect attribute
 PASS Check integrity attribute
 FAIL Check isReloadNavigation attribute assert_true: request has isReloadNavigation attribute expected true got false
 FAIL Check isHistoryNavigation attribute assert_true: request has isHistoryNavigation attribute expected true got false
-FAIL Check duplex attribute assert_true: request has duplex attribute expected true got false
+PASS Check duplex attribute
 PASS Check bodyUsed attribute
 PASS Request does not expose priority attribute
 PASS Request does not expose internalpriority attribute

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/api/request/request-structure.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/api/request/request-structure.any.sharedworker-expected.txt
@@ -18,7 +18,7 @@ PASS Check redirect attribute
 PASS Check integrity attribute
 FAIL Check isReloadNavigation attribute assert_true: request has isReloadNavigation attribute expected true got false
 FAIL Check isHistoryNavigation attribute assert_true: request has isHistoryNavigation attribute expected true got false
-FAIL Check duplex attribute assert_true: request has duplex attribute expected true got false
+PASS Check duplex attribute
 PASS Check bodyUsed attribute
 PASS Request does not expose priority attribute
 PASS Request does not expose internalpriority attribute

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/api/request/request-structure.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/api/request/request-structure.any.worker-expected.txt
@@ -18,7 +18,7 @@ PASS Check redirect attribute
 PASS Check integrity attribute
 FAIL Check isReloadNavigation attribute assert_true: request has isReloadNavigation attribute expected true got false
 FAIL Check isHistoryNavigation attribute assert_true: request has isHistoryNavigation attribute expected true got false
-FAIL Check duplex attribute assert_true: request has duplex attribute expected true got false
+PASS Check duplex attribute
 PASS Check bodyUsed attribute
 PASS Request does not expose priority attribute
 PASS Request does not expose internalpriority attribute

--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -424,6 +424,7 @@ set(WebCore_NON_SVG_IDL_FILES
     Modules/fetch/FetchRequestCache.idl
     Modules/fetch/FetchRequestCredentials.idl
     Modules/fetch/FetchRequestDestination.idl
+    Modules/fetch/FetchRequestDuplex.idl
     Modules/fetch/FetchRequestInit.idl
     Modules/fetch/FetchRequestMode.idl
     Modules/fetch/FetchRequestRedirect.idl

--- a/Source/WebCore/DerivedSources-input.xcfilelist
+++ b/Source/WebCore/DerivedSources-input.xcfilelist
@@ -481,6 +481,7 @@ $(PROJECT_DIR)/Modules/fetch/FetchRequest.idl
 $(PROJECT_DIR)/Modules/fetch/FetchRequestCache.idl
 $(PROJECT_DIR)/Modules/fetch/FetchRequestCredentials.idl
 $(PROJECT_DIR)/Modules/fetch/FetchRequestDestination.idl
+$(PROJECT_DIR)/Modules/fetch/FetchRequestDuplex.idl
 $(PROJECT_DIR)/Modules/fetch/FetchRequestInit.idl
 $(PROJECT_DIR)/Modules/fetch/FetchRequestMode.idl
 $(PROJECT_DIR)/Modules/fetch/FetchRequestRedirect.idl

--- a/Source/WebCore/DerivedSources-output.xcfilelist
+++ b/Source/WebCore/DerivedSources-output.xcfilelist
@@ -1113,6 +1113,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSFetchRequestCredentials.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSFetchRequestCredentials.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSFetchRequestDestination.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSFetchRequestDestination.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSFetchRequestDuplex.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSFetchRequestDuplex.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSFetchRequestInit.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSFetchRequestInit.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSFetchRequestMode.cpp

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -346,6 +346,7 @@ JS_BINDING_IDLS := \
     $(WebCore)/Modules/fetch/FetchRequestCache.idl \
     $(WebCore)/Modules/fetch/FetchRequestCredentials.idl \
     $(WebCore)/Modules/fetch/FetchRequestDestination.idl \
+    $(WebCore)/Modules/fetch/FetchRequestDuplex.idl \
     $(WebCore)/Modules/fetch/FetchRequestInit.idl \
     $(WebCore)/Modules/fetch/FetchRequestMode.idl \
     $(WebCore)/Modules/fetch/FetchRequestRedirect.idl \

--- a/Source/WebCore/Modules/fetch/FetchRequest.cpp
+++ b/Source/WebCore/Modules/fetch/FetchRequest.cpp
@@ -73,7 +73,7 @@ static ExceptionOr<String> computeReferrer(ScriptExecutionContext& context, cons
     return String { referrerURL.string() };
 }
 
-static std::optional<Exception> buildOptions(FetchOptions& options, ResourceRequest& request, String& referrer, RequestPriority& priority, ScriptExecutionContext& context, const FetchRequest::Init& init)
+static std::optional<Exception> buildOptions(FetchOptions& options, ResourceRequest& request, String& referrer, RequestPriority& priority, std::optional<FetchRequestDuplex>& duplex, ScriptExecutionContext& context, const FetchRequest::Init& init)
 {
     if (!init.window.isUndefinedOrNull() && !init.window.isEmpty())
         return Exception { ExceptionCode::TypeError, "Window can only be null."_s };
@@ -97,6 +97,9 @@ static std::optional<Exception> buildOptions(FetchOptions& options, ResourceRequ
 
     if (init.priority)
         priority = *init.priority;
+
+    if (init.duplex)
+        duplex = init.duplex;
 
     if (init.mode) {
         options.mode = init.mode.value();
@@ -165,7 +168,7 @@ ExceptionOr<void> FetchRequest::initializeOptions(const Init& init)
 {
     ASSERT(scriptExecutionContext());
 
-    auto exception = buildOptions(m_options, m_request, m_referrer, m_priority, *protect(scriptExecutionContext()), init);
+    auto exception = buildOptions(m_options, m_request, m_referrer, m_priority, m_duplex, *protect(scriptExecutionContext()), init);
     if (exception)
         return WTF::move(exception.value());
 
@@ -247,6 +250,7 @@ ExceptionOr<void> FetchRequest::initializeWith(FetchRequest& input, Init&& init)
     m_options = input.m_options;
     m_referrer = input.m_referrer;
     m_priority = input.m_priority;
+    m_duplex = input.m_duplex;
     m_enableContentExtensionsCheck = input.m_enableContentExtensionsCheck;
 
     auto optionsResult = initializeOptions(init);
@@ -284,6 +288,11 @@ ExceptionOr<void> FetchRequest::initializeWith(FetchRequest& input, Init&& init)
     return { };
 }
 
+static bool shouldCheckDuplex(ScriptExecutionContext* context)
+{
+    return context && context->settingsValues().fetchUploadStreamsEnabled;
+}
+
 ExceptionOr<void> FetchRequest::setBody(FetchBody::Init&& body)
 {
     if (!methodCanHaveBody(m_request))
@@ -293,6 +302,9 @@ ExceptionOr<void> FetchRequest::setBody(FetchBody::Init&& body)
     auto result = extractBody(WTF::move(body));
     if (result.hasException())
         return result;
+
+    if (isReadableStreamBody() && !m_duplex && shouldCheckDuplex(protect(scriptExecutionContext())))
+        return Exception { ExceptionCode::TypeError, "Request with a ReadableStream body requires the 'duplex' option to be set"_s };
 
     if (m_options.keepAlive && hasReadableStreamBody())
         return Exception { ExceptionCode::TypeError, "Request cannot have a ReadableStream body and keepalive set to true"_s };
@@ -304,15 +316,18 @@ ExceptionOr<void> FetchRequest::setBody(FetchRequest& request)
     if (request.isDisturbedOrLocked())
         return Exception { ExceptionCode::TypeError, "Request input is disturbed or locked."_s };
 
+    RefPtr context = scriptExecutionContext();
     if (!request.isBodyNull()) {
         if (!methodCanHaveBody(m_request))
             return Exception { ExceptionCode::TypeError, makeString("Request has method '"_s, m_request.httpMethod(), "' and cannot have a body"_s) };
 
-        RefPtr context = scriptExecutionContext();
         auto* globalObject = context ? downcast<JSDOMGlobalObject>(context->globalObject()) : nullptr;
         m_body = request.m_body->createProxy(*globalObject);
         request.setDisturbed();
     }
+
+    if (isReadableStreamBody() && !m_duplex && shouldCheckDuplex(context))
+        return Exception { ExceptionCode::TypeError, "Request with a ReadableStream body requires the 'duplex' option to be set"_s };
 
     if (m_options.keepAlive && hasReadableStreamBody())
         return Exception { ExceptionCode::TypeError, "Request cannot have a ReadableStream body and keepalive set to true"_s };
@@ -385,6 +400,7 @@ ExceptionOr<Ref<FetchRequest>> FetchRequest::clone(JSDOMGlobalObject& globalObje
         return Exception { ExceptionCode::InvalidStateError, "Cannot clone FetchRequest without a valid script execution context"_s };
     auto clone = adoptRef(*new FetchRequest(*context, std::nullopt, FetchHeaders::create(m_headers.get()), ResourceRequest { m_request }, FetchOptions { m_options }, String { m_referrer }));
     clone->suspendIfNeeded();
+    clone->m_duplex = m_duplex;
     clone->cloneBody(globalObject, *this);
     clone->setNavigationPreloadIdentifier(m_navigationPreloadIdentifier);
     clone->m_enableContentExtensionsCheck = m_enableContentExtensionsCheck;

--- a/Source/WebCore/Modules/fetch/FetchRequest.h
+++ b/Source/WebCore/Modules/fetch/FetchRequest.h
@@ -73,6 +73,7 @@ public:
     Cache cache() const { return m_options.cache; }
     Redirect redirect() const { return m_options.redirect; }
     bool keepalive() const { return m_options.keepAlive; };
+    FetchRequestDuplex duplex() const { return m_duplex.value_or(FetchRequestDuplex::Half); }
     AbortSignal& signal() { return m_signal.get(); }
 
     const String& integrity() const LIFETIME_BOUND { return m_options.integrity; }
@@ -110,6 +111,7 @@ private:
     URLKeepingBlobAlive m_requestURL;
     FetchOptions m_options;
     RequestPriority m_priority { RequestPriority::Auto };
+    std::optional<FetchRequestDuplex> m_duplex;
     String m_referrer;
     const Ref<AbortSignal> m_signal;
     Markable<FetchIdentifier> m_navigationPreloadIdentifier;

--- a/Source/WebCore/Modules/fetch/FetchRequest.idl
+++ b/Source/WebCore/Modules/fetch/FetchRequest.idl
@@ -50,6 +50,7 @@ typedef (FetchRequest or USVString) RequestInfo;
     readonly attribute FetchRequestRedirect redirect;
     readonly attribute DOMString integrity;
     readonly attribute boolean keepalive;
+    [EnabledBySetting=FetchUploadStreamsEnabled] readonly attribute FetchRequestDuplex duplex;
     // FIXME: Implement 'isReloadNavigation'.
     // readonly attribute boolean isReloadNavigation;
     // FIXME: Implement 'isHistoryNavigation'.

--- a/Source/WebCore/Modules/fetch/FetchRequestDuplex.h
+++ b/Source/WebCore/Modules/fetch/FetchRequestDuplex.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,37 +25,10 @@
 
 #pragma once
 
-#include "AbortSignal.h"
-#include "FetchBody.h"
-#include "FetchHeaders.h"
-#include "FetchOptions.h"
-#include "FetchRequestDuplex.h"
-#include "IPAddressSpace.h"
-#include "RequestPriority.h"
-#include <JavaScriptCore/JSCJSValue.h>
-#include <wtf/text/WTFString.h>
-
 namespace WebCore {
 
-struct FetchRequestInit {
-    String method;
-    std::optional<FetchHeaders::Init> headers;
-    std::optional<std::optional<FetchBody::Init>> body;
-    String referrer;
-    std::optional<ReferrerPolicy> referrerPolicy;
-    std::optional<FetchOptions::Mode> mode;
-    std::optional<FetchOptions::Credentials> credentials;
-    std::optional<FetchOptions::Cache> cache;
-    std::optional<FetchOptions::Redirect> redirect;
-    String integrity;
-    std::optional<bool> keepalive;
-    JSC::JSValue signal;
-    std::optional<RequestPriority> priority;
-    std::optional<FetchRequestDuplex> duplex;
-    JSC::JSValue window;
-    std::optional<IPAddressSpace> targetAddressSpace;
-
-    bool hasMembers() const { return !method.isEmpty() || headers || body || !referrer.isEmpty() || referrerPolicy || mode || credentials || cache || redirect || !integrity.isEmpty() || keepalive || duplex || !window.isUndefined() || !signal.isUndefined() || (targetAddressSpace && *targetAddressSpace != IPAddressSpace::Public); }
+enum class FetchRequestDuplex : bool {
+    Half
 };
 
 }

--- a/Source/WebCore/Modules/fetch/FetchRequestDuplex.idl
+++ b/Source/WebCore/Modules/fetch/FetchRequestDuplex.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,26 +23,4 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-typedef (sequence<sequence<ByteString>> or record<ByteString, ByteString>) HeadersInit;
-
-typedef (Blob or BufferSource or DOMFormData or URLSearchParams or ReadableStream or USVString) BodyInit;
-
-dictionary FetchRequestInit {
-    ByteString method;
-    HeadersInit headers;
-    BodyInit? body;
-    USVString referrer;
-    FetchReferrerPolicy referrerPolicy;
-    FetchRequestMode mode;
-    FetchRequestCredentials credentials;
-    FetchRequestCache cache;
-    FetchRequestRedirect redirect;
-    DOMString integrity;
-    boolean keepalive;
-    // FIXME: 'signal' should be of type AbortSignal?.
-    any signal;
-    RequestPriority priority;
-    [EnabledBySetting=FetchUploadStreamsEnabled] FetchRequestDuplex duplex;
-    any window; // can only be set to null
-    [EnabledBySetting=LocalNetworkAccessEnabled] IPAddressSpace targetAddressSpace;
-};
+enum FetchRequestDuplex { "half" };

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -4230,6 +4230,7 @@ JSFetchRequest.cpp
 JSFetchRequestCache.cpp
 JSFetchRequestCredentials.cpp
 JSFetchRequestDestination.cpp
+JSFetchRequestDuplex.cpp
 JSFetchRequestInit.cpp
 JSFetchRequestMode.cpp
 JSFetchRequestRedirect.cpp

--- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
+++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
@@ -1617,6 +1617,7 @@
 		41E12E9F24FE74E20093FFB4 /* WebSocketIdentifier.h in Headers */ = {isa = PBXBuildFile; fileRef = 41E12E9D24FE74E20093FFB4 /* WebSocketIdentifier.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		41E1B1D10FF5986900576B3B /* AbstractWorker.h in Headers */ = {isa = PBXBuildFile; fileRef = 41E1B1CB0FF5986900576B3B /* AbstractWorker.h */; };
 		41E27170300934A90015A3AF /* PendingStreamIdentifier.h in Headers */ = {isa = PBXBuildFile; fileRef = 41E2716F300934A20015A3AF /* PendingStreamIdentifier.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		41E2806F300A38020015A3AF /* FetchRequestDuplex.h in Headers */ = {isa = PBXBuildFile; fileRef = 41E2806D300A37F90015A3AF /* FetchRequestDuplex.h */; };
 		41E2F199274FAECF00A089EE /* NavigationPreloadManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 41E2F197274FAECB00A089EE /* NavigationPreloadManager.h */; };
 		41E4C3E729A3D03300EA6B3A /* BackgroundFetch.h in Headers */ = {isa = PBXBuildFile; fileRef = 418B491D29A3CF80007B3135 /* BackgroundFetch.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		41E4C3E829A3D03900EA6B3A /* BackgroundFetchEngine.h in Headers */ = {isa = PBXBuildFile; fileRef = 418B491E29A3CF81007B3135 /* BackgroundFetchEngine.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -11537,6 +11538,8 @@
 		41E1F33D248A62B60022D5DE /* AudioSampleBufferConverter.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = AudioSampleBufferConverter.mm; sourceTree = "<group>"; };
 		41E1F33F248A62B60022D5DE /* AudioSampleBufferConverter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AudioSampleBufferConverter.h; sourceTree = "<group>"; };
 		41E2716F300934A20015A3AF /* PendingStreamIdentifier.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PendingStreamIdentifier.h; sourceTree = "<group>"; };
+		41E2806D300A37F90015A3AF /* FetchRequestDuplex.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FetchRequestDuplex.h; sourceTree = "<group>"; };
+		41E2806E300A37F90015A3AF /* FetchRequestDuplex.idl */ = {isa = PBXFileReference; lastKnownFileType = text; path = FetchRequestDuplex.idl; sourceTree = "<group>"; };
 		41E2F195274FAECA00A089EE /* NavigationPreloadManager.idl */ = {isa = PBXFileReference; lastKnownFileType = text; path = NavigationPreloadManager.idl; sourceTree = "<group>"; };
 		41E2F197274FAECB00A089EE /* NavigationPreloadManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NavigationPreloadManager.h; sourceTree = "<group>"; };
 		41E2F198274FAECB00A089EE /* NavigationPreloadManager.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = NavigationPreloadManager.cpp; sourceTree = "<group>"; };
@@ -27893,6 +27896,8 @@
 				7CE191541F2A9B1D00272F78 /* FetchRequestCredentials.idl */,
 				464D4C7D28D2407B001C47C7 /* FetchRequestDestination.h */,
 				464D4C7C28D2407A001C47C7 /* FetchRequestDestination.idl */,
+				41E2806D300A37F90015A3AF /* FetchRequestDuplex.h */,
+				41E2806E300A37F90015A3AF /* FetchRequestDuplex.idl */,
 				7CE191471F2A98AF00272F78 /* FetchRequestInit.h */,
 				7CE191491F2A98B000272F78 /* FetchRequestInit.idl */,
 				7CE1914F1F2A9B0A00272F78 /* FetchRequestMode.h */,
@@ -45421,6 +45426,7 @@
 				7CE1915A1F2A9B3400272F78 /* FetchRequestCache.h in Headers */,
 				7CE191551F2A9B1D00272F78 /* FetchRequestCredentials.h in Headers */,
 				464D4C7E28D24080001C47C7 /* FetchRequestDestination.h in Headers */,
+				41E2806F300A38020015A3AF /* FetchRequestDuplex.h in Headers */,
 				7CE1914A1F2A98B900272F78 /* FetchRequestInit.h in Headers */,
 				7CE191511F2A9B0A00272F78 /* FetchRequestMode.h in Headers */,
 				7CE191601F2A9B4F00272F78 /* FetchRequestRedirect.h in Headers */,


### PR DESCRIPTION
#### df40d92d0fcd348b3fb39bb138e6c5565f6c3d3e
<pre>
Implement FetchRequest duplex property
<a href="https://rdar.apple.com/182802330">rdar://182802330</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=319891">https://bugs.webkit.org/show_bug.cgi?id=319891</a>

Reviewed by Alex Christensen.

We introduce FetchRequest.duplex and FetchRequestInit.duplex to allow feature detection of fetch stream uploads.
As per spec, we only allow stream with the duplex property.

Covered by updated and rebased tests.

* LayoutTests/http/wpt/fetch/fetch-request-with-stream-body.html:
* LayoutTests/http/wpt/fetch/request-clone-resizable.html:
* LayoutTests/http/wpt/fetch/request-clone.html:
* LayoutTests/http/wpt/fetch/request-stream-empty.html:
* LayoutTests/http/wpt/fetch/request-stream-error.html:
* LayoutTests/imported/w3c/web-platform-tests/fetch/api/idlharness.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fetch/api/idlharness.https.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fetch/api/idlharness.https.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fetch/api/idlharness.https.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fetch/api/request/request-init-stream.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fetch/api/request/request-init-stream.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fetch/api/request/request-init-stream.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fetch/api/request/request-init-stream.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fetch/api/request/request-structure.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fetch/api/request/request-structure.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fetch/api/request/request-structure.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fetch/api/request/request-structure.any.worker-expected.txt:
* Source/WebCore/CMakeLists.txt:
* Source/WebCore/DerivedSources-input.xcfilelist:
* Source/WebCore/DerivedSources-output.xcfilelist:
* Source/WebCore/DerivedSources.make:
* Source/WebCore/Modules/fetch/FetchRequest.cpp:
(WebCore::buildOptions):
(WebCore::FetchRequest::initializeOptions):
(WebCore::FetchRequest::initializeWith):
(WebCore::shouldCheckDuplex):
(WebCore::FetchRequest::setBody):
(WebCore::FetchRequest::clone):
* Source/WebCore/Modules/fetch/FetchRequest.h:
* Source/WebCore/Modules/fetch/FetchRequest.idl:
* Source/WebCore/Modules/fetch/FetchRequestDuplex.h: Added..
* Source/WebCore/Modules/fetch/FetchRequestDuplex.idl: Copied from Source/WebCore/Modules/fetch/FetchRequestInit.idl.
* Source/WebCore/Modules/fetch/FetchRequestInit.h:
(WebCore::FetchRequestInit::hasMembers const):
* Source/WebCore/Modules/fetch/FetchRequestInit.idl:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/317768@main">https://commits.webkit.org/317768@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f367ae00bbdb7520c7d94117f2f20e5e8f95df34

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176134 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50069 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43859 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185730 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/138369 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bb29fb47-bab9-41ac-9c26-b377ca4cfa48) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/177997 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51361 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49753 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137180 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/138369 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b432e625-1b08-4df5-981f-bf356847ceea) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179090 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40661 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157960 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117655 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3a2e451c-6379-4748-8486-e044113a89a5) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39310 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37678 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149726 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37457 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34198 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41785 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41889 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188153 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49734 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/157505 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146205 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39361 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50417 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34075 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/held.https.any.sharedworker.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146030 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40806 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122620 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/116589 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48922 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12429 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48324 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48558 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48382 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->