### PR TITLE
libwebrtc workerThread should be networkThread and not signalingThread

### DIFF
--- a/Source/ThirdParty/libwebrtc/Source/webrtc/media/engine/webrtc_video_engine.cc
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/media/engine/webrtc_video_engine.cc
@@ -3303,8 +3303,17 @@ void WebRtcVideoReceiveChannel::OnPacketReceived(RtpPacketReceived packet) {
 
   call_->Receiver()->DeliverRtpPacket(
       MediaType::VIDEO, std::move(packet),
+#if defined(WEBRTC_WEBKIT_BUILD)
+      [this, safety = task_safety_.flag()](const RtpPacketReceived& packet) {
+        if (!safety->alive())
+          return false;
+        RTC_DCHECK_RUN_ON(&thread_checker_);
+        return MaybeCreateDefaultReceiveStream(packet);
+      });
+#else
       absl::bind_front(
           &WebRtcVideoReceiveChannel::MaybeCreateDefaultReceiveStream, this));
+#endif
 }
 
 bool WebRtcVideoReceiveChannel::MaybeCreateDefaultReceiveStream(

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/media/engine/webrtc_voice_engine.cc
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/media/engine/webrtc_voice_engine.cc
@@ -2623,8 +2623,17 @@ void WebRtcVoiceReceiveChannel::OnPacketReceived(RtpPacketReceived packet) {
 
   call_->Receiver()->DeliverRtpPacket(
       MediaType::AUDIO, std::move(packet),
+#if defined(WEBRTC_WEBKIT_BUILD)
+      [this, safety = task_safety_.flag()](const RtpPacketReceived& packet) {
+        if (!safety->alive())
+          return false;
+        RTC_DCHECK_RUN_ON(worker_thread_);
+        return MaybeCreateDefaultReceiveStream(packet);
+      });
+#else
       absl::bind_front(
           &WebRtcVoiceReceiveChannel::MaybeCreateDefaultReceiveStream, this));
+#endif
 }
 
 bool WebRtcVoiceReceiveChannel::MaybeCreateDefaultReceiveStream(

--- a/Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCProvider.cpp
+++ b/Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCProvider.cpp
@@ -350,7 +350,7 @@ Ref<webrtc::PeerConnectionFactoryInterface> LibWebRTCProvider::createPeerConnect
 #endif
     );
     dependencies.network_thread = networkThread;
-    dependencies.worker_thread = signalingThread;
+    dependencies.worker_thread = networkThread;
     dependencies.signaling_thread = signalingThread;
     dependencies.event_log_factory = std::make_unique<webrtc::RtcEventLogFactory>();
 


### PR DESCRIPTION
#### 73766fe6de29197f943066aaa14fb7d1ca7cd009
<pre>
libwebrtc workerThread should be networkThread and not signalingThread
<a href="https://rdar.apple.com/182758228">rdar://182758228</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=319969">https://bugs.webkit.org/show_bug.cgi?id=319969</a>

Reviewed by Jean-Yves Avenard.

In M150 libwebrtc resync, explicit hopping from network thread to worker thread was removed from WebRtcVideoReceiveChannel::OnPacketReceived.
This is ok in Chrome since network thread and worker thread are the same.
We apply the same setup in WebKit in LibWebRTCProvider::createPeerConnectionFactory.

The issue is that while Call::DeliverRtpPacket use a safety task to make sure the Call pointer is valid after hopping to worker thread,
the OnUndemuxablePacketHandler is keeping a pointer to WebRtcVideoReceiveChannel/WebRtcVoiceReceiveChannel, which are not guaranteed to stay valid in our previous config where worker thread and signalling thread were the same.
For good measure, we make sure that the OnUndemuxablePacketHandler given to Call::DeliverRtpPacket from WebRtcVideoReceiveChannel and WebRtcVoiceReceiveChannel use safety flags so that we protect from any misuse pointers.

* Source/ThirdParty/libwebrtc/Source/webrtc/media/engine/webrtc_video_engine.cc:
* Source/ThirdParty/libwebrtc/Source/webrtc/media/engine/webrtc_voice_engine.cc:
* Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCProvider.cpp:
(WebCore::LibWebRTCProvider::createPeerConnectionFactory):

Canonical link: <a href="https://commits.webkit.org/317713@main">https://commits.webkit.org/317713@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bb03f3c5c72be1155755c5cb1912ca10bf739b6e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176046 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49979 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43763 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185640 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/138270 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/177909 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51271 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49661 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137099 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/138270 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3ea2f420-1e3e-4ce6-9f5a-5bee69b58fd6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179002 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40568 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157870 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117578 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/39d7edba-ffb9-47a9-be08-2156bb095ce6) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39211 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37599 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149629 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37364 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34109 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41688 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41809 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188062 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49646 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146109 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39320 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50327 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33991 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145944 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40723 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122522 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/116438 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48833 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12343 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48235 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48467 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48292 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->