### PR TITLE
[GFC] Implement fit-content sizing for non-replaced elements.

### DIFF
--- a/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.cpp
@@ -242,7 +242,37 @@ static bool NODELETE hasScrollableBlockComputedOverflowValue(const PlacedGridIte
     return computedOverflow == Overflow::Hidden || computedOverflow == Overflow::Scroll || computedOverflow == Overflow::Auto;
 }
 
-LayoutUnit inlinePreferredSize(const PlacedGridItem& placedGridItem, LayoutUnit borderAndPadding, LayoutUnit columnsSize)
+// https://www.w3.org/TR/css-sizing-3/#stretch-fit-size
+// The size a box would take if its outer size filled the available space in the given axis:
+// the available space (the grid area size) less the box's margins, border, and padding. Auto
+// margins resolve to zero for this purpose.
+static BorderBoxSize stretchFitSize(const ComputedSizes& axisSizes, LayoutUnit borderAndPadding, LayoutUnit availableSize, const Style::ZoomFactor& usedZoom)
+{
+    auto usedMargin = [&](const auto& margin) {
+        if (auto fixed = margin.tryFixed())
+            return LayoutUnit { fixed->resolveZoom(usedZoom) };
+        if (margin.isPercentOrCalculated()) {
+            ASSERT_NOT_IMPLEMENTED_YET();
+            return 0_lu;
+        }
+        if (margin.isAuto())
+            return 0_lu;
+        ASSERT_NOT_REACHED();
+        return 0_lu;
+    };
+    auto usedMarginStart = usedMargin(axisSizes.marginStart);
+    auto usedMarginEnd = usedMargin(axisSizes.marginEnd);
+    return BorderBoxSize { ContentBoxSize { availableSize - usedMarginStart - usedMarginEnd - borderAndPadding }, borderAndPadding };
+}
+
+// https://www.w3.org/TR/css-sizing-3/#fit-content-size
+// fit-content size = clamp(min-content, stretch-fit, max-content).
+static LayoutUnit fitContentSize(BorderBoxSize minContentSize, BorderBoxSize maxContentSize, BorderBoxSize stretchFit)
+{
+    return std::max(minContentSize, std::min(maxContentSize, stretchFit)).value;
+}
+
+LayoutUnit inlinePreferredSize(const PlacedGridItem& placedGridItem, LayoutUnit borderAndPadding, LayoutUnit columnsSize, const IntegrationUtils& integrationUtils)
 {
     auto& inlineAxisSizes = placedGridItem.inlineAxisSizes();
     ASSERT(inlineAxisSizes.maximumSize.isFixed() || inlineAxisSizes.maximumSize.isNone());
@@ -260,14 +290,17 @@ LayoutUnit inlinePreferredSize(const PlacedGridItem& placedGridItem, LayoutUnit 
         // When the box’s computed width/height (as appropriate to the axis) is auto and neither of
         // its margins (in the appropriate axis) are auto, sets the box’s used size to the length
         // necessary to make its outer size as close to filling the alignment container as possible.
-        if (isStretchedForAutomaticSize(placedGridItem, inlineAxisSizes, placedGridItem.inlineAxisAlignment())) {
-            auto& marginStart = inlineAxisSizes.marginStart;
-            auto& marginEnd = inlineAxisSizes.marginEnd;
-            auto& usedZoom = placedGridItem.usedZoom();
-            auto usedMarginStart = LayoutUnit { marginStart.tryFixed()->resolveZoom(usedZoom) };
-            auto usedMarginEnd = LayoutUnit { marginEnd.tryFixed()->resolveZoom(usedZoom) };
-            auto stretchedContentBoxWidth = ContentBoxSize { columnsSize - usedMarginStart - usedMarginEnd - borderAndPadding };
-            return BorderBoxSize { stretchedContentBoxWidth, borderAndPadding }.value;
+        if (isStretchedForAutomaticSize(placedGridItem, inlineAxisSizes, placedGridItem.inlineAxisAlignment()))
+            return stretchFitSize(inlineAxisSizes, borderAndPadding, columnsSize, placedGridItem.usedZoom()).value;
+
+        // https://drafts.csswg.org/css-grid-1/#grid-item-sizing
+        // Otherwise (self-alignment is not stretch, and does not behave as stretch), a non-replaced
+        // grid item with an automatic size is sized to its fit-content size in the axis.
+        if (!placedGridItem.isReplacedElement() && !preferredAspectRatio(placedGridItem.layoutBox())) {
+            auto minContentBorderBoxWidth = BorderBoxSize { ContentBoxSize { integrationUtils.minContentWidth(placedGridItem.layoutBox()) }, borderAndPadding };
+            auto maxContentBorderBoxWidth = BorderBoxSize { ContentBoxSize { integrationUtils.maxContentWidth(placedGridItem.layoutBox()) }, borderAndPadding };
+            auto stretchFitBorderBoxWidth = stretchFitSize(inlineAxisSizes, borderAndPadding, columnsSize, placedGridItem.usedZoom());
+            return fitContentSize(minContentBorderBoxWidth, maxContentBorderBoxWidth, stretchFitBorderBoxWidth);
         }
 
         ASSERT_NOT_IMPLEMENTED_YET();
@@ -385,18 +418,7 @@ static BorderBoxSize automaticMinimumBlockSize(const PlacedGridItem& gridItem, L
     return contentBasedMinimumSize();
 }
 
-LayoutUnit stretchedBlockSize(const PlacedGridItem& placedGridItem, LayoutUnit borderAndPadding, LayoutUnit rowsSize)
-{
-    auto& blockAxisSizes = placedGridItem.blockAxisSizes();
-    ASSERT(isStretchedForAutomaticSize(placedGridItem, blockAxisSizes, placedGridItem.blockAxisAlignment()));
-    auto& usedZoom = placedGridItem.usedZoom();
-    auto usedMarginStart = LayoutUnit { blockAxisSizes.marginStart.tryFixed()->resolveZoom(usedZoom) };
-    auto usedMarginEnd = LayoutUnit { blockAxisSizes.marginEnd.tryFixed()->resolveZoom(usedZoom) };
-    auto stretchedContentBoxHeight = ContentBoxSize { rowsSize - usedMarginStart - usedMarginEnd - borderAndPadding };
-    return BorderBoxSize { stretchedContentBoxHeight, borderAndPadding }.value;
-}
-
-LayoutUnit blockPreferredSize(const PlacedGridItem& placedGridItem, LayoutUnit borderAndPadding, LayoutUnit rowsSize)
+LayoutUnit blockPreferredSize(const PlacedGridItem& placedGridItem, LayoutUnit borderAndPadding, LayoutUnit rowsSize, const GridFormattingContext& formattingContext, LayoutUnit inlineAxisConstraint)
 {
     auto& blockAxisSizes = placedGridItem.blockAxisSizes();
     ASSERT(blockAxisSizes.maximumSize.isFixed() || blockAxisSizes.maximumSize.isNone());
@@ -416,7 +438,22 @@ LayoutUnit blockPreferredSize(const PlacedGridItem& placedGridItem, LayoutUnit b
         // its margins (in the appropriate axis) are auto, sets the box's used size to the length
         // necessary to make its outer size as close to filling the alignment container as possible.
         if (isStretchedForAutomaticSize(placedGridItem, blockAxisSizes, placedGridItem.blockAxisAlignment()))
-            return stretchedBlockSize(placedGridItem, borderAndPadding, rowsSize);
+            return stretchFitSize(blockAxisSizes, borderAndPadding, rowsSize, placedGridItem.usedZoom()).value;
+
+        // https://drafts.csswg.org/css-grid-1/#grid-item-sizing
+        // Otherwise (self-alignment is not stretch, and does not behave as stretch), a non-replaced
+        // grid item with an automatic size is sized to its fit-content size in the axis.
+        if (!placedGridItem.isReplacedElement() && !preferredAspectRatio(placedGridItem.layoutBox())) {
+            auto stretchFitBorderBoxHeight = stretchFitSize(blockAxisSizes, borderAndPadding, rowsSize, placedGridItem.usedZoom());
+
+            auto& integrationUtils = formattingContext.integrationUtils();
+            auto minContentBorderBoxHeight = BorderBoxSize::fromIntegrationFunction(integrationUtils.minContentHeightForGridItem(placedGridItem.layoutBox(), inlineAxisConstraint));
+            auto maxContentBorderBoxHeight = BorderBoxSize::fromIntegrationFunction(integrationUtils.maxContentHeightForGridItem(placedGridItem.layoutBox(), inlineAxisConstraint));
+            return fitContentSize(minContentBorderBoxHeight, maxContentBorderBoxHeight, stretchFitBorderBoxHeight);
+        }
+
+        ASSERT_NOT_IMPLEMENTED_YET();
+        return { };
     }
 
     if (preferredSize.isFixed() || preferredSize.isPercent() || preferredSize.isCalculated())
@@ -493,7 +530,7 @@ LayoutUnit blockMaximumSize(const PlacedGridItem& gridItem, LayoutUnit borderAnd
 // Lay out the grid items into their respective containing blocks. Each grid area's width and height are considered definite for this purpose.
 LayoutUnit inlineUsedSize(const PlacedGridItem& gridItem, const TrackSizingFunctionsList& trackSizingFunctions, LayoutUnit borderAndPadding, LayoutUnit columnsSize, const IntegrationUtils& integrationUtils)
 {
-    auto preferredSize = inlinePreferredSize(gridItem, borderAndPadding, columnsSize);
+    auto preferredSize = inlinePreferredSize(gridItem, borderAndPadding, columnsSize, integrationUtils);
     auto minimumSize = inlineMinimumSize(gridItem, trackSizingFunctions, borderAndPadding, columnsSize, integrationUtils);
     auto maximumSize = inlineMaximumSize(gridItem, borderAndPadding);
     return std::max(minimumSize, std::min(maximumSize, preferredSize));
@@ -504,7 +541,7 @@ LayoutUnit inlineUsedSize(const PlacedGridItem& gridItem, const TrackSizingFunct
 // Lay out the grid items into their respective containing blocks. Each grid area's width and height are considered definite for this purpose.
 LayoutUnit blockUsedSize(const PlacedGridItem& gridItem, const TrackSizingFunctionsList& trackSizingFunctions, LayoutUnit borderAndPadding, LayoutUnit rowsSize, const GridFormattingContext& formattingContext, LayoutUnit inlineAxisConstraint)
 {
-    auto preferredSize = blockPreferredSize(gridItem, borderAndPadding, rowsSize);
+    auto preferredSize = blockPreferredSize(gridItem, borderAndPadding, rowsSize, formattingContext, inlineAxisConstraint);
     auto minimumSize = blockMinimumSize(gridItem, trackSizingFunctions, borderAndPadding, rowsSize, formattingContext, inlineAxisConstraint);
     auto maximumSize = blockMaximumSize(gridItem, borderAndPadding);
     return std::max(minimumSize, std::min(maximumSize, preferredSize));

--- a/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.h
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.h
@@ -49,9 +49,8 @@ namespace GridLayoutUtils {
 
 LayoutUnit NODELETE totalGuttersSize(size_t tracksCount, LayoutUnit gapsSize);
 
-LayoutUnit inlinePreferredSize(const PlacedGridItem&, LayoutUnit borderAndPadding, LayoutUnit columnsSize);
-LayoutUnit blockPreferredSize(const PlacedGridItem&, LayoutUnit borderAndPadding, LayoutUnit rowsSize);
-LayoutUnit stretchedBlockSize(const PlacedGridItem&, LayoutUnit borderAndPadding, LayoutUnit rowsSize);
+LayoutUnit inlinePreferredSize(const PlacedGridItem&, LayoutUnit borderAndPadding, LayoutUnit columnsSize, const IntegrationUtils&);
+LayoutUnit blockPreferredSize(const PlacedGridItem&, LayoutUnit borderAndPadding, LayoutUnit rowsSize, const GridFormattingContext&, LayoutUnit inlineAxisConstraint);
 
 LayoutUnit inlineMinimumSize(const PlacedGridItem&, const TrackSizingFunctionsList&, LayoutUnit borderAndPadding, LayoutUnit columnsSize, const IntegrationUtils&);
 LayoutUnit blockMinimumSize(const PlacedGridItem&, const TrackSizingFunctionsList&, LayoutUnit borderAndPadding, LayoutUnit rowsSize, const GridFormattingContext&, LayoutUnit inlineAxisConstraint);

--- a/Source/WebCore/layout/integration/LayoutIntegrationFormattingContextLayout.h
+++ b/Source/WebCore/layout/integration/LayoutIntegrationFormattingContextLayout.h
@@ -52,6 +52,7 @@ LayoutUnit formattingContextRootLogicalWidthForType(const Layout::ElementBox&, L
 
 enum class LogicalHeightType : uint8_t  {
     MinContent,
+    MaxContent,
     MinContentContribution,
     MaxContentContribution
 };

--- a/Source/WebCore/layout/integration/LayoutIntegrationUtils.cpp
+++ b/Source/WebCore/layout/integration/LayoutIntegrationUtils.cpp
@@ -47,7 +47,7 @@ void IntegrationUtils::layoutWithFormattingContextForBox(const ElementBox& box, 
 
 LayoutUnit IntegrationUtils::maxContentWidth(const ElementBox& box) const
 {
-    ASSERT(box.isFlexItem());
+    ASSERT(box.isFlexItem() || box.isGridItem());
     return m_globalLayoutState->logicalWidthWithFormattingContextForBox(box, LayoutIntegration::LogicalWidthType::MaxContent);
 }
 
@@ -69,10 +69,8 @@ static LayoutUnit blockSizeForGridItem(const LayoutState& layoutState, const Ele
     CheckedRef renderer = downcast<RenderBox>(*box.rendererForIntegration());
 
     switch (logicalHeightType) {
-    // A grid item's block-axis min-content size, min-content contribution and max-content
-    // contribution all resolve to its post-layout border-box block size at the given inline
-    // size, so these currently coincide.
     case LayoutIntegration::LogicalHeightType::MinContent:
+    case LayoutIntegration::LogicalHeightType::MaxContent:
     case LayoutIntegration::LogicalHeightType::MinContentContribution:
     case LayoutIntegration::LogicalHeightType::MaxContentContribution: {
         renderer->setGridAreaContentLogicalWidth(inlineAxisConstraint);
@@ -92,16 +90,25 @@ static LayoutUnit blockSizeForGridItem(const LayoutState& layoutState, const Ele
 
 LayoutUnit IntegrationUtils::minContentHeightForGridItem(const ElementBox& box, LayoutUnit inlineAxisConstraint) const
 {
+    ASSERT(box.isGridItem());
     return blockSizeForGridItem(m_globalLayoutState, box, inlineAxisConstraint, LayoutIntegration::LogicalHeightType::MinContent);
+}
+
+LayoutUnit IntegrationUtils::maxContentHeightForGridItem(const ElementBox& box, LayoutUnit inlineAxisConstraint) const
+{
+    ASSERT(box.isGridItem());
+    return blockSizeForGridItem(m_globalLayoutState, box, inlineAxisConstraint, LayoutIntegration::LogicalHeightType::MaxContent);
 }
 
 LayoutUnit IntegrationUtils::minContentContributionHeightForGridItem(const ElementBox& box, LayoutUnit inlineAxisConstraint) const
 {
+    ASSERT(box.isGridItem());
     return blockSizeForGridItem(m_globalLayoutState, box, inlineAxisConstraint, LayoutIntegration::LogicalHeightType::MinContentContribution);
 }
 
 LayoutUnit IntegrationUtils::maxContentContributionHeightForGridItem(const ElementBox& box, LayoutUnit inlineAxisConstraint) const
 {
+    ASSERT(box.isGridItem());
     return blockSizeForGridItem(m_globalLayoutState, box, inlineAxisConstraint, LayoutIntegration::LogicalHeightType::MaxContentContribution);
 }
 

--- a/Source/WebCore/layout/integration/LayoutIntegrationUtils.h
+++ b/Source/WebCore/layout/integration/LayoutIntegrationUtils.h
@@ -49,6 +49,7 @@ public:
     LayoutUnit minContentWidth(const ElementBox&) const;
     LayoutUnit minContentHeight(const ElementBox&) const;
     LayoutUnit minContentHeightForGridItem(const ElementBox&, LayoutUnit inlineAxisConstraint) const;
+    LayoutUnit maxContentHeightForGridItem(const ElementBox&, LayoutUnit inlineAxisConstraint) const;
     LayoutUnit minContentContributionHeightForGridItem(const ElementBox&, LayoutUnit inlineAxisConstraint) const;
     LayoutUnit maxContentContributionHeightForGridItem(const ElementBox&, LayoutUnit inlineAxisConstraint) const;
     LayoutUnit minContentLogicalWidthContribution(const ElementBox&) const;


### PR DESCRIPTION
#### 25f9a54701a9457c5acfc8347221a0297a06ba1b
<pre>
[GFC] Implement fit-content sizing for non-replaced elements.
<a href="https://bugs.webkit.org/show_bug.cgi?id=319914">https://bugs.webkit.org/show_bug.cgi?id=319914</a>
<a href="https://rdar.apple.com/problem/182834140">rdar://problem/182834140</a>

Reviewed by Elika Etemad.

<a href="https://drafts.csswg.org/css-grid-1/#grid-item-sizing">https://drafts.csswg.org/css-grid-1/#grid-item-sizing</a>

Here we implement the case where we have a non-replaced element without
a preferred aspect ratio and an alignment that is not normal or stretch.
In this case the automatic size for that grid item is the fit-content
size. We can simply expand the preferred size functions to detect this,
compute each of the sizes that goes into the fit-content size, and then
return the result.

* Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.cpp:
(WebCore::Layout::GridLayoutUtils::stretchFitSize):
This is a pretty common operation at this point that is used in a few
different scenarios so we might as well move it over to a helper
function.

(WebCore::Layout::GridLayoutUtils::stretchedBlockSize): Deleted.
Folded into the generic stretch fit size function since the logic is the
same for both inline and block version.

* Source/WebCore/layout/integration/LayoutIntegrationUtils.cpp:
(WebCore::Layout::IntegrationUtils::maxContentWidth const):
We already used the respective minContentWidth integration function to
get the min content width of a grid item so now that we do the same with
the max content width we need to update this assert.

(WebCore::Layout::blockSizeForGridItem):
(WebCore::Layout::IntegrationUtils::maxContentHeightForGridItem const):
* Source/WebCore/layout/integration/LayoutIntegrationUtils.h:
This new integration API mirrors the one that we have to get the min
content height for a grid item. This ends up calling into
blockSizeForGridItem with the type of height we are querying for the
grid item.

Canonical link: <a href="https://commits.webkit.org/317674@main">https://commits.webkit.org/317674@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d9c3144f39cf01f3567162d5ec1af2f9ce157c63

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175984 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49917 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/43701 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185578 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/138196 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9c7f61b4-9ea4-4b49-90b5-5391daec2e51) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/177847 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51209 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49599 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/137042 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/138196 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e2e45508-c8e8-4a14-9b09-de35413c056a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178940 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/40515 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/43701 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117521 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/734e43df-6f70-489b-8ae5-731c32775695) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/39158 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/37531 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/43701 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/149576 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/43701 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34047 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/41619 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/41737 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187999 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49584 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/43701 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/146046 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39289 "Built successfully and passed tests") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/50264 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/43701 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/145884 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/50264 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/122460 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/116338 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48771 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/43701 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48173 "Built successfully") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/48405 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/48230 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->