### PR TITLE
[EWS] Don't blame PR author for pre-existing flaky API test failures

### DIFF
--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -5958,6 +5958,7 @@ class RunAPITests(shell.Test, AddToLogMixin, ShellMixin):
     test_failures_log_name = 'test-failures'
     results_db_log_name = 'results-db'
     suffix = 'first_run'
+    MAX_FAILURES_TO_CHECK_RESULTS_DB = 50
     command = ['python3', 'Tools/Scripts/run-api-tests', '--timestamps', '--no-build',
                WithProperties('--%(configuration)s'), '--verbose', '--json-output={0}'.format(jsonFileName)]
     failedTestsFormatString = '%d api test%s failed or timed out'
@@ -6154,7 +6155,7 @@ class RunAPITests(shell.Test, AddToLogMixin, ShellMixin):
             if not has_commit:
                 yield self._addToLog(self.results_db_log_name, f"'{identifier}' could not be found on the results database, falling back to tip-of-tree\n")
 
-        for test in failing_tests:
+        for test in failing_tests[:self.MAX_FAILURES_TO_CHECK_RESULTS_DB]:
             data = yield ResultsDatabase.is_test_pre_existing_failure(
                 test, configuration=configuration,
                 commit=identifier if has_commit else None,
@@ -6164,10 +6165,6 @@ class RunAPITests(shell.Test, AddToLogMixin, ShellMixin):
             if data['is_existing_failure']:
                 self.preexisting_failures_in_results_db.append(test)
                 self.failing_tests_filtered.remove(test)
-            else:
-                # Optimization to skip consulting results-db for every failure if we encounter any new failure,
-                # since until there is atleast one failure which is not pre-existing, we will anayways have to continue with retry logic.
-                break
 
 
 class ReRunAPITests(RunAPITests):
@@ -6222,6 +6219,15 @@ class AnalyzeAPITestsResults(buildstep.BuildStep, AddToLogMixin):
             self.build.buildFinished(['Unable to parse API test results'], RETRY)
             defer.returnValue(RETRY)
             return
+
+        # Prefer the results-db-filtered lists (pre-existing failures already removed) so a known
+        # pre-existing flaky failure is not reported as new even if it passed on the clean tree.
+        first_run_failures_filtered = self.getProperty('first_run_failures_filtered', None)
+        if first_run_failures_filtered is not None:
+            first_run_failures = set(first_run_failures_filtered)
+        second_run_failures_filtered = self.getProperty('second_run_failures_filtered', None)
+        if second_run_failures_filtered is not None:
+            second_run_failures = set(second_run_failures_filtered)
 
         clean_tree_failures = set(self.getProperty('clean_tree_run_failures', []))
         clean_tree_failures_to_display = list(clean_tree_failures)[:self.NUM_FAILURES_TO_DISPLAY]

--- a/Tools/CISupport/ews-build/steps_unittest.py
+++ b/Tools/CISupport/ews-build/steps_unittest.py
@@ -6097,6 +6097,125 @@ class TestAnalyzeAPITestsResults(BuildStepMixinAdditions, unittest.TestCase):
         self.expect_outcome(result=RETRY, state_string='analyze-api-tests-results (retry)')
         return self.run_step()
 
+    def test_pre_existing_flaky_failure_not_blamed_on_author(self):
+        # A pre-existing flaky failure fails in both runs but passes on the clean tree. It is stripped
+        # from the *_filtered lists by results-db, so it must not be reported as a new failure.
+        self.configureStep()
+        self.setProperty('first_run_failures', ['suite.MultipleAccounts', 'suite.real_failure'])
+        self.setProperty('second_run_failures', ['suite.MultipleAccounts', 'suite.real_failure'])
+        self.setProperty('first_run_failures_filtered', ['suite.real_failure'])
+        self.setProperty('second_run_failures_filtered', ['suite.real_failure'])
+        self.setProperty('clean_tree_run_failures', ['suite.real_failure'])
+        self.expect_outcome(result=SUCCESS, state_string='Passed API tests')
+        return self.run_step()
+
+    def test_new_failure_still_reported_with_filtered_lists(self):
+        # A genuinely new failure remains in the *_filtered lists, so it must still be reported.
+        self.configureStep()
+        self.setProperty('first_run_failures', ['suite.MultipleAccounts', 'suite.real_failure'])
+        self.setProperty('second_run_failures', ['suite.MultipleAccounts', 'suite.real_failure'])
+        self.setProperty('first_run_failures_filtered', ['suite.real_failure'])
+        self.setProperty('second_run_failures_filtered', ['suite.real_failure'])
+        self.setProperty('clean_tree_run_failures', [])
+        self.expect_outcome(result=FAILURE, state_string='Found 1 new API test failure: suite.real_failure (failure)')
+        return self.run_step()
+
+    def test_all_failures_pre_existing_filtered_lists_empty(self):
+        # If every failure was pre-existing, both *_filtered lists are empty and the build passes.
+        self.configureStep()
+        self.setProperty('first_run_failures', ['suite.MultipleAccounts'])
+        self.setProperty('second_run_failures', ['suite.MultipleAccounts'])
+        self.setProperty('first_run_failures_filtered', [])
+        self.setProperty('second_run_failures_filtered', [])
+        self.setProperty('clean_tree_run_failures', [])
+        self.expect_outcome(result=SUCCESS, state_string='Passed API tests')
+        return self.run_step()
+
+    def test_falls_back_to_unfiltered_when_filtered_absent(self):
+        # When the *_filtered properties are absent, behavior degrades to the unfiltered lists.
+        self.configureStep()
+        self.setProperty('first_run_failures', ['suite.test1'])
+        self.setProperty('second_run_failures', ['suite.test1'])
+        self.expect_outcome(result=FAILURE, state_string='Found 1 new API test failure: suite.test1 (failure)')
+        return self.run_step()
+
+
+class TestFilterAPITestFailuresUsingResultsDB(BuildStepMixinAdditions, unittest.TestCase):
+    def setUp(self):
+        self.longMessage = True
+        return self.setup_test_build_step()
+
+    def tearDown(self):
+        return self.tear_down_test_build_step()
+
+    def _configure(self, pre_existing):
+        # pre_existing: set of test names results-db considers pre-existing failures.
+        self.setup_step(RunAPITests())
+        step = self.get_nth_step(0)
+        step._addToLog = lambda logName, message: defer.succeed(None)
+
+        def fake_is_pre_existing(cls, test, **kwargs):
+            return defer.succeed({
+                'is_existing_failure': test in pre_existing,
+                'pass_rate': 0 if test in pre_existing else 100,
+                'raw_data': {},
+                'logs': '',
+                'request_failed': False,
+            })
+
+        self.patch(ResultsDatabase, 'is_test_pre_existing_failure', classmethod(fake_is_pre_existing))
+        self.patch(ResultsDatabase, 'has_commit', classmethod(lambda cls, commit=None: defer.succeed(False)))
+        return step
+
+    @defer.inlineCallbacks
+    def _check_order(self, failing_tests, pre_existing):
+        step = self._configure(pre_existing)
+        yield step.filter_api_test_failures_using_results_db(failing_tests)
+        self.assertEqual(step.failing_tests_filtered, ['suite.real_failure'])
+        self.assertEqual(sorted(step.preexisting_failures_in_results_db), ['suite.AlsoFlaky', 'suite.MultipleAccounts'])
+
+    def test_pre_existing_after_real_failure_still_stripped(self):
+        # Regression guard: a pre-existing failure listed after a non-pre-existing one must still be
+        # filtered out (previously an early-break would stop at the first non-pre-existing test).
+        return self._check_order(
+            ['suite.real_failure', 'suite.MultipleAccounts', 'suite.AlsoFlaky'],
+            {'suite.MultipleAccounts', 'suite.AlsoFlaky'},
+        )
+
+    def test_pre_existing_before_real_failure_stripped(self):
+        return self._check_order(
+            ['suite.MultipleAccounts', 'suite.real_failure', 'suite.AlsoFlaky'],
+            {'suite.MultipleAccounts', 'suite.AlsoFlaky'},
+        )
+
+    def test_pre_existing_interleaved_with_real_failure_stripped(self):
+        return self._check_order(
+            ['suite.AlsoFlaky', 'suite.MultipleAccounts', 'suite.real_failure'],
+            {'suite.MultipleAccounts', 'suite.AlsoFlaky'},
+        )
+
+    @defer.inlineCallbacks
+    def test_caps_number_of_results_db_queries(self):
+        # Only the first MAX_FAILURES_TO_CHECK_RESULTS_DB failures are checked against results-db.
+        queried = []
+
+        def fake_is_pre_existing(cls, test, **kwargs):
+            queried.append(test)
+            return defer.succeed({
+                'is_existing_failure': True, 'pass_rate': 0, 'raw_data': {}, 'logs': '', 'request_failed': False,
+            })
+
+        self.setup_step(RunAPITests())
+        step = self.get_nth_step(0)
+        step._addToLog = lambda logName, message: defer.succeed(None)
+        self.patch(ResultsDatabase, 'is_test_pre_existing_failure', classmethod(fake_is_pre_existing))
+        self.patch(ResultsDatabase, 'has_commit', classmethod(lambda cls, commit=None: defer.succeed(False)))
+
+        cap = RunAPITests.MAX_FAILURES_TO_CHECK_RESULTS_DB
+        failing_tests = [f'suite.test{i}' for i in range(cap + 10)]
+        yield step.filter_api_test_failures_using_results_db(failing_tests)
+        self.assertEqual(len(queried), cap)
+
 
 class TestRunAPITestsParallelSafety(BuildStepMixinAdditions, unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
#### 60edc560c7b85a4b258d6ed501459fef5eddcbaa
<pre>
[EWS] Don&apos;t blame PR author for pre-existing flaky API test failures
<a href="https://bugs.webkit.org/show_bug.cgi?id=318816">https://bugs.webkit.org/show_bug.cgi?id=318816</a>
<a href="https://rdar.apple.com/problem/181634454">rdar://problem/181634454</a>

Reviewed by Ryan Haddad.

A pre-existing flaky API test can fail with the change and then pass on the clean-tree run
(because it is flaky), which made AnalyzeAPITestsResults report it as a new failure and blame
the PR author. Use the results-db-filtered failure lists, which already have pre-existing
failures removed, so such a test is never counted as new. This relies on those lists being
complete, so we no longer stop the results-db lookup at the first non-pre-existing failure.

* Tools/CISupport/ews-build/steps.py:
(RunAPITests.filter_api_test_failures_using_results_db):
(AnalyzeAPITestsResults.run):
* Tools/CISupport/ews-build/steps_unittest.py:
(TestAnalyzeAPITestsResults):
(TestFilterAPITestFailuresUsingResultsDB):

Canonical link: <a href="https://commits.webkit.org/317657@main">https://commits.webkit.org/317657@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1d69f3a0dff36251ec145f902112e1a72d7e6737

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175897 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49830 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/43614 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185490 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/138099 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/758e1dae-18f2-4c74-9618-c9c78e941700) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/177760 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51122 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49512 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/136976 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/138099 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/cb3c01f0-64fa-41f8-b647-605a0a7f4557) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178853 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/40441 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/157756 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117455 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ad68ed25-0144-46e2-a11c-c22453462e01) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/39083 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/37462 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/149502 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/37248 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33960 "Built successfully") | | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/41668 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187911 "Built successfully") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/175300 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49497 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/157307 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/145980 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/50177 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/33872 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/145815 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26735 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/50177 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/116236 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48684 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/12228 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48086 "Built successfully") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/48318 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48143 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->