### PR TITLE
[JSC] Add OOB mode to `StringCharCodeAt` node in DFG/FTL

### DIFF
--- a/JSTests/microbenchmarks/string-charcodeat-out-of-bounds-lookahead.js
+++ b/JSTests/microbenchmarks/string-charcodeat-out-of-bounds-lookahead.js
@@ -1,0 +1,22 @@
+function scan(string) {
+    let count = 0;
+    for (let i = 0; i < string.length; i++) {
+        const c = string.charCodeAt(i);
+        const next = string.charCodeAt(i + 1);
+        if (c === 47 && next === 47)
+            count += 3;
+        count += c & 1;
+    }
+    return count;
+}
+noInline(scan);
+
+let string = "";
+for (let i = 0; i < 500; i++)
+    string += String.fromCharCode(32 + (i * 7) % 95);
+
+let result = 0;
+for (let i = 0; i < 1e4; i++)
+    result += scan(string);
+if (result !== 2480000)
+    throw new Error("Bad result: " + result);

--- a/JSTests/stress/string-charcodeat-cse-array-mode.js
+++ b/JSTests/stress/string-charcodeat-cse-array-mode.js
@@ -1,0 +1,22 @@
+//@ requireOptions("--jitPolicyScale=0.1")
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual + ' expected: ' + expected);
+}
+
+function opt(s, i) {
+    let a = s.charCodeAt(i);
+    let b = s.charCodeAt(i);
+    return `${a}_${b}_end`;
+}
+noInline(opt);
+
+for (let j = 0; j < 20000; j++)
+    shouldBe(opt("hello", 1), "101_101_end");
+for (let j = 0; j < 200; j++)
+    shouldBe(opt("hello", 100), "NaN_NaN_end");
+for (let j = 0; j < 20000; j++) {
+    shouldBe(opt("hello", 1), "101_101_end");
+    shouldBe(opt("hello", 100), "NaN_NaN_end");
+}

--- a/JSTests/stress/string-charcodeat-out-of-bounds-constant-folding.js
+++ b/JSTests/stress/string-charcodeat-out-of-bounds-constant-folding.js
@@ -1,0 +1,26 @@
+function shouldBe(actual, expected) {
+    if (!Object.is(actual, expected))
+        throw new Error('bad value: ' + actual + ' expected: ' + expected);
+}
+
+function charCodeAt(i) {
+    return "abc".charCodeAt(i);
+}
+
+function foldedInRange() {
+    return charCodeAt(1);
+}
+noInline(foldedInRange);
+
+function foldedOutOfRange() {
+    return charCodeAt(9);
+}
+noInline(foldedOutOfRange);
+
+for (let i = 0; i < testLoopCount; i++)
+    shouldBe(charCodeAt(i % 5), i % 5 < 3 ? 97 + (i % 5) : NaN);
+
+for (let i = 0; i < testLoopCount; i++) {
+    shouldBe(foldedInRange(), 98);
+    shouldBe(foldedOutOfRange(), NaN);
+}

--- a/JSTests/stress/string-charcodeat-out-of-bounds-mode.js
+++ b/JSTests/stress/string-charcodeat-out-of-bounds-mode.js
@@ -1,0 +1,24 @@
+function shouldBe(actual, expected) {
+    if (!Object.is(actual, expected))
+        throw new Error("bad value: " + actual + " expected: " + expected);
+}
+
+function charCodeAt(string, index) {
+    return string.charCodeAt(index);
+}
+noInline(charCodeAt);
+
+let string8 = "hello world!";
+let string16 = "あいうえお";
+
+for (let i = 0; i < testLoopCount; i++) {
+    let index = i % 20;
+    shouldBe(charCodeAt(string8, index), index < string8.length ? string8.charCodeAt(index) : NaN);
+    index = i % 9;
+    shouldBe(charCodeAt(string16, index), index < string16.length ? string16.charCodeAt(index) : NaN);
+}
+
+shouldBe(charCodeAt(string8, -1), NaN);
+shouldBe(charCodeAt(string8, 4294967296), NaN);
+shouldBe(charCodeAt(string8, 0.5), 104);
+shouldBe(charCodeAt("", 0), NaN);

--- a/JSTests/stress/string-charcodeat-out-of-bounds-uses.js
+++ b/JSTests/stress/string-charcodeat-out-of-bounds-uses.js
@@ -1,0 +1,51 @@
+function shouldBe(actual, expected) {
+    if (!Object.is(actual, expected))
+        throw new Error('bad value: ' + actual + ' expected: ' + expected);
+}
+
+function bitOr(s, i) { return s.charCodeAt(i) | 0; }
+noInline(bitOr);
+function bitAnd(s, i) { return s.charCodeAt(i) & 0xff; }
+noInline(bitAnd);
+function plusOne(s, i) { return s.charCodeAt(i) + 1; }
+noInline(plusOne);
+function isSlash(s, i) { return s.charCodeAt(i) === 47; }
+noInline(isSlash);
+function isNaNResult(s, i) { return Number.isNaN(s.charCodeAt(i)); }
+noInline(isNaNResult);
+function switchOn(s, i) {
+    switch (s.charCodeAt(i)) {
+    case 47:
+        return 1;
+    case 97:
+        return 2;
+    default:
+        return 0;
+    }
+}
+noInline(switchOn);
+function rope(a, b, i) { return (a + b).charCodeAt(i); }
+noInline(rope);
+
+let string = "a/b";
+for (let i = 0; i < testLoopCount; i++) {
+    let index = i % 5;
+    let code = index < 3 ? [97, 47, 98][index] : NaN;
+    shouldBe(bitOr(string, index), Number.isNaN(code) ? 0 : code);
+    shouldBe(bitAnd(string, index), Number.isNaN(code) ? 0 : code & 0xff);
+    shouldBe(plusOne(string, index), code + 1);
+    shouldBe(isSlash(string, index), code === 47);
+    shouldBe(isNaNResult(string, index), Number.isNaN(code));
+    shouldBe(switchOn(string, index), code === 47 ? 1 : (code === 97 ? 2 : 0));
+    shouldBe(rope("a/", "b", index), code);
+}
+
+function anyIndex(s, i) { return s.charCodeAt(i); }
+noInline(anyIndex);
+for (let i = 0; i < testLoopCount; i++)
+    shouldBe(anyIndex(string, i % 5), i % 5 < 3 ? [97, 47, 98][i % 5] : NaN);
+shouldBe(anyIndex(string, Infinity), NaN);
+shouldBe(anyIndex(string, -Infinity), NaN);
+shouldBe(anyIndex(string, "1"), 47);
+shouldBe(anyIndex(string, 1.9), 47);
+shouldBe(anyIndex(string, NaN), 97);

--- a/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
@@ -2750,19 +2750,28 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
 
     case StringCharCodeAt:
     case StringCodePointAt: {
+        bool isOutOfBounds = node->op() == StringCharCodeAt && node->arrayMode().isOutOfBounds();
         if (auto string = node->child1()->tryGetString(m_graph); !string.isNull()) {
             if (node->child2()->isInt32Constant()) {
                 int32_t index = node->child2()->asInt32();
                 if (index >= 0 && static_cast<unsigned>(index) < string.length()) {
-                    if (node->op() == StringCharCodeAt)
-                        setConstant(node, jsNumber(string.codeUnitAt(static_cast<unsigned>(index))));
-                    else
+                    if (node->op() == StringCharCodeAt) {
+                        char16_t code = string.codeUnitAt(static_cast<unsigned>(index));
+                        setConstant(node, isOutOfBounds ? jsDoubleNumber(code) : jsNumber(code));
+                    } else
                         setConstant(node, jsNumber(codePointAt(string, static_cast<unsigned>(index), string.length())));
+                    break;
+                }
+                if (isOutOfBounds) {
+                    setConstant(node, jsNaN());
                     break;
                 }
             }
         }
-        setNonCellTypeForNode(node, SpecInt32Only);
+        if (isOutOfBounds)
+            setNonCellTypeForNode(node, SpecAnyIntAsDouble | SpecDoublePureNaN);
+        else
+            setNonCellTypeForNode(node, SpecInt32Only);
         break;
     }
 

--- a/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
+++ b/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
@@ -3314,7 +3314,7 @@ auto ByteCodeParser::handleIntrinsicCall(Node* callee, Operand resultOperand, Ca
             if (argumentCountIncludingThis < 1)
                 return CallOptimizationResult::DidNothing;
 
-            if (m_inlineStackTop->m_exitProfile.hasExitSite(m_currentIndex, Uncountable) || m_inlineStackTop->m_exitProfile.hasExitSite(m_currentIndex, BadType))
+            if (m_inlineStackTop->m_exitProfile.hasExitSite(m_currentIndex, BadType))
                 return CallOptimizationResult::DidNothing;
 
             insertChecks();
@@ -3322,7 +3322,10 @@ auto ByteCodeParser::handleIntrinsicCall(Node* callee, Operand resultOperand, Ca
             Node* index = argumentCountIncludingThis == 1
                 ? jsConstant(jsNumber(0))
                 : get(virtualRegisterForArgumentIncludingThis(1, registerOffset));
-            Node* charCode = addToGraph(StringCharCodeAt, OpInfo(ArrayMode(Array::String, Array::Read).asWord()), get(thisOperand), index);
+            bool hasOutOfBoundsExitSite = m_inlineStackTop->m_exitProfile.hasExitSite(m_currentIndex, OutOfBounds);
+            Node* charCode = addToGraph(StringCharCodeAt, OpInfo(ArrayMode(Array::String, Array::Read, hasOutOfBoundsExitSite ? Array::OutOfBounds : Array::InBounds).asWord()), get(thisOperand), index);
+            if (hasOutOfBoundsExitSite)
+                charCode->setResult(NodeResultDouble);
 
             setResult(charCode);
             return CallOptimizationResult::Inlined;

--- a/Source/JavaScriptCore/dfg/DFGClobberize.h
+++ b/Source/JavaScriptCore/dfg/DFGClobberize.h
@@ -239,7 +239,6 @@ void clobberize(Graph& graph, Node* node, const ReadFunctor& read, const WriteFu
     case GetScope:
     case SkipScope:
     case GetGlobalObject:
-    case StringCharCodeAt:
     case StringCodePointAt:
     case StringIndexOf:
     case StringLastIndexOf:
@@ -2349,9 +2348,10 @@ void clobberize(Graph& graph, Node* node, const ReadFunctor& read, const WriteFu
         return;
 
     case StringAt:
+    case StringCharCodeAt:
         // String.prototype.at returns a string when in bounds and undefined when OOB. This is
-        // unlike charAt, which always returns a string. Include arrayMode to prevent CSE across
-        // modes.
+        // unlike charAt, which always returns a string. Likewise charCodeAt returns an int32 when
+        // in bounds and NaN (double) when OOB. Include arrayMode to prevent CSE across modes.
         def(PureValue(node, node->arrayMode().asWord()));
         return;
     case StringCharAt:

--- a/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
@@ -1156,10 +1156,12 @@ private:
         case StringCharCodeAt:
         case StringCodePointAt: {
             // Currently we have no good way of refining these.
-            if (op == StringAt)
+            if (op == StringAt || op == StringCharCodeAt)
                 ASSERT(node->arrayMode() == ArrayMode(Array::String, Array::Read, Array::OutOfBounds) || node->arrayMode() == ArrayMode(Array::String, Array::Read, Array::InBounds));
             else
                 ASSERT(node->arrayMode() == ArrayMode(Array::String, Array::Read));
+            if (op == StringCharCodeAt)
+                ASSERT(node->arrayMode().isOutOfBounds() == (node->result() == NodeResultDouble));
             blessArrayOperation(node->child1(), node->child2(), node->child1()); // Rewrite child1 with ResolveRope.
             fixEdge<KnownStringUse>(node->child1());
             fixEdge<Int32Use>(node->child2());

--- a/Source/JavaScriptCore/dfg/DFGMayExit.cpp
+++ b/Source/JavaScriptCore/dfg/DFGMayExit.cpp
@@ -411,6 +411,12 @@ ExitMode mayExitImpl(Graph& graph, Node* node, StateType& state)
         break;
     }
 
+    case StringCharCodeAt: {
+        if (node->arrayMode().isOutOfBounds())
+            break;
+        return Exits;
+    }
+
     case StringReplaceString: {
         if (node->child3().useKind() == StringUse) {
             result = ExitsForExceptions;

--- a/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
@@ -1205,7 +1205,14 @@ private:
             break;
         }
 
-        case StringCharCodeAt:
+        case StringCharCodeAt: {
+            if (m_currentNode->arrayMode().isOutOfBounds())
+                setPrediction(SpecAnyIntAsDouble | SpecDoublePureNaN);
+            else
+                setPrediction(SpecInt32Only);
+            break;
+        }
+
         case StringCodePointAt: {
             setPrediction(SpecInt32Only);
             break;

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -2754,13 +2754,24 @@ void SpeculativeJIT::compileGetCharCodeAt(Node* node)
     GPRTemporary scratch(this);
     GPRReg scratchReg = scratch.gpr();
 
+    bool isOutOfBounds = node->arrayMode().isOutOfBounds();
+    std::optional<FPRTemporary> result;
+    FPRReg resultFPR = InvalidFPRReg;
+    if (isOutOfBounds) {
+        result.emplace(this);
+        resultFPR = result->fpr();
+    }
+
     loadPtr(Address(stringReg, JSString::offsetOfValue()), scratchReg);
 
     // unsigned comparison so we can filter out negative indices and indices that are too large
+    Jump outOfBounds;
     if (auto stringLength = tryGetConstantStringLength(node->child1()))
-        speculationCheck(Uncountable, JSValueRegs(), nullptr, branch32(AboveOrEqual, indexReg, TrustedImm32(*stringLength)));
+        outOfBounds = branch32(AboveOrEqual, indexReg, TrustedImm32(*stringLength));
     else
-        speculationCheck(Uncountable, JSValueRegs(), nullptr, branch32(AboveOrEqual, indexReg, Address(scratchReg, StringImpl::lengthMemoryOffset())));
+        outOfBounds = branch32(AboveOrEqual, indexReg, Address(scratchReg, StringImpl::lengthMemoryOffset()));
+    if (!isOutOfBounds)
+        speculationCheck(OutOfBounds, JSValueRegs(), nullptr, outOfBounds);
 
     // Load the character into scratchReg
     Jump is16Bit = branchTest32(Zero, Address(scratchReg, StringImpl::flagsOffset()), TrustedImm32(StringImpl::flagIs8Bit()));
@@ -2776,7 +2787,17 @@ void SpeculativeJIT::compileGetCharCodeAt(Node* node)
 
     cont8Bit.link(this);
 
-    strictInt32Result(scratchReg, m_currentNode);
+    if (!isOutOfBounds) {
+        strictInt32Result(scratchReg, m_currentNode);
+        return;
+    }
+
+    convertInt32ToDouble(scratchReg, resultFPR);
+    Jump done = jump();
+    outOfBounds.link(this);
+    move64ToDouble(TrustedImm64(std::bit_cast<uint64_t>(PNaN)), resultFPR);
+    done.link(this);
+    doubleResult(resultFPR, node);
 }
 
 void SpeculativeJIT::compileGetByValOnString(Node* node, const ScopedLambda<std::tuple<JSValueRegs, DataFormat>(DataFormat preferredFormat, bool needsFlush)>& prefix)

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -12134,15 +12134,24 @@ IGNORE_CLANG_WARNINGS_END
         LValue stringImpl = m_out.loadPtr(base, m_heaps.JSString_value);
         LValue data = m_out.loadPtr(stringImpl, m_heaps.StringImpl_data);
 
-        if (!m_node->arrayMode().isInBounds()) {
+        bool isOutOfBounds = m_node->arrayMode().isOutOfBounds();
+        ValueFromBlock outOfBoundsResult;
+        LBasicBlock lastNext = nullptr;
+        if (isOutOfBounds) {
             LValue length;
             if (auto stringLength = tryGetConstantStringLength(m_node->child1()))
                 length = m_out.constInt32(*stringLength);
             else
                 length = m_out.load32NonNegative(stringImpl, m_heaps.StringImpl_length);
-            speculate(
-                Uncountable, noValue(), nullptr,
-                m_out.aboveOrEqual(index, length));
+            LBasicBlock inBounds = m_out.newBlock();
+            LBasicBlock outOfBounds = m_out.newBlock();
+            m_out.branch(m_out.aboveOrEqual(index, length), rarely(outOfBounds), usually(inBounds));
+
+            lastNext = m_out.appendTo(outOfBounds, inBounds);
+            outOfBoundsResult = m_out.anchor(m_out.constDouble(PNaN));
+            m_out.jump(continuation);
+
+            m_out.appendTo(inBounds, is8Bit);
         }
 
         m_out.branch(
@@ -12151,18 +12160,25 @@ IGNORE_CLANG_WARNINGS_END
                 m_out.constInt32(StringImpl::flagIs8Bit())),
             unsure(is16Bit), unsure(is8Bit));
 
-        LBasicBlock lastNext = m_out.appendTo(is8Bit, is16Bit);
-        ValueFromBlock char8Bit = m_out.anchor(m_out.load8ZeroExt32(baseIndexWithProvenValue(m_heaps.characters8, data, index, m_node->child2())));
+        LBasicBlock next8Bit = m_out.appendTo(is8Bit, is16Bit);
+        if (!lastNext)
+            lastNext = next8Bit;
+        LValue char8BitValue = m_out.load8ZeroExt32(baseIndexWithProvenValue(m_heaps.characters8, data, index, m_node->child2()));
+        ValueFromBlock char8Bit = m_out.anchor(isOutOfBounds ? m_out.intToDouble(char8BitValue) : char8BitValue);
         m_out.jump(continuation);
 
         m_out.appendTo(is16Bit, continuation);
-        ValueFromBlock char16Bit = m_out.anchor(m_out.load16ZeroExt32(baseIndexWithProvenValue(m_heaps.characters16, data, index, m_node->child2())));
+        LValue char16BitValue = m_out.load16ZeroExt32(baseIndexWithProvenValue(m_heaps.characters16, data, index, m_node->child2()));
+        ValueFromBlock char16Bit = m_out.anchor(isOutOfBounds ? m_out.intToDouble(char16BitValue) : char16BitValue);
         m_out.jump(continuation);
 
         m_out.appendTo(continuation, lastNext);
         // We have to keep base alive since that keeps storage alive.
         ensureStillAliveHere(base);
-        setInt32(m_out.phi(Int32, char8Bit, char16Bit));
+        if (isOutOfBounds)
+            setDouble(m_out.phi(Double, outOfBoundsResult, char8Bit, char16Bit));
+        else
+            setInt32(m_out.phi(Int32, char8Bit, char16Bit));
     }
 
     void compileStringCodePointAt()


### PR DESCRIPTION
#### 89be2da97f720db0fec908746d1cfe3a3c56c91c
<pre>
[JSC] Add OOB mode to `StringCharCodeAt` node in DFG/FTL
<a href="https://bugs.webkit.org/show_bug.cgi?id=319928">https://bugs.webkit.org/show_bug.cgi?id=319928</a>

Reviewed by Yusuke Suzuki.

When the inlined StringCharCodeAt hits an out-of-bounds index, it OSR exits (Uncountable in
DFG, OutOfBounds in FTL), and once that exit site is recorded the bytecode parser never inlines
that call site again, leaving a generic Call forever.

This patch does what StringAt already does: the in-bounds code exits with OutOfBounds, and when
that exit site is present the bytecode parser emits StringCharCodeAt in an out-of-bounds mode that
performs the length check inline and returns NaN.

Since charCodeAt returns NaN for out-of-bounds indices, the out-of-bounds mode uses
NodeResultDouble.

                                                   Baseline                  Patched

string-at-char-code-at                          9.0700+-0.2991            9.0434+-0.2745
string-char-code-at                             2.3423+-0.1432            2.3154+-0.1080          might be 1.0116x faster
string-codePointAt-constant-folding             0.8742+-0.0722            0.8419+-0.0475          might be 1.0384x faster
string-charcodeat-out-of-bounds-lookahead
                                               10.8058+-0.2333     ^      4.8701+-0.2511        ^ definitely 2.2188x faster

Tests: JSTests/microbenchmarks/string-charcodeat-out-of-bounds-lookahead.js
       JSTests/stress/string-charcodeat-cse-array-mode.js
       JSTests/stress/string-charcodeat-out-of-bounds-constant-folding.js
       JSTests/stress/string-charcodeat-out-of-bounds-mode.js
       JSTests/stress/string-charcodeat-out-of-bounds-uses.js

* JSTests/microbenchmarks/string-charcodeat-out-of-bounds-lookahead.js: Added.
(scan):
* JSTests/stress/string-charcodeat-cse-array-mode.js: Added.
(shouldBe):
(opt):
* JSTests/stress/string-charcodeat-out-of-bounds-constant-folding.js: Added.
(shouldBe):
(charCodeAt):
(foldedInRange):
(foldedOutOfRange):
* JSTests/stress/string-charcodeat-out-of-bounds-mode.js: Added.
(shouldBe):
(charCodeAt):
* JSTests/stress/string-charcodeat-out-of-bounds-uses.js: Added.
(shouldBe):
(bitOr):
(bitAnd):
(plusOne):
(isSlash):
(isNaNResult):
(switchOn):
(rope):
(anyIndex):
* Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h:
(JSC::DFG::AbstractInterpreter&lt;AbstractStateType&gt;::executeEffects):
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::handleIntrinsicCall):
* Source/JavaScriptCore/dfg/DFGClobberize.h:
(JSC::DFG::clobberize):
* Source/JavaScriptCore/dfg/DFGFixupPhase.cpp:
(JSC::DFG::FixupPhase::fixupNode):
* Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
(JSC::DFG::SpeculativeJIT::compileGetCharCodeAt):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileStringCharCodeAt):

Canonical link: <a href="https://commits.webkit.org/317823@main">https://commits.webkit.org/317823@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a980db6f3959c7cf1dc114b00523ab5ca92a45ed

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176315 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50250 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44040 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185911 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/138569 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51542 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49934 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137331 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/138569 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179271 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40814 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158109 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117806 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39463 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37825 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/6618 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149879 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37607 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34380 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/37583 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41985 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42036 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; Skipped layout-tests; Ignored 2 pre-existing failure based on results-db; Uploaded test results") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188335 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49915 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146367 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39396 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50599 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34224 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146184 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40957 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122803 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/116808 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49103 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12581 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48505 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48739 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48564 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->