### PR TITLE
AX: VoiceOver cursor vertically mirrored for frames whose isolated tree is built by the AXObjectCache constructor timer

### DIFF
--- a/LayoutTests/accessibility/mac/primary-screen-height-iframe-expected.txt
+++ b/LayoutTests/accessibility/mac/primary-screen-height-iframe-expected.txt
@@ -1,0 +1,9 @@
+This test ensures AXPrimaryScreenHeight is non-zero for an iframe whose accessibility tree is built after accessibility is already active (a height of 0 mirrors elements vertically).
+
+PASS: Main-frame root element AXPrimaryScreenHeight is > 0.
+PASS: Iframe descendant element AXPrimaryScreenHeight is > 0.
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/mac/primary-screen-height-iframe.html
+++ b/LayoutTests/accessibility/mac/primary-screen-height-iframe.html
@@ -1,0 +1,61 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+
+<div id="container"></div>
+
+<script>
+window.jsTestIsAsync = true;
+
+var output = "This test ensures AXPrimaryScreenHeight is non-zero for an iframe whose accessibility tree is built after accessibility is already active (a height of 0 mirrors elements vertically).\n\n";
+
+function checkPrimaryScreenHeight(element, label) {
+    return new Promise((resolve) => {
+        element.attributeValueAsync("_AXPrimaryScreenHeight", (value) => {
+            if (value > 0)
+                output += `PASS: ${label} AXPrimaryScreenHeight is > 0.\n`;
+            else
+                output += `FAIL: ${label} AXPrimaryScreenHeight should be > 0 but was ${value}.\n`;
+            resolve();
+        });
+    });
+}
+
+window.addEventListener("load", () => {
+    setTimeout(async () => {
+        if (!window.accessibilityController) {
+            finishJSTest();
+            return;
+        }
+
+        // Touch the main tree so the web process transitions to isolated-tree (AXThread) mode. Any
+        // AXObjectCache constructed after this point arms its build timer in its constructor, so the
+        // iframe we insert below gets its isolated tree built via that timer (the previously-broken path).
+        const root = accessibilityController.rootElement;
+        await waitForFrameGeometryReady();
+        await checkPrimaryScreenHeight(root, "Main-frame root element");
+
+        // Now insert the iframe. Because AXThread mode is already active, its cache builds the isolated
+        // tree via the constructor's build timer -> AXIsolatedTree::create(), not getOrCreateIsolatedTree().
+        document.getElementById("container").innerHTML =
+            "<iframe id='iframe' src=\"data:text/html,<body><h1 id='target'>Iframe heading</h1></body>\"></iframe>";
+
+        // Wait for the iframe's isolated tree and frame geometry to be built, then read
+        // AXPrimaryScreenHeight from an element inside it. It must be > 0.
+        const target = await waitForIframeAccessibilityReady("container", "target");
+        if (!target)
+            output += "FAIL: could not find the iframe's target element in the accessibility tree.\n";
+        else
+            await checkPrimaryScreenHeight(target, "Iframe descendant element");
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+});
+</script>
+</body>
+</html>

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -1253,11 +1253,6 @@ RefPtr<AXIsolatedTree> AXObjectCache::getOrCreateIsolatedTree()
         tree = nullptr;
     }
 
-    // A new isolated tree needs to be created. Initialize the GeometryManager primary screen rect to be ready when needed.
-    m_geometryManager->initializePrimaryScreenRect();
-    // Schedule a paint to cache the rects for the objects in this new isolated tree.
-    scheduleObjectRegionsUpdate(true /* scheduleImmediately */);
-
     if (clientIsInTestMode()) [[unlikely]] {
         // For test clients (LayoutTests / XCTests) build the whole isolated tree synchronously.
         // This is necessary because tests assume that APIs like accessibleElementById can
@@ -1276,6 +1271,14 @@ RefPtr<AXIsolatedTree> AXObjectCache::getOrCreateIsolatedTree()
     }
 
     return tree;
+}
+
+void AXObjectCache::initializeIsolatedTreeGeometry()
+{
+    // Cache the primary display's rect on the geometry manager (its height is exposed to AX clients as
+    // AXPrimaryScreenHeight) and schedule an immediate object-region paint to cache per-object rects.
+    m_geometryManager->initializePrimaryScreenRect();
+    scheduleObjectRegionsUpdate(true /* scheduleImmediately */);
 }
 
 void AXObjectCache::buildIsolatedTree()

--- a/Source/WebCore/accessibility/AXObjectCache.h
+++ b/Source/WebCore/accessibility/AXObjectCache.h
@@ -801,6 +801,7 @@ public:
     WEBCORE_EXPORT static void initializeAXThreadIfNeeded();
     WEBCORE_EXPORT static bool NODELETE isAXThreadInitialized();
     WEBCORE_EXPORT RefPtr<AXIsolatedTree> getOrCreateIsolatedTree();
+    void initializeIsolatedTreeGeometry();
 
     static bool isAccessibilityList(Element&);
 private:

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
@@ -121,6 +121,7 @@ Ref<AXIsolatedTree> AXIsolatedTree::createEmpty(AXObjectCache& axObjectCache)
     AX_ASSERT(isMainThread());
 
     auto tree = adoptRef(*new AXIsolatedTree(axObjectCache));
+    axObjectCache.initializeIsolatedTreeGeometry();
 
     if (RefPtr axRoot = axObjectCache.document() ? axObjectCache.getOrCreate(axObjectCache.document()->view()) : nullptr) {
         tree->updatingSubtree(axRoot.get());
@@ -193,6 +194,7 @@ RefPtr<AXIsolatedTree> AXIsolatedTree::create(AXObjectCache& axObjectCache)
     auto tree = adoptRef(*new AXIsolatedTree(axObjectCache));
     if (RefPtr existingTree = isolatedTreeForID(tree->treeID()))
         tree->m_replacingTree = existingTree;
+    axObjectCache.initializeIsolatedTreeGeometry();
 
     RefPtr document = axObjectCache.document();
     if (!document)


### PR DESCRIPTION
#### 46b3fcfd6171a66e90ca9cb410f9a3f3f5926426
<pre>
AX: VoiceOver cursor vertically mirrored for frames whose isolated tree is built by the AXObjectCache constructor timer
<a href="https://bugs.webkit.org/show_bug.cgi?id=319899">https://bugs.webkit.org/show_bug.cgi?id=319899</a>
<a href="https://rdar.apple.com/182818999">rdar://182818999</a>

Reviewed by Dominic Mazzoni and Chris Fleizach.

AXPrimaryScreenHeight was reported as 0 for any frame whose isolated tree was
built by the AXObjectCache constructor&apos;s build timer, causing VoiceOver to render
the cursor and element bounds vertically mirrored for every element in that frame.

Primary-screen-rect initialization -- and the initial object-region paint that
caches per-object rects -- lived only in AXObjectCache::getOrCreateIsolatedTree().
317449@main added a second build path: the AXObjectCache constructor arms a timer
that runs buildIsolatedTree() -&gt; AXIsolatedTree::create() directly, bypassing
getOrCreateIsolatedTree() and thus both setup steps. After a navigation (and for
every reloaded or inserted iframe, which gets a fresh AXObjectCache) the tree was
built with an uninitialized primary screen rect, so
AXIsolatedObject::primaryScreenRect() returned an empty rect and
AXPrimaryScreenHeight came back as 0.

Move both setup steps into AXObjectCache::initializeIsolatedTreeGeometry() and
invoke it from AXIsolatedTree::create() and createEmpty(), which every build path
funnels through, so the initialization can no longer be skipped.

* LayoutTests/accessibility/mac/primary-screen-height-iframe-expected.txt: Added.
* LayoutTests/accessibility/mac/primary-screen-height-iframe.html: Added.
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::getOrCreateIsolatedTree):
(WebCore::AXObjectCache::initializeIsolatedTreeGeometry):
* Source/WebCore/accessibility/AXObjectCache.h:
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp:
(WebCore::AXIsolatedTree::createEmpty):
(WebCore::AXIsolatedTree::create):

Canonical link: <a href="https://commits.webkit.org/317689@main">https://commits.webkit.org/317689@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9690660e959568db08875afb768df270553e635c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175875 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49808 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43592 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185468 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/138070 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/90aeb8de-32a0-4053-866f-087baf57d85c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/177738 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51100 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49490 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136954 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/138070 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/03519f79-7053-4df0-a117-f49729bff4fc) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178831 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40417 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157733 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117433 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a28396d7-087d-4674-add3-9b7de69b544e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39059 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37441 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149478 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37225 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33938 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41508 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41647 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187889 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49475 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/157284 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145950 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39295 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50155 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33849 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145791 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40585 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122351 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/116213 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48662 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12205 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48064 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48296 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48121 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->