### PR TITLE
[EWS] Refactor AnalyzeAPITestsResults to read build properties like layout tests

### DIFF
--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -6007,7 +6007,8 @@ class RunAPITests(shell.Test, AddToLogMixin, ShellMixin):
         if self.failedTestCount:
             rc = FAILURE
 
-        yield self.analyze_failures_using_results_db()
+        failures = yield self.parse_and_set_failures()
+        yield self.analyze_failures_using_results_db(failures)
 
         if SHOULD_FILTER_LOGS is True:
             self.steps_to_add += [
@@ -6087,12 +6088,14 @@ class RunAPITests(shell.Test, AddToLogMixin, ShellMixin):
         return {'step': status}
 
     @defer.inlineCallbacks
-    def analyze_failures_using_results_db(self):
+    def parse_and_set_failures(self):
         yield self._addToLog('json', '\n')
-        logTextJson = self.log_observer_json.getStdout().rstrip()
-
-        failures = self.parse_api_failures_from_string(logTextJson)
+        failures = self.parse_api_failures_from_string(self.log_observer_json.getStdout().rstrip())
         self.setProperty(f'{self.suffix}_failures', sorted(failures))
+        defer.returnValue(failures)
+
+    @defer.inlineCallbacks
+    def analyze_failures_using_results_db(self, failures):
         if failures:
             yield self._addToLog(self.test_failures_log_name, '\n'.join(failures))
             yield self.filter_api_test_failures_using_results_db(failures)
@@ -6192,11 +6195,12 @@ class ReRunAPITests(RunAPITests):
 
 class RunAPITestsWithoutChange(RunAPITests):
     name = 'run-api-tests-without-change'
+    suffix = 'clean_tree_run'
 
     def doOnFailure(self):
         pass
 
-    def analyze_failures_using_results_db(self):
+    def analyze_failures_using_results_db(self, failures):
         pass
 
 
@@ -6208,42 +6212,18 @@ class AnalyzeAPITestsResults(buildstep.BuildStep, AddToLogMixin):
 
     @defer.inlineCallbacks
     def run(self):
-        self.results = {}
-        yield self.getTestsResults(RunAPITests.name)
-        yield self.getTestsResults(ReRunAPITests.name)
-        yield self.getTestsResults(RunAPITestsWithoutChange.name)
-        result = yield self.analyzeResults()
+        first_run_failures = set(self.getProperty('first_run_failures', []))
+        second_run_failures = set(self.getProperty('second_run_failures', []))
 
-        defer.returnValue(result)
-
-    @defer.inlineCallbacks
-    def analyzeResults(self):
-        if not self.results or len(self.results) == 0:
-            yield self._addToLog('stderr', 'Unable to parse API test results: {}'.format(self.results))
+        # This step runs only after both runs failed, so a missing or empty failure list means a run
+        # failed without producing parseable results: an infrastructure issue that should retry.
+        if not first_run_failures or not second_run_failures:
+            yield self._addToLog('stderr', 'Unable to parse API test results')
             self.build.buildFinished(['Unable to parse API test results'], RETRY)
             defer.returnValue(RETRY)
             return
 
-        first_run_results = self.results.get(RunAPITests.name)
-        second_run_results = self.results.get(ReRunAPITests.name)
-        clean_tree_results = self.results.get(RunAPITestsWithoutChange.name)
-
-        if not (first_run_results and second_run_results):
-            self.build.buildFinished(['Unable to parse API test results'], RETRY)
-            defer.returnValue(RETRY)
-            return
-
-        def getAPITestFailures(result):
-            if not result:
-                return set([])
-            # TODO: Analyze Time-out, Crash and Failure independently
-            return set([failure.get('name') for failure in result.get('Timedout', [])] +
-                       [failure.get('name') for failure in result.get('Crashed', [])] +
-                       [failure.get('name') for failure in result.get('Failed', [])])
-
-        first_run_failures = getAPITestFailures(first_run_results)
-        second_run_failures = getAPITestFailures(second_run_results)
-        clean_tree_failures = getAPITestFailures(clean_tree_results)
+        clean_tree_failures = set(self.getProperty('clean_tree_run_failures', []))
         clean_tree_failures_to_display = list(clean_tree_failures)[:self.NUM_FAILURES_TO_DISPLAY]
         clean_tree_failures_string = ', '.join(clean_tree_failures_to_display)
 
@@ -6288,38 +6268,6 @@ class AnalyzeAPITestsResults(buildstep.BuildStep, AddToLogMixin):
                     self.send_email_for_flaky_failure(flaky_failure)
             self.build.buildFinished([message], SUCCESS)
             defer.returnValue(SUCCESS)
-
-    def getBuildStepByName(self, name):
-        for step in self.build.executedSteps:
-            if step.name == name:
-                return step
-        return None
-
-    @defer.inlineCallbacks
-    def getTestsResults(self, name):
-        step = self.getBuildStepByName(name)
-        if not step:
-            yield self._addToLog('stderr', 'ERROR: step not found: {}'.format(step))
-            defer.returnValue(None)
-            return
-
-        logs = yield self.master.db.logs.getLogs(step.stepid)
-        log = next((log for log in logs if log['name'] == 'json'), None)
-        if not log:
-            yield self._addToLog('stderr', 'ERROR: log for step not found: {}'.format(step))
-            defer.returnValue(None)
-            return
-
-        lastline = int(max(0, log['num_lines'] - 1))
-        logLines = yield self.master.db.logs.getLogLines(log['id'], 0, lastline)
-        if log['type'] == 's':
-            logLines = ''.join([line[1:] for line in logLines.splitlines()])
-
-        try:
-            self.results[name] = json.loads(logLines)
-            defer.returnValue(self.results[name])
-        except Exception as ex:
-            yield self._addToLog('stderr', 'ERROR: unable to parse data, exception: {}'.format(ex))
 
     def send_email_for_flaky_failure(self, test_name):
         try:
@@ -6696,7 +6644,7 @@ class RunAPITestsParallelSafety(RunAPITests):
         # No retry needed for parallel safety tests - failures are legitimate
         pass
 
-    def analyze_failures_using_results_db(self):
+    def analyze_failures_using_results_db(self, failures):
         # Skip results DB checking for parallel safety tests
         pass
 

--- a/Tools/CISupport/ews-build/steps_unittest.py
+++ b/Tools/CISupport/ews-build/steps_unittest.py
@@ -6040,6 +6040,64 @@ Ran 1296 tests of 1298 with 1293 successful
         return self.run_step()
 
 
+class TestAnalyzeAPITestsResults(BuildStepMixinAdditions, unittest.TestCase):
+    def setUp(self):
+        self.longMessage = True
+        return self.setup_test_build_step()
+
+    def tearDown(self):
+        return self.tear_down_test_build_step()
+
+    def configureStep(self):
+        self.setup_step(AnalyzeAPITestsResults())
+        self.setProperty('clean_tree_run_failures', [])
+
+    def test_new_failure_introduced_by_change(self):
+        self.configureStep()
+        self.setProperty('first_run_failures', ['suite.test1'])
+        self.setProperty('second_run_failures', ['suite.test1'])
+        self.expect_outcome(result=FAILURE, state_string='Found 1 new API test failure: suite.test1 (failure)')
+        return self.run_step()
+
+    def test_pre_existing_failure_on_clean_tree(self):
+        self.configureStep()
+        self.setProperty('first_run_failures', ['suite.test1'])
+        self.setProperty('second_run_failures', ['suite.test1'])
+        self.setProperty('clean_tree_run_failures', ['suite.test1'])
+        self.expect_outcome(result=SUCCESS, state_string='Passed API tests')
+        return self.run_step()
+
+    def test_flaky_failure(self):
+        # test1 and test2 fail in different runs (never both), so they are flaky, not new failures.
+        self.configureStep()
+        self.setProperty('first_run_failures', ['suite.test1'])
+        self.setProperty('second_run_failures', ['suite.test2'])
+        self.expect_outcome(result=SUCCESS, state_string='Passed API tests')
+        return self.run_step()
+
+    def test_retry_when_both_runs_empty(self):
+        # This step runs only after both runs failed, so empty failure lists mean the results could
+        # not be parsed (an infrastructure issue), which should retry.
+        self.configureStep()
+        self.setProperty('first_run_failures', [])
+        self.setProperty('second_run_failures', [])
+        self.expect_outcome(result=RETRY, state_string='analyze-api-tests-results (retry)')
+        return self.run_step()
+
+    def test_retry_when_results_missing(self):
+        # A missing first_run_failures/second_run_failures property means the run step produced no
+        # parseable results, which is an infrastructure issue that should retry.
+        self.configureStep()
+        self.expect_outcome(result=RETRY, state_string='analyze-api-tests-results (retry)')
+        return self.run_step()
+
+    def test_retry_when_second_run_results_missing(self):
+        self.configureStep()
+        self.setProperty('first_run_failures', ['suite.test1'])
+        self.expect_outcome(result=RETRY, state_string='analyze-api-tests-results (retry)')
+        return self.run_step()
+
+
 class TestRunAPITestsParallelSafety(BuildStepMixinAdditions, unittest.TestCase):
     def setUp(self):
         self.longMessage = True


### PR DESCRIPTION
#### 436208095697b206723e6b6e30776368ff967ce9
<pre>
[EWS] Refactor AnalyzeAPITestsResults to read build properties like layout tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=319898">https://bugs.webkit.org/show_bug.cgi?id=319898</a>
<a href="https://rdar.apple.com/problem/182817323">rdar://problem/182817323</a>

Reviewed by Ryan Haddad.

AnalyzeAPITestsResults re-fetches and re-parses the json log of each API test run step from the  database,
instead of reading the failure lists that the run steps already computed and stored as build properties.
This also created various inefficiencies and edge cases bugs.

For layout-tests we use a much better approach, AnalyzeLayoutTestsResults reads first_run_failures /
second_run_failures / clean_tree_run_failures directly as properties.

This improves AnalyzeAPITestsResults to use the same pattern.

* Tools/CISupport/ews-build/steps.py:
(RunAPITests.run): Parse and publish failures, then run results-db analysis.
(RunAPITests.parse_and_set_failures): Added; parse the json log and set {suffix}_failures.
(RunAPITests.analyze_failures_using_results_db): Now takes the parsed failures and only does
results-db filtering.
(RunAPITestsWithoutChange): Set suffix to &apos;clean_tree_run&apos; so parse_and_set_failures publishes
clean_tree_run_failures; skip results-db filtering.
(RunAPITestsParallelSafety.analyze_failures_using_results_db): Match the new signature.
(AnalyzeAPITestsResults.run): Read failure lists from build properties; merge the former
analyzeResults logic in and drop the redundant json re-parsing.
(AnalyzeAPITestsResults.analyzeResults): Removed; folded into run.
(AnalyzeAPITestsResults.getBuildStepByName): Removed; no longer needed.
(AnalyzeAPITestsResults.getTestsResults): Removed; no longer needed.
* Tools/CISupport/ews-build/steps_unittest.py:
(TestAnalyzeAPITestsResults): Added.

Canonical link: <a href="https://commits.webkit.org/317641@main">https://commits.webkit.org/317641@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/056d905afc74d3a407234093039e475f9de06e01

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175893 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/49826 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/43610 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/185486 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/138092 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d6c22bda-71d4-41cc-b5b8-508e27305cbd) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/177756 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51118 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/49508 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/185486 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/138092 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/170f0c48-c3fb-41bd-a096-82d24bb989a2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178849 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/40434 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/43610 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/185486 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/79cb529e-cbdf-48db-b17f-b617e3abf13b) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/39076 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/49508 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/185486 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/43610 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/149495 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/43610 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33956 "Failed to checkout and rebase branch from PR 69856") | | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/49508 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187907 "Built successfully") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/175296 "Passed tests") | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/49493 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/43610 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/145968 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/50173 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/43610 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/145809 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26723 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/50173 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/116232 "Failed to checkout and rebase branch from PR 69856") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/48680 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/43610 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/48082 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/48314 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/48139 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->