### PR TITLE
[WKProcessPool _requestWebProcessTermination:] only terminates the first web process in the pool

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKProcessPool.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKProcessPool.mm
@@ -437,9 +437,10 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 - (BOOL)_requestWebProcessTermination:(pid_t)pid
 {
     for (Ref process : borrow(_processPool->processes()).get()) {
-        if (process->processID() == pid)
+        if (process->processID() == pid) {
             process->requestTermination(WebKit::ProcessTerminationReason::RequestedByClient);
-        return YES;
+            return YES;
+        }
     }
     return NO;
 }

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebProcessTerminate.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebProcessTerminate.mm
@@ -32,6 +32,7 @@
 #import <WebKit/WKProcessPoolPrivate.h>
 #import <WebKit/WKWebViewPrivate.h>
 #import <WebKit/WebKit.h>
+#import <WebKit/_WKProcessPoolConfiguration.h>
 #import <wtf/RetainPtr.h>
 
 TEST(WebKit, WebProcessTerminate)
@@ -48,6 +49,83 @@ TEST(WebKit, WebProcessTerminate)
 
     auto pid2 = [webView _webProcessIdentifier];
     EXPECT_TRUE(pid != pid2);
+}
+
+@interface WebProcessTerminationSchemeHandler : NSObject <WKURLSchemeHandler>
+@end
+
+@implementation WebProcessTerminationSchemeHandler
+- (void)webView:(WKWebView *)webView startURLSchemeTask:(id<WKURLSchemeTask>)task
+{
+    RetainPtr data = [@"<html><body>hello</body></html>" dataUsingEncoding:NSUTF8StringEncoding];
+    RetainPtr response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:@"text/html" expectedContentLength:[data length] textEncodingName:nil]);
+    [task didReceiveResponse:response.get()];
+    [task didReceiveData:data.get()];
+    [task didFinish];
+}
+
+- (void)webView:(WKWebView *)webView stopURLSchemeTask:(id<WKURLSchemeTask>)task
+{
+}
+@end
+
+// The pool keeps its web content processes in creation order, so a process created later is never
+// first in the list. -[WKProcessPool _requestWebProcessTermination:] must still terminate it.
+TEST(WebKit, RequestWebProcessTerminationForNonFirstProcess)
+{
+    RetainPtr processPoolConfiguration = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
+    processPoolConfiguration.get().processSwapsOnNavigation = YES;
+    processPoolConfiguration.get().processSwapsOnNavigationWithinSameNonHTTPFamilyProtocol = YES;
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+
+    RetainPtr handler = adoptNS([[WebProcessTerminationSchemeHandler alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    [configuration setProcessPool:processPool.get()];
+    [configuration setURLSchemeHandler:handler.get() forURLScheme:@"termtest"];
+
+    RetainPtr navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
+    __block bool didFinishNavigation = false;
+    [navigationDelegate setDidFinishNavigation:^(WKWebView *, WKNavigation *) {
+        didFinishNavigation = true;
+    }];
+
+    // First web view -> first web content process in the pool's list.
+    RetainPtr firstWebView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    [firstWebView setNavigationDelegate:navigationDelegate.get()];
+    [firstWebView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"termtest://first.example/"]]];
+    TestWebKitAPI::Util::run(&didFinishNavigation);
+    didFinishNavigation = false;
+    auto firstPID = [firstWebView _webProcessIdentifier];
+
+    // Second web view (different site) -> a second, non-first web content process.
+    RetainPtr secondWebView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    [secondWebView setNavigationDelegate:navigationDelegate.get()];
+    [secondWebView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"termtest://second.example/"]]];
+    TestWebKitAPI::Util::run(&didFinishNavigation);
+    didFinishNavigation = false;
+    auto secondPID = [secondWebView _webProcessIdentifier];
+
+    // Sanity: two distinct web content processes exist, and the second was created after the first.
+    EXPECT_NE(firstPID, secondPID);
+    EXPECT_EQ(2U, [processPool _webProcessCountIgnoringPrewarmed]);
+
+    WKWebView *secondWebViewToMatch = secondWebView.get();
+    __block bool secondWebViewProcessTerminated = false;
+    [navigationDelegate setWebContentProcessDidTerminate:^(WKWebView *webView, _WKProcessTerminationReason) {
+        if (webView == secondWebViewToMatch)
+            secondWebViewProcessTerminated = true;
+    }];
+
+    EXPECT_TRUE([processPool _requestWebProcessTermination:secondPID]);
+
+    // The (non-first) second process must actually be terminated within a bounded time. With the bug,
+    // only the first process is examined, so this never happens and the wait times out.
+    TestWebKitAPI::Util::runFor(&secondWebViewProcessTerminated, 5_s);
+    EXPECT_TRUE(secondWebViewProcessTerminated);
+    EXPECT_EQ(0, [secondWebView _webProcessIdentifier]);
+
+    // The first process must be left running.
+    EXPECT_EQ(firstPID, [firstWebView _webProcessIdentifier]);
 }
 
 TEST(WebKit, TerminateAllProcessesDuringLaunch)


### PR DESCRIPTION
#### 00bfe4a98d52a1792e3f82e01c079f782a560295
<pre>
[WKProcessPool _requestWebProcessTermination:] only terminates the first web process in the pool
<a href="https://bugs.webkit.org/show_bug.cgi?id=319973">https://bugs.webkit.org/show_bug.cgi?id=319973</a>

Reviewed by Per Arne Vollan.

[WKProcessPool _requestWebProcessTermination:] walks the pool&apos;s web content
processes looking for the one whose PID matches the argument, but a misplaced
`return YES;` sat inside the loop and outside the `if` that tests for a match.
As a result the method only ever examined the *first* process in the list: it
terminated that process if its PID matched, did nothing for any other PID, and
in every case unconditionally returned YES after the first iteration -- which
also made the trailing `return NO` (the &quot;no such process&quot; path) dead code.
Requesting termination of any process that was not first in the pool&apos;s list
therefore silently failed while still reporting success.

The pool stores its processes in creation order, so any process created after
the first can never be terminated through this SPI. This has been broken since
the method was introduced in 234716@main.

Move the `return YES;` inside the matching branch so the loop keeps scanning
until it finds the process with the requested PID, terminates it, and returns
YES, and so the method returns NO when no process matches.

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebProcessTerminate.mm

* Source/WebKit/UIProcess/API/Cocoa/WKProcessPool.mm:
(-[WKProcessPool _requestWebProcessTermination:]):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebProcessTerminate.mm:
(-[WebProcessTerminationSchemeHandler webView:startURLSchemeTask:]):
(-[WebProcessTerminationSchemeHandler webView:stopURLSchemeTask:]):
(TEST(WebKit, RequestWebProcessTerminationForNonFirstProcess)):

Canonical link: <a href="https://commits.webkit.org/317756@main">https://commits.webkit.org/317756@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/947750c0488a3902b63a97a8c25f193397ca4d77

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176055 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49988 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43772 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185649 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/138279 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/259507df-035c-4282-b474-81e3780ba82e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/177918 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51280 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49670 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137103 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/138279 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0358fa21-ee81-44ed-9383-620a71ae6649) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179011 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40574 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157878 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117582 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9b0669fd-45b2-428b-bb5e-38c2ee3342c7) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39233 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37603 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149650 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37372 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34118 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41707 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41814 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188071 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49655 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146116 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39347 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50336 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33999 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145950 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40728 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122544 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/116447 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48842 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12351 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48244 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48476 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48301 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->