### PR TITLE
moneycontrol.com: Overlapping content at zoom level 50%

### DIFF
--- a/LayoutTests/fast/css/zoom-page-max-width-text-wrap-expected.txt
+++ b/LayoutTests/fast/css/zoom-page-max-width-text-wrap-expected.txt
@@ -1,0 +1,1 @@
+PASS bold lines=1 (expected 1), normal lines=1 (expected 1) PASS weight-independent

--- a/LayoutTests/fast/css/zoom-page-max-width-text-wrap.html
+++ b/LayoutTests/fast/css/zoom-page-max-width-text-wrap.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>rdar://66569768: a width-capped inline label must not wrap under native page zoom (weight-independent)</title>
+<style>
+  body { margin: 8px; font-family: Arial, "Helvetica Neue", sans-serif; }
+  .stname { max-width: 100px; font-family: Lato, Arial, "Helvetica Neue", sans-serif; }
+  .stname strong { font-size: 10px; }
+  #bold strong { font-weight: 700; }
+  #normal strong { font-weight: 400; }
+</style>
+</head>
+<body>
+<div class="stname" id="bold"><strong>NIFTY Midcap 100</strong></div>
+<div class="stname" id="normal"><strong>NIFTY Midcap 100</strong></div>
+<pre id="result">running</pre>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+if (window.internals)
+    internals.setPageZoomFactor(0.5);
+
+function lineCount(id) {
+    return document.querySelector('#' + id + ' strong').getClientRects().length;
+}
+
+function check() {
+    var bold = lineCount('bold');
+    var normal = lineCount('normal');
+    var pass = bold === 1 && normal === 1;
+    var weightIndependent = bold === normal;
+    var text = (pass ? 'PASS' : 'FAIL') +
+        ' bold lines=' + bold + ' (expected 1), normal lines=' + normal + ' (expected 1)' +
+        (weightIndependent ? ' PASS weight-independent' : ' FAIL weight-dependent (bold != normal)');
+    // Replace the sample markup with only the result so dumpAsText output is stable.
+    document.body.textContent = text;
+    if (window.testRunner)
+        testRunner.notifyDone();
+}
+
+// Let layout settle after the zoom change (and after any web font loads).
+if (document.fonts && document.fonts.ready)
+    document.fonts.ready.then(function () { requestAnimationFrame(check); });
+else
+    requestAnimationFrame(check);
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/glib/fast/backgrounds/background-position-parsing-expected.txt
+++ b/LayoutTests/platform/glib/fast/backgrounds/background-position-parsing-expected.txt
@@ -1,6 +1,6 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x381
+layer at (0,0) size 800x380
   RenderBlock {HTML} at (0,0) size 800x381
     RenderBody {BODY} at (8,16) size 784x18
       RenderBlock {P} at (0,0) size 784x18
@@ -9,150 +9,150 @@ layer at (0,0) size 800x381
       RenderBlock (floating) {DIV} at (1,35) size 78x53 [border: (1px solid #000000)]
         RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (82,35) size 78x53 [border: (1px solid #000000)]
+      RenderBlock (floating) {DIV} at (81,35) size 78x53 [border: (1px solid #000000)]
         RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (162,35) size 78x53 [border: (1px solid #000000)]
+      RenderBlock (floating) {DIV} at (161,35) size 78x53 [border: (1px solid #000000)]
         RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (243,35) size 78x53 [border: (1px solid #000000)]
+      RenderBlock (floating) {DIV} at (242,35) size 78x53 [border: (1px solid #000000)]
         RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (324,35) size 78x53 [border: (1px solid #000000)]
+      RenderBlock (floating) {DIV} at (322,35) size 78x53 [border: (1px solid #000000)]
         RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (404,35) size 78x53 [border: (1px solid #000000)]
+      RenderBlock (floating) {DIV} at (402,35) size 78x53 [border: (1px solid #000000)]
         RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (485,35) size 78x53 [border: (1px solid #000000)]
+      RenderBlock (floating) {DIV} at (482,35) size 78x53 [border: (1px solid #000000)]
         RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (565,35) size 78x53 [border: (1px solid #000000)]
+      RenderBlock (floating) {DIV} at (562,35) size 78x53 [border: (1px solid #000000)]
         RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (646,35) size 78x53 [border: (1px solid #000000)]
+      RenderBlock (floating) {DIV} at (643,35) size 78x53 [border: (1px solid #000000)]
         RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
       RenderBlock (floating) {DIV} at (1,90) size 78x53 [border: (1px solid #000000)]
         RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (82,90) size 78x53 [border: (1px solid #000000)]
+      RenderBlock (floating) {DIV} at (81,90) size 78x53 [border: (1px solid #000000)]
         RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (162,90) size 78x53 [border: (1px solid #000000)]
+      RenderBlock (floating) {DIV} at (161,90) size 78x53 [border: (1px solid #000000)]
         RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (243,90) size 78x53 [border: (1px solid #000000)]
+      RenderBlock (floating) {DIV} at (242,90) size 78x53 [border: (1px solid #000000)]
         RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (324,90) size 78x53 [border: (1px solid #000000)]
+      RenderBlock (floating) {DIV} at (322,90) size 78x53 [border: (1px solid #000000)]
         RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (404,90) size 78x53 [border: (1px solid #000000)]
+      RenderBlock (floating) {DIV} at (402,90) size 78x53 [border: (1px solid #000000)]
         RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (485,90) size 78x53 [border: (1px solid #000000)]
+      RenderBlock (floating) {DIV} at (482,90) size 78x53 [border: (1px solid #000000)]
         RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (565,90) size 78x53 [border: (1px solid #000000)]
+      RenderBlock (floating) {DIV} at (562,90) size 78x53 [border: (1px solid #000000)]
         RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (646,90) size 78x53 [border: (1px solid #000000)]
+      RenderBlock (floating) {DIV} at (643,90) size 78x53 [border: (1px solid #000000)]
         RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
       RenderBlock (floating) {DIV} at (1,145) size 78x53 [border: (1px solid #000000)]
         RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (82,145) size 78x53 [border: (1px solid #000000)]
+      RenderBlock (floating) {DIV} at (81,145) size 78x53 [border: (1px solid #000000)]
         RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (162,145) size 78x53 [border: (1px solid #000000)]
+      RenderBlock (floating) {DIV} at (161,145) size 78x53 [border: (1px solid #000000)]
         RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (243,145) size 78x53 [border: (1px solid #000000)]
+      RenderBlock (floating) {DIV} at (242,145) size 78x53 [border: (1px solid #000000)]
         RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (324,145) size 78x53 [border: (1px solid #000000)]
+      RenderBlock (floating) {DIV} at (322,145) size 78x53 [border: (1px solid #000000)]
         RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (404,145) size 78x53 [border: (1px solid #000000)]
+      RenderBlock (floating) {DIV} at (402,145) size 78x53 [border: (1px solid #000000)]
         RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (485,145) size 78x53 [border: (1px solid #000000)]
+      RenderBlock (floating) {DIV} at (482,145) size 78x53 [border: (1px solid #000000)]
         RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (565,145) size 78x53 [border: (1px solid #000000)]
+      RenderBlock (floating) {DIV} at (562,145) size 78x53 [border: (1px solid #000000)]
         RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (646,145) size 78x53 [border: (1px solid #000000)]
+      RenderBlock (floating) {DIV} at (643,145) size 78x53 [border: (1px solid #000000)]
         RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
       RenderBlock (floating) {DIV} at (1,200) size 78x53 [border: (1px solid #000000)]
         RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (82,200) size 78x53 [border: (1px solid #000000)]
+      RenderBlock (floating) {DIV} at (81,200) size 78x53 [border: (1px solid #000000)]
         RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (162,200) size 78x53 [border: (1px solid #000000)]
+      RenderBlock (floating) {DIV} at (161,200) size 78x53 [border: (1px solid #000000)]
         RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (243,200) size 78x53 [border: (1px solid #000000)]
+      RenderBlock (floating) {DIV} at (242,200) size 78x53 [border: (1px solid #000000)]
         RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (324,200) size 78x53 [border: (1px solid #000000)]
+      RenderBlock (floating) {DIV} at (322,200) size 78x53 [border: (1px solid #000000)]
         RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (404,200) size 78x53 [border: (1px solid #000000)]
+      RenderBlock (floating) {DIV} at (402,200) size 78x53 [border: (1px solid #000000)]
         RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (485,200) size 78x53 [border: (1px solid #000000)]
+      RenderBlock (floating) {DIV} at (482,200) size 78x53 [border: (1px solid #000000)]
         RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (565,200) size 78x53 [border: (1px solid #000000)]
+      RenderBlock (floating) {DIV} at (562,200) size 78x53 [border: (1px solid #000000)]
         RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (646,200) size 78x53 [border: (1px solid #000000)]
+      RenderBlock (floating) {DIV} at (643,200) size 78x53 [border: (1px solid #000000)]
         RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
       RenderBlock (floating) {DIV} at (1,255) size 78x53 [border: (1px solid #000000)]
         RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (82,255) size 78x53 [border: (1px solid #000000)]
+      RenderBlock (floating) {DIV} at (81,255) size 78x53 [border: (1px solid #000000)]
         RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (162,255) size 78x53 [border: (1px solid #000000)]
+      RenderBlock (floating) {DIV} at (161,255) size 78x53 [border: (1px solid #000000)]
         RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (243,255) size 78x53 [border: (1px solid #000000)]
+      RenderBlock (floating) {DIV} at (242,255) size 78x53 [border: (1px solid #000000)]
         RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (324,255) size 78x53 [border: (1px solid #000000)]
+      RenderBlock (floating) {DIV} at (322,255) size 78x53 [border: (1px solid #000000)]
         RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (404,255) size 78x53 [border: (1px solid #000000)]
+      RenderBlock (floating) {DIV} at (402,255) size 78x53 [border: (1px solid #000000)]
         RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (485,255) size 78x53 [border: (1px solid #000000)]
+      RenderBlock (floating) {DIV} at (482,255) size 78x53 [border: (1px solid #000000)]
         RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (565,255) size 78x53 [border: (1px solid #000000)]
+      RenderBlock (floating) {DIV} at (562,255) size 78x53 [border: (1px solid #000000)]
         RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (646,255) size 78x53 [border: (1px solid #000000)]
+      RenderBlock (floating) {DIV} at (643,255) size 78x53 [border: (1px solid #000000)]
         RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
       RenderBlock (floating) {DIV} at (1,310) size 78x53 [border: (1px solid #000000)]
         RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (82,310) size 78x53 [border: (1px solid #000000)]
+      RenderBlock (floating) {DIV} at (81,310) size 78x53 [border: (1px solid #000000)]
         RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (162,310) size 78x53 [border: (1px solid #000000)]
+      RenderBlock (floating) {DIV} at (161,310) size 78x53 [border: (1px solid #000000)]
         RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (243,310) size 78x53 [border: (1px solid #000000)]
+      RenderBlock (floating) {DIV} at (242,310) size 78x53 [border: (1px solid #000000)]
         RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (324,310) size 78x53 [border: (1px solid #000000)]
+      RenderBlock (floating) {DIV} at (322,310) size 78x53 [border: (1px solid #000000)]
         RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34

--- a/LayoutTests/platform/glib/svg/stroke/nan-stroke-width-crash-expected.txt
+++ b/LayoutTests/platform/glib/svg/stroke/nan-stroke-width-crash-expected.txt
@@ -1,24 +1,24 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x68
-  RenderBlock {HTML} at (0,0) size 800x68
-    RenderBody {BODY} at (8,16) size 784x44
+layer at (0,0) size 800x59
+  RenderBlock {HTML} at (0,0) size 800x59
+    RenderBody {BODY} at (8,16) size 784x35
       RenderBlock {P} at (0,0) size 784x18
         RenderText {#text} at (0,0) size 276x18
           text run at (0,0) width 276: "This test passes if it does not crash or assert."
-      RenderBlock {DIV} at (0,34) size 784x10
-        RenderBlock {DIV} at (0,0) size 784x10
-          RenderBlock {DIV} at (0,0) size 784x10
-            RenderBlock {DIV} at (0,0) size 784x10
-              RenderBlock {DIV} at (0,0) size 784x10
-                RenderBlock {DIV} at (0,0) size 784x10
-                  RenderBlock {DIV} at (0,0) size 784x10
-                    RenderBlock {DIV} at (0,0) size 784x10
-                      RenderBlock {DIV} at (0,0) size 784x10
-                        RenderBlock {DIV} at (0,0) size 784x10
-                          RenderBlock {DIV} at (0,0) size 784x10
-                            RenderBlock {DIV} at (0,0) size 784x10
-                              RenderSVGRoot {svg} at (8,58) size 0x0
-                                RenderSVGEllipse {circle} at (8,58) size 0x0 [stroke={[type=SOLID] [color=#FF0000] [stroke width=0.00]}] [fill={[type=SOLID] [color=#000000]}] [cx=0.00] [cy=0.00] [r=1.00]
-                                RenderSVGRect {rect} at (8,58) size 0x0 [stroke={[type=SOLID] [color=#FF0000] [stroke width=0.00]}] [fill={[type=SOLID] [color=#000000]}] [x=0.00] [y=0.00] [width=1.00] [height=1.00]
+      RenderBlock {DIV} at (0,34) size 784x1
+        RenderBlock {DIV} at (0,0) size 784x1
+          RenderBlock {DIV} at (0,0) size 784x1
+            RenderBlock {DIV} at (0,0) size 784x1
+              RenderBlock {DIV} at (0,0) size 784x1
+                RenderBlock {DIV} at (0,0) size 784x1
+                  RenderBlock {DIV} at (0,0) size 784x1
+                    RenderBlock {DIV} at (0,0) size 784x1
+                      RenderBlock {DIV} at (0,0) size 784x1
+                        RenderBlock {DIV} at (0,0) size 784x1
+                          RenderBlock {DIV} at (0,0) size 784x1
+                            RenderBlock {DIV} at (0,0) size 784x1
+                              RenderSVGRoot {svg} at (8,51) size 0x0
+                                RenderSVGEllipse {circle} at (8,51) size 0x0 [stroke={[type=SOLID] [color=#FF0000] [stroke width=0.00]}] [fill={[type=SOLID] [color=#000000]}] [cx=0.00] [cy=0.00] [r=1.00]
+                                RenderSVGRect {rect} at (8,51) size 0x0 [stroke={[type=SOLID] [color=#FF0000] [stroke width=0.00]}] [fill={[type=SOLID] [color=#000000]}] [x=0.00] [y=0.00] [width=1.00] [height=1.00]
                               RenderText {#text} at (0,0) size 0x0

--- a/LayoutTests/platform/ios/fast/backgrounds/background-position-parsing-expected.txt
+++ b/LayoutTests/platform/ios/fast/backgrounds/background-position-parsing-expected.txt
@@ -1,6 +1,6 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x387
+layer at (0,0) size 800x386
   RenderBlock {HTML} at (0,0) size 800x387
     RenderBody {BODY} at (8,16) size 784x18
       RenderBlock {P} at (0,0) size 784x18
@@ -9,150 +9,150 @@ layer at (0,0) size 800x387
       RenderBlock (floating) {DIV} at (1,35) size 79x54 [border: (1.50px solid #000000)]
         RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (83,35) size 79x54 [border: (1.50px solid #000000)]
+      RenderBlock (floating) {DIV} at (82,35) size 79x54 [border: (1.50px solid #000000)]
         RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (164,35) size 79x54 [border: (1.50px solid #000000)]
+      RenderBlock (floating) {DIV} at (163,35) size 79x54 [border: (1.50px solid #000000)]
         RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (246,35) size 79x54 [border: (1.50px solid #000000)]
+      RenderBlock (floating) {DIV} at (245,35) size 79x54 [border: (1.50px solid #000000)]
         RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (328,35) size 79x54 [border: (1.50px solid #000000)]
+      RenderBlock (floating) {DIV} at (326,35) size 79x54 [border: (1.50px solid #000000)]
         RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (409,35) size 79x54 [border: (1.50px solid #000000)]
+      RenderBlock (floating) {DIV} at (407,35) size 79x54 [border: (1.50px solid #000000)]
         RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (491,35) size 79x54 [border: (1.50px solid #000000)]
+      RenderBlock (floating) {DIV} at (488,35) size 79x54 [border: (1.50px solid #000000)]
         RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (572,35) size 79x54 [border: (1.50px solid #000000)]
+      RenderBlock (floating) {DIV} at (569,35) size 79x54 [border: (1.50px solid #000000)]
         RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (654,35) size 79x54 [border: (1.50px solid #000000)]
+      RenderBlock (floating) {DIV} at (651,35) size 79x54 [border: (1.50px solid #000000)]
         RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
       RenderBlock (floating) {DIV} at (1,91) size 79x54 [border: (1.50px solid #000000)]
         RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (83,91) size 79x54 [border: (1.50px solid #000000)]
+      RenderBlock (floating) {DIV} at (82,91) size 79x54 [border: (1.50px solid #000000)]
         RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (164,91) size 79x54 [border: (1.50px solid #000000)]
+      RenderBlock (floating) {DIV} at (163,91) size 79x54 [border: (1.50px solid #000000)]
         RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (246,91) size 79x54 [border: (1.50px solid #000000)]
+      RenderBlock (floating) {DIV} at (245,91) size 79x54 [border: (1.50px solid #000000)]
         RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (328,91) size 79x54 [border: (1.50px solid #000000)]
+      RenderBlock (floating) {DIV} at (326,91) size 79x54 [border: (1.50px solid #000000)]
         RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (409,91) size 79x54 [border: (1.50px solid #000000)]
+      RenderBlock (floating) {DIV} at (407,91) size 79x54 [border: (1.50px solid #000000)]
         RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (491,91) size 79x54 [border: (1.50px solid #000000)]
+      RenderBlock (floating) {DIV} at (488,91) size 79x54 [border: (1.50px solid #000000)]
         RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (572,91) size 79x54 [border: (1.50px solid #000000)]
+      RenderBlock (floating) {DIV} at (569,91) size 79x54 [border: (1.50px solid #000000)]
         RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (654,91) size 79x54 [border: (1.50px solid #000000)]
+      RenderBlock (floating) {DIV} at (651,91) size 79x54 [border: (1.50px solid #000000)]
         RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
       RenderBlock (floating) {DIV} at (1,147) size 79x54 [border: (1.50px solid #000000)]
         RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (83,147) size 79x54 [border: (1.50px solid #000000)]
+      RenderBlock (floating) {DIV} at (82,147) size 79x54 [border: (1.50px solid #000000)]
         RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (164,147) size 79x54 [border: (1.50px solid #000000)]
+      RenderBlock (floating) {DIV} at (163,147) size 79x54 [border: (1.50px solid #000000)]
         RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (246,147) size 79x54 [border: (1.50px solid #000000)]
+      RenderBlock (floating) {DIV} at (245,147) size 79x54 [border: (1.50px solid #000000)]
         RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (328,147) size 79x54 [border: (1.50px solid #000000)]
+      RenderBlock (floating) {DIV} at (326,147) size 79x54 [border: (1.50px solid #000000)]
         RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (409,147) size 79x54 [border: (1.50px solid #000000)]
+      RenderBlock (floating) {DIV} at (407,147) size 79x54 [border: (1.50px solid #000000)]
         RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (491,147) size 79x54 [border: (1.50px solid #000000)]
+      RenderBlock (floating) {DIV} at (488,147) size 79x54 [border: (1.50px solid #000000)]
         RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (572,147) size 79x54 [border: (1.50px solid #000000)]
+      RenderBlock (floating) {DIV} at (569,147) size 79x54 [border: (1.50px solid #000000)]
         RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (654,147) size 79x54 [border: (1.50px solid #000000)]
+      RenderBlock (floating) {DIV} at (651,147) size 79x54 [border: (1.50px solid #000000)]
         RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
       RenderBlock (floating) {DIV} at (1,203) size 79x54 [border: (1.50px solid #000000)]
         RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (83,203) size 79x54 [border: (1.50px solid #000000)]
+      RenderBlock (floating) {DIV} at (82,203) size 79x54 [border: (1.50px solid #000000)]
         RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (164,203) size 79x54 [border: (1.50px solid #000000)]
+      RenderBlock (floating) {DIV} at (163,203) size 79x54 [border: (1.50px solid #000000)]
         RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (246,203) size 79x54 [border: (1.50px solid #000000)]
+      RenderBlock (floating) {DIV} at (245,203) size 79x54 [border: (1.50px solid #000000)]
         RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (328,203) size 79x54 [border: (1.50px solid #000000)]
+      RenderBlock (floating) {DIV} at (326,203) size 79x54 [border: (1.50px solid #000000)]
         RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (409,203) size 79x54 [border: (1.50px solid #000000)]
+      RenderBlock (floating) {DIV} at (407,203) size 79x54 [border: (1.50px solid #000000)]
         RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (491,203) size 79x54 [border: (1.50px solid #000000)]
+      RenderBlock (floating) {DIV} at (488,203) size 79x54 [border: (1.50px solid #000000)]
         RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (572,203) size 79x54 [border: (1.50px solid #000000)]
+      RenderBlock (floating) {DIV} at (569,203) size 79x54 [border: (1.50px solid #000000)]
         RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (654,203) size 79x54 [border: (1.50px solid #000000)]
+      RenderBlock (floating) {DIV} at (651,203) size 79x54 [border: (1.50px solid #000000)]
         RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
       RenderBlock (floating) {DIV} at (1,259) size 79x54 [border: (1.50px solid #000000)]
         RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (83,259) size 79x54 [border: (1.50px solid #000000)]
+      RenderBlock (floating) {DIV} at (82,259) size 79x54 [border: (1.50px solid #000000)]
         RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (164,259) size 79x54 [border: (1.50px solid #000000)]
+      RenderBlock (floating) {DIV} at (163,259) size 79x54 [border: (1.50px solid #000000)]
         RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (246,259) size 79x54 [border: (1.50px solid #000000)]
+      RenderBlock (floating) {DIV} at (245,259) size 79x54 [border: (1.50px solid #000000)]
         RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (328,259) size 79x54 [border: (1.50px solid #000000)]
+      RenderBlock (floating) {DIV} at (326,259) size 79x54 [border: (1.50px solid #000000)]
         RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (409,259) size 79x54 [border: (1.50px solid #000000)]
+      RenderBlock (floating) {DIV} at (407,259) size 79x54 [border: (1.50px solid #000000)]
         RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (491,259) size 79x54 [border: (1.50px solid #000000)]
+      RenderBlock (floating) {DIV} at (488,259) size 79x54 [border: (1.50px solid #000000)]
         RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (572,259) size 79x54 [border: (1.50px solid #000000)]
+      RenderBlock (floating) {DIV} at (569,259) size 79x54 [border: (1.50px solid #000000)]
         RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (654,259) size 79x54 [border: (1.50px solid #000000)]
+      RenderBlock (floating) {DIV} at (651,259) size 79x54 [border: (1.50px solid #000000)]
         RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
       RenderBlock (floating) {DIV} at (1,315) size 79x54 [border: (1.50px solid #000000)]
         RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (83,315) size 79x54 [border: (1.50px solid #000000)]
+      RenderBlock (floating) {DIV} at (82,315) size 79x54 [border: (1.50px solid #000000)]
         RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (164,315) size 79x54 [border: (1.50px solid #000000)]
+      RenderBlock (floating) {DIV} at (163,315) size 79x54 [border: (1.50px solid #000000)]
         RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (246,315) size 79x54 [border: (1.50px solid #000000)]
+      RenderBlock (floating) {DIV} at (245,315) size 79x54 [border: (1.50px solid #000000)]
         RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (328,315) size 79x54 [border: (1.50px solid #000000)]
+      RenderBlock (floating) {DIV} at (326,315) size 79x54 [border: (1.50px solid #000000)]
         RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34

--- a/LayoutTests/platform/ios/svg/stroke/nan-stroke-width-crash-expected.txt
+++ b/LayoutTests/platform/ios/svg/stroke/nan-stroke-width-crash-expected.txt
@@ -1,24 +1,24 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x68
-  RenderBlock {HTML} at (0,0) size 800x68
-    RenderBody {BODY} at (8,16) size 784x44
+layer at (0,0) size 800x58
+  RenderBlock {HTML} at (0,0) size 800x58
+    RenderBody {BODY} at (8,16) size 784x34
       RenderBlock {P} at (0,0) size 784x18
         RenderText {#text} at (0,0) size 284x18
           text run at (0,0) width 284: "This test passes if it does not crash or assert."
-      RenderBlock {DIV} at (0,34) size 784x10
-        RenderBlock {DIV} at (0,0) size 784x10
-          RenderBlock {DIV} at (0,0) size 784x10
-            RenderBlock {DIV} at (0,0) size 784x10
-              RenderBlock {DIV} at (0,0) size 784x10
-                RenderBlock {DIV} at (0,0) size 784x10
-                  RenderBlock {DIV} at (0,0) size 784x10
-                    RenderBlock {DIV} at (0,0) size 784x10
-                      RenderBlock {DIV} at (0,0) size 784x10
-                        RenderBlock {DIV} at (0,0) size 784x10
-                          RenderBlock {DIV} at (0,0) size 784x10
-                            RenderBlock {DIV} at (0,0) size 784x10
-                              RenderSVGRoot {svg} at (8,58) size 0x0
-                                RenderSVGEllipse {circle} at (8,58) size 0x0 [stroke={[type=SOLID] [color=#FF0000] [stroke width=0.00]}] [fill={[type=SOLID] [color=#000000]}] [cx=0.00] [cy=0.00] [r=1.00]
-                                RenderSVGRect {rect} at (8,58) size 0x0 [stroke={[type=SOLID] [color=#FF0000] [stroke width=0.00]}] [fill={[type=SOLID] [color=#000000]}] [x=0.00] [y=0.00] [width=1.00] [height=1.00]
+      RenderBlock {DIV} at (0,34) size 784x0
+        RenderBlock {DIV} at (0,0) size 784x0
+          RenderBlock {DIV} at (0,0) size 784x0
+            RenderBlock {DIV} at (0,0) size 784x0
+              RenderBlock {DIV} at (0,0) size 784x0
+                RenderBlock {DIV} at (0,0) size 784x0
+                  RenderBlock {DIV} at (0,0) size 784x0
+                    RenderBlock {DIV} at (0,0) size 784x0
+                      RenderBlock {DIV} at (0,0) size 784x0
+                        RenderBlock {DIV} at (0,0) size 784x0
+                          RenderBlock {DIV} at (0,0) size 784x0
+                            RenderBlock {DIV} at (0,0) size 784x0
+                              RenderSVGRoot {svg} at (8,50) size 0x0
+                                RenderSVGEllipse {circle} at (8,50) size 0x0 [stroke={[type=SOLID] [color=#FF0000] [stroke width=0.00]}] [fill={[type=SOLID] [color=#000000]}] [cx=0.00] [cy=0.00] [r=1.00]
+                                RenderSVGRect {rect} at (8,50) size 0x0 [stroke={[type=SOLID] [color=#FF0000] [stroke width=0.00]}] [fill={[type=SOLID] [color=#000000]}] [x=0.00] [y=0.00] [width=1.00] [height=1.00]
                               RenderText {#text} at (0,0) size 0x0

--- a/LayoutTests/platform/mac/fast/backgrounds/background-position-parsing-expected.txt
+++ b/LayoutTests/platform/mac/fast/backgrounds/background-position-parsing-expected.txt
@@ -1,6 +1,6 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x381
+layer at (0,0) size 800x380
   RenderBlock {HTML} at (0,0) size 800x381
     RenderBody {BODY} at (8,16) size 784x18
       RenderBlock {P} at (0,0) size 784x18
@@ -9,150 +9,150 @@ layer at (0,0) size 800x381
       RenderBlock (floating) {DIV} at (1,35) size 78x53 [border: (1px solid #000000)]
         RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (82,35) size 78x53 [border: (1px solid #000000)]
+      RenderBlock (floating) {DIV} at (81,35) size 78x53 [border: (1px solid #000000)]
         RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (162,35) size 78x53 [border: (1px solid #000000)]
+      RenderBlock (floating) {DIV} at (161,35) size 78x53 [border: (1px solid #000000)]
         RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (243,35) size 78x53 [border: (1px solid #000000)]
+      RenderBlock (floating) {DIV} at (242,35) size 78x53 [border: (1px solid #000000)]
         RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (324,35) size 78x53 [border: (1px solid #000000)]
+      RenderBlock (floating) {DIV} at (322,35) size 78x53 [border: (1px solid #000000)]
         RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (404,35) size 78x53 [border: (1px solid #000000)]
+      RenderBlock (floating) {DIV} at (402,35) size 78x53 [border: (1px solid #000000)]
         RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (485,35) size 78x53 [border: (1px solid #000000)]
+      RenderBlock (floating) {DIV} at (482,35) size 78x53 [border: (1px solid #000000)]
         RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (565,35) size 78x53 [border: (1px solid #000000)]
+      RenderBlock (floating) {DIV} at (562,35) size 78x53 [border: (1px solid #000000)]
         RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (646,35) size 78x53 [border: (1px solid #000000)]
+      RenderBlock (floating) {DIV} at (643,35) size 78x53 [border: (1px solid #000000)]
         RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
       RenderBlock (floating) {DIV} at (1,90) size 78x53 [border: (1px solid #000000)]
         RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (82,90) size 78x53 [border: (1px solid #000000)]
+      RenderBlock (floating) {DIV} at (81,90) size 78x53 [border: (1px solid #000000)]
         RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (162,90) size 78x53 [border: (1px solid #000000)]
+      RenderBlock (floating) {DIV} at (161,90) size 78x53 [border: (1px solid #000000)]
         RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (243,90) size 78x53 [border: (1px solid #000000)]
+      RenderBlock (floating) {DIV} at (242,90) size 78x53 [border: (1px solid #000000)]
         RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (324,90) size 78x53 [border: (1px solid #000000)]
+      RenderBlock (floating) {DIV} at (322,90) size 78x53 [border: (1px solid #000000)]
         RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (404,90) size 78x53 [border: (1px solid #000000)]
+      RenderBlock (floating) {DIV} at (402,90) size 78x53 [border: (1px solid #000000)]
         RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (485,90) size 78x53 [border: (1px solid #000000)]
+      RenderBlock (floating) {DIV} at (482,90) size 78x53 [border: (1px solid #000000)]
         RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (565,90) size 78x53 [border: (1px solid #000000)]
+      RenderBlock (floating) {DIV} at (562,90) size 78x53 [border: (1px solid #000000)]
         RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (646,90) size 78x53 [border: (1px solid #000000)]
+      RenderBlock (floating) {DIV} at (643,90) size 78x53 [border: (1px solid #000000)]
         RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
       RenderBlock (floating) {DIV} at (1,145) size 78x53 [border: (1px solid #000000)]
         RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (82,145) size 78x53 [border: (1px solid #000000)]
+      RenderBlock (floating) {DIV} at (81,145) size 78x53 [border: (1px solid #000000)]
         RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (162,145) size 78x53 [border: (1px solid #000000)]
+      RenderBlock (floating) {DIV} at (161,145) size 78x53 [border: (1px solid #000000)]
         RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (243,145) size 78x53 [border: (1px solid #000000)]
+      RenderBlock (floating) {DIV} at (242,145) size 78x53 [border: (1px solid #000000)]
         RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (324,145) size 78x53 [border: (1px solid #000000)]
+      RenderBlock (floating) {DIV} at (322,145) size 78x53 [border: (1px solid #000000)]
         RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (404,145) size 78x53 [border: (1px solid #000000)]
+      RenderBlock (floating) {DIV} at (402,145) size 78x53 [border: (1px solid #000000)]
         RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (485,145) size 78x53 [border: (1px solid #000000)]
+      RenderBlock (floating) {DIV} at (482,145) size 78x53 [border: (1px solid #000000)]
         RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (565,145) size 78x53 [border: (1px solid #000000)]
+      RenderBlock (floating) {DIV} at (562,145) size 78x53 [border: (1px solid #000000)]
         RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (646,145) size 78x53 [border: (1px solid #000000)]
+      RenderBlock (floating) {DIV} at (643,145) size 78x53 [border: (1px solid #000000)]
         RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
       RenderBlock (floating) {DIV} at (1,200) size 78x53 [border: (1px solid #000000)]
         RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (82,200) size 78x53 [border: (1px solid #000000)]
+      RenderBlock (floating) {DIV} at (81,200) size 78x53 [border: (1px solid #000000)]
         RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (162,200) size 78x53 [border: (1px solid #000000)]
+      RenderBlock (floating) {DIV} at (161,200) size 78x53 [border: (1px solid #000000)]
         RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (243,200) size 78x53 [border: (1px solid #000000)]
+      RenderBlock (floating) {DIV} at (242,200) size 78x53 [border: (1px solid #000000)]
         RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (324,200) size 78x53 [border: (1px solid #000000)]
+      RenderBlock (floating) {DIV} at (322,200) size 78x53 [border: (1px solid #000000)]
         RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (404,200) size 78x53 [border: (1px solid #000000)]
+      RenderBlock (floating) {DIV} at (402,200) size 78x53 [border: (1px solid #000000)]
         RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (485,200) size 78x53 [border: (1px solid #000000)]
+      RenderBlock (floating) {DIV} at (482,200) size 78x53 [border: (1px solid #000000)]
         RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (565,200) size 78x53 [border: (1px solid #000000)]
+      RenderBlock (floating) {DIV} at (562,200) size 78x53 [border: (1px solid #000000)]
         RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (646,200) size 78x53 [border: (1px solid #000000)]
+      RenderBlock (floating) {DIV} at (643,200) size 78x53 [border: (1px solid #000000)]
         RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
       RenderBlock (floating) {DIV} at (1,255) size 78x53 [border: (1px solid #000000)]
         RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (82,255) size 78x53 [border: (1px solid #000000)]
+      RenderBlock (floating) {DIV} at (81,255) size 78x53 [border: (1px solid #000000)]
         RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (162,255) size 78x53 [border: (1px solid #000000)]
+      RenderBlock (floating) {DIV} at (161,255) size 78x53 [border: (1px solid #000000)]
         RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (243,255) size 78x53 [border: (1px solid #000000)]
+      RenderBlock (floating) {DIV} at (242,255) size 78x53 [border: (1px solid #000000)]
         RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (324,255) size 78x53 [border: (1px solid #000000)]
+      RenderBlock (floating) {DIV} at (322,255) size 78x53 [border: (1px solid #000000)]
         RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (404,255) size 78x53 [border: (1px solid #000000)]
+      RenderBlock (floating) {DIV} at (402,255) size 78x53 [border: (1px solid #000000)]
         RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (485,255) size 78x53 [border: (1px solid #000000)]
+      RenderBlock (floating) {DIV} at (482,255) size 78x53 [border: (1px solid #000000)]
         RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (565,255) size 78x53 [border: (1px solid #000000)]
+      RenderBlock (floating) {DIV} at (562,255) size 78x53 [border: (1px solid #000000)]
         RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (646,255) size 78x53 [border: (1px solid #000000)]
+      RenderBlock (floating) {DIV} at (643,255) size 78x53 [border: (1px solid #000000)]
         RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
       RenderBlock (floating) {DIV} at (1,310) size 78x53 [border: (1px solid #000000)]
         RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (82,310) size 78x53 [border: (1px solid #000000)]
+      RenderBlock (floating) {DIV} at (81,310) size 78x53 [border: (1px solid #000000)]
         RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (162,310) size 78x53 [border: (1px solid #000000)]
+      RenderBlock (floating) {DIV} at (161,310) size 78x53 [border: (1px solid #000000)]
         RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (243,310) size 78x53 [border: (1px solid #000000)]
+      RenderBlock (floating) {DIV} at (242,310) size 78x53 [border: (1px solid #000000)]
         RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (324,310) size 78x53 [border: (1px solid #000000)]
+      RenderBlock (floating) {DIV} at (322,310) size 78x53 [border: (1px solid #000000)]
         RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34

--- a/LayoutTests/platform/mac/svg/stroke/nan-stroke-width-crash-expected.txt
+++ b/LayoutTests/platform/mac/svg/stroke/nan-stroke-width-crash-expected.txt
@@ -1,24 +1,24 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x68
-  RenderBlock {HTML} at (0,0) size 800x68
-    RenderBody {BODY} at (8,16) size 784x44
+layer at (0,0) size 800x58
+  RenderBlock {HTML} at (0,0) size 800x58
+    RenderBody {BODY} at (8,16) size 784x34
       RenderBlock {P} at (0,0) size 784x18
         RenderText {#text} at (0,0) size 284x18
           text run at (0,0) width 284: "This test passes if it does not crash or assert."
-      RenderBlock {DIV} at (0,34) size 784x10
-        RenderBlock {DIV} at (0,0) size 784x10
-          RenderBlock {DIV} at (0,0) size 784x10
-            RenderBlock {DIV} at (0,0) size 784x10
-              RenderBlock {DIV} at (0,0) size 784x10
-                RenderBlock {DIV} at (0,0) size 784x10
-                  RenderBlock {DIV} at (0,0) size 784x10
-                    RenderBlock {DIV} at (0,0) size 784x10
-                      RenderBlock {DIV} at (0,0) size 784x10
-                        RenderBlock {DIV} at (0,0) size 784x10
-                          RenderBlock {DIV} at (0,0) size 784x10
-                            RenderBlock {DIV} at (0,0) size 784x10
-                              RenderSVGRoot {svg} at (8,57) size 0x0
-                                RenderSVGEllipse {circle} at (8,57) size 0x0 [stroke={[type=SOLID] [color=#FF0000] [stroke width=0.00]}] [fill={[type=SOLID] [color=#000000]}] [cx=0.00] [cy=0.00] [r=1.00]
-                                RenderSVGRect {rect} at (8,57) size 0x0 [stroke={[type=SOLID] [color=#FF0000] [stroke width=0.00]}] [fill={[type=SOLID] [color=#000000]}] [x=0.00] [y=0.00] [width=1.00] [height=1.00]
+      RenderBlock {DIV} at (0,34) size 784x0
+        RenderBlock {DIV} at (0,0) size 784x0
+          RenderBlock {DIV} at (0,0) size 784x0
+            RenderBlock {DIV} at (0,0) size 784x0
+              RenderBlock {DIV} at (0,0) size 784x0
+                RenderBlock {DIV} at (0,0) size 784x0
+                  RenderBlock {DIV} at (0,0) size 784x0
+                    RenderBlock {DIV} at (0,0) size 784x0
+                      RenderBlock {DIV} at (0,0) size 784x0
+                        RenderBlock {DIV} at (0,0) size 784x0
+                          RenderBlock {DIV} at (0,0) size 784x0
+                            RenderBlock {DIV} at (0,0) size 784x0
+                              RenderSVGRoot {svg} at (8,50) size 0x0
+                                RenderSVGEllipse {circle} at (8,50) size 0x0 [stroke={[type=SOLID] [color=#FF0000] [stroke width=0.00]}] [fill={[type=SOLID] [color=#000000]}] [cx=0.00] [cy=0.00] [r=1.00]
+                                RenderSVGRect {rect} at (8,50) size 0x0 [stroke={[type=SOLID] [color=#FF0000] [stroke width=0.00]}] [fill={[type=SOLID] [color=#000000]}] [x=0.00] [y=0.00] [width=1.00] [height=1.00]
                               RenderText {#text} at (0,0) size 0x0

--- a/Source/WebCore/style/StyleFontSizeFunctions.cpp
+++ b/Source/WebCore/style/StyleFontSizeFunctions.cpp
@@ -2,7 +2,7 @@
  * Copyright (C) 1999 Lars Knoll (knoll@kde.org)
  *           (C) 2004-2005 Allan Sandfeld Jensen (kde@carewolf.com)
  * Copyright (C) 2006, 2007 Nicholas Shanks (webkit@nickshanks.com)
- * Copyright (C) 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013 Apple Inc. All rights reserved.
+ * Copyright (C) 2005-2026 Apple Inc. All rights reserved.
  * Copyright (C) 2007 Alexey Proskuryakov <ap@webkit.org>
  * Copyright (C) 2007, 2008 Eric Seidel <eric@webkit.org>
  * Copyright (C) 2008, 2009 Torch Mobile Inc. All rights reserved. (http://www.torchmobile.com/)
@@ -75,8 +75,15 @@ float computedFontSizeFromSpecifiedSize(float specifiedSize, bool isAbsoluteSize
     // after zooming. The font size must either be relative to the user default or the original size
     // must have been acceptable. In other words, we only apply the smart minimum whenever we're positive
     // doing so won't disrupt the layout.
-    if (minimumSizeRule == MinimumFontSizeRule::AbsoluteAndRelative && (specifiedSize >= minLogicalSize || !isAbsoluteSize))
-        zoomedSize = std::max(zoomedSize, static_cast<float>(minLogicalSize));
+    if (minimumSizeRule == MinimumFontSizeRule::AbsoluteAndRelative && (specifiedSize >= minLogicalSize || !isAbsoluteSize)) {
+        // The smart minimum is a logical (pre-zoom) readability floor, not a device-space floor. When
+        // zooming the page out, scale it by the zoom factor so small text still shrinks proportionally
+        // with the page (as other engines do) instead of being pinned to a minLogicalSize device floor
+        // that overflows a fixed-px width cap. At zoomFactor >= 1 this is unchanged, preserving the
+        // readability floor and the device-space minimum for zoom-in.
+        float smartMinimum = zoomFactor < 1 ? static_cast<float>(minLogicalSize) * zoomFactor : static_cast<float>(minLogicalSize);
+        zoomedSize = std::max(zoomedSize, smartMinimum);
+    }
 
     // Also clamp to a reasonable maximum to prevent insane font sizes from causing crashes on various
     // platforms. (I'm looking at you, Windows.)


### PR DESCRIPTION
#### 006da4a5c5bdb70f48561d57b8574763ad72076e
<pre>
moneycontrol.com: Overlapping content at zoom level 50%
<a href="https://bugs.webkit.org/show_bug.cgi?id=319939">https://bugs.webkit.org/show_bug.cgi?id=319939</a>
&lt;<a href="https://rdar.apple.com/66569768">rdar://66569768</a>&gt;

Reviewed by Vitor Roriz.

Under native page zoom-out, the smart minimum (minLogicalFontSize) was applied as a
device-space floor, so small text could not shrink below ~9px while a fixed-px max-width
cap scaled down normally. The oversized text advance then overflowed the shrunken cap and
wrapped.

This patch resolves this by scaling the smart minimum font size by the zoom factor when
zooming out so that text shrinks with the page. Behavior when non-zoomed or zoomed-in
is unchanged.

Test: fast/css/zoom-page-max-width-text-wrap.html

* LayoutTests/fast/css/zoom-page-max-width-text-wrap-expected.txt: Added.
* LayoutTests/fast/css/zoom-page-max-width-text-wrap.html: Added.
* LayoutTests/platform/glib/fast/backgrounds/background-position-parsing-expected.txt: Rebaselined.
* LayoutTests/platform/glib/svg/stroke/nan-stroke-width-crash-expected.txt: Rebaselined.
* LayoutTests/platform/ios/fast/backgrounds/background-position-parsing-expected.txt: Rebaselined.
* LayoutTests/platform/ios/svg/stroke/nan-stroke-width-crash-expected.txt: Rebaselined.
* LayoutTests/platform/mac/fast/backgrounds/background-position-parsing-expected.txt: Rebaselined.
* LayoutTests/platform/mac/svg/stroke/nan-stroke-width-crash-expected.txt: Rebaselined.
* Source/WebCore/style/StyleFontSizeFunctions.cpp:
(WebCore::Style::computedFontSizeFromSpecifiedSize):

Canonical link: <a href="https://commits.webkit.org/318509@main">https://commits.webkit.org/318509@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/36864705f18a329608e2848f7094b72bb4611a33

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178514 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52452 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46247 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188130 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/141763 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6e03c282-70c1-49f1-81bb-646041bb724f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/180377 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53746 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52162 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139176 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/141763 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/31a62c27-556b-4da1-b3e9-acb7b1c56f6c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181471 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42731 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159927 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119630 "Build is in progress. Recent messages:Printed configuration; Checked out pull request; run-api-tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/048b88a7-3417-420b-bfcf-dd26511d0f00) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41397 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/39749 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151797 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39427 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36585 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45052 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/43991 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190557 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52121 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/159451 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148336 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39823 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52802 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/36050 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148106 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42815 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125069 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119705 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51320 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14402 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50705 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50945 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50767 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->