### PR TITLE
[Memory64] Implement Table64 in the BBQ tier

### DIFF
--- a/JSTests/wasm/stress/table64-bulk.js
+++ b/JSTests/wasm/stress/table64-bulk.js
@@ -1,5 +1,5 @@
 //@ skip if $addressBits <= 32
-//@ runDefaultWasm("-m", "--useWasmMemory64=1", "--useBBQJIT=0", "--useOMGJIT=0")
+//@ runDefaultWasm("-m", "--useWasmMemory64=1", "--useOMGJIT=0")
 import { instantiate } from "../wabt-wrapper.js";
 import * as assert from "../assert.js";
 

--- a/JSTests/wasm/stress/table64-call-indirect.js
+++ b/JSTests/wasm/stress/table64-call-indirect.js
@@ -1,5 +1,5 @@
 //@ skip if $addressBits <= 32
-//@ runDefaultWasm("-m", "--useWasmMemory64=1", "--useBBQJIT=0", "--useOMGJIT=0")
+//@ runDefaultWasm("-m", "--useWasmMemory64=1", "--useOMGJIT=0")
 import { instantiate } from "../wabt-wrapper.js";
 import * as assert from "../assert.js";
 

--- a/JSTests/wasm/stress/table64-get-and-set.js
+++ b/JSTests/wasm/stress/table64-get-and-set.js
@@ -1,5 +1,5 @@
 //@ skip if $addressBits <= 32
-//@ runDefaultWasm("-m", "--useWasmMemory64=1", "--useBBQJIT=0", "--useOMGJIT=0")
+//@ runDefaultWasm("-m", "--useWasmMemory64=1", "--useOMGJIT=0")
 import { instantiate } from "../wabt-wrapper.js";
 import * as assert from "../assert.js";
 

--- a/JSTests/wasm/stress/table64-grow-and-size.js
+++ b/JSTests/wasm/stress/table64-grow-and-size.js
@@ -1,5 +1,5 @@
 //@ skip if $addressBits <= 32
-//@ runDefaultWasm("-m", "--useWasmMemory64=1", "--useBBQJIT=0", "--useOMGJIT=0")
+//@ runDefaultWasm("-m", "--useWasmMemory64=1", "--useOMGJIT=0")
 import { instantiate } from "../wabt-wrapper.js";
 import * as assert from "../assert.js";
 

--- a/JSTests/wasm/stress/table64-overflow.js
+++ b/JSTests/wasm/stress/table64-overflow.js
@@ -1,5 +1,5 @@
 //@ skip if $addressBits <= 32
-//@ runDefaultWasm("-m", "--useWasmMemory64=1", "--useBBQJIT=0", "--useOMGJIT=0")
+//@ runDefaultWasm("-m", "--useWasmMemory64=1", "--useOMGJIT=0")
 import { instantiate } from "../wabt-wrapper.js";
 import * as assert from "../assert.js";
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/js/memory64/table64.wast.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/js/memory64/table64.wast.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWasmMemory64=1", "--useBBQJIT=0", "--useOMGJIT=0", "--useWasmIPInt=1")
+//@ requireOptions("--useWasmMemory64=1", "--useOMGJIT=0", "--useWasmIPInt=1")
 (function table64_wast_js() {
 
 // table64.wast:1

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/js/memory64/table_copy64.wast.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/js/memory64/table_copy64.wast.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWasmMemory64=1", "--useBBQJIT=0", "--useOMGJIT=0", "--useWasmIPInt=1")
+//@ requireOptions("--useWasmMemory64=1", "--useOMGJIT=0", "--useWasmIPInt=1")
 (function table_copy64_wast_js() {
 
 // table_copy64.wast:6

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/js/memory64/table_fill64.wast.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/js/memory64/table_fill64.wast.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWasmMemory64=1", "--useBBQJIT=0", "--useOMGJIT=0", "--useWasmIPInt=1")
+//@ requireOptions("--useWasmMemory64=1", "--useOMGJIT=0", "--useWasmIPInt=1")
 (function table_fill64_wast_js() {
 
 // table_fill64.wast:1

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/js/memory64/table_get64.wast.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/js/memory64/table_get64.wast.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWasmMemory64=1", "--useBBQJIT=0", "--useOMGJIT=0", "--useWasmIPInt=1")
+//@ requireOptions("--useWasmMemory64=1", "--useOMGJIT=0", "--useWasmIPInt=1")
 (function table_get64_wast_js() {
 
 // table_get64.wast:1

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/js/memory64/table_grow64.wast.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/js/memory64/table_grow64.wast.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWasmMemory64=1", "--useBBQJIT=0", "--useOMGJIT=0", "--useWasmIPInt=1")
+//@ requireOptions("--useWasmMemory64=1", "--useOMGJIT=0", "--useWasmIPInt=1")
 (function table_grow64_wast_js() {
 
 // table_grow64.wast:1

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/js/memory64/table_init64.wast.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/js/memory64/table_init64.wast.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWasmMemory64=1", "--useBBQJIT=0", "--useOMGJIT=0", "--useWasmIPInt=1")
+//@ requireOptions("--useWasmMemory64=1", "--useOMGJIT=0", "--useWasmIPInt=1")
 (function table_init64_wast_js() {
 
 // table_init64.wast:6

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/js/memory64/table_set64.wast.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/js/memory64/table_set64.wast.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWasmMemory64=1", "--useBBQJIT=0", "--useOMGJIT=0", "--useWasmIPInt=1")
+//@ requireOptions("--useWasmMemory64=1", "--useOMGJIT=0", "--useWasmIPInt=1")
 (function table_set64_wast_js() {
 
 // table_set64.wast:1

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/js/memory64/table_size64.wast.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/js/memory64/table_size64.wast.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWasmMemory64=1", "--useBBQJIT=0", "--useOMGJIT=0", "--useWasmIPInt=1")
+//@ requireOptions("--useWasmMemory64=1", "--useOMGJIT=0", "--useWasmIPInt=1")
 (function table_size64_wast_js() {
 
 // table_size64.wast:1

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/address64.wast.js.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/address64.wast.js.html
@@ -1,4 +1,4 @@
-<!doctype html><!-- webkit-test-runner [ jscOptions=--useBBQJIT=false,--useOMGJIT=false ] -->
+<!doctype html><!-- webkit-test-runner [ jscOptions=--useOMGJIT=false ] -->
 <html>
     <head>
         <meta charset="UTF-8">

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/align64.wast.js.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/align64.wast.js.html
@@ -1,4 +1,4 @@
-<!doctype html><!-- webkit-test-runner [ jscOptions=--useBBQJIT=false,--useOMGJIT=false ] -->
+<!doctype html><!-- webkit-test-runner [ jscOptions=--useOMGJIT=false ] -->
 <html>
     <head>
         <meta charset="UTF-8">

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/binary_leb128_64.wast.js.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/binary_leb128_64.wast.js.html
@@ -1,4 +1,4 @@
-<!doctype html><!-- webkit-test-runner [ jscOptions=--useBBQJIT=false,--useOMGJIT=false ] -->
+<!doctype html><!-- webkit-test-runner [ jscOptions=--useOMGJIT=false ] -->
 <html>
     <head>
         <meta charset="UTF-8">

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/bulk64.wast.js.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/bulk64.wast.js.html
@@ -1,4 +1,4 @@
-<!doctype html><!-- webkit-test-runner [ jscOptions=--useBBQJIT=false,--useOMGJIT=false ] -->
+<!doctype html><!-- webkit-test-runner [ jscOptions=--useOMGJIT=false ] -->
 <html>
     <head>
         <meta charset="UTF-8">

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/call_indirect64.wast.js.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/call_indirect64.wast.js.html
@@ -1,4 +1,4 @@
-<!doctype html><!-- webkit-test-runner [ jscOptions=--useBBQJIT=false,--useOMGJIT=false ] -->
+<!doctype html><!-- webkit-test-runner [ jscOptions=--useOMGJIT=false ] -->
 <html>
     <head>
         <meta charset="UTF-8">

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/endianness64.wast.js.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/endianness64.wast.js.html
@@ -1,4 +1,4 @@
-<!doctype html><!-- webkit-test-runner [ jscOptions=--useBBQJIT=false,--useOMGJIT=false ] -->
+<!doctype html><!-- webkit-test-runner [ jscOptions=--useOMGJIT=false ] -->
 <html>
     <head>
         <meta charset="UTF-8">

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/float_memory64.wast.js.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/float_memory64.wast.js.html
@@ -1,4 +1,4 @@
-<!doctype html><!-- webkit-test-runner [ jscOptions=--useBBQJIT=false,--useOMGJIT=false ] -->
+<!doctype html><!-- webkit-test-runner [ jscOptions=--useOMGJIT=false ] -->
 <html>
     <head>
         <meta charset="UTF-8">

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/load64.wast.js.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/load64.wast.js.html
@@ -1,4 +1,4 @@
-<!doctype html><!-- webkit-test-runner [ jscOptions=--useBBQJIT=false,--useOMGJIT=false ] -->
+<!doctype html><!-- webkit-test-runner [ jscOptions=--useOMGJIT=false ] -->
 <html>
     <head>
         <meta charset="UTF-8">

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/memory64-imports.wast.js.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/memory64-imports.wast.js.html
@@ -1,4 +1,4 @@
-<!doctype html><!-- webkit-test-runner [ jscOptions=--useBBQJIT=false,--useOMGJIT=false ] -->
+<!doctype html><!-- webkit-test-runner [ jscOptions=--useOMGJIT=false ] -->
 <html>
     <head>
         <meta charset="UTF-8">

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/memory64.wast.js.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/memory64.wast.js.html
@@ -1,4 +1,4 @@
-<!doctype html><!-- webkit-test-runner [ jscOptions=--useBBQJIT=false,--useOMGJIT=false ] -->
+<!doctype html><!-- webkit-test-runner [ jscOptions=--useOMGJIT=false ] -->
 <html>
     <head>
         <meta charset="UTF-8">

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/memory_copy64.wast.js.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/memory_copy64.wast.js.html
@@ -1,4 +1,4 @@
-<!doctype html><!-- webkit-test-runner [ jscOptions=--useBBQJIT=false,--useOMGJIT=false ] -->
+<!doctype html><!-- webkit-test-runner [ jscOptions=--useOMGJIT=false ] -->
 <html>
     <head>
         <meta charset="UTF-8">

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/memory_fill64.wast.js.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/memory_fill64.wast.js.html
@@ -1,4 +1,4 @@
-<!doctype html><!-- webkit-test-runner [ jscOptions=--useBBQJIT=false,--useOMGJIT=false ] -->
+<!doctype html><!-- webkit-test-runner [ jscOptions=--useOMGJIT=false ] -->
 <html>
     <head>
         <meta charset="UTF-8">

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/memory_grow64.wast.js.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/memory_grow64.wast.js.html
@@ -1,4 +1,4 @@
-<!doctype html><!-- webkit-test-runner [ jscOptions=--useBBQJIT=false,--useOMGJIT=false ] -->
+<!doctype html><!-- webkit-test-runner [ jscOptions=--useOMGJIT=false ] -->
 <html>
     <head>
         <meta charset="UTF-8">

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/memory_init64.wast.js.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/memory_init64.wast.js.html
@@ -1,4 +1,4 @@
-<!doctype html><!-- webkit-test-runner [ jscOptions=--useBBQJIT=false,--useOMGJIT=false ] -->
+<!doctype html><!-- webkit-test-runner [ jscOptions=--useOMGJIT=false ] -->
 <html>
     <head>
         <meta charset="UTF-8">

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/memory_redundancy64.wast.js.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/memory_redundancy64.wast.js.html
@@ -1,4 +1,4 @@
-<!doctype html><!-- webkit-test-runner [ jscOptions=--useBBQJIT=false,--useOMGJIT=false ] -->
+<!doctype html><!-- webkit-test-runner [ jscOptions=--useOMGJIT=false ] -->
 <html>
     <head>
         <meta charset="UTF-8">

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/memory_trap64.wast.js.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/memory_trap64.wast.js.html
@@ -1,4 +1,4 @@
-<!doctype html><!-- webkit-test-runner [ jscOptions=--useBBQJIT=false,--useOMGJIT=false ] -->
+<!doctype html><!-- webkit-test-runner [ jscOptions=--useOMGJIT=false ] -->
 <html>
     <head>
         <meta charset="UTF-8">

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table64.wast.js.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table64.wast.js.html
@@ -1,4 +1,4 @@
-<!doctype html><!-- webkit-test-runner [ jscOptions=--useBBQJIT=false,--useOMGJIT=false ] -->
+<!doctype html><!-- webkit-test-runner [ jscOptions=--useOMGJIT=false ] -->
 <html>
     <head>
         <meta charset="UTF-8">

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table_copy64.wast.js.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table_copy64.wast.js.html
@@ -1,4 +1,4 @@
-<!doctype html><!-- webkit-test-runner [ jscOptions=--useBBQJIT=false,--useOMGJIT=false ] -->
+<!doctype html><!-- webkit-test-runner [ jscOptions=--useOMGJIT=false ] -->
 <html>
     <head>
         <meta charset="UTF-8">

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table_copy_mixed.wast.js.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table_copy_mixed.wast.js.html
@@ -1,4 +1,4 @@
-<!doctype html><!-- webkit-test-runner [ jscOptions=--useBBQJIT=false,--useOMGJIT=false ] -->
+<!doctype html><!-- webkit-test-runner [ jscOptions=--useOMGJIT=false ] -->
 <html>
     <head>
         <meta charset="UTF-8">

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table_fill64.wast.js.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table_fill64.wast.js.html
@@ -1,4 +1,4 @@
-<!doctype html><!-- webkit-test-runner [ jscOptions=--useBBQJIT=false,--useOMGJIT=false ] -->
+<!doctype html><!-- webkit-test-runner [ jscOptions=--useOMGJIT=false ] -->
 <html>
     <head>
         <meta charset="UTF-8">

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table_get64.wast.js.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table_get64.wast.js.html
@@ -1,4 +1,4 @@
-<!doctype html><!-- webkit-test-runner [ jscOptions=--useBBQJIT=false,--useOMGJIT=false ] -->
+<!doctype html><!-- webkit-test-runner [ jscOptions=--useOMGJIT=false ] -->
 <html>
     <head>
         <meta charset="UTF-8">

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table_grow64.wast.js.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table_grow64.wast.js.html
@@ -1,4 +1,4 @@
-<!doctype html><!-- webkit-test-runner [ jscOptions=--useBBQJIT=false,--useOMGJIT=false ] -->
+<!doctype html><!-- webkit-test-runner [ jscOptions=--useOMGJIT=false ] -->
 <html>
     <head>
         <meta charset="UTF-8">

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table_init64.wast.js.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table_init64.wast.js.html
@@ -1,4 +1,4 @@
-<!doctype html><!-- webkit-test-runner [ jscOptions=--useBBQJIT=false,--useOMGJIT=false ] -->
+<!doctype html><!-- webkit-test-runner [ jscOptions=--useOMGJIT=false ] -->
 <html>
     <head>
         <meta charset="UTF-8">

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table_set64.wast.js.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table_set64.wast.js.html
@@ -1,4 +1,4 @@
-<!doctype html><!-- webkit-test-runner [ jscOptions=--useBBQJIT=false,--useOMGJIT=false ] -->
+<!doctype html><!-- webkit-test-runner [ jscOptions=--useOMGJIT=false ] -->
 <html>
     <head>
         <meta charset="UTF-8">

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table_size64.wast.js.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table_size64.wast.js.html
@@ -1,4 +1,4 @@
-<!doctype html><!-- webkit-test-runner [ jscOptions=--useBBQJIT=false,--useOMGJIT=false ] -->
+<!doctype html><!-- webkit-test-runner [ jscOptions=--useOMGJIT=false ] -->
 <html>
     <head>
         <meta charset="UTF-8">

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
@@ -854,7 +854,7 @@ PartialResult BBQJIT::addLocal(Type type, uint32_t numberOfLocals)
 [[nodiscard]] PartialResult BBQJIT::addTableSet(unsigned tableIndex, Value index, Value value)
 {
     // FIXME: Emit this inline <https://bugs.webkit.org/show_bug.cgi?id=198506>.
-    ASSERT(index.type() == TypeKind::I32);
+    ASSERT(index.type() == m_info.table(tableIndex).addressType().asWasmTypeKind());
 
     Vector<Value, 8> arguments = {
         instanceValue(),
@@ -878,7 +878,7 @@ PartialResult BBQJIT::addLocal(Type type, uint32_t numberOfLocals)
 
 [[nodiscard]] PartialResult BBQJIT::addTableInit(unsigned elementIndex, unsigned tableIndex, ExpressionType dstOffset, ExpressionType srcOffset, ExpressionType length)
 {
-    ASSERT(dstOffset.type() == TypeKind::I32);
+    ASSERT(dstOffset.type() == m_info.table(tableIndex).addressType().asWasmTypeKind());
     ASSERT(srcOffset.type() == TypeKind::I32);
     ASSERT(length.type() == TypeKind::I32);
 
@@ -921,7 +921,7 @@ PartialResult BBQJIT::addLocal(Type type, uint32_t numberOfLocals)
         instanceValue(),
         Value::fromI32(tableIndex)
     };
-    result = topValue(TypeKind::I32);
+    result = topValue(m_info.table(tableIndex).addressType().asWasmTypeKind());
     emitCCall(&operationGetWasmTableSize, arguments, result);
 
     LOG_INSTRUCTION("TableSize", tableIndex, RESULT(result));
@@ -930,14 +930,15 @@ PartialResult BBQJIT::addLocal(Type type, uint32_t numberOfLocals)
 
 [[nodiscard]] PartialResult BBQJIT::addTableGrow(unsigned tableIndex, Value fill, Value delta, Value& result)
 {
-    ASSERT(delta.type() == TypeKind::I32);
+    auto tableAddressTypeKind = m_info.table(tableIndex).addressType().asWasmTypeKind();
+    ASSERT(delta.type() == tableAddressTypeKind);
 
     Vector<Value, 8> arguments = {
         instanceValue(),
         Value::fromI32(tableIndex),
         fill, delta
     };
-    result = topValue(TypeKind::I32);
+    result = topValue(tableAddressTypeKind);
     emitCCall(&operationWasmTableGrow, arguments, result);
 
     LOG_INSTRUCTION("TableGrow", tableIndex, fill, delta, RESULT(result));
@@ -946,8 +947,8 @@ PartialResult BBQJIT::addLocal(Type type, uint32_t numberOfLocals)
 
 [[nodiscard]] PartialResult BBQJIT::addTableFill(unsigned tableIndex, Value offset, Value fill, Value count)
 {
-    ASSERT(offset.type() == TypeKind::I32);
-    ASSERT(count.type() == TypeKind::I32);
+    ASSERT(offset.type() == m_info.table(tableIndex).addressType().asWasmTypeKind());
+    ASSERT(count.type() == m_info.table(tableIndex).addressType().asWasmTypeKind());
 
     Vector<Value, 8> arguments = {
         instanceValue(),
@@ -969,9 +970,9 @@ PartialResult BBQJIT::addLocal(Type type, uint32_t numberOfLocals)
 
 [[nodiscard]] PartialResult BBQJIT::addTableCopy(unsigned dstTableIndex, unsigned srcTableIndex, Value dstOffset, Value srcOffset, Value length)
 {
-    ASSERT(dstOffset.type() == TypeKind::I32);
-    ASSERT(srcOffset.type() == TypeKind::I32);
-    ASSERT(length.type() == TypeKind::I32);
+    ASSERT(dstOffset.type() == m_info.table(srcTableIndex).addressType().asWasmTypeKind());
+    ASSERT(srcOffset.type() == m_info.table(dstTableIndex).addressType().asWasmTypeKind());
+    ASSERT(m_info.table(dstTableIndex).addressType().is64Bit() && m_info.table(srcTableIndex).addressType().is64Bit() ? length.type() == TypeKind::I64 : length.type() == TypeKind::I32);
 
     Vector<Value, 8> arguments = {
         instanceValue(),
@@ -4906,7 +4907,9 @@ void BBQJIT::emitIndirectTailCall(const char* opcode, const Value& callee, GPRRe
             ASSERT(calleeIndexLocation.isGPR());
 
             JIT_COMMENT(m_jit, "Check the index we are looking for is valid");
-            recordJumpToThrowException(ExceptionType::OutOfBoundsCallIndirect, m_jit.branch32(RelationalCondition::AboveOrEqual, calleeIndexLocation.asGPR(), wasmScratchGPR));
+            if (!tableInformation.addressType().is64Bit())
+                m_jit.zeroExtend32ToWord(calleeIndexLocation.asGPR(), calleeIndexLocation.asGPR());
+            recordJumpToThrowException(ExceptionType::OutOfBoundsCallIndirect, m_jit.branch64(RelationalCondition::AboveOrEqual, calleeIndexLocation.asGPR(), wasmScratchGPR));
 
             // Neither callableFunctionBuffer nor wasmScratchGPR are used before any of these
             // are def'd below, so we can reuse the registers and save some pressure.

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp
@@ -162,8 +162,9 @@ Value BBQJIT::instanceValue()
 [[nodiscard]] PartialResult BBQJIT::addTableGet(unsigned tableIndex, Value index, Value& result)
 {
     // FIXME: Emit this inline <https://bugs.webkit.org/show_bug.cgi?id=198506>.
-    ASSERT(index.type() == TypeKind::I32);
-    TypeKind returnType = m_info.tables[tableIndex].wasmType().kind();
+    auto table = m_info.table(tableIndex);
+    ASSERT(index.type() == table.addressType().asWasmTypeKind());
+    TypeKind returnType = table.wasmType().kind();
     ASSERT(typeKindSizeInBytes(returnType) == 8);
 
     Vector<Value, 8> arguments = {

--- a/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp
+++ b/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp
@@ -632,7 +632,7 @@ WASM_IPINT_EXTERN_CPP_DECL(table_grow, IPIntStackEntry* sp, TableGrowMetadata* m
     if (!n)
         IPINT_RETURN(static_cast<intptr_t>(-1));
 
-    WASM_RETURN_TWO(std::bit_cast<void*>(Wasm::tableGrow(instance, metadata->tableIndex, fill, *n)), 0);
+    WASM_RETURN_TWO(reinterpret_cast<void*>(Wasm::tableGrow(instance, metadata->tableIndex, fill, *n)), 0);
 }
 
 WASM_IPINT_EXTERN_CPP_DECL(memory_grow, int64_t delta, uint8_t memoryIndex)

--- a/Source/JavaScriptCore/wasm/WasmOperations.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOperations.cpp
@@ -1551,17 +1551,17 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationWasmMemoryCopy, UCPUStrictInt32, (JSW
     return toUCPUStrictInt32(memoryCopy(instance, dstAddress, srcAddress, count, dstMemoryIndex, srcMemoryIndex));
 }
 
-JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationGetWasmTableElement, EncodedJSValue, (JSWebAssemblyInstance* instance, unsigned tableIndex, int32_t signedIndex))
+JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationGetWasmTableElement, EncodedJSValue, (JSWebAssemblyInstance* instance, unsigned tableIndex, uint64_t index))
 {
-    return tableGet(instance, tableIndex, signedIndex);
+    return tableGet(instance, tableIndex, index);
 }
 
-JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationSetWasmTableElement, UCPUStrictInt32, (JSWebAssemblyInstance* instance, unsigned tableIndex, uint32_t signedIndex, EncodedJSValue encValue))
+JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationSetWasmTableElement, UCPUStrictInt32, (JSWebAssemblyInstance* instance, unsigned tableIndex, uint64_t signedIndex, EncodedJSValue encValue))
 {
     return toUCPUStrictInt32(tableSet(instance, tableIndex, signedIndex, encValue));
 }
 
-JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationWasmTableInit, UCPUStrictInt32, (JSWebAssemblyInstance* instance, unsigned elementIndex, unsigned tableIndex, uint32_t dstOffset, uint32_t srcOffset, uint32_t length))
+JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationWasmTableInit, UCPUStrictInt32, (JSWebAssemblyInstance* instance, unsigned elementIndex, unsigned tableIndex, uint64_t dstOffset, uint32_t srcOffset, uint32_t length))
 {
     CallFrame* callFrame = DECLARE_WASM_CALL_FRAME(instance);
     assertCalleeIsReferenced(callFrame, instance);
@@ -1575,17 +1575,17 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationWasmElemDrop, void, (JSWebAssemblyIns
     return elemDrop(instance, elementIndex);
 }
 
-JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationWasmTableGrow, UCPUStrictInt32, (JSWebAssemblyInstance* instance, unsigned tableIndex, EncodedJSValue fill, uint32_t delta))
+JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationWasmTableGrow, int64_t, (JSWebAssemblyInstance* instance, unsigned tableIndex, EncodedJSValue fill, uint64_t delta))
 {
-    return toUCPUStrictInt32(tableGrow(instance, tableIndex, fill, delta));
+    return tableGrow(instance, tableIndex, fill, delta);
 }
 
-JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationWasmTableFill, UCPUStrictInt32, (JSWebAssemblyInstance* instance, unsigned tableIndex, uint32_t offset, EncodedJSValue fill, uint32_t count))
+JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationWasmTableFill, UCPUStrictInt32, (JSWebAssemblyInstance* instance, unsigned tableIndex, uint64_t offset, EncodedJSValue fill, uint64_t count))
 {
     return toUCPUStrictInt32(tableFill(instance, tableIndex, offset, fill, count));
 }
 
-JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationWasmTableCopy, UCPUStrictInt32, (JSWebAssemblyInstance* instance, unsigned dstTableIndex, unsigned srcTableIndex, int32_t dstOffset, int32_t srcOffset, int32_t length))
+JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationWasmTableCopy, UCPUStrictInt32, (JSWebAssemblyInstance* instance, unsigned dstTableIndex, unsigned srcTableIndex, uint64_t dstOffset, uint64_t srcOffset, uint64_t length))
 {
     return toUCPUStrictInt32(tableCopy(instance, dstTableIndex, srcTableIndex, dstOffset, srcOffset, length));
 }

--- a/Source/JavaScriptCore/wasm/WasmOperations.h
+++ b/Source/JavaScriptCore/wasm/WasmOperations.h
@@ -95,14 +95,14 @@ JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationWasmMemorySizeInPages, int64_t, (JSW
 JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationWasmMemoryFill, UCPUStrictInt32, (JSWebAssemblyInstance*, uint64_t dstAddress, uint32_t targetValue, uint64_t count, uint8_t memoryIndex));
 JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationWasmMemoryCopy, UCPUStrictInt32, (JSWebAssemblyInstance*, uint64_t dstAddress, uint64_t srcAddress, uint64_t count, uint8_t dstMemoryIndex, uint8_t srcMemoryIndex));
 
-JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationGetWasmTableElement, EncodedJSValue, (JSWebAssemblyInstance*, unsigned, int32_t));
-JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationSetWasmTableElement, UCPUStrictInt32, (JSWebAssemblyInstance*, unsigned, uint32_t, EncodedJSValue encValue));
+JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationGetWasmTableElement, EncodedJSValue, (JSWebAssemblyInstance*, unsigned, uint64_t));
+JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationSetWasmTableElement, UCPUStrictInt32, (JSWebAssemblyInstance*, unsigned, uint64_t, EncodedJSValue encValue));
 JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationWasmRefFunc, EncodedJSValue, (JSWebAssemblyInstance*, uint32_t));
-JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationWasmTableInit, UCPUStrictInt32, (JSWebAssemblyInstance*, unsigned elementIndex, unsigned tableIndex, uint32_t dstOffset, uint32_t srcOffset, uint32_t length));
+JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationWasmTableInit, UCPUStrictInt32, (JSWebAssemblyInstance*, unsigned elementIndex, unsigned tableIndex, uint64_t dstOffset, uint32_t srcOffset, uint32_t length));
 JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationWasmElemDrop, void, (JSWebAssemblyInstance*, unsigned elementIndex));
-JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationWasmTableGrow, UCPUStrictInt32, (JSWebAssemblyInstance*, unsigned, EncodedJSValue fill, uint32_t delta));
-JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationWasmTableFill, UCPUStrictInt32, (JSWebAssemblyInstance*, unsigned, uint32_t offset, EncodedJSValue fill, uint32_t count));
-JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationWasmTableCopy, UCPUStrictInt32, (JSWebAssemblyInstance*, unsigned dstTableIndex, unsigned srcTableIndex, int32_t dstOffset, int32_t srcOffset, int32_t length));
+JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationWasmTableGrow, int64_t, (JSWebAssemblyInstance*, unsigned, EncodedJSValue fill, uint64_t delta));
+JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationWasmTableFill, UCPUStrictInt32, (JSWebAssemblyInstance*, unsigned, uint64_t offset, EncodedJSValue fill, uint64_t count));
+JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationWasmTableCopy, UCPUStrictInt32, (JSWebAssemblyInstance*, unsigned dstTableIndex, unsigned srcTableIndex, uint64_t dstOffset, uint64_t srcOffset, uint64_t length));
 JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationGetWasmTableSize, UCPUStrictInt32, (JSWebAssemblyInstance*, unsigned));
 
 JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationMemoryAtomicWait32, UCPUStrictInt32, (JSWebAssemblyInstance* instance, uint64_t base, uint64_t offset, int32_t value, int64_t timeout, uint8_t memoryIndex));

--- a/Source/JavaScriptCore/wasm/WasmOperationsInlines.h
+++ b/Source/JavaScriptCore/wasm/WasmOperationsInlines.h
@@ -535,20 +535,16 @@ inline EncodedJSValue externInternalize(EncodedJSValue reference)
     return JSValue::encode(Wasm::internalizeExternref(JSValue::decode(reference)));
 }
 
-inline EncodedJSValue tableGet(JSWebAssemblyInstance* instance, unsigned tableIndex, int32_t signedIndex)
+inline EncodedJSValue tableGet(JSWebAssemblyInstance* instance, unsigned tableIndex, uint64_t index)
 {
     ASSERT(tableIndex < instance->module().moduleInformation().tableCount());
-    if (signedIndex < 0)
-        return 0;
-
-    uint32_t index = signedIndex;
     if (index >= instance->table(tableIndex)->length())
         return 0;
 
     return JSValue::encode(instance->table(tableIndex)->get(index));
 }
 
-inline bool tableSet(JSWebAssemblyInstance* instance, unsigned tableIndex, uint32_t index, EncodedJSValue encValue)
+inline bool tableSet(JSWebAssemblyInstance* instance, unsigned tableIndex, uint64_t index, EncodedJSValue encValue)
 {
     ASSERT(tableIndex < instance->module().moduleInformation().tableCount());
 
@@ -564,7 +560,7 @@ inline bool tableSet(JSWebAssemblyInstance* instance, unsigned tableIndex, uint3
     return true;
 }
 
-inline bool tableInit(JSWebAssemblyInstance* instance, unsigned elementIndex, unsigned tableIndex, uint32_t dstOffset, uint32_t srcOffset, uint32_t length)
+inline bool tableInit(JSWebAssemblyInstance* instance, unsigned elementIndex, unsigned tableIndex, uint64_t dstOffset, uint32_t srcOffset, uint32_t length)
 {
     ASSERT(elementIndex < instance->module().moduleInformation().elementCount());
     ASSERT(tableIndex < instance->module().moduleInformation().tableCount());
@@ -572,7 +568,7 @@ inline bool tableInit(JSWebAssemblyInstance* instance, unsigned elementIndex, un
     if (WTF::sumOverflows<uint32_t>(srcOffset, length))
         return false;
 
-    if (WTF::sumOverflows<uint32_t>(dstOffset, length))
+    if (WTF::sumOverflows<uint64_t>(dstOffset, length))
         return false;
 
     if (dstOffset + length > instance->table(tableIndex)->length())
@@ -589,23 +585,23 @@ inline bool tableInit(JSWebAssemblyInstance* instance, unsigned elementIndex, un
     return true;
 }
 
-inline bool tableFill(JSWebAssemblyInstance* instance, unsigned tableIndex, uint32_t offset, EncodedJSValue fill, uint32_t count)
+inline bool tableFill(JSWebAssemblyInstance* instance, unsigned tableIndex, uint64_t offset, EncodedJSValue fill, uint64_t count)
 {
     ASSERT(tableIndex < instance->module().moduleInformation().tableCount());
 
-    if (WTF::sumOverflows<uint32_t>(offset, count))
+    if (WTF::sumOverflows<uint64_t>(offset, count))
         return false;
 
     if (offset + count > instance->table(tableIndex)->length())
         return false;
 
-    for (uint32_t index = 0; index < count; ++index)
+    for (uint64_t index = 0; index < count; ++index)
         tableSet(instance, tableIndex, offset + index, fill);
 
     return true;
 }
 
-inline size_t tableGrow(JSWebAssemblyInstance* instance, unsigned tableIndex, EncodedJSValue fill, uint32_t delta)
+inline int64_t tableGrow(JSWebAssemblyInstance* instance, unsigned tableIndex, EncodedJSValue fill, uint64_t delta)
 {
     ASSERT(tableIndex < instance->module().moduleInformation().tableCount());
     auto oldSize = instance->table(tableIndex)->length();
@@ -619,7 +615,7 @@ inline size_t tableGrow(JSWebAssemblyInstance* instance, unsigned tableIndex, En
     return oldSize;
 }
 
-inline bool tableCopy(JSWebAssemblyInstance* instance, unsigned dstTableIndex, unsigned srcTableIndex, int32_t dstOffset, int32_t srcOffset, int32_t length)
+inline bool tableCopy(JSWebAssemblyInstance* instance, unsigned dstTableIndex, unsigned srcTableIndex, uint64_t dstOffset, uint64_t srcOffset, uint64_t length)
 {
     ASSERT(dstTableIndex < instance->module().moduleInformation().tableCount());
     ASSERT(srcTableIndex < instance->module().moduleInformation().tableCount());
@@ -627,11 +623,8 @@ inline bool tableCopy(JSWebAssemblyInstance* instance, unsigned dstTableIndex, u
     const Table* srcTable = instance->table(srcTableIndex);
     ASSERT(dstTable->type() == srcTable->type());
 
-    if ((srcOffset < 0) || (dstOffset < 0) || (length < 0))
-        return false;
-
-    CheckedUint32 lastDstElementIndexChecked = static_cast<uint32_t>(dstOffset);
-    lastDstElementIndexChecked += static_cast<uint32_t>(length);
+    CheckedUint64 lastDstElementIndexChecked = dstOffset;
+    lastDstElementIndexChecked += length;
 
     if (lastDstElementIndexChecked.hasOverflowed())
         return false;
@@ -639,8 +632,8 @@ inline bool tableCopy(JSWebAssemblyInstance* instance, unsigned dstTableIndex, u
     if (lastDstElementIndexChecked > dstTable->length())
         return false;
 
-    CheckedUint32 lastSrcElementIndexChecked = static_cast<uint32_t>(srcOffset);
-    lastSrcElementIndexChecked += static_cast<uint32_t>(length);
+    CheckedUint64 lastSrcElementIndexChecked = srcOffset;
+    lastSrcElementIndexChecked += length;
 
     if (lastSrcElementIndexChecked.hasOverflowed())
         return false;

--- a/Source/JavaScriptCore/wasm/WasmTable.cpp
+++ b/Source/JavaScriptCore/wasm/WasmTable.cpp
@@ -114,7 +114,7 @@ RefPtr<Table> Table::tryCreate(VM& vm, uint32_t initial, std::optional<uint64_t>
     RELEASE_ASSERT_NOT_REACHED();
 }
 
-std::optional<uint32_t> Table::grow(uint32_t delta, JSValue defaultValue)
+std::optional<uint32_t> Table::grow(uint64_t delta, JSValue defaultValue)
 {
     RELEASE_ASSERT(m_owner);
     if (delta == 0)
@@ -122,12 +122,12 @@ std::optional<uint32_t> Table::grow(uint32_t delta, JSValue defaultValue)
 
     Locker locker { m_owner->cellLock() };
 
-    CheckedUint32 newLengthChecked = length();
+    CheckedUint64 newLengthChecked = length();
     newLengthChecked += delta;
     if (newLengthChecked.hasOverflowed())
         return std::nullopt;
 
-    uint32_t newLength = newLengthChecked;
+    uint64_t newLength = newLengthChecked;
     if (maximum() && newLength > *maximum())
         return std::nullopt;
     if (!isValidLength(newLength))

--- a/Source/JavaScriptCore/wasm/WasmTable.h
+++ b/Source/JavaScriptCore/wasm/WasmTable.h
@@ -81,13 +81,13 @@ public:
     Wasm::AddressType addressType() const { return m_addressType; }
     FuncRefTable* NODELETE asFuncrefTable();
 
-    static bool isValidLength(uint32_t length) { return length < maxTableEntries; }
+    static bool isValidLength(uint64_t length) { return length < maxTableEntries; }
 
     void clear(uint32_t);
     void set(uint32_t, JSValue);
     JSValue get(uint32_t);
 
-    std::optional<uint32_t> grow(uint32_t delta, JSValue defaultValue);
+    std::optional<uint32_t> grow(uint64_t delta, JSValue defaultValue);
     void copy(Table* srcTable, uint32_t dstIndex, uint32_t srcIndex);
 
     DECLARE_VISIT_AGGREGATE;


### PR DESCRIPTION
#### d202bedc5ff6a3256f6de16f842ff12a48f0fcac
<pre>
[Memory64] Implement Table64 in the BBQ tier
<a href="https://bugs.webkit.org/show_bug.cgi?id=319924">https://bugs.webkit.org/show_bug.cgi?id=319924</a>
<a href="https://rdar.apple.com/182851267">rdar://182851267</a>

Reviewed by Keith Miller.

This patch introduces support for Table64 in the BBQ tier. Most of the table
functions in the BBQ tier are just C calls to wasmOperations.h functions, so
a lot of this patch is fixing asserts and argument types when passing values
from BBQ to C++ land.

* JSTests/wasm/stress/table64-bulk.js:
* JSTests/wasm/stress/table64-call-indirect.js:
* JSTests/wasm/stress/table64-get-and-set.js:
* JSTests/wasm/stress/table64-grow-and-size.js:
* JSTests/wasm/stress/table64-overflow.js:
* LayoutTests/imported/w3c/web-platform-tests/wasm/core/js/memory64/table64.wast.js:
* LayoutTests/imported/w3c/web-platform-tests/wasm/core/js/memory64/table_copy64.wast.js:
* LayoutTests/imported/w3c/web-platform-tests/wasm/core/js/memory64/table_fill64.wast.js:
* LayoutTests/imported/w3c/web-platform-tests/wasm/core/js/memory64/table_get64.wast.js:
* LayoutTests/imported/w3c/web-platform-tests/wasm/core/js/memory64/table_grow64.wast.js:
* LayoutTests/imported/w3c/web-platform-tests/wasm/core/js/memory64/table_init64.wast.js:
* LayoutTests/imported/w3c/web-platform-tests/wasm/core/js/memory64/table_set64.wast.js:
* LayoutTests/imported/w3c/web-platform-tests/wasm/core/js/memory64/table_size64.wast.js:
* LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/address64.wast.js.html:
* LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/align64.wast.js.html:
* LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/binary_leb128_64.wast.js.html:
* LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/bulk64.wast.js.html:
* LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/call_indirect64.wast.js.html:
* LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/endianness64.wast.js.html:
* LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/float_memory64.wast.js.html:
* LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/load64.wast.js.html:
* LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/memory64-imports.wast.js.html:
* LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/memory64.wast.js.html:
* LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/memory_copy64.wast.js.html:
* LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/memory_fill64.wast.js.html:
* LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/memory_grow64.wast.js.html:
* LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/memory_init64.wast.js.html:
* LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/memory_redundancy64.wast.js.html:
* LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/memory_trap64.wast.js.html:
* LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table64.wast.js.html:
* LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table_copy64.wast.js.html:
* LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table_copy_mixed.wast.js.html:
* LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table_fill64.wast.js.html:
* LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table_get64.wast.js.html:
* LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table_grow64.wast.js.html:
* LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table_init64.wast.js.html:
* LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table_set64.wast.js.html:
* LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table_size64.wast.js.html:
* Source/JavaScriptCore/wasm/WasmBBQJIT.cpp:
(JSC::Wasm::BBQJITImpl::BBQJIT::addTableSet):
(JSC::Wasm::BBQJITImpl::BBQJIT::addTableInit):
(JSC::Wasm::BBQJITImpl::BBQJIT::addTableSize):
(JSC::Wasm::BBQJITImpl::BBQJIT::addTableGrow):
(JSC::Wasm::BBQJITImpl::BBQJIT::addTableFill):
(JSC::Wasm::BBQJITImpl::BBQJIT::addTableCopy):
(JSC::Wasm::BBQJITImpl::BBQJIT::addCallIndirect):
* Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp:
(JSC::Wasm::BBQJITImpl::BBQJIT::addTableGet):
* Source/JavaScriptCore/wasm/WasmOperations.cpp:
(JSC::Wasm::JSC_DEFINE_NOEXCEPT_JIT_OPERATION):
* Source/JavaScriptCore/wasm/WasmOperations.h:
* Source/JavaScriptCore/wasm/WasmOperationsInlines.h:
(JSC::Wasm::tableGet):
(JSC::Wasm::tableSet):
(JSC::Wasm::tableInit):
(JSC::Wasm::tableFill):
(JSC::Wasm::tableGrow):
(JSC::Wasm::tableCopy):
* Source/JavaScriptCore/wasm/WasmTable.cpp:
(JSC::Wasm::Table::grow):
* Source/JavaScriptCore/wasm/WasmTable.h:
(JSC::Wasm::Table::isValidLength):

Canonical link: <a href="https://commits.webkit.org/318016@main">https://commits.webkit.org/318016@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3490520f57f6d204c11991ee7feb36e1b5b8d01f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177078 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51015 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/44810 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186681 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140314 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f02113ce-a523-4c7a-9274-f2404864e46d) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52308 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50701 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/137972 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140314 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180034 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/41480 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/44810 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/118440 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/40136 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/38504 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/251/builds/409 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/44810 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/150546 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/44810 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35149 "Built successfully") | | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/38349 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/42789 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/42722 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189107 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50682 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/44810 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/147054 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39518 "Built successfully and passed tests") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/51365 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/44810 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146845 "Passed tests") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/51365 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/123579 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/117866 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49870 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/44810 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/49269 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/49506 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49330 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->