### PR TITLE
[Custom Highlight] text-underline-offset is mispositioned in vertical writing mode.

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -5691,8 +5691,6 @@ webkit.org/b/217931 imported/w3c/web-platform-tests/html/semantics/scripting-1/t
 webkit.org/b/220325 imported/w3c/web-platform-tests/css/css-highlight-api/highlight-text-cascade.html [ ImageOnlyFailure ]
 
 # Tests need updating relating to Highlight Spec
-imported/w3c/web-platform-tests/css/css-highlight-api/painting/custom-highlight-dynamic-logical-metrics-001.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-highlight-api/painting/custom-highlight-logical-metrics-002.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-highlight-api/painting/custom-highlight-painting-below-selection-transparency.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-highlight-api/painting/custom-highlight-painting-inheritance-001.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-highlight-api/painting/custom-highlight-painting-inheritance-002.html [ ImageOnlyFailure ]

--- a/LayoutTests/fast/repaint/text-decoration-overflow-repaint-expected.txt
+++ b/LayoutTests/fast/repaint/text-decoration-overflow-repaint-expected.txt
@@ -4,7 +4,7 @@ content
 content
 (repaint rects
   (rect 48 46 112 25)
-  (rect 39 82 25 112)
-  (rect 39 214 25 112)
+  (rect 35 82 29 112)
+  (rect 35 214 29 112)
 )
 

--- a/LayoutTests/fast/repaint/vertical-rl-repaint-when-decoration-changes-expected.txt
+++ b/LayoutTests/fast/repaint/vertical-rl-repaint-when-decoration-changes-expected.txt
@@ -2,7 +2,7 @@ XXX
 XXX
 XXX
 (repaint rects
-  (rect 128 8 60 60)
-  (rect -52 8 60 60)
+  (rect 124 8 64 60)
+  (rect -56 8 64 60)
 )
 

--- a/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContentBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContentBuilder.cpp
@@ -1234,7 +1234,8 @@ void InlineDisplayContentBuilder::collectInkOverflowForTextDecorations(std::span
             if (!logicalBottomForTextDecoration)
                 logicalBottomForTextDecoration = logicalBottomForTextDecorationContent(boxes, isHorizontalWritingMode);
             auto textRunLogicalOffsetFromLineBottom = *logicalBottomForTextDecoration - (isHorizontalWritingMode ? displayBox.bottom() : displayBox.right());
-            return inkOverflowForDecorations(parentStyle, { displayBox.height(), textRunLogicalOffsetFromLineBottom });
+            auto textRunLogicalHeight = isHorizontalWritingMode ? displayBox.height() : displayBox.width();
+            return inkOverflowForDecorations(parentStyle, { textRunLogicalHeight, textRunLogicalOffsetFromLineBottom });
         }();
 
         if (!decorationOverflow.isZero()) {

--- a/Source/WebCore/style/InlineTextBoxStyle.cpp
+++ b/Source/WebCore/style/InlineTextBoxStyle.cpp
@@ -255,9 +255,8 @@ bool isAlignedForUnder(const Style::ComputedStyle& decoratingBoxStyle)
         // In vertical typographic modes, the underline is aligned as for under for 'left' and 'right'.
         return true;
     case Style::TextUnderlinePosition::Side::NoPreference:
-        // When left/right support is not enabled.
-        // FIXME: The offset check is mostly about visual overflow, consider splitting out.
-        return underlinePosition.isAuto() && decoratingBoxStyle.textUnderlineOffset().isAuto();
+        // A non-auto text-underline-offset must not disable vertical under-alignment; it is applied within the under branch.
+        return underlinePosition.isAuto();
     }
     RELEASE_ASSERT_NOT_REACHED();
 }


### PR DESCRIPTION
#### 892029d23764c2c8f0cda40bd46c7aa70d8f3c76
<pre>
[Custom Highlight] text-underline-offset is mispositioned in vertical writing mode.
<a href="https://bugs.webkit.org/show_bug.cgi?id=319963">https://bugs.webkit.org/show_bug.cgi?id=319963</a>
<a href="https://rdar.apple.com/182889143">rdar://182889143</a>

Reviewed by Alan Baradlay.

In a vertical writing mode with text-underline-position: auto, the underline should be under-aligned (to the text&apos;s under edge),
with text-underline-offset shifting it from there. isAlignedForUnder() additionally required text-underline-offset to be auto,
so specifying an explicit offset dropped the text out of the under-alignment path into the horizontal ascent + offset computation,
positioning the underline incorrectly. This was exposed by custom highlights: a ::highlight carries its offset as an override on an
originating box whose own offset is auto, so the highlight under-aligned correctly while an equivalently-styled plain element
(with a non-auto offset) did not — the two diverged in vertical-lr. Dropping the offset condition lets any vertical
text-underline-position: auto text under-align, applying the offset within that branch, so highlights and directly-styled elements agree.

Correcting the underline position surfaced a second, pre-existing issue in the ink-overflow (repaint) path:
collectInkOverflowForTextDecorations passed the run&apos;s physical height as the logical run height, which is only correct in horizontal
writing modes. Once the underline under-aligns in vertical text, this over-inflated the computed ink overflow and the tracked repaint
rectangle. It now uses the run&apos;s block-axis extent (physical width in vertical writing modes), matching the paint path, so the repaint
rects stay tight. The two fast/repaint baselines are updated to reflect the corrected underline position.

This addresses only the offset-gated under-alignment and its repaint side-effect; other vertical decoration-positioning issues
(e.g. the non-root path FIXME in TextBoxPainter.cpp, and custom-highlight-painting-vertical-writing-mode-001) are unrelated and remain.

imported/w3c/web-platform-tests/css/css-highlight-api/painting/custom-highlight-logical-metrics-002.html
imported/w3c/web-platform-tests/css/css-highlight-api/painting/custom-highlight-dynamic-logical-metrics-001.html

* LayoutTests/TestExpectations:
* LayoutTests/fast/repaint/text-decoration-overflow-repaint-expected.txt:
* LayoutTests/fast/repaint/vertical-rl-repaint-when-decoration-changes-expected.txt:
* Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContentBuilder.cpp:
(WebCore::Layout::InlineDisplayContentBuilder::collectInkOverflowForTextDecorations):
* Source/WebCore/style/InlineTextBoxStyle.cpp:
(WebCore::isAlignedForUnder):

Canonical link: <a href="https://commits.webkit.org/318107@main">https://commits.webkit.org/318107@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d07fb4c62921574278a71dee5b05d0a552b2236e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177169 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51106 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44901 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186772 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140405 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/85ba2324-e9ac-4ef7-b7fb-77fdc444c522) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179032 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52399 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50960 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138041 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140405 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/08d33456-c022-45c5-a328-9329f9aa76d8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180125 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41552 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158808 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118508 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6a659317-7207-4c20-a51d-0e8e89fec7d8) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40208 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38582 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150618 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38307 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35240 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42887 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/42950 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189198 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50773 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/158347 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147131 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39572 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51456 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34936 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146925 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41658 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123670 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117968 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49961 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13287 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49360 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49597 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49421 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->