### PR TITLE
Begin implementing WebTransport.getStats

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/stats.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/stats.https.any-expected.txt
@@ -1,10 +1,10 @@
 
-FAIL WebTransport client should be able to provide stats after connection has been established assert_greater_than: minRtt expected a number greater than 0 but got 0
-FAIL WebTransport client should be able to provide stats after connection has been closed promise_test: Unhandled rejection with value: object "InvalidStateError: The object is in an invalid state."
-FAIL WebTransport client should be able to provide stats requested right before connection has been closed assert_greater_than: minRtt expected a number greater than 0 but got 0
-FAIL WebTransport client should be able to provide valid stats when requested before connection established assert_greater_than: minRtt expected a number greater than 0 but got 0
-FAIL WebTransport client should throw an error when stats are requested for a failed connection assert_equals: expected (number) 11 but got (undefined) undefined
-FAIL WebTransport client should be able to handle multiple concurrent stats requests assert_greater_than: minRtt expected a number greater than 0 but got 0
-FAIL WebTransport client should be able to handle multiple sequential stats requests assert_greater_than: minRtt expected a number greater than 0 but got 0
+PASS WebTransport client should be able to provide stats after connection has been established
+PASS WebTransport client should be able to provide stats after connection has been closed
+PASS WebTransport client should be able to provide stats requested right before connection has been closed
+PASS WebTransport client should be able to provide valid stats when requested before connection established
+PASS WebTransport client should throw an error when stats are requested for a failed connection
+PASS WebTransport client should be able to handle multiple concurrent stats requests
+PASS WebTransport client should be able to handle multiple sequential stats requests
 FAIL WebTransport client should be able to provide droppedIncoming values for datagrams assert_greater_than: expected a number greater than 0 but got 0
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/stats.https.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/stats.https.any.serviceworker-expected.txt
@@ -1,10 +1,10 @@
 
-FAIL WebTransport client should be able to provide stats after connection has been established assert_greater_than: minRtt expected a number greater than 0 but got 0
-FAIL WebTransport client should be able to provide stats after connection has been closed promise_test: Unhandled rejection with value: object "InvalidStateError: The object is in an invalid state."
-FAIL WebTransport client should be able to provide stats requested right before connection has been closed assert_greater_than: minRtt expected a number greater than 0 but got 0
-FAIL WebTransport client should be able to provide valid stats when requested before connection established assert_greater_than: minRtt expected a number greater than 0 but got 0
-FAIL WebTransport client should throw an error when stats are requested for a failed connection assert_equals: expected (number) 11 but got (undefined) undefined
-FAIL WebTransport client should be able to handle multiple concurrent stats requests assert_greater_than: minRtt expected a number greater than 0 but got 0
-FAIL WebTransport client should be able to handle multiple sequential stats requests assert_greater_than: minRtt expected a number greater than 0 but got 0
+PASS WebTransport client should be able to provide stats after connection has been established
+PASS WebTransport client should be able to provide stats after connection has been closed
+PASS WebTransport client should be able to provide stats requested right before connection has been closed
+PASS WebTransport client should be able to provide valid stats when requested before connection established
+PASS WebTransport client should throw an error when stats are requested for a failed connection
+PASS WebTransport client should be able to handle multiple concurrent stats requests
+PASS WebTransport client should be able to handle multiple sequential stats requests
 FAIL WebTransport client should be able to provide droppedIncoming values for datagrams assert_greater_than: expected a number greater than 0 but got 0
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/stats.https.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/stats.https.any.sharedworker-expected.txt
@@ -1,10 +1,10 @@
 
-FAIL WebTransport client should be able to provide stats after connection has been established assert_greater_than: minRtt expected a number greater than 0 but got 0
-FAIL WebTransport client should be able to provide stats after connection has been closed promise_test: Unhandled rejection with value: object "InvalidStateError: The object is in an invalid state."
-FAIL WebTransport client should be able to provide stats requested right before connection has been closed assert_greater_than: minRtt expected a number greater than 0 but got 0
-FAIL WebTransport client should be able to provide valid stats when requested before connection established assert_greater_than: minRtt expected a number greater than 0 but got 0
-FAIL WebTransport client should throw an error when stats are requested for a failed connection assert_equals: expected (number) 11 but got (undefined) undefined
-FAIL WebTransport client should be able to handle multiple concurrent stats requests assert_greater_than: minRtt expected a number greater than 0 but got 0
-FAIL WebTransport client should be able to handle multiple sequential stats requests assert_greater_than: minRtt expected a number greater than 0 but got 0
+PASS WebTransport client should be able to provide stats after connection has been established
+PASS WebTransport client should be able to provide stats after connection has been closed
+PASS WebTransport client should be able to provide stats requested right before connection has been closed
+PASS WebTransport client should be able to provide valid stats when requested before connection established
+PASS WebTransport client should throw an error when stats are requested for a failed connection
+PASS WebTransport client should be able to handle multiple concurrent stats requests
+PASS WebTransport client should be able to handle multiple sequential stats requests
 FAIL WebTransport client should be able to provide droppedIncoming values for datagrams assert_greater_than: expected a number greater than 0 but got 0
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/stats.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/stats.https.any.worker-expected.txt
@@ -1,10 +1,10 @@
 
-FAIL WebTransport client should be able to provide stats after connection has been established assert_greater_than: minRtt expected a number greater than 0 but got 0
-FAIL WebTransport client should be able to provide stats after connection has been closed promise_test: Unhandled rejection with value: object "InvalidStateError: The object is in an invalid state."
-FAIL WebTransport client should be able to provide stats requested right before connection has been closed assert_greater_than: minRtt expected a number greater than 0 but got 0
-FAIL WebTransport client should be able to provide valid stats when requested before connection established assert_greater_than: minRtt expected a number greater than 0 but got 0
-FAIL WebTransport client should throw an error when stats are requested for a failed connection assert_equals: expected (number) 11 but got (undefined) undefined
-FAIL WebTransport client should be able to handle multiple concurrent stats requests assert_greater_than: minRtt expected a number greater than 0 but got 0
-FAIL WebTransport client should be able to handle multiple sequential stats requests assert_greater_than: minRtt expected a number greater than 0 but got 0
+PASS WebTransport client should be able to provide stats after connection has been established
+PASS WebTransport client should be able to provide stats after connection has been closed
+PASS WebTransport client should be able to provide stats requested right before connection has been closed
+PASS WebTransport client should be able to provide valid stats when requested before connection established
+PASS WebTransport client should throw an error when stats are requested for a failed connection
+PASS WebTransport client should be able to handle multiple concurrent stats requests
+PASS WebTransport client should be able to handle multiple sequential stats requests
 FAIL WebTransport client should be able to provide droppedIncoming values for datagrams assert_greater_than: expected a number greater than 0 but got 0
 

--- a/Source/WebCore/Modules/webtransport/WebTransport.cpp
+++ b/Source/WebCore/Modules/webtransport/WebTransport.cpp
@@ -166,6 +166,7 @@ void WebTransport::initializeOverHTTP(SocketProvider& provider, ScriptExecutionC
 
     // FIXME: Rename SocketProvider to NetworkProvider or something to reflect that it provides a little more than just simple sockets. SocketAndTransportProvider?
     auto [session, promise] = provider.initializeWebTransportSession(context, *this, url, options);
+    ASSERT(!m_session);
     m_session = WTF::move(session);
     m_datagrams->attachTo(*this);
 
@@ -196,6 +197,8 @@ WebTransport::WebTransport(ScriptExecutionContext& context, JSDOMGlobalObject& g
     , m_receiveStreamSource(WTF::move(receiveStreamSource))
     , m_bidirectionalStreamSource(WTF::move(bidirectionalStreamSource))
 {
+    // FIXME: Change initializeWebTransportSession to being called in the constructor,
+    // and change m_session to being a const Ref.
 }
 
 WebTransport::~WebTransport() = default;
@@ -250,7 +253,7 @@ void WebTransport::receiveIncomingUnidirectionalStream(WebTransportStreamIdentif
         ASSERT(!m_readStreamSources.contains(identifier));
         m_readStreamSources.add(identifier, WTF::move(incomingStream));
     } else
-        protect(m_session)->destroyStream(identifier, std::nullopt);
+        session->destroyStream(identifier, std::nullopt);
 }
 
 static ExceptionOr<Ref<WebTransportBidirectionalStream>> createBidirectionalStream(WebTransport& transport, WebTransportSession& session, JSDOMGlobalObject& globalObject, Ref<WebTransportSendStreamSink>&& sink, Ref<WebTransportReceiveStreamByteSource>&& source, const WebTransportSendStreamOptions& options)
@@ -301,7 +304,7 @@ void WebTransport::receiveBidirectionalStream(WebTransportStreamIdentifier ident
         ASSERT(!m_sendStreamSinks.contains(identifier));
         m_sendStreamSinks.add(identifier, WTF::move(sink));
     } else
-        protect(m_session)->destroyStream(identifier, std::nullopt);
+        session->destroyStream(identifier, std::nullopt);
 }
 
 void WebTransport::streamReceiveBytes(WebTransportStreamIdentifier identifier, std::span<const uint8_t> span, bool withFin, std::optional<Exception>&& exception)
@@ -365,6 +368,9 @@ void WebTransport::getStats(ScriptExecutionContext& context, Ref<DeferredPromise
 {
     RefPtr session = m_session;
     if (!session)
+        return promise->reject(ExceptionCode::InvalidStateError);
+
+    if (m_state == State::Failed)
         return promise->reject(ExceptionCode::InvalidStateError);
 
     context.enqueueTaskWhenSettled(session->getStats(), WebCore::TaskSource::Networking, [promise = WTF::move(promise)] (auto&& stats) mutable {
@@ -462,7 +468,7 @@ void WebTransport::cleanupContext()
     // (frame detached, null global object) and drop the rejection; this instead runs on resume.
     if (m_state == State::Connected) {
         m_state = State::Failed;
-        if (auto session = std::exchange(m_session, nullptr))
+        if (RefPtr session = m_session)
             session->terminate(0, { });
         queueTaskKeepingObjectAlive(*this, TaskSource::Networking, [](auto& transport) {
             transport.cleanupWithSessionError();
@@ -479,7 +485,7 @@ void WebTransport::close(WebTransportCloseInfo&& closeInfo)
         return;
     if (m_state == State::Connecting)
         return cleanupWithSessionError();
-    if (auto session = std::exchange(m_session, nullptr))
+    if (RefPtr session = m_session)
         session->terminate(closeInfo.closeCode, trimToValidUTF8Length1024(closeInfo.reason.utf8()));
     cleanup(DOMException::create(ExceptionCode::AbortError), WTF::move(closeInfo));
 }
@@ -535,8 +541,6 @@ void WebTransport::cleanup(Ref<DOMException>&& exception, std::optional<WebTrans
         for (Ref datagramsWritable : std::exchange(m_datagramsWritables, { }))
             datagramsWritable->errorIfPossible(jsDOMGlobalObject, jsException);
     }
-
-    m_session = nullptr;
 }
 
 void WebTransport::datagramsWritableCreated(WebTransportDatagramsWritable& writable)

--- a/Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.cpp
+++ b/Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.cpp
@@ -35,13 +35,18 @@
 #include <WebCore/WebTransportConnectionStats.h>
 #include <WebCore/WebTransportReceiveStreamStats.h>
 #include <WebCore/WebTransportSendStreamStats.h>
+#include <wtf/ReducedResolutionSeconds.h>
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(NetworkTransportSession);
 
-NetworkTransportSession::~NetworkTransportSession() = default;
+NetworkTransportSession::~NetworkTransportSession()
+{
+    for (auto&& statsRequest : std::exchange(m_statsRequestsBeforeInitialization, { }))
+        statsRequest(std::nullopt);
+}
 
 IPC::Connection* NetworkTransportSession::messageSenderConnection() const
 {
@@ -63,6 +68,7 @@ void NetworkTransportSession::streamSendBytes(WebCore::WebTransportStreamIdentif
 
 void NetworkTransportSession::receiveDatagram(std::span<const uint8_t> datagram, bool withFin, std::optional<WebCore::Exception>&& exception)
 {
+    m_datagramBytesReceived += datagram.size();
     send(Messages::WebTransportSession::ReceiveDatagram(datagram, withFin, WTF::move(exception)));
 }
 
@@ -105,8 +111,11 @@ void NetworkTransportSession::cancelSendStream(WebCore::WebTransportStreamIdenti
 
 void NetworkTransportSession::destroyStream(WebCore::WebTransportStreamIdentifier identifier, std::optional<WebCore::WebTransportStreamErrorCode> errorCode)
 {
-    if (RefPtr stream = m_streams.take(identifier))
+    if (RefPtr stream = m_streams.take(identifier)) {
         stream->cancel(errorCode);
+        m_bytesSentOnClosedStreams += stream->bytesSent();
+        m_bytesReceivedOnClosedStreams += stream->bytesReceived();
+    }
 }
 
 std::optional<SharedPreferencesForWebProcess> NetworkTransportSession::sharedPreferencesForWebProcess() const
@@ -136,7 +145,7 @@ void NetworkTransportSession::getReceiveStreamStats(WebCore::WebTransportStreamI
 void NetworkTransportSession::getSendGroupStats(WebCore::WebTransportSendGroupIdentifier identifier, CompletionHandler<void(std::optional<WebCore::WebTransportSendStreamStats>&&)>&& completionHandler)
 {
     // FIXME: Get better data from the stream.
-    uint64_t bytesSent = m_datagramStats.get(identifier);
+    uint64_t bytesSent = m_datagramBytesSent.get(identifier);
     completionHandler(WebCore::WebTransportSendStreamStats {
         bytesSent,
         bytesSent,
@@ -162,6 +171,66 @@ void NetworkTransportSession::incomingMaxBufferedDatagramsUpdated(uint32_t)
 void NetworkTransportSession::outgoingMaxBufferedDatagramsUpdated(uint32_t)
 {
     // FIXME: Use this value.
+}
+
+void NetworkTransportSession::getStats(CompletionHandler<void(std::optional<WebCore::WebTransportConnectionStats>&&)>&& completionHandler)
+{
+    switch (m_initializationState) {
+    case InitializationState::Waiting:
+        m_statsRequestsBeforeInitialization.append(WTF::move(completionHandler));
+        return;
+    case InitializationState::Failed:
+        return completionHandler(std::nullopt);
+    case InitializationState::Succeeded:
+        break;
+    }
+
+    // FIXME: Get better stats from the network implementation.
+    uint64_t bytesSent = m_bytesSentOnClosedStreams;
+    uint64_t bytesReceived = m_bytesReceivedOnClosedStreams;
+    for (Ref stream : m_streams.values()) {
+        bytesSent += stream->bytesSent();
+        bytesReceived += stream->bytesReceived();
+    }
+    for (uint64_t datagramBytesSent : m_datagramBytesSent.values())
+        bytesSent += datagramBytesSent;
+    bytesReceived += m_datagramBytesReceived;
+
+    // https://www.w3.org/TR/hr-time-3/#dfn-coarsen-time
+    auto roundTo100Microseconds = [] (Seconds time) {
+        return ReducedResolutionSeconds::reduce(time, 100_us).milliseconds();
+    };
+
+    completionHandler(WebCore::WebTransportConnectionStats {
+        bytesSent,
+        0, /* packetsSent */
+        0, /* bytesLost */
+        0, /* packetsLost */
+        bytesReceived,
+        0, /* packetsReceived */
+        roundTo100Microseconds(m_initializationTime), /* smoothedRtt */
+        0, /* rttVariation */
+        roundTo100Microseconds(m_initializationTime), /* minRtt */
+        WebCore::WebTransportDatagramStats { },
+        std::nullopt, /* estimatedSendRate */
+        false /* atSendCapacity */
+    });
+}
+
+void NetworkTransportSession::completeStatsRequestsAfterInitialization(std::optional<Seconds> initializationTime)
+{
+    ASSERT(!m_initializationTime);
+    ASSERT(m_initializationState == InitializationState::Waiting);
+    if (!initializationTime) {
+        m_initializationState = InitializationState::Failed;
+        for (auto&& statsRequest : std::exchange(m_statsRequestsBeforeInitialization, { }))
+            statsRequest(std::nullopt);
+        return;
+    }
+    m_initializationState = InitializationState::Succeeded;
+    m_initializationTime = *initializationTime;
+    for (auto&& statsRequest : std::exchange(m_statsRequestsBeforeInitialization, { }))
+        getStats(WTF::move(statsRequest));
 }
 
 #if !PLATFORM(COCOA)
@@ -193,11 +262,6 @@ void NetworkTransportSession::createOutgoingUnidirectionalStream(CompletionHandl
 void NetworkTransportSession::createBidirectionalStream(CompletionHandler<void(std::optional<WebCore::WebTransportStreamIdentifier>)>&& completionHandler)
 {
     completionHandler(std::nullopt);
-}
-
-void NetworkTransportSession::getStats(CompletionHandler<void(WebCore::WebTransportConnectionStats&&)>&& completionHandler)
-{
-    completionHandler({ });
 }
 
 void NetworkTransportSession::terminate(WebCore::WebTransportSessionErrorCode, CString&&)

--- a/Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.h
+++ b/Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.h
@@ -80,7 +80,7 @@ public:
     void sendDatagram(std::optional<WebCore::WebTransportSendGroupIdentifier>, std::span<const uint8_t>, CompletionHandler<void(std::optional<WebCore::Exception>&&)>&&);
     void createOutgoingUnidirectionalStream(CompletionHandler<void(std::optional<WebCore::WebTransportStreamIdentifier>)>&&);
     void createBidirectionalStream(CompletionHandler<void(std::optional<WebCore::WebTransportStreamIdentifier>)>&&);
-    void getStats(CompletionHandler<void(WebCore::WebTransportConnectionStats&&)>&&);
+    void getStats(CompletionHandler<void(std::optional<WebCore::WebTransportConnectionStats>&&)>&&);
     void getSendStreamStats(WebCore::WebTransportStreamIdentifier, CompletionHandler<void(std::optional<WebCore::WebTransportSendStreamStats>&&)>&&);
     void getReceiveStreamStats(WebCore::WebTransportStreamIdentifier, CompletionHandler<void(std::optional<WebCore::WebTransportReceiveStreamStats>&&)>&&);
     void getSendGroupStats(WebCore::WebTransportSendGroupIdentifier, CompletionHandler<void(std::optional<WebCore::WebTransportSendStreamStats>&&)>&&);
@@ -121,12 +121,24 @@ private:
     void setupDatagramConnection(CompletionHandler<void(std::optional<WebCore::WebTransportConnectionInfo>&&)>&&);
     void receiveDatagramLoop();
     void createStream(NetworkTransportStreamType, CompletionHandler<void(std::optional<WebCore::WebTransportStreamIdentifier>)>&&);
+    void completeStatsRequestsAfterInitialization(std::optional<Seconds>);
 
     HashMap<WebCore::WebTransportStreamIdentifier, Ref<NetworkTransportStream>> m_streams;
     WeakPtr<NetworkConnectionToWebProcess> m_connectionToWebProcess;
     const WebTransportSessionIdentifier m_identifier;
     const WebCore::WebTransportOptions m_options;
-    HashMap<WebCore::WebTransportSendGroupIdentifier, uint64_t> m_datagramStats;
+    HashMap<WebCore::WebTransportSendGroupIdentifier, uint64_t> m_datagramBytesSent;
+    uint64_t m_datagramBytesReceived { 0 };
+
+    uint64_t m_bytesSentOnClosedStreams { 0 };
+    uint64_t m_bytesReceivedOnClosedStreams { 0 };
+    Seconds m_initializationTime;
+    enum class InitializationState : uint8_t {
+        Waiting,
+        Succeeded,
+        Failed
+    } m_initializationState { InitializationState::Waiting };
+    Vector<CompletionHandler<void(std::optional<WebCore::WebTransportConnectionStats>&&)>> m_statsRequestsBeforeInitialization;
 
 #if PLATFORM(COCOA)
     const RetainPtr<nw_connection_group_t> m_connectionGroup;

--- a/Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.messages.in
+++ b/Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.messages.in
@@ -29,7 +29,7 @@ messages -> NetworkTransportSession {
     SendDatagram(std::optional<WebCore::WebTransportSendGroupIdentifier> identifier, std::span<const uint8_t> datagram) -> (std::optional<WebCore::Exception> exception)
     CreateOutgoingUnidirectionalStream() -> (std::optional<WebCore::WebTransportStreamIdentifier> identifier)
     CreateBidirectionalStream() -> (std::optional<WebCore::WebTransportStreamIdentifier> identifier)
-    GetStats() -> (struct WebCore::WebTransportConnectionStats stats)
+    GetStats() -> (struct std::optional<WebCore::WebTransportConnectionStats> stats)
     GetSendStreamStats(WebCore::WebTransportStreamIdentifier identifier) -> (struct std::optional<WebCore::WebTransportSendStreamStats> stats)
     GetReceiveStreamStats(WebCore::WebTransportStreamIdentifier identifier) -> (struct std::optional<WebCore::WebTransportReceiveStreamStats> stats)
     GetSendGroupStats(WebCore::WebTransportSendGroupIdentifier identifier) -> (struct std::optional<WebCore::WebTransportSendStreamStats> stats)

--- a/Source/WebKit/NetworkProcess/webtransport/NetworkTransportStream.h
+++ b/Source/WebKit/NetworkProcess/webtransport/NetworkTransportStream.h
@@ -73,6 +73,8 @@ public:
     void cancel(std::optional<WebCore::WebTransportStreamErrorCode>);
     WebCore::WebTransportSendStreamStats NODELETE getSendStreamStats();
     WebCore::WebTransportReceiveStreamStats NODELETE getReceiveStreamStats();
+    uint64_t bytesSent() const { return m_bytesSent; }
+    uint64_t bytesReceived() const { return m_bytesReceived; }
 
 private:
 #if PLATFORM(COCOA)

--- a/Source/WebKit/NetworkProcess/webtransport/cocoa/NetworkTransportSessionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/webtransport/cocoa/NetworkTransportSessionCocoa.mm
@@ -296,9 +296,15 @@ void NetworkTransportSession::initialize(CompletionHandler<void(std::optional<We
         return;
     }
 
-    auto creationCompletionHandler = [completionHandler = WTF::move(completionHandler)] (std::optional<WebCore::WebTransportConnectionInfo>&& connectionInfo) mutable {
+    auto creationCompletionHandler = [
+        completionHandler = WTF::move(completionHandler),
+        initializationStartTime = MonotonicTime::now(),
+        weakThis = WeakPtr { *this }
+    ] (std::optional<WebCore::WebTransportConnectionInfo>&& connectionInfo) mutable {
         if (!completionHandler)
             return;
+        if (RefPtr strongThis = weakThis.get())
+            strongThis->completeStatsRequestsAfterInitialization(connectionInfo ? std::optional(MonotonicTime::now() - initializationStartTime) : std::nullopt);
         return completionHandler(WTF::move(connectionInfo));
     };
 
@@ -378,12 +384,6 @@ void NetworkTransportSession::createBidirectionalStream(CompletionHandler<void(s
     createStream(NetworkTransportStreamType::Bidirectional, WTF::move(completionHandler));
 }
 
-void NetworkTransportSession::getStats(CompletionHandler<void(WebCore::WebTransportConnectionStats&&)>&& completionHandler)
-{
-    // FIXME: Implement.
-    completionHandler({ });
-}
-
 void NetworkTransportSession::createOutgoingUnidirectionalStream(CompletionHandler<void(std::optional<WebCore::WebTransportStreamIdentifier>)>&& completionHandler)
 {
     createStream(NetworkTransportStreamType::OutgoingUnidirectional, WTF::move(completionHandler));
@@ -448,7 +448,7 @@ void NetworkTransportSession::setupDatagramConnection(CompletionHandler<void(std
 void NetworkTransportSession::sendDatagram(std::optional<WebCore::WebTransportSendGroupIdentifier> identifier, std::span<const uint8_t> data, CompletionHandler<void(std::optional<WebCore::Exception>&&)>&& completionHandler)
 {
     if (identifier) {
-        m_datagramStats.ensure(*identifier, [] {
+        m_datagramBytesSent.ensure(*identifier, [] {
             return uint64_t { };
         }).iterator->value += data.size();
     }

--- a/Source/WebKit/WebProcess/Network/WebTransportSession.cpp
+++ b/Source/WebKit/WebProcess/Network/WebTransportSession.cpp
@@ -170,9 +170,9 @@ Ref<WebCore::WebTransportConnectionStatsPromise> WebTransportSession::getStats()
 {
     return sendWithPromisedReply(Messages::NetworkTransportSession::GetStats())->whenSettled(RunLoop::mainSingleton(), [] (auto&& stats) mutable {
         ASSERT(RunLoop::isMain());
-        if (!stats)
+        if (!stats || !*stats)
             return WebCore::WebTransportConnectionStatsPromise::createAndReject();
-        return WebCore::WebTransportConnectionStatsPromise::createAndResolve(WTF::move(*stats));
+        return WebCore::WebTransportConnectionStatsPromise::createAndResolve(WTF::move(**stats));
     });
 }
 


### PR DESCRIPTION
#### a4b377ac567badb50a448d4ff2f7039a9e788107
<pre>
Begin implementing WebTransport.getStats
<a href="https://bugs.webkit.org/show_bug.cgi?id=319926">https://bugs.webkit.org/show_bug.cgi?id=319926</a>
<a href="https://rdar.apple.com/182852612">rdar://182852612</a>

Reviewed by Basuke Suzuki.

This required a few things to get right:
1. We need to be able to get stats after a connection has closed, so we can&apos;t null out m_session
   because that&apos;s our only way to communicate with the network process.  We need to keep it non-null
   and use m_state for any JS-visible early returns.  I audited use of m_session to make sure
   that the early returns from m_session being null are not JS-visible.
2. getStats can be called before the WebTransport session has been initialized over the network.
   To implement this, I added a Vector&lt;CompletionHandler&gt; on NetworkTransportSession to keep the
   completion handlers that we receive before initialization has completed.
3. I keep some more statistics on NetworkTransportSession to be able to provide stats that we can
   keep without asking the networking implementation to provide more stats, which hasn&apos;t been implemented
   yet.  The trickiest one was m_initializationTime which is the amount of time it took to initialize
   over the network, which is the one API call we have that we know did a roundtrip over the network.
   I use this as the basis for my bad implementation of rtt stats, to be improved upon once we have
   support in Network.framework.
4. When network setup fails, we need to fail any stats requests we&apos;ve already received before it failed
   with DOMException.INVALID_STATE_ERR.  To make this possible, I need to change the promised async
   return type from WebTransportConnectionInfo to std::optional&lt;WebTransportConnectionInfo&gt; to handle failure.

* LayoutTests/imported/w3c/web-platform-tests/webtransport/stats.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webtransport/stats.https.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webtransport/stats.https.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webtransport/stats.https.any.worker-expected.txt:
* Source/WebCore/Modules/webtransport/WebTransport.cpp:
(WebCore::WebTransport::initializeOverHTTP):
(WebCore::WebTransport::WebTransport):
(WebCore::WebTransport::receiveIncomingUnidirectionalStream):
(WebCore::WebTransport::receiveBidirectionalStream):
(WebCore::WebTransport::getStats):
(WebCore::WebTransport::cleanupContext):
(WebCore::WebTransport::close):
(WebCore::WebTransport::cleanup):
* Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.cpp:
(WebKit::NetworkTransportSession::~NetworkTransportSession):
(WebKit::NetworkTransportSession::receiveDatagram):
(WebKit::NetworkTransportSession::destroyStream):
(WebKit::NetworkTransportSession::getSendGroupStats):
(WebKit::NetworkTransportSession::getStats):
(WebKit::NetworkTransportSession::completeStatsRequestsAfterInitialization):
* Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.h:
* Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.messages.in:
* Source/WebKit/NetworkProcess/webtransport/NetworkTransportStream.h:
(WebKit::NetworkTransportStream::bytesSent const):
(WebKit::NetworkTransportStream::bytesReceived const):
* Source/WebKit/NetworkProcess/webtransport/cocoa/NetworkTransportSessionCocoa.mm:
(WebKit::NetworkTransportSession::initialize):
(WebKit::NetworkTransportSession::sendDatagram):
(WebKit::NetworkTransportSession::getStats): Deleted.
* Source/WebKit/WebProcess/Network/WebTransportSession.cpp:
(WebKit::WebTransportSession::getStats):

Canonical link: <a href="https://commits.webkit.org/317679@main">https://commits.webkit.org/317679@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aa3392c1bb1334647e1708045398f874ee62c924

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175964 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49897 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43681 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185557 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/138175 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bfb6f045-e26c-427f-b24a-fb23d8155e2e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/177827 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51189 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49579 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137029 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/138175 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5c00f74d-fc49-42e0-8167-8ba758f29010) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178920 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40503 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157806 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117508 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/aa4643aa-0885-40af-a3b5-a2db5195640b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39145 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37516 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149564 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37298 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34027 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41598 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/41722 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187979 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49564 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146029 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50244 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/33923 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145866 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26742 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40652 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122440 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/116318 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48751 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12279 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48153 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48385 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48210 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->