### PR TITLE
[WebTransport] WebTransport pages should be restorable from the back/forward cache

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6841,10 +6841,6 @@ imported/w3c/web-platform-tests/webtransport/idlharness.https.sub.any.servicewor
 imported/w3c/web-platform-tests/webtransport/idlharness.https.sub.any.sharedworker.html [ Skip ]
 imported/w3c/web-platform-tests/webtransport/idlharness.https.sub.any.worker.html [ Skip ]
 
-# BFCache.
-imported/w3c/web-platform-tests/webtransport/back-forward-cache-with-open-webtransport-connection.https.window.html [ Skip ]
-imported/w3c/web-platform-tests/webtransport/back-forward-cache-with-closed-webtransport-connection.https.window.html [ Skip ]
-
 # Some of Canvas Layer API features are not supported yet.
 imported/w3c/web-platform-tests/html/canvas/element/layers/2d.layer.anisotropic-blur.isotropic.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/html/canvas/element/layers/2d.layer.anisotropic-blur.mostly-x.html [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/back-forward-cache-with-closed-webtransport-connection.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/back-forward-cache-with-closed-webtransport-connection.https.window-expected.txt
@@ -1,3 +1,3 @@
 
-NOTRUN Testing BFCache support for page with closed WebTransport connection. BFCache not supported.
+PASS Testing BFCache support for page with closed WebTransport connection.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/back-forward-cache-with-open-webtransport-connection.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/back-forward-cache-with-open-webtransport-connection.https.window-expected.txt
@@ -1,3 +1,3 @@
 
-NOTRUN Testing BFCache support for page with open WebTransport connection. BFCache not supported.
+PASS Testing BFCache support for page with open WebTransport connection.
 

--- a/Source/WebCore/Modules/webtransport/WebTransport.cpp
+++ b/Source/WebCore/Modules/webtransport/WebTransport.cpp
@@ -46,6 +46,7 @@
 #include "ReadableStream.h"
 #include "ScriptExecutionContextInlines.h"
 #include "SocketProvider.h"
+#include "TaskSource.h"
 #include "WebTransportBidirectionalStreamSource.h"
 #include "WebTransportCloseInfo.h"
 #include "WebTransportCongestionControl.h"
@@ -212,10 +213,8 @@ bool WebTransport::virtualHasPendingActivity() const
 
 void WebTransport::suspend(ReasonForSuspension why)
 {
-    if (why == ReasonForSuspension::BackForwardCache) {
-        if (RefPtr context = scriptExecutionContext())
-            cleanupContext(*context);
-    }
+    if (why == ReasonForSuspension::BackForwardCache)
+        cleanupContext();
 }
 
 void WebTransport::receiveDatagram(std::span<const uint8_t> datagram, bool withFin, std::optional<Exception>&& exception)
@@ -456,15 +455,17 @@ void WebTransport::cleanupWithSessionError()
     }), std::nullopt);
 }
 
-void WebTransport::cleanupContext(ScriptExecutionContext& context)
+void WebTransport::cleanupContext()
 {
     // https://www.w3.org/TR/webtransport/#web-transport-context-cleanup-steps
+    // Use a suspendable event-loop task, not postTask: postTask would run during back/forward cache entry
+    // (frame detached, null global object) and drop the rejection; this instead runs on resume.
     if (m_state == State::Connected) {
         m_state = State::Failed;
         if (auto session = std::exchange(m_session, nullptr))
             session->terminate(0, { });
-        context.postTask([protectedThis = Ref { *this }] (auto&) {
-            protectedThis->cleanupWithSessionError();
+        queueTaskKeepingObjectAlive(*this, TaskSource::Networking, [](auto& transport) {
+            transport.cleanupWithSessionError();
         });
     }
     if (m_state == State::Connecting)

--- a/Source/WebCore/Modules/webtransport/WebTransport.h
+++ b/Source/WebCore/Modules/webtransport/WebTransport.h
@@ -102,7 +102,7 @@ public:
 
     RefPtr<WebTransportSession> NODELETE session();
     void datagramsWritableCreated(WebTransportDatagramsWritable&);
-    void cleanupContext(ScriptExecutionContext&);
+    void cleanupContext();
 
     void sendStreamClosed(WebTransportStreamIdentifier);
     void receiveStreamClosed(WebTransportStreamIdentifier);

--- a/Tools/TestRunnerShared/TestFeatures.cpp
+++ b/Tools/TestRunnerShared/TestFeatures.cpp
@@ -148,7 +148,8 @@ static bool shouldEnableSiteIsolation(const std::string& pathOrURL)
 static bool shouldUseBackForwardCache(const std::string& pathOrURL)
 {
     return pathContains(pathOrURL, "navigation-api/")
-        || pathContains(pathOrURL, "websockets/back-forward-cache");
+        || pathContains(pathOrURL, "websockets/back-forward-cache")
+        || pathContains(pathOrURL, "webtransport/back-forward-cache");
 }
 
 static bool shouldDisableMutationEvents(const std::string& pathOrURL)


### PR DESCRIPTION
#### 1fb66e16eddacd6ead9e4c01ba6b01b647a3709d
<pre>
[WebTransport] WebTransport pages should be restorable from the back/forward cache
<a href="https://bugs.webkit.org/show_bug.cgi?id=319915">https://bugs.webkit.org/show_bug.cgi?id=319915</a>
<a href="https://rdar.apple.com/172715074">rdar://172715074</a>

Reviewed by Alex Christensen.

Two WPT tests for WebTransport back/forward cache behavior were skipped and never actually
exercised the feature:

- back-forward-cache-with-open-webtransport-connection.https.window
- back-forward-cache-with-closed-webtransport-connection.https.window

There were two root causes:

1. WebKitTestRunner&apos;s shouldUseBackForwardCache() only enabled the UsesBackForwardCache
preference for the navigation-api/ and websockets/back-forward-cache test paths, not
webtransport/back-forward-cache. The WebTransport test windows therefore ran with the
back/forward cache disabled, so the page was never cached and the tests reported the
assert_implements_optional precondition failure &quot;BFCache not supported&quot;.

2. WebTransport::cleanupContext() queued the closed/ready promise rejection with
ScriptExecutionContext::postTask(), which is not a suspendable event-loop task. When invoked
from suspend() during back/forward cache entry, that task ran after the frame was detached,
when the script execution context has no global object, so cleanup() early-returned and
silently dropped the rejection. As a result WebTransport.closed never settled after the page
was restored from the back/forward cache; a page with an open WebTransport connection would
leave closed pending forever after restore.

Enable the preference for the webtransport/back-forward-cache test path, and queue the cleanup
on the event loop (queueTaskKeepingObjectAlive, TaskSource::Networking) instead of
ScriptExecutionContext::postTask. This keeps the asynchronous &quot;queue a network task&quot; of the
context cleanup steps (WebTransport spec section 6.7) while ensuring the task is held during
suspension and runs on resume, when the global object is valid again, so closed rejects after
the page is restored. The now-unused ScriptExecutionContext&amp; parameter is removed.

Covered by the two now-unskipped WPT tests rebaselined below.

* LayoutTests/TestExpectations: Unskip the two tests.
* LayoutTests/imported/w3c/web-platform-tests/webtransport/back-forward-cache-with-closed-webtransport-connection.https.window-expected.txt: Rebaseline to PASS.
* LayoutTests/imported/w3c/web-platform-tests/webtransport/back-forward-cache-with-open-webtransport-connection.https.window-expected.txt: Rebaseline to PASS.
* Source/WebCore/Modules/webtransport/WebTransport.cpp:
(WebCore::WebTransport::suspend):
(WebCore::WebTransport::cleanupContext):
* Source/WebCore/Modules/webtransport/WebTransport.h:
* Tools/TestRunnerShared/TestFeatures.cpp:
(WTR::shouldUseBackForwardCache):

Canonical link: <a href="https://commits.webkit.org/317667@main">https://commits.webkit.org/317667@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/187f264f30c1b5d2500779e34cc38e59ec55793e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175948 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49881 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/43665 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185541 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/138159 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/387bbd42-a1b4-4433-828e-c3ded2ea8d0a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/177811 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51173 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49563 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/137025 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/138159 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178904 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40481 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/157797 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/117504 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39123 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/37508 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/149542 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/37289 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34011 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/41581 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/41714 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187963 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49548 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/157348 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/146019 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39285 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50228 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/33914 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/145857 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/40646 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/122424 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/116302 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48735 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/12270 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48137 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48369 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48194 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->