### PR TITLE
RenderLayer::paintOutlineForFragments() does unnecessary work when there is no outline to paint

### DIFF
--- a/LayoutTests/fast/layers/layer-with-no-outline-still-paints-descendant-outlines-expected.html
+++ b/LayoutTests/fast/layers/layer-with-no-outline-still-paints-descendant-outlines-expected.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<title>Reference</title>
+<style>
+    body { margin: 0; }
+    div {
+        position: absolute;
+        background: silver;
+    }
+</style>
+<div style="top: 10px; left: 10px; width: 50px; height: 50px; outline: 10px solid blue;"></div>
+<div style="top: 80px; left: 10px; width: 50px; height: 30px; outline: 10px solid green;"></div>

--- a/LayoutTests/fast/layers/layer-with-no-outline-still-paints-descendant-outlines.html
+++ b/LayoutTests/fast/layers/layer-with-no-outline-still-paints-descendant-outlines.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<title>webkit.org/b/319962: skipping RenderLayer::paintOutlineForFragments() when the layer's own renderer has no outline must not affect outlines painted by its positioned (z-order list) children or its in-flow descendants</title>
+<style>
+    body { margin: 0; }
+    .stack {
+        position: relative;
+        width: 150px;
+        height: 200px;
+        padding-top: 80px;
+        background: white;
+    }
+    .positioned-child {
+        position: absolute;
+        top: 10px;
+        left: 10px;
+        width: 50px;
+        height: 50px;
+        background: silver;
+        outline: 10px solid blue;
+    }
+    .inflow-child {
+        margin-left: 10px;
+        width: 50px;
+        height: 30px;
+        background: silver;
+        outline: 10px solid green;
+    }
+</style>
+<div class="stack">
+    <div class="positioned-child"></div>
+    <div class="inflow-child"></div>
+</div>

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -3871,6 +3871,9 @@ void RenderLayer::paintLayerContents(GraphicsContext& context, const LayerPainti
         }
 
         bool shouldPaintOutline = [&]() {
+            if (!renderer().hasOutline())
+                return false;
+
             if (!isSelfPaintingLayer)
                 return false;
 


### PR DESCRIPTION
#### 90680138d80a6baa4a3f69456d3aa5a5b6e98f85
<pre>
RenderLayer::paintOutlineForFragments() does unnecessary work when there is no outline to paint
<a href="https://bugs.webkit.org/show_bug.cgi?id=319962">https://bugs.webkit.org/show_bug.cgi?id=319962</a>
<a href="https://rdar.apple.com/182885984">rdar://182885984</a>

Reviewed by NOBODY (OOPS!).

shouldPaintOutline did not check whether the layer&apos;s renderer actually
has an outline before triggering paintOutlineForFragments(), which
builds a PaintInfo, saves graphics/region context state, and calls
clipToRect() (including the border-radius ancestor-clipping walk) for
every fragment, then dispatches into renderer().paint() only to have
each renderer&apos;s own paintObject() bail out via its existing hasOutline()
check.

Add a hasOutline() check to the front of the shouldPaintOutline lambda
so we skip paintOutlineForFragments() entirely when there&apos;s nothing to
paint.

This early-out does not need to walk this layer&apos;s z-order lists.
shouldPaintOutline only gates paintOutlineForFragments(), which paints
PaintPhase::SelfOutline for this layer&apos;s own renderer() and nothing
else (RenderBlock::paintObject skips paintContents() for SelfOutline,
so there is no descendant recursion). Descendants that don&apos;t have
their own RenderLayer get their outlines painted unconditionally via
the ChildOutlines phase in paintForegroundForFragments(), which this
change does not touch. Descendants that do have their own RenderLayer
are painted through paintList(), which recurses into
paintLayerContents() again for that child layer, independently
re-evaluating shouldPaintOutline against that child&apos;s own renderer().
Added a test covering both cases.

* LayoutTests/fast/layers/layer-with-no-outline-still-paints-descendant-outlines-expected.html: Added.
* LayoutTests/fast/layers/layer-with-no-outline-still-paints-descendant-outlines.html: Added.
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::paintLayerContents):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/90680138d80a6baa4a3f69456d3aa5a5b6e98f85

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176297 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50232 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44022 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185893 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/138544 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9f526121-ab16-4c3f-b319-29be96ff0780) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178160 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51524 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49916 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137314 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96241 "4 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5be59083-e5fe-4c55-b59d-968abdb53dcf) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179253 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40800 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158094 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117789 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fafe0d7a-83c9-4659-a33c-c2511af31d88) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39449 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37810 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149865 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37592 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34362 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41957 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42021 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188317 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49897 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/157639 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146350 "Found 1 new test failure: compositing/color-matching/image-color-matching.html (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50581 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34209 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146168 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40944 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122785 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/116785 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49085 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12565 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48487 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48721 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48546 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->