### PR TITLE
Add PixelFormat to ShareableBitmapConfiguration

### DIFF
--- a/LayoutTests/fast/canvas/hdr/float16-canvas-imagedata-large-unaccelerated-expected.txt
+++ b/LayoutTests/fast/canvas/hdr/float16-canvas-imagedata-large-unaccelerated-expected.txt
@@ -3,6 +3,10 @@ Tests that put/getImageData work with float16 canvas.
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
+canvas.width: 32768
+canvas.height: 32
+PASS context.getContextAttributes().colorType is "float16"
+Effective renderingMode: Unaccelerated
 PASS created_imageData_float16.width is 1
 PASS created_imageData_float16.height is 1
 PASS created_imageData_float16.data.constructor is Float16Array
@@ -23,6 +27,16 @@ PASS gotten_imageData_float16.data.at(0) is within 0.001953125 of 0
 PASS gotten_imageData_float16.data.at(1) is within 0.001953125 of 0.5019607843137255
 PASS gotten_imageData_float16.data.at(2) is within 0.001953125 of 1
 PASS gotten_imageData_float16.data.at(3) is within 0.001953125 of 1
+PASS gotten_imageData_float16_last.width is 1
+PASS gotten_imageData_float16_last.height is 1
+PASS gotten_imageData_float16_last.data.constructor is Float16Array
+PASS gotten_imageData_float16_last.data.BYTES_PER_ELEMENT is 2
+PASS gotten_imageData_float16_last.data.length is 4
+PASS gotten_imageData_float16_last.data.byteLength is 8
+PASS gotten_imageData_float16_last.data.at(0) is within 0.001953125 of 0
+PASS gotten_imageData_float16_last.data.at(1) is within 0.001953125 of 0.5019607843137255
+PASS gotten_imageData_float16_last.data.at(2) is within 0.001953125 of 1
+PASS gotten_imageData_float16_last.data.at(3) is within 0.001953125 of 1
 PASS created_imageData_uint8.width is 1
 PASS created_imageData_uint8.height is 1
 PASS created_imageData_uint8.data.constructor is Uint8ClampedArray
@@ -43,6 +57,16 @@ PASS gotten_imageData_uint8.data.at(0) is 0
 PASS gotten_imageData_uint8.data.at(1) is 128
 PASS gotten_imageData_uint8.data.at(2) is 255
 PASS gotten_imageData_uint8.data.at(3) is 255
+PASS gotten_imageData_uint8_last.width is 1
+PASS gotten_imageData_uint8_last.height is 1
+PASS gotten_imageData_uint8_last.data.constructor is Uint8ClampedArray
+PASS gotten_imageData_uint8_last.data.BYTES_PER_ELEMENT is 1
+PASS gotten_imageData_uint8_last.data.length is 4
+PASS gotten_imageData_uint8_last.data.byteLength is 4
+PASS gotten_imageData_uint8_last.data.at(0) is 0
+PASS gotten_imageData_uint8_last.data.at(1) is 128
+PASS gotten_imageData_uint8_last.data.at(2) is 255
+PASS gotten_imageData_uint8_last.data.at(3) is 255
 PASS gotten_imageData_uint8_from_float16.width is 1
 PASS gotten_imageData_uint8_from_float16.height is 1
 PASS gotten_imageData_uint8_from_float16.data.constructor is Uint8ClampedArray

--- a/LayoutTests/fast/canvas/hdr/float16-canvas-imagedata-large-unaccelerated.html
+++ b/LayoutTests/fast/canvas/hdr/float16-canvas-imagedata-large-unaccelerated.html
@@ -1,0 +1,11 @@
+<!-- webkit-test-runner [ CanvasColorTypeEnabled=true ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../resources/js-test.js"></script>
+</head>
+<body>
+    <canvas id="canvas" width="32768" height="32"></canvas>
+<script src="float16-canvas-imagedata.js"></script>
+</body>
+</html>

--- a/LayoutTests/fast/canvas/hdr/float16-canvas-imagedata-small-accelerated-expected.txt
+++ b/LayoutTests/fast/canvas/hdr/float16-canvas-imagedata-small-accelerated-expected.txt
@@ -1,0 +1,131 @@
+Tests that put/getImageData work with float16 canvas.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+canvas.width: 100
+canvas.height: 32
+PASS context.getContextAttributes().colorType is "float16"
+Effective renderingMode: Accelerated
+PASS created_imageData_float16.width is 1
+PASS created_imageData_float16.height is 1
+PASS created_imageData_float16.data.constructor is Float16Array
+PASS created_imageData_float16.data.BYTES_PER_ELEMENT is 2
+PASS created_imageData_float16.data.length is 4
+PASS created_imageData_float16.data.byteLength is 8
+PASS created_imageData_float16.data.at(0) is 0
+PASS created_imageData_float16.data.at(1) is 0
+PASS created_imageData_float16.data.at(2) is 0
+PASS created_imageData_float16.data.at(3) is 0
+PASS gotten_imageData_float16.width is 1
+PASS gotten_imageData_float16.height is 1
+PASS gotten_imageData_float16.data.constructor is Float16Array
+PASS gotten_imageData_float16.data.BYTES_PER_ELEMENT is 2
+PASS gotten_imageData_float16.data.length is 4
+PASS gotten_imageData_float16.data.byteLength is 8
+PASS gotten_imageData_float16.data.at(0) is within 0.001953125 of 0
+PASS gotten_imageData_float16.data.at(1) is within 0.001953125 of 0.5019607843137255
+PASS gotten_imageData_float16.data.at(2) is within 0.001953125 of 1
+PASS gotten_imageData_float16.data.at(3) is within 0.001953125 of 1
+PASS gotten_imageData_float16_last.width is 1
+PASS gotten_imageData_float16_last.height is 1
+PASS gotten_imageData_float16_last.data.constructor is Float16Array
+PASS gotten_imageData_float16_last.data.BYTES_PER_ELEMENT is 2
+PASS gotten_imageData_float16_last.data.length is 4
+PASS gotten_imageData_float16_last.data.byteLength is 8
+PASS gotten_imageData_float16_last.data.at(0) is within 0.001953125 of 0
+PASS gotten_imageData_float16_last.data.at(1) is within 0.001953125 of 0.5019607843137255
+PASS gotten_imageData_float16_last.data.at(2) is within 0.001953125 of 1
+PASS gotten_imageData_float16_last.data.at(3) is within 0.001953125 of 1
+PASS created_imageData_uint8.width is 1
+PASS created_imageData_uint8.height is 1
+PASS created_imageData_uint8.data.constructor is Uint8ClampedArray
+PASS created_imageData_uint8.data.BYTES_PER_ELEMENT is 1
+PASS created_imageData_uint8.data.length is 4
+PASS created_imageData_uint8.data.byteLength is 4
+PASS created_imageData_uint8.data.at(0) is 0
+PASS created_imageData_uint8.data.at(1) is 0
+PASS created_imageData_uint8.data.at(2) is 0
+PASS created_imageData_uint8.data.at(3) is 0
+PASS gotten_imageData_uint8.width is 1
+PASS gotten_imageData_uint8.height is 1
+PASS gotten_imageData_uint8.data.constructor is Uint8ClampedArray
+PASS gotten_imageData_uint8.data.BYTES_PER_ELEMENT is 1
+PASS gotten_imageData_uint8.data.length is 4
+PASS gotten_imageData_uint8.data.byteLength is 4
+PASS gotten_imageData_uint8.data.at(0) is 0
+PASS gotten_imageData_uint8.data.at(1) is 128
+PASS gotten_imageData_uint8.data.at(2) is 255
+PASS gotten_imageData_uint8.data.at(3) is 255
+PASS gotten_imageData_uint8_last.width is 1
+PASS gotten_imageData_uint8_last.height is 1
+PASS gotten_imageData_uint8_last.data.constructor is Uint8ClampedArray
+PASS gotten_imageData_uint8_last.data.BYTES_PER_ELEMENT is 1
+PASS gotten_imageData_uint8_last.data.length is 4
+PASS gotten_imageData_uint8_last.data.byteLength is 4
+PASS gotten_imageData_uint8_last.data.at(0) is 0
+PASS gotten_imageData_uint8_last.data.at(1) is 128
+PASS gotten_imageData_uint8_last.data.at(2) is 255
+PASS gotten_imageData_uint8_last.data.at(3) is 255
+PASS gotten_imageData_uint8_from_float16.width is 1
+PASS gotten_imageData_uint8_from_float16.height is 1
+PASS gotten_imageData_uint8_from_float16.data.constructor is Uint8ClampedArray
+PASS gotten_imageData_uint8_from_float16.data.BYTES_PER_ELEMENT is 1
+PASS gotten_imageData_uint8_from_float16.data.length is 4
+PASS gotten_imageData_uint8_from_float16.data.byteLength is 4
+PASS gotten_imageData_uint8_from_float16.data.at(0) is 0
+PASS gotten_imageData_uint8_from_float16.data.at(1) is 128
+PASS gotten_imageData_uint8_from_float16.data.at(2) is 255
+PASS gotten_imageData_uint8_from_float16.data.at(3) is 255
+PASS canvas.width * canvas.height >= 256 * componentsToTest is true
+PASS pixelOffset is 256 * componentsToTest
+PASS gotten_imageData_uint8.width is expected_imageData_uint8.width
+PASS gotten_imageData_uint8.height is expected_imageData_uint8.height
+PASS gotten_imageData_uint8.data.constructor is expected_imageData_uint8.data.constructor
+PASS gotten_imageData_uint8.data.BYTES_PER_ELEMENT is expected_imageData_uint8.data.BYTES_PER_ELEMENT
+PASS gotten_imageData_uint8.data.length is expected_imageData_uint8.data.length
+PASS gotten_imageData_uint8.data.byteLength is expected_imageData_uint8.data.byteLength
+PASS gotten_imageData_float16.width is expected_imageData_float16.width
+PASS gotten_imageData_float16.height is expected_imageData_float16.height
+PASS gotten_imageData_float16.data.constructor is expected_imageData_float16.data.constructor
+PASS gotten_imageData_float16.data.BYTES_PER_ELEMENT is expected_imageData_float16.data.BYTES_PER_ELEMENT
+PASS gotten_imageData_float16.data.length is expected_imageData_float16.data.length
+PASS gotten_imageData_float16.data.byteLength is expected_imageData_float16.data.byteLength
+PASS gotten_imageData_float16.width is expected_imageData_float16.width
+PASS gotten_imageData_float16.height is expected_imageData_float16.height
+PASS gotten_imageData_float16.data.constructor is expected_imageData_float16.data.constructor
+PASS gotten_imageData_float16.data.BYTES_PER_ELEMENT is expected_imageData_float16.data.BYTES_PER_ELEMENT
+PASS gotten_imageData_float16.data.length is expected_imageData_float16.data.length
+PASS gotten_imageData_float16.data.byteLength is expected_imageData_float16.data.byteLength
+PASS gotten_imageData_uint8.width is expected_imageData_uint8.width
+PASS gotten_imageData_uint8.height is expected_imageData_uint8.height
+PASS gotten_imageData_uint8.data.constructor is expected_imageData_uint8.data.constructor
+PASS gotten_imageData_uint8.data.BYTES_PER_ELEMENT is expected_imageData_uint8.data.BYTES_PER_ELEMENT
+PASS gotten_imageData_uint8.data.length is expected_imageData_uint8.data.length
+PASS gotten_imageData_uint8.data.byteLength is expected_imageData_uint8.data.byteLength
+PASS canvas.width * canvas.height >= (extraValues.length + divisions) * componentsToTest is true
+PASS pixelOffset is (extraValues.length + divisions) * componentsToTest
+PASS gotten_imageData_uint8.width is expected_imageData_uint8.width
+PASS gotten_imageData_uint8.height is expected_imageData_uint8.height
+PASS gotten_imageData_uint8.data.constructor is expected_imageData_uint8.data.constructor
+PASS gotten_imageData_uint8.data.BYTES_PER_ELEMENT is expected_imageData_uint8.data.BYTES_PER_ELEMENT
+PASS gotten_imageData_uint8.data.length is expected_imageData_uint8.data.length
+PASS gotten_imageData_uint8.data.byteLength is expected_imageData_uint8.data.byteLength
+PASS gotten_imageData_uint8_from_float16.width is expected_imageData_uint8.width
+PASS gotten_imageData_uint8_from_float16.height is expected_imageData_uint8.height
+PASS gotten_imageData_uint8_from_float16.data.constructor is expected_imageData_uint8.data.constructor
+PASS gotten_imageData_uint8_from_float16.data.BYTES_PER_ELEMENT is expected_imageData_uint8.data.BYTES_PER_ELEMENT
+PASS gotten_imageData_uint8_from_float16.data.length is expected_imageData_uint8.data.length
+PASS gotten_imageData_uint8_from_float16.data.byteLength is expected_imageData_uint8.data.byteLength
+PASS gotten_imageData_float16.width is expected_imageData_float16.width
+PASS gotten_imageData_float16.height is expected_imageData_float16.height
+PASS gotten_imageData_float16.data.constructor is expected_imageData_float16.data.constructor
+PASS gotten_imageData_float16.data.BYTES_PER_ELEMENT is expected_imageData_float16.data.BYTES_PER_ELEMENT
+PASS gotten_imageData_float16.data.length is expected_imageData_float16.data.length
+PASS gotten_imageData_float16.data.byteLength is expected_imageData_float16.data.byteLength
+PASS context.createImageData(1, 1, { pixelFormat: "foo" }) threw exception TypeError: Type error.
+PASS context.getImageData(0, 0, 1, 1, { pixelFormat: "foo" }) threw exception TypeError: Type error.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/canvas/hdr/float16-canvas-imagedata-small-accelerated.html
+++ b/LayoutTests/fast/canvas/hdr/float16-canvas-imagedata-small-accelerated.html
@@ -1,0 +1,11 @@
+<!-- webkit-test-runner [ CanvasColorTypeEnabled=true ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../resources/js-test.js"></script>
+</head>
+<body>
+    <canvas id="canvas" width="100" height="32"></canvas>
+<script src="float16-canvas-imagedata.js"></script>
+</body>
+</html>

--- a/LayoutTests/fast/canvas/hdr/float16-canvas-imagedata.js
+++ b/LayoutTests/fast/canvas/hdr/float16-canvas-imagedata.js
@@ -1,24 +1,22 @@
-<!-- webkit-test-runner [ CanvasColorTypeEnabled=true ] -->
-<!DOCTYPE html>
-<html>
-<head>
-<script src="../../../resources/js-test-pre.js"></script>
-</head>
-<body>
-<script>
 description("Tests that put/getImageData work with float16 canvas.");
 
-var canvas = document.createElement("canvas");
-canvas.width = 10;
-canvas.height = 10;
+debug(`canvas.width: ${canvas.width}`)
+debug(`canvas.height: ${canvas.height}`)
+
 var context = canvas.getContext("2d", { colorType: "float16" });
+shouldBe('context.getContextAttributes().colorType', '"float16"');
+
+if (typeof context.getEffectiveRenderingModeForTesting !== "undefined") {
+    debug(`Effective renderingMode: ${context.getEffectiveRenderingModeForTesting()}`);
+}
+
 var r = 0;
 var g = 128;
 var b = 255;
 var a = 255;
 // FIXME: Fill still only works in SRGB/uint8, adapt when extended/float16 support is available.
 context.fillStyle = `rgb(${r} ${g} ${b})`;
-context.fillRect(0, 0, 1, 1);
+context.fillRect(0, 0, canvas.width, canvas.height);
 
 const componentsPerPixel = 4;
 
@@ -71,12 +69,18 @@ verifyImageData('created_imageData_float16', 'Float16Array', float16_bytes_per_e
 var gotten_imageData_float16 = context.getImageData(0, 0, 1, 1, { pixelFormat: "rgba-float16" });
 verifyImageData('gotten_imageData_float16', 'Float16Array', float16_bytes_per_element, r / 255, g / 255, b / 255, a / 255, float16_nonzero_tolerance);
 
+var gotten_imageData_float16_last = context.getImageData(canvas.width - 1, canvas.height - 2, 1, 1, { pixelFormat: "rgba-float16" });
+verifyImageData('gotten_imageData_float16_last', 'Float16Array', float16_bytes_per_element, r / 255, g / 255, b / 255, a / 255, float16_nonzero_tolerance);
+
 var created_imageData_uint8 = context.createImageData(1, 1, { pixelFormat: "rgba-unorm8" });
 verifyImageData('created_imageData_uint8', 'Uint8ClampedArray', uint8_bytes_per_element, 0, 0, 0, 0);
 
 // This verifies the basic float16->uint8 conversion:
 var gotten_imageData_uint8 = context.getImageData(0, 0, 1, 1, { pixelFormat: "rgba-unorm8" });
 verifyImageData('gotten_imageData_uint8', 'Uint8ClampedArray', uint8_bytes_per_element, r, g, b, a);
+
+var gotten_imageData_uint8_last = context.getImageData(canvas.width - 1, canvas.height - 2, 1, 1, { pixelFormat: "rgba-unorm8" });
+verifyImageData('gotten_imageData_uint8_last', 'Uint8ClampedArray', uint8_bytes_per_element, r, g, b, a);
 
 // Put the float16 ImageData back into the (uint8-backed) canvas, and get a default (uint8) ImageData.
 // This verifies the basic uint8->float16 conversion.
@@ -86,8 +90,6 @@ var gotten_imageData_uint8_from_float16 = context.getImageData(0, 0, 1, 1);
 verifyImageData('gotten_imageData_uint8_from_float16', 'Uint8ClampedArray', uint8_bytes_per_element, r, g, b, a);
 
 // Exhaustive uint8->float16->uint8 round-trip test for all possible individual SRGB/uint8 component values. Only log errors.
-canvas.width = 64;
-canvas.height = 16;
 var componentsToTest = componentsPerPixel;
 shouldBeTrue('canvas.width * canvas.height >= 256 * componentsToTest');
 
@@ -140,8 +142,6 @@ gotten_imageData_uint8 = context.getImageData(0, 0, canvas.width, canvas.height,
 areEqualImageData('gotten_imageData_uint8', 'expected_imageData_uint8', 0);
 
 // Deeper float16->(same)float16->uint8->(nearby)float16 round-trip test for many possible individual component values. Only log errors.
-canvas.width = 100;
-canvas.height = 32;
 const divisions = 1024;
 componentsToTest = 3;
 const maxValue = 2;
@@ -208,7 +208,3 @@ areEqualImageData('gotten_imageData_float16', 'expected_imageData_float16', floa
 
 shouldThrowErrorName(`context.createImageData(1, 1, { pixelFormat: "foo" })`, "TypeError")
 shouldThrowErrorName(`context.getImageData(0, 0, 1, 1, { pixelFormat: "foo" })`, "TypeError")
-</script>
-<script src="../../../resources/js-test-post.js"></script>
-</body>
-</html>

--- a/Source/WebCore/platform/graphics/ImageBufferBackend.cpp
+++ b/Source/WebCore/platform/graphics/ImageBufferBackend.cpp
@@ -44,7 +44,7 @@ IntSize ImageBufferBackend::calculateSafeBackendSize(const Parameters& parameter
     if (backendSize.isEmpty())
         return backendSize;
 
-    auto bytesPerRow = 4 * CheckedUint32(backendSize.width());
+    auto bytesPerRow = PixelBuffer::bytesPerPixel(parameters.bufferFormat.pixelFormat) * CheckedUint32(backendSize.width());
     if (bytesPerRow.hasOverflowed())
         return { };
 

--- a/Source/WebCore/platform/graphics/ShareableBitmap.cpp
+++ b/Source/WebCore/platform/graphics/ShareableBitmap.cpp
@@ -36,26 +36,31 @@ namespace WebCore {
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER_AND_EXPORT(ShareableBitmap, WTF_INTERNAL);
 DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(ShareableBitmap);
 
-ShareableBitmapConfiguration::ShareableBitmapConfiguration(const IntSize& size, std::optional<DestinationColorSpace> colorSpace, Headroom baseImageHeadroom, bool isOpaque)
+ShareableBitmapConfiguration::ShareableBitmapConfiguration(const IntSize& size, const DestinationColorSpace& colorSpace, std::optional<PixelFormat> pixelFormat, Headroom baseImageHeadroom, bool isOpaque)
     : m_size(size)
     , m_colorSpace(validateColorSpace(colorSpace))
+#if ENABLE(PIXEL_FORMAT_RGBA16F)
+    , m_pixelFormat(pixelFormat ? *pixelFormat : (m_colorSpace.usesExtendedRange() ? PixelFormat::RGBA16F : PixelFormat::RGBA8))
+#else
+    , m_pixelFormat(pixelFormat ? *pixelFormat : PixelFormat::RGBA8)
+#endif
     , m_baseImageHeadroom(baseImageHeadroom)
     , m_isOpaque(isOpaque)
-    , m_bitsPerComponent(calculateBitsPerComponent(this->colorSpace()))
-    , m_bytesPerPixel(calculateBytesPerPixel(this->colorSpace()))
-    , m_bytesPerRow(calculateBytesPerRow(size, this->colorSpace()))
+    , m_bitsPerComponent(calculateBitsPerComponent(m_pixelFormat, m_colorSpace))
+    , m_bytesPerPixel(calculateBytesPerPixel(m_pixelFormat, m_colorSpace))
+    , m_bytesPerRow(calculateBytesPerRow(size, m_pixelFormat, m_colorSpace))
 #if USE(CG)
-    , m_bitmapInfo(calculateBitmapInfo(this->colorSpace(), isOpaque))
+    , m_bitmapInfo(calculateBitmapInfo(m_pixelFormat, isOpaque))
 #endif
 #if USE(SKIA)
-    , m_imageInfo(SkImageInfo::MakeN32Premul(size.width(), size.height(), this->colorSpace().platformColorSpace()))
+    , m_imageInfo(SkImageInfo::MakeN32Premul(size.width(), size.height(), m_colorSpace.platformColorSpace()))
 #endif
 {
     ASSERT(!m_size.isEmpty());
     ASSERT(m_baseImageHeadroom >= Headroom::None);
 }
 
-ShareableBitmapConfiguration::ShareableBitmapConfiguration(const IntSize& size, std::optional<DestinationColorSpace> colorSpace, Headroom baseImageHeadroom, bool isOpaque, unsigned bitsPerComponent, unsigned bytesPerPixel, unsigned bytesPerRow
+ShareableBitmapConfiguration::ShareableBitmapConfiguration(const IntSize& size, const DestinationColorSpace& colorSpace, PixelFormat pixelFormat, Headroom baseImageHeadroom, bool isOpaque, unsigned bitsPerComponent, unsigned bytesPerPixel, unsigned bytesPerRow
 #if USE(CG)
     , CGBitmapInfo bitmapInfo
     , std::optional<ShareableGainMap>&& shareableGainMap
@@ -63,6 +68,7 @@ ShareableBitmapConfiguration::ShareableBitmapConfiguration(const IntSize& size, 
 )
     : m_size(size)
     , m_colorSpace(colorSpace)
+    , m_pixelFormat(pixelFormat)
     , m_baseImageHeadroom(baseImageHeadroom)
     , m_isOpaque(isOpaque)
     , m_bitsPerComponent(bitsPerComponent)
@@ -73,7 +79,7 @@ ShareableBitmapConfiguration::ShareableBitmapConfiguration(const IntSize& size, 
     , m_shareableGainMap(WTF::move(shareableGainMap))
 #endif
 #if USE(SKIA)
-    , m_imageInfo(SkImageInfo::MakeN32Premul(size.width(), size.height(), this->colorSpace().platformColorSpace()))
+    , m_imageInfo(SkImageInfo::MakeN32Premul(size.width(), size.height(), m_colorSpace.platformColorSpace()))
 #endif
 {
     // This constructor is called when decoding ShareableBitmapConfiguration. So this constructor
@@ -81,9 +87,9 @@ ShareableBitmapConfiguration::ShareableBitmapConfiguration(const IntSize& size, 
     ASSERT(m_baseImageHeadroom >= Headroom::None);
 }
 
-CheckedUint32 ShareableBitmapConfiguration::calculateSizeInBytes(const IntSize& size, const DestinationColorSpace& colorSpace)
+CheckedUint32 ShareableBitmapConfiguration::calculateSizeInBytes(const IntSize& size, PixelFormat pixelFormat, const DestinationColorSpace& colorSpace)
 {
-    return calculateBytesPerRow(size, colorSpace) * size.height();
+    return calculateBytesPerRow(size, pixelFormat, colorSpace) * size.height();
 }
 
 RefPtr<ShareableBitmap> ShareableBitmap::create(const ShareableBitmapConfiguration& configuration)

--- a/Source/WebCore/platform/graphics/ShareableBitmap.h
+++ b/Source/WebCore/platform/graphics/ShareableBitmap.h
@@ -29,6 +29,7 @@
 #include <WebCore/DestinationColorSpace.h>
 #include <WebCore/ImageTypes.h>
 #include <WebCore/IntRect.h>
+#include <WebCore/PixelFormat.h>
 #include <WebCore/PlatformImage.h>
 #include <WebCore/SharedMemory.h>
 #include <wtf/ArgumentCoder.h>
@@ -54,6 +55,7 @@ class GraphicsContext;
 class Image;
 class NativeImage;
 
+inline constexpr auto unspecifiedPixelFormat = std::optional<PixelFormat> { };
 inline constexpr auto defaultCopyOnWrite = SharedMemory::CopyOnWrite::No;
 
 class ShareableBitmapConfiguration {
@@ -62,13 +64,7 @@ public:
     explicit ShareableBitmapConfiguration(const ShareableBitmapConfiguration&) = default;
     ShareableBitmapConfiguration(ShareableBitmapConfiguration&&) = default;
 
-    WEBCORE_EXPORT ShareableBitmapConfiguration(const IntSize&, std::optional<DestinationColorSpace> = std::nullopt, Headroom = Headroom::None, bool isOpaque = false);
-    WEBCORE_EXPORT ShareableBitmapConfiguration(const IntSize&, std::optional<DestinationColorSpace>, Headroom, bool isOpaque, unsigned bitsPerComponent, unsigned bytesPerPixel, unsigned bytesPerRow
-#if USE(CG)
-        , CGBitmapInfo
-        , std::optional<ShareableGainMap>&&
-#endif
-    );
+    WEBCORE_EXPORT ShareableBitmapConfiguration(const IntSize&, const DestinationColorSpace& = DestinationColorSpace::SRGB(), std::optional<PixelFormat> = unspecifiedPixelFormat, Headroom = Headroom::None, bool isOpaque = false);
 #if USE(CG)
     ShareableBitmapConfiguration(const NativeImage&);
 #endif
@@ -76,8 +72,9 @@ public:
     ShareableBitmapConfiguration& operator=(ShareableBitmapConfiguration&&) = default;
 
     IntSize size() const { return m_size; }
-    const DestinationColorSpace& colorSpace() const { return m_colorSpace ? *m_colorSpace : DestinationColorSpace::SRGB(); }
+    const DestinationColorSpace& colorSpace() const { return m_colorSpace; }
     PlatformColorSpaceValue platformColorSpace() const { return colorSpace().platformColorSpace(); }
+    PixelFormat pixelFormat() const { return m_pixelFormat; }
     Headroom baseImageHeadroom() const { return m_baseImageHeadroom; }
     bool isOpaque() const { return m_isOpaque; }
 
@@ -94,21 +91,28 @@ public:
 
     CheckedUint32 sizeInBytes() const { return m_bytesPerRow * m_size.height(); }
 
-    WEBCORE_EXPORT static CheckedUint32 calculateBytesPerRow(const IntSize&, const DestinationColorSpace&);
-    WEBCORE_EXPORT static CheckedUint32 calculateSizeInBytes(const IntSize&, const DestinationColorSpace&);
+    WEBCORE_EXPORT static CheckedUint32 calculateBytesPerRow(const IntSize&, PixelFormat, const DestinationColorSpace&);
+    WEBCORE_EXPORT static CheckedUint32 calculateSizeInBytes(const IntSize&, PixelFormat, const DestinationColorSpace&);
 
 private:
     friend struct IPC::ArgumentCoder<ShareableBitmapConfiguration>;
-
-    static std::optional<DestinationColorSpace> validateColorSpace(std::optional<DestinationColorSpace>);
-    static CheckedUint32 calculateBitsPerComponent(const DestinationColorSpace&);
-    static CheckedUint32 calculateBytesPerPixel(const DestinationColorSpace&);
+    WEBCORE_EXPORT ShareableBitmapConfiguration(const IntSize&, const DestinationColorSpace&, PixelFormat, Headroom, bool isOpaque, unsigned bitsPerComponent, unsigned bytesPerPixel, unsigned bytesPerRow
 #if USE(CG)
-    static CGBitmapInfo calculateBitmapInfo(const DestinationColorSpace&, bool isOpaque);
+        , CGBitmapInfo
+        , std::optional<ShareableGainMap>&&
+#endif
+    );
+
+    static DestinationColorSpace validateColorSpace(const DestinationColorSpace&);
+    static CheckedUint32 calculateBitsPerComponent(PixelFormat, const DestinationColorSpace&);
+    static CheckedUint32 calculateBytesPerPixel(PixelFormat, const DestinationColorSpace&);
+#if USE(CG)
+    static CGBitmapInfo calculateBitmapInfo(PixelFormat, bool isOpaque);
 #endif
 
     IntSize m_size;
-    std::optional<DestinationColorSpace> m_colorSpace;
+    DestinationColorSpace m_colorSpace { DestinationColorSpace::SRGB() };
+    PixelFormat m_pixelFormat { PixelFormat::RGBA8 };
     Headroom m_baseImageHeadroom { Headroom::None };
     bool m_isOpaque { false };
 
@@ -185,7 +189,8 @@ public:
     WEBCORE_EXPORT std::span<uint8_t> NODELETE mutableSpan() LIFETIME_BOUND;
     size_t bytesPerRow() const { return m_configuration.bytesPerRow(); }
     size_t sizeInBytes() const { return m_configuration.sizeInBytes(); }
-    const DestinationColorSpace& colorSpace() const { return  m_configuration.colorSpace(); }
+    const DestinationColorSpace& colorSpace() const { return m_configuration.colorSpace(); }
+    PixelFormat pixelFormat() const { return m_configuration.pixelFormat(); }
 
     // Create a graphics context that can be used to paint into the backing store.
     WEBCORE_EXPORT std::unique_ptr<GraphicsContext> createGraphicsContext();

--- a/Source/WebCore/platform/graphics/cairo/ShareableBitmapCairo.cpp
+++ b/Source/WebCore/platform/graphics/cairo/ShareableBitmapCairo.cpp
@@ -38,23 +38,33 @@ namespace WebCore {
 
 static const cairo_format_t cairoFormat = CAIRO_FORMAT_ARGB32;
 
-std::optional<DestinationColorSpace> ShareableBitmapConfiguration::validateColorSpace(std::optional<DestinationColorSpace> colorSpace)
+DestinationColorSpace ShareableBitmapConfiguration::validateColorSpace(const DestinationColorSpace& colorSpace)
 {
     return colorSpace;
 }
 
-CheckedUint32 ShareableBitmapConfiguration::calculateBitsPerComponent(const DestinationColorSpace& colorSpace)
+CheckedUint32 ShareableBitmapConfiguration::calculateBitsPerComponent(PixelFormat pixelFormat, const DestinationColorSpace& colorSpace)
 {
-    return (calculateBytesPerPixel(colorSpace) / 4) * 8;
+    return (calculateBytesPerPixel(pixelFormat, colorSpace) / 4) * 8;
 }
 
-CheckedUint32 ShareableBitmapConfiguration::calculateBytesPerPixel(const DestinationColorSpace&)
+CheckedUint32 ShareableBitmapConfiguration::calculateBytesPerPixel(PixelFormat pixelFormat, const DestinationColorSpace&)
 {
+#if ENABLE(PIXEL_FORMAT_RGBA16F)
+    RELEASE_ASSERT(pixelFormat != PixelFormat::RGBA16F);
+#else
+    UNUSED_PARAM(pixelFormat);
+#endif
     return 4;
 }
 
-CheckedUint32 ShareableBitmapConfiguration::calculateBytesPerRow(const IntSize& size, const DestinationColorSpace&)
+CheckedUint32 ShareableBitmapConfiguration::calculateBytesPerRow(const IntSize& size, PixelFormat pixelFormat, const DestinationColorSpace&)
 {
+#if ENABLE(PIXEL_FORMAT_RGBA16F)
+    RELEASE_ASSERT(pixelFormat != PixelFormat::RGBA16F);
+#else
+    UNUSED_PARAM(pixelFormat);
+#endif
     return cairo_format_stride_for_width(cairoFormat, size.width());
 }
 

--- a/Source/WebCore/platform/graphics/cg/ImageBufferCGBitmapBackend.cpp
+++ b/Source/WebCore/platform/graphics/cg/ImageBufferCGBitmapBackend.cpp
@@ -50,6 +50,9 @@ size_t ImageBufferCGBitmapBackend::calculateMemoryCost(const Parameters& paramet
 std::unique_ptr<ImageBufferCGBitmapBackend> ImageBufferCGBitmapBackend::create(const Parameters& parameters, const ImageBufferCreationContext&)
 {
     ASSERT(parameters.bufferFormat.pixelFormat == PixelFormat::BGRA8);
+#if ENABLE(PIXEL_FORMAT_RGBA16F)
+    RELEASE_ASSERT(parameters.bufferFormat.pixelFormat != PixelFormat::RGBA16F);
+#endif
 
     IntSize backendSize = calculateSafeBackendSize(parameters);
     if (backendSize.isEmpty())

--- a/Source/WebCore/platform/graphics/cg/ShareableBitmapCG.mm
+++ b/Source/WebCore/platform/graphics/cg/ShareableBitmapCG.mm
@@ -53,30 +53,33 @@ ShareableBitmapConfiguration::ShareableBitmapConfiguration(const NativeImage& im
 {
 }
 
-std::optional<DestinationColorSpace> ShareableBitmapConfiguration::validateColorSpace(std::optional<DestinationColorSpace> colorSpace)
+DestinationColorSpace ShareableBitmapConfiguration::validateColorSpace(const DestinationColorSpace& colorSpace)
 {
-    if (!colorSpace)
-        return std::nullopt;
-
-    if (auto colorSpaceAsRGB = colorSpace->asRGB())
-        return colorSpaceAsRGB;
+    if (auto colorSpaceAsRGB = colorSpace.asRGB())
+        return *colorSpaceAsRGB;
 
     return DestinationColorSpace::ExtendedSRGB();
 }
 
-CheckedUint32 ShareableBitmapConfiguration::calculateBitsPerComponent(const DestinationColorSpace& colorSpace)
+CheckedUint32 ShareableBitmapConfiguration::calculateBitsPerComponent(PixelFormat pixelFormat, const DestinationColorSpace& colorSpace)
 {
-    return (calculateBytesPerPixel(colorSpace) / 4) * 8;
+    return (calculateBytesPerPixel(pixelFormat, colorSpace) / 4) * 8;
 }
 
-CheckedUint32 ShareableBitmapConfiguration::calculateBytesPerPixel(const DestinationColorSpace& colorSpace)
+CheckedUint32 ShareableBitmapConfiguration::calculateBytesPerPixel(PixelFormat pixelFormat, const DestinationColorSpace&)
 {
-    return colorSpace.usesExtendedRange() ? 8 : 4;
+#if ENABLE(PIXEL_FORMAT_RGBA16F)
+    if (pixelFormat == PixelFormat::RGBA16F)
+        return sizeof(Float16) * 4;
+#else
+    UNUSED_PARAM(pixelFormat);
+#endif
+    return 4;
 }
 
-CheckedUint32 ShareableBitmapConfiguration::calculateBytesPerRow(const IntSize& size, const DestinationColorSpace& colorSpace)
+CheckedUint32 ShareableBitmapConfiguration::calculateBytesPerRow(const IntSize& size, PixelFormat pixelFormat, const DestinationColorSpace& colorSpace)
 {
-    CheckedUint32 bytesPerRow = calculateBytesPerPixel(colorSpace) * size.width();
+    CheckedUint32 bytesPerRow = calculateBytesPerPixel(pixelFormat, colorSpace) * size.width();
 #if HAVE(IOSURFACE)
     if (bytesPerRow.hasOverflowed())
         return bytesPerRow;
@@ -87,24 +90,29 @@ CheckedUint32 ShareableBitmapConfiguration::calculateBytesPerRow(const IntSize& 
 #endif
 }
 
-CGBitmapInfo ShareableBitmapConfiguration::calculateBitmapInfo(const DestinationColorSpace& colorSpace, bool isOpaque)
+CGBitmapInfo ShareableBitmapConfiguration::calculateBitmapInfo(PixelFormat pixelFormat, bool isOpaque)
 {
     CGBitmapInfo info = 0;
-    if (colorSpace.usesExtendedRange()) {
+#if ENABLE(PIXEL_FORMAT_RGBA16F)
+    if (pixelFormat == PixelFormat::RGBA16F) {
         info |= kCGBitmapFloatComponents | static_cast<CGBitmapInfo>(kCGBitmapByteOrder16Host);
 
         if (isOpaque)
             info |= kCGImageAlphaNoneSkipLast;
         else
             info |= kCGImageAlphaPremultipliedLast;
-    } else {
-        info |= static_cast<CGBitmapInfo>(kCGBitmapByteOrder32Host);
-
-        if (isOpaque)
-            info |= kCGImageAlphaNoneSkipFirst;
-        else
-            info |= kCGImageAlphaPremultipliedFirst;
+        return info;
     }
+#else
+    UNUSED_PARAM(pixelFormat);
+#endif
+
+    info |= static_cast<CGBitmapInfo>(kCGBitmapByteOrder32Host);
+
+    if (isOpaque)
+        info |= kCGImageAlphaNoneSkipFirst;
+    else
+        info |= kCGImageAlphaPremultipliedFirst;
 
     return info;
 }

--- a/Source/WebCore/platform/graphics/skia/ShareableBitmapSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/ShareableBitmapSkia.cpp
@@ -37,23 +37,33 @@ WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 
 namespace WebCore {
 
-std::optional<DestinationColorSpace> ShareableBitmapConfiguration::validateColorSpace(std::optional<DestinationColorSpace> colorSpace)
+DestinationColorSpace ShareableBitmapConfiguration::validateColorSpace(const DestinationColorSpace& colorSpace)
 {
     return colorSpace;
 }
 
-CheckedUint32 ShareableBitmapConfiguration::calculateBitsPerComponent(const DestinationColorSpace& colorSpace)
+CheckedUint32 ShareableBitmapConfiguration::calculateBitsPerComponent(PixelFormat pixelFormat, const DestinationColorSpace& colorSpace)
 {
-    return (calculateBytesPerPixel(colorSpace) / 4) * 8;
+    return (calculateBytesPerPixel(pixelFormat, colorSpace) / 4) * 8;
 }
 
-CheckedUint32 ShareableBitmapConfiguration::calculateBytesPerPixel(const DestinationColorSpace& colorSpace)
+CheckedUint32 ShareableBitmapConfiguration::calculateBytesPerPixel(PixelFormat pixelFormat, const DestinationColorSpace& colorSpace)
 {
+#if ENABLE(PIXEL_FORMAT_RGBA16F)
+    RELEASE_ASSERT(pixelFormat != PixelFormat::RGBA16F);
+#else
+    UNUSED_PARAM(pixelFormat);
+#endif
     return SkImageInfo::MakeN32Premul(1, 1, colorSpace.platformColorSpace()).bytesPerPixel();
 }
 
-CheckedUint32 ShareableBitmapConfiguration::calculateBytesPerRow(const IntSize& size, const DestinationColorSpace& colorSpace)
+CheckedUint32 ShareableBitmapConfiguration::calculateBytesPerRow(const IntSize& size, PixelFormat pixelFormat, const DestinationColorSpace& colorSpace)
 {
+#if ENABLE(PIXEL_FORMAT_RGBA16F)
+    RELEASE_ASSERT(pixelFormat != PixelFormat::RGBA16F);
+#else
+    UNUSED_PARAM(pixelFormat);
+#endif
     return SkImageInfo::MakeN32Premul(size.width(), size.height(), colorSpace.platformColorSpace()).minRowBytes();
 }
 

--- a/Source/WebKit/GPUProcess/media/RemoteImageDecoderAVFProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteImageDecoderAVFProxy.cpp
@@ -159,7 +159,7 @@ void RemoteImageDecoderAVFProxy::createFrameImageAtIndex(ImageDecoderIdentifier 
         return;
     bool isOpaque = false;
     auto imageSize = nativeImage->size();
-    auto bitmap = ShareableBitmap::create({ imageSize, nativeImage->colorSpace(), nativeImage->headroom(), isOpaque });
+    auto bitmap = ShareableBitmap::create({ imageSize, nativeImage->colorSpace(), unspecifiedPixelFormat, nativeImage->headroom(), isOpaque });
     if (!bitmap)
         return;
     auto context = bitmap->createGraphicsContext();

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -6436,7 +6436,7 @@ header: <WebCore/ShareableCVPixelBuffer.h>
     WebCore::ShareableCVPixelBufferConfiguration m_configuration;
     Ref<WebCore::ShareableCVPixelBufferBytes> m_bytes;
 }
-    
+
 [CustomHeader, RefCounted] class WebCore::ShareableCVPixelBufferWithPlanarBytes {
     WebCore::ShareableCVPixelBufferConfiguration m_configuration;
     Vector<Ref<WebCore::ShareableCVPixelBufferBytes>> m_planes;
@@ -6459,7 +6459,8 @@ header: <WebCore/ShareableGainMap.h>
 header: <WebCore/ShareableBitmap.h>
 [CustomHeader] class WebCore::ShareableBitmapConfiguration {
     [Validator='m_size->width() > 0 && m_size->height() > 0'] WebCore::IntSize m_size;
-    std::optional<WebCore::DestinationColorSpace> m_colorSpace;
+    WebCore::DestinationColorSpace m_colorSpace;
+    WebCore::PixelFormat m_pixelFormat;
     WebCore::Headroom m_baseImageHeadroom;
     bool m_isOpaque;
     [Validator='*bitsPerComponent >= 1 && *bitsPerComponent <= 16'] unsigned bitsPerComponent();

--- a/Source/WebKit/WebProcess/GPU/graphics/ImageBufferShareableBitmapBackend.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/ImageBufferShareableBitmapBackend.cpp
@@ -48,7 +48,7 @@ IntSize ImageBufferShareableBitmapBackend::calculateSafeBackendSize(const Parame
     if (backendSize.isEmpty())
         return { };
 
-    CheckedUint32 numBytes = ShareableBitmapConfiguration::calculateSizeInBytes(backendSize, parameters.colorSpace);
+    CheckedUint32 numBytes = ShareableBitmapConfiguration::calculateSizeInBytes(backendSize, parameters.bufferFormat.pixelFormat, parameters.colorSpace);
     if (numBytes.hasOverflowed())
         return { };
 
@@ -58,7 +58,7 @@ IntSize ImageBufferShareableBitmapBackend::calculateSafeBackendSize(const Parame
 unsigned ImageBufferShareableBitmapBackend::calculateBytesPerRow(const Parameters& parameters, const IntSize& backendSize)
 {
     ASSERT(!backendSize.isEmpty());
-    return ShareableBitmapConfiguration::calculateBytesPerRow(backendSize, parameters.colorSpace);
+    return ShareableBitmapConfiguration::calculateBytesPerRow(backendSize, parameters.bufferFormat.pixelFormat, parameters.colorSpace);
 }
 
 size_t ImageBufferShareableBitmapBackend::calculateMemoryCost(const Parameters& parameters)
@@ -78,7 +78,7 @@ std::unique_ptr<ImageBufferShareableBitmapBackend> ImageBufferShareableBitmapBac
     if (backendSize.isEmpty())
         return nullptr;
 
-    auto bitmap = ShareableBitmap::create({ backendSize, parameters.colorSpace });
+    auto bitmap = ShareableBitmap::create({ backendSize, parameters.colorSpace, parameters.bufferFormat.pixelFormat });
     if (!bitmap)
         return nullptr;
     if (creationContext.resourceOwner)


### PR DESCRIPTION
#### 1e66e746033fb1e8e29c91cd301149d76a62888e
<pre>
Add PixelFormat to ShareableBitmapConfiguration
<a href="https://bugs.webkit.org/show_bug.cgi?id=319966">https://bugs.webkit.org/show_bug.cgi?id=319966</a>
<a href="https://rdar.apple.com/182891101">rdar://182891101</a>

Reviewed by Mike Wyrzykowski.

In order to correctly share bitmap buffers between processes, their
pixel format is needed to compute the buffer memory size, especially
when potentially dealing with HDR float16 buffers.

- Add PixelFormat to ShareableBitmapConfiguration, and ensure it&apos;s
  de/serialized.
- If not specified, infer it from whether the color space uses extended-
  range color values.
- Use this PixelFormat (instead of the color space) when computing
  memory sizes. Note that some platforms still rely solely on the color
  space.
- Test that HDR pixels near the end of a canvas are correctly written
  and read.

Additionally:
- Remove the std::optional shell around
  ShareableBitmapConfiguration::m_colorSpace, it was effectively
  checked at every access, so instead it&apos;s now pre-computed once during
  construction.
- Make the deserializing ShareableBitmapConfiguration constructor
  private, as it&apos;s only used by friend struct IPC::ArgumentCoder.

Tests: fast/canvas/hdr/float16-canvas-imagedata-large-unaccelerated.html
       fast/canvas/hdr/float16-canvas-imagedata-small-accelerated.html

* LayoutTests/fast/canvas/hdr/float16-canvas-imagedata-large-unaccelerated-expected.txt: Copied from LayoutTests/fast/canvas/hdr/float16-canvas-imagedata-expected.txt.
* LayoutTests/fast/canvas/hdr/float16-canvas-imagedata-large-unaccelerated.html: Added.
* LayoutTests/fast/canvas/hdr/float16-canvas-imagedata-small-accelerated-expected.txt: Renamed from LayoutTests/fast/canvas/hdr/float16-canvas-imagedata-expected.txt.
* LayoutTests/fast/canvas/hdr/float16-canvas-imagedata-small-accelerated.html: Added.
* LayoutTests/fast/canvas/hdr/float16-canvas-imagedata.js: Renamed from LayoutTests/fast/canvas/hdr/float16-canvas-imagedata.html.
* Source/WebCore/platform/graphics/ImageBufferBackend.cpp:
(WebCore::ImageBufferBackend::calculateSafeBackendSize):
* Source/WebCore/platform/graphics/ShareableBitmap.cpp:
(WebCore::ShareableBitmapConfiguration::ShareableBitmapConfiguration):
(WebCore::ShareableBitmapConfiguration::calculateSizeInBytes):
* Source/WebCore/platform/graphics/ShareableBitmap.h:
(WebCore::ShareableBitmapConfiguration::colorSpace const):
(WebCore::ShareableBitmapConfiguration::pixelFormat const):
(WebCore::ShareableBitmap::colorSpace const):
(WebCore::ShareableBitmap::pixelFormat const):
* Source/WebCore/platform/graphics/cairo/ShareableBitmapCairo.cpp:
(WebCore::ShareableBitmapConfiguration::validateColorSpace):
(WebCore::ShareableBitmapConfiguration::calculateBitsPerComponent):
(WebCore::ShareableBitmapConfiguration::calculateBytesPerPixel):
(WebCore::ShareableBitmapConfiguration::calculateBytesPerRow):
* Source/WebCore/platform/graphics/cg/ImageBufferCGBitmapBackend.cpp:
(WebCore::ImageBufferCGBitmapBackend::create):
* Source/WebCore/platform/graphics/cg/ShareableBitmapCG.mm:
(WebCore::ShareableBitmapConfiguration::validateColorSpace):
(WebCore::ShareableBitmapConfiguration::calculateBitsPerComponent):
(WebCore::ShareableBitmapConfiguration::calculateBytesPerPixel):
(WebCore::ShareableBitmapConfiguration::calculateBytesPerRow):
(WebCore::ShareableBitmapConfiguration::calculateBitmapInfo):
* Source/WebCore/platform/graphics/skia/ShareableBitmapSkia.cpp:
(WebCore::ShareableBitmapConfiguration::validateColorSpace):
(WebCore::ShareableBitmapConfiguration::calculateBitsPerComponent):
(WebCore::ShareableBitmapConfiguration::calculateBytesPerPixel):
(WebCore::ShareableBitmapConfiguration::calculateBytesPerRow):
* Source/WebKit/GPUProcess/media/RemoteImageDecoderAVFProxy.cpp:
(WebKit::RemoteImageDecoderAVFProxy::createFrameImageAtIndex):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/WebProcess/GPU/graphics/ImageBufferShareableBitmapBackend.cpp:
(WebKit::ImageBufferShareableBitmapBackend::calculateSafeBackendSize):
(WebKit::ImageBufferShareableBitmapBackend::calculateBytesPerRow):
(WebKit::ImageBufferShareableBitmapBackend::create):

Canonical link: <a href="https://commits.webkit.org/317817@main">https://commits.webkit.org/317817@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/10bd15b8297a5e79104fdcf325ac7f7bbbdf0f46

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176295 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50230 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44020 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185891 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/138542 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/97a4689f-9dcb-43e2-9abf-80a1d0330901) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178158 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51522 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49914 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137319 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/138542 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/eb05103c-ed51-4327-ac3c-d8e688858843) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179251 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40798 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158092 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117794 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/74487acc-302d-43f1-9996-689194a7d1b8) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39447 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37809 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149863 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37590 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-highlight-api/painting/custom-highlight-dynamic-font-metrics-001.html (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34360 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41954 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42020 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188315 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49895 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/157637 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146349 "Found 1 new test failure: ipc/display-list-recorder-leak.html (failure)") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39388 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50579 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34207 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146167 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40940 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122783 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/116782 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49083 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12563 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48485 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48719 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48544 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->