### PR TITLE
[Text Extraction] Simulated clicks should target the innermost descendant in the targeted element

### DIFF
--- a/LayoutTests/fast/text-extraction/debug-text-extraction-basic-expected.txt
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-basic-expected.txt
@@ -57,6 +57,8 @@ root
             button uid=… class=user-menu-btn 'MN' […]
             button uid=… 'Sign In' […]
             button uid=… label=Profile 'YZ' […]
+            uid=… role=button class=account-btn
+                image uid=… […]
             input uid=… […] placeholder=Username
     'Footer content with' […]
     role=img label='copyright symbol' '©' […]

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-basic.html
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-basic.html
@@ -124,6 +124,7 @@ canvas {
         <button class="user-menu-btn">MN</button>
         <button class="login-button">Sign In</button>
         <button class="user-avatar" aria-label="Profile">YZ</button>
+        <div class="account-btn" role="button"><svg width="16" height="16"><path d="M3 13 L11 5 L13 7 L5 15 Z" fill="black"></path></svg></div>
         <input type="text" class="user-input" placeholder="Username" />
     </section>
 </main>

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-scrolling-expected.txt
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-scrolling-expected.txt
@@ -1,4 +1,4 @@
 root scrollPosition=(0,0) contentSize=[…]
-    scrollable scrollPosition=(5000,0) contentSize=[…]
+    scrollable class=scroller scrollPosition=(5000,0) contentSize=[…]
         link url=https://webkit.org/
     scrollable scrollPosition=(10,0) contentSize=[…] '2. Hello world'

--- a/Source/WebCore/page/text-extraction/TextExtraction.cpp
+++ b/Source/WebCore/page/text-extraction/TextExtraction.cpp
@@ -1971,6 +1971,30 @@ static Node* findNodeAtRootViewLocation(const LocalFrameView& view, Document& do
     return document.hitTest(defaultHitTestOptions, result) ? result.innerNode() : nullptr;
 }
 
+static RefPtr<Element> frontmostHitTestedElementInSubtree(const LocalFrameView& view, Document& document, FloatPoint locationInRootView, const Element& target)
+{
+    static constexpr OptionSet listBasedHitTestOptions {
+        HitTestRequest::Type::ReadOnly,
+        HitTestRequest::Type::DisallowUserAgentShadowContent,
+        HitTestRequest::Type::CollectMultipleElements,
+        HitTestRequest::Type::IncludeAllElementsUnderPoint,
+    };
+
+    HitTestResult result { view.rootViewToContents(roundedIntPoint(locationInRootView)) };
+    document.hitTest(listBasedHitTestOptions, result);
+
+    for (auto& node : result.listBasedTestResult()) {
+        RefPtr element = dynamicDowncast<Element>(node.get());
+        if (!element)
+            element = node->parentElementInComposedTree();
+
+        if (element && (element == &target || element->isShadowIncludingDescendantOf(target)))
+            return element;
+    }
+
+    return nullptr;
+}
+
 struct ResolvedMouseTarget {
     Ref<Element> element;
     Ref<LocalFrame> frame;
@@ -2062,8 +2086,11 @@ static void dispatchSimulatedClick(Node& targetNode, const String& searchText, C
 
     UserGestureIndicator indicator { IsProcessingUserGesture::Yes, document.ptr() };
 
-    // Fall back to dispatching a programmatic click.
-    if (protect(element)->dispatchSimulatedClick(nullptr, SendMouseUpDownEvents))
+    Ref clickTarget = element;
+    if (RefPtr descendant = frontmostHitTestedElementInSubtree(view, document, centerInRootView, element))
+        clickTarget = descendant.releaseNonNull();
+
+    if (protect(clickTarget)->dispatchSimulatedClick(nullptr, SendMouseUpDownEvents))
         completion(true, { });
     else
         completion(false, "Failed to click (tried falling back to dispatching programmatic click since target could not be hit-tested)"_s);

--- a/Source/WebKit/Shared/TextExtractionToStringConversion.cpp
+++ b/Source/WebKit/Shared/TextExtractionToStringConversion.cpp
@@ -1121,7 +1121,7 @@ static std::pair<Vector<String>, String> recognizedClassesAndIdForItem(const Tex
     if (item.classNames.isEmpty() && item.idAttribute.isEmpty())
         return { };
 
-    if (!item.accessibilityRole.isEmpty() || !item.title.isEmpty())
+    if (!item.title.isEmpty())
         return { };
 
     if (!item.ariaAttributes.isEmpty() || !item.clientAttributes.isEmpty())
@@ -1163,11 +1163,10 @@ static std::pair<Vector<String>, String> recognizedClassesAndIdForItem(const Tex
         return { };
 
     if (item.children.size() == 1) {
-        auto* textData = std::get_if<TextExtraction::TextItemData>(&item.children[0].data);
-        if (!textData)
-            return { };
-        if (textData->content.trim(isASCIIWhitespace).length() > 2)
-            return { };
+        if (auto* textData = std::get_if<TextExtraction::TextItemData>(&item.children[0].data)) {
+            if (textData->content.trim(isASCIIWhitespace).length() > 2)
+                return { };
+        }
     }
 
 #if PLATFORM(COCOA)

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/TextExtractionTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/TextExtractionTests.mm
@@ -395,6 +395,32 @@ TEST(TextExtractionTests, InteractionDescriptionUsesAdjacentTextForUnlabeledIcon
     EXPECT_NULL(error);
 }
 
+TEST(TextExtractionTests, InteractionClicksThroughOccludingOverlay)
+{
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    [[configuration preferences] _setTextExtractionEnabled:YES];
+
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration]);
+    [webView synchronouslyLoadHTMLString:@"<a aria-label='Log in' href='#' style='position:absolute; top:10px; left:10px; width:80px; height:60px;'>"
+        "<span id='login-button' role='button' style='display:block; width:100%; height:100%;'>"
+        "<svg width='36' height='36' viewBox='0 0 36 36'><circle cx='18' cy='18' r='18' fill='black'></circle></svg>"
+        "</span></a>"
+        "<div style='position:fixed; top:0; left:0; width:100%; height:100%; background:rgba(0,0,0,0.1);'></div>"
+        "<script>window.loginClicked = false;"
+        "document.getElementById('login-button').addEventListener('click', () => { window.loginClicked = true; });</script>"];
+
+    RetainPtr debugText = [webView synchronouslyGetDebugText:nil];
+    RetainPtr loginLinkID = extractNodeIdentifier(debugText, @"Log in");
+    EXPECT_NOT_NULL(loginLinkID);
+
+    RetainPtr interaction = adoptNS([[_WKTextExtractionInteraction alloc] initWithAction:_WKTextExtractionActionClick]);
+    [interaction setNodeIdentifier:loginLinkID];
+    RetainPtr result = [webView synchronouslyPerformInteraction:interaction];
+    EXPECT_NULL([result error]);
+
+    EXPECT_TRUE([[webView objectByEvaluatingJavaScript:@"window.loginClicked"] boolValue]);
+}
+
 TEST(TextExtractionTests, InteractionDebugDescriptionWithStaleNodeIdentifier)
 {
     RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);


### PR DESCRIPTION
#### 60f57c6dce48e685b7a9a27020bfb1f1d45633f6
<pre>
[Text Extraction] Simulated clicks should target the innermost descendant in the targeted element
<a href="https://bugs.webkit.org/show_bug.cgi?id=319901">https://bugs.webkit.org/show_bug.cgi?id=319901</a>
<a href="https://rdar.apple.com/182822622">rdar://182822622</a>

Reviewed by Abrar Rahman Protyasha.

Make a couple of adjustments which allow the agent to click the &quot;Me&quot; (login) button on www.iq.com,
even when the promotional overlay is showing up over the rest of the page:

1.  Surface more context for elements with only an accessibility role (like `uid=… role=button`), so
    that if the `class` and/or `id` happen to contain additional context, agents are still able to
    reason about it.

2.  Currently, if the agent tries to click an element, we first try to simulate real mousedown/up
    events near the center of the targeted element. In the case where the element is obscured by
    another container (in this case, a modal promotional overlay), we fall back to simulating a
    programmatic click on the target. While this works well in most cases, because it&apos;s dispatched
    onto the target element directly, it doesn&apos;t bubble up the event target chain properly (so if
    the content expects the event target to be an inner descendant, the click doesn&apos;t behave as
    expected).

    To fix this, we perform a piercing hit-test to find the innermost descendant at the center of
    the target element, and then simulate the programmatic click over that innermost descendant
    instead (allowing the event to bubble up the chain to the target).

Test: TextExtractionTests.InteractionClicksThroughOccludingOverlay

* LayoutTests/fast/text-extraction/debug-text-extraction-basic-expected.txt:
* LayoutTests/fast/text-extraction/debug-text-extraction-basic.html:

Augment an existing layout test to cover the changes for [1] above.

* Source/WebCore/page/text-extraction/TextExtraction.cpp:
(WebCore::TextExtraction::frontmostHitTestedElementInSubtree):

See [2] above.

(WebCore::TextExtraction::dispatchSimulatedClick):
* Source/WebKit/Shared/TextExtractionToStringConversion.cpp:
(WebKit::recognizedClassesAndIdForItem):

See [1] above.

* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/TextExtractionTests.mm:
(TestWebKitAPI::TEST(TextExtractionTests, InteractionClicksThroughOccludingOverlay)):

Add an API test for [2] above.

Canonical link: <a href="https://commits.webkit.org/317666@main">https://commits.webkit.org/317666@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0a0ee930ec7548cf2ca596133f7736522554a525

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175916 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49849 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43633 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185509 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/138118 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3e788806-340e-413a-a775-27da90424ec3) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/177779 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51141 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49531 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136992 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/138118 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8a8dfaa7-8f2e-4a99-9365-1c88efaad0d7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178872 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40457 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157765 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117471 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/43e049a8-b4a4-47c5-bd31-86f3586667b9) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39099 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37479 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149518 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37257 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33979 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41549 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41685 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187930 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49516 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/157316 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145991 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39284 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50196 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/33882 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145830 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40621 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122392 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/116255 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48703 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12238 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48105 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48337 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48162 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->