### PR TITLE
Rename WKJSHandle.frame to WKJSHandle.sourceFrame

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKJSHandle.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKJSHandle.h
@@ -57,11 +57,11 @@ WK_CLASS_AVAILABLE(macos(27.0), ios(27.0), visionos(27.0))
 + (instancetype)new NS_UNAVAILABLE;
 - (instancetype)init NS_UNAVAILABLE;
 
-/*! @abstract The frame in which the `WKJSHandle` can be used.
+/*! @abstract The frame from which the `WKJSHandle` originates and where it can be used.
  @discussion If the `WKJSHandle` is used as an argument to JavaScript in another frame or after the indicated frame has navigated,
  it will be interpreted as the JavaScript value `undefined`.
  */
-@property (nonatomic, readonly, copy) WKFrameInfo *frame;
+@property (nonatomic, readonly, copy) WKFrameInfo *sourceFrame;
 
 /*! @abstract The world in which the `WKJSHandle` can be used.
  @discussion If the `WKJSHandle` is used in another world it will be interpreted as the JavaScript value `undefined`.

--- a/Source/WebKit/UIProcess/API/Cocoa/WKJSHandle.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKJSHandle.mm
@@ -47,7 +47,7 @@
     [super dealloc];
 }
 
-- (WKFrameInfo *)frame
+- (WKFrameInfo *)sourceFrame
 {
     return wrapper(API::FrameInfo::create(WebKit::FrameInfoData { _ref->info().frameInfo })).autorelease();
 }
@@ -103,6 +103,11 @@
 - (WKContentWorld *)world
 {
     return [self contentWorld];
+}
+
+- (WKFrameInfo *)frame
+{
+    return [self sourceFrame];
 }
 
 - (void)windowFrameInfo:(void (^)(WKFrameInfo * _Nullable))completionHandler

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKJSHandle.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKJSHandle.h
@@ -30,6 +30,7 @@ NS_ASSUME_NONNULL_BEGIN
 WK_CLASS_AVAILABLE(macos(26.4), ios(26.4), visionos(26.4))
 @interface _WKJSHandle : WKJSHandle
 @property (nonatomic, readonly, weak) WKContentWorld *world;
+@property (nonatomic, readonly, copy) WKFrameInfo *frame;
 - (void)windowFrameInfo:(void (^)(WKFrameInfo * _Nullable))completionHandler;
 @end
 


### PR DESCRIPTION
#### 2ec7fdde9d38c50157326629df576514451468b4
<pre>
Rename WKJSHandle.frame to WKJSHandle.sourceFrame
<a href="https://rdar.apple.com/182612413">rdar://182612413</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=319922">https://bugs.webkit.org/show_bug.cgi?id=319922</a>

Reviewed by Alex Christensen.

There&apos;s already many `.frame` properties on various classes on Cocoa platforms, most of which are NS/CGRect.
This new property is a bit confusing for devs cognitively, and also trips up tooling.

Let&apos;s rename to something that already has WebKit precedent.

* Source/WebKit/UIProcess/API/Cocoa/WKJSHandle.h:
* Source/WebKit/UIProcess/API/Cocoa/WKJSHandle.mm:
(-[WKJSHandle sourceFrame]):
(-[_WKJSHandle frame]):
(-[WKJSHandle frame]): Deleted.
* Source/WebKit/UIProcess/API/Cocoa/_WKJSHandle.h:

Canonical link: <a href="https://commits.webkit.org/317714@main">https://commits.webkit.org/317714@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dbecde74311b9ab0be90c87972532d32498ebf74

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176099 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50034 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43824 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185695 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/138329 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ee5ef350-eb9c-4b7a-8899-2b99f78f1e98) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51326 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49718 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/137152 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/138329 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9affbd4e-c1c3-424d-84b4-a5cb7968e1cd) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179055 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40624 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157927 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117627 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b1ba1dd3-5455-4fb6-ae7b-59884990e00e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39273 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37642 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149689 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37424 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34163 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/41750 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/41853 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188118 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49699 "Built successfully") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/146167 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39317 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50382 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/34042 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145996 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40776 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/122585 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/116529 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48887 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12396 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48288 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48523 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48347 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->