### PR TITLE
[WebTransport] WebTransportSendStream should reflect sendOrder and sendGroup from creation options

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6819,7 +6819,7 @@ imported/w3c/web-platform-tests/webtransport/streams-close.https.any.servicework
 imported/w3c/web-platform-tests/webtransport/streams-close.https.any.sharedworker.html [ Skip ]
 imported/w3c/web-platform-tests/webtransport/streams-close.https.any.worker.html [ Skip ]
 
-# Backend gaps (datagram flow-control, getStats, sendOrder, close, historical, idlharness exportKeyingMaterial).
+# Backend gaps (datagram flow-control, getStats, close, historical, idlharness exportKeyingMaterial).
 imported/w3c/web-platform-tests/webtransport/datagrams.https.any.html [ Skip ]
 imported/w3c/web-platform-tests/webtransport/datagrams.https.any.serviceworker.html [ Skip ]
 imported/w3c/web-platform-tests/webtransport/datagrams.https.any.sharedworker.html [ Skip ]
@@ -6828,10 +6828,6 @@ imported/w3c/web-platform-tests/webtransport/stats.https.any.html [ Skip ]
 imported/w3c/web-platform-tests/webtransport/stats.https.any.serviceworker.html [ Skip ]
 imported/w3c/web-platform-tests/webtransport/stats.https.any.sharedworker.html [ Skip ]
 imported/w3c/web-platform-tests/webtransport/stats.https.any.worker.html [ Skip ]
-imported/w3c/web-platform-tests/webtransport/sendorder.https.any.html [ Skip ]
-imported/w3c/web-platform-tests/webtransport/sendorder.https.any.serviceworker.html [ Skip ]
-imported/w3c/web-platform-tests/webtransport/sendorder.https.any.sharedworker.html [ Skip ]
-imported/w3c/web-platform-tests/webtransport/sendorder.https.any.worker.html [ Skip ]
 imported/w3c/web-platform-tests/webtransport/close.https.any.html [ Skip ]
 imported/w3c/web-platform-tests/webtransport/close.https.any.serviceworker.html [ Skip ]
 imported/w3c/web-platform-tests/webtransport/close.https.any.sharedworker.html [ Skip ]

--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/sendorder.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/sendorder.https.any-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL WebTransport client should be able to create and handle a bidirectional stream with sendOrder assert_equals: expected (number) 3 but got (object) null
-FAIL WebTransport client should be able to modify unset sendOrder after stream creation assert_equals: expected (number) 0 but got (object) null
-FAIL WebTransport client should be able to modify existing sendOrder after stream creation assert_equals: expected (number) 3 but got (object) null
+PASS WebTransport client should be able to create and handle a bidirectional stream with sendOrder
+PASS WebTransport client should be able to modify unset sendOrder after stream creation
+PASS WebTransport client should be able to modify existing sendOrder after stream creation
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/sendorder.https.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/sendorder.https.any.serviceworker-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL WebTransport client should be able to create and handle a bidirectional stream with sendOrder assert_equals: expected (number) 3 but got (object) null
-FAIL WebTransport client should be able to modify unset sendOrder after stream creation assert_equals: expected (number) 0 but got (object) null
-FAIL WebTransport client should be able to modify existing sendOrder after stream creation assert_equals: expected (number) 3 but got (object) null
+PASS WebTransport client should be able to create and handle a bidirectional stream with sendOrder
+PASS WebTransport client should be able to modify unset sendOrder after stream creation
+PASS WebTransport client should be able to modify existing sendOrder after stream creation
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/sendorder.https.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/sendorder.https.any.sharedworker-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL WebTransport client should be able to create and handle a bidirectional stream with sendOrder assert_equals: expected (number) 3 but got (object) null
-FAIL WebTransport client should be able to modify unset sendOrder after stream creation assert_equals: expected (number) 0 but got (object) null
-FAIL WebTransport client should be able to modify existing sendOrder after stream creation assert_equals: expected (number) 3 but got (object) null
+PASS WebTransport client should be able to create and handle a bidirectional stream with sendOrder
+PASS WebTransport client should be able to modify unset sendOrder after stream creation
+PASS WebTransport client should be able to modify existing sendOrder after stream creation
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/sendorder.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/sendorder.https.any.worker-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL WebTransport client should be able to create and handle a bidirectional stream with sendOrder assert_equals: expected (number) 3 but got (object) null
-FAIL WebTransport client should be able to modify unset sendOrder after stream creation assert_equals: expected (number) 0 but got (object) null
-FAIL WebTransport client should be able to modify existing sendOrder after stream creation assert_equals: expected (number) 3 but got (object) null
+PASS WebTransport client should be able to create and handle a bidirectional stream with sendOrder
+PASS WebTransport client should be able to modify unset sendOrder after stream creation
+PASS WebTransport client should be able to modify existing sendOrder after stream creation
 

--- a/Source/WebCore/Modules/webtransport/WebTransport.cpp
+++ b/Source/WebCore/Modules/webtransport/WebTransport.cpp
@@ -60,6 +60,7 @@
 #include "WebTransportReliabilityMode.h"
 #include "WebTransportSendGroup.h"
 #include "WebTransportSendStream.h"
+#include "WebTransportSendStreamOptions.h"
 #include "WebTransportSendStreamSink.h"
 #include "WebTransportSession.h"
 #include "WorkerGlobalScope.h"
@@ -253,12 +254,12 @@ void WebTransport::receiveIncomingUnidirectionalStream(WebTransportStreamIdentif
         protect(m_session)->destroyStream(identifier, std::nullopt);
 }
 
-static ExceptionOr<Ref<WebTransportBidirectionalStream>> createBidirectionalStream(WebTransport& transport, WebTransportSession& session, JSDOMGlobalObject& globalObject, Ref<WebTransportSendStreamSink>&& sink, Ref<WebTransportReceiveStreamByteSource>&& source)
+static ExceptionOr<Ref<WebTransportBidirectionalStream>> createBidirectionalStream(WebTransport& transport, WebTransportSession& session, JSDOMGlobalObject& globalObject, Ref<WebTransportSendStreamSink>&& sink, Ref<WebTransportReceiveStreamByteSource>&& source, const WebTransportSendStreamOptions& options)
 {
     auto identifier = sink->identifier();
     auto sendStream = [&] {
         Locker<JSC::JSLock> locker(globalObject.vm().apiLock());
-        return WebTransportSendStream::create(transport, globalObject, WTF::move(sink));
+        return WebTransportSendStream::create(transport, globalObject, WTF::move(sink), options);
     } ();
     if (sendStream.hasException())
         return sendStream.releaseException();
@@ -286,7 +287,7 @@ void WebTransport::receiveBidirectionalStream(WebTransportStreamIdentifier ident
     Ref sink = WebTransportSendStreamSink::create(*this, identifier);
     auto& jsDOMGlobalObject = *downcast<JSDOMGlobalObject>(globalObject);
     Ref incomingStream = WebTransportReceiveStreamByteSource::create(*this, identifier);
-    auto stream = WebCore::createBidirectionalStream(*this, *session, jsDOMGlobalObject, sink.copyRef(), incomingStream.copyRef());
+    auto stream = WebCore::createBidirectionalStream(*this, *session, jsDOMGlobalObject, sink.copyRef(), incomingStream.copyRef(), WebTransportSendStreamOptions { });
     if (stream.hasException())
         return;
     Ref bidiStream = stream.releaseReturnValue();
@@ -547,7 +548,7 @@ WebTransportDatagramDuplexStream& WebTransport::datagrams()
     return m_datagrams.get();
 }
 
-void WebTransport::createBidirectionalStream(ScriptExecutionContext& context, WebTransportSendStreamOptions&&, Ref<DeferredPromise>&& promise)
+void WebTransport::createBidirectionalStream(ScriptExecutionContext& context, WebTransportSendStreamOptions&& options, Ref<DeferredPromise>&& promise)
 {
     // https://www.w3.org/TR/webtransport/#dom-webtransport-createbidirectionalstream
     RefPtr session = m_session;
@@ -558,7 +559,8 @@ void WebTransport::createBidirectionalStream(ScriptExecutionContext& context, We
         promise = WTF::move(promise),
         context = WeakPtr { context },
         protectedThis = Ref { *this },
-        session
+        session,
+        options = WTF::move(options)
     ] (auto&& identifier) mutable {
         if (!identifier)
             return promise->reject(ExceptionCode::InvalidStateError);
@@ -571,7 +573,7 @@ void WebTransport::createBidirectionalStream(ScriptExecutionContext& context, We
         Ref sink = WebTransportSendStreamSink::create(protectedThis.get(), *identifier);
         auto& jsDOMGlobalObject = *downcast<JSDOMGlobalObject>(globalObject);
         Ref incomingStream = WebTransportReceiveStreamByteSource::create(protectedThis.get(), *identifier);
-        auto stream = WebCore::createBidirectionalStream(protectedThis, *session, jsDOMGlobalObject, sink.copyRef(), incomingStream.copyRef());
+        auto stream = WebCore::createBidirectionalStream(protectedThis, *session, jsDOMGlobalObject, sink.copyRef(), incomingStream.copyRef(), options);
         if (stream.hasException())
             return promise->reject(stream.releaseException());
         Ref bidiStream = stream.releaseReturnValue();
@@ -592,7 +594,7 @@ ReadableStream& WebTransport::incomingBidirectionalStreams()
     return m_incomingBidirectionalStreams.get();
 }
 
-void WebTransport::createUnidirectionalStream(ScriptExecutionContext& context, WebTransportSendStreamOptions&&, Ref<DeferredPromise>&& promise)
+void WebTransport::createUnidirectionalStream(ScriptExecutionContext& context, WebTransportSendStreamOptions&& options, Ref<DeferredPromise>&& promise)
 {
     // https://www.w3.org/TR/webtransport/#dom-webtransport-createunidirectionalstream
     RefPtr session = m_session;
@@ -603,7 +605,8 @@ void WebTransport::createUnidirectionalStream(ScriptExecutionContext& context, W
         promise = WTF::move(promise),
         context = WeakPtr { context },
         protectedThis = Ref { *this },
-        session
+        session,
+        options = WTF::move(options)
     ] (auto&& identifier) mutable {
         if (!identifier)
             return promise->reject(ExceptionCode::InvalidStateError);
@@ -617,7 +620,7 @@ void WebTransport::createUnidirectionalStream(ScriptExecutionContext& context, W
         auto& jsDOMGlobalObject = *downcast<JSDOMGlobalObject>(globalObject);
         auto stream = [&] {
             Locker<JSC::JSLock> locker(jsDOMGlobalObject.vm().apiLock());
-            return WebTransportSendStream::create(protectedThis, jsDOMGlobalObject, sink.copyRef());
+            return WebTransportSendStream::create(protectedThis, jsDOMGlobalObject, sink.copyRef(), options);
         } ();
         if (stream.hasException())
             return promise->reject(stream.releaseException());

--- a/Source/WebCore/Modules/webtransport/WebTransportSendStream.cpp
+++ b/Source/WebCore/Modules/webtransport/WebTransportSendStream.cpp
@@ -34,6 +34,7 @@
 #include "TaskSource.h"
 #include "WebTransport.h"
 #include "WebTransportSendGroup.h"
+#include "WebTransportSendStreamOptions.h"
 #include "WebTransportSendStreamSink.h"
 #include "WebTransportSendStreamStats.h"
 #include "WebTransportSession.h"
@@ -43,14 +44,18 @@ namespace WebCore {
 
 // FIXME: use this to implement the check in the setter of https://www.w3.org/TR/webtransport/#dom-webtransportsendstream-sendgroup
 
-ExceptionOr<Ref<WebTransportSendStream>> WebTransportSendStream::create(WebTransport& transport, JSDOMGlobalObject& globalObject, Ref<WebTransportSendStreamSink>&& sink)
+ExceptionOr<Ref<WebTransportSendStream>> WebTransportSendStream::create(WebTransport& transport, JSDOMGlobalObject& globalObject, Ref<WebTransportSendStreamSink>&& sink, const WebTransportSendStreamOptions& options)
 {
     auto identifier = sink->identifier();
     auto result = createInternalWritableStream(globalObject, WTF::move(sink));
     if (result.hasException())
         return result.releaseException();
 
-    return adoptRef(*new WebTransportSendStream(identifier, transport, result.releaseReturnValue()));
+    Ref sendStream = adoptRef(*new WebTransportSendStream(identifier, transport, result.releaseReturnValue()));
+    if (auto sendGroupResult = sendStream->setSendGroup(options.sendGroup.get()); sendGroupResult.hasException())
+        return sendGroupResult.releaseException();
+    sendStream->setSendOrder(options.sendOrder);
+    return sendStream;
 }
 
 WebTransportSendStream::WebTransportSendStream(WebTransportStreamIdentifier identifier, WebTransport& transport, Ref<InternalWritableStream>&& stream)

--- a/Source/WebCore/Modules/webtransport/WebTransportSendStream.h
+++ b/Source/WebCore/Modules/webtransport/WebTransportSendStream.h
@@ -35,6 +35,7 @@ class WebTransport;
 class WebTransportSendGroup;
 class WebTransportSendStreamSink;
 
+struct WebTransportSendStreamOptions;
 struct WebTransportSendStreamStats;
 struct WebTransportStreamIdentifierType;
 
@@ -42,7 +43,7 @@ using WebTransportStreamIdentifier = ObjectIdentifier<WebTransportStreamIdentifi
 
 class WebTransportSendStream : public WritableStream {
 public:
-    static ExceptionOr<Ref<WebTransportSendStream>> create(WebTransport&, JSDOMGlobalObject&, Ref<WebTransportSendStreamSink>&&);
+    static ExceptionOr<Ref<WebTransportSendStream>> create(WebTransport&, JSDOMGlobalObject&, Ref<WebTransportSendStreamSink>&&, const WebTransportSendStreamOptions&);
     ~WebTransportSendStream();
 
     void getStats(ScriptExecutionContext&, Ref<DeferredPromise>&&);


### PR DESCRIPTION
#### 689509d66dd53e195d05c56683f1dcaae2ae3870
<pre>
[WebTransport] WebTransportSendStream should reflect sendOrder and sendGroup from creation options
<a href="https://bugs.webkit.org/show_bug.cgi?id=319875">https://bugs.webkit.org/show_bug.cgi?id=319875</a>
<a href="https://rdar.apple.com/161685860">rdar://161685860</a>

Reviewed by Alex Christensen.

WebTransport::createBidirectionalStream and createUnidirectionalStream discarded their
WebTransportSendStreamOptions argument, so the sendOrder and sendGroup supplied at stream
creation never reached the resulting WebTransportSendStream. As a result writable.sendOrder
did not reflect the value passed to createBidirectionalStream({sendOrder: N}).

Thread the creation options into WebTransportSendStream::create so the created stream reflects
the requested sendOrder (defaulting to 0) and sendGroup, propagating the sendGroup
transport-ownership check. Server-initiated streams keep the default (sendOrder 0, no group).
This is the WebCore/attribute-level part; actual wire-level send scheduling is tracked
separately in <a href="https://rdar.apple.com/161685860">rdar://161685860</a>.

This unskips imported/w3c/web-platform-tests/webtransport/sendorder.https.any.*, which now
pass (all three subtests, across the window/worker/serviceworker/sharedworker variants).

* LayoutTests/TestExpectations: Unskip the sendorder tests and drop sendOrder from the
backend-gaps comment.
* LayoutTests/imported/w3c/web-platform-tests/webtransport/sendorder.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webtransport/sendorder.https.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webtransport/sendorder.https.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webtransport/sendorder.https.any.worker-expected.txt:
* Source/WebCore/Modules/webtransport/WebTransport.cpp:
(WebCore::createBidirectionalStream):
(WebCore::WebTransport::createBidirectionalStream):
(WebCore::WebTransport::createUnidirectionalStream):
* Source/WebCore/Modules/webtransport/WebTransportSendStream.cpp:
(WebCore::WebTransportSendStream::create):
* Source/WebCore/Modules/webtransport/WebTransportSendStream.h:

Canonical link: <a href="https://commits.webkit.org/317665@main">https://commits.webkit.org/317665@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d7d92c7754427540ea115754be919414d358c60a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175920 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49853 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43637 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185513 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/138122 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2728e26a-9b02-46e1-ac93-d50c7ba20e60) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/177783 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51145 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49535 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/136995 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/138122 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8558dfe9-b427-484b-a396-feca6c9b642b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178876 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40460 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157771 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117474 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/114c67f4-dfa9-4388-acbf-f089ed2234f8) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39102 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37483 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149521 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37263 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33983 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41553 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/41689 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187934 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49520 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145995 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39283 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50200 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/33888 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145834 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40625 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122396 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/116273 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48707 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12244 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48109 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48341 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48166 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->