### PR TITLE
REGRESSION (292080@main): [WK1] DocumentLoader::m_originalSubstituteDataWasValid is always false because it reads a moved-from SubstituteData

### DIFF
--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -193,7 +193,7 @@ DocumentLoader::DocumentLoader(ResourceRequest&& request, SubstituteData&& subst
     , m_originalRequestCopy(originalRequest.isNull() ? request : WTF::move(originalRequest))
     , m_request(WTF::move(request))
     , m_substituteResourceDeliveryTimer(*this, &DocumentLoader::substituteResourceDeliveryTimerFired)
-    , m_originalSubstituteDataWasValid(substituteData.isValid())
+    , m_originalSubstituteDataWasValid(m_substituteData.isValid())
 {
 }
 

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -1097,6 +1097,7 @@
 				WebKit/WKWebView/WKWebExtensionAPILocalization.mm,
 				WebKit/WKWebView/WKWebViewLogging.mm,
 				WebKit/WKWebView/WKWebViewSpatialTrackingLabels.mm,
+				WebKitLegacy/cocoa/SubstituteDataLocalResourceAccess.mm,
 				WebKitLegacy/cocoa/WebPreferencesTest.mm,
 				WebKitLegacy/ios/AudioSessionCategoryIOS.mm,
 				WebKitLegacy/ios/DateTimeInputsAccessoryViewTests.mm,

--- a/Tools/TestWebKitAPI/Tests/WebKitLegacy/cocoa/SubstituteDataLocalResourceAccess.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitLegacy/cocoa/SubstituteDataLocalResourceAccess.mm
@@ -1,0 +1,113 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "Helpers/DeprecatedGlobalValues.h"
+#import "Helpers/PlatformUtilities.h"
+#import "Helpers/Test.h"
+#import <WebCore/SecurityPolicy.h>
+#import <WebKit/WebPreferencesPrivate.h>
+#import <WebKit/WebViewPrivate.h>
+#import <wtf/FileHandle.h>
+#import <wtf/FileSystem.h>
+#import <wtf/RetainPtr.h>
+#import <wtf/URL.h>
+
+#if PLATFORM(IOS_FAMILY)
+#import <WebKit/WebUIKitSupport.h>
+#endif
+
+@interface SubstituteDataLocalResourceAccessFrameLoadDelegate : NSObject <WebFrameLoadDelegate>
+@end
+
+@implementation SubstituteDataLocalResourceAccessFrameLoadDelegate
+
+- (void)webView:(WebView *)sender didFinishLoadForFrame:(WebFrame *)frame
+{
+    didFinishLoad = true;
+}
+
+@end
+
+namespace TestWebKitAPI {
+
+// A document loaded via -loadHTMLString:baseURL: is loaded with SubstituteData. Its origin is
+// derived from the base URL (here http:, which is not a local scheme), so it does not qualify for
+// local resource access on its own. Loading a classic <script src> from a file: URL must succeed
+// via the local-content grant applied in DocumentLoader::commitData(), which only applies to the
+// document that was constructed with the substitute data. A classic script load uses NoCors mode,
+// which is gated by SecurityOrigin::canDisplay() -- unlike fetch()'s default SameOrigin mode,
+// which is always same-origin-restricted regardless of the grant.
+//
+// The script communicates its result via window.testResult, read back with
+// -stringByEvaluatingJavaScriptFromString: after the load completes, rather than a native
+// callback bridge installed through -webView:didCreateJavaScriptContext:forFrame:.
+TEST(WebKitLegacy, SubstituteDataDocumentCanLoadLocalResource)
+{
+    didFinishLoad = false;
+
+    auto [tempFilePath, tempFileHandle] = FileSystem::openTemporaryFile("SubstituteDataLocalResourceAccess"_s, ".js"_s);
+    ASCIILiteral scriptContents = "window.testResult = 'local file contents'"_s;
+    tempFileHandle.write(scriptContents.span8());
+    tempFileHandle = { };
+
+    URL tempFileURL = URL::fileURLWithFileSystemPath(tempFilePath);
+    RetainPtr nsTempFileURL = tempFileURL.createNSURL();
+
+    RetainPtr preferences = adoptNS([[WebPreferences alloc] init]);
+    preferences.get().webSecurityEnabled = YES;
+    preferences.get().allowUniversalAccessFromFileURLs = NO;
+
+#if PLATFORM(IOS_FAMILY)
+    // WebKitInitialize() is normally called by UIKit before any WebView is created; call it
+    // directly here (without linking UIKit) since this test creates a WebView on its own.
+    WebKitInitialize();
+#endif
+
+    RetainPtr webView = adoptNS([[WebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400) frameName:nil groupName:nil]);
+    webView.get().preferences = preferences.get();
+
+    // -initWithFrame:frameName:groupName: only sets AllowLocalLoadsForLocalAndSubstituteData when the
+    // app is linked against an SDK older than WEBKIT_FIRST_VERSION_WITH_MORE_STRICT_LOCAL_RESOURCE_SECURITY_RESTRICTION
+    // (2008-era), which is never true for a modern test binary. Set the policy directly so the
+    // local-content grant this test exercises is actually reachable.
+    WebCore::SecurityPolicy::setLocalLoadPolicy(WebCore::SecurityPolicy::AllowLocalLoadsForLocalAndSubstituteData);
+
+    RetainPtr delegate = adoptNS([[SubstituteDataLocalResourceAccessFrameLoadDelegate alloc] init]);
+    webView.get().frameLoadDelegate = delegate.get();
+
+    RetainPtr html = adoptNS([[NSString alloc] initWithFormat:@"<script>window.onerror = () => window.testResult = 'script failed'</script><script src=\"%s\" onerror=\"window.testResult = 'script failed'\"></script>", nsTempFileURL.get().absoluteString.UTF8String]);
+    [[webView mainFrame] loadHTMLString:html.get() baseURL:[NSURL URLWithString:@"http://example.com/"]];
+    Util::run(&didFinishLoad);
+
+    WebCore::SecurityPolicy::setLocalLoadPolicy(WebCore::SecurityPolicy::AllowLocalLoadsForLocalOnly);
+
+    NSString *scriptResult = [webView.get() stringByEvaluatingJavaScriptFromString:@"window.testResult"];
+    EXPECT_WK_STREQ("local file contents", scriptResult);
+
+    FileSystem::deleteFile(tempFilePath);
+}
+
+} // namespace TestWebKitAPI


### PR DESCRIPTION
#### af3738924f767a576348b9730ef598920dd722cc
<pre>
REGRESSION (292080@main): [WK1] DocumentLoader::m_originalSubstituteDataWasValid is always false because it reads a moved-from SubstituteData
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=319892">https://bugs.webkit.org/show_bug.cgi?id=319892</a>&gt;
&lt;<a href="https://rdar.apple.com/182804763">rdar://182804763</a>&gt;

Reviewed by Brent Fulgham.

The constructor initializes `m_substituteData` from the moved-from
`substituteData` parameter, then reads `substituteData.isValid()` to
compute `m_originalSubstituteDataWasValid`.  Member initialization
follows declaration order, and `m_substituteData` is declared before
`m_originalSubstituteDataWasValid`, so `substituteData` has already
been moved from by the time `isValid()` is called on it, making the
field always false regardless of the original data&apos;s validity.

`m_originalSubstituteDataWasValid` gates the local-resource-load grant
in `DocumentLoader::commitData()`, so this silently drops local
resource access for documents loaded with substitute data.

Test: Tools/TestWebKitAPI/Tests/WebKitLegacy/cocoa/SubstituteDataLocalResourceAccess.mm

* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::DocumentLoader::DocumentLoader):
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKitLegacy/cocoa/SubstituteDataLocalResourceAccess.mm: Add.
(TestWebKitAPI::TEST(WebKitLegacy, SubstituteDataDocumentCanLoadLocalResource)):

Canonical link: <a href="https://commits.webkit.org/317750@main">https://commits.webkit.org/317750@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4ef2b6f8333e2bbd0ca8cad9b94380591927f3d1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176079 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50014 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43804 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185675 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/138309 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/177942 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51306 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49698 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137131 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/138309 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179035 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40606 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157905 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117606 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39255 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37622 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149671 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37402 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34143 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41730 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41833 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188097 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49679 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146148 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50362 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34020 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145978 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26769 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40756 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122565 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/116482 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48867 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12374 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48268 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48503 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48327 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->