### PR TITLE
document.write() from an iframe's onload handler causes the frame's load event to refire indefinitely when the written content contains an <audio> element

### DIFF
--- a/LayoutTests/fast/frames/iframe-load-event-fires-once-despite-repeated-document-write-expected.txt
+++ b/LayoutTests/fast/frames/iframe-load-event-fires-once-despite-repeated-document-write-expected.txt
@@ -1,0 +1,6 @@
+Tests that an iframe's "load" event cannot be made to refire by document.write().
+
+
+
+PASS document.write()-ing an <audio> element from an iframe's onload handler must not cause the owner element's load event to refire on its own
+

--- a/LayoutTests/fast/frames/iframe-load-event-fires-once-despite-repeated-document-write.html
+++ b/LayoutTests/fast/frames/iframe-load-event-fires-once-despite-repeated-document-write.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+</head>
+<body>
+<p>Tests that an iframe's "load" event cannot be made to refire by document.write().</p>
+<script>
+let loadCount = 0;
+let generation = 0;
+const MAX_GENERATIONS = 10;
+
+function innerHTML() {
+    return "<!DOCTYPE html><html><body><audio src='../../media/content/silence.mp3'></audio></body></html>";
+}
+
+const iframe = document.createElement("iframe");
+iframe.addEventListener("load", () => {
+    loadCount++;
+    if (generation < MAX_GENERATIONS) {
+        generation++;
+        iframe.contentDocument.open();
+        iframe.contentDocument.write(innerHTML());
+        iframe.contentDocument.close();
+    }
+});
+document.body.appendChild(iframe);
+
+async_test(t => {
+    const STABLE_FRAMES_NEEDED = 60;
+    let lastLoadCount = -1;
+    let stableFrames = 0;
+
+    function checkStable() {
+        if (loadCount === lastLoadCount) {
+            stableFrames++;
+        } else {
+            lastLoadCount = loadCount;
+            stableFrames = 0;
+        }
+
+        if (stableFrames < STABLE_FRAMES_NEEDED) {
+            requestAnimationFrame(checkStable);
+            return;
+        }
+
+        assert_equals(loadCount, 1, "the iframe owner element's \"load\" event should fire exactly once");
+        t.done();
+    }
+
+    requestAnimationFrame(checkStable);
+}, "document.write()-ing an <audio> element from an iframe's onload handler must not cause the owner element's load event to refire on its own");
+</script>
+</body>
+</html>

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -684,9 +684,18 @@ bool FrameLoader::didOpenURL()
 
     m_isComplete = false;
     m_didCallImplicitClose = false;
+    m_didDispatchLoadEventToOwnerElement = false;
 
     started();
 
+    return true;
+}
+
+bool FrameLoader::shouldDispatchLoadEventToOwnerElement()
+{
+    if (m_didDispatchLoadEventToOwnerElement)
+        return false;
+    m_didDispatchLoadEventToOwnerElement = true;
     return true;
 }
 

--- a/Source/WebCore/loader/FrameLoader.h
+++ b/Source/WebCore/loader/FrameLoader.h
@@ -245,6 +245,12 @@ public:
 
     void didExplicitOpen();
 
+    // Returns true the first time it's called since the last real navigation (see didOpenURL()),
+    // and false on every subsequent call. A script calling document.open()/write()/close() from
+    // within the very load handler that's currently firing must not be able to make the owner
+    // element's load event fire again until an actual new navigation happens.
+    bool shouldDispatchLoadEventToOwnerElement();
+
     // Callbacks from DocumentWriter
     void didBeginDocument(bool dispatchWindowObjectAvailable, LocalDOMWindow* previousWindow);
 
@@ -533,6 +539,7 @@ private:
     bool m_isExecutingJavaScriptFormAction { false };
 
     bool m_didCallImplicitClose { true };
+    bool m_didDispatchLoadEventToOwnerElement { false };
     bool m_wasUnloadEventEmitted { false };
 
     PageDismissalType m_pageDismissalEventBeingDispatched { PageDismissalType::None };

--- a/Source/WebCore/page/LocalDOMWindow.cpp
+++ b/Source/WebCore/page/LocalDOMWindow.cpp
@@ -2456,9 +2456,14 @@ void LocalDOMWindow::dispatchLoadEvent()
         WTFEndSignpost(document.get(), NavigationAndPaintTiming);
     }
 
-    // Send a separate load event to the element that owns this frame.
-    if (RefPtr frame = this->frame())
-        frame->dispatchLoadEventToParent();
+    // Send a separate load event to the element that owns this frame. This must only happen once
+    // per navigation: a script can make this window's own load event fire again (e.g. by calling
+    // document.open()/write()/close() from within this very handler), but that must not be able to
+    // make the owner element's load event fire again and again.
+    if (RefPtr frame = this->frame()) {
+        if (frame->loader().shouldDispatchLoadEventToOwnerElement())
+            frame->dispatchLoadEventToParent();
+    }
 
     InspectorInstrumentation::loadEventFired(protect(this->frame()).get());
 }


### PR DESCRIPTION
#### ce4bc22830d004ed9427b458af73263b098cbb23
<pre>
document.write() from an iframe&apos;s onload handler causes the frame&apos;s load event to refire indefinitely when the written content contains an &lt;audio&gt; element
<a href="https://bugs.webkit.org/show_bug.cgi?id=319961">https://bugs.webkit.org/show_bug.cgi?id=319961</a>
<a href="https://rdar.apple.com/182885784">rdar://182885784</a>

Reviewed by NOBODY (OOPS!).

An iframe whose onload handler calls document.open()/write()/close() on
its own contentDocument can end up firing that iframe&apos;s &quot;load&quot; event
forever, without any further script action, if the written content
contains a media element (e.g. &lt;audio&gt;).

A media element&apos;s resource-selection algorithm delays the document&apos;s
LocalFrame::dispatchLoadEventToParent() — with no guard preventing
this from happening more than once per navigation.

document.open() (FrameLoader::didExplicitOpen()) resets
m_didCallImplicitClose so the newly-written document can complete its
own load cycle, which is legitimate. But since nothing distinguished
&quot;a real navigation&quot; from &quot;a script re-opened the current document&quot;,
each onload invocation&apos;s document.write() call re-armed the same
mechanism: a new media element started a fresh delay, the delay
cleared, the owner&apos;s load event fired again, the handler ran again,
and so on, with no bound.

Add FrameLoader::shouldDispatchLoadEventToOwnerElement(), backed by a
new m_didDispatchLoadEventToOwnerElement flag that is only reset by
FrameLoader::didOpenURL() (a real navigation), not by didExplicitOpen()
(a script-initiated document.open()). LocalDOMWindow::dispatchLoadEvent()
now consults it before calling dispatchLoadEventToParent(), so the
owner element&apos;s load event fires at most once per navigation, no
matter how many times the contained document&apos;s own load event
re-fires internally afterwards.

Test: fast/frames/iframe-load-event-fires-once-despite-repeated-document-write.html

* LayoutTests/fast/frames/iframe-load-event-fires-once-despite-repeated-document-write-expected.txt: Added.
* LayoutTests/fast/frames/iframe-load-event-fires-once-despite-repeated-document-write.html: Added.
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::didOpenURL):
(WebCore::FrameLoader::shouldDispatchLoadEventToOwnerElement):
* Source/WebCore/loader/FrameLoader.h:
* Source/WebCore/page/LocalDOMWindow.cpp:
(WebCore::LocalDOMWindow::dispatchLoadEvent):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ce4bc22830d004ed9427b458af73263b098cbb23

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176031 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49964 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43748 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185625 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/138248 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/177894 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51256 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49646 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137115 "Found 157 new test failures: imported/blink/loader/iframe-sync-loads.html imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/javascript-url-security-check-multi-globals.sub.html imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/location_reload_javascript_url.html imported/w3c/web-platform-tests/html/browsers/origin/inheritance/javascript-url.html imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/getter-special-cases/data-to-javascript-no.https.html imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/getter-special-cases/data-to-javascript-yes.https.html imported/w3c/web-platform-tests/html/semantics/embedded-content/the-embed-element/embed-javascript-url.html imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/iframe_navigate_javascript_url.htm imported/w3c/web-platform-tests/html/semantics/embedded-content/the-object-element/object-javascript-url.html imported/w3c/web-platform-tests/html/syntax/parsing/html5lib_adoption01.html?run_type=write ... (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96229 "4 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178987 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40556 "Found 3 new test failures: http/tests/security/frame-loading-via-document-write-async-delegates.html http/tests/security/frame-loading-via-document-write.html imported/blink/loader/iframe-sync-loads.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157860 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117566 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39231 "Found 60 new test failures: imported/w3c/web-platform-tests/dom/events/scrolling/scrollend-event-fired-for-scroll-attr-change.html?include=root-scrollTop-smooth imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/javascript-url-security-check-multi-globals.sub.html imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/location_reload_javascript_url.html imported/w3c/web-platform-tests/html/browsers/origin/inheritance/javascript-url.html imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/getter-special-cases/data-to-javascript-no.https.html imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/getter-special-cases/data-to-javascript-yes.https.html imported/w3c/web-platform-tests/html/semantics/embedded-content/the-embed-element/embed-javascript-url.html imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/iframe_navigate_javascript_url.htm imported/w3c/web-platform-tests/html/semantics/embedded-content/the-object-element/object-javascript-url.html imported/w3c/web-platform-tests/html/syntax/parsing/html5lib_adoption01.html?run_type=write ... (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37575 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149617 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37354 "Found 60 new test failures: fast/shadow-dom/css-scoping-shadow-slot-style.html http/tests/performance/performance-resource-timing-cross-origin-media.html http/tests/security/frame-loading-via-document-write-async-delegates.html http/tests/security/frame-loading-via-document-write.html http/wpt/background-fetch/change-documents-in-progress-event.window.html imported/blink/loader/iframe-sync-loads.html imported/w3c/web-platform-tests/css/css-highlight-api/painting/custom-highlight-dynamic-font-metrics-001.html imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/javascript-url-security-check-multi-globals.sub.html imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/location_reload_javascript_url.html imported/w3c/web-platform-tests/html/browsers/origin/inheritance/javascript-url.html ... (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34094 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41671 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41796 "Found 60 new test failures: fast/parser/entities-in-html.html http/tests/navigation/redirect-to-random-url-versus-memory-cache.html http/tests/security/cookie-module-propagate.html http/tests/security/frame-loading-via-document-write-async-delegates.html http/tests/security/frame-loading-via-document-write.html http/wpt/beacon/cors/crossorigin-arraybufferview-no-preflight.html imported/blink/loader/iframe-sync-loads.html imported/w3c/web-platform-tests/IndexedDB/nested-cloning-large-multiple.any.worker.html imported/w3c/web-platform-tests/css/css-anchor-position/long-anchor-chain-crash.html imported/w3c/web-platform-tests/css/css-shapes/shape-outside/shape-image/shape-image-013.html ... (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188047 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49631 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/157411 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146127 "Found 159 new test failures: http/tests/security/frame-loading-via-document-write-async-delegates.html http/tests/security/frame-loading-via-document-write.html imported/blink/loader/iframe-sync-loads.html imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/javascript-url-security-check-multi-globals.sub.html imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/location_reload_javascript_url.html imported/w3c/web-platform-tests/html/browsers/origin/inheritance/javascript-url.html imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/getter-special-cases/data-to-javascript-no.https.html imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/getter-special-cases/data-to-javascript-yes.https.html imported/w3c/web-platform-tests/html/semantics/embedded-content/the-embed-element/embed-javascript-url.html imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/iframe_navigate_javascript_url.htm ... (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50312 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33981 "Found 60 new test failures: compositing/style-change/perspective-change.html css3/font-feature-settings-calc.html fast/canvas/canvas-draw-large-svg-image.html fast/canvas/webgl/context-attributes-alpha.html fast/canvas/webgl/copy-tex-image-and-sub-image-2d.html fast/canvas/webgl/tex-input-validation.html fast/canvas/webgl/webgl-clear-composited-notshowing.html fast/css/inline-block-line-break.html http/tests/security/contentSecurityPolicy/1.1/scripthash-tests.html http/tests/security/frame-loading-via-document-write-async-delegates.html ... (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145932 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40709 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122507 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/116414 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48818 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12333 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48220 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48452 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48277 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->