### PR TITLE
[JSC][Temporal] japanese calendar can use ISO year, day, month, monthcode

### DIFF
--- a/JSTests/stress/temporal-japanese-calendar-proleptic-gregorian.js
+++ b/JSTests/stress/temporal-japanese-calendar-proleptic-gregorian.js
@@ -1,0 +1,132 @@
+//@ requireOptions("--useTemporal=1")
+
+// The Japanese calendar is Gregorian-based: its year/month/day/monthCode (and
+// daysInMonth/daysInYear/monthsInYear/inLeapYear) are the proleptic-Gregorian
+// (i.e. ISO) values for every year. Only era/eraYear are era-relative.
+//
+// These accessors must NOT route through ICU's Japanese calendar, which uses
+// Julian arithmetic before the 1582 cutover and would give a different month
+// or day for old dates. They route through the proleptic Gregorian calendar,
+// so the values always match the plain ISO date. Only era/eraYear gate on the
+// 1873 (Meiji 6) transition, where Temporal reports "ce"/"bce" for Meiji 1-5.
+
+function shouldBe(actual, expected, msg) {
+    if (actual !== expected)
+        throw new Error(`${msg}: expected ${JSON.stringify(expected)} but got ${JSON.stringify(actual)}`);
+}
+
+function monthCode(month) {
+    return "M" + (month < 10 ? "0" : "") + month;
+}
+
+// Japanese date fields equal the ISO date fields (any year), and era/eraYear match.
+function checkDateFields(isoYear, isoMonth, isoDay, expectedEra, expectedEraYear) {
+    const jp = new Temporal.PlainDate(isoYear, isoMonth, isoDay, "japanese");
+    const iso = new Temporal.PlainDate(isoYear, isoMonth, isoDay); // iso8601
+    const tag = `${isoYear}-${isoMonth}-${isoDay}`;
+
+    // Date fields equal the ISO values.
+    shouldBe(jp.year, isoYear, `${tag} year`);
+    shouldBe(jp.month, isoMonth, `${tag} month`);
+    shouldBe(jp.monthCode, monthCode(isoMonth), `${tag} monthCode`);
+    shouldBe(jp.day, isoDay, `${tag} day`);
+
+    // ... and match the iso8601 date exactly, including the derived quantities.
+    shouldBe(jp.month, iso.month, `${tag} month == iso`);
+    shouldBe(jp.monthCode, iso.monthCode, `${tag} monthCode == iso`);
+    shouldBe(jp.day, iso.day, `${tag} day == iso`);
+    shouldBe(jp.daysInMonth, iso.daysInMonth, `${tag} daysInMonth == iso`);
+    shouldBe(jp.daysInYear, iso.daysInYear, `${tag} daysInYear == iso`);
+    shouldBe(jp.monthsInYear, 12, `${tag} monthsInYear`);
+    shouldBe(jp.inLeapYear, iso.inLeapYear, `${tag} inLeapYear == iso`);
+
+    // Era / eraYear.
+    shouldBe(jp.era, expectedEra, `${tag} era`);
+    shouldBe(jp.eraYear, expectedEraYear, `${tag} eraYear`);
+}
+
+// Pre-1582 Julian territory in ICU: fields must be proleptic Gregorian, not Julian.
+checkDateFields(1000, 6, 15, "ce", 1000);
+checkDateFields(1300, 2, 28, "ce", 1300); // 1300: Julian leap, proleptic-Gregorian common -> Feb has 28 days
+checkDateFields(1500, 2, 28, "ce", 1500); // 1500: same divergence
+checkDateFields(1500, 3, 1, "ce", 1500);
+checkDateFields(1582, 10, 4, "ce", 1582); // day before the historical Julian->Gregorian cutover
+checkDateFields(1582, 10, 15, "ce", 1582); // first historical Gregorian day; nothing special proleptically
+
+// Between the 1582 cutover and Japan's 1873 Gregorian adoption.
+checkDateFields(1700, 2, 28, "ce", 1700); // 1700: not a proleptic-Gregorian leap year
+checkDateFields(1868, 1, 1, "ce", 1868); // Meiji began 1868-10-23, but Meiji 1-5 are reported as CE
+checkDateFields(1868, 11, 1, "ce", 1868); // ICU would call this Meiji 1; Temporal reports CE
+checkDateFields(1872, 12, 31, "ce", 1872); // Meiji 5 -> CE (last day before Gregorian adoption)
+
+// Meiji 6 (1873) onward: real Japanese eras.
+checkDateFields(1873, 1, 1, "meiji", 6); // Gregorian adoption; first day reported as "meiji"
+checkDateFields(1900, 1, 1, "meiji", 33);
+checkDateFields(1920, 1, 1, "taisho", 9);
+checkDateFields(1930, 1, 1, "showa", 5);
+checkDateFields(2000, 2, 29, "heisei", 12); // 2000 is a proleptic-Gregorian leap year
+checkDateFields(2024, 6, 1, "reiwa", 6);
+
+// BCE / year <= 0 (proleptic).
+checkDateFields(0, 1, 1, "bce", 1); // ISO year 0 == 1 BCE
+checkDateFields(-100, 7, 4, "bce", 101);
+
+// Era boundary at 1873-01-01 (Meiji 6) and the modern era transitions.
+// This is the one place the 1873 constant is load-bearing: ICU4C reports "meiji"
+// for 1868-1872, but Temporal treats Meiji 1-5 as CE. The transition endpoints
+// below are fixed by CLDR/ICU era data.
+function checkEra(isoY, isoM, isoD, era, eraYear) {
+    const pd = new Temporal.PlainDate(isoY, isoM, isoD, "japanese");
+    const tag = `${isoY}-${isoM}-${isoD}`;
+    shouldBe(pd.era, era, `${tag} era`);
+    shouldBe(pd.eraYear, eraYear, `${tag} eraYear`);
+    shouldBe(pd.year, isoY, `${tag} year`);
+}
+
+checkEra(1872, 12, 31, "ce", 1872); // last CE day
+checkEra(1873, 1, 1, "meiji", 6); // first meiji day
+checkEra(1912, 7, 29, "meiji", 45); // Meiji ends 1912-07-30
+checkEra(1912, 7, 30, "taisho", 1); // Taisho begins
+checkEra(1926, 12, 24, "taisho", 15); // Taisho ends 1926-12-25
+checkEra(1926, 12, 25, "showa", 1); // Showa begins
+checkEra(1989, 1, 7, "showa", 64); // Showa ends 1989-01-07
+checkEra(1989, 1, 8, "heisei", 1); // Heisei begins
+checkEra(2019, 4, 30, "heisei", 31); // Heisei ends 2019-04-30
+checkEra(2019, 5, 1, "reiwa", 1); // Reiwa begins
+
+// isoToCalendarFields batch path (used by .with / .from and by ZonedDateTime).
+// A pre-cutover date must resolve proleptic-Gregorian month/monthCode/day so that
+// .with() (which reuses the calendar-native fallback fields) lands on the right date.
+{
+    const pd = new Temporal.PlainDate(1500, 3, 10, "japanese");
+    const changed = pd.with({ day: 20 });
+    shouldBe(changed.year, 1500, "PlainDate.with year");
+    shouldBe(changed.month, 3, "PlainDate.with month");
+    shouldBe(changed.monthCode, "M03", "PlainDate.with monthCode");
+    shouldBe(changed.day, 20, "PlainDate.with day");
+    shouldBe(changed.era, "ce", "PlainDate.with era");
+    shouldBe(changed.eraYear, 1500, "PlainDate.with eraYear");
+}
+{
+    // Meiji-5 date: CE era, ISO fields, preserved across .with().
+    const pd = new Temporal.PlainDate(1872, 6, 1, "japanese");
+    shouldBe(pd.era, "ce", "1872 era");
+    shouldBe(pd.eraYear, 1872, "1872 eraYear");
+    const changed = pd.with({ day: 15 });
+    shouldBe(changed.toString(), "1872-06-15[u-ca=japanese]", "1872 with day toString");
+    shouldBe(changed.era, "ce", "1872 with era");
+    shouldBe(changed.eraYear, 1872, "1872 with eraYear");
+}
+{
+    // ZonedDateTime.with uses isoToCalendarFields for its fallback fields.
+    const zdt = Temporal.ZonedDateTime.from("1500-03-10T12:00[UTC][u-ca=japanese]");
+    shouldBe(zdt.era, "ce", "zdt era");
+    shouldBe(zdt.eraYear, 1500, "zdt eraYear");
+    shouldBe(zdt.month, 3, "zdt month");
+    shouldBe(zdt.day, 10, "zdt day");
+    const changed = zdt.with({ day: 20 });
+    shouldBe(changed.month, 3, "zdt with month");
+    shouldBe(changed.day, 20, "zdt with day");
+    shouldBe(changed.era, "ce", "zdt with era");
+    shouldBe(changed.eraYear, 1500, "zdt with eraYear");
+}

--- a/Source/JavaScriptCore/runtime/temporal/core/CalendarICUBridge.cpp
+++ b/Source/JavaScriptCore/runtime/temporal/core/CalendarICUBridge.cpp
@@ -230,6 +230,7 @@ static std::optional<ISO8601::PlainDate> isoDateFromCalendarChecked(UCalendar* c
 
 // Japanese era table — start years are historically fixed calendar facts.
 // icu4x: components/calendar/src/cal/japanese.rs Japanese::eras()
+// https://github.com/tc39/proposal-intl-era-monthcode/issues/86
 static constexpr int32_t japaneseCalendarGregorianTransitionYear = 1873;
 
 struct JapaneseEra {
@@ -526,12 +527,12 @@ TemporalResult<CalendarFields> isoToCalendarFields(CalendarID calendarId, const 
     fields.monthCode = WTF::move(*raw.monthCode);
 
     if (calendarId == japaneseCalendarID()) {
+        // Japanese uses proleptic Gregorian for its date fields, so year/month/day/monthCode are
+        // always the ISO values regardless of era. Only era/eraYear differ.
         fields.year = isoDate.year();
-        if (isoDate.year() < japaneseCalendarGregorianTransitionYear) {
-            fields.month = isoDate.month();
-            fields.day = isoDate.day();
-            fields.monthCode = ISO8601::monthCode(isoDate.month());
-        }
+        fields.month = isoDate.month();
+        fields.day = isoDate.day();
+        fields.monthCode = ISO8601::monthCode(isoDate.month());
     }
 
     // isLeapMonth is re-derived from the month code (avoids needing UCAL_IS_LEAP_MONTH in raw)
@@ -598,9 +599,11 @@ TemporalResult<int32_t> calendarYear(CalendarID calendarId, const ISO8601::Plain
 TemporalResult<uint8_t> calendarMonth(CalendarID calendarId, const ISO8601::PlainDate& isoDate)
 {
     // 1. Return the ordinal month (1-based position in year, counting leap months) of isoDate in calendarId.
-    // NOTE: Japanese pre-1873 "ce"/"bce" eras use ISO month directly to bypass ICU Julian conversion.
-    if (calendarId == japaneseCalendarID() && isoDate.year() < japaneseCalendarGregorianTransitionYear)
+
+    // Japanese uses proleptic Gregorian for its date fields, so the month is always the ISO month.
+    if (calendarId == japaneseCalendarID())
         return isoDate.month();
+
     return withCalendar(gregorianArithmeticCalendarFor(calendarId), [&](UCalendar* cal) -> TemporalResult<uint8_t> {
         if (!cal) [[unlikely]]
             return makeUnexpected(rangeError(icuOpenCalendarFailed));
@@ -622,9 +625,11 @@ TemporalResult<uint8_t> calendarMonth(CalendarID calendarId, const ISO8601::Plai
 TemporalResult<String> calendarMonthCode(CalendarID calendarId, const ISO8601::PlainDate& isoDate)
 {
     // 1. Return the month code string (e.g. "M01", "M05L") of isoDate in calendarId.
-    // NOTE: Japanese pre-1873 "ce"/"bce" eras use ISO month code directly to bypass ICU Julian conversion.
-    if (calendarId == japaneseCalendarID() && isoDate.year() < japaneseCalendarGregorianTransitionYear)
+
+    // Japanese uses proleptic Gregorian for its date fields, so the month code is always the ISO month code.
+    if (calendarId == japaneseCalendarID())
         return ISO8601::monthCode(isoDate.month());
+
     return withCalendar(gregorianArithmeticCalendarFor(calendarId), [&](UCalendar* cal) -> TemporalResult<String> {
         if (!cal) [[unlikely]]
             return makeUnexpected(rangeError(icuOpenCalendarFailed));
@@ -646,9 +651,11 @@ TemporalResult<String> calendarMonthCode(CalendarID calendarId, const ISO8601::P
 TemporalResult<uint8_t> calendarDay(CalendarID calendarId, const ISO8601::PlainDate& isoDate)
 {
     // 1. Return the day-of-month of isoDate in calendarId.
-    // NOTE: Japanese pre-1873 "ce"/"bce" eras return ISO day directly to bypass ICU Julian conversion.
-    if (calendarId == japaneseCalendarID() && isoDate.year() < japaneseCalendarGregorianTransitionYear)
+
+    // Japanese uses proleptic Gregorian for its date fields, so the day is always the ISO day.
+    if (calendarId == japaneseCalendarID())
         return isoDate.day();
+
     return withCalendar(gregorianArithmeticCalendarFor(calendarId), [&](UCalendar* cal) -> TemporalResult<uint8_t> {
         if (!cal) [[unlikely]]
             return makeUnexpected(rangeError(icuOpenCalendarFailed));


### PR DESCRIPTION
#### 57b041070824fe1a7ad9675c08cdb05711eadb00
<pre>
[JSC][Temporal] japanese calendar can use ISO year, day, month, monthcode
<a href="https://bugs.webkit.org/show_bug.cgi?id=319964">https://bugs.webkit.org/show_bug.cgi?id=319964</a>
<a href="https://rdar.apple.com/182889728">rdar://182889728</a>

Reviewed by Yijia Huang.

Since japanese calendar is using proleptic Gregorian calendar, for year,
day, month, monthcode, we do not need to query to the calendar, we can
just use ISO 8601 values. For era related ones need to query to the
actual calendar.

Test: JSTests/stress/temporal-japanese-calendar-proleptic-gregorian.js

* JSTests/stress/temporal-japanese-calendar-proleptic-gregorian.js: Added.
(shouldBe):
(checkDateFields):
(checkEra):
* Source/JavaScriptCore/runtime/temporal/core/CalendarICUBridge.cpp:
(JSC::TemporalCore::isoToCalendarFields):
(JSC::TemporalCore::calendarMonth):
(JSC::TemporalCore::calendarMonthCode):
(JSC::TemporalCore::calendarDay):

Canonical link: <a href="https://commits.webkit.org/317717@main">https://commits.webkit.org/317717@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3d8baa7088556f6450433d1384bc31f693a38394

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176035 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49968 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43752 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185629 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/138254 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/76d85c3a-c70f-4cc3-8e24-3ef0aafe58ae) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51260 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49650 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137090 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/138254 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/078ae460-192f-4fe7-a8ed-b384994ee715) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178991 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40558 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157868 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117569 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c08c1fdf-c90a-40d3-bf36-801af9ea067e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39201 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37579 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/6377 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149648 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37362 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34098 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/37299 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41675 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41799 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188051 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49635 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146101 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50316 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33989 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145936 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26755 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40713 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122511 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/116418 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48822 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12341 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48224 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48456 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48281 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->