### PR TITLE
Support external and data: URL clip-path references on HTML elements

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -3077,7 +3077,6 @@ imported/w3c/web-platform-tests/css/css-masking/mask-image/mask-origin-3.html [ 
 imported/w3c/web-platform-tests/css/css-masking/animations/clip-path-interpolation-shape-arc-direction-agnostic-radius.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-polygon-014.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-url-reference-empty-while-loading.tentative.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-url-reference-external.html [ ImageOnlyFailure ]
 
 # A support file for a test
 imported/w3c/web-platform-tests/css/css-masking/clip-path/svg-clipPath.svg [ Skip ]

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/img-src/css-clip-path-blocked.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/img-src/css-clip-path-blocked.tentative-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Blocked CSS clip-path: SVG
+

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/img-src/css-clip-path-blocked.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/img-src/css-clip-path-blocked.tentative.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta http-equiv="Content-Security-Policy" content="img-src 'none'">
+    <title>SVG in CSS clip-path: blocked as img</title>
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <script>
+      async_test(t => {
+        window.addEventListener('securitypolicyviolation',
+                                t.step_func_done(e => {
+          assert_equals(e.effectiveDirective, "img-src");
+          assert_true(e.blockedURI.endsWith("clip-path.svg"));
+        }));
+      }, "Blocked CSS clip-path: SVG");
+    </script>
+</head>
+<body>
+  <style>
+    body {
+      clip-path: url("clip-path.svg#circle");
+    }
+  </style>
+</body>
+</html>

--- a/Source/WebCore/rendering/ReferencedSVGResources.cpp
+++ b/Source/WebCore/rendering/ReferencedSVGResources.cpp
@@ -28,6 +28,7 @@
 #include "ReferencedSVGResources.h"
 
 #include "ContainerNodeInlines.h"
+#include "Document.h"
 #include "DocumentView.h"
 #include "LegacyRenderSVGResourceClipper.h"
 #include "LegacyRenderSVGResourceContainerInlines.h"
@@ -40,6 +41,8 @@
 #include "RenderSVGResourcePaintServer.h"
 #include "RenderSVGResourcePattern.h"
 #include "SVGClipPathElement.h"
+#include "SVGDocument.h"
+#include "SVGDocumentExtensions.h"
 #include "SVGElementTypeHelpers.h"
 #include "SVGFilterElement.h"
 #include "SVGMarkerElement.h"
@@ -359,6 +362,16 @@ LegacyRenderSVGResourceClipper* ReferencedSVGResources::referencedClipperRendere
 {
     if (clipPath.fragment().isEmpty())
         return nullptr;
+
+    Ref document = treeScope.documentScope();
+    CheckedRef extensions = document->svgExtensions();
+    if (auto externalDocument = extensions->externalResourceDocument(clipPath.url().resolved)) {
+        RefPtr resolvedDocument = *externalDocument;
+        if (!resolvedDocument)
+            return nullptr;
+        return getRenderSVGResourceById<LegacyRenderSVGResourceClipper>(*resolvedDocument, clipPath.fragment());
+    }
+
     // For some reason, SVG stores a cache of id -> renderer, rather than just using getElementById() and renderer().
     return getRenderSVGResourceById<LegacyRenderSVGResourceClipper>(treeScope, clipPath.fragment());
 }

--- a/Source/WebCore/rendering/svg/legacy/SVGResources.cpp
+++ b/Source/WebCore/rendering/svg/legacy/SVGResources.cpp
@@ -204,26 +204,6 @@ static CheckedPtr<LegacyRenderSVGResourceContainer> paintingResourceFromTreeScop
     return container;
 }
 
-// The return value is tri-state because callers need to distinguish whether the reference is external at
-// all, and if so whether it's loaded yet: nullopt = not an external/data reference (resolve locally);
-// null RefPtr = external but not loaded yet (resolve to nothing); non-null = the isolated document to
-// resolve in.
-// FIXME: The external-or-not classification could be computed once at style-build time on Style::URL.
-static std::optional<RefPtr<SVGDocument>> externalSVGResourceDocument(Document& document, const WTF::URL& url)
-{
-    if (!document.settings().svgExternalResourcesEnabled())
-        return std::nullopt;
-
-    if (!url.protocolIsData() && !SVGURIReference::isExternalURIReference(url.string(), document))
-        return std::nullopt;
-
-    auto documentURL = url;
-    documentURL.removeFragmentIdentifier();
-
-    RefPtr isolatedContext = document.svgExtensions().isolatedSVGDocumentContext(documentURL);
-    return RefPtr { isolatedContext ? isolatedContext->document() : nullptr };
-}
-
 static inline CheckedPtr<LegacyRenderSVGResourceContainer> paintingResourceFromSVGPaint(TreeScope& treeScope, const Style::SVGPaint& paint, AtomString& id, bool& hasPendingResource)
 {
     auto paintURL = paint.tryAnyURL();
@@ -232,7 +212,7 @@ static inline CheckedPtr<LegacyRenderSVGResourceContainer> paintingResourceFromS
 
     Ref document = treeScope.documentScope();
 
-    if (auto externalDocument = externalSVGResourceDocument(document, paintURL->resolved)) {
+    if (auto externalDocument = document->svgExtensions().externalResourceDocument(paintURL->resolved)) {
         id = paintURL->resolved.fragmentIdentifier().toAtomString();
         RefPtr resolvedDocument = *externalDocument;
         if (id.isEmpty() || !resolvedDocument)
@@ -272,10 +252,9 @@ std::unique_ptr<SVGResources> SVGResources::buildCachedResources(const RenderEle
     if (clipperFilterMaskerTags().contains(tagName)) {
         WTF::switchOn(style.clipPath(),
             [&](const Style::ReferencePath& clipPath) {
-                if (auto externalDocument = externalSVGResourceDocument(document, clipPath.url().resolved)) {
+                if (auto externalDocument = document->svgExtensions().externalResourceDocument(clipPath.url().resolved)) {
                     if (RefPtr resolvedDocument = *externalDocument) {
-                        auto id = clipPath.url().resolved.fragmentIdentifier().toAtomString();
-                        if (auto* clipper = getRenderSVGResourceById<LegacyRenderSVGResourceClipper>(*resolvedDocument, id))
+                        if (auto* clipper = getRenderSVGResourceById<LegacyRenderSVGResourceClipper>(*resolvedDocument, clipPath.fragment()))
                             ensureResources(foundResources).setClipper(clipper);
                     }
                     return;
@@ -292,7 +271,7 @@ std::unique_ptr<SVGResources> SVGResources::buildCachedResources(const RenderEle
             WTF::switchOn(style.filter().first(),
                 [&](const Style::FilterReference& filterReference) {
                     auto& id = filterReference.cachedFragment;
-                    if (auto externalDocument = externalSVGResourceDocument(document, filterReference.url.resolved)) {
+                    if (auto externalDocument = document->svgExtensions().externalResourceDocument(filterReference.url.resolved)) {
                         if (RefPtr resolvedDocument = *externalDocument) {
                             if (auto* filter = getRenderSVGResourceById<LegacyRenderSVGResourceFilter>(*resolvedDocument, id))
                                 ensureResources(foundResources).setFilter(filter);
@@ -323,7 +302,7 @@ std::unique_ptr<SVGResources> SVGResources::buildCachedResources(const RenderEle
     if (markerTags().contains(tagName) && style.hasMarkers()) {
         auto buildCachedMarkerResource = [&](const Style::SVGMarkerResource& markerResource, bool (SVGResources::*setMarker)(LegacyRenderSVGResourceMarker*)) {
             if (auto markerURL = markerResource.tryURL()) {
-                if (auto externalDocument = externalSVGResourceDocument(document, markerURL->resolved)) {
+                if (auto externalDocument = document->svgExtensions().externalResourceDocument(markerURL->resolved)) {
                     if (RefPtr resolvedDocument = *externalDocument) {
                         auto markerId = markerURL->resolved.fragmentIdentifier().toAtomString();
                         if (auto* marker = getRenderSVGResourceById<LegacyRenderSVGResourceMarker>(*resolvedDocument, markerId))

--- a/Source/WebCore/style/StylePendingResources.cpp
+++ b/Source/WebCore/style/StylePendingResources.cpp
@@ -164,27 +164,28 @@ void loadPendingResources(Style::ComputedStyle& style, Document& document, const
     if (RefPtr shapeValueImage = style.shapeOutside().image())
         loadPendingImage(document, shapeValueImage.get(), element, LoadPolicy::Anonymous);
 
-    // External/data: SVG paint servers and filters resolve through SVGResources, which only applies
-    // to SVG elements. Restrict loading to them so CSS filter on non-SVG elements (a separate path)
-    // isn't pulled through here.
-    if (document.settings().svgExternalResourcesEnabled() && element && is<SVGElement>(*element)) {
-        loadPendingExternalSVGPaint(document, style.fill());
-        loadPendingExternalSVGPaint(document, style.stroke());
+    if (document.settings().svgExternalResourcesEnabled()) {
+        // Paint servers, markers, and filter= resolve through SVGResources, which only applies to SVG
+        // elements.
+        if (element && is<SVGElement>(*element)) {
+            loadPendingExternalSVGPaint(document, style.fill());
+            loadPendingExternalSVGPaint(document, style.stroke());
 
-        loadPendingExternalSVGMarker(document, style.markerStart());
-        loadPendingExternalSVGMarker(document, style.markerMid());
-        loadPendingExternalSVGMarker(document, style.markerEnd());
+            loadPendingExternalSVGMarker(document, style.markerStart());
+            loadPendingExternalSVGMarker(document, style.markerMid());
+            loadPendingExternalSVGMarker(document, style.markerEnd());
+
+            if (style.filter().size() == 1) {
+                WTF::switchOn(style.filter().first(),
+                    [&](const Style::FilterReference& filterReference) {
+                        loadExternalSVGResource(document, filterReference.url.resolved);
+                    },
+                    [](const auto&) { }
+                );
+            }
+        }
 
         loadPendingExternalSVGClipPath(document, style.clipPath());
-
-        if (style.filter().size() == 1) {
-            WTF::switchOn(style.filter().first(),
-                [&](const Style::FilterReference& filterReference) {
-                    loadExternalSVGResource(document, filterReference.url.resolved);
-                },
-                [](const auto&) { }
-            );
-        }
     }
 
     // Are there other pseudo-elements that need resource loading?

--- a/Source/WebCore/style/values/shapes/StylePathOperationWrappers.cpp
+++ b/Source/WebCore/style/values/shapes/StylePathOperationWrappers.cpp
@@ -61,9 +61,10 @@ RefPtr<PathOperation> CSSValueConversion<RefPtr<PathOperation>>::operator()(Buil
     if (RefPtr url = dynamicDowncast<CSSURLValue>(value)) {
         auto styleURL = toStyle(url->url(), state);
 
-        // FIXME: ReferencePathOperation are not hooked up to support remote URLs yet, so only works with document local references. To see an example of how this should work, see Style::FilterReference which supports both document local and remote URLs.
-
-        auto fragment = SVGURIReference::fragmentIdentifierFromIRIString(styleURL, state.document());
+        // FIXME: Unify all the fragment accessing/construction.
+        auto fragment = styleURL.resolved.string().startsWith('#')
+            ? StringView(styleURL.resolved.string()).substring(1).toAtomString()
+            : styleURL.resolved.fragmentIdentifier().toAtomString();
 
         Ref treeScope = [&] -> Ref<const TreeScope> {
             if (auto* element = state.element())

--- a/Source/WebCore/svg/SVGDocumentExtensions.cpp
+++ b/Source/WebCore/svg/SVGDocumentExtensions.cpp
@@ -30,12 +30,15 @@
 #include "IsolatedSVGDocumentContext.h"
 #include "LocalFrame.h"
 #include "SMILTimeContainer.h"
+#include "SVGDocument.h"
 #include "SVGElement.h"
 #include "SVGFontFaceElement.h"
 #include "SVGResourcesCache.h"
 #include "SVGSMILElement.h"
 #include "SVGSVGElement.h"
+#include "SVGURIReference.h"
 #include "SVGUseElement.h"
+#include "Settings.h"
 #include <JavaScriptCore/ConsoleTypes.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/AtomString.h>
@@ -188,6 +191,22 @@ IsolatedSVGDocumentContext* SVGDocumentExtensions::isolatedSVGDocumentContext(co
 {
     auto it = m_externalSVGDocuments.find(url);
     return it != m_externalSVGDocuments.end() ? it->value.ptr() : nullptr;
+}
+
+std::optional<RefPtr<SVGDocument>> SVGDocumentExtensions::externalResourceDocument(const URL& url) const
+{
+    Ref document = m_document.get();
+    if (!document->settings().svgExternalResourcesEnabled())
+        return std::nullopt;
+
+    if (!url.protocolIsData() && !SVGURIReference::isExternalURIReference(url.string(), document))
+        return std::nullopt;
+
+    auto documentURL = url;
+    documentURL.removeFragmentIdentifier();
+
+    RefPtr isolatedContext = isolatedSVGDocumentContext(documentURL);
+    return RefPtr { isolatedContext ? isolatedContext->document() : nullptr };
 }
 
 }

--- a/Source/WebCore/svg/SVGDocumentExtensions.h
+++ b/Source/WebCore/svg/SVGDocumentExtensions.h
@@ -34,6 +34,7 @@ class CachedImage;
 class Document;
 class IsolatedSVGDocumentContext;
 class Element;
+class SVGDocument;
 class SVGElement;
 class SVGFontFaceElement;
 class SVGResourcesCache;
@@ -78,6 +79,12 @@ public:
     bool hasExternalSVGResource(const URL&) const;
     void addExternalSVGResource(const URL&, CachedImage&, Document&);
     IsolatedSVGDocumentContext* isolatedSVGDocumentContext(const URL&) const;
+
+    // The return value is tri-state because callers need to distinguish whether the reference is external
+    // at all, and if so whether it's loaded yet: nullopt = not an external/data reference (resolve
+    // locally); null RefPtr = external but not loaded yet (resolve to nothing); non-null = the isolated
+    // document to resolve in. Requires the SVGExternalResourcesEnabled setting.
+    std::optional<RefPtr<SVGDocument>> externalResourceDocument(const URL&) const;
 
 private:
     WeakRef<Document, WeakPtrImplWithEventTargetData> m_document;


### PR DESCRIPTION
#### bf937fc6f209b17f453d09a2ca0949af5f7b3f4b
<pre>
Support external and data: URL clip-path references on HTML elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=319927">https://bugs.webkit.org/show_bug.cgi?id=319927</a>
<a href="https://rdar.apple.com/182853131">rdar://182853131</a>

Reviewed by Simon Fraser.

clip-path now resolves a &lt;clipPath&gt; referenced by an external file or a
data: URL, on HTML elements.

Also adds a tentative CSP test: an external clip-path resource is fetched
as an image, so it is subject to img-src. This is the first external
SVG-resource reference loaded from an HTML element, so it is the first to
exercise that shared loader behavior under CSP.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/img-src/css-clip-path-blocked.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/img-src/css-clip-path-blocked.tentative.html: Added.
* Source/WebCore/rendering/ReferencedSVGResources.cpp:
(WebCore::ReferencedSVGResources::referencedClipperRenderer):
* Source/WebCore/rendering/svg/legacy/SVGResources.cpp:
(WebCore::paintingResourceFromSVGPaint):
(WebCore::SVGResources::buildCachedResources):
(WebCore::externalSVGResourceDocument): Deleted.
* Source/WebCore/style/StylePendingResources.cpp:
(WebCore::Style::loadPendingResources):
* Source/WebCore/style/values/shapes/StylePathOperationWrappers.cpp:
(WebCore::Style::CSSValueConversion&lt;RefPtr&lt;PathOperation&gt;&gt;::operator):
* Source/WebCore/svg/SVGDocumentExtensions.cpp:
(WebCore::SVGDocumentExtensions::externalResourceDocument const):
* Source/WebCore/svg/SVGDocumentExtensions.h:

Canonical link: <a href="https://commits.webkit.org/317774@main">https://commits.webkit.org/317774@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/704a5ce8cde2ac1fd5754412efe6e79c236bc8b0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176247 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50182 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43972 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185843 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/138491 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/70e823f9-6999-42f6-8b18-36b8f0b99d72) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178110 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51474 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49866 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137271 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/138491 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/28b366b5-270d-477b-8931-bb1f0c262c66) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179203 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40752 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158046 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117746 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/99c8d149-75c3-4466-a0b9-a97dcfd25474) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39401 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37762 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149817 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37543 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34312 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41904 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41973 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188267 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49847 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/157591 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146305 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39364 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50531 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34161 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146130 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40895 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122735 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/116711 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49035 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12515 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48437 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48671 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48496 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->