### PR TITLE
[EvaluationTimeZoom] Convert view-timeline-inset property to use unzoomed lengths

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/view-timeline-inset-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/view-timeline-inset-ref.html
@@ -1,0 +1,123 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.group {
+  outline: 1px solid black;
+  padding: 20px;
+  margin: 10px;
+  width: max-content;
+  position: relative;
+  top: 250px;
+}
+.spacer {
+  height: 500px;
+}
+.scroller {
+  outline: 1px solid black;
+  display: inline-block;
+  margin: 0 10px;
+  padding: 0;
+  border: 0;
+  overflow-y: auto;
+  width: 200px;
+  height: 200px;
+}
+
+.indicator {
+  display: block;
+  position: fixed;
+  width: 100px;
+  height: 100px;
+  top: 100px;
+  margin: 0;
+  padding: 0;
+  background-color: green
+}
+#indicator1 {
+  left: 100px;
+}
+
+#indicator2 {
+  left: 300px;
+}
+
+#indicator3 {
+  left: 500px;
+}
+
+#indicator4 {
+  left: 700px;
+}
+
+.target {
+  height: 100px;
+  width: 100px;
+  background-color: black;
+}
+</style>
+</head>
+<body>
+<p>There should be 4 green boxes below.</p>
+<div class="group">
+  <div class="scroller" id="scroller1">
+    <div class="spacer"></div>
+    <div class="target" id="target1">
+      <div class="indicator" id="indicator1"></div>
+    </div>
+    <div class="spacer"></div>
+  </div>
+
+  <div class="scroller" id="scroller2">
+    <div class="spacer"></div>
+    <div class="target" id="target2">
+      <div class="indicator" id="indicator2"></div>
+    </div>
+    <div class="spacer"></div>
+  </div>
+</div>
+
+<div class="group">
+  <div class="scroller" id="scroller3">
+    <div class="spacer"></div>
+    <div class="target" id="target3">
+      <div class="indicator" id="indicator3"></div>
+    </div>
+    <div class="spacer"></div>
+  </div>
+
+  <div class="scroller" id="scroller4">
+    <div class="spacer"></div>
+    <div class="target" id="target4">
+      <div class="indicator" id="indicator4"></div>
+    </div>
+    <div class="spacer"></div>
+  </div>
+</div>
+<script>
+  window.addEventListener('load', function() {
+    const target1 = document.getElementById('target1');
+    const target2 = document.getElementById('target2');
+    const target3 = document.getElementById('target3');
+    const target4 = document.getElementById('target4');
+
+    const scroller1 = document.getElementById('scroller1');
+    const scroller2 = document.getElementById('scroller2');
+    const scroller3 = document.getElementById('scroller3');
+    const scroller4 = document.getElementById('scroller4');
+
+    const maxScroll1 = scroller1.scrollHeight - scroller1.clientHeight;
+    scroller1.scrollTop = (maxScroll1 - 250) * 0.5;
+
+    const maxScroll2 = scroller2.scrollHeight - scroller2.clientHeight;
+    scroller2.scrollTop = (maxScroll2 - 250) * 0.5;
+
+    const maxScroll3 = scroller3.scrollHeight - scroller3.clientHeight;
+    scroller3.scrollTop = (maxScroll3 - 250) * 0.5;
+
+    const maxScroll4 = scroller4.scrollHeight - scroller4.clientHeight;
+    scroller4.scrollTop = (maxScroll4 - 250) * 0.5;
+  });
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/view-timeline-inset-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/view-timeline-inset-expected.html
@@ -1,0 +1,123 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.group {
+  outline: 1px solid black;
+  padding: 20px;
+  margin: 10px;
+  width: max-content;
+  position: relative;
+  top: 250px;
+}
+.spacer {
+  height: 500px;
+}
+.scroller {
+  outline: 1px solid black;
+  display: inline-block;
+  margin: 0 10px;
+  padding: 0;
+  border: 0;
+  overflow-y: auto;
+  width: 200px;
+  height: 200px;
+}
+
+.indicator {
+  display: block;
+  position: fixed;
+  width: 100px;
+  height: 100px;
+  top: 100px;
+  margin: 0;
+  padding: 0;
+  background-color: green
+}
+#indicator1 {
+  left: 100px;
+}
+
+#indicator2 {
+  left: 300px;
+}
+
+#indicator3 {
+  left: 500px;
+}
+
+#indicator4 {
+  left: 700px;
+}
+
+.target {
+  height: 100px;
+  width: 100px;
+  background-color: black;
+}
+</style>
+</head>
+<body>
+<p>There should be 4 green boxes below.</p>
+<div class="group">
+  <div class="scroller" id="scroller1">
+    <div class="spacer"></div>
+    <div class="target" id="target1">
+      <div class="indicator" id="indicator1"></div>
+    </div>
+    <div class="spacer"></div>
+  </div>
+
+  <div class="scroller" id="scroller2">
+    <div class="spacer"></div>
+    <div class="target" id="target2">
+      <div class="indicator" id="indicator2"></div>
+    </div>
+    <div class="spacer"></div>
+  </div>
+</div>
+
+<div class="group">
+  <div class="scroller" id="scroller3">
+    <div class="spacer"></div>
+    <div class="target" id="target3">
+      <div class="indicator" id="indicator3"></div>
+    </div>
+    <div class="spacer"></div>
+  </div>
+
+  <div class="scroller" id="scroller4">
+    <div class="spacer"></div>
+    <div class="target" id="target4">
+      <div class="indicator" id="indicator4"></div>
+    </div>
+    <div class="spacer"></div>
+  </div>
+</div>
+<script>
+  window.addEventListener('load', function() {
+    const target1 = document.getElementById('target1');
+    const target2 = document.getElementById('target2');
+    const target3 = document.getElementById('target3');
+    const target4 = document.getElementById('target4');
+
+    const scroller1 = document.getElementById('scroller1');
+    const scroller2 = document.getElementById('scroller2');
+    const scroller3 = document.getElementById('scroller3');
+    const scroller4 = document.getElementById('scroller4');
+
+    const maxScroll1 = scroller1.scrollHeight - scroller1.clientHeight;
+    scroller1.scrollTop = (maxScroll1 - 250) * 0.5;
+
+    const maxScroll2 = scroller2.scrollHeight - scroller2.clientHeight;
+    scroller2.scrollTop = (maxScroll2 - 250) * 0.5;
+
+    const maxScroll3 = scroller3.scrollHeight - scroller3.clientHeight;
+    scroller3.scrollTop = (maxScroll3 - 250) * 0.5;
+
+    const maxScroll4 = scroller4.scrollHeight - scroller4.clientHeight;
+    scroller4.scrollTop = (maxScroll4 - 250) * 0.5;
+  });
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/view-timeline-inset.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/view-timeline-inset.html
@@ -1,0 +1,204 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<head>
+<title>CSS Zoom applies to view-timeline-inset</title>
+<link rel="author" title="Sam Weinig" href="mailto:sam@webkit.org">
+<link rel="help" href="https://drafts.csswg.org/css-viewport/">
+<link rel="match" href="reference/view-timeline-inset-ref.html">
+<script src="/web-animations/testcommon.js"></script>
+<script src="/common/reftest-wait.js"></script>
+<style>
+.group {
+  outline: 1px solid black;
+  padding: 20px;
+  margin: 10px;
+  width: max-content;
+  position: relative;
+  top: 250px;
+}
+.spacer {
+  height: 500px;
+}
+.scroller {
+  outline: 1px solid black;
+  display: inline-block;
+  margin: 0 10px;
+  padding: 0;
+  border: 0;
+  overflow-y: auto;
+  width: 200px;
+  height: 200px;
+  view-timeline-inset: 50px 50px;
+}
+
+.scroller-zoomed {
+  display: inline-block;
+  outline: 1px solid black;
+  margin: 0 10px;
+  padding: 0;
+  border: 0;
+  overflow-y: scroll;
+  width: 200px;
+  height: 200px;
+  view-timeline-inset: 25px 25px;
+}
+
+@keyframes grow {
+  from { --bg: yellow; }
+  to { --bg: red; }
+}
+
+.indicator {
+  display: block;
+  position: fixed;
+  width: 100px;
+  height: 100px;
+  top: 100px;
+  margin: 0;
+  padding: 0;
+  background-color: var(--bg);
+}
+#indicator1 {
+  left: 100px;
+}
+
+#indicator2 {
+  left: 300px;
+}
+
+#indicator3 {
+  top: 50px;
+  width: 50px;
+  height: 50px;
+  left: 250px;
+}
+
+#indicator4 {
+  top: 50px;
+  width: 50px;
+  height: 50px;
+  left: 350px;
+}
+
+.target {
+  height: 100px;
+  width: 100px;
+  --bg: green;
+  background-color: black;
+}
+.target-zoomed {
+  height: 50px;
+  width: 50px;
+  --bg: green;
+  background-color: black;
+}
+
+.anim-1 {
+  animation: grow step-end 1 forwards;
+  animation-timeline: --t1;
+
+  view-timeline-name: --t1;
+  view-timeline-inset: 50px 50px;
+}
+.anim-2 {
+  animation: grow step-end 1 forwards;
+  animation-timeline: --t1;
+
+  view-timeline-name: --t1;
+  view-timeline-inset: inherit;
+}
+.anim-3 {
+  animation: grow step-end 1 forwards;
+  animation-timeline: --t1;
+
+  view-timeline-name: --t1;
+  view-timeline-inset: 25px 25px;
+}
+.anim-4 {
+  animation: grow step-end 1 forwards;
+  animation-timeline: --t1;
+
+  view-timeline-name: --t1;
+  view-timeline-inset: inherit;
+}
+</style>
+</head>
+<body>
+<p>There should be 4 green boxes below.</p>
+<div class="group">
+  <div class="scroller" id="scroller1">
+    <div class="spacer"></div>
+    <div class="target" id="target1" style="zoom: 1">
+      <div class="indicator" id="indicator1"></div>
+    </div>
+    <div class="spacer"></div>
+  </div>
+
+  <div class="scroller" id="scroller2">
+    <div class="spacer"></div>
+    <div class="target" id="target2" style="zoom: 1">
+      <div class="indicator" id="indicator2"></div>
+    </div>
+    <div class="spacer"></div>
+  </div>
+</div>
+
+<div class="group">
+  <div class="scroller-zoomed" id="scroller3">
+    <div class="spacer"></div>
+    <div class="target-zoomed" id="target3" style="zoom: 2">
+      <div class="indicator" id="indicator3"></div>
+    </div>
+    <div class="spacer"></div>
+  </div>
+
+  <div class="scroller-zoomed" id="scroller4">
+    <div class="spacer"></div>
+    <div class="target-zoomed" id="target4" style="zoom: 2">
+      <div class="indicator" id="indicator4"></div>
+    </div>
+    <div class="spacer"></div>
+  </div>
+</div>
+
+<script>
+  const target1 = document.getElementById('target1');
+  const target2 = document.getElementById('target2');
+  const target3 = document.getElementById('target3');
+  const target4 = document.getElementById('target4');
+
+  const scroller1 = document.getElementById('scroller1');
+  const scroller2 = document.getElementById('scroller2');
+  const scroller3 = document.getElementById('scroller3');
+  const scroller4 = document.getElementById('scroller4');
+
+  target1.classList.add("anim-1");
+  const animation1 = target1.getAnimations()[0];
+
+  target2.classList.add("anim-2");
+  const animation2 = target2.getAnimations()[0];
+
+  target3.classList.add("anim-3");
+  const animation3 = target3.getAnimations()[0];
+
+  target4.classList.add("anim-4");
+  const animation4 = target4.getAnimations()[0];
+
+  Promise.all([animation1.ready, animation2.ready, animation3.ready, animation4.ready]).then(() => {
+    const maxScroll1 = scroller1.scrollHeight - scroller1.clientHeight;
+    scroller1.scrollTop = (maxScroll1 - 250) * 0.5;
+
+    const maxScroll2 = scroller2.scrollHeight - scroller2.clientHeight;
+    scroller2.scrollTop = (maxScroll2 - 250) * 0.5;
+
+    const maxScroll3 = scroller3.scrollHeight - scroller3.clientHeight;
+    scroller3.scrollTop = (maxScroll3 - 250) * 0.5;
+
+    const maxScroll4 = scroller4.scrollHeight - scroller4.clientHeight;
+    scroller4.scrollTop = (maxScroll4 - 250) * 0.5;
+
+    waitForAnimationFrames(2).then(takeScreenshot);
+  });
+</script>
+</body>
+</html>

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -894,6 +894,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     animation/OptionalEffectTiming.h
     animation/PlaybackDirection.h
     animation/ResolvableTimelineRange.h
+    animation/ResolvableViewTimelineInsets.h
     animation/ScrollAxis.h
     animation/ScrollTimeline.h
     animation/ScrollTimelineOptions.h

--- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
+++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
@@ -5572,6 +5572,7 @@
 		BCB16C280979C3BD00467741 /* CachedXSLStyleSheet.h in Headers */ = {isa = PBXBuildFile; fileRef = BCB16C0F0979C3BD00467741 /* CachedXSLStyleSheet.h */; };
 		BCB16C2A0979C3BD00467741 /* CachedResourceLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = BCB16C110979C3BD00467741 /* CachedResourceLoader.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BCB19186300A967C00A9A5C7 /* ResolvableTimelineRange.h in Headers */ = {isa = PBXBuildFile; fileRef = BCB19185300A93CD00A9A5C7 /* ResolvableTimelineRange.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		BCB1CBBA300E960900A9A5C7 /* ResolvableViewTimelineInsets.h in Headers */ = {isa = PBXBuildFile; fileRef = BCB1CBB9300E960200A9A5C7 /* ResolvableViewTimelineInsets.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BCB271F92CC16DD500265123 /* CSSPathValue.h in Headers */ = {isa = PBXBuildFile; fileRef = BCB271F82CC16DD500265123 /* CSSPathValue.h */; };
 		BCB271FB2CC174D400265123 /* StyleSVGPathData.h in Headers */ = {isa = PBXBuildFile; fileRef = BCB271F52CC16CF600265123 /* StyleSVGPathData.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BCB271FF2CC1E6CD00265123 /* CSSPrimitiveNumericTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = BCB271DA2CC0142C00265123 /* CSSPrimitiveNumericTypes.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -20245,6 +20246,7 @@
 		BCB16C100979C3BD00467741 /* CachedResourceLoader.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CachedResourceLoader.cpp; sourceTree = "<group>"; };
 		BCB16C110979C3BD00467741 /* CachedResourceLoader.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; path = CachedResourceLoader.h; sourceTree = "<group>"; };
 		BCB19185300A93CD00A9A5C7 /* ResolvableTimelineRange.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ResolvableTimelineRange.h; sourceTree = "<group>"; };
+		BCB1CBB9300E960200A9A5C7 /* ResolvableViewTimelineInsets.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ResolvableViewTimelineInsets.h; sourceTree = "<group>"; };
 		BCB271952CBC466500265123 /* CSSPropertyParserConsumer+FlexDefinitions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "CSSPropertyParserConsumer+FlexDefinitions.h"; sourceTree = "<group>"; };
 		BCB271962CBC466F00265123 /* CSSPropertyParserConsumer+FrequencyDefinitions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "CSSPropertyParserConsumer+FrequencyDefinitions.h"; sourceTree = "<group>"; };
 		BCB2719F2CBD7D4C00265123 /* CSSGradient.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CSSGradient.h; sourceTree = "<group>"; };
@@ -31720,6 +31722,7 @@
 				712BE47E1FE8649D002031CC /* PlaybackDirection.h */,
 				712BE47F1FE8649E002031CC /* PlaybackDirection.idl */,
 				BCB19185300A93CD00A9A5C7 /* ResolvableTimelineRange.h */,
+				BCB1CBB9300E960200A9A5C7 /* ResolvableViewTimelineInsets.h */,
 				BCB0259A2C87DDD800ACC2B3 /* ScrollAxis.cpp */,
 				713516962AE6D29600718EBE /* ScrollAxis.h */,
 				713516952AE6D29600718EBE /* ScrollAxis.idl */,
@@ -48285,6 +48288,7 @@
 				0FD6A68A26EEC32B007B2231 /* ResizeObserverOptions.h in Headers */,
 				0FD6A68E26EEC5E9007B2231 /* ResizeObserverSize.h in Headers */,
 				BCB19186300A967C00A9A5C7 /* ResolvableTimelineRange.h in Headers */,
+				BCB1CBBA300E960900A9A5C7 /* ResolvableViewTimelineInsets.h in Headers */,
 				CD14C2432ECB999900F9C56D /* ResolvedCaptionDisplaySettingsOptions.h in Headers */,
 				CD14C2562ECC65D500F9C56D /* ResolvedCaptionDisplaySettingsOptionsWrapper.h in Headers */,
 				EE62BD9D2DE12C1B006C9A05 /* ResolvedScopedName.h in Headers */,

--- a/Source/WebCore/animation/CSSAnimation.cpp
+++ b/Source/WebCore/animation/CSSAnimation.cpp
@@ -232,10 +232,10 @@ void CSSAnimation::syncStyleOriginatedTimeline()
         },
         [&](const Style::ViewFunction& viewFunction) {
             if (RefPtr existingViewTimeline = dynamicDowncast<ViewTimeline>(timeline())) {
-                if (existingViewTimeline->matchesAnonymousViewFunctionForSubject(viewFunction, *owningElement()))
+                if (existingViewTimeline->matchesAnonymousViewFunctionForSubject(viewFunction, m_backingStyleZoomForLength, *owningElement()))
                     return;
             }
-            auto viewTimeline = ViewTimeline::create(nullAtom(), viewFunction->axis, viewFunction->insets);
+            auto viewTimeline = ViewTimeline::create(nullAtom(), viewFunction->axis, viewFunction->insets, m_backingStyleZoomForLength);
             viewTimeline->setSubject(*owningElement());
             setTimeline(WTF::move(viewTimeline));
         }

--- a/Source/WebCore/animation/ResolvableViewTimelineInsets.h
+++ b/Source/WebCore/animation/ResolvableViewTimelineInsets.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2026 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <WebCore/StyleViewTimelineInsetItem.h>
+#include <WebCore/StyleZoomPrimitives.h>
+
+namespace WebCore {
+
+struct ResolvableViewTimelineInsets {
+    Style::ViewTimelineInsetItem insets;
+    Style::ZoomFactor zoom;
+
+    bool operator==(const ResolvableViewTimelineInsets&) const = default;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/animation/StyleOriginatedTimelinesController.cpp
+++ b/Source/WebCore/animation/StyleOriginatedTimelinesController.cpp
@@ -255,7 +255,7 @@ void StyleOriginatedTimelinesController::documentDidResolveStyle()
     m_removedTimelines.clear();
 }
 
-void StyleOriginatedTimelinesController::registerNamedViewTimeline(const AtomString& name, const Styleable& subject, ScrollAxis axis, const Style::ViewTimelineInsetItem& insets)
+void StyleOriginatedTimelinesController::registerNamedViewTimeline(const AtomString& name, const Styleable& subject, ScrollAxis axis, const Style::ViewTimelineInsetItem& insets, const Style::ZoomFactor& usedZoomForLength)
 {
     LOG_WITH_STREAM(Animations, stream << "StyleOriginatedTimelinesController::registerNamedViewTimeline: " << name << " subject: " << subject);
 
@@ -272,9 +272,9 @@ void StyleOriginatedTimelinesController::registerNamedViewTimeline(const AtomStr
     if (hasExistingTimeline) {
         Ref existingViewTimeline = downcast<ViewTimeline>(timelines[existingTimelineIndex].get());
         existingViewTimeline->setAxis(axis);
-        existingViewTimeline->setInsets(insets);
+        existingViewTimeline->setInsets(ResolvableViewTimelineInsets { insets, usedZoomForLength });
     } else {
-        auto newViewTimeline = ViewTimeline::create(name, axis, insets);
+        auto newViewTimeline = ViewTimeline::create(name, axis, insets, usedZoomForLength);
         newViewTimeline->setSubject(subject);
         updateTimelineForTimelineScope(newViewTimeline, name);
         timelines.append(WTF::move(newViewTimeline));

--- a/Source/WebCore/animation/StyleOriginatedTimelinesController.h
+++ b/Source/WebCore/animation/StyleOriginatedTimelinesController.h
@@ -65,7 +65,7 @@ public:
     ~StyleOriginatedTimelinesController() = default;
 
     void registerNamedScrollTimeline(const AtomString&, const Styleable&, ScrollAxis);
-    void registerNamedViewTimeline(const AtomString&, const Styleable&, ScrollAxis, const Style::ViewTimelineInsetItem&);
+    void registerNamedViewTimeline(const AtomString&, const Styleable&, ScrollAxis, const Style::ViewTimelineInsetItem&, const Style::ZoomFactor&);
     void unregisterNamedTimeline(const AtomString&, const Styleable&);
     void attachAnimation(CSSAnimation&);
     void updateNamedTimelineMapForTimelineScope(const Style::NameScope&, const Styleable&);

--- a/Source/WebCore/animation/ViewTimeline.cpp
+++ b/Source/WebCore/animation/ViewTimeline.cpp
@@ -89,20 +89,20 @@ ExceptionOr<Ref<ViewTimeline>> ViewTimeline::create(Document& document, ViewTime
     return viewTimeline;
 }
 
-Ref<ViewTimeline> ViewTimeline::create(const AtomString& name, ScrollAxis axis, const Style::ViewTimelineInsetItem& insetItem)
+Ref<ViewTimeline> ViewTimeline::create(const AtomString& name, ScrollAxis axis, const Style::ViewTimelineInsetItem& insets, const Style::ZoomFactor& usedZoomForLength)
 {
-    return adoptRef(*new ViewTimeline(name, axis, insetItem));
+    return adoptRef(*new ViewTimeline(name, axis, insets, usedZoomForLength));
 }
 
 ViewTimeline::ViewTimeline(ScrollAxis axis)
     : ScrollTimeline(nullAtom(), axis)
-    , m_insets(CSS::Keyword::Auto { })
+    , m_insets({ .insets = CSS::Keyword::Auto { }, .zoom = Style::ZoomFactor::none() })
 {
 }
 
-ViewTimeline::ViewTimeline(const AtomString& name, ScrollAxis axis, const Style::ViewTimelineInsetItem& insetItem)
+ViewTimeline::ViewTimeline(const AtomString& name, ScrollAxis axis, const Style::ViewTimelineInsetItem& insets, const Style::ZoomFactor& usedZoomForLength)
     : ScrollTimeline(name, axis)
-    , m_insets(insetItem)
+    , m_insets({ .insets = insets, .zoom = usedZoomForLength })
 {
 }
 
@@ -367,47 +367,59 @@ void ViewTimeline::cacheCurrentTime()
 
             if (m_specifiedInsets->start && m_specifiedInsets->end) {
                 m_insets = {
-                    computedInset(protect(*m_specifiedInsets->start)),
-                    computedInset(protect(*m_specifiedInsets->end)),
+                    .insets = {
+                        computedInset(protect(*m_specifiedInsets->start)),
+                        computedInset(protect(*m_specifiedInsets->end)),
+                    },
+                    .zoom = Style::ZoomFactor::none(),
                 };
             } else if (m_specifiedInsets->start) {
                 m_insets = {
-                    computedInset(protect(*m_specifiedInsets->start)),
+                    .insets {
+                        computedInset(protect(*m_specifiedInsets->start)),
+                    },
+                    .zoom = Style::ZoomFactor::none(),
                 };
             } else if (m_specifiedInsets->end) {
                 m_insets = {
-                    Style::ViewTimelineInsetItem::Offset { CSS::Keyword::Auto { } },
-                    computedInset(protect(*m_specifiedInsets->end)),
+                    .insets {
+                        Style::ViewTimelineInsetItem::Offset { CSS::Keyword::Auto { } },
+                        computedInset(protect(*m_specifiedInsets->end)),
+                    },
+                    .zoom = Style::ZoomFactor::none(),
                 };
             } else {
                 m_insets = {
-                    Style::ViewTimelineInsetItem::Offset { CSS::Keyword::Auto { } },
-                    Style::ViewTimelineInsetItem::Offset { CSS::Keyword::Auto { } },
+                    .insets {
+                        Style::ViewTimelineInsetItem::Offset { CSS::Keyword::Auto { } },
+                        Style::ViewTimelineInsetItem::Offset { CSS::Keyword::Auto { } },
+                    },
+                    .zoom = Style::ZoomFactor::none(),
                 };
             }
         }
 
-        enum class PaddingEdge : bool { Start, End };
-        auto scrollPadding = [&](PaddingEdge edge) {
-            auto& style = sourceRenderer->style();
-            if (edge == PaddingEdge::Start)
-                return scrollDirection.isVertical ? style.scrollPaddingTop() : style.scrollPaddingLeft();
-            return scrollDirection.isVertical ? style.scrollPaddingBottom() : style.scrollPaddingRight();
+        auto scrollPaddingStart = [&] {
+            CheckedRef style = sourceRenderer->style();
+            return Style::evaluate<float>(scrollDirection.isVertical ? style->scrollPaddingTop() : style->scrollPaddingLeft(), scrollContainerSize, style->usedZoomForLength());
         };
-        auto zoom = sourceRenderer->style().usedZoomForLength();
+        auto scrollPaddingEnd = [&] {
+            CheckedRef style = sourceRenderer->style();
+            return Style::evaluate<float>(scrollDirection.isVertical ? style->scrollPaddingBottom() : style->scrollPaddingRight(), scrollContainerSize, style->usedZoomForLength());
+        };
 
         float insetStart = 0;
         float insetEnd = 0;
 
-        if (m_insets.start().isAuto())
-            insetStart = Style::evaluate<float>(scrollPadding(PaddingEdge::Start), scrollContainerSize, zoom);
+        if (m_insets.insets.start().isAuto())
+            insetStart = scrollPaddingStart();
         else
-            insetStart = Style::evaluate<float>(m_insets.start(), scrollContainerSize, Style::ZoomNeeded { });
+            insetStart = Style::evaluate<float>(m_insets.insets.start(), scrollContainerSize, m_insets.zoom);
 
-        if (m_insets.end().isAuto())
-            insetEnd = Style::evaluate<float>(scrollPadding(PaddingEdge::End), scrollContainerSize, zoom);
+        if (m_insets.insets.end().isAuto())
+            insetEnd = scrollPaddingEnd();
         else
-            insetEnd = Style::evaluate<float>(m_insets.end(), scrollContainerSize, Style::ZoomNeeded { });
+            insetEnd = Style::evaluate<float>(m_insets.insets.end(), scrollContainerSize, m_insets.zoom);
 
         StickinessAdjustmentData stickyData;
         if (CheckedPtr stickyContainer = dynamicDowncast<RenderBoxModelObject>(this->stickyContainer().get())) {
@@ -672,9 +684,14 @@ Ref<CSSNumericValue> ViewTimeline::endOffset() const
     return CSSNumericFactory::px(computeTimelineData().rangeEnd);
 }
 
-bool ViewTimeline::matchesAnonymousViewFunctionForSubject(const Style::ViewFunction& viewFunction, const Styleable& subject) const
+bool ViewTimeline::matchesAnonymousViewFunctionForSubject(const Style::ViewFunction& viewFunction, const Style::ZoomFactor& usedZoomForLength, const Styleable& subject) const
 {
-    return isStyleOriginated() && name().isEmpty() && m_insets == viewFunction->insets && axis() == viewFunction->axis && m_subject.styleable() == subject;
+    return isStyleOriginated()
+        && name().isEmpty()
+        && m_insets.insets == viewFunction->insets
+        && m_insets.zoom == usedZoomForLength
+        && axis() == viewFunction->axis
+        && m_subject.styleable() == subject;
 }
 
 WTF::TextStream& operator<<(WTF::TextStream& ts, const StickinessAdjustmentData& stickiness)
@@ -698,7 +715,7 @@ WTF::TextStream& operator<<(WTF::TextStream& ts, const StickinessAdjustmentData:
 
 TextStream& operator<<(TextStream& ts, const ViewTimeline& timeline)
 {
-    return ts << timeline.name() << ' ' << timeline.axis() << ' ' << timeline.insets();
+    return ts << timeline.name() << ' ' << timeline.axis() << ' ' << timeline.insets().insets;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/animation/ViewTimeline.h
+++ b/Source/WebCore/animation/ViewTimeline.h
@@ -27,9 +27,9 @@
 
 #include <WebCore/CSSNumericValue.h>
 #include <WebCore/CSSPrimitiveValue.h>
+#include <WebCore/ResolvableViewTimelineInsets.h>
 #include <WebCore/ScrollTimeline.h>
 #include <WebCore/StyleViewFunction.h>
-#include <WebCore/StyleViewTimelineInsetItem.h>
 #include <WebCore/Styleable.h>
 #include <WebCore/ViewTimelineOptions.h>
 #include <wtf/Ref.h>
@@ -38,7 +38,6 @@
 namespace WebCore {
 
 namespace Style {
-class BuilderState;
 enum class SingleAnimationRangeName : uint8_t;
 }
 
@@ -73,15 +72,15 @@ struct StickinessAdjustmentData {
 class ViewTimeline final : public ScrollTimeline {
 public:
     static ExceptionOr<Ref<ViewTimeline>> create(Document&, ViewTimelineOptions&& = { });
-    static Ref<ViewTimeline> create(const AtomString&, ScrollAxis, const Style::ViewTimelineInsetItem&);
+    static Ref<ViewTimeline> create(const AtomString&, ScrollAxis, const Style::ViewTimelineInsetItem&, const Style::ZoomFactor&);
 
     const Element* NODELETE subject() const;
     const WeakStyleable subjectStyleable() const { return m_subject; }
     void setSubject(Element*);
     void setSubject(const Styleable&);
 
-    const Style::ViewTimelineInsetItem& insets() const LIFETIME_BOUND { return m_insets; }
-    void setInsets(const Style::ViewTimelineInsetItem& insets) { m_insets = insets; }
+    const ResolvableViewTimelineInsets& insets() const LIFETIME_BOUND { return m_insets; }
+    void setInsets(ResolvableViewTimelineInsets&& insets) { m_insets = WTF::move(insets); }
 
     Ref<CSSNumericValue> startOffset() const;
     Ref<CSSNumericValue> endOffset() const;
@@ -99,7 +98,7 @@ public:
     std::pair<double, double> offsetIntervalForAttachmentRange(const ResolvableTimelineRange&) const;
     std::pair<double, double> offsetIntervalForTimelineRangeName(Style::SingleAnimationRangeName) const;
 
-    bool matchesAnonymousViewFunctionForSubject(const Style::ViewFunction&, const Styleable&) const;
+    bool matchesAnonymousViewFunctionForSubject(const Style::ViewFunction&, const Style::ZoomFactor&, const Styleable&) const;
     WebAnimationTime NODELETE epsilon() const;
 
 private:
@@ -108,7 +107,7 @@ private:
     template<typename F> double mapOffsetToTimelineRange(const ScrollTimeline::Data&, Style::SingleAnimationRangeName, F&&) const;
 
     explicit ViewTimeline(ScrollAxis);
-    explicit ViewTimeline(const AtomString&, ScrollAxis, const Style::ViewTimelineInsetItem&);
+    explicit ViewTimeline(const AtomString&, ScrollAxis, const Style::ViewTimelineInsetItem&, const Style::ZoomFactor&);
 
     bool isViewTimeline() const final { return true; }
 
@@ -134,7 +133,8 @@ private:
 
     WeakStyleable m_subject;
     std::optional<SpecifiedViewTimelineInsets> m_specifiedInsets;
-    Style::ViewTimelineInsetItem m_insets;
+    ResolvableViewTimelineInsets m_insets;
+
     CurrentTimeData m_cachedCurrentTimeData { };
 };
 

--- a/Source/WebCore/style/Styleable.cpp
+++ b/Source/WebCore/style/Styleable.cpp
@@ -912,7 +912,7 @@ void Styleable::updateCSSViewTimelines(const Style::ComputedStyle* currentStyle,
                 // Nothing to register.
             },
             [&](const Style::CustomIdent& identifier) {
-                styleOriginatedTimelinesController->registerNamedViewTimeline(identifier.value, *this, viewTimeline.axis(), viewTimeline.inset());
+                styleOriginatedTimelinesController->registerNamedViewTimeline(identifier.value, *this, viewTimeline.axis(), viewTimeline.inset(), afterChangeStyle.usedZoomForLength());
                 registeredViewTimelineNames.add(identifier.value);
             }
         );

--- a/Source/WebCore/style/values/scroll-animations/StyleViewTimelineInsetItem.h
+++ b/Source/WebCore/style/values/scroll-animations/StyleViewTimelineInsetItem.h
@@ -29,7 +29,6 @@
 
 namespace WebCore {
 
-class CSSPrimitiveValue;
 class CSSValuePair;
 
 namespace Style {
@@ -37,7 +36,7 @@ namespace Style {
 // <single-view-timeline-inset-item> = [ [ auto | <length-percentage> ]{1,2} ]
 // https://drafts.csswg.org/scroll-animations-1/#propdef-view-timeline-inset
 struct ViewTimelineInsetItem {
-    struct Offset : PrimitiveNumericOrKeyword<LengthPercentage<>, CSS::Keyword::Auto> {
+    struct Offset : PrimitiveNumericOrKeyword<LengthPercentage<CSS::AllUnzoomed>, CSS::Keyword::Auto> {
         using Base::Base;
 
         bool isAuto() const { return holdsAlternative<CSS::Keyword::Auto>(); }


### PR DESCRIPTION
#### 27b5f7b5a093eb497506f0d4af22af72044dbba6
<pre>
[EvaluationTimeZoom] Convert view-timeline-inset property to use unzoomed lengths
<a href="https://bugs.webkit.org/show_bug.cgi?id=319905">https://bugs.webkit.org/show_bug.cgi?id=319905</a>

Reviewed by Antoine Quint.

Converts the view-timeline-inset CSS property to use unzoomed lengths.

New test added showing view-timeline-inset working properly with inherited + zoomed values.

Tests: imported/w3c/web-platform-tests/css/css-viewport/zoom/view-timeline-inset.html
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/view-timeline-inset-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/view-timeline-inset-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/view-timeline-inset.html: Added.
* Source/WebCore/Headers.cmake:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/animation/CSSAnimation.cpp:
* Source/WebCore/animation/ResolvableViewTimelineInsets.h: Added.
* Source/WebCore/animation/StyleOriginatedTimelinesController.cpp:
* Source/WebCore/animation/StyleOriginatedTimelinesController.h:
* Source/WebCore/animation/ViewTimeline.cpp:
* Source/WebCore/animation/ViewTimeline.h:
* Source/WebCore/style/Styleable.cpp:
* Source/WebCore/style/values/scroll-animations/StyleViewTimelineInsetItem.h:

Canonical link: <a href="https://commits.webkit.org/317702@main">https://commits.webkit.org/317702@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/274f914d5c42d85cb549c9b574006ec3a67294c3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175994 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49927 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43711 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185588 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/138206 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/177857 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51219 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49609 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137055 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/138206 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178950 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40520 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157825 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117534 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39163 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37540 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149581 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37317 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34057 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41629 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41746 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188009 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49594 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/157376 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146059 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39307 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50275 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33942 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145901 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40679 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122470 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/116348 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48781 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12298 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48183 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48415 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48240 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->