### PR TITLE
[YARR] `InputStream::reread()` should check the code unit before a trail surrogate, not after

### DIFF
--- a/JSTests/stress/regexp-backreference-lone-trail-then-lone-lead.js
+++ b/JSTests/stress/regexp-backreference-lone-trail-then-lone-lead.js
@@ -1,0 +1,39 @@
+function shouldBe(actual, expected, message) {
+    if (actual !== expected)
+        throw new Error(`FAIL ${message}: expected ${expected}, got ${actual}`);
+}
+
+const trail = "\uDC00";
+const lead = "\uD800";
+const pair = "\uD800\uDC00";
+
+const units = [
+    [trail + lead + "a", "trail lead a"],
+    ["a" + trail + lead, "a trail lead"],
+    [lead + "a" + trail, "lead a trail"],
+    [trail + trail + "a", "trail trail a"],
+    [lead + lead + "a", "lead lead a"],
+];
+
+for (const [unit, name] of units) {
+    shouldBe([...unit].length, 3, `${name} code point count`);
+    shouldBe([...(unit + unit)].length, 6, `${name} doubled code point count`);
+}
+
+for (let i = 0; i < testLoopCount; ++i) {
+    for (const [unit, name] of units) {
+        const doubled = unit + unit;
+        shouldBe(/(?<=^)(...)\1/u.test(doubled), true, `${name} interpreter forward`);
+        shouldBe(/^(...)\1/u.test(doubled), true, `${name} jit forward`);
+        shouldBe(/(?<=^)(...)\1/iu.test(doubled), true, `${name} interpreter ignore case`);
+        shouldBe(/(?<=(...)\1)x/u.test(doubled + "x"), true, `${name} interpreter backward`);
+        shouldBe(/(?<=^)(...)\1/u.exec(doubled)[1], unit, `${name} interpreter capture`);
+        shouldBe(/(?<=^)(...)\1/u.test(unit + trail + lead + "b"), false, `${name} interpreter mismatch`);
+    }
+
+    shouldBe(/(?<=^)(.)\1/u.test(pair + pair), true, "surrogate pair backreference");
+    shouldBe(/(?<=^)(..)\1/u.test(pair + "a" + pair + "a"), true, "surrogate pair with trailing ascii");
+    shouldBe(/(?<=^)(.)\1/u.test("\uD801\uD802"), false, "two lone leads are different code points");
+    shouldBe(/(?<=^)(.)\1/u.test("\uDC01\uDC02"), false, "two lone trails are different code points");
+    shouldBe(/(?<=^)(.)\1/u.test(pair + lead), false, "pair followed by lone lead");
+}

--- a/Source/JavaScriptCore/yarr/YarrInterpreter.cpp
+++ b/Source/JavaScriptCore/yarr/YarrInterpreter.cpp
@@ -376,10 +376,10 @@ public:
         {
             ASSERT(from < length);
             auto result = input[from];
-            if (decodeSurrogatePairs && from + 1 < length) {
-                if (U16_IS_LEAD(result) && U16_IS_TRAIL(input[from + 1]))
+            if (decodeSurrogatePairs) {
+                if (U16_IS_LEAD(result) && from + 1 < length && U16_IS_TRAIL(input[from + 1]))
                     return U16_GET_SUPPLEMENTARY(result, input[from + 1]);
-                if (U16_IS_TRAIL(result) && U16_IS_LEAD(input[from + 1]))
+                if (U16_IS_TRAIL(result) && from > 0 && U16_IS_LEAD(input[from - 1]))
                     return errorCodePoint;
             }
             return result;


### PR DESCRIPTION
#### 8c6275e1441775ef617f65034e8fe99de9e517f5
<pre>
[YARR] `InputStream::reread()` should check the code unit before a trail surrogate, not after
<a href="https://bugs.webkit.org/show_bug.cgi?id=319932">https://bugs.webkit.org/show_bug.cgi?id=319932</a>

Reviewed by Yusuke Suzuki.

reread() returns errorCodePoint for a trail surrogate whose *following* code
unit is a lead. The error case is a read landing in the middle of a pair, so it
must look at the preceding unit; readCheckedDontAdvance() already does this.

tryConsumeBackReference() rereads the captured text, and errorCodePoint there
fails the backreference unconditionally. Patterns with a lookbehind always run
in the interpreter, so this reproduces with default options:

    var unit = &quot;\uDC00\uD800a&quot;;
    /(?&lt;=^)(...)\1/u.test(unit + unit);  // false, should be true

Also move the from + 1 &lt; length check into the lead branch, so that a trail
surrogate at the end of the input is still checked.

Introduced in 280563@main.

Test: JSTests/stress/regexp-backreference-lone-trail-then-lone-lead.js

* JSTests/stress/regexp-backreference-lone-trail-then-lone-lead.js: Added.
(shouldBe):
* Source/JavaScriptCore/yarr/YarrInterpreter.cpp:
(JSC::Yarr::Interpreter::InputStream::reread):

Canonical link: <a href="https://commits.webkit.org/317694@main">https://commits.webkit.org/317694@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c62025deef5e27ed16d3c79b93572431d40fb5c3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176027 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49960 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43744 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185621 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/138243 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51252 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49642 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137084 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/138243 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178983 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40552 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157855 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117563 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39195 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/37571 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/6364 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149613 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37349 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34090 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/37291 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/41664 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/41777 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188043 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49627 "Built successfully") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/146094 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39300 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50308 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/33972 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145929 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40705 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122503 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/116404 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48814 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12328 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48216 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48448 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48273 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->