### PR TITLE
Classify the real resolved connection IP for Local Network Access on Cocoa

### DIFF
--- a/Source/WebCore/Modules/fetch/FetchRequest.cpp
+++ b/Source/WebCore/Modules/fetch/FetchRequest.cpp
@@ -140,8 +140,9 @@ static IPAddressSpace updateTargetAddressSpaceIfNeeded(IPAddressSpace currentAdd
     if (host.isEmpty())
         return currentAddressSpace;
 
-    if (WebCore::isLocalIPAddressSpace(url))
-        return IPAddressSpace::Local;
+    auto addressSpace = WebCore::determineIPAddressSpace(url);
+    if (addressSpace != IPAddressSpace::Public)
+        return addressSpace;
 
     if (host.endsWithIgnoringASCIICase(".local"_s))
         return IPAddressSpace::Local;

--- a/Source/WebCore/Modules/fetch/IPAddressSpace.cpp
+++ b/Source/WebCore/Modules/fetch/IPAddressSpace.cpp
@@ -36,27 +36,22 @@
 
 namespace WebCore {
 
-IPAddressSpace determineIPAddressSpace(const URL& url)
+static IPAddressSpace classifyHost(String host)
 {
-    // Defined in https://wicg.github.io/local-network-access/#ip-address-space-section
-    String host = url.host().toString();
-    host = makeStringByReplacingAll(host, '[', ""_s);
-    host = makeStringByReplacingAll(host, ']', ""_s);
-
     if (!URL::hostIsIPAddress(host))
         return IPAddressSpace::Public;
 
     // Handle IPv6 addresses (check for colon to distinguish from IPv4)
     if (host.contains(':')) {
-        // ::1/128 - IPv6 Local - loopback
+        // ::1/128 - IPv6 Loopback
         if (host == "::1")
-            return IPAddressSpace::Local;
+            return IPAddressSpace::Loopback;
 
-        // fc00::/7 - Unique Loopback - local
+        // fc00::/7 - Unique Local - local
         if (host.startsWith("fc"_s) || host.startsWith("fd"_s))
             return IPAddressSpace::Local;
 
-        // fe80::/10 - Link-Loopback Unicast - local
+        // fe80::/10 - Link-Local Unicast - local
         if (host.startsWith("fe8"_s) || host.startsWith("fe9"_s) || host.startsWith("fea"_s) || host.startsWith("feb"_s))
             return IPAddressSpace::Local;
         // ::ffff: - IPv4 Mapped IPv6 Addresses - format for parsing by IPv4 Algorithm.
@@ -104,9 +99,9 @@ IPAddressSpace determineIPAddressSpace(const URL& url)
 
         // Check IPv4 address blocks according to spec table:
 
-        // 127.0.0.0/8 - IPv4 Loopback - loopback
+        // 127.0.0.0/8 - IPv4 Loopback
         if (parts[0] == 127)
-            return IPAddressSpace::Local;
+            return IPAddressSpace::Loopback;
 
         // 10.0.0.0/8 - Local Use - local
         if (parts[0] == 10)
@@ -137,9 +132,14 @@ IPAddressSpace determineIPAddressSpace(const URL& url)
     return IPAddressSpace::Public;
 }
 
-bool isLocalIPAddressSpace(const URL& url)
+IPAddressSpace determineIPAddressSpace(const URL& url)
 {
-    return determineIPAddressSpace(url) == IPAddressSpace::Local;
+    // Defined in https://wicg.github.io/local-network-access/#ip-address-space-section
+    StringView host = url.host();
+    if (host.startsWith('[') && host.endsWith(']'))
+        host = host.substring(1, host.length() - 2);
+
+    return classifyHost(host.toString());
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/fetch/IPAddressSpace.cpp
+++ b/Source/WebCore/Modules/fetch/IPAddressSpace.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "IPAddressSpace.h"
 
+#include "DNS.h"
 #include <array>
 #include <cstdio>
 #include <wtf/URL.h>
@@ -33,6 +34,10 @@
 #include <wtf/text/MakeString.h>
 #include <wtf/text/StringToIntegerConversion.h>
 #include <wtf/text/StringView.h>
+
+#if OS(UNIX)
+#include <arpa/inet.h>
+#endif
 
 namespace WebCore {
 
@@ -141,5 +146,28 @@ IPAddressSpace determineIPAddressSpace(const URL& url)
 
     return classifyHost(host.toString());
 }
+
+#if OS(UNIX)
+IPAddressSpace classifyIPAddressSpace(const IPAddress& address)
+{
+    char buffer[INET6_ADDRSTRLEN];
+    if (address.isIPv4()) {
+        if (!inet_ntop(AF_INET, &address.ipv4Address(), buffer, sizeof(buffer)))
+            return IPAddressSpace::Public;
+    } else if (address.isIPv6()) {
+        if (!inet_ntop(AF_INET6, &address.ipv6Address(), buffer, sizeof(buffer)))
+            return IPAddressSpace::Public;
+    } else
+        return IPAddressSpace::Public;
+
+    return classifyHost(String::fromLatin1(buffer));
+}
+#else
+IPAddressSpace classifyIPAddressSpace(const IPAddress&)
+{
+    // IPAddress::fromString() is OS(UNIX)-only (see DNS.cpp), so there is no resolved IPAddress to classify here yet.
+    return IPAddressSpace::Public;
+}
+#endif
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/fetch/IPAddressSpace.h
+++ b/Source/WebCore/Modules/fetch/IPAddressSpace.h
@@ -27,14 +27,30 @@
 
 namespace WebCore {
 
-enum class IPAddressSpace : bool {
+enum class IPAddressSpace : uint8_t {
     Public,
-    Local
+    Local,
+    Loopback
 };
 
-WEBCORE_EXPORT IPAddressSpace determineIPAddressSpace(const WTF::URL&);
+constexpr uint8_t publicnessRank(IPAddressSpace space)
+{
+    switch (space) {
+    case IPAddressSpace::Loopback:
+        return 0;
+    case IPAddressSpace::Local:
+        return 1;
+    case IPAddressSpace::Public:
+        return 2;
+    }
+    return 2;
+}
 
-WEBCORE_EXPORT bool isLocalIPAddressSpace(IPAddressSpace);
-WEBCORE_EXPORT bool isLocalIPAddressSpace(const WTF::URL&);
+inline bool isLessPublicThan(IPAddressSpace a, IPAddressSpace b)
+{
+    return publicnessRank(a) < publicnessRank(b);
+}
+
+WEBCORE_EXPORT IPAddressSpace determineIPAddressSpace(const WTF::URL&);
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/fetch/IPAddressSpace.h
+++ b/Source/WebCore/Modules/fetch/IPAddressSpace.h
@@ -27,6 +27,8 @@
 
 namespace WebCore {
 
+class IPAddress;
+
 enum class IPAddressSpace : uint8_t {
     Public,
     Local,
@@ -52,5 +54,7 @@ inline bool isLessPublicThan(IPAddressSpace a, IPAddressSpace b)
 }
 
 WEBCORE_EXPORT IPAddressSpace determineIPAddressSpace(const WTF::URL&);
+
+WEBCORE_EXPORT IPAddressSpace classifyIPAddressSpace(const IPAddress&);
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/fetch/IPAddressSpace.idl
+++ b/Source/WebCore/Modules/fetch/IPAddressSpace.idl
@@ -23,4 +23,6 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
  
- enum IPAddressSpace { "public", "local" };
+[
+    ExportMacro=WEBCORE_EXPORT
+] enum IPAddressSpace { "public", "local", "loopback" };

--- a/Source/WebCore/platform/network/ResourceRequestBase.h
+++ b/Source/WebCore/platform/network/ResourceRequestBase.h
@@ -41,7 +41,7 @@
 
 namespace WebCore {
 
-enum class IPAddressSpace : bool;
+enum class IPAddressSpace : uint8_t;
 
 enum class ResourceRequestCachePolicy : uint8_t {
     UseProtocolCachePolicy, // normal load, equivalent to fetch "default" cache mode.

--- a/Source/WebCore/platform/network/ResourceResponseBase.h
+++ b/Source/WebCore/platform/network/ResourceResponseBase.h
@@ -63,8 +63,8 @@ enum class WasPrivateRelayed : bool { No, Yes };
 static constexpr unsigned bitWidthOfWasPrivateRelayed = 1;
 static_assert(static_cast<unsigned>(WasPrivateRelayed::Yes) <= ((1U << bitWidthOfWasPrivateRelayed) - 1));
 
-static constexpr unsigned bitWidthOfIPAddressSpace = 1;
-static_assert(static_cast<unsigned>(IPAddressSpace::Local) <= ((1U << bitWidthOfIPAddressSpace) - 1));
+static constexpr unsigned bitWidthOfIPAddressSpace = 2;
+static_assert(((1U << bitWidthOfIPAddressSpace) - 1) >= static_cast<unsigned>(IPAddressSpace::Loopback));
 
 enum class ResourceResponseBaseType : uint8_t { Basic, Cors, Default, Error, Opaque, Opaqueredirect };
 enum class ResourceResponseBaseTainting : uint8_t { Basic, Cors, Opaque, Opaqueredirect };

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm
@@ -39,6 +39,7 @@
 #import <WebCore/AdvancedPrivacyProtections.h>
 #import <WebCore/AuthenticationChallenge.h>
 #import <WebCore/HTTPStatusCodes.h>
+#import <WebCore/IPAddressSpace.h>
 #import <WebCore/NetworkStorageSession.h>
 #import <WebCore/NotImplemented.h>
 #import <WebCore/OriginAccessPatterns.h>
@@ -429,12 +430,18 @@ void NetworkDataTaskCocoa::didReceiveResponse(WebCore::ResourceResponse&& respon
             session->reportNetworkIssue(*m_webPageProxyID, firstRequest().url());
     }
 #endif
-    NetworkDataTask::didReceiveResponse(WTF::move(response), negotiatedLegacyTLS, privateRelayed, WebCore::IPAddress::fromString(lastRemoteIPAddress(m_task.get())), WTF::move(completionHandler));
+    auto resolvedIPAddress = WebCore::IPAddress::fromString(lastRemoteIPAddress(m_task.get()));
+    if (resolvedIPAddress)
+        response.setIPAddressSpace(WebCore::classifyIPAddressSpace(*resolvedIPAddress));
+    NetworkDataTask::didReceiveResponse(WTF::move(response), negotiatedLegacyTLS, privateRelayed, resolvedIPAddress, WTF::move(completionHandler));
 }
 
 void NetworkDataTaskCocoa::willPerformHTTPRedirection(WebCore::ResourceResponse&& redirectResponse, WebCore::ResourceRequest&& request, RedirectCompletionHandler&& completionHandler)
 {
     WTFEmitSignpost(m_task.get(), DataTask, "redirect");
+
+    if (auto resolvedIPAddress = WebCore::IPAddress::fromString(lastRemoteIPAddress(m_task.get())))
+        redirectResponse.setIPAddressSpace(WebCore::classifyIPAddressSpace(*resolvedIPAddress));
 
     networkLoadMetrics().hasCrossOriginRedirect = networkLoadMetrics().hasCrossOriginRedirect || !WebCore::SecurityOrigin::create(request.url())->canRequest(redirectResponse.url(), WebCore::EmptyOriginAccessPatterns::singleton());
 

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -32,7 +32,13 @@ enum class WebCore::ContactProperty : uint8_t {
 
 header: <WebCore/IDBResultData.h>
 
-enum class WebCore::IPAddressSpace : bool;
+header: <WebCore/IPAddressSpace.h>
+
+enum class WebCore::IPAddressSpace : uint8_t {
+    Public,
+    Local,
+    Loopback
+};
 
 enum class WebCore::NotificationEventType : bool;
 

--- a/Tools/TestWebKitAPI/Tests/WebCore/IPAddressSpaceTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/IPAddressSpaceTests.cpp
@@ -33,10 +33,10 @@ namespace TestWebKitAPI {
 // Test IPv4 loopback addresses (127.0.0.0/8)
 TEST(IPAddressSpace, IPv4Loopback)
 {
-    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://127.0.0.1/"_s)), WebCore::IPAddressSpace::Local);
-    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://127.0.0.2/"_s)), WebCore::IPAddressSpace::Local);
-    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://127.255.255.255/"_s)), WebCore::IPAddressSpace::Local);
-    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("https://127.1.2.3:8080/"_s)), WebCore::IPAddressSpace::Local);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://127.0.0.1/"_s)), WebCore::IPAddressSpace::Loopback);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://127.0.0.2/"_s)), WebCore::IPAddressSpace::Loopback);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://127.255.255.255/"_s)), WebCore::IPAddressSpace::Loopback);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("https://127.1.2.3:8080/"_s)), WebCore::IPAddressSpace::Loopback);
 }
 
 // Test IPv4 private address ranges
@@ -115,8 +115,8 @@ TEST(IPAddressSpace, IPv4PublicAddresses)
 // Test IPv6 loopback (::1/128)
 TEST(IPAddressSpace, IPv6Loopback)
 {
-    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://[::1]/"_s)), WebCore::IPAddressSpace::Local);
-    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("https://[::1]:8080/"_s)), WebCore::IPAddressSpace::Local);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://[::1]/"_s)), WebCore::IPAddressSpace::Loopback);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("https://[::1]:8080/"_s)), WebCore::IPAddressSpace::Loopback);
 }
 
 // Test IPv6 Unique Local addresses (fc00::/7)
@@ -150,7 +150,8 @@ TEST(IPAddressSpace, IPv6LinkLocal)
 TEST(IPAddressSpace, IPv6MappedIPv4DottedDecimal)
 {
     // Local IPv4 addresses mapped to IPv6
-    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://[::ffff:127.0.0.1]/"_s)), WebCore::IPAddressSpace::Local);
+    // ::ffff:127.0.0.1 maps to a loopback address, so it's classified as ::Loopback, not ::Local.
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://[::ffff:127.0.0.1]/"_s)), WebCore::IPAddressSpace::Loopback);
     EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://[::ffff:10.0.0.1]/"_s)), WebCore::IPAddressSpace::Local);
     EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://[::ffff:192.168.1.1]/"_s)), WebCore::IPAddressSpace::Local);
     EXPECT_EQ(WebCore::determineIPAddressSpace(URL("https://[::ffff:172.16.0.1]:443/"_s)), WebCore::IPAddressSpace::Local);
@@ -219,15 +220,13 @@ TEST(IPAddressSpace, EdgeCasesAndMalformed)
 // Test the utility functions
 TEST(IPAddressSpace, UtilityFunctions)
 {
-    // Test isLocalIPAddressSpace(const URL&)
-    EXPECT_TRUE(WebCore::isLocalIPAddressSpace(URL("http://127.0.0.1/"_s)));
-    EXPECT_TRUE(WebCore::isLocalIPAddressSpace(URL("http://192.168.1.1/"_s)));
-    EXPECT_TRUE(WebCore::isLocalIPAddressSpace(URL("http://[::1]/"_s)));
-    EXPECT_TRUE(WebCore::isLocalIPAddressSpace(URL("http://[fc00::1]/"_s)));
-
-    EXPECT_FALSE(WebCore::isLocalIPAddressSpace(URL("http://8.8.8.8/"_s)));
-    EXPECT_FALSE(WebCore::isLocalIPAddressSpace(URL("https://www.example.com/"_s)));
-    EXPECT_FALSE(WebCore::isLocalIPAddressSpace(URL("http://[2001:db8::1]/"_s)));
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://127.0.0.1/"_s)), WebCore::IPAddressSpace::Loopback);
+    EXPECT_TRUE(WebCore::isLessPublicThan(WebCore::IPAddressSpace::Loopback, WebCore::IPAddressSpace::Local));
+    EXPECT_TRUE(WebCore::isLessPublicThan(WebCore::IPAddressSpace::Loopback, WebCore::IPAddressSpace::Public));
+    EXPECT_TRUE(WebCore::isLessPublicThan(WebCore::IPAddressSpace::Local, WebCore::IPAddressSpace::Public));
+    EXPECT_FALSE(WebCore::isLessPublicThan(WebCore::IPAddressSpace::Public, WebCore::IPAddressSpace::Local));
+    EXPECT_FALSE(WebCore::isLessPublicThan(WebCore::IPAddressSpace::Local, WebCore::IPAddressSpace::Loopback));
+    EXPECT_FALSE(WebCore::isLessPublicThan(WebCore::IPAddressSpace::Public, WebCore::IPAddressSpace::Public));
 }
 
 // Test different URL schemes
@@ -254,9 +253,9 @@ TEST(IPAddressSpace, DifferentURLSchemes)
 TEST(IPAddressSpace, URLsWithPorts)
 {
     // Local addresses with various ports
-    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://127.0.0.1:8080/"_s)), WebCore::IPAddressSpace::Local);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://127.0.0.1:8080/"_s)), WebCore::IPAddressSpace::Loopback);
     EXPECT_EQ(WebCore::determineIPAddressSpace(URL("https://192.168.1.1:443/"_s)), WebCore::IPAddressSpace::Local);
-    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://[::1]:3000/"_s)), WebCore::IPAddressSpace::Local);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://[::1]:3000/"_s)), WebCore::IPAddressSpace::Loopback);
     EXPECT_EQ(WebCore::determineIPAddressSpace(URL("https://[fc00::1]:8443/"_s)), WebCore::IPAddressSpace::Local);
 
     // Public addresses with ports

--- a/Tools/TestWebKitAPI/Tests/WebCore/IPAddressSpaceTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/IPAddressSpaceTests.cpp
@@ -25,6 +25,7 @@
 
 #include "config.h"
 
+#include <WebCore/DNS.h>
 #include <WebCore/IPAddressSpace.h>
 #include <wtf/URL.h>
 
@@ -283,6 +284,18 @@ TEST(IPAddressSpace, IPv4BoundaryConditions)
     EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://198.19.255.255/"_s)), WebCore::IPAddressSpace::Local);
     EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://198.17.255.255/"_s)), WebCore::IPAddressSpace::Public);
     EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://198.20.0.0/"_s)), WebCore::IPAddressSpace::Public);
+}
+
+// classifyIPAddressSpace() goes through IPAddress::fromString() -> inet_ntop() rather than URL
+// parsing, so it's worth confirming it agrees with determineIPAddressSpace() above.
+TEST(IPAddressSpace, ClassifyIPAddressSpaceFromResolvedAddress)
+{
+    EXPECT_EQ(WebCore::classifyIPAddressSpace(*WebCore::IPAddress::fromString("127.0.0.1"_s)), WebCore::IPAddressSpace::Loopback);
+    EXPECT_EQ(WebCore::classifyIPAddressSpace(*WebCore::IPAddress::fromString("::1"_s)), WebCore::IPAddressSpace::Loopback);
+    EXPECT_EQ(WebCore::classifyIPAddressSpace(*WebCore::IPAddress::fromString("192.168.1.1"_s)), WebCore::IPAddressSpace::Local);
+    EXPECT_EQ(WebCore::classifyIPAddressSpace(*WebCore::IPAddress::fromString("fc00::1"_s)), WebCore::IPAddressSpace::Local);
+    EXPECT_EQ(WebCore::classifyIPAddressSpace(*WebCore::IPAddress::fromString("8.8.8.8"_s)), WebCore::IPAddressSpace::Public);
+    EXPECT_EQ(WebCore::classifyIPAddressSpace(*WebCore::IPAddress::fromString("2001:4860:4860::8888"_s)), WebCore::IPAddressSpace::Public);
 }
 
 }

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebViewServerTrustKVC.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebViewServerTrustKVC.mm
@@ -25,6 +25,7 @@
 
 #import "config.h"
 
+#import "Helpers/PlatformUtilities.h"
 #import "Helpers/Test.h"
 #import "Helpers/cocoa/HTTPServer.h"
 #import "Helpers/cocoa/TestNavigationDelegate.h"


### PR DESCRIPTION
#### d9e97c2494a116e5264d4ece7ee7b44ee3353034
<pre>
Classify the real resolved connection IP for Local Network Access on Cocoa
<a href="https://bugs.webkit.org/show_bug.cgi?id=319906">https://bugs.webkit.org/show_bug.cgi?id=319906</a>
<a href="https://rdar.apple.com/182830220">rdar://182830220</a>

Reviewed by NOBODY (OOPS!).

Adds classifyIPAddressSpace(const IPAddress&amp;) and wires it into
NetworkDataTaskCocoa so the resolved connection address, not the request
URL&apos;s host, is what gets classified into an IPAddressSpace. The request
URL&apos;s host is attacker-controlled (a DNS-rebinding server can point a
public-looking hostname at 127.0.0.1), so any local-network access policy
decision needs to be based on what actually got connected to. Both the
final response (didReceiveResponse) and each redirect hop
(willPerformHTTPRedirection) are classified, since a redirect is a
separate connection that could target a local/loopback address on its own.

* Source/WebCore/Modules/fetch/IPAddressSpace.cpp:
(WebCore::classifyIPAddressSpace):
* Source/WebCore/Modules/fetch/IPAddressSpace.h:
* Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm:
(WebKit::NetworkDataTaskCocoa::didReceiveResponse):
(WebKit::NetworkDataTaskCocoa::willPerformHTTPRedirection):
* Tools/TestWebKitAPI/Tests/WebCore/IPAddressSpaceTests.cpp:
(TestWebKitAPI::TEST(IPAddressSpace, ClassifyIPAddressSpaceFromResolvedAddress)):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f5ef258d74c71c27a4dce7c28ebf0c4e33c25d66

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175933 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49866 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43650 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185526 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/138141 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/177796 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51158 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49548 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/137019 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/138141 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178889 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/40477 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/157785 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/117498 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39119 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/37498 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/149538 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37277 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33996 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/41566 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/41704 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187948 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49533 "Built successfully") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/146013 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50213 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/33902 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/145851 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/40639 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/122409 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/116286 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48720 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12258 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48122 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48354 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48179 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->