### PR TITLE
[YARR] `tryReadUnicodeChar` should take the BMP fast path for any non-surrogate character

### DIFF
--- a/JSTests/microbenchmarks/regexp-unicode-bmp-above-latin.js
+++ b/JSTests/microbenchmarks/regexp-unicode-bmp-above-latin.js
@@ -1,0 +1,34 @@
+function splitmix32(seed) {
+    var a = seed;
+    return function () {
+        a |= 0; a = (a + 0x9e3779b9) | 0;
+        var t = a ^ (a >>> 16); t = Math.imul(t, 0x21f0aaad);
+        t = t ^ (t >>> 15); t = Math.imul(t, 0x735a2d97);
+        return ((t = t ^ (t >>> 15)) >>> 0) / 4294967296;
+    };
+}
+
+function makeString(codePoints, length, seed) {
+    var rnd = splitmix32(seed);
+    var out = [];
+    for (var i = 0; i < length; ++i)
+        out.push(String.fromCharCode(codePoints[rnd() * codePoints.length | 0]));
+    out.push("X");
+    return out.join("");
+}
+
+var codePoints = [0x0416, 0x2014, 0x3042, 0x4e2d, 0x201c, 0xff21];
+var subjects = [];
+for (var k = 0; k < 8; ++k)
+    subjects.push(makeString(codePoints, 500, 0x1000 + k));
+
+var re = /[^X]*X/u;
+var count = 0;
+
+for (var i = 0; i < 1e5; ++i) {
+    if (re.test(subjects[i & 7]))
+        count++;
+}
+
+if (count !== 1e5)
+    throw new Error("bad");

--- a/JSTests/microbenchmarks/regexp-unicode-bmp-hangul-and-fullwidth.js
+++ b/JSTests/microbenchmarks/regexp-unicode-bmp-hangul-and-fullwidth.js
@@ -1,0 +1,34 @@
+function splitmix32(seed) {
+    var a = seed;
+    return function () {
+        a |= 0; a = (a + 0x9e3779b9) | 0;
+        var t = a ^ (a >>> 16); t = Math.imul(t, 0x21f0aaad);
+        t = t ^ (t >>> 15); t = Math.imul(t, 0x735a2d97);
+        return ((t = t ^ (t >>> 15)) >>> 0) / 4294967296;
+    };
+}
+
+function makeString(codePoints, length, seed) {
+    var rnd = splitmix32(seed);
+    var out = [];
+    for (var i = 0; i < length; ++i)
+        out.push(String.fromCharCode(codePoints[rnd() * codePoints.length | 0]));
+    out.push("X");
+    return out.join("");
+}
+
+var codePoints = [0x8a3a, 0xac00, 0xd7a3, 0xff21, 0xff9f, 0x9f8d];
+var subjects = [];
+for (var k = 0; k < 8; ++k)
+    subjects.push(makeString(codePoints, 500, 0x1000 + k));
+
+var re = /[^X]*X/u;
+var count = 0;
+
+for (var i = 0; i < 1e5; ++i) {
+    if (re.test(subjects[i & 7]))
+        count++;
+}
+
+if (count !== 1e5)
+    throw new Error("bad");

--- a/JSTests/microbenchmarks/regexp-unicode-latin-before-surrogate.js
+++ b/JSTests/microbenchmarks/regexp-unicode-latin-before-surrogate.js
@@ -1,0 +1,33 @@
+function splitmix32(seed) {
+    var a = seed;
+    return function () {
+        a |= 0; a = (a + 0x9e3779b9) | 0;
+        var t = a ^ (a >>> 16); t = Math.imul(t, 0x21f0aaad);
+        t = t ^ (t >>> 15); t = Math.imul(t, 0x735a2d97);
+        return ((t = t ^ (t >>> 15)) >>> 0) / 4294967296;
+    };
+}
+
+function makeString(length, seed) {
+    var rnd = splitmix32(seed);
+    var out = [];
+    for (var i = 0; i < length; ++i)
+        out.push("a", String.fromCharCode(0xd800 + (rnd() * 0x400 | 0)));
+    out.push("X");
+    return out.join("");
+}
+
+var subjects = [];
+for (var k = 0; k < 8; ++k)
+    subjects.push(makeString(250, 0x3000 + k));
+
+var re = /[^X]*X/u;
+var count = 0;
+
+for (var i = 0; i < 1e5; ++i) {
+    if (re.test(subjects[i & 7]))
+        count++;
+}
+
+if (count !== 1e5)
+    throw new Error("bad");

--- a/JSTests/microbenchmarks/regexp-unicode-surrogate-pairs.js
+++ b/JSTests/microbenchmarks/regexp-unicode-surrogate-pairs.js
@@ -1,0 +1,33 @@
+function splitmix32(seed) {
+    var a = seed;
+    return function () {
+        a |= 0; a = (a + 0x9e3779b9) | 0;
+        var t = a ^ (a >>> 16); t = Math.imul(t, 0x21f0aaad);
+        t = t ^ (t >>> 15); t = Math.imul(t, 0x735a2d97);
+        return ((t = t ^ (t >>> 15)) >>> 0) / 4294967296;
+    };
+}
+
+function makeString(length, seed) {
+    var rnd = splitmix32(seed);
+    var out = [];
+    for (var i = 0; i < length; ++i)
+        out.push(String.fromCodePoint(0x10000 + (rnd() * 0x400 | 0)));
+    out.push("X");
+    return out.join("");
+}
+
+var subjects = [];
+for (var k = 0; k < 8; ++k)
+    subjects.push(makeString(500, 0x2000 + k));
+
+var re = /[^X]*X/u;
+var count = 0;
+
+for (var i = 0; i < 1e5; ++i) {
+    if (re.test(subjects[i & 7]))
+        count++;
+}
+
+if (count !== 1e5)
+    throw new Error("bad");

--- a/JSTests/stress/regexp-unicode-bmp-fast-path-code-points.js
+++ b/JSTests/stress/regexp-unicode-bmp-fast-path-code-points.js
@@ -1,0 +1,46 @@
+function shouldBe(actual, expected, message) {
+    if (actual !== expected)
+        throw new Error(`FAIL ${message}: expected ${expected}, got ${actual}`);
+}
+
+const codeUnits = [];
+for (let unit = 0; unit < 0x10000; unit += 0x40)
+    codeUnits.push(unit);
+for (const unit of [0x03ff, 0x0400, 0x2014, 0xd7ff, 0xd800, 0xdbff, 0xdc00, 0xdfff, 0xe000, 0xfffd, 0xffff])
+    codeUnits.push(unit);
+
+const followers = [0x0061, 0x0400, 0x3042, 0xd800, 0xdbff, 0xdc00, 0xdfff, 0xffff];
+
+function codePointsOf(string) {
+    const result = [];
+    for (const character of string)
+        result.push(character.codePointAt(0));
+    return result;
+}
+
+const singleCodePoint = /^.$/u;
+const twoCodePoints = /^(.)(.)$/u;
+const greedy = /^([^X]*)X$/u;
+
+for (let i = 0; i < testLoopCount; ++i) {
+    for (const first of codeUnits) {
+        for (const second of followers) {
+            const subject = String.fromCharCode(first, second);
+            const expected = codePointsOf(subject);
+            const tag = `[${first.toString(16)},${second.toString(16)}]`;
+
+            shouldBe(singleCodePoint.test(subject), expected.length === 1, `single code point ${tag}`);
+
+            const matched = twoCodePoints.exec(subject);
+            shouldBe(matched !== null, expected.length === 2, `two code points ${tag}`);
+            if (matched) {
+                shouldBe(matched[1].codePointAt(0), expected[0], `first code point ${tag}`);
+                shouldBe(matched[2].codePointAt(0), expected[1], `second code point ${tag}`);
+            }
+
+            const scanned = greedy.exec(subject + "X");
+            shouldBe(scanned !== null, true, `greedy scan ${tag}`);
+            shouldBe(scanned[1], subject, `greedy capture ${tag}`);
+        }
+    }
+}

--- a/Source/JavaScriptCore/yarr/YarrJIT.cpp
+++ b/Source/JavaScriptCore/yarr/YarrJIT.cpp
@@ -457,6 +457,9 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(MaskedAlternativeInfo);
 
 static constexpr MacroAssembler::TrustedImm32 surrogateTagMask = MacroAssembler::TrustedImm32(0xfc00fc00);
 static constexpr MacroAssembler::TrustedImm32 surrogatePairTags = MacroAssembler::TrustedImm32(0xdc00d800);
+static constexpr MacroAssembler::TrustedImm32 firstCharacterNonBMPBit = MacroAssembler::TrustedImm32(0x8000);
+static constexpr MacroAssembler::TrustedImm32 firstCharacterSurrogateTagMask = MacroAssembler::TrustedImm32(0xf800);
+static constexpr MacroAssembler::TrustedImm32 firstCharacterSurrogateTag = MacroAssembler::TrustedImm32(0xd800);
 
 #if ENABLE(YARR_JIT_UNICODE_EXPRESSIONS)
 template<TryReadUnicodeCharGenFirstNonBMPOptimization useNonBMPOptimization>
@@ -478,14 +481,9 @@ void tryReadUnicodeCharImpl(VM& vm, CCallHelpers& jit, MacroAssembler::RegisterI
     // Load and try to process two UTF-16 characters.
     // If they are a proper surrogate pair, compute the non-BMP codepoint.
     jit.load32(MacroAssembler::Address(regs.regUnicodeInputAndTrail), resultReg);
-#if CPU(ARM64)
-    jit.and32AndSetFlags(surrogateTagMask, resultReg, regs.unicodeAndSubpatternIdTemp);
-    isBMP.append(jit.branch(MacroAssembler::Zero));
-#else
+    isBMP.append(jit.branchTest32(MacroAssembler::Zero, resultReg, firstCharacterNonBMPBit));
     jit.and32(surrogateTagMask, resultReg, regs.unicodeAndSubpatternIdTemp);
-    isBMP.append(jit.branch32(MacroAssembler::Equal, regs.unicodeAndSubpatternIdTemp, MacroAssembler::TrustedImm32(0)));
-#endif
-    slowCases.append(jit.branch32(MacroAssembler::NotEqual, regs.unicodeAndSubpatternIdTemp, surrogatePairTags));
+    MacroAssembler::Jump notSurrogatePair = jit.branch32(MacroAssembler::NotEqual, regs.unicodeAndSubpatternIdTemp, surrogatePairTags);
 
     // Create the UTF32 character from the surrogate pair.
 #if CPU(ARM64)
@@ -504,6 +502,10 @@ void tryReadUnicodeCharImpl(VM& vm, CCallHelpers& jit, MacroAssembler::RegisterI
         jit.move(MacroAssembler::TrustedImm32(1), regs.firstCharacterAdditionalReadSize);
 #endif
     done.append(jit.jump());
+
+    notSurrogatePair.link(&jit);
+    jit.and32(firstCharacterSurrogateTagMask, regs.unicodeAndSubpatternIdTemp, regs.unicodeAndSubpatternIdTemp);
+    slowCases.append(jit.branch32(MacroAssembler::Equal, regs.unicodeAndSubpatternIdTemp, firstCharacterSurrogateTag));
 
     isBMP.link(jit);
     jit.and32(MacroAssembler::TrustedImm32(0xffff), resultReg);


### PR DESCRIPTION
#### 016fcfbca076fd98152cf0ad5d3d65c1ec695237
<pre>
[YARR] `tryReadUnicodeChar` should take the BMP fast path for any non-surrogate character
<a href="https://bugs.webkit.org/show_bug.cgi?id=319943">https://bugs.webkit.org/show_bug.cgi?id=319943</a>

Reviewed by Yusuke Suzuki.

tryReadUnicodeChar loads two code units at once and masks the pair with
0xfc00fc00, taking the inline BMP path only when the result is zero, i.e. only
when both code units are below U+0400. That path returns just the first code
unit, so the second one should not gate it: a first code unit that is not a
surrogate is a BMP code point on its own, whatever follows it.

Surrogates are U+D800-U+DFFF, so a first code unit with bit 15 clear can never
be one. Branch on that bit before masking. It is a single tbz on ARM64, so
U+0000-U+7FFF reaches the BMP path in fewer instructions than the pair-is-zero
test used to take, and the mask is only computed on the paths that need it. This
also recovers U+2000-U+23FF, which was on the fast path until 317399@main
corrected the mask from 0xdc00 to 0xfc00.

Failing the surrogate pair test does not mean the read is a surrogate at all, so
check the first code unit against the surrogate tag there as well. U+8000-U+FFFF
then stops calling the slow thunk too, and since that test sits behind the pair
test it only runs where the thunk used to be called.

The BMP test is no longer against zero, so the ARM64 and32AndSetFlags special
case goes away.

                                            Baseline           Patched

regexp-unicode-bmp-hangul-and-fullwidth 62.2569+-0.8130    44.1657+-1.3399   definitely 1.4096x faster
regexp-unicode-bmp-above-latin          61.6626+-0.8342    43.9289+-0.4469   definitely 1.4037x faster
regexp-unicode-latin-before-surrogate   62.2440+-0.9320    53.3576+-1.1463   definitely 1.1665x faster
regexp-unicode-surrogate-pairs          45.8066+-1.4352    44.0832+-1.2427   neutral

Tests: JSTests/microbenchmarks/regexp-unicode-bmp-above-latin.js
       JSTests/microbenchmarks/regexp-unicode-latin-before-surrogate.js
       JSTests/microbenchmarks/regexp-unicode-surrogate-pairs.js
       JSTests/stress/regexp-unicode-bmp-fast-path-code-points.js

* JSTests/microbenchmarks/regexp-unicode-bmp-above-latin.js: Added.
(splitmix32):
(makeString):
* JSTests/microbenchmarks/regexp-unicode-latin-before-surrogate.js: Added.
(splitmix32):
(makeString):
* JSTests/microbenchmarks/regexp-unicode-surrogate-pairs.js: Added.
(splitmix32):
(makeString):
* JSTests/stress/regexp-unicode-bmp-fast-path-code-points.js: Added.
(shouldBe):
(codePointsOf):
(i.const.first.of.codeUnits.const.second.of.followers.first.toString):
* Source/JavaScriptCore/yarr/YarrJIT.cpp:
(JSC::Yarr::tryReadUnicodeCharImpl):

Canonical link: <a href="https://commits.webkit.org/317749@main">https://commits.webkit.org/317749@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dfc410cfa706d4ecb756bac2a63dbd19f2cb51d6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176250 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50185 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43975 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185846 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/138494 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51477 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49869 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/137273 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/138494 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179206 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/40757 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/158047 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117748 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/39406 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/37768 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/218/builds/6556 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/149822 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37544 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34315 "Built successfully") | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/37518 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/41907 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/41979 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188270 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49850 "Built successfully") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/146308 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39341 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50534 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/34162 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146128 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40898 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/122738 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/116714 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49038 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12516 "") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48440 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48674 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48499 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->