### PR TITLE
Classify the real resolved connection IP for Local Network Access on Cocoa

### DIFF
--- a/Source/WebCore/Modules/fetch/IPAddressSpace.cpp
+++ b/Source/WebCore/Modules/fetch/IPAddressSpace.cpp
@@ -26,13 +26,17 @@
 #include "config.h"
 #include "IPAddressSpace.h"
 
+#include "DNS.h"
 #include <array>
-#include <cstdio>
 #include <wtf/URL.h>
 #include <wtf/Vector.h>
 #include <wtf/text/MakeString.h>
 #include <wtf/text/StringToIntegerConversion.h>
 #include <wtf/text/StringView.h>
+
+#if OS(UNIX)
+#include <arpa/inet.h>
+#endif
 
 namespace WebCore {
 
@@ -141,5 +145,28 @@ IPAddressSpace determineIPAddressSpace(const URL& url)
 
     return classifyHost(host.toString());
 }
+
+#if OS(UNIX)
+IPAddressSpace classifyIPAddressSpace(const IPAddress& address)
+{
+    char buffer[INET6_ADDRSTRLEN];
+    if (address.isIPv4()) {
+        if (!inet_ntop(AF_INET, &address.ipv4Address(), buffer, sizeof(buffer)))
+            return IPAddressSpace::Unknown;
+    } else if (address.isIPv6()) {
+        if (!inet_ntop(AF_INET6, &address.ipv6Address(), buffer, sizeof(buffer)))
+            return IPAddressSpace::Unknown;
+    } else
+        return IPAddressSpace::Unknown;
+
+    return classifyHost(String::fromLatin1(buffer));
+}
+#else
+IPAddressSpace classifyIPAddressSpace(const IPAddress&)
+{
+    // IPAddress::fromString() is OS(UNIX)-only (see DNS.cpp), so there's no address to classify here.
+    return IPAddressSpace::Unknown;
+}
+#endif
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/fetch/IPAddressSpace.h
+++ b/Source/WebCore/Modules/fetch/IPAddressSpace.h
@@ -27,10 +27,13 @@
 
 namespace WebCore {
 
+class IPAddress;
+
 enum class IPAddressSpace : uint8_t {
     Public,
     Local,
-    Loopback
+    Loopback,
+    Unknown
 };
 
 constexpr uint8_t publicnessRank(IPAddressSpace space)
@@ -42,6 +45,8 @@ constexpr uint8_t publicnessRank(IPAddressSpace space)
         return 1;
     case IPAddressSpace::Public:
         return 2;
+    case IPAddressSpace::Unknown:
+        return 0;
     }
     return 2;
 }
@@ -52,5 +57,7 @@ inline bool isLessPublicThan(IPAddressSpace a, IPAddressSpace b)
 }
 
 WEBCORE_EXPORT IPAddressSpace determineIPAddressSpace(const WTF::URL&);
+
+WEBCORE_EXPORT IPAddressSpace classifyIPAddressSpace(const IPAddress&);
 
 } // namespace WebCore

--- a/Source/WebCore/platform/network/ResourceResponseBase.cpp
+++ b/Source/WebCore/platform/network/ResourceResponseBase.cpp
@@ -90,7 +90,7 @@ ResourceResponseBase::ResourceResponseBase(std::optional<ResourceResponseData>&&
     , m_tainting(data ? data->tainting : Tainting::Basic)
     , m_source(data ? data->source : Source::Unknown)
     , m_type(data ? data->type : Type::Default)
-    , m_ipAddressSpace(data ? data->ipAddressSpace : IPAddressSpace::Public)
+    , m_ipAddressSpace(data ? data->ipAddressSpace : IPAddressSpace::Unknown)
 {
 }
 
@@ -1058,7 +1058,7 @@ std::optional<WebCore::ResourceResponseData> Coder<WebCore::ResourceResponseData
         WTF::move(*proxyName),
         *isRangeRequested,
         WTF::move(*certificateInfo),
-        WebCore::IPAddressSpace::Public
+        WebCore::IPAddressSpace::Unknown
     };
 }
 

--- a/Source/WebCore/platform/network/ResourceResponseBase.h
+++ b/Source/WebCore/platform/network/ResourceResponseBase.h
@@ -64,7 +64,7 @@ static constexpr unsigned bitWidthOfWasPrivateRelayed = 1;
 static_assert(static_cast<unsigned>(WasPrivateRelayed::Yes) <= ((1U << bitWidthOfWasPrivateRelayed) - 1));
 
 static constexpr unsigned bitWidthOfIPAddressSpace = 2;
-static_assert(((1U << bitWidthOfIPAddressSpace) - 1) >= static_cast<unsigned>(IPAddressSpace::Loopback));
+static_assert(((1U << bitWidthOfIPAddressSpace) - 1) >= static_cast<unsigned>(IPAddressSpace::Unknown));
 
 enum class ResourceResponseBaseType : uint8_t { Basic, Cors, Default, Error, Opaque, Opaqueredirect };
 enum class ResourceResponseBaseTainting : uint8_t { Basic, Cors, Opaque, Opaqueredirect };
@@ -153,7 +153,7 @@ public:
     void setProxyName(String&& proxyName) { m_proxyName = WTF::move(proxyName); }
     const String& proxyName() const LIFETIME_BOUND { return m_proxyName; }
 
-    IPAddressSpace ipAddressSpace() { return m_ipAddressSpace; }
+    IPAddressSpace ipAddressSpace() const { return m_ipAddressSpace; }
     void setIPAddressSpace(IPAddressSpace ipAddressSpace) { m_ipAddressSpace = ipAddressSpace; }
 
     // These functions return parsed values of the corresponding response headers.
@@ -297,7 +297,7 @@ private:
     Tainting m_tainting : bitWidthOfTainting { Tainting::Basic };
     Source m_source : bitWidthOfSource { Source::Unknown };
     Type m_type : bitWidthOfType { Type::Default };
-    IPAddressSpace m_ipAddressSpace : bitWidthOfIPAddressSpace { IPAddressSpace::Public };
+    IPAddressSpace m_ipAddressSpace : bitWidthOfIPAddressSpace { IPAddressSpace::Unknown };
 
 };
 

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm
@@ -39,6 +39,7 @@
 #import <WebCore/AdvancedPrivacyProtections.h>
 #import <WebCore/AuthenticationChallenge.h>
 #import <WebCore/HTTPStatusCodes.h>
+#import <WebCore/IPAddressSpace.h>
 #import <WebCore/NetworkStorageSession.h>
 #import <WebCore/NotImplemented.h>
 #import <WebCore/OriginAccessPatterns.h>
@@ -453,12 +454,18 @@ void NetworkDataTaskCocoa::didReceiveResponse(WebCore::ResourceResponse&& respon
             session->reportNetworkIssue(*m_webPageProxyID, firstRequest().url());
     }
 #endif
-    NetworkDataTask::didReceiveResponse(WTF::move(response), negotiatedLegacyTLS, privateRelayed, WebCore::IPAddress::fromString(lastRemoteIPAddress(m_task.get())), WTF::move(completionHandler));
+    auto resolvedIPAddress = WebCore::IPAddress::fromString(lastRemoteIPAddress(m_task.get()));
+    if (resolvedIPAddress)
+        response.setIPAddressSpace(WebCore::classifyIPAddressSpace(*resolvedIPAddress));
+    NetworkDataTask::didReceiveResponse(WTF::move(response), negotiatedLegacyTLS, privateRelayed, resolvedIPAddress, WTF::move(completionHandler));
 }
 
 void NetworkDataTaskCocoa::willPerformHTTPRedirection(WebCore::ResourceResponse&& redirectResponse, WebCore::ResourceRequest&& request, RedirectCompletionHandler&& completionHandler)
 {
     WTFEmitSignpost(m_task.get(), DataTask, "redirect");
+
+    if (auto resolvedIPAddress = WebCore::IPAddress::fromString(lastRemoteIPAddress(m_task.get())))
+        redirectResponse.setIPAddressSpace(WebCore::classifyIPAddressSpace(*resolvedIPAddress));
 
     networkLoadMetrics().hasCrossOriginRedirect = networkLoadMetrics().hasCrossOriginRedirect || !WebCore::SecurityOrigin::create(request.url())->canRequest(redirectResponse.url(), WebCore::EmptyOriginAccessPatterns::singleton());
 

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -37,7 +37,8 @@ header: <WebCore/IPAddressSpace.h>
 enum class WebCore::IPAddressSpace : uint8_t {
     Public,
     Local,
-    Loopback
+    Loopback,
+    Unknown
 };
 
 enum class WebCore::NotificationEventType : bool;

--- a/Tools/TestWebKitAPI/Tests/WebCore/IPAddressSpaceTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/IPAddressSpaceTests.cpp
@@ -25,7 +25,9 @@
 
 #include "config.h"
 
+#include <WebCore/DNS.h>
 #include <WebCore/IPAddressSpace.h>
+#include <WebCore/ResourceResponse.h>
 #include <wtf/URL.h>
 
 namespace TestWebKitAPI {
@@ -283,6 +285,37 @@ TEST(IPAddressSpace, IPv4BoundaryConditions)
     EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://198.19.255.255/"_s)), WebCore::IPAddressSpace::Local);
     EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://198.17.255.255/"_s)), WebCore::IPAddressSpace::Public);
     EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://198.20.0.0/"_s)), WebCore::IPAddressSpace::Public);
+}
+
+// classifyIPAddressSpace() goes through IPAddress::fromString() -> inet_ntop() rather than URL
+// parsing, so it's worth confirming it agrees with determineIPAddressSpace() above.
+TEST(IPAddressSpace, ClassifyIPAddressSpaceFromResolvedAddress)
+{
+    EXPECT_EQ(WebCore::classifyIPAddressSpace(*WebCore::IPAddress::fromString("127.0.0.1"_s)), WebCore::IPAddressSpace::Loopback);
+    EXPECT_EQ(WebCore::classifyIPAddressSpace(*WebCore::IPAddress::fromString("::1"_s)), WebCore::IPAddressSpace::Loopback);
+    EXPECT_EQ(WebCore::classifyIPAddressSpace(*WebCore::IPAddress::fromString("192.168.1.1"_s)), WebCore::IPAddressSpace::Local);
+    EXPECT_EQ(WebCore::classifyIPAddressSpace(*WebCore::IPAddress::fromString("fc00::1"_s)), WebCore::IPAddressSpace::Local);
+    EXPECT_EQ(WebCore::classifyIPAddressSpace(*WebCore::IPAddress::fromString("8.8.8.8"_s)), WebCore::IPAddressSpace::Public);
+    EXPECT_EQ(WebCore::classifyIPAddressSpace(*WebCore::IPAddress::fromString("2001:4860:4860::8888"_s)), WebCore::IPAddressSpace::Public);
+
+    // IPv4-mapped IPv6 addresses must classify by their embedded IPv4 address, not as opaque IPv6.
+    EXPECT_EQ(WebCore::classifyIPAddressSpace(*WebCore::IPAddress::fromString("::ffff:192.168.1.1"_s)), WebCore::IPAddressSpace::Local);
+    EXPECT_EQ(WebCore::classifyIPAddressSpace(*WebCore::IPAddress::fromString("::ffff:127.0.0.1"_s)), WebCore::IPAddressSpace::Loopback);
+}
+
+TEST(IPAddressSpace, ClassifyUnclassifiableAddressIsUnknown)
+{
+    WebCore::IPAddress unclassifiable { WTF::HashTableEmptyValue };
+    EXPECT_EQ(WebCore::classifyIPAddressSpace(unclassifiable), WebCore::IPAddressSpace::Unknown);
+}
+
+TEST(IPAddressSpace, ResourceResponseAddressSpaceDefaultsToUnknown)
+{
+    WebCore::ResourceResponse response;
+    EXPECT_EQ(response.ipAddressSpace(), WebCore::IPAddressSpace::Unknown);
+
+    response.setIPAddressSpace(WebCore::IPAddressSpace::Local);
+    EXPECT_EQ(response.ipAddressSpace(), WebCore::IPAddressSpace::Local);
 }
 
 }


### PR DESCRIPTION
#### 40d5429223cabe6e37ca0fdc31c7ad6d76ad541d
<pre>
Classify the real resolved connection IP for Local Network Access on Cocoa
<a href="https://bugs.webkit.org/show_bug.cgi?id=319906">https://bugs.webkit.org/show_bug.cgi?id=319906</a>
<a href="https://rdar.apple.com/182830220">rdar://182830220</a>

Reviewed by Alex Christensen.

Adds classifyIPAddressSpace(const IPAddress&amp;) and wires it into
NetworkDataTaskCocoa so the resolved connection address, not the request
URL&apos;s host, is what gets classified into an IPAddressSpace. The request
URL&apos;s host is attacker-controlled (a DNS-rebinding server can point a
public-looking hostname at 127.0.0.1), so any local-network access policy
decision needs to be based on what actually got connected to. Both the
final response (didReceiveResponse) and each redirect hop
(willPerformHTTPRedirection) are classified, since a redirect is a
separate connection that could target a local/loopback address on its own.

When the connection address cannot be classified (no resolved address, or
one that is neither IPv4 nor IPv6) the space is left as
IPAddressSpace::Unknown, which ranks as the least public space so the local
network access check fails closed instead of defaulting to Public. Unknown
is kept last in the enum so the web-exposed { public, local, loopback }
values in IPAddressSpace.idl keep their indices.

* Source/WebCore/Modules/fetch/IPAddressSpace.cpp:
(WebCore::classifyIPAddressSpace):
* Source/WebCore/Modules/fetch/IPAddressSpace.h:
(WebCore::publicnessRank):
* Source/WebCore/platform/network/ResourceResponseBase.cpp:
(WebCore::ResourceResponseBase::ResourceResponseBase):
* Source/WebCore/platform/network/ResourceResponseBase.h:
(WebCore::ResourceResponseBase::ipAddressSpace const):
* Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm:
(WebKit::NetworkDataTaskCocoa::didReceiveResponse):
(WebKit::NetworkDataTaskCocoa::willPerformHTTPRedirection):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Tools/TestWebKitAPI/Tests/WebCore/IPAddressSpaceTests.cpp:
(TestWebKitAPI::TEST(IPAddressSpace, ClassifyIPAddressSpaceFromResolvedAddress)):
(TestWebKitAPI::TEST(IPAddressSpace, ClassifyUnclassifiableAddressIsUnknown)):
(TestWebKitAPI::TEST(IPAddressSpace, ResourceResponseAddressSpaceDefaultsToUnknown)):

Canonical link: <a href="https://commits.webkit.org/317821@main">https://commits.webkit.org/317821@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/11cf9370bcaf7c09a1c1f04c7b828c3918d6f445

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176369 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50304 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44094 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185968 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/138626 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178232 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51596 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49988 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137383 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/138626 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179325 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40864 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158159 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117858 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39513 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37874 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | 
| [⏳ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/JSC-Tests-x86-64-EWS "Waiting to run tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149929 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37657 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34436 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42033 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42085 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188391 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49969 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146417 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39395 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50653 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34274 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146232 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41005 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122857 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/116904 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49157 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12632 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48559 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48793 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48618 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->