### PR TITLE
LayoutTests: Update Dynamic Code Brand Checks WPT tests

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-function-constructor-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-function-constructor-expected.txt
@@ -60,8 +60,8 @@ PASS AsyncFunction constructor with mixed plain and trusted strings, mask #14
 PASS GeneratorFunction constructor with mixed plain and trusted strings, mask #14
 PASS AsyncGeneratorFunction constructor with mixed plain and trusted strings, mask #14
 PASS Function constructor with mixed plain and trusted strings, mask #15
-PASS Function constructor with trusted strings, and a forged toString() for the one at index 0
-PASS Function constructor with trusted strings, and a forged toString() for the one at index 1
-PASS Function constructor with trusted strings, and a forged toString() for the one at index 2
-PASS Function constructor with trusted strings, and a forged toString() for the one at index 3
+FAIL Function constructor with trusted strings, and a forged toString() for the one at index 0 Refused to evaluate a string as JavaScript because this document requires a 'Trusted Type' assignment.
+FAIL Function constructor with trusted strings, and a forged toString() for the one at index 1 Refused to evaluate a string as JavaScript because this document requires a 'Trusted Type' assignment.
+FAIL Function constructor with trusted strings, and a forged toString() for the one at index 2 Refused to evaluate a string as JavaScript because this document requires a 'Trusted Type' assignment.
+FAIL Function constructor with trusted strings, and a forged toString() for the one at index 3 Refused to evaluate a string as JavaScript because this document requires a 'Trusted Type' assignment.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-function-constructor-untrusted-arguments-and-applying-default-policy-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-function-constructor-untrusted-arguments-and-applying-default-policy-expected.txt
@@ -7,12 +7,8 @@ PASS plain string at index 0 (default policy leaving the function text unchanged
 PASS plain string at index 1 (default policy leaving the function text unchanged).
 PASS plain string at index 2 (default policy leaving the function text unchanged).
 PASS plain string at index 3 (default policy leaving the function text unchanged).
-PASS TrustedScript with forged toString() at index 0 (default policy modifying the function text).
-PASS TrustedScript with forged toString() at index 1 (default policy modifying the function text).
-PASS TrustedScript with forged toString() at index 2 (default policy modifying the function text).
-PASS TrustedScript with forged toString() at index 3 (default policy modifying the function text).
-PASS TrustedScript with forged toString() at index 0 (default policy leaving the function text unchanged).
-PASS TrustedScript with forged toString() at index 1 (default policy leaving the function text unchanged).
-PASS TrustedScript with forged toString() at index 2 (default policy leaving the function text unchanged).
-PASS TrustedScript with forged toString() at index 3 (default policy leaving the function text unchanged).
+FAIL TrustedScript with forged toString() at index 0 (default policy not invoked). assert_equals: toString() should never be called on a TrustedScript argument expected 0 but got 2
+FAIL TrustedScript with forged toString() at index 1 (default policy not invoked). assert_equals: toString() should never be called on a TrustedScript argument expected 0 but got 2
+FAIL TrustedScript with forged toString() at index 2 (default policy not invoked). assert_equals: toString() should never be called on a TrustedScript argument expected 0 but got 2
+FAIL TrustedScript with forged toString() at index 3 (default policy not invoked). assert_equals: toString() should never be called on a TrustedScript argument expected 0 but got 2
 

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-function-constructor-untrusted-arguments-and-applying-default-policy.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-function-constructor-untrusted-arguments-and-applying-default-policy.html
@@ -17,45 +17,65 @@
     createScript: s => renameVariableXtoY(s)
   });
 
-  // As in eval-function-constructor.html we consider two kind of untrusted
-  // arguments: plain string or TrustedScript with a forged toString().
-  const untrusted_argument_factory = {
-    "plain string": arg_value => arg_value,
-    "TrustedScript with forged toString()": arg_value => Object.assign(
-      policy.createScript(arg_value), { toString: () => ` ${arg_value} ` })
-  };
+  // A plain string is still untrusted, so it still triggers the default
+  // policy's variable-renaming behavior.
+  const args = ["X1", "X2", "X3 = 5", "return (X1+X2)*X3;"];
+  // Wrap the function arguments into TrustedTypes, except for the one at the
+  // specified index. That argument will cause isTrusted=false in
+  // EnsureCSPDoesNotBlockStringCompilation and so "Get Trusted Type
+  // compliant string" will be executed on the function text, which use Xn
+  // variables. Consequently, the default policy will modify the function text
+  // which will cause an EvalError to be thrown.
+  args.forEach((_, index) => {
+    test(t => {
+      let mixed_args = args.map((arg_value, arg_index) =>
+        arg_index == index ? arg_value : policy.createScript(arg_value));
+      assert_throws_js(EvalError, _ => new Function(...mixed_args));
+    }, `plain string at index ${index} (default policy modifying the function text).`);
+  });
 
-  for (const [untrusted_argument_name, untrusted_argument_builder] of
-       Object.entries(untrusted_argument_factory)) {
-    const args = ["X1", "X2", "X3 = 5", "return (X1+X2)*X3;"];
-    // Wrap the function arguments into TrustedTypes, except for the one at the
-    // specified index. That argument will cause isTrusted=false in
-    // EnsureCSPDoesNotBlockStringCompilation and so "Get Trusted Type
-    // compliant string" will be executed on the function text, which use Xn
-    // variables. Consequently, the default policy will modify the function text
-    // which will cause an EvalError to be thrown.
-    args.forEach((_, index) => {
-      test(t => {
-        let mixed_args = args.map((arg_value, arg_index) =>
-          arg_index == index ? untrusted_argument_builder(arg_value)
-                             : policy.createScript(arg_value));
-        assert_throws_js(EvalError, _ => new Function(...mixed_args));
-      }, `${untrusted_argument_name} at index ${index} (default policy modifying the function text).`);
-    });
+  // Do the same but apply the variable renaming before building the function,
+  // so that the default policy won't modify the function text anymore. In
+  // that case, the function is built without error.
+  const argsWithY = args.map(renameVariableXtoY);
+  argsWithY.forEach((_, index) => {
+    test(t => {
+      let mixed_args = argsWithY.map((arg_value, arg_index) =>
+        arg_index == index ? arg_value : policy.createScript(arg_value));
+      const f = new Function(...mixed_args);
+      assert_equals(f(1,2,3), 9);
+      assert_equals(f(1,2), 15);
+    }, `plain string at index ${index} (default policy leaving the function text unchanged).`);
+  });
 
-    // Do the same but apply the variable renaming before building the function,
-    // so that the default policy won't modify the function text anymore. In
-    // that case, the function is built without error.
-    const argsWithY = args.map(renameVariableXtoY);
-    argsWithY.forEach((_, index) => {
-      test(t => {
-        let mixed_args = argsWithY.map((arg_value, arg_index) =>
-          arg_index == index ? untrusted_argument_builder(arg_value)
-                             : policy.createScript(arg_value));
-        const f = new Function(...mixed_args);
-        assert_equals(f(1,2,3), 9);
-        assert_equals(f(1,2), 15);
-      }, `${untrusted_argument_name} at index ${index} (default policy leaving the function text unchanged).`);
-    });
-  }
+  // A TrustedScript with a forged toString() is still genuinely trusted:
+  // trust is derived from HostGetCodeForEval reading the real internal data,
+  // not from ToString(). So isTrusted is always true here, the default
+  // policy is never invoked, and the function is always built from the
+  // real trusted text. The forged toString() values below are chosen to
+  // produce a different, observable result (a ReferenceError or a wrong
+  // number) if they were ever mistakenly used instead of the real trusted
+  // data, so a regression to the old toString()-based behavior would make
+  // this test fail. A call counter also verifies toString() is never invoked
+  // at all
+  const trustedArgs = ["a", "b", "c = 5", "return (a+b)*c;"];
+  const forgedArgs = ["a2", "b2", "c = 50", "return (a+b)*c+1;"];
+  trustedArgs.forEach((_, index) => {
+    test(t => {
+      let toStringCallCount = 0;
+      let mixed_args = trustedArgs.map((arg_value, arg_index) => {
+        let obj = policy.createScript(arg_value);
+        return arg_index == index ?
+          Object.assign(obj, { toString: () => {
+            toStringCallCount++;
+            return forgedArgs[arg_index];
+          }}) : obj;
+      });
+      const f = new Function(...mixed_args);
+      assert_equals(toStringCallCount, 0,
+        "toString() should never be called on a TrustedScript argument");
+      assert_equals(f(1,2,3), 9);
+      assert_equals(f(1,2), 15);
+    }, `TrustedScript with forged toString() at index ${index} (default policy not invoked).`);
+  });
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-function-constructor.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-function-constructor.html
@@ -71,17 +71,29 @@
   }, `Function constructor with mixed plain and trusted strings, mask #${arg_max}`);
 
   // Similarly wrap all args in TrustedScript objects, but forges the toString()
-  // method at one index so that it adds extra leading/trailing space compared
-  // to the trusted data. This string mismatch also lead to isTrusted=false in
-  // EnsureCSPDoesNotBlockStringCompilation.
+  // method at one index. Trust is derived from HostGetCodeForEval reading the
+  // real internal data, not from ToString(), so the forged toString() has no
+  // effect and the function is built from the real trusted text. The forged
+  // values are chosen to produce a different, observable result if they were
+  // ever mistakenly used, so a regression would make this test fail.
+  // A call counter also directly verifies toString() is never invoked at all.
+  const forgedArgs = ["a2", "b2", "c = 50", "return (a+b)*c+1;"];
   args.forEach((_, index) => {
     test(t => {
+      let toStringCallCount = 0;
       let mixed_args = args.map((arg_value, arg_index) => {
         let obj = policy.createScript(arg_value);
         return arg_index == index ?
-          Object.assign(obj, { toString: () => ` ${arg_value} ` }) : obj;
+          Object.assign(obj, { toString: () => {
+            toStringCallCount++;
+            return forgedArgs[arg_index];
+          }}) : obj;
       });
-      assert_throws_js(EvalError, _ => new Function(...mixed_args));
+      const f = new Function(...mixed_args);
+      assert_equals(toStringCallCount, 0,
+        "toString() should never be called on a TrustedScript argument");
+      assert_equals(f(1,2,3), 9);
+      assert_equals(f(1,2), 15);
     }, `Function constructor with trusted strings, and a forged toString() for the one at index ${index}`);
   });
 </script>


### PR DESCRIPTION
#### 970134c173209618a7bc15c93ba8543e02632849
<pre>
LayoutTests: Update Dynamic Code Brand Checks WPT tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=319409">https://bugs.webkit.org/show_bug.cgi?id=319409</a>

Reviewed by Adrian Perez de Castro.

Update the imported Trusted Types web-platform-tests for the Dynamic
Code Brand Checks proposal and regenerate the corresponding expected
results.

No functional engine changes. I&apos;m doing a follow up implmentation fix
for the Dynamic Code Brand Checks proposal in JSC that will make the
new Function constructor not call toString on code-like objects, so
the tests for that behavior are being updated here.

* LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-function-constructor-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-function-constructor-untrusted-arguments-and-applying-default-policy-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-function-constructor-untrusted-arguments-and-applying-default-policy.html:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-function-constructor.html:

Canonical link: <a href="https://commits.webkit.org/317975@main">https://commits.webkit.org/317975@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b8583bb847cdb7fb2c45d039b0b148e76ca38f2d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176933 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50870 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44665 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186536 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140169 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52163 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50556 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137855 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140169 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179889 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41364 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158642 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118324 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40020 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/38386 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150430 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38142 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-highlight-api/painting/custom-highlight-dynamic-font-metrics-001.html (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35004 "Built successfully") | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42604 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188959 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50537 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/158182 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146930 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39497 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51220 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/34766 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146726 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41488 "Passed tests") | | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/117699 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49725 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13122 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49124 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49361 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49185 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->