### PR TITLE
Unify mouse/pen/touch code paths in SimulatedInputDispatcher::transitionInputSourceToState

### DIFF
--- a/Source/WebCore/dom/PointerEventTypeNames.h
+++ b/Source/WebCore/dom/PointerEventTypeNames.h
@@ -31,6 +31,6 @@ namespace WebCore {
 
 WEBCORE_EXPORT const String& mousePointerEventType();
 WEBCORE_EXPORT const String& penPointerEventType();
-const String& touchPointerEventType();
+WEBCORE_EXPORT const String& touchPointerEventType();
 
 } // namespace WebCore

--- a/Source/WebKit/UIProcess/Automation/SimulatedInputDispatcher.cpp
+++ b/Source/WebKit/UIProcess/Automation/SimulatedInputDispatcher.cpp
@@ -262,6 +262,24 @@ static std::optional<TouchInteraction> touchInteractionForMouseInteraction(Mouse
 }
 #endif
 
+static const String& pointerTypeForInputSource(SimulatedInputSourceType type)
+{
+    switch (type) {
+    case SimulatedInputSourceType::Mouse:
+        return WebCore::mousePointerEventType();
+    case SimulatedInputSourceType::Touch:
+        return WebCore::touchPointerEventType();
+    case SimulatedInputSourceType::Pen:
+        return WebCore::penPointerEventType();
+    case SimulatedInputSourceType::Null:
+    case SimulatedInputSourceType::Keyboard:
+    case SimulatedInputSourceType::Wheel:
+        break;
+    }
+    ASSERT_NOT_REACHED();
+    return emptyString();
+}
+
 void SimulatedInputDispatcher::transitionInputSourceToState(SimulatedInputSource& inputSource, SimulatedInputSourceState& newState, AutomationCompletionHandler&& completionHandler)
 {
     // Make cases and conditionals more readable by aliasing pre/post states as 'a' and 'b'.
@@ -292,50 +310,18 @@ void SimulatedInputDispatcher::transitionInputSourceToState(SimulatedInputSource
         eventDispatchFinished(std::nullopt);
         break;
     case SimulatedInputSourceType::Mouse:
+    case SimulatedInputSourceType::Touch:
     case SimulatedInputSourceType::Pen: {
+        bool isTouch = inputSource.type == SimulatedInputSourceType::Touch;
+#if !ENABLE(WEBDRIVER_MOUSE_INTERACTIONS) && !ENABLE(WEBDRIVER_TOUCH_INTERACTIONS)
+        RELEASE_ASSERT_NOT_REACHED();
+#else
 #if !ENABLE(WEBDRIVER_MOUSE_INTERACTIONS)
-        RELEASE_ASSERT_NOT_REACHED();
-#else
-        resolveLocation(valueOrDefault(a.location), b.location, b.origin.value_or(MouseMoveOrigin::Pointer), b.nodeHandle, [this, protectedThis = Ref { *this }, &a, &b, inputSource = inputSource.type, eventDispatchFinished = WTF::move(eventDispatchFinished)](std::optional<WebCore::IntPoint> location, std::optional<AutomationCommandError> error) mutable {
-            if (error) {
-                eventDispatchFinished(error);
-                return;
-            }
-
-            if (!location) {
-                eventDispatchFinished(AUTOMATION_COMMAND_ERROR_WITH_NAME(ElementNotInteractable));
-                return;
-            }
-
-            const String& pointerType = inputSource == SimulatedInputSourceType::Mouse ? WebCore::mousePointerEventType() : WebCore::penPointerEventType();
-
-            b.location = location;
-            // The "dispatch a pointer{Down,Up,Move} action" algorithms (§17.4 Dispatching Actions).
-            if (b.mouseInteraction) {
-                const auto stateTransitionIsNoop = [&a, &b] {
-                    return std::tie(a.location, a.mouseInteraction, a.pressedMouseButton) == std::tie(b.location, b.mouseInteraction, b.pressedMouseButton);
-                }();
-
-                if (!stateTransitionIsNoop) {
-#if !LOG_DISABLED
-                    String interactionName = Inspector::Protocol::AutomationHelpers::getEnumConstantValue(b.mouseInteraction.value());
-                    String mouseButtonName = Inspector::Protocol::AutomationHelpers::getEnumConstantValue(b.pressedMouseButton.value_or(MouseButton::None));
-                    LOG(Automation, "SimulatedInputDispatcher[%p]: simulating %s[button=%s] @ (%d, %d) for transition to %d.%d", this, interactionName.utf8().data(), mouseButtonName.utf8().data(), b.location.value().x(), b.location.value().y(), m_keyframeIndex, m_inputSourceStateIndex);
+        RELEASE_ASSERT(isTouch);
+#elif !ENABLE(WEBDRIVER_TOUCH_INTERACTIONS)
+        RELEASE_ASSERT(!isTouch);
 #endif
-                    m_client.simulateMouseInteraction(protect(m_page), b.mouseInteraction.value(), b.pressedMouseButton.value_or(MouseButton::None), b.location.value(), pointerType, WTF::move(eventDispatchFinished));
-                } else
-                    eventDispatchFinished({ });
-            } else
-                eventDispatchFinished(std::nullopt);
-        });
-#endif // ENABLE(WEBDRIVER_MOUSE_INTERACTIONS)
-        break;
-    }
-    case SimulatedInputSourceType::Touch: {
-#if !ENABLE(WEBDRIVER_TOUCH_INTERACTIONS)
-        RELEASE_ASSERT_NOT_REACHED();
-#else
-        resolveLocation(valueOrDefault(a.location), b.location, b.origin.value_or(MouseMoveOrigin::Viewport), b.nodeHandle, [this, protectedThis = Ref { *this }, &a, &b, eventDispatchFinished = WTF::move(eventDispatchFinished)](std::optional<WebCore::IntPoint> location, std::optional<AutomationCommandError> error) mutable {
+        resolveLocation(valueOrDefault(a.location), b.location, b.origin.value_or(isTouch ? MouseMoveOrigin::Viewport : MouseMoveOrigin::Pointer), b.nodeHandle, [this, protectedThis = Ref { *this }, &a, &b, pointerType = pointerTypeForInputSource(inputSource.type), isTouch, eventDispatchFinished = WTF::move(eventDispatchFinished)](std::optional<WebCore::IntPoint> location, std::optional<AutomationCommandError> error) mutable {
             if (error) {
                 eventDispatchFinished(error);
                 return;
@@ -354,24 +340,41 @@ void SimulatedInputDispatcher::transitionInputSourceToState(SimulatedInputSource
                 }();
 
                 if (!stateTransitionIsNoop) {
-                    auto touchInteraction = touchInteractionForMouseInteraction(b.mouseInteraction.value());
-                    if (!touchInteraction || (touchInteraction == TouchInteraction::MoveTo && a.location == b.location)) {
+                    if (isTouch && b.mouseInteraction == MouseInteraction::Move && a.location == b.location) {
                         eventDispatchFinished(std::nullopt);
                         return;
                     }
 
-                    std::optional<Seconds> duration = touchInteraction == TouchInteraction::MoveTo ? std::optional<Seconds>(a.duration.value_or(0_s)) : std::nullopt;
 #if !LOG_DISABLED
                     String interactionName = Inspector::Protocol::AutomationHelpers::getEnumConstantValue(b.mouseInteraction.value());
-                    LOG(Automation, "SimulatedInputDispatcher[%p]: simulating touch %s @ (%d, %d) for transition to %d.%d", this, interactionName.utf8().data(), b.location.value().x(), b.location.value().y(), m_keyframeIndex, m_inputSourceStateIndex);
+                    String mouseButtonName = Inspector::Protocol::AutomationHelpers::getEnumConstantValue(b.pressedMouseButton.value_or(MouseButton::None));
+                    LOG(Automation, "SimulatedInputDispatcher[%p]: simulating %s %s[button=%s] @ (%d, %d) for transition to %d.%d", this, pointerType.utf8().data(), interactionName.utf8().data(), mouseButtonName.utf8().data(), b.location.value().x(), b.location.value().y(), m_keyframeIndex, m_inputSourceStateIndex);
 #endif
-                    m_client.simulateTouchInteraction(protect(m_page), touchInteraction.value(), b.location.value(), duration, WTF::move(eventDispatchFinished));
+
+                    if (isTouch) {
+#if ENABLE(WEBDRIVER_TOUCH_INTERACTIONS)
+                        auto touchInteraction = touchInteractionForMouseInteraction(b.mouseInteraction.value());
+                        if (!touchInteraction) {
+                            eventDispatchFinished(std::nullopt);
+                            return;
+                        }
+
+                        std::optional<Seconds> duration = touchInteraction == TouchInteraction::MoveTo ? std::optional<Seconds>(a.duration.value_or(0_s)) : std::nullopt;
+                        m_client.simulateTouchInteraction(protect(m_page), touchInteraction.value(), b.location.value(), duration, WTF::move(eventDispatchFinished));
+#endif
+                    } else {
+#if ENABLE(WEBDRIVER_MOUSE_INTERACTIONS)
+                        m_client.simulateMouseInteraction(protect(m_page), b.mouseInteraction.value(), b.pressedMouseButton.value_or(MouseButton::None), b.location.value(), pointerType, WTF::move(eventDispatchFinished));
+#else
+                        UNUSED_VARIABLE(pointerType);
+#endif
+                    }
                 } else
                     eventDispatchFinished({ });
             } else
                 eventDispatchFinished(std::nullopt);
         });
-#endif // !ENABLE(WEBDRIVER_TOUCH_INTERACTIONS)
+#endif // !ENABLE(WEBDRIVER_MOUSE_INTERACTIONS) && !ENABLE(WEBDRIVER_TOUCH_INTERACTIONS)
         break;
     }
     case SimulatedInputSourceType::Keyboard: {


### PR DESCRIPTION
#### 7c90505b4e531de4fdc64f48af63cc45ca041478
<pre>
Unify mouse/pen/touch code paths in SimulatedInputDispatcher::transitionInputSourceToState
<a href="https://bugs.webkit.org/show_bug.cgi?id=319923">https://bugs.webkit.org/show_bug.cgi?id=319923</a>
<a href="https://rdar.apple.com/182850897">rdar://182850897</a>

Reviewed by Abrar Rahman Protyasha and BJ Burg.

Since the previous commit, the Touch case in transitionInputSourceToState
dispatches off b.mouseInteraction exactly like the Mouse/Pen case, so the
two switch cases now differ only in a few small platform-specific
details. Keeping the logic duplicated across two cases is exactly what
let the Touch case regress in the first place: a change to the shared
dispatch logic was applied to Mouse/Pen and silently forgotten in Touch.
Merge them into a single case to remove that duplication.

* Source/WebCore/dom/PointerEventTypeNames.h:
* Source/WebKit/UIProcess/Automation/SimulatedInputDispatcher.cpp:
(WebKit::pointerTypeForInputSource):
(WebKit::SimulatedInputDispatcher::transitionInputSourceToState):

Canonical link: <a href="https://commits.webkit.org/318475@main">https://commits.webkit.org/318475@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e882ab8e4350ec43992757249db467fb29d9437f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176693 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50630 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44422 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186295 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/139941 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/039eca1f-8864-4dd9-a547-7e71d9d4a92b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178556 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51923 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50316 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137638 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96261 "2 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/be420461-41ea-481e-abe4-044fb7d077da) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179649 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41139 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158430 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118112 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/00f0c4b9-679f-4f85-a8ce-0a90491ab728) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39794 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38164 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150206 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37928 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34763 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42370 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42380 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188719 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50297 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146702 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39805 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50980 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34549 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146507 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41269 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124966 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117316 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49485 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12907 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48884 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49120 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48945 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->