### PR TITLE
Trigger rendering before scheduled tasks after interaction.

### DIFF
--- a/LayoutTests/fast/events/interaction-rendering-priority-expected.txt
+++ b/LayoutTests/fast/events/interaction-rendering-priority-expected.txt
@@ -1,0 +1,10 @@
+Tests that a pending interaction rendering update runs before a DOM timer.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS order.join(',') is "raf,first immediate timer,second immediate timer,delayed timer"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Choose

--- a/LayoutTests/fast/events/interaction-rendering-priority-microtask-expected.txt
+++ b/LayoutTests/fast/events/interaction-rendering-priority-microtask-expected.txt
@@ -1,0 +1,10 @@
+Tests that rendering requested by an interaction microtask runs before a DOM timer.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS order.join(',') is "raf,timer"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Click

--- a/LayoutTests/fast/events/interaction-rendering-priority-microtask.html
+++ b/LayoutTests/fast/events/interaction-rendering-priority-microtask.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+<button id="target">Click</button>
+<script>
+
+'use strict';
+
+description('Tests that rendering requested by an interaction microtask runs before a DOM timer.');
+window.jsTestIsAsync = true;
+let order;
+
+function busyWait(milliseconds)
+{
+    const endTime = performance.now() + milliseconds;
+    while (performance.now() < endTime) { }
+}
+
+async function runTest()
+{
+    if (!window.eventSender || !window.internals) {
+        testFailed('This test requires eventSender and internals.');
+        finishJSTest();
+        return;
+    }
+
+    await testRunner.displayAndTrackRepaints();
+
+    order = [];
+    target.addEventListener('click', () => {
+        setTimeout(() => {
+            order.push('timer');
+            shouldBeEqualToString('order.join(\',\')', 'raf,timer');
+            finishJSTest();
+        }, 0);
+
+        queueMicrotask(() => {
+            target.style.backgroundColor = 'green';
+            requestAnimationFrame(() => order.push('raf'));
+
+            // Make the timer eligible before the pending rendering update runs.
+            busyWait((internals.timeToNextRenderingUpdate() || 16) + internals.preferredRenderingUpdateInterval() + 2);
+        });
+    }, { once: true });
+
+    await eventSender.asyncMouseMoveTo(target.offsetLeft + target.offsetWidth / 2, target.offsetTop + target.offsetHeight / 2);
+    await eventSender.asyncMouseDown();
+    await eventSender.asyncMouseUp();
+}
+
+runTest();
+
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/events/interaction-rendering-priority.html
+++ b/LayoutTests/fast/events/interaction-rendering-priority.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+<label id="target"><input id="choice" type="radio" name="choice">Choose</label>
+<script>
+
+'use strict';
+
+description('Tests that a pending interaction rendering update runs before a DOM timer.');
+window.jsTestIsAsync = true;
+let order;
+
+function busyWait(milliseconds)
+{
+    const endTime = performance.now() + milliseconds;
+    while (performance.now() < endTime) { }
+}
+
+async function runTest()
+{
+    if (!window.eventSender || !window.internals) {
+        testFailed('This test requires eventSender and internals.');
+        finishJSTest();
+        return;
+    }
+
+    await testRunner.displayAndTrackRepaints();
+
+    order = [];
+    choice.addEventListener('change', () => {
+        target.style.backgroundColor = 'green';
+        // Create the delayed timer first to verify that prioritizing rendering does not
+        // disturb the timers' eligibility order.
+        setTimeout(() => {
+            order.push('delayed timer');
+            shouldBeEqualToString('order.join(\',\')', 'raf,first immediate timer,second immediate timer,delayed timer');
+            finishJSTest();
+        }, 10);
+        setTimeout(() => order.push('first immediate timer'), 0);
+        setTimeout(() => order.push('second immediate timer'), 0);
+        requestAnimationFrame(() => order.push('raf'));
+
+        // Match the manual repro by crossing at least two rendering opportunities.
+        busyWait((internals.timeToNextRenderingUpdate() || 16) + internals.preferredRenderingUpdateInterval() + 2);
+    });
+
+    await eventSender.asyncMouseMoveTo(choice.offsetLeft + choice.offsetWidth / 2, choice.offsetTop + choice.offsetHeight / 2);
+    await eventSender.asyncMouseDown();
+    await eventSender.asyncMouseUp();
+}
+
+runTest();
+
+</script>
+</body>
+</html>

--- a/Source/WebCore/dom/EventDispatcher.cpp
+++ b/Source/WebCore/dom/EventDispatcher.cpp
@@ -27,8 +27,10 @@
 #include "EventDispatcher.h"
 
 #include "CompositionEvent.h"
+#include "DocumentPage.h"
 #include "DocumentView.h"
 #include "EventContext.h"
+#include "EventLoop.h"
 #include "EventNames.h"
 #include "EventPath.h"
 #include "FrameDestructionObserverInlines.h"
@@ -41,6 +43,7 @@
 #include "Logging.h"
 #include "MouseEvent.h"
 #include "NodeDocument.h"
+#include "Page.h"
 #include "ScopedEventQueue.h"
 #include "ScriptDisallowedScope.h"
 #include "Settings.h"
@@ -189,6 +192,18 @@ void EventDispatcher::dispatchEvent(Node& node, Event& event)
 
     auto typeInfo = eventNames().typeInfoForEvent(event.type());
     auto listenerCounts = eventListenerCounts(document, event);
+
+    bool shouldPrioritizeInteractionRendering = document->page() && event.isTrusted() && typeInfo.isInCategory(EventCategory::EventTimingEligible);
+    auto prioritizeInteractionRendering = makeScopeExit([&] {
+        if (!shouldPrioritizeInteractionRendering)
+            return;
+        document->eventLoop().runAtEndOfMicrotaskCheckpoint([weakDocument = WeakPtr<Document, WeakPtrImplWithEventTargetData> { document }] {
+            if (RefPtr document = weakDocument.get()) {
+                if (RefPtr page = document->page())
+                    page->prioritizeRenderingUpdateAfterInteraction(*document);
+            }
+        });
+    });
 
     RefPtr window = document->window();
     std::optional<PerformanceEventTimingCandidate> pendingEventTiming;

--- a/Source/WebCore/page/ChromeClient.h
+++ b/Source/WebCore/page/ChromeClient.h
@@ -482,6 +482,8 @@ public:
     virtual bool shouldTriggerRenderingUpdate(unsigned) const { return true; }
     // Makes a rendering update happen soon, typically in the current runloop.
     virtual void triggerRenderingUpdate() = 0;
+    // Prioritize an already scheduled rendering update over other work in the current runloop cycle.
+    virtual void prioritizeRenderingUpdate() { }
     // Schedule a rendering update that coordinates with display refresh. Returns true if scheduled. (This is only used by SVGImageChromeClient.)
     virtual bool scheduleRenderingUpdate() { return false; }
     virtual void renderingUpdateFramesPerSecondChanged() { }

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -2170,6 +2170,18 @@ std::optional<Seconds> Page::timeToNextRenderingUpdateForTesting() const
     return *nextUpdate - MonotonicTime::now();
 }
 
+void Page::prioritizeRenderingUpdateAfterInteraction(Document& document)
+{
+    if (!document.isFullyActive() || document.page() != this)
+        return;
+    if (!isVisibleAndActive() || chrome().client().layerTreeStateIsFrozen())
+        return;
+    if (!m_renderingUpdateIsScheduled)
+        return;
+
+    chrome().client().prioritizeRenderingUpdate();
+}
+
 void Page::didScheduleRenderingUpdate()
 {
 #if ENABLE(ASYNC_SCROLLING)

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -840,6 +840,7 @@ public:
 
     // Schedule a rendering update that coordinates with display refresh.
     WEBCORE_EXPORT void scheduleRenderingUpdate(OptionSet<RenderingUpdateStep> requestedSteps);
+    void prioritizeRenderingUpdateAfterInteraction(Document&);
     void didScheduleRenderingUpdate();
     // Trigger a rendering update in the current runloop. Only used for testing.
     void triggerRenderingUpdateForTesting();

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -1329,6 +1329,16 @@ void WebChromeClient::triggerRenderingUpdate()
         drawingArea->triggerRenderingUpdate();
 }
 
+void WebChromeClient::prioritizeRenderingUpdate()
+{
+    RefPtr page = m_page.get();
+    if (!page)
+        return;
+
+    if (RefPtr drawingArea = page->drawingArea())
+        drawingArea->prioritizeRenderingUpdate();
+}
+
 bool WebChromeClient::scheduleRenderingUpdate()
 {
     RefPtr page = m_page.get();

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
@@ -246,6 +246,7 @@ private:
     void setNeedsOneShotDrawingSynchronization() final;
     bool shouldTriggerRenderingUpdate(unsigned rescheduledRenderingUpdateCount) const final;
     void triggerRenderingUpdate() final;
+    void prioritizeRenderingUpdate() final;
     bool scheduleRenderingUpdate() final;
     void renderingUpdateFramesPerSecondChanged() final;
     unsigned remoteImagesCountForTesting() const final;

--- a/Source/WebKit/WebProcess/WebPage/DrawingArea.h
+++ b/Source/WebKit/WebProcess/WebPage/DrawingArea.h
@@ -138,6 +138,7 @@ public:
 
     // Cause a rendering update to happen as soon as possible.
     virtual void triggerRenderingUpdate() = 0;
+    virtual void prioritizeRenderingUpdate() { }
     virtual bool scheduleRenderingUpdate() { return false; }
     virtual void renderingUpdateFramesPerSecondChanged() { }
 

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.h
@@ -40,6 +40,7 @@
 
 namespace WebCore {
 class PlatformCALayer;
+class RunLoopObserver;
 class ThreadSafeImageBufferFlusher;
 class TiledBacking;
 }
@@ -87,6 +88,7 @@ private:
     void addRootFrame(WebCore::FrameIdentifier) final;
     void removeRootFrame(WebCore::FrameIdentifier) final;
     void triggerRenderingUpdate() final;
+    void prioritizeRenderingUpdate() final;
     bool scheduleRenderingUpdate() final;
     void renderingUpdateFramesPerSecondChanged() final;
     void attachViewOverlayGraphicsLayer(WebCore::FrameIdentifier, WebCore::GraphicsLayer*) final;
@@ -134,6 +136,9 @@ private:
 
     void addCommitHandlers();
     void startRenderingUpdateTimer();
+    void startRenderingUpdateObserver();
+    void invalidateRenderingUpdateObserver();
+    void renderingUpdateRunLoopObserverFired();
     void didCompleteRenderingUpdateDisplayFlush(bool flushSucceeded);
 
     TransactionID takeNextTransactionID() { return m_currentTransactionID.increment(); }
@@ -178,6 +183,7 @@ private:
 
     std::optional<WebCore::FloatRect> m_viewExposedRect;
 
+    std::unique_ptr<WebCore::RunLoopObserver> m_renderingUpdateRunLoopObserver;
     WebCore::Timer m_updateRenderingTimer;
     Markable<MonotonicTime> m_updateStartTime;
     bool m_isRenderingSuspended { false };

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm
@@ -51,9 +51,11 @@
 #import <WebCore/PageOverlayController.h>
 #import <WebCore/RenderLayerCompositor.h>
 #import <WebCore/RenderView.h>
+#import <WebCore/RunLoopObserver.h>
 #import <WebCore/ScrollView.h>
 #import <WebCore/Settings.h>
 #import <WebCore/TiledBacking.h>
+#import <WebCore/WindowEventLoop.h>
 #import <pal/spi/cocoa/QuartzCoreSPI.h>
 #import <wtf/BlockPtr.h>
 #import <wtf/SetForScope.h>
@@ -72,6 +74,9 @@ constexpr FramesPerSecond DefaultPreferredFramesPerSecond = 60;
 RemoteLayerTreeDrawingArea::RemoteLayerTreeDrawingArea(WebPage& webPage, const WebPageCreationParameters& parameters)
     : DrawingArea(parameters.drawingAreaIdentifier, webPage)
     , m_remoteLayerTreeContext(RemoteLayerTreeContext::create(webPage))
+    , m_renderingUpdateRunLoopObserver(makeUnique<RunLoopObserver>(RunLoopObserver::WellKnownOrder::RenderingUpdate, [this] {
+        renderingUpdateRunLoopObserverFired();
+    }))
     , m_updateRenderingTimer(*this, &RemoteLayerTreeDrawingArea::updateRendering)
     , m_commitQueue(WorkQueue::create("com.apple.WebKit.WebContent.RemoteLayerTreeDrawingArea.CommitQueue"_s, WorkQueue::QOS::UserInteractive))
     , m_backingStoreFlusher(BackingStoreFlusher::create(*WebProcess::singleton().parentProcessConnection()))
@@ -82,7 +87,10 @@ RemoteLayerTreeDrawingArea::RemoteLayerTreeDrawingArea(WebPage& webPage, const W
         setViewExposedRect(viewExposedRect);
 }
 
-RemoteLayerTreeDrawingArea::~RemoteLayerTreeDrawingArea() = default;
+RemoteLayerTreeDrawingArea::~RemoteLayerTreeDrawingArea()
+{
+    invalidateRenderingUpdateObserver();
+}
 
 void RemoteLayerTreeDrawingArea::setNeedsDisplay()
 {
@@ -237,7 +245,12 @@ void RemoteLayerTreeDrawingArea::setLayerTreeStateIsFrozen(bool isFrozen)
 
     m_isRenderingSuspended = isFrozen;
 
-    if (!m_isRenderingSuspended && m_hasDeferredRenderingUpdate) {
+    if (m_isRenderingSuspended) {
+        if (m_renderingUpdateRunLoopObserver->isScheduled()) {
+            invalidateRenderingUpdateObserver();
+            m_hasDeferredRenderingUpdate = true;
+        }
+    } else if (m_hasDeferredRenderingUpdate) {
         m_hasDeferredRenderingUpdate = false;
         startRenderingUpdateTimer();
     }
@@ -299,11 +312,31 @@ void RemoteLayerTreeDrawingArea::setExposedContentRect(const FloatRect& exposedC
 
 void RemoteLayerTreeDrawingArea::startRenderingUpdateTimer()
 {
-    if (m_updateRenderingTimer.isActive())
+    if (m_updateRenderingTimer.isActive() || m_renderingUpdateRunLoopObserver->isScheduled())
         return;
     if (!m_updateStartTime)
         m_updateStartTime = MonotonicTime::now();
     m_updateRenderingTimer.startOneShot(0_s);
+}
+
+void RemoteLayerTreeDrawingArea::startRenderingUpdateObserver()
+{
+    if (m_renderingUpdateRunLoopObserver->isScheduled())
+        return;
+
+    m_renderingUpdateRunLoopObserver->schedule();
+    WindowEventLoop::breakToAllowRenderingUpdate();
+}
+
+void RemoteLayerTreeDrawingArea::invalidateRenderingUpdateObserver()
+{
+    m_renderingUpdateRunLoopObserver->invalidate();
+}
+
+void RemoteLayerTreeDrawingArea::renderingUpdateRunLoopObserverFired()
+{
+    invalidateRenderingUpdateObserver();
+    updateRendering();
 }
 
 void RemoteLayerTreeDrawingArea::triggerRenderingUpdate()
@@ -314,6 +347,19 @@ void RemoteLayerTreeDrawingArea::triggerRenderingUpdate()
     }
 
     startRenderingUpdateTimer();
+}
+
+void RemoteLayerTreeDrawingArea::prioritizeRenderingUpdate()
+{
+    if (m_isRenderingSuspended)
+        return;
+    if (!m_isScheduled && !m_scheduleRenderingTimer.isActive() && !m_updateRenderingTimer.isActive())
+        return;
+
+    m_isScheduled = false;
+    m_scheduleRenderingTimer.stop();
+    m_updateRenderingTimer.stop();
+    startRenderingUpdateObserver();
 }
 
 void RemoteLayerTreeDrawingArea::updateRendering()
@@ -466,7 +512,7 @@ void RemoteLayerTreeDrawingArea::displayDidRefresh(MonotonicTime start)
         triggerRenderingUpdate();
         m_deferredRenderingUpdateWhileWaitingForBackingStoreSwap = false;
         m_isScheduled = false;
-    } else if (wasWaitingForBackingStoreSwap && m_updateRenderingTimer.isActive())
+    } else if (wasWaitingForBackingStoreSwap && (m_updateRenderingTimer.isActive() || m_renderingUpdateRunLoopObserver->isScheduled()))
         m_deferredRenderingUpdateWhileWaitingForBackingStoreSwap = true;
     else
         send(Messages::RemoteLayerTreeDrawingAreaProxy::NotifyPendingCommitLayerTree(std::nullopt));
@@ -573,10 +619,10 @@ bool RemoteLayerTreeDrawingArea::scheduleRenderingUpdate()
             return true;
 
         callOnMainRunLoop([self = WeakPtr { this }] () {
-            if (self) {
-                self->m_isScheduled = false;
-                self->triggerRenderingUpdate();
-            }
+            if (!self || !self->m_isScheduled)
+                return;
+            self->m_isScheduled = false;
+            self->triggerRenderingUpdate();
         });
     } else
         m_scheduleRenderingTimer.startOneShot(m_preferredRenderingUpdateInterval);


### PR DESCRIPTION
#### b4b809acea593ed5f56380a3407a3157610d6371
<pre>
Trigger rendering before scheduled tasks after interaction.
<a href="https://bugs.webkit.org/show_bug.cgi?id=319911">https://bugs.webkit.org/show_bug.cgi?id=319911</a>

Reviewed by NOBODY (OOPS!).

When an eligible event happnes, we schedule the rendering at the end of the microtask queue.
That way the rendering triggers before any other potentially-slow scheduled tasks.

Tests: fast/events/interaction-rendering-priority-microtask.html
       fast/events/interaction-rendering-priority.html

* LayoutTests/fast/events/interaction-rendering-priority-expected.txt: Added.
* LayoutTests/fast/events/interaction-rendering-priority-microtask-expected.txt: Added.
* LayoutTests/fast/events/interaction-rendering-priority-microtask.html: Added.
* LayoutTests/fast/events/interaction-rendering-priority.html: Added.
* Source/WebCore/dom/EventDispatcher.cpp:
(WebCore::EventDispatcher::dispatchEvent): when an eligible event happens, request the rendering prioritization
* Source/WebCore/page/ChromeClient.h:
(WebCore::ChromeClient::prioritizeRenderingUpdate):
* Source/WebCore/page/Page.cpp:
(WebCore::Page::prioritizeRenderingUpdateAfterInteraction): validates page/document and forwards the prioritization request
* Source/WebCore/page/Page.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::prioritizeRenderingUpdate): pipe rendering prioritization to the drawing area
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h:
* Source/WebKit/WebProcess/WebPage/DrawingArea.h:
(WebKit::DrawingArea::prioritizeRenderingUpdate):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm:
(WebKit::RemoteLayerTreeDrawingArea::RemoteLayerTreeDrawingArea): creates the rendering-priority run-loop observer
(WebKit::RemoteLayerTreeDrawingArea::~RemoteLayerTreeDrawingArea): invalidates the observer before destroying the drawing area
(WebKit::RemoteLayerTreeDrawingArea::setLayerTreeStateIsFrozen): cancels a pending priority observer on freeze and records that rendering must resume after unfreeze
(WebKit::RemoteLayerTreeDrawingArea::startRenderingUpdateTimer): does not schedule the normal zero-delay timer while the priority observer is already scheduled
(WebKit::RemoteLayerTreeDrawingArea::startRenderingUpdateObserver): schedules the observer and breaks ordinary same-cycle run-loop work
(WebKit::RemoteLayerTreeDrawingArea::invalidateRenderingUpdateObserver): cancels a pending observer
(WebKit::RemoteLayerTreeDrawingArea::renderingUpdateRunLoopObserverFired): clears the observer and performs the normal rendering update
(WebKit::RemoteLayerTreeDrawingArea::prioritizeRenderingUpdate): replaces pending normal rendering scheduling with a rendering-order observer
(WebKit::RemoteLayerTreeDrawingArea::displayDidRefresh): treats a pending priority observer like a pending normal rendering timer when handling a backing-store swap
(WebKit::RemoteLayerTreeDrawingArea::scheduleRenderingUpdate): makes a previously queued main-run-loop scheduling callback harmless after priority promotion cancels its scheduled-update marker
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b4b809acea593ed5f56380a3407a3157610d6371

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175896 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49829 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43613 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185489 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/138098 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/177759 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51121 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49511 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136979 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/138098 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178852 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40438 "Found 2 new test failures: fast/events/interaction-rendering-priority-microtask.html fast/events/interaction-rendering-priority.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157755 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117458 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39080 "Exiting early after 10 failures. 10 tests run. 2 failures") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37460 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149499 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37247 "Found 2 new test failures: fast/events/interaction-rendering-priority-microtask.html fast/events/interaction-rendering-priority.html (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33959 "Built successfully") | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41529 "Found 1 new failure in dom/EventDispatcher.cpp") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41666 "Found 2 new test failures: fast/events/interaction-rendering-priority-microtask.html fast/events/interaction-rendering-priority.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187910 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49496 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/157306 "Exiting early after 10 failures. 10 tests run. 2 failures") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145971 "Found 2 new test failures: fast/events/interaction-rendering-priority-microtask.html fast/events/interaction-rendering-priority.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50176 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33871 "Found 2 new test failures: fast/events/interaction-rendering-priority-microtask.html fast/events/interaction-rendering-priority.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145812 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40607 "Passed tests") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122372 "Found 1 new failure in dom/EventDispatcher.cpp") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/116235 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48683 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12227 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48085 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48317 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48142 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->