### PR TITLE
[JSC] Use op_async_iterator_open and op_async_iterator_next for yield*

### DIFF
--- a/JSTests/microbenchmarks/async-generator-yield-star.js
+++ b/JSTests/microbenchmarks/async-generator-yield-star.js
@@ -1,0 +1,28 @@
+// Microbenchmark: `yield*` delegation inside an async generator.
+//
+// createAsyncGen delegates its whole output to `list` via `yield*`. This exercises the
+// op_async_iterator_open / op_async_iterator_next path (GetIterator(async) + the delegated
+// next()/await loop) rather than the old generic manual iterator-protocol loop, and it lets the
+// delegation participate in the fast async-generator consumer/driver optimizations. The result is
+// driven by a `for await` consumer, so both the producer's `yield*` and the consumer's iteration
+// are measured end to end.
+
+var list = [];
+for (var i = 0; i < 100; ++i)
+    list.push(i);
+
+async function* createAsyncGen(list) {
+    yield* list;
+}
+
+async function run() {
+    var sum = 0;
+    for (var n = 0; n < 15e3; ++n) {
+        for await (var v of createAsyncGen(list))
+            sum += v;
+    }
+    return sum;
+}
+
+run();
+drainMicrotasks();

--- a/JSTests/stress/async-iteration-yield-star-resume-value.js
+++ b/JSTests/stress/async-iteration-yield-star-resume-value.js
@@ -1,0 +1,122 @@
+// yield* in async generators must forward the resume value to the delegated iterator's
+// next(value)/throw(value)/return(value), and expose the delegated iterator's return value.
+// It must NOT change `for await` (which calls next() with zero arguments). Covers the fast
+// async-generator driver path, the generic async-iterator path, and the async-from-sync path.
+
+function assert(actual, expected, message) {
+    if (actual !== expected)
+        throw new Error(`${message || "assert"}: expected ${expected} but got ${actual}`);
+}
+
+// 1. Driver path: delegate to a genuine async generator, forward resume values, expose return value.
+async function driverPath() {
+    async function* inner() {
+        const a = yield "i0";
+        const b = yield "i1:" + a;
+        return "ret:" + b;
+    }
+    async function* outer() {
+        const r = yield* inner();
+        yield "o:" + r;
+    }
+    const it = outer();
+    assert((await it.next()).value, "i0", "driver step0");
+    assert((await it.next("A")).value, "i1:A", "driver step1 forwards A");
+    assert((await it.next("B")).value, "o:ret:B", "driver return value forwards B");
+    assert((await it.next()).done, true, "driver done");
+}
+
+// 2. Generic async iterator: next/throw/return receive the forwarded value with exactly one argument.
+async function genericPath() {
+    let events = [];
+    function makeIterable() {
+        let i = 0;
+        return { [Symbol.asyncIterator]() {
+            return {
+                next(v) { events.push(`next(${JSON.stringify(v)})#${arguments.length}`); return Promise.resolve(i < 2 ? { value: "v" + (i++), done: false } : { value: "fin", done: true }); },
+                return(v) { events.push(`return(${JSON.stringify(v)})#${arguments.length}`); return Promise.resolve({ value: v, done: true }); },
+                throw(v) { events.push(`throw(${JSON.stringify(v)})#${arguments.length}`); return Promise.resolve({ value: "handled", done: true }); },
+            };
+        } };
+    }
+
+    async function* outer() { return yield* makeIterable(); }
+    let it = outer();
+    assert((await it.next()).value, "v0", "generic step0");        // next(undefined)
+    assert((await it.next("X")).value, "v1", "generic step1");      // next("X")
+    assert((await it.next("Y")).value, "fin", "generic return");    // next("Y") -> done, value "fin"
+    assert(events.join(","), 'next(undefined)#1,next("X")#1,next("Y")#1', "generic next arg forwarding");
+
+    // throw() delegation forwards value with one argument.
+    events = [];
+    it = outer();
+    await it.next();
+    assert((await it.throw("E")).value, "handled", "generic throw result");
+    assert(events.join(","), 'next(undefined)#1,throw("E")#1', "generic throw arg forwarding");
+
+    // return() delegation forwards value with one argument.
+    events = [];
+    it = outer();
+    await it.next();
+    assert((await it.return("R")).value, "R", "generic return result");
+    assert(events.join(","), 'next(undefined)#1,return("R")#1', "generic return arg forwarding");
+}
+
+// 3. `for await` must call next() with ZERO arguments (yield* change must not regress this).
+async function forAwaitZeroArgs() {
+    let argCounts = [];
+    let i = 0;
+    const iterable = { [Symbol.asyncIterator]() {
+        return { next() { argCounts.push(arguments.length); return Promise.resolve(i < 3 ? { value: i++, done: false } : { value: undefined, done: true }); } };
+    } };
+    let sum = 0;
+    for await (const x of iterable)
+        sum += x;
+    assert(sum, 3, "for-await sum");
+    assert(argCounts.join(","), "0,0,0,0", "for-await calls next() with zero args");
+}
+
+// 4. async-from-sync: yield* over a sync iterable forwards the resume value to the sync next(value).
+async function asyncFromSyncPath() {
+    let events = [];
+    function makeSyncIterable() {
+        let i = 0;
+        return { [Symbol.iterator]() {
+            return { next(v) { events.push(`${JSON.stringify(v)}#${arguments.length}`); return i < 2 ? { value: "s" + (i++), done: false } : { value: "sfin", done: true }; } };
+        } };
+    }
+    async function* outer() { return yield* makeSyncIterable(); }
+    const it = outer();
+    assert((await it.next()).value, "s0", "afs step0");
+    assert((await it.next("P")).value, "s1", "afs step1");
+    assert((await it.next("Q")).value, "sfin", "afs return");
+    // AsyncFromSync forwards the argument to the underlying sync next().
+    assert(events.join(","), 'undefined#1,"P"#1,"Q"#1', "async-from-sync arg forwarding");
+
+    // Builtin array fast path values are correct.
+    async function* outerArr() { return yield* [7, 8, 9]; }
+    const it2 = outerArr();
+    assert((await it2.next()).value, 7, "afs array 0");
+    assert((await it2.next()).value, 8, "afs array 1");
+    assert((await it2.next()).value, 9, "afs array 2");
+    assert((await it2.next()).done, true, "afs array done");
+}
+
+async function main() {
+    // Loop to encourage tier-up within each stress configuration.
+    for (let i = 0; i < 200; ++i) {
+        await driverPath();
+        await genericPath();
+        await forAwaitZeroArgs();
+        await asyncFromSyncPath();
+    }
+}
+
+let caught = null;
+let completed = false;
+main().then(() => { completed = true; }, e => { caught = e; });
+drainMicrotasks();
+if (caught)
+    throw caught;
+if (!completed)
+    throw new Error("async work did not complete after draining microtasks");

--- a/Source/JavaScriptCore/bytecode/BytecodeList.rb
+++ b/Source/JavaScriptCore/bytecode/BytecodeList.rb
@@ -486,16 +486,22 @@ op :call_ignore_result,
         arrayProfile: ArrayProfile,
     }
 
-# dst = next.call(iterator), or -- if next is the fast async generator driver sentinel -- enqueue
-# onto the producer instead (dst unused; the result is awaited via a separate op_yield). Unlike
-# op_iterator_next there are no getDone/getValue checkpoints: the intervening await makes .done/.value
-# separate get_by_id bytecodes after suspension.
+# dst = next.call(iterator [, value]), or -- if next is the fast async generator driver sentinel --
+# enqueue value onto the producer instead (dst unused; the result is awaited via a separate op_yield).
+# The resume value (yield* passes the received value; for-await leaves hasValue false, so next() is
+# called with just `this`) is call argument index 1: like op_call's argc/argv model, there's no separate
+# VirtualRegister field for it -- its register is derived from stackOffset via
+# virtualRegisterForArgumentIncludingThis(1, -stackOffset) whenever hasValue is set. This keeps every
+# arg field a plain unsigned/bool, so an absent resume value never forces this bytecode to Wide32
+# encoding. Unlike op_iterator_next there are no getDone/getValue checkpoints: the intervening await
+# makes .done/.value separate get_by_id bytecodes after suspension.
 op :async_iterator_next,
     args: {
         dst: VirtualRegister,
         next: VirtualRegister,
         iterator: VirtualRegister,
         driver: VirtualRegister,
+        hasValue: bool,
         stackOffset: unsigned,
         valueProfile: unsigned,
     },

--- a/Source/JavaScriptCore/bytecode/BytecodeOperandsForCheckpoint.h
+++ b/Source/JavaScriptCore/bytecode/BytecodeOperandsForCheckpoint.h
@@ -137,7 +137,8 @@ unsigned argumentCountIncludingThisFor(const Bytecode& bytecode, unsigned checkp
         ASSERT(checkpointIndex == OpIteratorNext::computeNext);
         return 1;
     } else if constexpr (Bytecode::opcodeID == op_async_iterator_next) {
-        return 1;
+        // yield* forwards a resume value to next() (m_hasValue); for-await calls next() with just `this`.
+        return bytecode.m_hasValue ? 2 : 1;
     } else
         return bytecode.m_argc;
 }
@@ -166,6 +167,14 @@ CallLinkInfo& callLinkInfoFor(BytecodeMetadata& metadata, unsigned checkpointInd
 {
     UNUSED_PARAM(checkpointIndex);
     return metadata.m_callLinkInfo;
+}
+
+// op_async_iterator_next has no stored VirtualRegister for its optional resume value: like op_call's
+// argc/argv model, it's call argument index 1, addressed via m_stackOffset. Only valid when m_hasValue.
+inline VirtualRegister resumeValueOperandFor(const OpAsyncIteratorNext& bytecode)
+{
+    ASSERT(bytecode.m_hasValue);
+    return virtualRegisterForArgumentIncludingThis(1, -static_cast<int>(bytecode.m_stackOffset));
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/bytecode/BytecodeUseDef.cpp
+++ b/Source/JavaScriptCore/bytecode/BytecodeUseDef.cpp
@@ -26,6 +26,8 @@
 #include "config.h"
 #include "BytecodeUseDef.h"
 
+#include "BytecodeOperandsForCheckpoint.h"
+
 namespace JSC {
 
 #define CALL_FUNCTOR(__arg) \
@@ -140,7 +142,6 @@ void computeUsesForBytecodeIndexImpl(const JSInstruction* instruction, Checkpoin
     USES(OpJneqPtr, value, specialPointer)
 
     USES(OpSetFunctionName, function, name)
-    USES(OpAsyncIteratorNext, next, iterator, driver)
     USES(OpLogShadowChickenTail, thisValue, scope)
 
     USES(OpPutByVal, base, property, value)
@@ -316,6 +317,18 @@ void computeUsesForBytecodeIndexImpl(const JSInstruction* instruction, Checkpoin
         auto bytecode = instruction->as<OpIteratorNext>();
         useAtEachCheckpoint(bytecode.m_iterator, bytecode.m_next);
         useAtEachCheckpointStartingWith(OpIteratorNext::computeNext, bytecode.m_iterable);
+        return;
+    }
+
+    case op_async_iterator_next: {
+        auto bytecode = instruction->as<OpAsyncIteratorNext>();
+        functor(bytecode.m_next);
+        functor(bytecode.m_iterator);
+        functor(bytecode.m_driver);
+        // The resume value isn't a stored field (see BytecodeList.rb); it's call argument index 1,
+        // derived from m_stackOffset, and only present when m_hasValue.
+        if (bytecode.m_hasValue)
+            functor(resumeValueOperandFor(bytecode));
         return;
     }
 

--- a/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp
+++ b/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp
@@ -3679,10 +3679,23 @@ void BytecodeGenerator::emitAsyncIteratorOpen(RegisterID* iterator, RegisterID* 
     OpAsyncIteratorOpen::emit(this, iterator, next, symbolIterator, iterable.thisRegister(), iterable.stackOffset(), nextValueProfileIndex(), nextValueProfileIndex(), nextValueProfileIndex());
 }
 
-RegisterID* BytecodeGenerator::emitAsyncIteratorNext(RegisterID* dst, RegisterID* next, RegisterID* iterator, const ThrowableExpressionData* node)
+void BytecodeGenerator::emitGetGenericAsyncIterator(RegisterID* iterator, RegisterID* next, RegisterID* subject, const ThrowableExpressionData* node)
 {
-    CallArguments nextArguments(*this, nullptr);
+    emitExpressionInfo(node->divot(), node->divotStart(), node->divotEnd());
+    RefPtr<RegisterID> symbolAsyncIterator = emitGetById(newTemporary(), subject, propertyNames().asyncIteratorSymbol);
+    CallArguments args(*this, nullptr, 0);
+    move(args.thisRegister(), subject);
+    emitAsyncIteratorOpen(iterator, next, symbolAsyncIterator.get(), args, node);
+}
+
+RegisterID* BytecodeGenerator::emitAsyncIteratorNext(RegisterID* dst, RegisterID* next, RegisterID* iterator, RegisterID* value, const ThrowableExpressionData* node)
+{
+    // dst is allowed to alias value (emitDelegateYield's async path reuses one temporary for both):
+    // value is read into the call's argument register below before dst is written by OpAsyncIteratorNext::emit.
+    CallArguments nextArguments(*this, nullptr, value ? 1 : 0);
     move(nextArguments.thisRegister(), iterator);
+    if (value)
+        move(nextArguments.argumentRegister(0), value);
 
     // Reserve space for call frame. Mirrors emitIteratorNext / emitAsyncIteratorOpen; the generic
     // branch of op_async_iterator_next makes a real next.call(iterator), so numCalleeLocals must
@@ -3692,7 +3705,7 @@ RegisterID* BytecodeGenerator::emitAsyncIteratorNext(RegisterID* dst, RegisterID
         callFrame.append(newTemporary());
 
     emitExpressionInfo(node->divot(), node->divotStart(), node->divotEnd());
-    OpAsyncIteratorNext::emit(this, kill(dst), next, nextArguments.thisRegister(), generatorRegister(), nextArguments.stackOffset(), nextValueProfileIndex());
+    OpAsyncIteratorNext::emit(this, kill(dst), next, nextArguments.thisRegister(), generatorRegister(), !!value, nextArguments.stackOffset(), nextValueProfileIndex());
     return dst;
 }
 
@@ -4952,13 +4965,7 @@ void BytecodeGenerator::emitEnumeration(ThrowableExpressionData* node, Expressio
         RefPtr<RegisterID> iterator = newTemporary();
         RefPtr<RegisterID> nextMethod = newTemporary();
 
-        {
-            emitExpressionInfo(node->divot(), node->divotStart(), node->divotEnd());
-            RefPtr<RegisterID> symbolAsyncIterator = emitGetById(newTemporary(), subject.get(), propertyNames().asyncIteratorSymbol);
-            CallArguments args(*this, nullptr, 0);
-            move(args.thisRegister(), subject.get());
-            emitAsyncIteratorOpen(iterator.get(), nextMethod.get(), symbolAsyncIterator.get(), args, node);
-        }
+        emitGetGenericAsyncIterator(iterator.get(), nextMethod.get(), subject.get(), node);
 
         Ref<Label> loopDone = newLabel();
 
@@ -4990,7 +4997,7 @@ void BytecodeGenerator::emitEnumeration(ThrowableExpressionData* node, Expressio
             emitDebugHook(forLoopNode->lexpr());
 
             {
-                emitAsyncIteratorNext(value.get(), nextMethod.get(), iterator.get(), node);
+                emitAsyncIteratorNext(value.get(), nextMethod.get(), iterator.get(), nullptr, node);
                 emitAwait(value.get(), value.get(), node->divot());
 
                 Ref<Label> typeIsObject = newLabel();
@@ -5509,47 +5516,23 @@ void BytecodeGenerator::emitIteratorGenericClose(RegisterID* iterator, const Thr
 }
 
 
-RegisterID* BytecodeGenerator::emitGetAsyncIterator(RegisterID* argument, ThrowableExpressionData* node)
-{
-    emitExpressionInfo(node->divot(), node->divotStart(), node->divotEnd());
-    RefPtr<RegisterID> iterator = emitGetById(newTemporary(), argument, propertyNames().asyncIteratorSymbol);
-    Ref<Label> asyncIteratorNotFound = newLabel();
-    Ref<Label> asyncIteratorFound = newLabel();
-    Ref<Label> iteratorReceived = newLabel();
-
-    emitJumpIfTrue(emitIsUndefinedOrNull(newTemporary(), iterator.get()), asyncIteratorNotFound.get());
-
-    emitJump(asyncIteratorFound.get());
-    emitLabel(asyncIteratorNotFound.get());
-
-    RefPtr<RegisterID> commonIterator = emitGetGenericIterator(argument, node);
-    move(iterator.get(), commonIterator.get());
-
-    RefPtr<RegisterID> createAsyncFromSyncIterator = moveLinkTimeConstant(nullptr, LinkTimeConstant::asyncFromSyncIteratorCreate);
-
-    CallArguments args(*this, nullptr, 1);
-    emitLoad(args.thisRegister(), jsUndefined());
-
-    move(args.argumentRegister(0), iterator.get());
-
-    JSTextPosition divot(m_scopeNode->firstLine(), m_scopeNode->startOffset(), m_scopeNode->lineStartOffset());
-    emitCall(iterator.get(), createAsyncFromSyncIterator.get(), NoExpectedFunction, args, divot, divot, divot, DebuggableCall::No);
-
-    emitJump(iteratorReceived.get());
-
-    emitLabel(asyncIteratorFound.get());
-    emitCallIterator(iterator.get(), argument, node);
-    emitLabel(iteratorReceived.get());
-
-    return iterator.unsafeGet();
-}
-
 RegisterID* BytecodeGenerator::emitDelegateYield(RegisterID* argument, ThrowableExpressionData* node)
 {
+    bool isAsync = parseMode() == SourceParseMode::AsyncGeneratorBodyMode;
+    EmitAwait emitAwaitInClose = isAsync ? EmitAwait::Yes : EmitAwait::No;
+
     RefPtr<RegisterID> value = newTemporary();
     {
-        RefPtr<RegisterID> iterator = parseMode() == SourceParseMode::AsyncGeneratorBodyMode ? emitGetAsyncIterator(argument, node) : emitGetGenericIterator(argument, node);
-        RefPtr<RegisterID> nextMethod = emitGetById(newTemporary(), iterator.get(), propertyNames().next);
+        RefPtr<RegisterID> iterator;
+        RefPtr<RegisterID> nextMethod;
+        if (isAsync) {
+            iterator = newTemporary();
+            nextMethod = newTemporary();
+            emitGetGenericAsyncIterator(iterator.get(), nextMethod.get(), argument, node);
+        } else {
+            iterator = emitGetGenericIterator(argument, node);
+            nextMethod = emitGetById(newTemporary(), iterator.get(), propertyNames().next);
+        }
 
         Ref<Label> loopDone = newLabel();
         {
@@ -5564,9 +5547,9 @@ RegisterID* BytecodeGenerator::emitDelegateYield(RegisterID* argument, Throwable
 
             Ref<Label> branchOnResult = newLabel();
             {
-                // `yield*` delegates the inner iterator's value without an enclosing Await (the iterator
-                // result was already Awaited above). YieldNoAwait tells the async driver not to await it.
-                // (Sync generators ignore the suspend reason.)
+                // `yield*` delegates the inner iterator's value without an enclosing Await (for the async
+                // case, the iterator result is already Awaited below). YieldNoAwait tells the async driver
+                // not to await it again.
                 emitYieldPoint(value.get(), JSAsyncGenerator::AsyncGeneratorSuspendReason::YieldNoAwait);
                 move(value.get(), generatorValueRegister());
 
@@ -5576,14 +5559,14 @@ RegisterID* BytecodeGenerator::emitDelegateYield(RegisterID* argument, Throwable
                 Ref<Label> returnLabel = newLabel();
                 emitJumpIfTrue(emitEqualityOp<OpStricteq>(newTemporary(), generatorResumeModeRegister(), emitLoad(nullptr, JSGenerator::ResumeMode::ReturnMode)), returnLabel.get());
 
-                // Throw.
+                // Throw. throw()/return() have no dedicated opcode, so call them generically (the fast
+                // async driver path only applies to the normal-mode next() below).
                 {
                     Ref<Label> throwMethodFound = newLabel();
                     RefPtr<RegisterID> throwMethod = emitGetById(newTemporary(), iterator.get(), propertyNames().throwKeyword);
                     emitJumpIfFalse(emitIsUndefinedOrNull(newTemporary(), throwMethod.get()), throwMethodFound.get());
 
-                    EmitAwait emitAwaitInIteratorClose = parseMode() == SourceParseMode::AsyncGeneratorBodyMode ? EmitAwait::Yes : EmitAwait::No;
-                    emitIteratorGenericClose(iterator.get(), node, emitAwaitInIteratorClose);
+                    emitIteratorGenericClose(iterator.get(), node, emitAwaitInClose);
 
                     emitThrowTypeError("The iterator, to which yield* delegated iteration, does not have a 'throw' method."_s);
 
@@ -5603,7 +5586,7 @@ RegisterID* BytecodeGenerator::emitDelegateYield(RegisterID* argument, Throwable
                     RefPtr<RegisterID> returnMethod = emitGetById(newTemporary(), iterator.get(), propertyNames().returnKeyword);
                     emitJumpIfFalse(emitIsUndefinedOrNull(newTemporary(), returnMethod.get()), returnMethodFound.get());
 
-                    if (parseMode() == SourceParseMode::AsyncGeneratorBodyMode)
+                    if (isAsync)
                         emitAwait(value.get(), value.get(), node->divot());
 
                     Ref<Label> returnSequence = newLabel();
@@ -5615,7 +5598,7 @@ RegisterID* BytecodeGenerator::emitDelegateYield(RegisterID* argument, Throwable
                     move(returnArguments.argumentRegister(0), value.get());
                     emitCall(value.get(), returnMethod.get(), NoExpectedFunction, returnArguments, node->divot(), node->divotStart(), node->divotEnd(), DebuggableCall::No);
 
-                    if (parseMode() == SourceParseMode::AsyncGeneratorBodyMode)
+                    if (isAsync)
                         emitAwait(value.get(), value.get(), node->divot());
 
                     Ref<Label> returnIteratorResultIsObject = newLabel();
@@ -5644,11 +5627,14 @@ RegisterID* BytecodeGenerator::emitDelegateYield(RegisterID* argument, Throwable
             }
 
             emitLabel(nextElement.get());
-            emitIteratorGenericNextWithValue(value.get(), nextMethod.get(), iterator.get(), value.get(), node);
+            if (isAsync)
+                emitAsyncIteratorNext(value.get(), nextMethod.get(), iterator.get(), value.get(), node);
+            else
+                emitIteratorGenericNextWithValue(value.get(), nextMethod.get(), iterator.get(), value.get(), node);
 
             emitLabel(branchOnResult.get());
 
-            if (parseMode() == SourceParseMode::AsyncGeneratorBodyMode)
+            if (isAsync)
                 emitAwait(value.get(), value.get(), node->divot());
 
             Ref<Label> iteratorValueIsObject = newLabel();
@@ -5667,7 +5653,6 @@ RegisterID* BytecodeGenerator::emitDelegateYield(RegisterID* argument, Throwable
     emitGetById(value.get(), value.get(), propertyNames().value);
     return value.unsafeGet();
 }
-
 
 void BytecodeGenerator::emitGeneratorStateChange(int32_t state)
 {

--- a/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.h
+++ b/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.h
@@ -786,7 +786,8 @@ namespace JSC {
         void emitSetFunctionName(RegisterID* value, const Identifier&);
 
         void emitAsyncIteratorOpen(RegisterID* iterator, RegisterID* next, RegisterID* symbolIterator, CallArguments& iterable, const ThrowableExpressionData* node);
-        RegisterID* emitAsyncIteratorNext(RegisterID* dst, RegisterID* next, RegisterID* iterator, const ThrowableExpressionData* node);
+        void emitGetGenericAsyncIterator(RegisterID* iterator, RegisterID* next, RegisterID* subject, const ThrowableExpressionData* node);
+        RegisterID* emitAsyncIteratorNext(RegisterID* dst, RegisterID* next, RegisterID* iterator, RegisterID* value, const ThrowableExpressionData* node);
 
         RegisterID* moveLinkTimeConstant(RegisterID* dst, LinkTimeConstant);
         RegisterID* moveEmptyValue(RegisterID* dst);
@@ -978,7 +979,6 @@ namespace JSC {
         void emitIteratorNext(RegisterID* done, RegisterID* value, RegisterID* iterable, RegisterID* nextOrIndex, CallArguments& iterator, const ThrowableExpressionData*);
 
         RegisterID* emitGetGenericIterator(RegisterID*, ThrowableExpressionData*);
-        RegisterID* emitGetAsyncIterator(RegisterID*, ThrowableExpressionData*);
 
         RegisterID* emitIteratorGenericNext(RegisterID* dst, RegisterID* nextMethod, RegisterID* iterator, const ThrowableExpressionData* node, JSC::EmitAwait = JSC::EmitAwait::No);
         RegisterID* emitIteratorGenericNextWithValue(RegisterID* dst, RegisterID* nextMethod, RegisterID* iterator, RegisterID* value, const ThrowableExpressionData* node);

--- a/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
+++ b/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
@@ -13239,7 +13239,8 @@ void ByteCodeParser::handleAsyncIteratorNext(const JSInstruction* currentInstruc
 
         Node* iterator = get(bytecode.m_iterator);
         Node* driver = get(bytecode.m_driver);
-        addToGraph(EnqueueAsyncGeneratorDriver, iterator, driver);
+        Node* resumeValue = bytecode.m_hasValue ? get(resumeValueOperandFor(bytecode)) : jsConstant(JSValue());
+        addToGraph(EnqueueAsyncGeneratorDriver, iterator, driver, resumeValue);
         set(bytecode.m_dst, jsConstant(m_vm->fastAsyncGeneratorSentinel()));
 
         m_currentIndex = osrExitIndex;
@@ -13277,11 +13278,13 @@ void ByteCodeParser::handleAsyncIteratorNext(const JSInstruction* currentInstruc
 
     if (!generatedCase) {
         // No mode observed (cold site): bail to the baseline, exactly like handleIteratorNext.
-        // Phantom every USES operand (next, iterator, driver) so all are recoverable on exit.
+        // Phantom every USES operand (next, iterator, driver, value) so all are recoverable on exit.
         addToGraph(ForceOSRExit);
         addToGraph(Phantom, get(bytecode.m_next));
         addToGraph(Phantom, get(bytecode.m_iterator));
         addToGraph(Phantom, get(bytecode.m_driver));
+        if (bytecode.m_hasValue)
+            addToGraph(Phantom, get(resumeValueOperandFor(bytecode)));
         set(bytecode.m_dst, jsConstant(jsUndefined()));
 
         m_currentIndex = osrExitIndex;

--- a/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
@@ -3183,6 +3183,7 @@ private:
         case EnqueueAsyncGeneratorDriver: {
             fixEdge<KnownCellUse>(node->child1());
             fixEdge<KnownCellUse>(node->child2());
+            fixEdge<UntypedUse>(node->child3());
             break;
         }
 

--- a/Source/JavaScriptCore/dfg/DFGOperations.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOperations.cpp
@@ -537,7 +537,7 @@ JSC_DEFINE_JIT_OPERATION(operationOpenAsyncFromSyncIterator, JSCell*, (JSGlobalO
     OPERATION_RETURN(scope, createAsyncFromSyncIteratorForIterable(globalObject, JSValue::decode(encodedIterable)));
 }
 
-JSC_DEFINE_JIT_OPERATION(operationEnqueueAsyncGeneratorDriver, void, (JSGlobalObject* globalObject, JSObject* iterator, JSObject* driver, MicrotaskCallCache* microtaskCallCache))
+JSC_DEFINE_JIT_OPERATION(operationEnqueueAsyncGeneratorDriver, void, (JSGlobalObject* globalObject, JSObject* iterator, JSObject* driver, EncodedJSValue resumeValue, MicrotaskCallCache* microtaskCallCache))
 {
     VM& vm = globalObject->vm();
     CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
@@ -545,9 +545,9 @@ JSC_DEFINE_JIT_OPERATION(operationEnqueueAsyncGeneratorDriver, void, (JSGlobalOb
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     if (auto* generator = dynamicDowncast<JSAsyncGenerator>(iterator))
-        enqueueAsyncGeneratorDriver(globalObject, generator, driver, microtaskCallCache);
+        enqueueAsyncGeneratorDriver(globalObject, generator, driver, JSValue::decode(resumeValue), microtaskCallCache);
     else
-        driveAsyncFromSyncIteratorWithDriver(globalObject, uncheckedDowncast<JSAsyncFromSyncIterator>(iterator), driver);
+        driveAsyncFromSyncIteratorWithDriver(globalObject, uncheckedDowncast<JSAsyncFromSyncIterator>(iterator), driver, JSValue::decode(resumeValue));
     OPERATION_RETURN(scope);
 }
 

--- a/Source/JavaScriptCore/dfg/DFGOperations.h
+++ b/Source/JavaScriptCore/dfg/DFGOperations.h
@@ -64,7 +64,7 @@ JSC_DECLARE_JIT_OPERATION(operationStringFromCodePointUntyped, EncodedJSValue, (
 // These routines provide callbacks out to C++ implementations of operations too complex to JIT.
 JSC_DECLARE_JIT_OPERATION(operationCallObjectConstructor, JSCell*, (JSGlobalObject*, EncodedJSValue encodedTarget));
 JSC_DECLARE_JIT_OPERATION(operationOpenAsyncFromSyncIterator, JSCell*, (JSGlobalObject*, EncodedJSValue encodedIterable));
-JSC_DECLARE_JIT_OPERATION(operationEnqueueAsyncGeneratorDriver, void, (JSGlobalObject*, JSObject*, JSObject*, MicrotaskCallCache*));
+JSC_DECLARE_JIT_OPERATION(operationEnqueueAsyncGeneratorDriver, void, (JSGlobalObject*, JSObject*, JSObject*, EncodedJSValue resumeValue, MicrotaskCallCache*));
 JSC_DECLARE_JIT_OPERATION(operationToObject, JSCell*, (JSGlobalObject*, EncodedJSValue encodedTarget, UniquedStringImpl*));
 JSC_DECLARE_JIT_OPERATION(operationObjectKeys, JSArray*, (JSGlobalObject*, EncodedJSValue));
 JSC_DECLARE_JIT_OPERATION(operationObjectKeysObject, JSArray*, (JSGlobalObject*, JSObject*));

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -8911,12 +8911,14 @@ void SpeculativeJIT::compileEnqueueAsyncGeneratorDriver(Node* node)
 {
     SpeculateCellOperand iterator(this, node->child1());
     SpeculateCellOperand driver(this, node->child2());
+    JSValueOperand resumeValue(this, node->child3());
 
     GPRReg iteratorGPR = iterator.gpr();
     GPRReg driverGPR = driver.gpr();
+    JSValueRegs resumeValueRegs = resumeValue.jsValueRegs();
 
     flushRegisters();
-    callOperation(operationEnqueueAsyncGeneratorDriver, LinkableConstant::globalObject(*this, node), iteratorGPR, driverGPR, TrustedImmPtr(&vm().syncResumeCallCache()));
+    callOperation(operationEnqueueAsyncGeneratorDriver, LinkableConstant::globalObject(*this, node), iteratorGPR, driverGPR, resumeValueRegs, TrustedImmPtr(&vm().syncResumeCallCache()));
 
     noResult(node);
 }

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -19941,7 +19941,7 @@ IGNORE_CLANG_WARNINGS_END
     {
         JSGlobalObject* globalObject = m_graph.globalObjectFor(m_origin.semantic);
         vmCall(Void, operationEnqueueAsyncGeneratorDriver, weakPointer(globalObject),
-            lowCell(m_node->child1()), lowCell(m_node->child2()), m_out.constIntPtr(&vm().syncResumeCallCache()));
+            lowCell(m_node->child1()), lowCell(m_node->child2()), lowJSValue(m_node->child3()), m_out.constIntPtr(&vm().syncResumeCallCache()));
     }
 
     void compileStringReplace()

--- a/Source/JavaScriptCore/jit/JITCall.cpp
+++ b/Source/JavaScriptCore/jit/JITCall.cpp
@@ -622,10 +622,15 @@ void JIT::emit_op_async_iterator_next(const JSInstruction* instruction)
     constexpr GPRReg globalObjectGPR = preferredArgumentGPR<SlowOperation, 0>();
     constexpr GPRReg iteratorGPR = preferredArgumentGPR<SlowOperation, 1>();
     constexpr GPRReg driverGPR = preferredArgumentGPR<SlowOperation, 2>();
+    constexpr JSValueRegs resumeValueJSR = preferredArgumentJSR<SlowOperation, 3>();
     emitGetVirtualRegisterPayload(bytecode.m_iterator, iteratorGPR);
     emitGetVirtualRegisterPayload(bytecode.m_driver, driverGPR);
+    if (bytecode.m_hasValue)
+        emitGetVirtualRegister(resumeValueOperandFor(bytecode), resumeValueJSR);
+    else
+        moveValue(JSValue(), resumeValueJSR);
     loadGlobalObject(globalObjectGPR);
-    callOperation(operationAsyncIteratorNextWithDriver, globalObjectGPR, iteratorGPR, driverGPR, TrustedImmPtr(&vm().syncResumeCallCache()));
+    callOperation(operationAsyncIteratorNextWithDriver, globalObjectGPR, iteratorGPR, driverGPR, resumeValueJSR, TrustedImmPtr(&vm().syncResumeCallCache()));
     emitPutVirtualRegister(bytecode.m_dst, returnValueJSR);
     Jump doneCase = jump();
 

--- a/Source/JavaScriptCore/jit/JITOperations.cpp
+++ b/Source/JavaScriptCore/jit/JITOperations.cpp
@@ -2906,14 +2906,14 @@ JSC_DEFINE_JIT_OPERATION(operationSetFunctionName, void, (JSGlobalObject* global
     OPERATION_RETURN(scope);
 }
 
-JSC_DEFINE_JIT_OPERATION(operationAsyncIteratorNextWithDriver, EncodedJSValue, (JSGlobalObject* globalObject, JSObject* iterator, JSObject* driver, MicrotaskCallCache* microtaskCallCache))
+JSC_DEFINE_JIT_OPERATION(operationAsyncIteratorNextWithDriver, EncodedJSValue, (JSGlobalObject* globalObject, JSObject* iterator, JSObject* driver, EncodedJSValue resumeValue, MicrotaskCallCache* microtaskCallCache))
 {
     VM& vm = globalObject->vm();
     CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
     JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    OPERATION_RETURN(scope, JSValue::encode(asyncIteratorNextWithDriver(globalObject, iterator, driver, microtaskCallCache)));
+    OPERATION_RETURN(scope, JSValue::encode(asyncIteratorNextWithDriver(globalObject, iterator, driver, JSValue::decode(resumeValue), microtaskCallCache)));
 }
 
 JSC_DEFINE_JIT_OPERATION(operationNewObject, JSCell*, (VM* vmPointer, Structure* structure))

--- a/Source/JavaScriptCore/jit/JITOperations.h
+++ b/Source/JavaScriptCore/jit/JITOperations.h
@@ -358,7 +358,7 @@ JSC_DECLARE_JIT_OPERATION(operationNewAsyncFunctionWithInvalidatedReallocationWa
 JSC_DECLARE_JIT_OPERATION(operationNewAsyncGeneratorFunction, EncodedJSValue, (JSGlobalObject*, JSScope*, JSCell*));
 JSC_DECLARE_JIT_OPERATION(operationNewAsyncGeneratorFunctionWithInvalidatedReallocationWatchpoint, EncodedJSValue, (JSGlobalObject*, JSScope*, JSCell*));
 JSC_DECLARE_JIT_OPERATION(operationSetFunctionName, void, (JSGlobalObject*, JSCell*, EncodedJSValue));
-JSC_DECLARE_JIT_OPERATION(operationAsyncIteratorNextWithDriver, EncodedJSValue, (JSGlobalObject*, JSObject*, JSObject*, MicrotaskCallCache*));
+JSC_DECLARE_JIT_OPERATION(operationAsyncIteratorNextWithDriver, EncodedJSValue, (JSGlobalObject*, JSObject*, JSObject*, EncodedJSValue resumeValue, MicrotaskCallCache*));
 JSC_DECLARE_JIT_OPERATION(operationNewObject, JSCell*, (VM*, Structure*));
 JSC_DECLARE_JIT_OPERATION(operationNewPromise, JSCell*, (VM*, Structure*));
 JSC_DECLARE_JIT_OPERATION(operationNewGenerator, JSCell*, (VM*, Structure*));

--- a/Source/JavaScriptCore/llint/LLIntSlowPaths.cpp
+++ b/Source/JavaScriptCore/llint/LLIntSlowPaths.cpp
@@ -2026,7 +2026,8 @@ LLINT_SLOW_PATH_DECL(slow_path_async_iterator_next_with_driver)
     metadata.m_iterationMetadata.seenModes = metadata.m_iterationMetadata.seenModes | IterationMode::FastAsyncGenerator;
     JSObject* iterator = asObject(getNonConstantOperand(callFrame, bytecode.m_iterator).asCell());
     auto* driver = asObject(getNonConstantOperand(callFrame, bytecode.m_driver).asCell());
-    JSValue result = asyncIteratorNextWithDriver(globalObject, iterator, driver, &vm.syncResumeCallCache());
+    JSValue resumeValue = bytecode.m_hasValue ? getOperand(callFrame, resumeValueOperandFor(bytecode)) : JSValue();
+    JSValue result = asyncIteratorNextWithDriver(globalObject, iterator, driver, resumeValue, &vm.syncResumeCallCache());
     LLINT_RETURN(result);
 }
 

--- a/Source/JavaScriptCore/llint/LowLevelInterpreter.asm
+++ b/Source/JavaScriptCore/llint/LowLevelInterpreter.asm
@@ -2415,11 +2415,21 @@ _js_trampoline_llint_function_for_construct_arity_check_tag_wide32:
     crash()
 
 # Value-representation-specific code.
+
+# Shared by LowLevelInterpreter64.asm and LowLevelInterpreter32_64.asm's op_async_iterator_next.
+# yield* forwards a resume value to next() (m_hasValue -> this + value); for-await leaves
+# m_hasValue false, so next() is called with just `this`.
+macro getArgumentIncludingThisCountForAsyncIteratorNext(size, dst)
+    getu(size, OpAsyncIteratorNext, m_hasValue, dst)
+    addi 1, dst
+end
+
 if JSVALUE64
     include LowLevelInterpreter64
 else
     include LowLevelInterpreter32_64
 end
+
 
 
 # Value-representation-agnostic code.

--- a/Source/JavaScriptCore/llint/LowLevelInterpreter32_64.asm
+++ b/Source/JavaScriptCore/llint/LowLevelInterpreter32_64.asm
@@ -3214,7 +3214,7 @@ llintOpWithMetadata(op_async_iterator_next, OpAsyncIteratorNext, macro (size, ge
     end
 
     macro getArgumentIncludingThisCount(dst)
-        move 1, dst
+        getArgumentIncludingThisCountForAsyncIteratorNext(size, dst)
     end
 
     metadata(t5, t0)

--- a/Source/JavaScriptCore/llint/LowLevelInterpreter64.asm
+++ b/Source/JavaScriptCore/llint/LowLevelInterpreter64.asm
@@ -3444,7 +3444,7 @@ llintOpWithMetadata(op_async_iterator_next, OpAsyncIteratorNext, macro (size, ge
     end
 
     macro getArgumentIncludingThisCount(dst)
-        move 1, dst
+        getArgumentIncludingThisCountForAsyncIteratorNext(size, dst)
     end
 
     metadata(t5, t0)

--- a/Source/JavaScriptCore/runtime/AsyncFromSyncIteratorPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/AsyncFromSyncIteratorPrototype.cpp
@@ -273,7 +273,7 @@ JSC_DEFINE_HOST_FUNCTION(asyncFromSyncIteratorPrototypeFuncThrow, (JSGlobalObjec
     return JSValue::encode(promise);
 }
 
-void driveAsyncFromSyncIteratorWithDriver(JSGlobalObject* globalObject, JSAsyncFromSyncIterator* iterator, JSObject* driver)
+void driveAsyncFromSyncIteratorWithDriver(JSGlobalObject* globalObject, JSAsyncFromSyncIterator* iterator, JSObject* driver, JSValue resumeValue)
 {
     VM& vm = globalObject->vm();
 
@@ -282,7 +282,7 @@ void driveAsyncFromSyncIteratorWithDriver(JSGlobalObject* globalObject, JSAsyncF
 
     {
         auto catchScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
-        done = driveSyncIterator(globalObject, vm, iterator, JSValue(), value);
+        done = driveSyncIterator(globalObject, vm, iterator, resumeValue, value);
 
         if (catchScope.exception()) [[unlikely]] {
             JSValue error = catchScope.exception()->value();

--- a/Source/JavaScriptCore/runtime/JSAsyncFromSyncIterator.h
+++ b/Source/JavaScriptCore/runtime/JSAsyncFromSyncIterator.h
@@ -90,7 +90,7 @@ private:
 
 STATIC_ASSERT_IS_TRIVIALLY_DESTRUCTIBLE(JSAsyncFromSyncIterator);
 
-void driveAsyncFromSyncIteratorWithDriver(JSGlobalObject*, JSAsyncFromSyncIterator*, JSObject* driver);
+void driveAsyncFromSyncIteratorWithDriver(JSGlobalObject*, JSAsyncFromSyncIterator*, JSObject* driver, JSValue resumeValue);
 JSValue asyncFromSyncIteratorNext(JSGlobalObject*, JSAsyncFromSyncIterator*, JSValue argument);
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/JSMicrotask.cpp
+++ b/Source/JavaScriptCore/runtime/JSMicrotask.cpp
@@ -661,9 +661,16 @@ void asyncGeneratorResume(JSGlobalObject* globalObject, JSAsyncGenerator* genera
     asyncGeneratorUnwrapYieldResumption(globalObject, generator, generator->resumeValue(), generator->resumeMode(), microtaskCallCache);
 }
 
-void enqueueAsyncGeneratorDriver(JSGlobalObject* globalObject, JSAsyncGenerator* iterator, JSObject* driver, MicrotaskCallCache* microtaskCallCache)
+static JSValue resumeValueOrUndefined(JSValue resumeValue)
+{
+    return resumeValue.isEmpty() ? jsUndefined() : resumeValue;
+}
+
+void enqueueAsyncGeneratorDriver(JSGlobalObject* globalObject, JSAsyncGenerator* iterator, JSObject* driver, JSValue resumeValue, MicrotaskCallCache* microtaskCallCache)
 {
     VM& vm = globalObject->vm();
+
+    resumeValue = resumeValueOrUndefined(resumeValue);
 
     // Mirror AsyncGeneratorEnqueue's completed-state fast path: settle { undefined, true } without enqueuing.
     int32_t state = iterator->state();
@@ -672,7 +679,7 @@ void enqueueAsyncGeneratorDriver(JSGlobalObject* globalObject, JSAsyncGenerator*
         return;
     }
 
-    iterator->enqueue(vm, jsUndefined(), static_cast<int32_t>(JSGenerator::ResumeMode::NormalMode), driver);
+    iterator->enqueue(vm, resumeValue, static_cast<int32_t>(JSGenerator::ResumeMode::NormalMode), driver);
 
     // https://tc39.es/ecma262/#sec-asyncgeneratorenqueue step 6: a non-busy generator resumes immediately.
     if (state == static_cast<int32_t>(JSAsyncGenerator::AsyncGeneratorState::Init) || JSAsyncGenerator::isSuspendedYieldState(state))
@@ -681,21 +688,21 @@ void enqueueAsyncGeneratorDriver(JSGlobalObject* globalObject, JSAsyncGenerator*
 
 // If the Promise species is tampered after the fused open, fall back to the real next() so the consumer's Await
 // still performs the observable PromiseResolve (Promise.prototype.constructor lookup) the fused driver would skip.
-JSValue asyncIteratorNextWithDriver(JSGlobalObject* globalObject, JSObject* iterator, JSObject* driver, MicrotaskCallCache* microtaskCallCache)
+JSValue asyncIteratorNextWithDriver(JSGlobalObject* globalObject, JSObject* iterator, JSObject* driver, JSValue resumeValue, MicrotaskCallCache* microtaskCallCache)
 {
     VM& vm = globalObject->vm();
     auto* generator = dynamicDowncast<JSAsyncGenerator>(iterator);
 
     if (globalObject->promiseSpeciesWatchpointSet().state() != IsWatched) [[unlikely]] {
         if (generator)
-            return asyncGeneratorNext(globalObject, generator, jsUndefined(), microtaskCallCache);
-        return asyncFromSyncIteratorNext(globalObject, uncheckedDowncast<JSAsyncFromSyncIterator>(iterator), JSValue());
+            return asyncGeneratorNext(globalObject, generator, resumeValueOrUndefined(resumeValue), microtaskCallCache);
+        return asyncFromSyncIteratorNext(globalObject, uncheckedDowncast<JSAsyncFromSyncIterator>(iterator), resumeValue);
     }
 
     if (generator)
-        enqueueAsyncGeneratorDriver(globalObject, generator, driver, microtaskCallCache);
+        enqueueAsyncGeneratorDriver(globalObject, generator, driver, resumeValue, microtaskCallCache);
     else
-        driveAsyncFromSyncIteratorWithDriver(globalObject, uncheckedDowncast<JSAsyncFromSyncIterator>(iterator), driver);
+        driveAsyncFromSyncIteratorWithDriver(globalObject, uncheckedDowncast<JSAsyncFromSyncIterator>(iterator), driver, resumeValue);
     return vm.fastAsyncGeneratorSentinel();
 }
 

--- a/Source/JavaScriptCore/runtime/JSMicrotask.h
+++ b/Source/JavaScriptCore/runtime/JSMicrotask.h
@@ -45,9 +45,9 @@ void asyncModuleResolveEvaluation(JSGlobalObject*, VM&, ThrowScope&, JSModuleRec
 void asyncGeneratorResume(JSGlobalObject*, JSAsyncGenerator*, MicrotaskCallCache*);
 void asyncGeneratorAwaitReturn(JSGlobalObject*, JSAsyncGenerator*);
 
-void enqueueAsyncGeneratorDriver(JSGlobalObject*, JSAsyncGenerator* iterator, JSObject* driver, MicrotaskCallCache*);
+void enqueueAsyncGeneratorDriver(JSGlobalObject*, JSAsyncGenerator* iterator, JSObject* driver, JSValue resumeValue, MicrotaskCallCache*);
 
-JSValue asyncIteratorNextWithDriver(JSGlobalObject*, JSObject* iterator, JSObject* driver, MicrotaskCallCache*);
+JSValue asyncIteratorNextWithDriver(JSGlobalObject*, JSObject* iterator, JSObject* driver, JSValue resumeValue, MicrotaskCallCache*);
 
 JSC_DECLARE_HOST_FUNCTION(asyncFunctionDrive);
 


### PR DESCRIPTION
#### 5e28b6ce22ee4fccd38c23498a469f3d8508a47a
<pre>
[JSC] Use op_async_iterator_open and op_async_iterator_next for yield*
<a href="https://bugs.webkit.org/show_bug.cgi?id=319946">https://bugs.webkit.org/show_bug.cgi?id=319946</a>
<a href="https://rdar.apple.com/182862712">rdar://182862712</a>

Reviewed by Yijia Huang.

This patch applies op_async_iterator_open and op_async_iterator_next to
yield* in async generator functions. Previously we cannot apply that
since op_async_iterator_next was always calling `next()` while yield*
will pass a resume value `next(resumeValue)`. This patch extends
op_async_iterator_next to have a flag &quot;hasValue&quot;, and based on that
argument will be pushed or not.

                                       ToT                     Patched

async-generator-yield-star       95.7791+-0.6264     ^     79.6243+-0.7356        ^ definitely 1.2029x faster

Tests: JSTests/microbenchmarks/async-generator-yield-star.js
       JSTests/stress/async-iteration-yield-star-resume-value.js

* JSTests/microbenchmarks/async-generator-yield-star.js: Added.
(async createAsyncGen):
(async run):
* JSTests/stress/async-iteration-yield-star-resume-value.js: Added.
(assert):
(async driverPath.async inner):
(async driverPath.async outer):
(async driverPath):
(async genericPath):
(async genericPath.async outer):
(async forAwaitZeroArgs):
(async asyncFromSyncPath):
(async asyncFromSyncPath.async outer):
(async asyncFromSyncPath.async outerArr):
(async main):
* Source/JavaScriptCore/bytecode/BytecodeList.rb:
* Source/JavaScriptCore/bytecode/BytecodeOperandsForCheckpoint.h:
(JSC::argumentCountIncludingThisFor):
(JSC::resumeValueOperandFor):
* Source/JavaScriptCore/bytecode/BytecodeUseDef.cpp:
(JSC::computeUsesForBytecodeIndexImpl):
* Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp:
(JSC::BytecodeGenerator::emitGetGenericAsyncIterator):
(JSC::BytecodeGenerator::emitAsyncIteratorNext):
(JSC::BytecodeGenerator::emitEnumeration):
(JSC::BytecodeGenerator::emitDelegateYield):
(JSC::BytecodeGenerator::emitGetAsyncIterator): Deleted.
* Source/JavaScriptCore/bytecompiler/BytecodeGenerator.h:
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::handleAsyncIteratorNext):
* Source/JavaScriptCore/dfg/DFGFixupPhase.cpp:
(JSC::DFG::FixupPhase::fixupNode):
* Source/JavaScriptCore/dfg/DFGOperations.cpp:
(JSC::DFG::JSC_DEFINE_JIT_OPERATION):
* Source/JavaScriptCore/dfg/DFGOperations.h:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileCompareStrictEq):
* Source/JavaScriptCore/jit/JITCall.cpp:
(JSC::JIT::emit_op_async_iterator_next):
* Source/JavaScriptCore/jit/JITOperations.cpp:
(JSC::JSC_DEFINE_JIT_OPERATION):
* Source/JavaScriptCore/jit/JITOperations.h:
* Source/JavaScriptCore/llint/LLIntSlowPaths.cpp:
(JSC::LLInt::LLINT_SLOW_PATH_DECL):
* Source/JavaScriptCore/llint/LowLevelInterpreter.asm:
* Source/JavaScriptCore/llint/LowLevelInterpreter32_64.asm:
* Source/JavaScriptCore/llint/LowLevelInterpreter64.asm:
* Source/JavaScriptCore/runtime/AsyncFromSyncIteratorPrototype.cpp:
(JSC::driveAsyncFromSyncIteratorWithDriver):
* Source/JavaScriptCore/runtime/JSAsyncFromSyncIterator.h:
* Source/JavaScriptCore/runtime/JSMicrotask.cpp:
(JSC::resumeValueOrUndefined):
(JSC::enqueueAsyncGeneratorDriver):
(JSC::asyncIteratorNextWithDriver):
* Source/JavaScriptCore/runtime/JSMicrotask.h:

Canonical link: <a href="https://commits.webkit.org/317906@main">https://commits.webkit.org/317906@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a061592d556b999e311f72d0d582eacce8794de7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176677 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50614 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44406 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186279 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/139557 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/63180dbd-6177-477c-901b-8331f9710923) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51907 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50300 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137630 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/139557 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6882ef93-46c3-4f15-ab32-9de0d46903d9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179633 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41129 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158417 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118104 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/161cde43-8bb7-4f4f-a180-791afbe52da7) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/39784 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38151 "Passed tests") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/251/builds/69 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/6924 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150196 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37915 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34747 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/37948 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42354 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/42367 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188703 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50281 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146690 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50964 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/34536 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146495 "Build is in progress. Recent messages:Printed configuration; Checked out pull request; run-api-tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26818 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41256 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123170 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117300 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49469 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12894 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48868 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49104 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48929 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->