### PR TITLE
[macOS] NSRefreshController may enter activation loop if window is short

### DIFF
--- a/Source/WebKit/UIProcess/mac/WebViewImpl.h
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.h
@@ -1231,6 +1231,7 @@ private:
     RetainPtr<CAShapeLayer> m_refreshControllerMask;
     CGFloat m_topScrollStretchForRefreshController { 0 };
     bool m_canShowRefreshController { false };
+    bool m_suppressRefreshControllerUpdates { false };
     CGFloat m_cachedTopScrollStretch { 0 };
 #endif
 

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -8179,6 +8179,7 @@ void WebViewImpl::setRefreshController(NSRefreshController *refreshController)
         [[m_refreshController refreshControl] removeFromSuperview];
         m_topScrollStretchForRefreshController = 0;
         m_refreshControllerMask = nil;
+        m_suppressRefreshControllerUpdates = false;
     }
 
     m_refreshController = refreshController;
@@ -8214,6 +8215,10 @@ void WebViewImpl::setRefreshController(NSRefreshController *refreshController)
 void WebViewImpl::applyRefreshControllerHeight(CGFloat height, bool animated)
 {
     m_topScrollStretchForRefreshController = height;
+
+    if (!height && m_cachedTopScrollStretch > 0)
+        m_suppressRefreshControllerUpdates = true;
+
     if (CheckedPtr scrollingCoordinator = m_page->scrollingCoordinatorProxy())
         scrollingCoordinator->setTopScrollStretchForRefreshController(height);
 }
@@ -8260,7 +8265,8 @@ void WebViewImpl::updateRefreshControllerFrame()
         [m_refreshControllerMask setPath:maskPath.get()];
     }
 
-    [[m_refreshController refreshControl] update];
+    if (!m_suppressRefreshControllerUpdates)
+        [[m_refreshController refreshControl] update];
 
     if (CheckedPtr scrollingCoordinator = m_page->scrollingCoordinatorProxy())
         scrollingCoordinator->setRefreshControllerSnappingThreshold(refreshControllerSnappingThreshold());
@@ -8272,6 +8278,10 @@ void WebViewImpl::topScrollStretchDidChange(CGFloat topScrollStretch)
         return;
 
     m_cachedTopScrollStretch = topScrollStretch;
+
+    if (m_suppressRefreshControllerUpdates && !topScrollStretch)
+        m_suppressRefreshControllerUpdates = false;
+
     if (m_refreshController)
         updateRefreshControllerFrame();
 }
@@ -8283,8 +8293,10 @@ void WebViewImpl::updateRefreshControllerForWheelEvent(NSEvent *event)
 
     // Track whether this scroll gesture began at the top of the page.
     // Only allow refresh control activation for gestures that started at top.
-    if (event.phase == NSEventPhaseBegan)
+    if (event.phase == NSEventPhaseBegan) {
         m_canShowRefreshController = pageIsScrolledToTop();
+        m_suppressRefreshControllerUpdates = false;
+    }
 }
 
 #if HAVE(APPKIT_GESTURES_SUPPORT)
@@ -8295,8 +8307,10 @@ void WebViewImpl::updateRefreshControllerForPanGesture(NSGestureRecognizerState 
 
     // Track whether this scroll gesture began at the top of the page.
     // Only allow refresh control activation for gestures that started at top.
-    if (state == NSGestureRecognizerStateBegan)
+    if (state == NSGestureRecognizerStateBegan) {
         m_canShowRefreshController = pageIsScrolledToTop();
+        m_suppressRefreshControllerUpdates = false;
+    }
 }
 #endif
 

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -1047,6 +1047,7 @@
 				WebKit/WKWebView/mac/MenuTypesForMouseEvents.mm,
 				WebKit/WKWebView/mac/MouseEventTests.mm,
 				WebKit/WKWebView/mac/NoPolicyDelegateResponse.mm,
+				WebKit/WKWebView/mac/NSRefreshControllerTests.mm,
 				WebKit/WKWebView/mac/NSResponderTests.mm,
 				WebKit/WKWebView/mac/PageVisibilityStateWithWindowChanges.mm,
 				WebKit/WKWebView/mac/RenderedImageFromDOMNode.mm,

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/NSRefreshControllerTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/NSRefreshControllerTests.mm
@@ -1,0 +1,138 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+
+#if HAVE(NSREFRESHCONTROLLER)
+
+#import "Helpers/PlatformUtilities.h"
+#import "Helpers/Test.h"
+#import "Helpers/cocoa/TestNavigationDelegate.h"
+#import "Helpers/cocoa/TestWKWebView.h"
+#import "Helpers/mac/AppKitSPI.h"
+#import <WebKit/WKWebViewPrivate.h>
+#import <wtf/RetainPtr.h>
+
+@interface TestRefreshControllerTarget : NSObject
+@property (nonatomic, readonly) NSUInteger activationCount;
+@property (nonatomic, weak) WKWebView *webView;
+- (void)refreshControllerActivated:(NSRefreshController *)sender;
+@end
+
+@implementation TestRefreshControllerTarget
+
+- (void)refreshControllerActivated:(NSRefreshController *)sender
+{
+    ++_activationCount;
+    [_webView reload];
+}
+
+@end
+
+namespace TestWebKitAPI {
+
+static void pullDownAndWaitForRefresh(TestWKWebView *webView, NSRefreshController *refreshController)
+{
+    auto eventLocation = NSMakePoint(NSMidX([webView bounds]), NSMidY([webView bounds]));
+    [webView wheelEventAtPoint:eventLocation wheelDelta:CGSizeMake(0, 1) phase:kCGScrollPhaseBegan momentumPhase:kCGMomentumScrollPhaseNone];
+
+    for (int i = 0; i < 200 && ![refreshController isRefreshing]; ++i) {
+        [webView wheelEventAtPoint:eventLocation wheelDelta:CGSizeMake(0, 100) phase:kCGScrollPhaseChanged momentumPhase:kCGMomentumScrollPhaseNone];
+        [webView waitForNextPresentationUpdate];
+    }
+
+    [webView wheelEventAtPoint:eventLocation wheelDelta:CGSizeMake(0, 0) phase:kCGScrollPhaseEnded momentumPhase:kCGMomentumScrollPhaseNone];
+    [webView waitForNextPresentationUpdate];
+}
+
+class NSRefreshControllerTests : public testing::Test {
+public:
+    RetainPtr<TestWKWebView> webView;
+    RetainPtr<NSRefreshController> refreshController;
+    RetainPtr<TestRefreshControllerTarget> target;
+
+    void setUpWithWindowHeight(CGFloat windowHeight)
+    {
+        RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+        webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, windowHeight) configuration:configuration.get() addToWindow:YES]);
+
+        refreshController = adoptNS([[NSRefreshController alloc] init]);
+        target = adoptNS([[TestRefreshControllerTarget alloc] init]);
+        [target setWebView:webView.get()];
+        [refreshController setTarget:target.get()];
+        [refreshController setAction:@selector(refreshControllerActivated:)];
+        [webView setRefreshController:refreshController.get()];
+    }
+};
+
+TEST_F(NSRefreshControllerTests, Basic)
+{
+    setUpWithWindowHeight(600);
+
+    [webView synchronouslyLoadHTMLString:@"<body style='height: 2000px;'></body>"];
+    [webView waitForNextPresentationUpdate];
+
+    pullDownAndWaitForRefresh(webView.get(), refreshController.get());
+
+    EXPECT_EQ([target activationCount], 1U);
+    EXPECT_TRUE([refreshController isRefreshing]);
+}
+
+TEST_F(NSRefreshControllerTests, DoesNotRefireDuringSettleAtSmallWindowHeight)
+{
+    setUpWithWindowHeight(200);
+
+    RetainPtr navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
+    [webView setNavigationDelegate:navigationDelegate.get()];
+
+    [webView loadHTMLString:@"<body style='height: 2000px;'></body>" baseURL:nil];
+    [navigationDelegate waitForDidFinishNavigation];
+    [webView waitForNextPresentationUpdate];
+
+    __block bool reloadFinished = false;
+    [navigationDelegate setDidFinishNavigation:^(WKWebView *, WKNavigation *) {
+        reloadFinished = true;
+    }];
+
+    pullDownAndWaitForRefresh(webView.get(), refreshController.get());
+    EXPECT_EQ([target activationCount], 1U);
+    ASSERT_TRUE([refreshController isRefreshing]);
+
+
+    Util::run(&reloadFinished);
+    [refreshController endRefreshing];
+
+    Util::waitForConditionWithLogging([&] {
+        return ![refreshController isRefreshing];
+    }, 5, @"Timed out waiting for refresh controller to leave the refreshing state.");
+
+    Util::runFor(1_s);
+    EXPECT_EQ([target activationCount], 1U);
+    EXPECT_FALSE([refreshController isRefreshing]);
+}
+
+} // namespace TestWebKitAPI
+
+#endif // HAVE(NSREFRESHCONTROLLER)


### PR DESCRIPTION
#### 19adb12b17aca01c1226574b0fea9c109e0a0b88
<pre>
[macOS] NSRefreshController may enter activation loop if window is short
<a href="https://webkit.org/b/319803">https://webkit.org/b/319803</a>
<a href="https://rdar.apple.com/182131572">rdar://182131572</a>

Reviewed by Abrar Rahman Protyasha.

Stop calling `update` on the refresh controller until the scroll stretch
settles after activation.

Added a basic NSRefreshController test along with a test for this specific
bug.

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/NSRefreshControllerTests.mm

* Source/WebKit/UIProcess/mac/WebViewImpl.h:
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::setRefreshController):
(WebKit::WebViewImpl::applyRefreshControllerHeight):
(WebKit::WebViewImpl::updateRefreshControllerFrame):
(WebKit::WebViewImpl::topScrollStretchDidChange):
(WebKit::WebViewImpl::updateRefreshControllerForWheelEvent):
(WebKit::WebViewImpl::updateRefreshControllerForPanGesture):
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/NSRefreshControllerTests.mm: Added.
(-[TestRefreshControllerTarget refreshControllerActivated:]):
(TestWebKitAPI::pullDownAndWaitForRefresh):
(TestWebKitAPI::TEST(NSRefreshControllerTests, Basic)):
(TestWebKitAPI::TEST(NSRefreshControllerTests, DoesNotRefireDuringSettleAtSmallWindowHeight)):

Canonical link: <a href="https://commits.webkit.org/317876@main">https://commits.webkit.org/317876@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cea4f10cd8b511bd1079b4cb9cab4a1a1fe13152

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176026 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49959 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43743 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185620 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/138242 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/00fbd04a-94a8-4377-a761-fd2745b37b3c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/177889 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51251 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49641 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137083 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/138242 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8b3ef4ae-ff01-426c-b2c5-26bd5bdda84a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178982 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40551 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157853 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117562 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fa1082dd-0a3c-434e-ae63-16852cd69049) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39194 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37570 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149612 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37346 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34089 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41663 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41793 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188042 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49626 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146093 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39432 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50307 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33975 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145928 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40704 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122502 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/116397 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48813 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12326 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48215 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48447 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48272 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->