### PR TITLE
AX: Inefficiencies around id dirtying and searching when building accessibility relations

### DIFF
--- a/LayoutTests/accessibility/aria-relations-disconnected-subtree-no-timeout-expected.txt
+++ b/LayoutTests/accessibility/aria-relations-disconnected-subtree-no-timeout-expected.txt
@@ -1,0 +1,10 @@
+This test ensures a large disconnected subtree whose elements carry ARIA relation attributes does not trigger a quadratic getElementByIdIncludingDisconnected() scan when accessibility relations are rebuilt.
+
+PASS: controlLabel.isEqual(control.titleUIElement()) === true
+PASS: Did not timeout.
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+fallback name
+the resolved label

--- a/LayoutTests/accessibility/aria-relations-disconnected-subtree-no-timeout.html
+++ b/LayoutTests/accessibility/aria-relations-disconnected-subtree-no-timeout.html
@@ -1,0 +1,60 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<script src="../resources/accessibility-helper.js"></script>
+<script src="../resources/js-test.js"></script>
+</head>
+<body>
+
+<button id="control" aria-labelledby="control-label">fallback name</button>
+<p id="control-label">the resolved label</p>
+
+<script>
+var output = "This test ensures a large disconnected subtree whose elements carry ARIA relation attributes does not trigger a quadratic getElementByIdIncludingDisconnected() scan when accessibility relations are rebuilt.\n\n";
+var control, controlLabel;
+
+if (window.accessibilityController && window.internals) {
+    window.jsTestIsAsync = true;
+
+    // Force the initial relations build so subsequent rebuilds take the incremental
+    // (m_elementsWithRelationAttributes) path rather than the full-tree walk.
+    accessibilityController.accessibleElementById("control").titleUIElement();
+
+    setTimeout(function() {
+        control = document.getElementById("control");
+
+        // Build one large detached subtree, then give every element ARIA relation attributes.
+        // Having large detached subtrees is a realistic scenario for heavy, web-app-style pages.
+        const count = 5000;
+        const detached = document.createElement("div");
+        for (let i = 0; i < count; i++) {
+            const element = document.createElement("div");
+            element.id = `d${i}`;
+            detached.appendChild(element);
+        }
+        for (let i = 0; i < count; i++) {
+            const element = detached.children[i];
+            element.setAttribute("aria-labelledby", "missing-a missing-b missing-c missing-d missing-e");
+            element.setAttribute("aria-owns", "missing-f missing-g missing-h missing-i missing-j");
+        }
+
+        // Repeatedly dirty relations and force a synchronous rebuild.
+        for (let i = 0; i < 20; i++) {
+            control.setAttribute("aria-labelledby", i % 2 ? "control-label" : "control-label ");
+            internals.forceAXObjectCacheUpdate();
+            accessibilityController.accessibleElementById("control").titleUIElement();
+        }
+
+        // The connected control's aria-labelledby must still resolve to #control-label.
+        control = accessibilityController.accessibleElementById("control");
+        controlLabel = accessibilityController.accessibleElementById("control-label");
+        output += expect("controlLabel.isEqual(control.titleUIElement())", "true");
+        output += "PASS: Did not timeout.\n";
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -5566,7 +5566,7 @@ void AXObjectCache::performDeferredCacheUpdate(ForceLayout forceLayout)
     AXLOGDeferredCollection("AttributeChange"_s, m_deferredAttributeChange);
     for (const auto& attributeChange : borrow(m_deferredAttributeChange).get()) {
         handleAttributeChange(protect(attributeChange.element.get()), attributeChange.attrName, attributeChange.oldValue, attributeChange.newValue);
-        if (attributeChange.attrName == idAttr)
+        if (attributeChange.attrName == idAttr && idChangeCanAffectRelations(attributeChange.element.get(), attributeChange.oldValue, attributeChange.newValue))
             markRelationsDirty();
     }
     m_deferredAttributeChange.clear();
@@ -6731,6 +6731,7 @@ void AXObjectCache::updateRelationsIfNeeded()
     m_recentlyRemovedRelations.clear();
     m_relationTargets.clear();
     m_unresolvedRelationTargetIds.clear();
+    m_referencedRelationTargetIds.clear();
     m_hasAriaOwnsRelations = false;
 
     if (!m_doneInitialRelationsBuild) {
@@ -6792,6 +6793,24 @@ void AXObjectCache::trackRelationAttributeElement(Element& element)
         relationsNeedUpdate(true);
 }
 
+bool AXObjectCache::idChangeCanAffectRelations(Element* element, const AtomString& oldID, const AtomString& newID) const
+{
+    auto isReferenced = [&](const AtomString& id) {
+        return !id.isEmpty() && m_referencedRelationTargetIds.contains(id);
+    };
+    if (isReferenced(oldID) || isReferenced(newID)) {
+        // An id change affects relations only if the old or new id is referenced by a relation attribute.
+        return true;
+    }
+
+    // A relation can also resolve through a shadow root's reference target, in which case it depends on
+    // an inner id (the reference target) rather than the relation attribute's value, so that inner id is
+    // not in m_referencedRelationTargetIds. Conservatively re-resolve when an id changes inside a shadow
+    // tree that uses a reference target.
+    RefPtr shadowRoot = element ? element->containingShadowRoot() : nullptr;
+    return shadowRoot && shadowRoot->hasReferenceTarget();
+}
+
 bool AXObjectCache::addRelation(Element& origin, const QualifiedName& attribute)
 {
     if (attribute == aria_labeledbyAttr && origin.hasAttribute(aria_labelledbyAttr)) {
@@ -6805,13 +6824,23 @@ bool AXObjectCache::addRelation(Element& origin, const QualifiedName& attribute)
         return false;
 
     // Remember any referenced ids whose target doesn't exist yet, so that if an element with one of
-    // these ids is inserted later, we know to dirty relations and re-resolve it
+    // these ids is inserted later, we know to dirty relations and re-resolve it. Also remember every
+    // referenced id (resolved or not) so that an id-attribute change can be cheaply checked against it.
     if (const auto& value = origin.attributeWithoutSynchronization(attribute); !value.isNull()) {
         Ref treeScope = origin.treeScope();
         for (auto& id : SpaceSplitString(value, SpaceSplitString::ShouldFoldCase::No)) {
+            m_referencedRelationTargetIds.add(id);
             if (!treeScope->elementByIdResolvingReferenceTarget(id))
                 m_unresolvedRelationTargetIds.add(id);
         }
+    }
+
+    if (!origin.isInTreeScope()) {
+        // When an origin is not in a tree scope, Element::elementsArrayForAttributeInternal() can't use the
+        // TreeScope id map and falls back to getElementByIdIncludingDisconnected(), which linearly scans
+        // the entire detached subtree once per referenced id. On pages with large detached subtrees this
+        // can cause performance issues.
+        return false;
     }
 
     if (Element::isElementReflectionAttribute(m_document->settings(), attribute)) {
@@ -6855,6 +6884,11 @@ bool AXObjectCache::addRelation(Element& origin, const QualifiedName& attribute)
 
 void AXObjectCache::addLabelForRelation(Element& origin)
 {
+    // A detached label has no accessibility object, so its label relations have no consumer. Skipping
+    // it here also avoids HTMLLabelElement::control()'s scan of the label's descendants.
+    if (!origin.isInTreeScope())
+        return;
+
     bool addedRelation = false;
 
     // LabelFor relations are established for <label for=...>.

--- a/Source/WebCore/accessibility/AXObjectCache.h
+++ b/Source/WebCore/accessibility/AXObjectCache.h
@@ -990,6 +990,7 @@ private:
     void updateLabeledBy(Element*);
     void updateRelationsIfNeeded();
     void updateRelationsForTree(ContainerNode&);
+    bool idChangeCanAffectRelations(Element*, const AtomString& oldID, const AtomString& newID) const;
     void relationsNeedUpdate(bool);
     void dirtyIsolatedTreeRelations();
     HashMap<AXID, AXRelations> relations();
@@ -1168,6 +1169,9 @@ private:
     // relations were last built. If an element with one of these ids is later inserted, we must
     // re-resolve relations.
     HashSet<AtomString> m_unresolvedRelationTargetIds;
+    // All ids referenced by a relation attribute (resolved or not) as of the last relations build.
+    // Used to decide whether an id-attribute change can affect any relation.
+    HashSet<AtomString> m_referencedRelationTargetIds;
 
 #if USE(ATSPI)
     ListHashSet<RefPtr<AccessibilityObject>> m_deferredParentChangedList;


### PR DESCRIPTION
#### 8b7c9b52a2c5166d71da7c97345fa12aec5b6d07
<pre>
AX: Inefficiencies around id dirtying and searching when building accessibility relations
<a href="https://bugs.webkit.org/show_bug.cgi?id=319937">https://bugs.webkit.org/show_bug.cgi?id=319937</a>
<a href="https://rdar.apple.com/182309307">rdar://182309307</a>

Reviewed by Dominic Mazzoni and Chris Fleizach.

When accessibility relations are rebuilt, updateRelationsIfNeeded() iterates
m_elementsWithRelationAttributes, which can hold detached elements. For an origin
that is not in a tree scope, Element::elementsArrayForAttributeInternal() cannot
use the TreeScope id map and falls back to getElementByIdIncludingDisconnected(),
which linearly scans the entire detached subtree once per referenced id. On pages
with large detached subtrees that carry ARIA relation attributes, this can severely
harm performance.

Fix this by skipping resolution of  relations for origins that are not in a tree scope.
Such elements have no accessibility object, so their relations have no consumer.

Additionally, this commit reduces how often relations are rebuilt. performDeferredCacheUpdate()
used to mark all relations dirty on every id-attribute change, forcing a full rebuild, regardless
of whether that id was part of a relation. Now we track every id referenced by a relation attribute
(resolved or not) in a new m_referencedRelationTargetIds set and only dirty relations when a changed
id can actually affect one.

* LayoutTests/accessibility/aria-relations-disconnected-subtree-no-timeout-expected.txt: Added.
* LayoutTests/accessibility/aria-relations-disconnected-subtree-no-timeout.html: Added.
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::performDeferredCacheUpdate):
(WebCore::AXObjectCache::updateRelationsIfNeeded):
(WebCore::AXObjectCache::idChangeCanAffectRelations const):
(WebCore::AXObjectCache::addRelation):
(WebCore::AXObjectCache::addLabelForRelation):
* Source/WebCore/accessibility/AXObjectCache.h:

Canonical link: <a href="https://commits.webkit.org/317690@main">https://commits.webkit.org/317690@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/61dcccc6657ef3f6019067afe3d295c50b45a37f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175981 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49914 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43698 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185574 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/138193 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e049afd5-c1f6-4876-adc2-75b3c5553470) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/177844 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51206 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49596 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137040 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/138193 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/638bbd6b-7e09-482e-bda4-6fee2c98df11) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178937 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40506 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157816 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117519 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9cb68a6b-c603-4635-a469-3aa418476f63) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39148 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37528 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149567 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37308 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34044 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41616 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/41734 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187996 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49581 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/157367 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146052 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39297 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50261 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/33933 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145882 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40666 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122457 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/116335 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48768 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12289 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48170 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48402 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48227 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->