### PR TITLE
Rename -webkit-initial-letter style accessors to make room for the standard initial-letter property

### DIFF
--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -11221,6 +11221,7 @@
             ],
             "codegen-properties": {
                 "computed-style-initial-constexpr": true,
+                "computed-style-name-for-methods": "WebkitInitialLetter",
                 "computed-style-storage-path": ["m_nonInheritedData", "rareData"],
                 "computed-style-storage-kind": "reference",
                 "computed-style-type": "Style::WebkitInitialLetter",

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLineBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLineBuilder.cpp
@@ -1240,7 +1240,7 @@ LineBuilder::RectAndFloatConstraints LineBuilder::adjustedLineRectWithCandidateI
 
 std::optional<LineBuilder::InitialLetterOffsets> LineBuilder::adjustLineRectForInitialLetterIfApplicable(const Box& floatBox)
 {
-    auto drop = floatBox.style().initialLetter().drop();
+    auto drop = floatBox.style().webkitInitialLetter().drop();
     auto isInitialLetter = floatBox.isFloatingPositioned() && floatBox.style().pseudoElementType() == PseudoElementType::FirstLetter && drop;
     if (!isInitialLetter)
         return { };
@@ -1265,7 +1265,7 @@ std::optional<LineBuilder::InitialLetterOffsets> LineBuilder::adjustLineRectForI
     }
 
     auto sunkenBelowFirstLineOffset = LayoutUnit { };
-    auto letterHeight = floatBox.style().initialLetter().height();
+    auto letterHeight = floatBox.style().webkitInitialLetter().height();
     if (drop < letterHeight) {
         // Sunken/raised initial letter pushes contents of the first line down.
         auto numberOfSunkenLines = letterHeight - drop;

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -2368,7 +2368,7 @@ LayoutUnit RenderBlockFlow::adjustForUnsplittableChild(RenderBox& child, LayoutU
         if (!hasUniformPageLogicalHeight && !pushToNextPageWithMinimumLogicalHeight(remainingLogicalHeight, logicalOffset, childLogicalHeight))
             return logicalOffset;
         auto result = logicalOffset + remainingLogicalHeight;
-        bool isInitialLetter = child.isFloating() && child.style().pseudoElementType() == PseudoElementType::FirstLetter && child.style().initialLetter().drop() > 0;
+        bool isInitialLetter = child.isFloating() && child.style().pseudoElementType() == PseudoElementType::FirstLetter && child.style().webkitInitialLetter().drop() > 0;
         if (isInitialLetter) {
             // Increase our logical height to ensure that lines all get pushed along with the letter.
             setLogicalHeight(logicalOffset + remainingLogicalHeight);
@@ -2852,7 +2852,7 @@ void RenderBlockFlow::computeLogicalLocationForFloat(FloatingObject& floatingObj
     LayoutUnit floatLogicalLeft;
 
     bool insideFragmentedFlow = enclosingFragmentedFlow();
-    bool isInitialLetter = childBox.style().pseudoElementType() == PseudoElementType::FirstLetter && childBox.style().initialLetter().drop() > 0;
+    bool isInitialLetter = childBox.style().pseudoElementType() == PseudoElementType::FirstLetter && childBox.style().webkitInitialLetter().drop() > 0;
 
     if (isInitialLetter) {
         if (auto lowestInitialLetterLogicalBottom = this->lowestInitialLetterLogicalBottom()) {
@@ -2930,7 +2930,7 @@ void RenderBlockFlow::adjustInitialLetterPosition(RenderBox& childBox, LayoutUni
 
     // For sunken and raised caps, we have to make some adjustments. Test if we're sunken or raised (dropHeightDelta will be
     // positive for raised and negative for sunken).
-    int dropHeightDelta = childBox.style().initialLetter().height() - childBox.style().initialLetter().drop();
+    int dropHeightDelta = childBox.style().webkitInitialLetter().height() - childBox.style().webkitInitialLetter().drop();
 
     // If we're sunken, the float needs to shift down but lines still need to avoid it. In order to do that we increase the float's margin.
     if (dropHeightDelta < 0)
@@ -3129,7 +3129,7 @@ std::optional<LayoutUnit> RenderBlockFlow::lowestInitialLetterLogicalBottom() co
     for (auto& floatingObject : m_floatingObjects->set()) {
         if (!floatingObject->renderer())
             continue;
-        if (floatingObject->isPlaced() && floatingObject->renderer()->style().pseudoElementType() == PseudoElementType::FirstLetter && floatingObject->renderer()->style().initialLetter().drop() > 0)
+        if (floatingObject->isPlaced() && floatingObject->renderer()->style().pseudoElementType() == PseudoElementType::FirstLetter && floatingObject->renderer()->style().webkitInitialLetter().drop() > 0)
             lowestFloatBottom = std::max(lowestFloatBottom.value_or(0_lu), logicalBottomForFloat(*floatingObject));
     }
     return lowestFloatBottom;

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -5021,7 +5021,7 @@ bool RenderBox::isUnsplittableForPagination() const
         || (is<HTMLFormControlElement>(element()) && !is<HTMLFieldSetElement>(element()))
         || hasUnsplittableScrollingOverflow()
         || (parent() && isWritingModeRoot())
-        || (isFloating() && style().pseudoElementType() == PseudoElementType::FirstLetter && style().initialLetter().drop() > 0)
+        || (isFloating() && style().pseudoElementType() == PseudoElementType::FirstLetter && style().webkitInitialLetter().drop() > 0)
         || shouldApplySizeContainment();
 }
 

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderFirstLetter.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderFirstLetter.cpp
@@ -55,12 +55,12 @@ static std::optional<Style::ComputedStyle> styleForFirstLetter(const RenderEleme
     auto firstLetterStyle = Style::ComputedStyle::clone(*style);
 
     // If we have an initial letter drop that is >= 1, then we need to force floating to be on.
-    if (firstLetterStyle.initialLetter().drop() >= 1 && firstLetterStyle.floating() == Float::None)
+    if (firstLetterStyle.webkitInitialLetter().drop() >= 1 && firstLetterStyle.floating() == Float::None)
         firstLetterStyle.setFloating(firstLetterStyle.writingMode().isBidiLTR() ? Float::Left : Float::Right);
 
     // We have to compute the correct font-size for the first-letter if it has an initial letter height set.
     auto* paragraph = firstLetterContainer.isRenderBlockFlow() ? &firstLetterContainer : firstLetterContainer.containingBlock();
-    if (firstLetterStyle.initialLetter().height() >= 1 && firstLetterStyle.metricsOfPrimaryFont().capHeight() && paragraph->style().metricsOfPrimaryFont().capHeight()) {
+    if (firstLetterStyle.webkitInitialLetter().height() >= 1 && firstLetterStyle.metricsOfPrimaryFont().capHeight() && paragraph->style().metricsOfPrimaryFont().capHeight()) {
         // FIXME: For ideographic baselines, we want to go from line edge to line edge. This is equivalent to (N-1)*line-height + the font height.
         // We don't yet support ideographic baselines.
         // For an N-line first-letter and for alphabetic baselines, the cap-height of the first letter needs to equal (N-1)*line-height of paragraph lines + cap-height of the paragraph
@@ -73,12 +73,12 @@ static std::optional<Style::ComputedStyle> styleForFirstLetter(const RenderEleme
         // because many fonts bake ascent into the font metrics. Therefore we have to look at actual measured cap height values in order to know when we have a good fit.
         auto newFontDescription = firstLetterStyle.fontDescription();
         float capRatio = firstLetterStyle.metricsOfPrimaryFont().capHeight().value() / firstLetterStyle.computedFontSize();
-        float startingFontSize = ((firstLetterStyle.initialLetter().height() - 1) * lineHeight + paragraph->style().metricsOfPrimaryFont().intCapHeight()) / capRatio;
+        float startingFontSize = ((firstLetterStyle.webkitInitialLetter().height() - 1) * lineHeight + paragraph->style().metricsOfPrimaryFont().intCapHeight()) / capRatio;
         newFontDescription.setSpecifiedSize(startingFontSize);
         newFontDescription.setComputedSize(startingFontSize);
         firstLetterStyle.setFontDescription(WTF::move(newFontDescription));
 
-        int desiredCapHeight = (firstLetterStyle.initialLetter().height() - 1) * lineHeight + paragraph->style().metricsOfPrimaryFont().intCapHeight();
+        int desiredCapHeight = (firstLetterStyle.webkitInitialLetter().height() - 1) * lineHeight + paragraph->style().metricsOfPrimaryFont().intCapHeight();
         int actualCapHeight = firstLetterStyle.metricsOfPrimaryFont().intCapHeight();
         while (actualCapHeight > desiredCapHeight) {
             auto newFontDescription = firstLetterStyle.fontDescription();

--- a/Source/WebCore/style/StyleDifference.cpp
+++ b/Source/WebCore/style/StyleDifference.cpp
@@ -228,7 +228,7 @@ public:
     {
         ASSERT(&a != &b);
 
-        if (a.lineClamp != b.lineClamp || a.initialLetter != b.initialLetter)
+        if (a.lineClamp != b.lineClamp || a.webkitInitialLetter != b.webkitInitialLetter)
             return true;
 
         if (a.shapeMargin != b.shapeMargin)

--- a/Source/WebCore/style/computed/data/StyleNonInheritedRareData.cpp
+++ b/Source/WebCore/style/computed/data/StyleNonInheritedRareData.cpp
@@ -41,7 +41,7 @@ NonInheritedRareData::NonInheritedRareData()
     , zoom(ComputedStyle::initialZoom())
     , maxLines(ComputedStyle::initialMaxLines())
     , touchAction(ComputedStyle::initialTouchAction())
-    , initialLetter(ComputedStyle::initialInitialLetter())
+    , webkitInitialLetter(ComputedStyle::initialWebkitInitialLetter())
     , marquee(MarqueeData::create())
     , backdropFilter(BackdropFilterData::create())
     , grid(GridData::create())
@@ -153,7 +153,7 @@ inline NonInheritedRareData::NonInheritedRareData(const NonInheritedRareData& o)
     , zoom(o.zoom)
     , maxLines(o.maxLines)
     , touchAction(o.touchAction)
-    , initialLetter(o.initialLetter)
+    , webkitInitialLetter(o.webkitInitialLetter)
     , marquee(o.marquee)
     , backdropFilter(o.backdropFilter)
     , grid(o.grid)
@@ -272,7 +272,7 @@ bool NonInheritedRareData::operator==(const NonInheritedRareData& o) const
         && zoom == o.zoom
         && maxLines == o.maxLines
         && touchAction == o.touchAction
-        && initialLetter == o.initialLetter
+        && webkitInitialLetter == o.webkitInitialLetter
         && marquee == o.marquee
         && backdropFilter == o.backdropFilter
         && grid == o.grid
@@ -407,7 +407,7 @@ void NonInheritedRareData::dumpDifferences(TextStream& ts, const NonInheritedRar
 
     LOG_IF_DIFFERENT(touchAction);
 
-    LOG_IF_DIFFERENT(initialLetter);
+    LOG_IF_DIFFERENT(webkitInitialLetter);
 
     LOG_IF_DIFFERENT(clip);
     LOG_IF_DIFFERENT(scrollMargin);

--- a/Source/WebCore/style/computed/data/StyleNonInheritedRareData.h
+++ b/Source/WebCore/style/computed/data/StyleNonInheritedRareData.h
@@ -129,7 +129,7 @@ public:
 
     TouchAction touchAction;
 
-    WebkitInitialLetter initialLetter;
+    WebkitInitialLetter webkitInitialLetter;
 
     DataRef<MarqueeData> marquee;
     DataRef<BackdropFilterData> backdropFilter;


### PR DESCRIPTION
#### a09cb19bd015c61ffeb8a24bb0dd4b0e27f6c689
<pre>
Rename -webkit-initial-letter style accessors to make room for the standard initial-letter property
<a href="https://bugs.webkit.org/show_bug.cgi?id=319972">https://bugs.webkit.org/show_bug.cgi?id=319972</a>

Reviewed by NOBODY (OOPS!).

This change is part of the prototype implementation of the standard CSS initial-letter property.
The complete implementation is available in the following pull request:
<a href="https://github.com/WebKit/WebKit/pull/69709">https://github.com/WebKit/WebKit/pull/69709</a>

The standard `initial-letter` property (CSS Inline Layout Module Level 3) is not yet implemented,
while the legacy `-webkit-initial-letter` property currently owns the canonical `initialLetter`
method and storage names. To free those names for the upcoming standard property, rename the legacy
property&apos;s generated accessors and its ComputedStyle storage member to the `webkitInitialLetter`
form.

This is a pure rename: no behavior, grammar, or value type changes. The `Style::WebkitInitialLetter`
type is untouched. Verified with the existing -webkit-initial-letter layout tests
(fast/css-generated-content/initial-letter-*, fast/text/non-integral-initial-letter-simple) and the
css-inline WPT suites, all passing with no regressions.

No tests since no behaviors changed.

* Source/WebCore/css/CSSProperties.json: Add computed-style-name-for-methods &quot;WebkitInitialLetter&quot;
to -webkit-initial-letter so the generated getter/setter/initial and storage member use the
webkitInitialLetter name.
* Source/WebCore/style/computed/data/StyleNonInheritedRareData.h: Rename the rareData member
initialLetter to webkitInitialLetter.
* Source/WebCore/style/computed/data/StyleNonInheritedRareData.cpp: Update the constructor, copy
constructor, operator==, and dumpDifferences to the renamed member.
* Source/WebCore/style/StyleDifference.cpp: Update the layout-diff check to use webkitInitialLetter.
* Source/WebCore/rendering/RenderBlockFlow.cpp: Update call sites to style().webkitInitialLetter().
* Source/WebCore/rendering/RenderBox.cpp: Ditto.
* Source/WebCore/rendering/updating/RenderTreeBuilderFirstLetter.cpp: Ditto.
* Source/WebCore/layout/formattingContexts/inline/InlineLineBuilder.cpp: Ditto.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a09cb19bd015c61ffeb8a24bb0dd4b0e27f6c689

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176057 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49990 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43774 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185651 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/138281 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/177920 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51282 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49672 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137120 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96231 "2 flakes 4 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179013 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40578 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157891 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117598 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39237 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37608 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149653 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37390 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34120 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41708 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41819 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188073 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49657 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146129 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50338 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34006 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145952 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40735 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122545 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/116449 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48844 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12358 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48246 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48478 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48303 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->