### PR TITLE
LogStream leaks its IPC connection (and Mach port / kqueue workloop) after the WebContent process exits

### DIFF
--- a/Source/WebKit/Shared/LogStream.mm
+++ b/Source/WebKit/Shared/LogStream.mm
@@ -62,7 +62,13 @@ void LogStream::stopListeningForIPC()
 {
     assertIsMainRunLoop();
 #if ENABLE(STREAMING_IPC_IN_LOG_FORWARDING)
+    // Fully tear down the stream connection. stopReceivingMessages() clears the StreamServerConnection's
+    // receiver map (breaking the m_receivers <-> m_connection retain cycle so the objects can be freed),
+    // and invalidate() invalidates the underlying IPC::Connection so its Mach port / kqueue workloop is
+    // released. Neither alone is sufficient; without this the connection leaked after the WebContent
+    // process was gone, until the UI process was killed for resource exhaustion. See rdar://182244946.
     m_connection->stopReceivingMessages(Messages::LogStream::messageReceiverName(), m_identifier.toUInt64());
+    m_connection->invalidate();
 #endif
 }
 

--- a/Source/WebKit/UIProcess/Cocoa/WebProcessProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebProcessProxyCocoa.mm
@@ -385,15 +385,21 @@ void WebProcessProxy::platformDestroy()
 #endif // PLATFORM(IOS_FAMILY)
 
 #if ENABLE(LOGD_BLOCKING_IN_WEBCONTENT)
-    if (m_logStream.get()) {
-#if !ENABLE(STREAMING_IPC_IN_LOG_FORWARDING)
-        removeMessageReceiver(Messages::LogStream::messageReceiverName(), m_logStream->identifier());
-#endif
-        m_logStream.reset();
-    }
-
+    stopLogStream();
 #endif
 }
+
+#if ENABLE(LOGD_BLOCKING_IN_WEBCONTENT)
+void WebProcessProxy::stopLogStream()
+{
+    if (!m_logStream.get())
+        return;
+#if !ENABLE(STREAMING_IPC_IN_LOG_FORWARDING)
+    removeMessageReceiver(Messages::LogStream::messageReceiverName(), m_logStream->identifier());
+#endif
+    m_logStream.reset();
+}
+#endif
 
 void WebProcessProxy::platformResumeProcess()
 {

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -771,6 +771,14 @@ void WebProcessProxy::shutDown()
 
     shutDownProcess();
 
+#if ENABLE(LOGD_BLOCKING_IN_WEBCONTENT)
+    // Tear down the log stream as soon as the process shuts down, rather than waiting for this
+    // proxy to be destroyed (which may be delayed, or leak). Otherwise its underlying default-QOS
+    // IPC connection — and the Mach port / kqueue workloop it holds — lingers with a dead peer and
+    // accumulates until the UI process is killed for resource exhaustion. See rdar://182244946.
+    stopLogStream();
+#endif
+
     m_backgroundResponsivenessTimer->invalidate();
     m_audibleMediaActivity = std::nullopt;
     m_mediaStreamingActivity = std::nullopt;

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -783,6 +783,7 @@ private:
 #else
     void createLogStream(LogStreamIdentifier, CompletionHandler<void()>&&);
 #endif
+    void stopLogStream();
 #endif
 
 #if ENABLE(REMOTE_INSPECTOR) && PLATFORM(COCOA)


### PR DESCRIPTION
#### 28f59c40aa4913fbacc1900cb2eb5e0ba55ef7f2
<pre>
LogStream leaks its IPC connection (and Mach port / kqueue workloop) after the WebContent process exits
<a href="https://bugs.webkit.org/show_bug.cgi?id=319952">https://bugs.webkit.org/show_bug.cgi?id=319952</a>

Reviewed by Per Arne Vollan.

When log forwarding is enabled, each WebContent process gets a LogStream in the UI process
(WebProcessProxy::createLogStream), backed by a StreamServerConnection over its own IPC::Connection.

LogStream::stopListeningForIPC() only called StreamServerConnection::stopReceivingMessages(),
which unregisters the message receiver but never invalidates the underlying IPC::Connection. An
open connection keeps itself alive through its Mach-receive dispatch source (which holds a Ref
back to the connection) and holds its Mach port / kqueue workloop until it is explicitly
invalidated. So tearing down the WebProcessProxy released its reference to the LogStream but did
not release the connection: StreamServerConnection::m_receivers and the connection&apos;s own receive
source kept the LogStream / StreamServerConnection / IPC::Connection alive as a self-sustaining
island with a dead peer.

One such connection leaked per WebContent process. Over a long session these accumulate in the UI
process until it is killed for Mach port exhaustion (32768) or kqueue workloop exhaustion (2048),
whichever limit is reached first.

Fix LogStream::stopListeningForIPC() to also invalidate() the connection: stopReceivingMessages()
clears the receiver map (breaking the m_receivers &lt;-&gt; m_connection retain cycle so the objects can
be freed) and invalidate() cancels the receive source and releases the Mach port / kqueue workloop.

Also tear the log stream down from WebProcessProxy::shutDown() (via a new stopLogStream() helper,
shared with platformDestroy()) so the connection is released as soon as the process shuts down,
rather than waiting for the proxy object to be destroyed.

* Source/WebKit/Shared/LogStream.mm:
(WebKit::LogStream::stopListeningForIPC):
* Source/WebKit/UIProcess/Cocoa/WebProcessProxyCocoa.mm:
(WebKit::WebProcessProxy::platformDestroy):
(WebKit::WebProcessProxy::stopLogStream):
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::shutDown):
* Source/WebKit/UIProcess/WebProcessProxy.h:

Canonical link: <a href="https://commits.webkit.org/317709@main">https://commits.webkit.org/317709@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/91f21ba394ab3ca314233072510c0d50517c648b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176016 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49949 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43733 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185610 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/138232 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5543e351-15f8-4434-a2f4-714eb6aad3e4) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51241 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49631 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137074 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/138232 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/796c03ef-6ea3-43ad-a402-b018dd05a12a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178972 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40540 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157844 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117553 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39183 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37560 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149601 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37336 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34079 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41653 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41766 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188032 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49616 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146081 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39315 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50297 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33961 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145918 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40694 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122492 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/116370 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48803 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12317 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48205 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48437 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48262 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->