### PR TITLE
[GFC] Compute definiteInlineGridAreaSize and thread grid area through intrinsic sizing

### DIFF
--- a/Source/WebCore/layout/formattingContexts/grid/GridItemSizingFunctions.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/GridItemSizingFunctions.cpp
@@ -31,18 +31,22 @@
 namespace WebCore {
 namespace Layout {
 
-GridItemSizingFunctions GridItemSizingFunctions::inlineAxis(const IntegrationUtils& integrationUtils)
+GridItemSizingFunctions GridItemSizingFunctions::inlineAxis(const IntegrationUtils& integrationUtils, const TrackSizingFunctionsList& columnTrackSizingFunctions, LayoutUnit columnGap)
 {
     return {
-        [&integrationUtils](const PlacedGridItem& gridItem, LayoutUnit blockAxisConstraint) {
-            return GridLayoutUtils::inlineAxisMinContentContribution(gridItem, blockAxisConstraint, integrationUtils);
+        [&integrationUtils, &columnTrackSizingFunctions, columnGap](const PlacedGridItem& gridItem, LayoutUnit) {
+            auto gridAreaInlineSize = GridLayoutUtils::definiteInlineGridAreaSize(gridItem, columnTrackSizingFunctions, columnGap);
+            return GridLayoutUtils::inlineAxisMinContentContribution(gridItem, gridAreaInlineSize, integrationUtils);
         },
-        [&integrationUtils](const PlacedGridItem& gridItem, LayoutUnit blockAxisConstraint) {
-            return GridLayoutUtils::inlineAxisMaxContentContribution(gridItem, blockAxisConstraint, integrationUtils);
+        [&integrationUtils, &columnTrackSizingFunctions, columnGap](const PlacedGridItem& gridItem, LayoutUnit) {
+            auto gridAreaInlineSize = GridLayoutUtils::definiteInlineGridAreaSize(gridItem, columnTrackSizingFunctions, columnGap);
+            return GridLayoutUtils::inlineAxisMaxContentContribution(gridItem, gridAreaInlineSize, integrationUtils);
         },
-        [&integrationUtils](const PlacedGridItem& gridItem, const TrackSizingFunctionsList& trackSizingFunctions, LayoutUnit borderAndPadding, LayoutUnit availableSpace, LayoutUnit blockAxisConstraint) {
-            UNUSED_PARAM(blockAxisConstraint);
-            return GridLayoutUtils::inlineMinimumSize(gridItem, trackSizingFunctions, borderAndPadding, availableSpace, integrationUtils);
+        [&integrationUtils, columnGap](const PlacedGridItem& gridItem, const TrackSizingFunctionsList& trackSizingFunctions, LayoutUnit borderAndPadding, LayoutUnit availableSpace, LayoutUnit) {
+            // The item's inline grid area is definite when it spans only definitely-sized columns; its
+            // percentages then resolve against that size, and against zero (std::nullopt) otherwise.
+            auto gridAreaInlineSize = GridLayoutUtils::definiteInlineGridAreaSize(gridItem, trackSizingFunctions, columnGap);
+            return GridLayoutUtils::inlineMinimumSize(gridItem, trackSizingFunctions, borderAndPadding, availableSpace, gridAreaInlineSize, integrationUtils);
         }
     };
 }

--- a/Source/WebCore/layout/formattingContexts/grid/GridItemSizingFunctions.h
+++ b/Source/WebCore/layout/formattingContexts/grid/GridItemSizingFunctions.h
@@ -50,7 +50,7 @@ struct GridItemSizingFunctions {
     {
     }
 
-    static GridItemSizingFunctions inlineAxis(const IntegrationUtils&);
+    static GridItemSizingFunctions inlineAxis(const IntegrationUtils&, const TrackSizingFunctionsList& columnTrackSizingFunctions, LayoutUnit columnGap);
     static GridItemSizingFunctions blockAxis(const GridFormattingContext&);
 
     Function<LayoutUnit(const PlacedGridItem&, LayoutUnit oppositeAxisConstraint)> minContentContribution;

--- a/Source/WebCore/layout/formattingContexts/grid/GridLayout.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayout.cpp
@@ -470,7 +470,7 @@ TrackSizes GridLayout::sizeColumnTracks(const PlacedGridItems& placedGridItems, 
     });
 
     return TrackSizingAlgorithm::sizeTracks(columnTrackSizingItems, columnTrackSizingFunctionsList,
-        layoutConstraints.inlineAxis, GridItemSizingFunctions::inlineAxis(formattingContext().integrationUtils()),
+        layoutConstraints.inlineAxis, GridItemSizingFunctions::inlineAxis(formattingContext().integrationUtils(), columnTrackSizingFunctionsList, layoutState.usedColumnGap),
         layoutState.usedColumnGap, layoutState.usedJustifyContent);
 }
 

--- a/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.cpp
@@ -189,10 +189,10 @@ static std::optional<LayoutUnit> NODELETE inlineTransferredSizeSuggestion(const 
     return { };
 }
 
-static BorderBoxSize inlineContentSizeSuggestion(const PlacedGridItem& gridItem, LayoutUnit borderAndPadding, const IntegrationUtils& integrationUtils)
+static BorderBoxSize inlineContentSizeSuggestion(const PlacedGridItem& gridItem, LayoutUnit borderAndPadding, std::optional<LayoutUnit> gridAreaInlineSize, const IntegrationUtils& integrationUtils)
 {
     ASSERT(!preferredAspectRatio(gridItem.layoutBox()), "Grid items with preferred aspect ratio not supported yet.");
-    return BorderBoxSize { ContentBoxSize { integrationUtils.minContentWidth(gridItem.layoutBox()) }, borderAndPadding };
+    return BorderBoxSize { ContentBoxSize { integrationUtils.minContentWidthForGridItem(gridItem.layoutBox(), gridAreaInlineSize) }, borderAndPadding };
 }
 
 // https://www.w3.org/TR/css-grid-2/#specified-size-suggestion
@@ -283,7 +283,7 @@ LayoutUnit inlinePreferredSize(const PlacedGridItem& placedGridItem, LayoutUnit 
 
 // https://drafts.csswg.org/css-grid-1/#min-size-auto
 static BorderBoxSize automaticMinimumInlineSize(const PlacedGridItem& gridItem, LayoutUnit borderAndPadding, const TrackSizingFunctionsList& trackSizingFunctions,
-    LayoutUnit containingBlockSize, const IntegrationUtils& integrationUtils)
+    LayoutUnit containingBlockSize, std::optional<LayoutUnit> gridAreaInlineSize, const IntegrationUtils& integrationUtils)
 {
     auto& inlineAxisSizes = gridItem.inlineAxisSizes();
     ASSERT(inlineAxisSizes.minimumSize.isAuto());
@@ -320,7 +320,7 @@ static BorderBoxSize automaticMinimumInlineSize(const PlacedGridItem& gridItem, 
                 return BorderBoxSize { ContentBoxSize { *transferredSizeSuggestion }, borderAndPadding };
         }
         // else its content size suggestion
-        return inlineContentSizeSuggestion(gridItem, borderAndPadding, integrationUtils);
+        return inlineContentSizeSuggestion(gridItem, borderAndPadding, gridAreaInlineSize, integrationUtils);
     };
 
     // In all cases, the size suggestion is additionally clamped by the maximum size in
@@ -427,7 +427,7 @@ LayoutUnit blockPreferredSize(const PlacedGridItem& placedGridItem, LayoutUnit b
 }
 
 LayoutUnit inlineMinimumSize(const PlacedGridItem& gridItem, const TrackSizingFunctionsList& trackSizingFunctions,
-    LayoutUnit borderAndPadding, LayoutUnit columnsSize, const IntegrationUtils& integrationUtils)
+    LayoutUnit borderAndPadding, LayoutUnit columnsSize, std::optional<LayoutUnit> gridAreaInlineSize, const IntegrationUtils& integrationUtils)
 {
     auto& minimumSize = gridItem.inlineAxisSizes().minimumSize;
     return WTF::switchOn(minimumSize,
@@ -441,7 +441,7 @@ LayoutUnit inlineMinimumSize(const PlacedGridItem& gridItem, const TrackSizingFu
             return BorderBoxSize { ContentBoxSize { Style::evaluate<LayoutUnit>(calculated, columnsSize, gridItem.usedZoom()) }, borderAndPadding }.value;
         },
         [&](const CSS::Keyword::Auto&) -> LayoutUnit {
-            return automaticMinimumInlineSize(gridItem, borderAndPadding, trackSizingFunctions, columnsSize, integrationUtils).value;
+            return automaticMinimumInlineSize(gridItem, borderAndPadding, trackSizingFunctions, columnsSize, gridAreaInlineSize, integrationUtils).value;
         },
         [](const auto&) -> LayoutUnit {
             ASSERT_NOT_IMPLEMENTED_YET();
@@ -494,7 +494,7 @@ LayoutUnit blockMaximumSize(const PlacedGridItem& gridItem, LayoutUnit borderAnd
 LayoutUnit inlineUsedSize(const PlacedGridItem& gridItem, const TrackSizingFunctionsList& trackSizingFunctions, LayoutUnit borderAndPadding, LayoutUnit columnsSize, const IntegrationUtils& integrationUtils)
 {
     auto preferredSize = inlinePreferredSize(gridItem, borderAndPadding, columnsSize);
-    auto minimumSize = inlineMinimumSize(gridItem, trackSizingFunctions, borderAndPadding, columnsSize, integrationUtils);
+    auto minimumSize = inlineMinimumSize(gridItem, trackSizingFunctions, borderAndPadding, columnsSize, std::nullopt, integrationUtils);
     auto maximumSize = inlineMaximumSize(gridItem, borderAndPadding);
     return std::max(minimumSize, std::min(maximumSize, preferredSize));
 }
@@ -539,16 +539,59 @@ LayoutUnit gridAreaDimensionSize(size_t startLine, size_t endLine, const TrackSi
     return sumOfTrackSizes + (numberOfInteriorGaps * gap);
 }
 
-LayoutUnit inlineAxisMinContentContribution(const PlacedGridItem& gridItem, LayoutUnit blockAxisConstraint, const IntegrationUtils& integrationUtils)
+// FIXME: A percentage track is also definite when the grid container's available inline size is
+// definite; treat those as definite too.
+bool hasDefiniteInlineGridAreaSize(const PlacedGridItem& gridItem, const TrackSizingFunctionsList& trackSizingFunctions)
 {
-    UNUSED_PARAM(blockAxisConstraint);
-    return BorderBoxSize::fromIntegrationFunction(integrationUtils.minContentLogicalWidthContribution(gridItem.layoutBox())).value;
+    for (auto trackIndex : std::views::iota(gridItem.columnStartLine(), gridItem.columnEndLine())) {
+        auto& trackSizingFunction = trackSizingFunctions[trackIndex];
+        if (!trackSizingFunction.min.isLength() || !trackSizingFunction.max.isLength())
+            return false;
+        auto minimumBreadth = trackSizingFunction.min.length().tryFixed();
+        auto maximumBreadth = trackSizingFunction.max.length().tryFixed();
+        // If either the min or max track sizing function is not a fixed length, the track is still being resolved, so the area is indefinite.
+        if (!minimumBreadth || !maximumBreadth)
+            return false;
+        auto minimumTrackSize = LayoutUnit { minimumBreadth->resolveZoom(Style::ZoomNeeded { }) };
+        auto maximumTrackSize = LayoutUnit { maximumBreadth->resolveZoom(Style::ZoomNeeded { }) };
+        // If the track's min and max sizes are not equal, the track is still being resolved, so the area is indefinite.
+        if (minimumTrackSize != maximumTrackSize)
+            return false;
+    }
+    return true;
 }
 
-LayoutUnit inlineAxisMaxContentContribution(const PlacedGridItem& gridItem, LayoutUnit blockAxisConstraint, const IntegrationUtils& integrationUtils)
+// The inline grid area's size when definite, or std::nullopt otherwise (see hasDefiniteInlineGridAreaSize).
+// The definite size is the sum of the spanned column track sizes plus their interior gutters, delegated
+// to gridAreaDimensionSize over the resolved spanned track sizes.
+std::optional<LayoutUnit> definiteInlineGridAreaSize(const PlacedGridItem& gridItem, const TrackSizingFunctionsList& trackSizingFunctions, LayoutUnit gap)
 {
-    UNUSED_PARAM(blockAxisConstraint);
-    return BorderBoxSize::fromIntegrationFunction(integrationUtils.maxContentLogicalWidthContribution(gridItem.layoutBox())).value;
+    if (!hasDefiniteInlineGridAreaSize(gridItem, trackSizingFunctions))
+        return { };
+
+    auto columnStartLine = gridItem.columnStartLine();
+    auto columnEndLine = gridItem.columnEndLine();
+
+    TrackSizes spannedTrackSizes;
+    spannedTrackSizes.reserveInitialCapacity(columnEndLine - columnStartLine);
+    for (auto trackIndex : std::views::iota(columnStartLine, columnEndLine)) {
+        auto fixedBreadth = trackSizingFunctions[trackIndex].min.length().tryFixed();
+        // hasDefiniteInlineGridAreaSize verified each spanned track's min breadth is a fixed length equal to its max.
+        ASSERT(fixedBreadth);
+        spannedTrackSizes.append(LayoutUnit { fixedBreadth->resolveZoom(Style::ZoomNeeded { }) });
+    }
+
+    return gridAreaDimensionSize(0, spannedTrackSizes.size(), spannedTrackSizes, gap);
+}
+
+LayoutUnit inlineAxisMinContentContribution(const PlacedGridItem& gridItem, std::optional<LayoutUnit> gridAreaInlineSize, const IntegrationUtils& integrationUtils)
+{
+    return BorderBoxSize::fromIntegrationFunction(integrationUtils.minContentLogicalWidthContribution(gridItem.layoutBox(), gridAreaInlineSize)).value;
+}
+
+LayoutUnit inlineAxisMaxContentContribution(const PlacedGridItem& gridItem, std::optional<LayoutUnit> gridAreaInlineSize, const IntegrationUtils& integrationUtils)
+{
+    return BorderBoxSize::fromIntegrationFunction(integrationUtils.maxContentLogicalWidthContribution(gridItem.layoutBox(), gridAreaInlineSize)).value;
 }
 
 // FIXME: this should be marginBoxHeight().

--- a/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.h
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.h
@@ -53,7 +53,7 @@ LayoutUnit inlinePreferredSize(const PlacedGridItem&, LayoutUnit borderAndPaddin
 LayoutUnit blockPreferredSize(const PlacedGridItem&, LayoutUnit borderAndPadding, LayoutUnit rowsSize);
 LayoutUnit stretchedBlockSize(const PlacedGridItem&, LayoutUnit borderAndPadding, LayoutUnit rowsSize);
 
-LayoutUnit inlineMinimumSize(const PlacedGridItem&, const TrackSizingFunctionsList&, LayoutUnit borderAndPadding, LayoutUnit columnsSize, const IntegrationUtils&);
+LayoutUnit inlineMinimumSize(const PlacedGridItem&, const TrackSizingFunctionsList&, LayoutUnit borderAndPadding, LayoutUnit columnsSize, std::optional<LayoutUnit> gridAreaInlineSize, const IntegrationUtils&);
 LayoutUnit blockMinimumSize(const PlacedGridItem&, const TrackSizingFunctionsList&, LayoutUnit borderAndPadding, LayoutUnit rowsSize, const GridFormattingContext&, LayoutUnit inlineAxisConstraint);
 LayoutUnit inlineMaximumSize(const PlacedGridItem&, LayoutUnit borderAndPadding);
 LayoutUnit blockMaximumSize(const PlacedGridItem&, LayoutUnit borderAndPadding);
@@ -62,9 +62,11 @@ LayoutUnit blockUsedSize(const PlacedGridItem&, const TrackSizingFunctionsList&,
 
 LayoutUnit computeGridLinePosition(size_t gridLineIndex, const TrackSizes&, LayoutUnit gap);
 LayoutUnit gridAreaDimensionSize(size_t startLine, size_t endLine, const TrackSizes&, LayoutUnit gap);
+bool hasDefiniteInlineGridAreaSize(const PlacedGridItem&, const TrackSizingFunctionsList&);
+std::optional<LayoutUnit> definiteInlineGridAreaSize(const PlacedGridItem&, const TrackSizingFunctionsList&, LayoutUnit gap);
 
-LayoutUnit inlineAxisMinContentContribution(const PlacedGridItem&, LayoutUnit blockAxisConstraint, const IntegrationUtils&);
-LayoutUnit inlineAxisMaxContentContribution(const PlacedGridItem&, LayoutUnit blockAxisConstraint, const IntegrationUtils&);
+LayoutUnit inlineAxisMinContentContribution(const PlacedGridItem&, std::optional<LayoutUnit> gridAreaInlineSize, const IntegrationUtils&);
+LayoutUnit inlineAxisMaxContentContribution(const PlacedGridItem&, std::optional<LayoutUnit> gridAreaInlineSize, const IntegrationUtils&);
 
 LayoutUnit blockAxisMinContentContribution(const PlacedGridItem&, LayoutUnit inlineAxisConstraint, const GridFormattingContext&);
 LayoutUnit blockAxisMaxContentContribution(const PlacedGridItem&, LayoutUnit inlineAxisConstraint, const GridFormattingContext&);

--- a/Source/WebCore/layout/integration/LayoutIntegrationUtils.cpp
+++ b/Source/WebCore/layout/integration/LayoutIntegrationUtils.cpp
@@ -35,6 +35,23 @@
 namespace WebCore {
 namespace Layout {
 
+// https://www.w3.org/TR/css-sizing-3/#cyclic-percentage-contribution
+// Percent/Calc padding and sizing resolves against the gridAreInlineSize, not the block size of the grid container.
+static LayoutUnit inlineWidthForGridItemWithGridArea(const LayoutState& layoutState, const ElementBox& box, LayoutIntegration::LogicalWidthType logicalWidthType, std::optional<LayoutUnit> gridAreaInlineSize)
+{
+    ASSERT(box.isGridItem());
+    CheckedRef renderer = downcast<RenderBox>(*box.rendererForIntegration());
+
+    renderer->setGridAreaContentLogicalWidth(gridAreaInlineSize);
+    renderer->setNeedsLayout(MarkingBehavior::MarkOnlyThis);
+
+    auto width = layoutState.logicalWidthWithFormattingContextForBox(box, logicalWidthType);
+
+    renderer->clearGridAreaContentSize();
+
+    return width;
+}
+
 IntegrationUtils::IntegrationUtils(const LayoutState& globalLayoutState)
     : m_globalLayoutState(globalLayoutState)
 {
@@ -53,8 +70,15 @@ LayoutUnit IntegrationUtils::maxContentWidth(const ElementBox& box) const
 
 LayoutUnit IntegrationUtils::minContentWidth(const ElementBox& box) const
 {
-    ASSERT(box.isFlexItem() || box.isGridItem());
+    ASSERT(box.isFlexItem());
     return m_globalLayoutState->logicalWidthWithFormattingContextForBox(box, LayoutIntegration::LogicalWidthType::MinContent);
+}
+
+// Min width contribution for grid items is resolved against the gridAreInlineSize, not the block size of the grid container.
+LayoutUnit IntegrationUtils::minContentWidthForGridItem(const ElementBox& box, std::optional<LayoutUnit> gridAreaInlineSize) const
+{
+    ASSERT(box.isGridItem());
+    return inlineWidthForGridItemWithGridArea(m_globalLayoutState, box, LayoutIntegration::LogicalWidthType::MinContent, gridAreaInlineSize);
 }
 
 LayoutUnit IntegrationUtils::minContentHeight(const ElementBox& box) const
@@ -105,17 +129,17 @@ LayoutUnit IntegrationUtils::maxContentContributionHeightForGridItem(const Eleme
     return blockSizeForGridItem(m_globalLayoutState, box, inlineAxisConstraint, LayoutIntegration::LogicalHeightType::MaxContentContribution);
 }
 
-LayoutUnit IntegrationUtils::minContentLogicalWidthContribution(const ElementBox& box) const
+LayoutUnit IntegrationUtils::minContentLogicalWidthContribution(const ElementBox& box, std::optional<LayoutUnit> gridAreaInlineSize) const
 {
     ASSERT(box.isGridItem());
-    return m_globalLayoutState->logicalWidthWithFormattingContextForBox(box, LayoutIntegration::LogicalWidthType::MinContentContribution);
+    return inlineWidthForGridItemWithGridArea(m_globalLayoutState, box, LayoutIntegration::LogicalWidthType::MinContentContribution, gridAreaInlineSize);
 }
 
 
-LayoutUnit IntegrationUtils::maxContentLogicalWidthContribution(const ElementBox& box) const
+LayoutUnit IntegrationUtils::maxContentLogicalWidthContribution(const ElementBox& box, std::optional<LayoutUnit> gridAreaInlineSize) const
 {
     ASSERT(box.isGridItem());
-    return m_globalLayoutState->logicalWidthWithFormattingContextForBox(box, LayoutIntegration::LogicalWidthType::MaxContentContribution);
+    return inlineWidthForGridItemWithGridArea(m_globalLayoutState, box, LayoutIntegration::LogicalWidthType::MaxContentContribution, gridAreaInlineSize);
 }
 
 void IntegrationUtils::layoutWithFormattingContextForBlockInInline(const ElementBox& block, LayoutPoint blockLineLogicalTopLeft, const InlineLayoutState& inlineLayoutState) const

--- a/Source/WebCore/layout/integration/LayoutIntegrationUtils.h
+++ b/Source/WebCore/layout/integration/LayoutIntegrationUtils.h
@@ -47,12 +47,13 @@ public:
     void layoutWithFormattingContextForBox(const ElementBox&, std::optional<LayoutUnit> widthConstraint = { }, std::optional<LayoutUnit> heightConstraint = { }) const;
     LayoutUnit maxContentWidth(const ElementBox&) const;
     LayoutUnit minContentWidth(const ElementBox&) const;
+    LayoutUnit minContentWidthForGridItem(const ElementBox&, std::optional<LayoutUnit> gridAreaInlineSize) const;
     LayoutUnit minContentHeight(const ElementBox&) const;
     LayoutUnit minContentHeightForGridItem(const ElementBox&, LayoutUnit inlineAxisConstraint) const;
     LayoutUnit minContentContributionHeightForGridItem(const ElementBox&, LayoutUnit inlineAxisConstraint) const;
     LayoutUnit maxContentContributionHeightForGridItem(const ElementBox&, LayoutUnit inlineAxisConstraint) const;
-    LayoutUnit minContentLogicalWidthContribution(const ElementBox&) const;
-    LayoutUnit maxContentLogicalWidthContribution(const ElementBox&) const;
+    LayoutUnit minContentLogicalWidthContribution(const ElementBox&, std::optional<LayoutUnit> gridAreaInlineSize) const;
+    LayoutUnit maxContentLogicalWidthContribution(const ElementBox&, std::optional<LayoutUnit> gridAreaInlineSize) const;
     void layoutWithFormattingContextForBlockInInline(const ElementBox& block, LayoutPoint blockLineLogicalTopLeft, const InlineLayoutState&) const;
 
     static BlockLayoutState::MarginState NODELETE toMarginState(const RenderBlockFlow::MarginInfo&);


### PR DESCRIPTION
#### 303f0d70307c64d92204fc02af66b654f9ed4a12
<pre>
[GFC] Compute definiteInlineGridAreaSize and thread grid area through intrinsic sizing
<a href="https://bugs.webkit.org/show_bug.cgi?id=319913">https://bugs.webkit.org/show_bug.cgi?id=319913</a>
&lt;<a href="https://rdar.apple.com/182833826">rdar://182833826</a>&gt;

Reviewed by NOBODY (OOPS!).

Grid items’ percentage padding resolves against the inline size
of its grid area if definite and 0px if indefinite. This PR adds

GridLayoutUtils::definiteInlineGridAreaSize()

to compute the grid item&apos;s inline grid when it can be resolved and
std::nullopt if not. it is only definite during intrinsic sizing
when every column track spanned by the grid item has identical and
fixed minWidth and maxWidth.

This PR also threads the std::optional&lt;LayoutUnit&gt; gridAreaInlineSize
through to the intrinsic sizing functions.

* Source/WebCore/layout/formattingContexts/grid/GridItemSizingFunctions.cpp:
(WebCore::Layout::GridItemSizingFunctions::inlineAxis):
* Source/WebCore/layout/formattingContexts/grid/GridItemSizingFunctions.h:
* Source/WebCore/layout/formattingContexts/grid/GridLayout.cpp:
(WebCore::Layout::GridLayout::sizeColumnTracks const):
* Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.cpp:
(WebCore::Layout::GridLayoutUtils::inlineContentSizeSuggestion):
(WebCore::Layout::GridLayoutUtils::automaticMinimumInlineSize):
(WebCore::Layout::GridLayoutUtils::inlineMinimumSize):
(WebCore::Layout::GridLayoutUtils::inlineUsedSize):
(WebCore::Layout::GridLayoutUtils::hasDefiniteInlineGridAreaSize):
(WebCore::Layout::GridLayoutUtils::definiteInlineGridAreaSize):
(WebCore::Layout::GridLayoutUtils::inlineAxisMinContentContribution):
(WebCore::Layout::GridLayoutUtils::inlineAxisMaxContentContribution):
* Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.h:
* Source/WebCore/layout/integration/LayoutIntegrationUtils.cpp:
(WebCore::Layout::inlineWidthForGridItemWithGridArea):
(WebCore::Layout::IntegrationUtils::minContentWidth const):
(WebCore::Layout::IntegrationUtils::minContentWidthForGridItem const):
(WebCore::Layout::IntegrationUtils::minContentLogicalWidthContribution const):
(WebCore::Layout::IntegrationUtils::maxContentLogicalWidthContribution const):
* Source/WebCore/layout/integration/LayoutIntegrationUtils.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/303f0d70307c64d92204fc02af66b654f9ed4a12

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175924 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49857 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43641 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185517 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/138126 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a478f52d-c23f-46d8-90d5-3998a0fc3afa) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/177787 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51149 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49539 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136999 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/138126 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/edec67d0-b21d-4e78-b043-f3b06a4456d4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178880 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40466 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157778 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117478 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/18bc9b9f-eea4-47f6-b6de-c170c795c660) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39108 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37488 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149527 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37270 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33987 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41557 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41694 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187938 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49524 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145998 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50204 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33895 "Found 1 new test failure: scrollingcoordinator/mac/latching/horizontal-overflow-back-swipe.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145837 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40629 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122400 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/116271 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48711 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12251 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48113 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48345 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48170 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->