### PR TITLE
[WPT import] META: variant= is not expanded into the generated wrapper for .window.js/.worker.js templated tests

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/remote-context-helper-tests/addIframe-urlType.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/remote-context-helper-tests/addIframe-urlType.window-expected.txt
@@ -1,3 +1,0 @@
-
-FAIL RemoteContextWrapper addIframe promise_test: Unhandled rejection with value: object "Error: Unknown urlType: null"
-

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/remote-context-helper-tests/addIframe-urlType.window.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/remote-context-helper-tests/addIframe-urlType.window.html
@@ -1,1 +1,5 @@
 <!-- This file is required for WebKit test infrastructure to run the templated test -->
+<!-- META: variant=?urlType=origin -->
+<!-- META: variant=?urlType=data -->
+<!-- META: variant=?urlType=blob -->
+<!-- META: variant=?urlType=blank -->

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/remote-context-helper-tests/addIframe-urlType.window_urlType=blank-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/remote-context-helper-tests/addIframe-urlType.window_urlType=blank-expected.txt
@@ -1,0 +1,3 @@
+
+PASS RemoteContextWrapper addIframe
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/remote-context-helper-tests/addIframe-urlType.window_urlType=blob-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/remote-context-helper-tests/addIframe-urlType.window_urlType=blob-expected.txt
@@ -1,0 +1,3 @@
+
+PASS RemoteContextWrapper addIframe
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/remote-context-helper-tests/addIframe-urlType.window_urlType=data-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/remote-context-helper-tests/addIframe-urlType.window_urlType=data-expected.txt
@@ -1,0 +1,3 @@
+
+PASS RemoteContextWrapper addIframe
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/remote-context-helper-tests/addIframe-urlType.window_urlType=origin-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/remote-context-helper-tests/addIframe-urlType.window_urlType=origin-expected.txt
@@ -1,0 +1,3 @@
+
+PASS RemoteContextWrapper addIframe
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/remote-context-helper-tests/addWindow-urlType.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/remote-context-helper-tests/addWindow-urlType.window-expected.txt
@@ -1,3 +1,0 @@
-
-FAIL RemoteContextHelper addWindow with urlType promise_test: Unhandled rejection with value: object "Error: Unknown urlType: null"
-

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/remote-context-helper-tests/addWindow-urlType.window.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/remote-context-helper-tests/addWindow-urlType.window.html
@@ -1,1 +1,4 @@
 <!-- This file is required for WebKit test infrastructure to run the templated test -->
+<!-- META: variant=?urlType=origin -->
+<!-- META: variant=?urlType=blob -->
+<!-- META: variant=?urlType=blank -->

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/remote-context-helper-tests/addWindow-urlType.window_urlType=blank-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/remote-context-helper-tests/addWindow-urlType.window_urlType=blank-expected.txt
@@ -1,0 +1,3 @@
+
+PASS RemoteContextHelper addWindow with urlType
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/remote-context-helper-tests/addWindow-urlType.window_urlType=blob-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/remote-context-helper-tests/addWindow-urlType.window_urlType=blob-expected.txt
@@ -1,0 +1,3 @@
+
+PASS RemoteContextHelper addWindow with urlType
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/remote-context-helper-tests/addWindow-urlType.window_urlType=origin-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/remote-context-helper-tests/addWindow-urlType.window_urlType=origin-expected.txt
@@ -1,0 +1,3 @@
+
+PASS RemoteContextHelper addWindow with urlType
+

--- a/Tools/Scripts/webkitpy/w3c/test_importer.py
+++ b/Tools/Scripts/webkitpy/w3c/test_importer.py
@@ -555,10 +555,12 @@ class TestImporter(object):
 
     def write_html_files_for_templated_js_tests(self, orig_filepath, new_filepath):
         if (orig_filepath.endswith('.window.js')):
-            self._write_html_template(new_filepath.replace('.window.js', '.window.html'))
+            _, variants = self._read_environments_and_variants_for_template_test(orig_filepath)
+            self._write_html_template(new_filepath.replace('.window.js', '.window.html'), variants)
             return
         if (orig_filepath.endswith('.worker.js')):
-            self._write_html_template(new_filepath.replace('.worker.js', '.worker.html'))
+            _, variants = self._read_environments_and_variants_for_template_test(orig_filepath)
+            self._write_html_template(new_filepath.replace('.worker.js', '.worker.html'), variants)
             return
         if (orig_filepath.endswith('.any.js')):
             environments, variants = self._read_environments_and_variants_for_template_test(orig_filepath)

--- a/Tools/Scripts/webkitpy/w3c/test_importer_unittest.py
+++ b/Tools/Scripts/webkitpy/w3c/test_importer_unittest.py
@@ -714,6 +714,30 @@ class TestImporterTest(unittest.TestCase):
         self.assertTrue('<!-- META: variant=?1-10 -->' in fs.read_text_file('/mock-checkout/LayoutTests/w3c/web-platform-tests/t/variant.any.html'))
         self.assertTrue('<!-- META: variant=?11-20 -->' in fs.read_text_file('/mock-checkout/LayoutTests/w3c/web-platform-tests/t/variant.any.html'))
 
+    def test_template_test_variant_window(self):
+        FAKE_FILES = {
+            f'{FAKE_WPT_DIR}/t/variant.window.js': '// META: variant=?urlType=origin\n// META: variant=?urlType=blob',
+        }
+        FAKE_FILES.update(FAKE_RESOURCES)
+
+        fs = self.import_downloaded_tests(['--no-fetch', '--import-all', '--no-clean-dest-dir', '-d', 'w3c'], FAKE_FILES)
+
+        self.assertTrue(fs.exists('/mock-checkout/LayoutTests/w3c/web-platform-tests/t/variant.window.html'))
+        self.assertTrue('<!-- META: variant=?urlType=origin -->' in fs.read_text_file('/mock-checkout/LayoutTests/w3c/web-platform-tests/t/variant.window.html'))
+        self.assertTrue('<!-- META: variant=?urlType=blob -->' in fs.read_text_file('/mock-checkout/LayoutTests/w3c/web-platform-tests/t/variant.window.html'))
+
+    def test_template_test_variant_worker(self):
+        FAKE_FILES = {
+            f'{FAKE_WPT_DIR}/t/variant.worker.js': '// META: variant=?1-10\n// META: variant=?11-20',
+        }
+        FAKE_FILES.update(FAKE_RESOURCES)
+
+        fs = self.import_downloaded_tests(['--no-fetch', '--import-all', '--no-clean-dest-dir', '-d', 'w3c'], FAKE_FILES)
+
+        self.assertTrue(fs.exists('/mock-checkout/LayoutTests/w3c/web-platform-tests/t/variant.worker.html'))
+        self.assertTrue('<!-- META: variant=?1-10 -->' in fs.read_text_file('/mock-checkout/LayoutTests/w3c/web-platform-tests/t/variant.worker.html'))
+        self.assertTrue('<!-- META: variant=?11-20 -->' in fs.read_text_file('/mock-checkout/LayoutTests/w3c/web-platform-tests/t/variant.worker.html'))
+
     def test_template_test_variant_dangling(self):
         FAKE_FILES = {
             f'{FAKE_WPT_DIR}/t/variant.any.js': '// META: variant=?1-10\n// META: variant=?11-20',


### PR DESCRIPTION
#### a7db8ec7ef72f912d9caa27928be356bb7b7bf7a
<pre>
[WPT import] META: variant= is not expanded into the generated wrapper for .window.js/.worker.js templated tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=319965">https://bugs.webkit.org/show_bug.cgi?id=319965</a>
<a href="https://rdar.apple.com/182891397">rdar://182891397</a>

Reviewed by Sam Sneddon.

import-w3c-tests only copied META: variant= lines into the generated
HTML wrapper for .any.js tests. For .window.js and .worker.js tests,
write_html_files_for_templated_js_tests() wrote a wrapper with no
variant info at all, so WebKit&apos;s test runner never split the test
into one run per variant. The test instead ran once with an empty
location.search, which addWindow-urlType.window.js and
addIframe-urlType.window.js treat as an unhandled urlType and throw.

Read variants from the .window.js/.worker.js source the same way
.any.js already does, and pass them through to the generated
wrapper&apos;s META: variant= comments so each variant runs and gets its
own expected result.

* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/remote-context-helper-tests/addIframe-urlType.window-expected.txt: Removed.
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/remote-context-helper-tests/addIframe-urlType.window.html:
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/remote-context-helper-tests/addIframe-urlType.window_urlType=blank-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/remote-context-helper-tests/addIframe-urlType.window_urlType=blob-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/remote-context-helper-tests/addIframe-urlType.window_urlType=data-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/remote-context-helper-tests/addIframe-urlType.window_urlType=origin-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/remote-context-helper-tests/addWindow-urlType.window-expected.txt: Removed.
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/remote-context-helper-tests/addWindow-urlType.window.html:
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/remote-context-helper-tests/addWindow-urlType.window_urlType=blank-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/remote-context-helper-tests/addWindow-urlType.window_urlType=blob-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/remote-context-helper-tests/addWindow-urlType.window_urlType=origin-expected.txt: Added.
* Tools/Scripts/webkitpy/w3c/test_importer.py:
(TestImporter.write_html_files_for_templated_js_tests):
* Tools/Scripts/webkitpy/w3c/test_importer_unittest.py:

Canonical link: <a href="https://commits.webkit.org/317729@main">https://commits.webkit.org/317729@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ceaed567f2a712dde5b10d7104f61deef6e631c6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176036 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49969 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43753 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185630 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/138255 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bc4210dc-3926-4577-a676-7a5dec120edf) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/177899 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51261 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49651 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137092 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/138255 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f9017fa0-d899-44bd-be9b-560386ac23e4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178992 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40562 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157864 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117571 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8970c32a-19e6-42d6-b665-871cb4ff3364) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/175359 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39205 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37580 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149623 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37358 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34099 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41800 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188052 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49636 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/157415 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146102 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39332 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50317 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33985 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145937 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40714 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/116420 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48823 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12337 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48225 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48457 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48282 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->