### PR TITLE
[JSC] Implement Joint Iteration proposal

### DIFF
--- a/JSTests/microbenchmarks/iterator-zip-keyed.js
+++ b/JSTests/microbenchmarks/iterator-zip-keyed.js
@@ -1,0 +1,30 @@
+//@ requireOptions("--useJointIteration=1")
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`Expected ${expected} but got ${actual}`);
+}
+
+const size = 128;
+const a = new Array(size);
+const b = new Array(size);
+const c = new Array(size);
+for (let i = 0; i < size; i++) {
+    a[i] = i;
+    b[i] = i * 2;
+    c[i] = i * 3;
+}
+
+function test() {
+    let sum = 0;
+    for (const { a: x, b: y, c: z } of Iterator.zipKeyed({ a, b, c }))
+        sum += x + y + z;
+    return sum;
+}
+noInline(test);
+
+let result;
+for (let i = 0; i < testLoopCount; i++)
+    result = test();
+
+shouldBe(result, 6 * (size * (size - 1) / 2));

--- a/JSTests/microbenchmarks/iterator-zip.js
+++ b/JSTests/microbenchmarks/iterator-zip.js
@@ -1,0 +1,30 @@
+//@ requireOptions("--useJointIteration=1")
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`Expected ${expected} but got ${actual}`);
+}
+
+const size = 128;
+const a = new Array(size);
+const b = new Array(size);
+const c = new Array(size);
+for (let i = 0; i < size; i++) {
+    a[i] = i;
+    b[i] = i * 2;
+    c[i] = i * 3;
+}
+
+function test() {
+    let sum = 0;
+    for (const [x, y, z] of Iterator.zip([a, b, c]))
+        sum += x + y + z;
+    return sum;
+}
+noInline(test);
+
+let result;
+for (let i = 0; i < testLoopCount; i++)
+    result = test();
+
+shouldBe(result, 6 * (size * (size - 1) / 2));

--- a/JSTests/stress/iterator-zip.js
+++ b/JSTests/stress/iterator-zip.js
@@ -1,0 +1,187 @@
+//@ requireOptions("--useJointIteration=1")
+
+// Test cases adapted from the Iterator.zip / Iterator.zipKeyed examples in the TC39 Joint Iteration proposal repository.
+
+function stringify(value) {
+    if (typeof value === "string")
+        return JSON.stringify(value);
+    if (typeof value !== "object" || value === null)
+        return String(value);
+    if (Array.isArray(value))
+        return "[" + value.map(stringify).join(", ") + "]";
+    var proto = Object.getPrototypeOf(value) === null ? ", __proto__: null" : "";
+    return "{" + Reflect.ownKeys(value).map((key) => `${String(key)}: ${stringify(value[key])}`).join(", ") + proto + "}";
+}
+
+function deepEqual(actual, expected) {
+    if (Object.is(actual, expected))
+        return true;
+
+    if (typeof actual !== "object" || actual === null || typeof expected !== "object" || expected === null)
+        return false;
+
+    if (Object.getPrototypeOf(actual) !== Object.getPrototypeOf(expected))
+        return false;
+
+    if (Array.isArray(expected)) {
+        if (!Array.isArray(actual) || actual.length !== expected.length)
+            return false;
+        for (var i = 0; i < expected.length; ++i) {
+            if (!deepEqual(actual[i], expected[i]))
+                return false;
+        }
+        return true;
+    }
+
+    var actualKeys = Reflect.ownKeys(actual);
+    var expectedKeys = Reflect.ownKeys(expected);
+    if (actualKeys.length !== expectedKeys.length)
+        return false;
+    for (var key of expectedKeys) {
+        if (!Object.prototype.hasOwnProperty.call(actual, key) || !deepEqual(actual[key], expected[key]))
+            return false;
+    }
+    return true;
+}
+
+function shouldBe(label, actual, expected) {
+    if (!deepEqual(actual, expected))
+        throw new Error(`FAIL (${label}): got ${stringify(actual)}, expected ${stringify(expected)}`);
+}
+
+function shouldThrow(label, callback, errorConstructor) {
+    try {
+        callback();
+    } catch (e) {
+        if (!(e instanceof errorConstructor))
+            throw new Error(`FAIL (${label}): expected ${errorConstructor.name}, got ${e}`);
+        return;
+    }
+    throw new Error(`FAIL (${label}): should have thrown ${errorConstructor.name}`);
+}
+
+shouldBe("positional shortest", Array.from(Iterator.zip([
+    [0],
+    [1, 2],
+])), [
+    [0, 1],
+]);
+
+shouldBe("positional equiv", Array.from(Iterator.zip([
+    [0, 1, 2],
+    [3, 4, 5],
+    [6, 7, 8],
+])), [
+    [0, 3, 6],
+    [1, 4, 7],
+    [2, 5, 8],
+]);
+
+shouldBe("positional empty", Array.from(Iterator.zip([])), []);
+
+shouldBe("positional longest", Array.from(Iterator.zip([
+    [0],
+    [1, 2],
+], { mode: "longest" })), [
+    [0, 1],
+    [undefined, 2],
+]);
+
+shouldThrow("positional strict", () => {
+    Array.from(Iterator.zip([
+        [0],
+        [1, 2],
+    ], { mode: "strict" }));
+}, TypeError);
+
+shouldBe("named shortest", Array.from(Iterator.zipKeyed({
+    a: [0],
+    b: [1, 2],
+})), [
+    { a: 0, b: 1, __proto__: null },
+]);
+
+shouldBe("named equiv", Array.from(Iterator.zipKeyed({
+    a: [0, 1, 2],
+    b: [3, 4, 5],
+    c: [6, 7, 8],
+})), [
+    { a: 0, b: 3, c: 6, __proto__: null },
+    { a: 1, b: 4, c: 7, __proto__: null },
+    { a: 2, b: 5, c: 8, __proto__: null },
+]);
+
+shouldBe("named empty", Array.from(Iterator.zipKeyed({})), []);
+
+shouldBe("named longest", Array.from(Iterator.zipKeyed({
+    a: [0],
+    b: [1, 2],
+}, { mode: "longest" })), [
+    { a: 0, b: 1, __proto__: null },
+    { a: undefined, b: 2, __proto__: null },
+]);
+
+shouldThrow("named strict", () => {
+    Array.from(Iterator.zipKeyed({
+        a: [0],
+        b: [1, 2],
+    }, { mode: "strict" }));
+}, TypeError);
+
+{
+    const padding = [{}, {}, {}, {}];
+
+    shouldBe("padding positional 2", Array.from(Iterator.zip([
+        [0],
+        [1, 2, 3],
+    ], { mode: "longest", padding })), [
+        [0, 1],
+        [padding[0], 2],
+        [padding[0], 3],
+    ]);
+
+    shouldBe("padding positional 4", Array.from(Iterator.zip([
+        [0],
+        [1, 2, 3],
+        [4, 5],
+        [],
+    ], { mode: "longest", padding })), [
+        [0, 1, 4, padding[3]],
+        [padding[0], 2, 5, padding[3]],
+        [padding[0], 3, padding[2], padding[3]],
+    ]);
+}
+
+{
+    const A_PADDING = {};
+    const B_PADDING = {};
+    const C_PADDING = {};
+    const D_PADDING = {};
+
+    const padding = {
+        a: A_PADDING,
+        b: B_PADDING,
+        c: C_PADDING,
+        d: D_PADDING,
+    };
+
+    shouldBe("padding named 2", Array.from(Iterator.zipKeyed({
+        a: [0],
+        b: [1, 2, 3],
+    }, { mode: "longest", padding })), [
+        { a: 0, b: 1, __proto__: null },
+        { a: A_PADDING, b: 2, __proto__: null },
+        { a: A_PADDING, b: 3, __proto__: null },
+    ]);
+
+    shouldBe("padding named 4", Array.from(Iterator.zipKeyed({
+        a: [0],
+        b: [1, 2, 3],
+        c: [4, 5],
+        d: [],
+    }, { mode: "longest", padding })), [
+        { a: 0, b: 1, c: 4, d: D_PADDING, __proto__: null },
+        { a: A_PADDING, b: 2, c: 5, d: D_PADDING, __proto__: null },
+        { a: A_PADDING, b: 3, c: C_PADDING, d: D_PADDING, __proto__: null },
+    ]);
+}

--- a/JSTests/test262/config.yaml
+++ b/JSTests/test262/config.yaml
@@ -10,13 +10,13 @@ flags:
   iterator-sequencing: useIteratorSequencing
   explicit-resource-management: useExplicitResourceManagement
   import-defer: useImportDefer
+  joint-iteration: useJointIteration
 skip:
   features:
     - callable-boundary-realms
     - FinalizationRegistry.prototype.cleanupSome
     - decorators
     - source-phase-imports
-    - joint-iteration
     - Intl.Era-monthcode
     - await-dictionary
     - import-bytes

--- a/Source/JavaScriptCore/builtins/BuiltinNames.h
+++ b/Source/JavaScriptCore/builtins/BuiltinNames.h
@@ -217,6 +217,7 @@ namespace JSC {
     macro(asyncFromSyncIteratorCreate) \
     macro(regExpStringIteratorCreate) \
     macro(iteratorHelperCreate) \
+    macro(ownKeys) \
     macro(includes) \
     macro(ReferenceError) \
     macro(SuppressedError) \

--- a/Source/JavaScriptCore/builtins/JSIteratorConstructor.js
+++ b/Source/JavaScriptCore/builtins/JSIteratorConstructor.js
@@ -52,6 +52,29 @@ function getIteratorFlattenable(obj, rejectStrings)
     return iterator;
 }
 
+@linkTimeConstant
+function getIteratorSync(obj)
+{
+    "use strict";
+
+    // GetIterator(obj, SYNC):
+    // 1. (The ASYNC kind is not applicable here.)
+    // 2.a. Let method be ? GetMethod(obj, %Symbol.iterator%).
+    var method = obj.@@iterator;
+
+    // 3. If method is undefined, throw a TypeError exception.
+    if (@isUndefinedOrNull(method))
+        @throwTypeError("Symbol.iterator is not defined");
+    if (!@isCallable(method))
+        @throwTypeError("Symbol.iterator is not callable");
+
+    // 4. Return ? GetIteratorFromMethod(obj, method).
+    var iterator = method.@call(obj);
+    if (!@isObject(iterator))
+        @throwTypeError("Iterator is not an object");
+    return iterator;
+}
+
 // https://tc39.es/proposal-iterator-helpers/#sec-iterator.from
 function from(value)
 {
@@ -116,4 +139,554 @@ function concat(/* ...items */)
     })();
 
     return @iteratorHelperCreate(generator, null);
+}
+
+@linkTimeConstant
+function iteratorZip(iters, nextMethods, mode, padding, finishResults)
+{
+    "use strict";
+
+    // 1. Let iterCount be the number of elements in iters.
+    var iterCount = iters.length;
+
+    // 2. Let openIters be a copy of iters.
+    var openIters = [];
+    for (var i = 0; i < iterCount; ++i)
+        @arrayPush(openIters, iters[i]);
+
+    // 4-6. The resulting Iterator Helper's single underlying iterator is a synthetic
+    // object whose return() closes every still-open iterator. It stands in for the
+    // spec's [[UnderlyingIterators]] List: closing the zip result (including via
+    // return() before the first next(), when the closure body has never run) then
+    // closes all of them. This is invoked with a return completion, so a failing
+    // return() propagates.
+    var underlyingIterators = { };
+    underlyingIterators.return = function () {
+        @iteratorCloseAllNormal(openIters);
+        return { done: true, value: @undefined };
+    };
+
+    // 3. Let closure be a new Abstract Closure with no parameters that captures iters,
+    //    iterCount, openIters, mode, padding, and finishResults, and performs the
+    //    following steps when called:
+    var generator = (function*() {
+        // 3.a. If iterCount = 0, return ReturnCompletion(undefined).
+        if (iterCount === 0)
+            return;
+
+        // 3.b. Repeat,
+        for (;;) {
+            // 3.b.i. Let results be a new empty List.
+            var results = [];
+
+            // 3.b.ii. Assert: openIters is not empty.
+
+            // 3.b.iii. For each integer i such that 0 ≤ i < iterCount, in ascending order, do
+            for (var i = 0; i < iterCount; ++i) {
+                // 3.b.iii.1. Let iter be iters[i].
+                var iter = iters[i];
+                var result;
+
+                // 3.b.iii.2. If iter is null, then
+                if (iter === null) {
+                    // 3.b.iii.2.a. Assert: mode is "longest".
+                    // 3.b.iii.2.b. Let result be padding[i].
+                    result = padding[i];
+                } else {
+                    // 3.b.iii.3.a. Let result be Completion(IteratorStepValue(iter)).
+                    var stepDone;
+                    var stepValue;
+                    try {
+                        var stepResult = @iteratorGenericNext(nextMethods[i], iter);
+                        stepDone = stepResult.done;
+                        if (!stepDone)
+                            stepValue = stepResult.value;
+                    } catch (e) {
+                        // 3.b.iii.3.b. If result is an abrupt completion, then
+                        // 3.b.iii.3.b.i. Remove iter from openIters.
+                        @removeFirstFromList(openIters, iter);
+                        // 3.b.iii.3.b.ii. Return ? IteratorCloseAll(openIters, result).
+                        @closeAllIterators(openIters);
+                        throw e;
+                    }
+
+                    // 3.b.iii.3.c. Set result to ! result.
+                    // 3.b.iii.3.d. If result is DONE, then
+                    if (stepDone) {
+                        // 3.b.iii.3.d.i. Remove iter from openIters.
+                        @removeFirstFromList(openIters, iter);
+
+                        // 3.b.iii.3.d.ii. If mode is "shortest", then
+                        if (mode === "shortest") {
+                            // Return ? IteratorCloseAll(openIters, ReturnCompletion(undefined)).
+                            @iteratorCloseAllNormal(openIters);
+                            return;
+                        }
+
+                        // 3.b.iii.3.d.iii. Else if mode is "strict", then
+                        if (mode === "strict") {
+                            // 3.b.iii.3.d.iii.i. If i ≠ 0, then
+                            if (i !== 0) {
+                                // Return ? IteratorCloseAll(openIters, ThrowCompletion(a newly created TypeError object)).
+                                @closeAllIterators(openIters);
+                                @throwTypeError("Iterator.zip strict mode requires all iterables to have the same number of elements");
+                            }
+
+                            // 3.b.iii.3.d.iii.ii. For each integer k such that 1 ≤ k < iterCount, in ascending order, do
+                            for (var k = 1; k < iterCount; ++k) {
+                                // 3.b.iii.3.d.iii.ii.i. Assert: iters[k] is not null.
+                                var otherIter = iters[k];
+                                var otherDone;
+                                try {
+                                    // 3.b.iii.3.d.iii.ii.ii. Let open be Completion(IteratorStep(iters[k])). (Value is not read.)
+                                    var otherResult = @iteratorGenericNext(nextMethods[k], otherIter);
+                                    otherDone = otherResult.done;
+                                } catch (e) {
+                                    // 3.b.iii.3.d.iii.ii.iii. If open is an abrupt completion, then
+                                    // 3.b.iii.3.d.iii.ii.iii.i. Remove iters[k] from openIters.
+                                    @removeFirstFromList(openIters, otherIter);
+                                    // 3.b.iii.3.d.iii.ii.iii.ii. Return ? IteratorCloseAll(openIters, open).
+                                    @closeAllIterators(openIters);
+                                    throw e;
+                                }
+
+                                // 3.b.iii.3.d.iii.ii.v. If open is DONE, then
+                                if (otherDone) {
+                                    // 3.b.iii.3.d.iii.ii.v.i. Remove iters[k] from openIters.
+                                    @removeFirstFromList(openIters, otherIter);
+                                } else {
+                                    // 3.b.iii.3.d.iii.ii.vi.i. Return ? IteratorCloseAll(openIters, ThrowCompletion(a newly created TypeError object)).
+                                    @closeAllIterators(openIters);
+                                    @throwTypeError("Iterator.zip strict mode requires all iterables to have the same number of elements");
+                                }
+                            }
+
+                            // 3.b.iii.3.d.iii.iii. Return ReturnCompletion(undefined).
+                            return;
+                        }
+
+                        // 3.b.iii.3.d.iv. Else (mode is "longest"),
+                        // 3.b.iii.3.d.iv.ii. If openIters is empty, return ReturnCompletion(undefined).
+                        if (openIters.length === 0)
+                            return;
+                        // 3.b.iii.3.d.iv.iii. Set iters[i] to null.
+                        iters[i] = null;
+                        // 3.b.iii.3.d.iv.iv. Set result to padding[i].
+                        result = padding[i];
+                    } else {
+                        result = stepValue;
+                    }
+                }
+
+                // 3.b.iii.4. Append result to results.
+                @arrayPush(results, result);
+            }
+
+            // 3.b.iv. Set results to finishResults(results).
+            results = finishResults(results);
+
+            // 3.b.v. Let completion be Completion(Yield(results)).
+            // 3.b.vi. If completion is an abrupt completion, then
+            // 3.b.vi.1. Return ? IteratorCloseAll(openIters, completion).
+            @ifAbruptCloseIterator(underlyingIterators, (
+                yield results
+            ));
+        }
+    })();
+
+    // 4. Let gen be CreateIteratorFromClosure(closure, "Iterator Helper", %IteratorHelperPrototype%, « [[UnderlyingIterators]] »).
+    // 5. Set gen.[[UnderlyingIterators]] to openIters.
+    // 6. Return gen.
+    return @iteratorHelperCreate(generator, underlyingIterators);
+}
+
+@linkTimeConstant
+function getOptionsObject(options)
+{
+    // 1. If options is undefined, then
+    if (options === @undefined) {
+        // 1.a. Return OrdinaryObjectCreate(null).
+        return {};
+    }
+
+    // 2. If options is an Object, then
+    if (@isObject(options)) {
+        // 2.a. Return options.
+        return options;
+    }
+
+    // 3. Throw a TypeError exception.
+    @throwTypeError("Expected object or null for options argument");
+}
+
+@linkTimeConstant
+function closeAllIterators(openIters)
+{
+    "use strict";
+
+    for (var i = openIters.length - 1; i >= 0; --i) {
+        try {
+            @iteratorGenericClose(openIters[i]);
+        } catch (e) { }
+    }
+}
+
+@linkTimeConstant
+function iteratorCloseAllNormal(openIters)
+{
+    "use strict";
+
+    var error;
+    var hasError = false;
+    for (var i = openIters.length - 1; i >= 0; --i) {
+        try {
+            @iteratorGenericClose(openIters[i]);
+        } catch (e) {
+            if (!hasError) {
+                hasError = true;
+                error = e;
+            }
+        }
+    }
+    if (hasError)
+        throw error;
+}
+
+// Removes the first occurrence of |value| from |list| (an Array used as a spec List),
+// preserving the order of the remaining elements.
+@linkTimeConstant
+function removeFirstFromList(list, value)
+{
+    "use strict";
+
+    var length = list.length;
+    var shifting = false;
+    for (var i = 0; i < length; ++i) {
+        if (shifting)
+            @putByValDirect(list, i - 1, list[i]);
+        else if (list[i] === value)
+            shifting = true;
+    }
+    if (shifting)
+        list.length = length - 1;
+}
+
+function zip(iterables /*, options */)
+{
+    "use strict";
+
+    var options = @argument(1);
+
+    // 1. If iterables is not an Object, throw a TypeError exception.
+    if (!@isObject(iterables))
+        @throwTypeError("Iterator.zip expects its first argument to be an object");
+
+    // 2. Set options to ? GetOptionsObject(options).
+    options = @getOptionsObject(options);
+
+    // 3. Let mode be ? Get(options, "mode").
+    var mode = options.mode;
+
+    // 4. If mode is undefined, set mode to "shortest".
+    if (mode === @undefined)
+        mode = "shortest";
+
+    // 5. If mode is not one of "shortest", "longest", or "strict", throw a TypeError exception.
+    if (mode !== "shortest" && mode !== "longest" && mode !== "strict")
+        @throwTypeError("Expected \"shortest\", \"longest\" or \"strict\" for options.mode");
+
+    // 6. Let paddingOption be undefined.
+    var paddingOption = @undefined;
+
+    // 7. If mode is "longest", then
+    if (mode === "longest") {
+        // 7.a. Set paddingOption to ? Get(options, "padding").
+        paddingOption = options.padding;
+        // 7.b. If paddingOption is not undefined and paddingOption is not an Object, throw a TypeError exception.
+        if (paddingOption !== @undefined && !@isObject(paddingOption))
+            @throwTypeError("Expected options.padding to be an object");
+    }
+
+    // 8. Let iters be a new empty List.
+    var iters = [];
+    var nextMethods = [];
+
+    // 9. Let padding be a new empty List.
+    var padding = [];
+
+    // 10. Let inputIter be ? GetIterator(iterables, SYNC).
+    var inputIter = @getIteratorSync(iterables);
+    var inputIterNextMethod = inputIter.next;
+
+    // 11. Let next be NOT-STARTED.
+    // 12. Repeat, while next is not DONE,
+    for (;;) {
+        var done;
+        var value;
+        try {
+            // 12.a. Set next to Completion(IteratorStepValue(inputIter)).
+            var result = @iteratorGenericNext(inputIterNextMethod, inputIter);
+            done = result.done;
+            if (!done)
+                value = result.value;
+        } catch (e) {
+            // 12.b. IfAbruptCloseIterators(next, iters).
+            @closeAllIterators(iters);
+            throw e;
+        }
+
+        // 12.c. If next is not DONE, then
+        if (done)
+            break;
+
+        var iter;
+        var iterNextMethod;
+        try {
+            // 12.c.i. Let iter be Completion(GetIteratorFlattenable(next, REJECT-PRIMITIVES)).
+            iter = @getIteratorFlattenable(value, /* rejectStrings: */ true);
+            iterNextMethod = iter.next;
+        } catch (e) {
+            // 12.c.ii. IfAbruptCloseIterators(iter, the list-concatenation of « inputIter » and iters).
+            @closeAllIterators(iters);
+            try {
+                @iteratorGenericClose(inputIter);
+            } catch (e2) { }
+            throw e;
+        }
+
+        // 12.c.iii. Append iter to iters.
+        @arrayPush(iters, iter);
+        @arrayPush(nextMethods, iterNextMethod);
+    }
+
+    // 13. Let iterCount be the number of elements in iters.
+    var iterCount = iters.length;
+
+    // 14. If mode is "longest", then
+    if (mode === "longest") {
+        // 14.a. If paddingOption is undefined, then
+        if (paddingOption === @undefined) {
+            // 14.a.i. Perform the following steps iterCount times:
+            for (var i = 0; i < iterCount; ++i) {
+                // 14.a.i.1. Append undefined to padding.
+                @arrayPush(padding, @undefined);
+            }
+        } else {
+            // 14.b.i. Let paddingIter be Completion(GetIterator(paddingOption, SYNC)).
+            var paddingIter;
+            var paddingIterNextMethod;
+            try {
+                paddingIter = @getIteratorSync(paddingOption);
+                paddingIterNextMethod = paddingIter.next;
+            } catch (e) {
+                // 14.b.ii. IfAbruptCloseIterators(paddingIter, iters).
+                @closeAllIterators(iters);
+                throw e;
+            }
+
+            // 14.b.iii. Let usingIterator be true.
+            var usingIterator = true;
+
+            // 14.b.iv. Perform the following steps iterCount times:
+            for (var i = 0; i < iterCount; ++i) {
+                // 14.b.iv.1. If usingIterator is true, then
+                if (usingIterator) {
+                    var paddingDone;
+                    var paddingValue;
+                    try {
+                        // 14.b.iv.1.a. Set next to Completion(IteratorStepValue(paddingIter)).
+                        var paddingResult = @iteratorGenericNext(paddingIterNextMethod, paddingIter);
+                        paddingDone = paddingResult.done;
+                        if (!paddingDone)
+                            paddingValue = paddingResult.value;
+                    } catch (e) {
+                        // 14.b.iv.1.b. IfAbruptCloseIterators(next, iters).
+                        @closeAllIterators(iters);
+                        throw e;
+                    }
+
+                    // 14.b.iv.1.c. If next is DONE, then
+                    if (paddingDone) {
+                        // 14.b.iv.1.c.i. Set usingIterator to false.
+                        usingIterator = false;
+                    } else {
+                        // 14.b.iv.1.d.i. Append next to padding.
+                        @arrayPush(padding, paddingValue);
+                    }
+                }
+
+                // 14.b.iv.2. If usingIterator is false, append undefined to padding.
+                if (!usingIterator)
+                    @arrayPush(padding, @undefined);
+            }
+
+            // 14.b.v. If usingIterator is true, then
+            if (usingIterator) {
+                try {
+                    // 14.b.v.1. Let completion be Completion(IteratorClose(paddingIter, NormalCompletion(UNUSED))).
+                    @iteratorGenericClose(paddingIter);
+                } catch (e) {
+                    // 14.b.v.2. IfAbruptCloseIterators(completion, iters).
+                    @closeAllIterators(iters);
+                    throw e;
+                }
+            }
+        }
+    }
+
+    // 15. Let finishResults be a new Abstract Closure with parameters (results) that captures nothing and performs the following steps when called:
+    var finishResults = (results) => {
+        // 15.a. Return CreateArrayFromList(results).
+        return results;
+    };
+
+    // 16. Return IteratorZip(iters, mode, padding, finishResults).
+    return @iteratorZip(iters, nextMethods, mode, padding, finishResults);
+}
+
+function zipKeyed(iterables /*, options */)
+{
+    "use strict";
+
+    var options = @argument(1);
+
+    // 1. If iterables is not an Object, throw a TypeError exception.
+    if (!@isObject(iterables))
+        @throwTypeError("Iterator.zipKeyed expects its first argument to be an object");
+
+    // 2. Set options to ? GetOptionsObject(options).
+    options = @getOptionsObject(options);
+
+    // 3. Let mode be ? Get(options, "mode").
+    var mode = options.mode;
+
+    // 4. If mode is undefined, set mode to "shortest".
+    if (mode === @undefined)
+        mode = "shortest";
+
+    // 5. If mode is not one of "shortest", "longest", or "strict", throw a TypeError exception.
+    if (mode !== "shortest" && mode !== "longest" && mode !== "strict")
+        @throwTypeError("Expected \"shortest\", \"longest\" or \"strict\" for options.mode");
+
+    // 6. Let paddingOption be undefined.
+    var paddingOption = @undefined;
+
+    // 7. If mode is "longest", then
+    if (mode === "longest") {
+        // 7.a. Set paddingOption to ? Get(options, "padding").
+        paddingOption = options.padding;
+        // 7.b. If paddingOption is not undefined and paddingOption is not an Object, throw a TypeError exception.
+        if (paddingOption !== @undefined && !@isObject(paddingOption))
+            @throwTypeError("Expected options.padding to be an object");
+    }
+
+    // 8. Let iters be a new empty List.
+    var iters = [];
+    var nextMethods = [];
+
+    // 9. Let padding be a new empty List.
+    var padding = [];
+
+    // 10. Let allKeys be ? iterables.[[OwnPropertyKeys]]().
+    var allKeys = @ownKeys(iterables);
+
+    // 11. Let keys be a new empty List.
+    var keys = [];
+
+    // 12. For each element key of allKeys, do
+    var allKeysCount = allKeys.length;
+    for (var k = 0; k < allKeysCount; ++k) {
+        var key = allKeys[k];
+
+        // 12.a. Let desc be Completion(iterables.[[GetOwnProperty]](key)).
+        var desc;
+        try {
+            desc = @Object.@getOwnPropertyDescriptor(iterables, key);
+        } catch (e) {
+            // 12.b. IfAbruptCloseIterators(desc, iters).
+            @closeAllIterators(iters);
+            throw e;
+        }
+
+        // 12.c. If desc is not undefined and desc.[[Enumerable]] is true, then
+        if (desc !== @undefined && desc.enumerable) {
+            // 12.c.i. Let value be Completion(Get(iterables, key)).
+            var value;
+            try {
+                value = iterables[key];
+            } catch (e) {
+                // 12.c.ii. IfAbruptCloseIterators(value, iters).
+                @closeAllIterators(iters);
+                throw e;
+            }
+
+            // 12.c.iii. If value is not undefined, then
+            if (value !== @undefined) {
+                // 12.c.iii.1. Append key to keys.
+                @arrayPush(keys, key);
+
+                // 12.c.iii.2. Let iter be Completion(GetIteratorFlattenable(value, REJECT-PRIMITIVES)).
+                var iter;
+                var iterNextMethod;
+                try {
+                    iter = @getIteratorFlattenable(value, /* rejectStrings: */ true);
+                    iterNextMethod = iter.next;
+                } catch (e) {
+                    // 12.c.iii.3. IfAbruptCloseIterators(iter, iters).
+                    @closeAllIterators(iters);
+                    throw e;
+                }
+
+                // 12.c.iii.4. Append iter to iters.
+                @arrayPush(iters, iter);
+                @arrayPush(nextMethods, iterNextMethod);
+            }
+        }
+    }
+
+    // 13. Let iterCount be the number of elements in iters.
+    var iterCount = iters.length;
+
+    // 14. If mode is "longest", then
+    if (mode === "longest") {
+        // 14.a. If paddingOption is undefined, then
+        if (paddingOption === @undefined) {
+            // 14.a.i. Perform the following steps iterCount times:
+            for (var i = 0; i < iterCount; ++i) {
+                // 14.a.i.1. Append undefined to padding.
+                @arrayPush(padding, @undefined);
+            }
+        } else {
+            // 14.b.i. For each element key of keys, do
+            for (var i = 0; i < iterCount; ++i) {
+                // 14.b.i.1. Let value be Completion(Get(paddingOption, key)).
+                var paddingValue;
+                try {
+                    paddingValue = paddingOption[keys[i]];
+                } catch (e) {
+                    // 14.b.i.2. IfAbruptCloseIterators(value, iters).
+                    @closeAllIterators(iters);
+                    throw e;
+                }
+                // 14.b.i.3. Append value to padding.
+                @arrayPush(padding, paddingValue);
+            }
+        }
+    }
+
+    // 15. Let finishResults be a new Abstract Closure with parameters (results) that captures keys and iterCount and performs the following steps when called:
+    var finishResults = (results) => {
+        // 15.a. Let obj be OrdinaryObjectCreate(null).
+        var obj = @Object.@create(null);
+        // 15.b. For each integer i such that 0 ≤ i < iterCount, in ascending order, do
+        for (var i = 0; i < iterCount; ++i) {
+            // 15.b.i. Perform ! CreateDataPropertyOrThrow(obj, keys[i], results[i]).
+            @putByValDirect(obj, keys[i], results[i]);
+        }
+        // 15.c. Return obj.
+        return obj;
+    };
+
+    // 16. Return IteratorZip(iters, mode, padding, finishResults).
+    return @iteratorZip(iters, nextMethods, mode, padding, finishResults);
 }

--- a/Source/JavaScriptCore/bytecode/LinkTimeConstant.h
+++ b/Source/JavaScriptCore/bytecode/LinkTimeConstant.h
@@ -152,6 +152,7 @@ class JSGlobalObject;
     v(asyncFromSyncIteratorCreate, nullptr) \
     v(regExpStringIteratorCreate, nullptr) \
     v(iteratorHelperCreate, nullptr) \
+    v(ownKeys, nullptr) \
     v(ReferenceError, nullptr) \
     v(SuppressedError, nullptr) \
     v(DisposableStack, nullptr) \

--- a/Source/JavaScriptCore/runtime/IteratorOperations.h
+++ b/Source/JavaScriptCore/runtime/IteratorOperations.h
@@ -65,9 +65,10 @@ JS_EXPORT_PRIVATE JSObject* createIteratorResultObject(JSGlobalObject*, JSValue,
 
 Structure* createIteratorResultObjectStructure(VM&, JSGlobalObject&);
 
-JS_EXPORT_PRIVATE JSValue iteratorMethod(JSGlobalObject*, JSObject*);
+// https://tc39.es/ecma262/multipage/abstract-operations.html#sec-getiterator, SYNC kind
 JS_EXPORT_PRIVATE IterationRecord iteratorForIterable(JSGlobalObject*, JSObject*, JSValue iteratorMethod);
 JS_EXPORT_PRIVATE IterationRecord iteratorForIterable(JSGlobalObject*, JSValue iterable);
+
 JS_EXPORT_PRIVATE IterationRecord iteratorDirect(JSGlobalObject*, JSValue);
 IterationRecord getAsyncIterator(JSGlobalObject&, JSValue);
 JS_EXPORT_PRIVATE IterationRecord getAsyncIteratorExported(JSGlobalObject&, JSValue);

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
@@ -1886,6 +1886,11 @@ capitalName ## Constructor* lowerName ## Constructor = featureFlag ? capitalName
         init.set(JSFunction::create(init.vm, init.owner, 2, "iteratorHelperCreate"_s, iteratorHelperPrivateFuncCreate, ImplementationVisibility::Private, IteratorHelperCreateIntrinsic));
     });
 
+    // Reflect.ownKeys as a private helper, i.e. the object's [[OwnPropertyKeys]] as an Array.
+    m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::ownKeys)].initLater([](const Initializer<JSCell>& init) {
+        init.set(JSFunction::create(init.vm, init.owner, 1, "ownKeys"_s, reflectObjectOwnKeys, ImplementationVisibility::Private, ReflectOwnKeysIntrinsic));
+    });
+
     // Global object and function helpers.
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::isFinite)].initLater([] (const Initializer<JSCell>& init) {
         init.set(JSFunction::create(init.vm, init.owner, 1, "isFinite"_s, globalFuncIsFinite, ImplementationVisibility::Private, GlobalIsFiniteIntrinsic));

--- a/Source/JavaScriptCore/runtime/JSIteratorConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/JSIteratorConstructor.cpp
@@ -59,6 +59,11 @@ void JSIteratorConstructor::finishCreation(VM& vm, JSGlobalObject* globalObject,
 
     if (Options::useIteratorSequencing())
         JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().concatPublicName(), jsIteratorConstructorConcatCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
+
+    if (Options::useJointIteration()) {
+        JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().zipPublicName(), jsIteratorConstructorZipCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
+        JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().zipKeyedPublicName(), jsIteratorConstructorZipKeyedCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
+    }
 }
 
 template<typename Visitor>

--- a/Source/JavaScriptCore/runtime/JSIteratorConstructor.h
+++ b/Source/JavaScriptCore/runtime/JSIteratorConstructor.h
@@ -35,7 +35,7 @@ class JSIteratorPrototype;
 // https://tc39.es/proposal-iterator-helpers/#sec-iterator-constructor
 class JSIteratorConstructor final : public InternalFunction {
 public:
-    typedef InternalFunction Base;
+    using Base = InternalFunction;
 
     static Structure* createStructure(VM&, JSGlobalObject*, JSValue);
     static JSIteratorConstructor* create(VM&, JSGlobalObject*, Structure*, JSIteratorPrototype*);

--- a/Source/JavaScriptCore/runtime/ReflectObject.cpp
+++ b/Source/JavaScriptCore/runtime/ReflectObject.cpp
@@ -36,7 +36,6 @@ static JSC_DECLARE_HOST_FUNCTION(reflectObjectDefineProperty);
 static JSC_DECLARE_HOST_FUNCTION(reflectObjectGetOwnPropertyDescriptor);
 static JSC_DECLARE_HOST_FUNCTION(reflectObjectGetPrototypeOf);
 static JSC_DECLARE_HOST_FUNCTION(reflectObjectIsExtensible);
-static JSC_DECLARE_HOST_FUNCTION(reflectObjectOwnKeys);
 static JSC_DECLARE_HOST_FUNCTION(reflectObjectPreventExtensions);
 static JSC_DECLARE_HOST_FUNCTION(reflectObjectSet);
 static JSC_DECLARE_HOST_FUNCTION(reflectObjectSetPrototypeOf);

--- a/Source/JavaScriptCore/runtime/ReflectObject.h
+++ b/Source/JavaScriptCore/runtime/ReflectObject.h
@@ -31,6 +31,8 @@ namespace JSC {
 
 inline constexpr ASCIILiteral ReflectOwnKeysNonObjectArgumentError { "Reflect.ownKeys requires the first argument be an object"_s };
 
+JSC_DECLARE_HOST_FUNCTION(reflectObjectOwnKeys);
+
 class ReflectObject final : public JSNonFinalObject {
 public:
     using Base = JSNonFinalObject;

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -379,7 +379,7 @@ AllowUniversalAccessFromFileURLs:
     WebCore:
       default: true
 
-# FIXME: This is not relevent for WebKitLegacy, so should be excluded from WebKitLegacy entirely.
+# FIXME: This is not relevant for WebKitLegacy, so it should be excluded from WebKitLegacy entirely.
 AllowViewportShrinkToFitContent:
   type: bool
   status: internal
@@ -1842,7 +1842,7 @@ CSSWrapInsideEnabled:
     WebCore:
       default: true
 
-# FIXME: This is not relevent for WebKitLegacy, so should be excluded from WebKitLegacy entirely (though we should still set the default value to false when initializing settings).
+# FIXME: This is not relevant for WebKitLegacy, so it should be excluded from WebKitLegacy entirely (though we should still set the default value to false when initializing settings).
 CacheAPIEnabled:
   type: bool
   status: embedder
@@ -4641,7 +4641,7 @@ IsFirstPartyWebsiteDataRemovalDisabled:
     WebCore:
       default: false
 
-# FIXME: This is not relevent for WebKitLegacy, so should be excluded from WebKitLegacy entirely.
+# FIXME: This is not relevant for WebKitLegacy, so it should be excluded from WebKitLegacy entirely.
 IsFirstPartyWebsiteDataRemovalLiveOnTestingEnabled:
   type: bool
   status: developer
@@ -4656,7 +4656,7 @@ IsFirstPartyWebsiteDataRemovalLiveOnTestingEnabled:
     WebCore:
       default: false
 
-# FIXME: This is not relevent for WebKitLegacy, so should be excluded from WebKitLegacy entirely.
+# FIXME: This is not relevant for WebKitLegacy, so it should be excluded from WebKitLegacy entirely.
 IsFirstPartyWebsiteDataRemovalReproTestingEnabled:
   type: bool
   status: developer
@@ -4753,7 +4753,7 @@ IteratorSequencingEnabled:
     WebKit:
       default: true
 
-# FIXME: This is not relevent for WebKitLegacy, so should be excluded from WebKitLegacy entirely (though we should still set the default value to false when initializing settings).
+# FIXME: This is not relevant for WebKitLegacy, so it should be excluded from WebKitLegacy entirely (though we should still set the default value to false when initializing settings).
 ItpDebugModeEnabled:
   type: bool
   status: developer
@@ -4859,6 +4859,23 @@ JavaScriptRuntimeFlags:
       default: 0
     WebCore:
       default: '{ }'
+
+JointIterationEnabled:
+  type: bool
+  status: testable
+  category: javascript
+  humanReadableName: "Joint Iteration"
+  humanReadableDescription: "Expose the Iterator.zip and Iterator.zipKeyed methods"
+  webcoreBinding: none
+  jscOptionName: useJointIteration
+  sharedPreferenceForWebProcess: true
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
 
 KeyboardDismissalGestureEnabled:
   type: bool
@@ -8146,7 +8163,7 @@ ShouldTakeNearSuspendedAssertions:
     WebCore:
       default: true
 
-# FIXME: This is not relevent for WebKitLegacy, so should be excluded from WebKitLegacy entirely (though we should still set the default value to false when initializing settings).
+# FIXME: This is not relevant for WebKitLegacy, so it should be excluded from WebKitLegacy entirely (though we should still set the default value to false when initializing settings).
 # FIXME: This is not used in WebCore, so should not have a binding to WebCore::Settings.
 ShouldUseServiceWorkerShortTimeout:
   type: bool
@@ -8963,7 +8980,7 @@ ThreadedTimeBasedAnimationsEnabled:
     WebCore:
       default: true
 
-# FIXME: This is not relevent for WebKitLegacy, so should be excluded from WebKitLegacy entirely.
+# FIXME: This is not relevant for WebKitLegacy, so it should be excluded from WebKitLegacy entirely.
 TiledScrollingIndicatorVisible:
   type: bool
   status: internal
@@ -10399,7 +10416,7 @@ WebRTCMediaPipelineAdditionalLoggingEnabled:
     WebCore:
       default: false
 
-# FIXME: This is not relevant for WebKitLegacy, so should be excluded from WebKitLegacy entirely.
+# FIXME: This is not relevant for WebKitLegacy, so it should be excluded from WebKitLegacy entirely.
 WebRTCPlatformCodecsInGPUProcessEnabled:
   type: bool
   status: embedder


### PR DESCRIPTION
#### 240de0cf9d96a953b256e8c87fa479a558bef9ef
<pre>
[JSC] Implement Joint Iteration proposal
<a href="https://bugs.webkit.org/show_bug.cgi?id=319921">https://bugs.webkit.org/show_bug.cgi?id=319921</a>
<a href="https://rdar.apple.com/180967133">rdar://180967133</a>

Reviewed by Yusuke Suzuki.

This patch implements Iterator.zip and Iterator.zipKeyed, which are
part of the TC39 Joint Iteration proposal (which is Stage 4 as of
this writing). The feature is gated behind the `useJointIteration`
option, which for now is default-off.

Tests: JSTests/microbenchmarks/iterator-zip-keyed.js
       JSTests/microbenchmarks/iterator-zip.js
       JSTests/stress/iterator-zip.js

* JSTests/microbenchmarks/iterator-zip-keyed.js: Added.
(shouldBe):
(test):
* JSTests/microbenchmarks/iterator-zip.js: Added.
(shouldBe):
(test):
* JSTests/stress/iterator-zip.js: Added.
(stringify):
(deepEqual):
(shouldBe):
(Array.from.Iterator.zipKeyed):
* JSTests/test262/config.yaml:
* Source/JavaScriptCore/builtins/BuiltinNames.h:
* Source/JavaScriptCore/builtins/JSIteratorConstructor.js:
(linkTimeConstant.getIteratorSync):
(underlyingIterators.return):
(generator):
(linkTimeConstant.iteratorZip):
(linkTimeConstant.getOptionsObject):
(linkTimeConstant.closeAllIterators):
(linkTimeConstant.iteratorCloseAllNormal):
(linkTimeConstant.removeFirstFromList):
(zip):
(zipKeyed):
* Source/JavaScriptCore/bytecode/LinkTimeConstant.h:
* Source/JavaScriptCore/runtime/IteratorOperations.h:
* Source/JavaScriptCore/runtime/JSGlobalObject.cpp:
(JSC::JSGlobalObject::init):
* Source/JavaScriptCore/runtime/JSIteratorConstructor.cpp:
(JSC::JSIteratorConstructor::finishCreation):
* Source/JavaScriptCore/runtime/JSIteratorConstructor.h:
* Source/JavaScriptCore/runtime/ReflectObject.cpp:
* Source/JavaScriptCore/runtime/ReflectObject.h:
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:

Canonical link: <a href="https://commits.webkit.org/317886@main">https://commits.webkit.org/317886@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/67bee8d95f3760444192bb985397cc59524d0fce

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176393 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50328 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44118 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185992 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/138653 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f965aa4f-47ad-41fe-a6a6-c92d811e8ede) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51620 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50012 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137407 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/138653 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c70a65c5-e6b0-4a02-b4a4-9ec1b6080356) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179349 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40886 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158184 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117882 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6caf5dfc-eeb6-4e3d-b0e2-9335841338f5) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39535 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37898 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/6693 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149951 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37682 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34460 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/37661 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42057 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42109 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188415 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49993 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146446 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39438 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50677 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34300 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146257 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41030 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122881 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/116931 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49181 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12657 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48583 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48817 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48642 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->