### PR TITLE
[Testing] Add more mock- tests for EME

### DIFF
--- a/LayoutTests/media/encrypted-media/clearKey/clearKey-cenc-audio-playback-mse.html
+++ b/LayoutTests/media/encrypted-media/clearKey/clearKey-cenc-audio-playback-mse.html
@@ -8,13 +8,14 @@
     <script src="encrypted-media-clearKey-handler.js"></script>
     <script>
 
-    const audioConf = streamMedias["simpleClearKeyMSE"].audio;
+    const media = streamMedias["simpleClearKeyMSE"];
+    const audioConf = media.audio;
 
     function runTest() {
 
         findMediaElement();
 
-        const emeHandler = new EncryptedMediaHandler(video, audioConf);
+        const emeHandler = new EncryptedMediaHandler(video, media);
         if (!emeHandler)
             endTest();
 

--- a/LayoutTests/media/encrypted-media/clearKey/clearKey-cenc-stop-playback-before-key.html
+++ b/LayoutTests/media/encrypted-media/clearKey/clearKey-cenc-stop-playback-before-key.html
@@ -8,13 +8,14 @@
     <script src="encrypted-media-clearKey-handler.js"></script>
     <script>
 
-     const audioConf = streamMedias["simpleClearKeyMSE"].audio;
+     const media = streamMedias["simpleClearKeyMSE"];
+     const audioConf = media.audio;
 
      function runTest() {
 
          findMediaElement();
 
-         const emeHandler = new EncryptedMediaHandler(video, audioConf);
+         const emeHandler = new EncryptedMediaHandler(video, media);
          if (!emeHandler)
              failTest();
 

--- a/LayoutTests/media/encrypted-media/clearKey/clearKey-cenc-video-playback-mse-multikey.html
+++ b/LayoutTests/media/encrypted-media/clearKey/clearKey-cenc-video-playback-mse-multikey.html
@@ -8,13 +8,14 @@
     <script src="encrypted-media-clearKey-handler.js"></script>
     <script>
 
-    const videoConf = streamMedias["multiKeyClearKeyVideoMSE"].video;
+    const media = streamMedias["multiKeyClearKeyVideoMSE"];
+    const videoConf = media.video;
 
     function runTest() {
 
         findMediaElement();
 
-        const emeHandler = new EncryptedMediaHandler(video, videoConf);
+        const emeHandler = new EncryptedMediaHandler(video, media);
         if (!emeHandler)
             endTest();
 

--- a/LayoutTests/media/encrypted-media/clearKey/clearKey-cenc-video-playback-mse.html
+++ b/LayoutTests/media/encrypted-media/clearKey/clearKey-cenc-video-playback-mse.html
@@ -8,13 +8,14 @@
     <script src="encrypted-media-clearKey-handler.js"></script>
     <script>
 
-    const videoConf = streamMedias["simpleClearKeyMSE"].video;
+    const media = streamMedias["simpleClearKeyMSE"];
+    const videoConf = media.video;
 
     function runTest() {
 
         findMediaElement();
 
-        const emeHandler = new EncryptedMediaHandler(video, videoConf);
+        const emeHandler = new EncryptedMediaHandler(video, media);
         if (!emeHandler)
             endTest();
 

--- a/LayoutTests/media/encrypted-media/clearKey/clearKey-message-cenc-event-mse.html
+++ b/LayoutTests/media/encrypted-media/clearKey/clearKey-message-cenc-event-mse.html
@@ -8,13 +8,13 @@
     <script src="encrypted-media-clearKey-handler.js"></script>
     <script>
 
-    const videoConf = streamMedias["simpleClearKeyMSE"].video;
+    const media = streamMedias["simpleClearKeyMSE"];
 
     function runTest() {
 
         findMediaElement();
 
-        let emeHandler = new EncryptedMediaHandler(video, videoConf);
+        let emeHandler = new EncryptedMediaHandler(video, media);
         if (!emeHandler)
             endTest();
 
@@ -23,7 +23,7 @@
             let msgStr = String.fromCharCode.apply(String, new Uint8Array(event.message));
             let msgJSON = JSON.parse(msgStr);
             let kid = Base64ToHex(msgJSON.kids[0]).toLowerCase();
-            let key = videoConf.keys[kid];
+            let key = media.video.keys[kid];
             if (key)
                 logResult(true, "Expected Kid");
             endTest();
@@ -32,7 +32,7 @@
         let ms = new MediaSourceLoaderSimple(video);
         ms.onready = function() {
             logResult(true, "Media source is opened");
-            ms.createSourceBuffer(videoConf, 1);
+            ms.createSourceBuffer(media.video, 1);
         };
     }
     </script>

--- a/LayoutTests/media/encrypted-media/clearKey/clearKey-message-cenc-event.html
+++ b/LayoutTests/media/encrypted-media/clearKey/clearKey-message-cenc-event.html
@@ -7,13 +7,14 @@
     <script src="encrypted-media-clearKey-handler.js"></script>
     <script>
 
-    const videoConf = streamMedias["simpleClearKey"].video;
+    const media = streamMedias["simpleClearKey"];
+    const videoConf = media.video;
 
     function runTest() {
 
         findMediaElement();
 
-        let emeHandler = new EncryptedMediaHandler(video, videoConf);
+        let emeHandler = new EncryptedMediaHandler(video, media);
         if (!emeHandler)
             endTest();
 

--- a/LayoutTests/media/encrypted-media/clearKey/clearKey-webm-video-playback-mse.html
+++ b/LayoutTests/media/encrypted-media/clearKey/clearKey-webm-video-playback-mse.html
@@ -8,13 +8,14 @@
     <script src="encrypted-media-clearKey-handler.js"></script>
     <script>
 
-    const videoConf = streamMedias["simpleClearKeyWebMMSE"].video;
+    const media = streamMedias["simpleClearKeyWebMMSE"];
+    const videoConf = media.video;
 
     function runTest() {
 
         findMediaElement();
 
-        const emeHandler = new EncryptedMediaHandler(video, videoConf);
+        const emeHandler = new EncryptedMediaHandler(video, media);
         if (!emeHandler)
             endTest();
 

--- a/LayoutTests/media/encrypted-media/clearKey/encrypted-media-clearKey-handler.js
+++ b/LayoutTests/media/encrypted-media/clearKey/encrypted-media-clearKey-handler.js
@@ -26,7 +26,7 @@ function stringToArray(s)
     return array;
 }
 
-function EncryptedMediaHandler(video, videoConf, audioConf)
+function EncryptedMediaHandler(video, media)
 {
     if (!navigator.requestMediaKeySystemAccess) {
         logResult(false, "EME API is not supported");
@@ -36,15 +36,9 @@ function EncryptedMediaHandler(video, videoConf, audioConf)
     }
 
     this.video = video;
-    this.keys = videoConf.keys;
-    this.audioConf = null;
-    if (audioConf) {
-        for (let attrname in audioConf.keys) {
-            this.keys[attrname] =  audioConf.keys[attrname];
-        }
-        this.audioConf = audioConf;
-    }
-    this.videoConf = videoConf;
+    this.videoConf = media.video || null;
+    this.audioConf = media.audio || null;
+    this.keys = Object.assign({ }, this.videoConf?.keys, this.audioConf?.keys);
     this.sessions = [];
     this.skipUpdateCallback = undefined;
     this.setMediaKeyPromise;
@@ -62,16 +56,14 @@ EncryptedMediaHandler.prototype = {
         let eventVideo = event.target;
 
         if (!this.setMediaKeyPromise) {
-            let options = [
-                {    initDataTypes: [self.videoConf.initDataType],
-                     videoCapabilities: [{contentType : self.videoConf.mimeType}] }
-            ];
+            let primaryConf = self.videoConf || self.audioConf;
+            let config = { initDataTypes: [primaryConf.initDataType] };
+            if (self.videoConf)
+                config.videoCapabilities = [{contentType : self.videoConf.mimeType}];
+            if (self.audioConf)
+                config.audioCapabilities = [{contentType : self.audioConf.mimeType}];
 
-            if (self.audioConf) {
-                options.audioCapabilities = [{contentType : self.audioConf.mimeType}];
-            }
-
-            this.setMediaKeyPromise = navigator.requestMediaKeySystemAccess("org.w3.clearkey", options).then(function(keySystemAccess) {
+            this.setMediaKeyPromise = navigator.requestMediaKeySystemAccess("org.w3.clearkey", [config]).then(function(keySystemAccess) {
                 return keySystemAccess.createMediaKeys();
             }).then(function(mediaKeys) {
                 logResult(true, "MediaKeys is created");

--- a/LayoutTests/media/encrypted-media/encrypted-media-append-clear-encrypted.html
+++ b/LayoutTests/media/encrypted-media/encrypted-media-append-clear-encrypted.html
@@ -8,13 +8,14 @@
     <script src="clearKey/encrypted-media-clearKey-handler.js"></script>
     <script>
 
-     const audioConf = streamMedias["clearToEncryptedMSE"].audio;
+     const media = streamMedias["clearToEncryptedMSE"];
+     const audioConf = media.audio;
 
      function runTest() {
 
          findMediaElement();
 
-         const emeHandler = new EncryptedMediaHandler(video, audioConf);
+         const emeHandler = new EncryptedMediaHandler(video, media);
          if (!emeHandler)
              endTest();
 

--- a/LayoutTests/media/encrypted-media/encrypted-media-append-encrypted-unencrypted.html
+++ b/LayoutTests/media/encrypted-media/encrypted-media-append-encrypted-unencrypted.html
@@ -8,13 +8,14 @@
     <script src="clearKey/encrypted-media-clearKey-handler.js"></script>
     <script>
 
-     const audioConf = streamMedias["encryptedToUnencryptedMSE"].audio;
+     const media = streamMedias["encryptedToUnencryptedMSE"];
+     const audioConf = media.audio;
 
      function runTest() {
 
          findMediaElement();
 
-         const emeHandler = new EncryptedMediaHandler(video, audioConf);
+         const emeHandler = new EncryptedMediaHandler(video, media);
          if (!emeHandler)
              endTest();
 

--- a/LayoutTests/media/encrypted-media/mock-MediaKeySession-invariants-expected.txt
+++ b/LayoutTests/media/encrypted-media/mock-MediaKeySession-invariants-expected.txt
@@ -1,0 +1,53 @@
+RUN(internals.initializeMockMediaSource())
+RUN(mock = internals.registerMockCDM())
+RUN(mock.supportedDataTypes = ["keyids"])
+RUN(capabilities.initDataTypes = ["keyids"])
+RUN(capabilities.videoCapabilities = [{ contentType: 'video/mock; codecs="mock"' }] )
+RUN(promise = navigator.requestMediaKeySystemAccess("org.webkit.mock", [capabilities]))
+Promise resolved OK
+RUN(promise = mediaKeySystemAccess.createMediaKeys())
+Promise resolved OK
+
+Two sessions from the same MediaKeys have distinct non-empty sessionIds.
+RUN(kids = JSON.stringify({ kids: [ "MTIzNDU=" ] }))
+RUN(window.session1 = mediaKeys.createSession("temporary"))
+RUN(promise = window.session1.generateRequest("keyids", stringToUInt8Array(kids)))
+Promise resolved OK
+RUN(window.session2 = mediaKeys.createSession("temporary"))
+RUN(promise = window.session2.generateRequest("keyids", stringToUInt8Array(kids)))
+Promise resolved OK
+EXPECTED (window.session1.sessionId.length > 0 == 'true') OK
+EXPECTED (window.session2.sessionId.length > 0 == 'true') OK
+EXPECTED (window.session1.sessionId !== window.session2.sessionId == 'true') OK
+
+Session with no license processed: expiration is NaN.
+RUN(window.session3 = mediaKeys.createSession("temporary"))
+RUN(promise = window.session3.generateRequest("keyids", stringToUInt8Array(kids)))
+Promise resolved OK
+EXPECTED (isNaN(window.session3.expiration) == 'true') OK
+
+After update() with a finite expiration, session.expiration is a finite Number.
+RUN(mock.expirationOnUpdate = 1735689600000)
+RUN(window.session4 = mediaKeys.createSession("temporary"))
+RUN(promise = window.session4.generateRequest("keyids", stringToUInt8Array(kids)))
+Promise resolved OK
+RUN(promise = window.session4.update(stringToUInt8Array("valid-response keys-changed")))
+Promise resolved OK
+EXPECTED (typeof window.session4.expiration == 'number') OK
+EXPECTED (isFinite(window.session4.expiration) == 'true') OK
+EXPECTED (window.session4.expiration == '1735689600000') OK
+RUN(mock.expirationOnUpdate = NaN)
+
+Two sessions with different initData: each records its own key IDs.
+RUN(window.kidsA = JSON.stringify({ kids: [ "MTIzNDU=" ] }))
+RUN(window.kidsB = JSON.stringify({ kids: [ "Njc4OTA=", "MTIzNDU=" ] }))
+RUN(window.sessionA = mediaKeys.createSession("temporary"))
+RUN(promise = window.sessionA.generateRequest("keyids", stringToUInt8Array(window.kidsA)))
+Promise resolved OK
+RUN(window.sessionB = mediaKeys.createSession("temporary"))
+RUN(promise = window.sessionB.generateRequest("keyids", stringToUInt8Array(window.kidsB)))
+Promise resolved OK
+EXPECTED (mock.keyCountForSession(window.sessionA.sessionId) == '1') OK
+EXPECTED (mock.keyCountForSession(window.sessionB.sessionId) == '2') OK
+END OF TEST
+

--- a/LayoutTests/media/encrypted-media/mock-MediaKeySession-invariants.html
+++ b/LayoutTests/media/encrypted-media/mock-MediaKeySession-invariants.html
@@ -1,0 +1,133 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <script src=../video-test.js></script>
+    <script type="text/javascript">
+    var mock;
+    var promise;
+    var mediaKeySystemAccess;
+    var mediaKeys;
+    var capabilities = {};
+    var kids;
+
+    function doTest()
+    {
+        if (!window.internals) {
+            failTest("Internals is required for this test.")
+            return;
+        }
+
+        run('internals.initializeMockMediaSource()');
+        run('mock = internals.registerMockCDM()');
+        run('mock.supportedDataTypes = ["keyids"]');
+        run('capabilities.initDataTypes = ["keyids"]');
+        run(`capabilities.videoCapabilities = [{ contentType: 'video/mock; codecs="mock"' }] `);
+        run('promise = navigator.requestMediaKeySystemAccess("org.webkit.mock", [capabilities])');
+        shouldResolve(promise).then(gotMediaKeySystemAccess, failTest);
+    }
+
+    function next() {
+        if (!tests.length) {
+            mock.unregister();
+            endTest()
+            return;
+        }
+        var nextTest = tests.shift();
+        consoleWrite('');
+        nextTest();
+    }
+
+    function gotMediaKeySystemAccess(result) {
+        mediaKeySystemAccess = result;
+        run('promise = mediaKeySystemAccess.createMediaKeys()');
+        shouldResolve(promise).then(gotMediaKeys, failTest);
+    }
+
+    function gotMediaKeys(result) {
+        mediaKeys = result;
+        next();
+    }
+
+    function stringToUInt8Array(str)
+    {
+       var array = new Uint8Array(str.length);
+       for (var i=0; i<str.length; i++)
+            array[i] = str.charCodeAt(i);
+       return array;
+    }
+
+    tests = [
+        // Behaviors 6 and 7: A new Session ID is generated each time a session is
+        // successfully created, and Session IDs are unique within the browsing context.
+        function() {
+            consoleWrite('Two sessions from the same MediaKeys have distinct non-empty sessionIds.');
+            run('kids = JSON.stringify({ kids: [ "MTIzNDU=" ] })');
+            run('window.session1 = mediaKeys.createSession("temporary")');
+            run('promise = window.session1.generateRequest("keyids", stringToUInt8Array(kids))');
+            shouldResolve(promise).then(() => {
+                run('window.session2 = mediaKeys.createSession("temporary")');
+                run('promise = window.session2.generateRequest("keyids", stringToUInt8Array(kids))');
+                return shouldResolve(promise);
+            }).then(() => {
+                testExpected('window.session1.sessionId.length > 0', true);
+                testExpected('window.session2.sessionId.length > 0', true);
+                testExpected('window.session1.sessionId !== window.session2.sessionId', true);
+                next();
+            }, next);
+        },
+
+        // Behavior 19: session.expiration is NaN when the session has no known
+        // expiration time (no update() has yet processed a license providing one).
+        function() {
+            consoleWrite('Session with no license processed: expiration is NaN.');
+            run('window.session3 = mediaKeys.createSession("temporary")');
+            run('promise = window.session3.generateRequest("keyids", stringToUInt8Array(kids))');
+            shouldResolve(promise).then(() => {
+                testExpected('isNaN(window.session3.expiration)', true);
+                next();
+            }, next);
+        },
+
+        // Behaviors 18 and 20: after update() delivers a license with an expiration,
+        // session.expiration is an ECMA-262 Time value (a finite Number, never Infinity).
+        function() {
+            consoleWrite('After update() with a finite expiration, session.expiration is a finite Number.');
+            run('mock.expirationOnUpdate = 1735689600000');  // 2025-01-01T00:00:00Z (ms since epoch)
+            run('window.session4 = mediaKeys.createSession("temporary")');
+            run('promise = window.session4.generateRequest("keyids", stringToUInt8Array(kids))');
+            shouldResolve(promise).then(() => {
+                run('promise = window.session4.update(stringToUInt8Array("valid-response keys-changed"))');
+                return shouldResolve(promise);
+            }).then(() => {
+                testExpected('typeof window.session4.expiration', 'number');
+                testExpected('isFinite(window.session4.expiration)', true);
+                testExpected('window.session4.expiration', 1735689600000);
+                // Reset so subsequent tests don't inherit an expiration.
+                run('mock.expirationOnUpdate = NaN');
+                next();
+            }, next);
+        },
+
+        // Behavior 5: Key IDs are tracked per-session; different sessions have their own key sets.
+        function() {
+            consoleWrite('Two sessions with different initData: each records its own key IDs.');
+            run('window.kidsA = JSON.stringify({ kids: [ "MTIzNDU=" ] })');
+            run('window.kidsB = JSON.stringify({ kids: [ "Njc4OTA=", "MTIzNDU=" ] })');
+            run('window.sessionA = mediaKeys.createSession("temporary")');
+            run('promise = window.sessionA.generateRequest("keyids", stringToUInt8Array(window.kidsA))');
+            shouldResolve(promise).then(() => {
+                run('window.sessionB = mediaKeys.createSession("temporary")');
+                run('promise = window.sessionB.generateRequest("keyids", stringToUInt8Array(window.kidsB))');
+                return shouldResolve(promise);
+            }).then(() => {
+                testExpected('mock.keyCountForSession(window.sessionA.sessionId)', 1);
+                testExpected('mock.keyCountForSession(window.sessionB.sessionId)', 2);
+                next();
+            }, next);
+        },
+    ];
+    </script>
+</head>
+<body onload="doTest()">
+</body>
+</html>

--- a/LayoutTests/media/encrypted-media/mock-MediaKeySession-persistence-expected.txt
+++ b/LayoutTests/media/encrypted-media/mock-MediaKeySession-persistence-expected.txt
@@ -1,0 +1,41 @@
+RUN(internals.initializeMockMediaSource())
+RUN(mock = internals.registerMockCDM())
+RUN(mock.supportedDataTypes = ["keyids"])
+RUN(capabilities.initDataTypes = ["keyids"])
+RUN(capabilities.videoCapabilities = [{ contentType: 'video/mock; codecs="mock"' }] )
+RUN(capabilities.sessionTypes = [ "temporary", "persistent-license" ])
+RUN(promise = navigator.requestMediaKeySystemAccess("org.webkit.mock", [capabilities]))
+Promise resolved OK
+RUN(promise = mediaKeySystemAccess.createMediaKeys())
+Promise resolved OK
+
+Temporary session: keys are purged when the session is closed.
+RUN(kids = JSON.stringify({ kids: [ "MTIzNDU=" ] }))
+RUN(window.tempSession = mediaKeys.createSession("temporary"))
+RUN(promise = window.tempSession.generateRequest("keyids", stringToUInt8Array(kids)))
+Promise resolved OK
+RUN(window.tempSessionID = window.tempSession.sessionId)
+EXPECTED (mock.keyCountForSession(window.tempSessionID) == '1') OK
+RUN(promise = window.tempSession.close())
+Promise resolved OK
+EXPECTED (mock.keyCountForSession(window.tempSessionID) == '0') OK
+
+Persistent-license session: keys are retained across close.
+RUN(kids = JSON.stringify({ kids: [ "Njc4OTA=" ] }))
+RUN(window.persistSession = mediaKeys.createSession("persistent-license"))
+RUN(promise = window.persistSession.generateRequest("keyids", stringToUInt8Array(kids)))
+Promise resolved OK
+RUN(window.persistSessionID = window.persistSession.sessionId)
+EXPECTED (mock.keyCountForSession(window.persistSessionID) == '1') OK
+RUN(promise = window.persistSession.close())
+Promise resolved OK
+EXPECTED (mock.keyCountForSession(window.persistSessionID) == '1') OK
+
+Persistent-license: load() restores a previously stored session.
+RUN(window.loadedSession = mediaKeys.createSession("persistent-license"))
+RUN(promise = window.loadedSession.load(window.persistSessionID))
+Promise resolved OK
+EXPECTED (window.loadedSession.sessionId === window.persistSessionID == 'true') OK
+EXPECTED (mock.keyCountForSession(window.loadedSession.sessionId) == '1') OK
+END OF TEST
+

--- a/LayoutTests/media/encrypted-media/mock-MediaKeySession-persistence.html
+++ b/LayoutTests/media/encrypted-media/mock-MediaKeySession-persistence.html
@@ -1,0 +1,115 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <script src=../video-test.js></script>
+    <script type="text/javascript">
+    var mock;
+    var promise;
+    var mediaKeySystemAccess;
+    var mediaKeys;
+    var capabilities = {};
+    var kids;
+
+    function doTest()
+    {
+        if (!window.internals) {
+            failTest("Internals is required for this test.")
+            return;
+        }
+
+        run('internals.initializeMockMediaSource()');
+        run('mock = internals.registerMockCDM()');
+        run('mock.supportedDataTypes = ["keyids"]');
+        run('capabilities.initDataTypes = ["keyids"]');
+        run(`capabilities.videoCapabilities = [{ contentType: 'video/mock; codecs="mock"' }] `);
+        run('capabilities.sessionTypes = [ "temporary", "persistent-license" ]');
+        run('promise = navigator.requestMediaKeySystemAccess("org.webkit.mock", [capabilities])');
+        shouldResolve(promise).then(gotMediaKeySystemAccess, failTest);
+    }
+
+    function next() {
+        if (!tests.length) {
+            mock.unregister();
+            endTest()
+            return;
+        }
+        var nextTest = tests.shift();
+        consoleWrite('');
+        nextTest();
+    }
+
+    function gotMediaKeySystemAccess(result) {
+        mediaKeySystemAccess = result;
+        run('promise = mediaKeySystemAccess.createMediaKeys()');
+        shouldResolve(promise).then(gotMediaKeys, failTest);
+    }
+
+    function gotMediaKeys(result) {
+        mediaKeys = result;
+        next();
+    }
+
+    function stringToUInt8Array(str)
+    {
+       var array = new Uint8Array(str.length);
+       for (var i=0; i<str.length; i++)
+            array[i] = str.charCodeAt(i);
+       return array;
+    }
+
+    tests = [
+        // Behavior 4 (temporary sessions): "All licenses and keys associated with a Key
+        // Session not explicitly stored MUST be destroyed when the session is closed."
+        // Temporary sessions have no persisted state and lose their keys on close().
+        function() {
+            consoleWrite('Temporary session: keys are purged when the session is closed.');
+            run('kids = JSON.stringify({ kids: [ "MTIzNDU=" ] })');
+            run('window.tempSession = mediaKeys.createSession("temporary")');
+            run('promise = window.tempSession.generateRequest("keyids", stringToUInt8Array(kids))');
+            shouldResolve(promise).then(() => {
+                run('window.tempSessionID = window.tempSession.sessionId');
+                testExpected('mock.keyCountForSession(window.tempSessionID)', 1);
+                run('promise = window.tempSession.close()');
+                return shouldResolve(promise);
+            }).then(() => {
+                testExpected('mock.keyCountForSession(window.tempSessionID)', 0);
+                next();
+            }, next);
+        },
+
+        // Behavior 4 (persistent-license sessions): keys are retained across close()
+        // because they are "explicitly stored" and can be reloaded via load().
+        function() {
+            consoleWrite('Persistent-license session: keys are retained across close.');
+            run('kids = JSON.stringify({ kids: [ "Njc4OTA=" ] })');
+            run('window.persistSession = mediaKeys.createSession("persistent-license")');
+            run('promise = window.persistSession.generateRequest("keyids", stringToUInt8Array(kids))');
+            shouldResolve(promise).then(() => {
+                run('window.persistSessionID = window.persistSession.sessionId');
+                testExpected('mock.keyCountForSession(window.persistSessionID)', 1);
+                run('promise = window.persistSession.close()');
+                return shouldResolve(promise);
+            }).then(() => {
+                testExpected('mock.keyCountForSession(window.persistSessionID)', 1);
+                next();
+            }, next);
+        },
+
+        // Behavior 4 corollary: a fresh persistent-license session can load() a previously
+        // closed session's ID and observe the retained keys.
+        function() {
+            consoleWrite('Persistent-license: load() restores a previously stored session.');
+            run('window.loadedSession = mediaKeys.createSession("persistent-license")');
+            run('promise = window.loadedSession.load(window.persistSessionID)');
+            shouldResolve(promise).then(() => {
+                testExpected('window.loadedSession.sessionId === window.persistSessionID', true);
+                testExpected('mock.keyCountForSession(window.loadedSession.sessionId)', 1);
+                next();
+            }, next);
+        },
+    ];
+    </script>
+</head>
+<body onload="doTest()">
+</body>
+</html>

--- a/LayoutTests/media/encrypted-media/mock-navigator-requestMediaKeySystemAccess-expected.txt
+++ b/LayoutTests/media/encrypted-media/mock-navigator-requestMediaKeySystemAccess-expected.txt
@@ -109,5 +109,40 @@ RUN(promise = navigator.requestMediaKeySystemAccess("org.webkit.mock", capabilit
 Promise resolved OK
 EXPECTED (access.getConfiguration().label == 'encryption-scheme-cbcs') OK
 EXPECTED (access.getConfiguration().videoCapabilities[0].encryptionScheme == 'cbcs') OK
+
+RUN(mock.persistentStateRequirement = "optional")
+SET capabilities = '[ { "initDataTypes": [ "mock" ], "videoCapabilities": [ { "contentType": "video/mock; codecs=\"mock\"" } ], "persistentState": "not-allowed", "sessionTypes": [ "persistent-license" ] } ]'
+RUN(promise = navigator.requestMediaKeySystemAccess("org.webkit.mock", capabilities))
+Promise rejected correctly OK
+EXPECTED (exceptionCode.name == 'NotSupportedError') OK
+
+RUN(mock.persistentStateRequirement = "optional")
+SET capabilities = '[ { "initDataTypes": [ "mock" ], "videoCapabilities": [ { "contentType": "video/mock; codecs=\"mock\"" } ], "persistentState": "optional", "sessionTypes": [ "persistent-license" ] } ]'
+RUN(promise = navigator.requestMediaKeySystemAccess("org.webkit.mock", capabilities))
+Promise resolved OK
+EXPECTED (access.getConfiguration().persistentState == 'required') OK
+EXPECTED (access.getConfiguration().sessionTypes.length == '1') OK
+EXPECTED (access.getConfiguration().sessionTypes[0] == 'persistent-license') OK
+
+SET capabilities = '[ { "initDataTypes": [ "mock" ], "audioCapabilities": [], "videoCapabilities": [] } ]'
+RUN(promise = navigator.requestMediaKeySystemAccess("org.webkit.mock", capabilities))
+Promise rejected correctly OK
+EXPECTED (exceptionCode.name == 'NotSupportedError') OK
+
+SET capabilities = '[ { "initDataTypes": [ "mock" ], "videoCapabilities": [ { "contentType": "audio/mock; codecs=\"mock\"" }, { "contentType": "video/mock; codecs=\"mock\"" } ] } ]'
+RUN(promise = navigator.requestMediaKeySystemAccess("org.webkit.mock", capabilities))
+Promise resolved OK
+EXPECTED (access.getConfiguration().videoCapabilities.length == '1') OK
+EXPECTED (access.getConfiguration().videoCapabilities[0].contentType == 'video/mock; codecs="mock"') OK
+
+SET capabilities = '[ { "initDataTypes": [ "mock" ], "videoCapabilities": [ { "contentType": "video/mock; codecs=\"mock\"" } ] } ]'
+RUN(promise = navigator.requestMediaKeySystemAccess("Org.Webkit.Mock", capabilities))
+Promise rejected correctly OK
+EXPECTED (exceptionCode.name == 'NotSupportedError') OK
+
+SET capabilities = '[ { "initDataTypes": [ "MOCK" ], "videoCapabilities": [ { "contentType": "video/mock; codecs=\"mock\"" } ] } ]'
+RUN(promise = navigator.requestMediaKeySystemAccess("org.webkit.mock", capabilities))
+Promise rejected correctly OK
+EXPECTED (exceptionCode.name == 'NotSupportedError') OK
 END OF TEST
 

--- a/LayoutTests/media/encrypted-media/mock-navigator-requestMediaKeySystemAccess.html
+++ b/LayoutTests/media/encrypted-media/mock-navigator-requestMediaKeySystemAccess.html
@@ -280,6 +280,96 @@
                     testExpected('access.getConfiguration().videoCapabilities[0].encryptionScheme', 'cbcs');
                 });
         },
+
+        // Behavior 49: persistentState 'not-allowed' with a persistent session type -> NotSupported.
+        function() {
+            run('mock.persistentStateRequirement = "optional"');
+            failingTestWithCapabilities([{
+                    initDataTypes: ['mock'],
+                    videoCapabilities: [{ contentType: 'video/mock; codecs="mock"' }],
+                    persistentState: 'not-allowed',
+                    sessionTypes: ['persistent-license']
+                }],
+                exceptionCode => {
+                    window.exceptionCode = exceptionCode;
+                    testExpected('exceptionCode.name', 'NotSupportedError');
+                });
+        },
+
+        // Behavior 50: persistentState 'optional' + persistent session type -> normalized to 'required'.
+        function() {
+            run('mock.persistentStateRequirement = "optional"');
+            passingTestWithCapabilities([{
+                    initDataTypes: ['mock'],
+                    videoCapabilities: [{ contentType: 'video/mock; codecs="mock"' }],
+                    persistentState: 'optional',
+                    sessionTypes: ['persistent-license']
+                }],
+                mediaKeySystemAccess => {
+                    window.access = mediaKeySystemAccess;
+                    testExpected('access.getConfiguration().persistentState', 'required');
+                    testExpected('access.getConfiguration().sessionTypes.length', '1');
+                    testExpected('access.getConfiguration().sessionTypes[0]', 'persistent-license');
+                });
+        },
+
+        // Behavior 51: both audioCapabilities and videoCapabilities empty -> NotSupported.
+        function() {
+            failingTestWithCapabilities([{
+                    initDataTypes: ['mock'],
+                    audioCapabilities: [],
+                    videoCapabilities: []
+                }],
+                exceptionCode => {
+                    window.exceptionCode = exceptionCode;
+                    testExpected('exceptionCode.name', 'NotSupportedError');
+                });
+        },
+
+        // Behavior 66: capability with a wrong-family MIME (audio in videoCapabilities) is filtered
+        // out; only the video-family capability survives.
+        function() {
+            passingTestWithCapabilities([{
+                    initDataTypes: ['mock'],
+                    videoCapabilities: [
+                        { contentType: 'audio/mock; codecs="mock"' },
+                        { contentType: 'video/mock; codecs="mock"' }
+                    ]
+                }],
+                mediaKeySystemAccess => {
+                    window.access = mediaKeySystemAccess;
+                    testExpected('access.getConfiguration().videoCapabilities.length', '1');
+                    testExpected('access.getConfiguration().videoCapabilities[0].contentType', 'video/mock; codecs="mock"');
+                });
+        },
+
+        // Behavior 1: Key System strings are compared case-sensitively — a mis-cased name
+        // MUST NOT match the registered CDM.
+        function() {
+            window.capabilities = [{
+                initDataTypes: ['mock'],
+                videoCapabilities: [{ contentType: 'video/mock; codecs="mock"' }]
+            }];
+            consoleWrite(`SET capabilities = '${ JSON.stringify(window.capabilities, null, 1) }'`);
+            run('promise = navigator.requestMediaKeySystemAccess("Org.Webkit.Mock", capabilities)');
+            shouldReject(promise).then(exceptionCode => {
+                window.exceptionCode = exceptionCode;
+                testExpected('exceptionCode.name', 'NotSupportedError');
+            }).then(next, next);
+        },
+
+        // Behavior 10: initDataType strings are compared case-sensitively — a mis-cased type
+        // ('MOCK' vs registered 'mock') MUST NOT match.
+        function() {
+            failingTestWithCapabilities([{
+                    initDataTypes: ['MOCK'],
+                    videoCapabilities: [{ contentType: 'video/mock; codecs="mock"' }]
+                }],
+                exceptionCode => {
+                    window.exceptionCode = exceptionCode;
+                    testExpected('exceptionCode.name', 'NotSupportedError');
+                });
+        },
     ];
     </script>
 </head>

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/encrypted-media/clearkey-mp4-requestmediakeysystemaccess.https-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/encrypted-media/clearkey-mp4-requestmediakeysystemaccess.https-expected.txt
@@ -28,8 +28,8 @@ PASS ContentType formatting must be preserved
 PASS org.w3.clearkey, requestMediaKeySystemAccess: Unsupported audio codec ('audio/webm; codecs=fake') should result in NotSupportedError
 PASS org.w3.clearkey, requestMediaKeySystemAccess: Unsupported video codec () should result in NotSupportedError
 FAIL org.w3.clearkey, requestMediaKeySystemAccess: Mismatched audio container/codec ('audio/webm; codecs=mp4a','audio/webm; codecs=mp4a.40.2') should result in NotSupportedError assert_unreached: Should have rejected: undefined Reached unreachable code
-FAIL org.w3.clearkey, requestMediaKeySystemAccess: Video codec specified in audio field ('video/mp4;codecs="avc1.4d401e"') should result in NotSupportedError assert_unreached: Should have rejected: undefined Reached unreachable code
-FAIL org.w3.clearkey, requestMediaKeySystemAccess: Audio codec specified in video field ('audio/mp4;codecs="mp4a.40.2"') should result in NotSupportedError assert_unreached: Should have rejected: undefined Reached unreachable code
+PASS org.w3.clearkey, requestMediaKeySystemAccess: Video codec specified in audio field ('video/mp4;codecs="avc1.4d401e"') should result in NotSupportedError
+PASS org.w3.clearkey, requestMediaKeySystemAccess: Audio codec specified in video field ('audio/mp4;codecs="mp4a.40.2"') should result in NotSupportedError
 FAIL org.w3.clearkey, requestMediaKeySystemAccess: Mismatched audio container/codec ('audio/webm; codecs=avc1','audio/webm; codecs=avc1.42e01e') should result in NotSupportedError assert_unreached: Should have rejected: undefined Reached unreachable code
 FAIL org.w3.clearkey, requestMediaKeySystemAccess: Mismatched audio container/codec ('audio/mp4; codecs=vorbis') should result in NotSupportedError assert_unreached: Should have rejected: undefined Reached unreachable code
 PASS Two configurations, one supported

--- a/Source/WebCore/Modules/encryptedmedia/MediaKeySession.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeySession.cpp
@@ -804,9 +804,15 @@ PlatformDisplayID MediaKeySession::displayID()
     return 0;
 }
 
-void MediaKeySession::updateExpiration(double)
+void MediaKeySession::updateExpiration(double newExpiration)
 {
-    notImplemented();
+    // https://w3c.github.io/encrypted-media/#update-expiration
+    // 1. Let the session be the associated MediaKeySession object.
+    // 2. Let expiration time be NaN.
+    // 3. If the license(s) and/or key(s) associated with the session expire at a specific time,
+    //    let expiration time be the expiration time in milliseconds since 01 January 1970 UTC.
+    // 4. Set the session's expiration attribute to expiration time.
+    m_expiration = newExpiration;
 }
 
 void MediaKeySession::sessionClosed()

--- a/Source/WebCore/platform/encryptedmedia/CDMPrivate.cpp
+++ b/Source/WebCore/platform/encryptedmedia/CDMPrivate.cpp
@@ -415,6 +415,10 @@ std::optional<Vector<CDMMediaCapability>> CDMPrivate::getSupportedCapabilitiesFo
         }
 
         // 3.11. If content type is not strictly a audio/video type, continue to the next iteration.
+        auto expectedTopLevel = (type == AudioVideoType::Video) ? "video/"_s : "audio/"_s;
+        if (!container.startsWithIgnoringASCIICase(expectedTopLevel))
+            continue;
+
         // 3.12. If robustness is not the empty string and contains an unrecognized value or a value not supported by
         //       implementation, continue to the next iteration. String comparison is case-sensitive.
         if (!robustness.isEmpty() && !supportedRobustnesses().contains(robustness))

--- a/Source/WebCore/testing/MockCDMFactory.cpp
+++ b/Source/WebCore/testing/MockCDMFactory.cpp
@@ -82,7 +82,7 @@ void MockCDMFactory::unregister()
 
 bool MockCDMFactory::supportsKeySystem(const String& keySystem)
 {
-    return equalLettersIgnoringASCIICase(keySystem, "org.webkit.mock"_s);
+    return keySystem == "org.webkit.mock"_s;
 }
 
 bool MockCDMFactory::hasSessionWithID(const String& id)
@@ -95,12 +95,17 @@ bool MockCDMFactory::hasSessionWithID(const String& id)
 
 void MockCDMFactory::removeSessionWithID(const String& id)
 {
-    if (!id.isEmpty())
-        m_sessions.remove(id);
+    if (id.isEmpty())
+        return;
+    m_sessions.remove(id);
+    m_sessionTypes.remove(id);
 }
 
 void MockCDMFactory::addKeysToSessionWithID(const String& id, Vector<Ref<SharedBuffer>>&& keys)
 {
+    if (id.isEmpty())
+        return;
+
     auto addResult = m_sessions.add(id, WTF::move(keys));
     if (addResult.isNewEntry)
         return;
@@ -112,6 +117,9 @@ void MockCDMFactory::addKeysToSessionWithID(const String& id, Vector<Ref<SharedB
 
 Vector<Ref<SharedBuffer>> MockCDMFactory::removeKeysFromSessionWithID(const String& id)
 {
+    if (id.isEmpty())
+        return { };
+
     auto it = m_sessions.find(id);
     if (it == m_sessions.end())
         return { };
@@ -121,10 +129,35 @@ Vector<Ref<SharedBuffer>> MockCDMFactory::removeKeysFromSessionWithID(const Stri
 
 const Vector<Ref<SharedBuffer>>* MockCDMFactory::keysForSessionWithID(const String& id) const
 {
+    if (id.isEmpty())
+        return { };
+
     auto it = m_sessions.find(id);
     if (it == m_sessions.end())
         return nullptr;
     return &it->value;
+}
+
+size_t MockCDMFactory::keyCountForSession(const String& id) const
+{
+    if (id.isEmpty())
+        return 0;
+
+    auto it = m_sessions.find(id);
+    if (it == m_sessions.end())
+        return 0;
+    return it->value.size();
+}
+
+std::optional<CDMSessionType> MockCDMFactory::sessionType(const String& id) const
+{
+    if (id.isEmpty())
+        return std::nullopt;
+
+    auto it = m_sessionTypes.find(id);
+    if (it == m_sessionTypes.end())
+        return std::nullopt;
+    return it->value;
 }
 
 void MockCDMFactory::setSupportedDataTypes(Vector<String>&& types)
@@ -147,23 +180,27 @@ MockCDM::MockCDM(WeakPtr<MockCDMFactory> factory, const String& mediaKeysHashSal
 
 Vector<String> MockCDM::supportedInitDataTypes() const
 {
-    if (m_factory)
-        return m_factory->supportedDataTypes();
+    if (RefPtr factory = this->factory())
+        return factory->supportedDataTypes();
     return { };
 }
 
 Vector<String> MockCDM::supportedRobustnesses() const
 {
-    if (m_factory)
-        return m_factory->supportedRobustness();
+    if (RefPtr factory = this->factory())
+        return factory->supportedRobustness();
     return { };
 }
 
 bool MockCDM::supportsConfiguration(const MediaKeySystemConfiguration& configuration) const
 {
-    auto capabilityHasSupportedEncryptionScheme = [this, checkedThis = CheckedRef { *this }] (auto& capability) {
+    RefPtr factory = this->factory();
+    if (!factory)
+        return false;
+
+    auto capabilityHasSupportedEncryptionScheme = [factory = factory.releaseNonNull()] (auto& capability) {
         if (capability.encryptionScheme)
-            return m_factory->supportedEncryptionSchemes().contains(capability.encryptionScheme.value());
+            return factory->supportedEncryptionSchemes().contains(capability.encryptionScheme.value());
         return true;
     };
 
@@ -179,10 +216,11 @@ bool MockCDM::supportsConfiguration(const MediaKeySystemConfiguration& configura
 
 bool MockCDM::supportsConfigurationWithRestrictions(const MediaKeySystemConfiguration& configuration, const MediaKeysRestrictions&) const
 {
-    if (!m_factory)
+    RefPtr factory = this->factory();
+    if (!factory)
         return true;
 
-    const auto& unsupportedVideoCodecs = m_factory->unsupportedVideoCodecs();
+    const auto& unsupportedVideoCodecs = factory->unsupportedVideoCodecs();
     if (unsupportedVideoCodecs.isEmpty())
         return true;
 
@@ -200,7 +238,7 @@ bool MockCDM::supportsConfigurationWithRestrictions(const MediaKeySystemConfigur
 
 bool MockCDM::supportsSessionTypeWithConfiguration(const MediaKeySessionType& sessionType, const MediaKeySystemConfiguration&) const
 {
-    if (!m_factory || !m_factory->supportedSessionTypes().contains(sessionType))
+    if (RefPtr factory = this->factory(); !factory || !factory->supportedSessionTypes().contains(sessionType))
         return false;
 
     // NOTE: Implement configuration checking;
@@ -209,15 +247,15 @@ bool MockCDM::supportsSessionTypeWithConfiguration(const MediaKeySessionType& se
 
 MediaKeysRequirement MockCDM::distinctiveIdentifiersRequirement(const MediaKeySystemConfiguration&, const MediaKeysRestrictions&) const
 {
-    if (m_factory)
-        return m_factory->distinctiveIdentifiersRequirement();
+    if (RefPtr factory = this->factory())
+        return factory->distinctiveIdentifiersRequirement();
     return MediaKeysRequirement::Optional;
 }
 
 MediaKeysRequirement MockCDM::persistentStateRequirement(const MediaKeySystemConfiguration&, const MediaKeysRestrictions&) const
 {
-    if (m_factory)
-        return m_factory->persistentStateRequirement();
+    if (RefPtr factory = this->factory())
+        return factory->persistentStateRequirement();
     return MediaKeysRequirement::Optional;
 }
 
@@ -229,9 +267,9 @@ bool MockCDM::distinctiveIdentifiersAreUniquePerOriginAndClearable(const MediaKe
 
 RefPtr<CDMInstance> MockCDM::createInstance()
 {
-    if (m_factory && !m_factory->canCreateInstances())
-        return nullptr;
-    return MockCDMInstance::create(*this);
+    if (RefPtr factory = this->factory(); factory && factory->canCreateInstances())
+        return MockCDMInstance::create(*this);
+    return nullptr;
 }
 
 void MockCDM::loadAndInitialize()
@@ -241,12 +279,16 @@ void MockCDM::loadAndInitialize()
 
 bool MockCDM::supportsServerCertificates() const
 {
-    return m_factory && m_factory->supportsServerCertificates();
+    if (RefPtr factory = this->factory())
+        return factory->supportsServerCertificates();
+    return false;
 }
 
 bool MockCDM::supportsSessions() const
 {
-    return m_factory && m_factory->supportsSessions();
+    if (RefPtr factory = this->factory())
+        return factory->supportsSessions();
+    return false;
 }
 
 bool MockCDM::supportsInitData(const String& initDataType, const SharedBuffer& initData) const
@@ -275,6 +317,10 @@ RefPtr<SharedBuffer> MockCDM::sanitizeResponse(const SharedBuffer& response) con
 std::optional<String> MockCDM::sanitizeSessionId(const String& sessionId) const
 {
     if (equalLettersIgnoringASCIICase(sessionId, "valid-loaded-session"_s))
+        return sessionId;
+    // Accept session IDs currently tracked by the factory so tests can round-trip
+    // (e.g. close a persistent-license session, then load() it again by the same ID).
+    if (RefPtr factory = this->factory(); factory && factory->hasSessionWithID(sessionId))
         return sessionId;
     return std::nullopt;
 }
@@ -345,14 +391,28 @@ RefPtr<CDMInstanceSession> MockCDMInstance::createSession()
     return adoptRef(new MockCDMInstanceSession(*this));
 }
 
+RefPtr<MockCDMFactory> MockCDMInstance::factory() const
+{
+    if (CheckedPtr cdm = m_cdm.get())
+        return cdm->factory();
+    return nullptr;
+}
+
 MockCDMInstanceSession::MockCDMInstanceSession(WeakPtr<MockCDMInstance>&& instance)
     : m_instance(WTF::move(instance))
 {
 }
 
+RefPtr<MockCDMFactory> MockCDMInstanceSession::factory() const
+{
+    if (RefPtr instance = m_instance.get())
+        return instance->factory();
+    return nullptr;
+}
+
 void MockCDMInstanceSession::requestLicense(LicenseType licenseType, KeyGroupingStrategy, const String& initDataType, Ref<SharedBuffer>&& initData, LicenseCallback&& callback)
 {
-    RefPtr factory = m_instance ? m_instance->factory() : nullptr;
+    RefPtr factory = this->factory();
     if (!factory) {
         callback(SharedBuffer::create(), emptyString(), false, SuccessValue::Failed);
         return;
@@ -371,6 +431,7 @@ void MockCDMInstanceSession::requestLicense(LicenseType licenseType, KeyGrouping
 
     String sessionID = createVersion4UUIDString();
     factory->addKeysToSessionWithID(sessionID, WTF::move(keyIDs.value()));
+    factory->setSessionType(sessionID, licenseType);
 
     CString license { "license"_s };
     callback(SharedBuffer::create(license.span()), sessionID, false, SuccessValue::Succeeded);
@@ -378,7 +439,7 @@ void MockCDMInstanceSession::requestLicense(LicenseType licenseType, KeyGrouping
 
 void MockCDMInstanceSession::updateLicense(const String& sessionID, LicenseType, Ref<SharedBuffer>&& response, LicenseUpdateCallback&& callback)
 {
-    RefPtr factory = m_instance ? m_instance->factory() : nullptr;
+    RefPtr factory = this->factory();
     if (!factory) {
         callback(false, std::nullopt, std::nullopt, std::nullopt, SuccessValue::Failed);
         return;
@@ -401,43 +462,57 @@ void MockCDMInstanceSession::updateLicense(const String& sessionID, LicenseType,
         }
     }
 
-    // FIXME: Session closure, expiration and message handling should be implemented
-    // once the relevant algorithms are supported.
+    std::optional<double> changedExpiration;
+    if (double expiration = factory->expirationOnUpdate(); !std::isnan(expiration))
+        changedExpiration = expiration;
 
-    callback(false, WTF::move(changedKeys), std::nullopt, std::nullopt, SuccessValue::Succeeded);
+    callback(false, WTF::move(changedKeys), WTF::move(changedExpiration), std::nullopt, SuccessValue::Succeeded);
 }
 
-void MockCDMInstanceSession::loadSession(LicenseType, const String&, const String&, LoadSessionCallback&& callback)
+void MockCDMInstanceSession::loadSession(LicenseType, const String& sessionID, const String&, LoadSessionCallback&& callback)
 {
-    RefPtr factory = m_instance ? m_instance->factory() : nullptr;
+    RefPtr factory = this->factory();
     if (!factory) {
         callback(std::nullopt, std::nullopt, std::nullopt, SuccessValue::Failed, SessionLoadFailure::Other);
         return;
     }
 
-    // FIXME: Key status and expiration handling should be implemented once the relevant algorithms are supported.
+    // If the factory is currently tracking this session (e.g. it was previously created
+    // as a persistent-license and closed but not removed), restore its key statuses so
+    // the loaded session sees its stored keys. Otherwise fall back to a minimal
+    // "session loaded" stub for tests that call load() with the sentinel ID.
+    std::optional<KeyStatusVector> knownKeys;
+    if (const auto* keys = factory->keysForSessionWithID(sessionID)) {
+        knownKeys = keys->map([](auto& key) {
+            return std::pair { key.copyRef(), KeyStatus::Usable };
+        });
+    }
 
     CString messageData { "session loaded"_s };
     Message message { MessageType::LicenseRenewal, SharedBuffer::create(messageData.span()) };
 
-    callback(std::nullopt, std::nullopt, WTF::move(message), SuccessValue::Succeeded, SessionLoadFailure::None);
+    callback(WTF::move(knownKeys), std::nullopt, WTF::move(message), SuccessValue::Succeeded, SessionLoadFailure::None);
 }
 
 void MockCDMInstanceSession::closeSession(const String& sessionID, CloseSessionCallback&& callback)
 {
-    RefPtr factory = m_instance ? m_instance->factory() : nullptr;
+    RefPtr factory = this->factory();
     if (!factory) {
         callback();
         return;
     }
 
-    factory->removeSessionWithID(sessionID);
+    // Per EME "Session Closed" algorithm, keys and licenses associated with a session
+    // MUST be destroyed on close unless the session was persistent-license (in which
+    // case the state is retained so it can be reloaded).
+    if (factory->sessionType(sessionID) != CDMSessionType::PersistentLicense)
+        factory->removeSessionWithID(sessionID);
     callback();
 }
 
 void MockCDMInstanceSession::removeSessionData(const String& id, LicenseType, RemoveSessionDataCallback&& callback)
 {
-    RefPtr factory = m_instance ? m_instance->factory() : nullptr;
+    RefPtr factory = this->factory();
     if (!factory) {
         callback({ }, nullptr, SuccessValue::Failed);
         return;

--- a/Source/WebCore/testing/MockCDMFactory.h
+++ b/Source/WebCore/testing/MockCDMFactory.h
@@ -32,6 +32,7 @@
 #include "CDMInstance.h"
 #include "CDMInstanceSession.h"
 #include "CDMPrivate.h"
+#include "CDMSessionType.h"
 #include "MediaKeyEncryptionScheme.h"
 #include "MediaKeysRequirement.h"
 #include <wtf/HashMap.h>
@@ -88,6 +89,13 @@ public:
     void addKeysToSessionWithID(const String& id, Vector<Ref<SharedBuffer>>&&);
     const Vector<Ref<SharedBuffer>>* keysForSessionWithID(const String& id) const;
     Vector<Ref<SharedBuffer>> removeKeysFromSessionWithID(const String& id);
+    size_t keyCountForSession(const String& id) const;
+
+    void setSessionType(const String& id, CDMSessionType type) { m_sessionTypes.set(id, type); }
+    std::optional<CDMSessionType> sessionType(const String& id) const;
+
+    double expirationOnUpdate() const { return m_expirationOnUpdate; }
+    void setExpirationOnUpdate(double t) { m_expirationOnUpdate = t; }
 
 private:
     MockCDMFactory();
@@ -106,6 +114,8 @@ private:
     bool m_supportsServerCertificates { true };
     bool m_supportsSessions { true };
     HashMap<String, Vector<Ref<SharedBuffer>>> m_sessions;
+    HashMap<String, CDMSessionType> m_sessionTypes;
+    double m_expirationOnUpdate { std::numeric_limits<double>::quiet_NaN() };
 };
 
 class MockCDM : public CDMPrivate {
@@ -114,7 +124,7 @@ class MockCDM : public CDMPrivate {
 public:
     MockCDM(WeakPtr<MockCDMFactory>, const String&);
 
-    MockCDMFactory* factory() { return m_factory.get(); }
+    RefPtr<MockCDMFactory> factory() const { return m_factory.get(); }
     const String& mediaKeysHashSalt() const LIFETIME_BOUND { return m_mediaKeysHashSalt; }
 
 private:
@@ -144,7 +154,7 @@ class MockCDMInstance : public CDMInstance, public CanMakeWeakPtr<MockCDMInstanc
 public:
     static Ref<MockCDMInstance> create(MockCDM&);
 
-    MockCDMFactory* factory() const { return m_cdm ? m_cdm->factory() : nullptr; }
+    RefPtr<MockCDMFactory> factory() const;
     bool distinctiveIdentifiersAllowed() const { return m_distinctiveIdentifiersAllowed; }
     bool persistentStateAllowed() const { return m_persistentStateAllowed; }
 
@@ -166,6 +176,8 @@ private:
 class MockCDMInstanceSession : public CDMInstanceSession {
 public:
     explicit MockCDMInstanceSession(WeakPtr<MockCDMInstance>&&);
+
+    RefPtr<MockCDMFactory> factory() const;
 
 private:
     void requestLicense(LicenseType, KeyGroupingStrategy, const String& initDataType, Ref<SharedBuffer>&& initData, LicenseCallback&&) final;

--- a/Source/WebCore/testing/MockCDMFactory.idl
+++ b/Source/WebCore/testing/MockCDMFactory.idl
@@ -39,6 +39,9 @@
     attribute sequence<MediaKeyEncryptionScheme> supportedEncryptionSchemes;
     attribute sequence<DOMString> unsupportedVideoCodecs;
 
+    attribute unrestricted double expirationOnUpdate;
+    unsigned long keyCountForSession(DOMString sessionId);
+
     undefined unregister();
 };
 


### PR DESCRIPTION
#### c3dc693948c295da745dfa16044aefc49295df80
<pre>
[Testing] Add more mock- tests for EME
<a href="https://rdar.apple.com/182833486">rdar://182833486</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=319912">https://bugs.webkit.org/show_bug.cgi?id=319912</a>

Reviewed by Eric Carlson.

Adds LayoutTests for 14 previously-uncovered EME spec behaviors, plus
mock-CDM plumbing to enable the new invariants and persistence tests.
Writing the tests surfaced three implementation gaps whose bodies were
already commented in as spec steps but never actually written:

- CDMPrivate::getSupportedCapabilitiesForAudioVideoType step 3.11 was
  a bare comment - an audio/* MIME type under videoCapabilities (or
  vice versa) survived instead of being filtered.
- MockCDMFactory::supportsKeySystem matched case-insensitively; spec
  says Key System strings are case-sensitive.
- MediaKeySession::updateExpiration was notImplemented(), so
  session.expiration stayed NaN even when a CDM reported an
  expiration.

Mock plumbing added to support the new tests: an expirationOnUpdate
attribute the mock returns in the update() callback, a
keyCountForSession(sessionId) introspection method, per-session type
tracking, differentiated closeSession (retains state for
persistent-license), and loadSession restoring stored key statuses.

* Source/WebCore/Modules/encryptedmedia/MediaKeySession.cpp:
(WebCore::MediaKeySession::updateExpiration): Implement per spec.

* Source/WebCore/platform/encryptedmedia/CDMPrivate.cpp:
(WebCore::CDMPrivate::getSupportedCapabilitiesForAudioVideoType):
Implement step 3.11 - skip capabilities whose top-level MIME type does
not match the requested audio/video type.

* Source/WebCore/testing/MockCDMFactory.h:
* Source/WebCore/testing/MockCDMFactory.cpp:
(WebCore::MockCDMFactory::supportsKeySystem): Case-sensitive match.
(WebCore::MockCDMFactory::keyCountForSession): New.
(WebCore::MockCDMFactory::sessionType): New.
(WebCore::MockCDMFactory::removeSessionWithID): Also clear session type.
(WebCore::MockCDM::sanitizeSessionId): Accept tracked session IDs so
tests can round-trip close()/load().
(WebCore::MockCDMInstanceSession::requestLicense): Record session type.
(WebCore::MockCDMInstanceSession::updateLicense): Pass expirationOnUpdate
in the callback when set.
(WebCore::MockCDMInstanceSession::loadSession): Return stored key
statuses for tracked sessions.
(WebCore::MockCDMInstanceSession::closeSession): Retain state for
persistent-license sessions.

* Source/WebCore/testing/MockCDMFactory.idl:
Add expirationOnUpdate attribute and keyCountForSession method.

* LayoutTests/media/encrypted-media/mock-navigator-requestMediaKeySystemAccess.html:
* LayoutTests/media/encrypted-media/mock-navigator-requestMediaKeySystemAccess-expected.txt:
* LayoutTests/media/encrypted-media/mock-MediaKeySession-invariants.html: Added.
* LayoutTests/media/encrypted-media/mock-MediaKeySession-invariants-expected.txt: Added.
* LayoutTests/media/encrypted-media/mock-MediaKeySession-persistence.html: Added.
* LayoutTests/media/encrypted-media/mock-MediaKeySession-persistence-expected.txt: Added.

Canonical link: <a href="https://commits.webkit.org/317998@main">https://commits.webkit.org/317998@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fedb904beee5e4fe42784f80968dd64245b46532

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176965 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50902 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44697 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186568 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140201 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e6793756-cfbb-47c5-863f-d67e83cdc66b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178828 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52195 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50588 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137879 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140201 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/db59591c-b7c5-4349-b8c6-12b282ad4c97) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179921 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41396 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158671 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118348 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40052 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38411 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150462 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38171 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35036 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42655 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/42629 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188991 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50569 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/158211 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146955 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39508 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51252 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/34795 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146752 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41515 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123465 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117753 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49757 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13151 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49156 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49393 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49217 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->