### PR TITLE
FormData upload should be able to dereference the stream from its identifier in networking process

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/api/redirect/redirect-upload.h2.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/api/redirect/redirect-upload.h2.any.serviceworker-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL Fetch upload streaming should be accepted on 303 promise_test: Unhandled rejection with value: object "TypeError: Load failed"
+PASS Fetch upload streaming should be accepted on 303
 PASS Fetch upload streaming should fail on 301
 PASS Fetch upload streaming should fail on 302
 PASS Fetch upload streaming should fail on 307

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/api/redirect/redirect-upload.h2.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/api/redirect/redirect-upload.h2.any.sharedworker-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL Fetch upload streaming should be accepted on 303 promise_test: Unhandled rejection with value: object "TypeError: Load failed"
+PASS Fetch upload streaming should be accepted on 303
 PASS Fetch upload streaming should fail on 301
 PASS Fetch upload streaming should fail on 302
 PASS Fetch upload streaming should fail on 307

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/api/redirect/redirect-upload.h2.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/api/redirect/redirect-upload.h2.any.worker-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL Fetch upload streaming should be accepted on 303 promise_test: Unhandled rejection with value: object "TypeError: Load failed"
+PASS Fetch upload streaming should be accepted on 303
 PASS Fetch upload streaming should fail on 301
 PASS Fetch upload streaming should fail on 302
 PASS Fetch upload streaming should fail on 307

--- a/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/fetch-event.https.h2-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/fetch-event.https.h2-expected.txt
@@ -1,8 +1,8 @@
 
 PASS global setup
 FAIL The streaming request body is readable in the service worker. promise_test: Unhandled rejection with value: object "TypeError: FetchEvent.respondWith received an error: NotSupportedError: Stream upload reading is not yet supported"
-FAIL Network fallback for streaming upload. promise_test: Unhandled rejection with value: object "TypeError: Load failed"
-PASS When the streaming request body is used, network fallback fails.
-FAIL Running clone() in the service worker does not prevent network fallback. promise_test: Unhandled rejection with value: object "TypeError: Load failed"
+FAIL Network fallback for streaming upload. assert_equals: body expected "i am the request body" but got ""
+FAIL When the streaming request body is used, network fallback fails. assert_unreached: Should have rejected: undefined Reached unreachable code
+FAIL Running clone() in the service worker does not prevent network fallback. assert_equals: body expected "i am the request body" but got ""
 PASS restore global state
 

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/fetch/api/redirect/redirect-upload.h2.any-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/fetch/api/redirect/redirect-upload.h2.any-expected.txt
@@ -1,5 +1,5 @@
 
-PASS Fetch upload streaming should be accepted on 303
+FAIL Fetch upload streaming should be accepted on 303 promise_test: Unhandled rejection with value: object "TypeError: Load failed"
 PASS Fetch upload streaming should fail on 301
 PASS Fetch upload streaming should fail on 302
 PASS Fetch upload streaming should fail on 307

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/fetch/api/redirect/redirect-upload.h2.any.serviceworker-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/fetch/api/redirect/redirect-upload.h2.any.serviceworker-expected.txt
@@ -1,5 +1,5 @@
 
-PASS Fetch upload streaming should be accepted on 303
+FAIL Fetch upload streaming should be accepted on 303 promise_test: Unhandled rejection with value: object "TypeError: Load failed"
 PASS Fetch upload streaming should fail on 301
 PASS Fetch upload streaming should fail on 302
 PASS Fetch upload streaming should fail on 307

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/fetch/api/redirect/redirect-upload.h2.any.sharedworker-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/fetch/api/redirect/redirect-upload.h2.any.sharedworker-expected.txt
@@ -1,5 +1,5 @@
 
-PASS Fetch upload streaming should be accepted on 303
+FAIL Fetch upload streaming should be accepted on 303 promise_test: Unhandled rejection with value: object "TypeError: Load failed"
 PASS Fetch upload streaming should fail on 301
 PASS Fetch upload streaming should fail on 302
 PASS Fetch upload streaming should fail on 307

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/fetch/api/redirect/redirect-upload.h2.any.worker-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/fetch/api/redirect/redirect-upload.h2.any.worker-expected.txt
@@ -1,5 +1,5 @@
 
-PASS Fetch upload streaming should be accepted on 303
+FAIL Fetch upload streaming should be accepted on 303 promise_test: Unhandled rejection with value: object "TypeError: Load failed"
 PASS Fetch upload streaming should fail on 301
 PASS Fetch upload streaming should fail on 302
 PASS Fetch upload streaming should fail on 307

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/service-workers/service-worker/fetch-event.https.h2-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/service-workers/service-worker/fetch-event.https.h2-expected.txt
@@ -1,0 +1,8 @@
+
+PASS global setup
+FAIL The streaming request body is readable in the service worker. promise_test: Unhandled rejection with value: object "TypeError: FetchEvent.respondWith received an error: NotSupportedError: Stream upload reading is not yet supported"
+FAIL Network fallback for streaming upload. promise_test: Unhandled rejection with value: object "TypeError: Load failed"
+PASS When the streaming request body is used, network fallback fails.
+FAIL Running clone() in the service worker does not prevent network fallback. promise_test: Unhandled rejection with value: object "TypeError: Load failed"
+PASS restore global state
+

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -2941,6 +2941,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/network/ParsedContentRange.h
     platform/network/ParsedContentType.h
     platform/network/PendingStreamIdentifier.h
+    platform/network/PendingStreamState.h
     platform/network/ProtectionSpace.h
     platform/network/ProtectionSpaceBase.h
     platform/network/ProtectionSpaceHash.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2880,6 +2880,7 @@ platform/network/NetworkStateNotifier.cpp
 platform/network/NetworkStorageSession.cpp
 platform/network/ParsedContentRange.cpp
 platform/network/ParsedContentType.cpp
+platform/network/PendingStreamState.cpp
 platform/network/ProtectionSpaceBase.cpp
 platform/network/RFC7230.cpp
 platform/network/RFC8941.cpp

--- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
+++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
@@ -1618,6 +1618,7 @@
 		41E1B1D10FF5986900576B3B /* AbstractWorker.h in Headers */ = {isa = PBXBuildFile; fileRef = 41E1B1CB0FF5986900576B3B /* AbstractWorker.h */; };
 		41E27170300934A90015A3AF /* PendingStreamIdentifier.h in Headers */ = {isa = PBXBuildFile; fileRef = 41E2716F300934A20015A3AF /* PendingStreamIdentifier.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		41E2806F300A38020015A3AF /* FetchRequestDuplex.h in Headers */ = {isa = PBXBuildFile; fileRef = 41E2806D300A37F90015A3AF /* FetchRequestDuplex.h */; };
+		41E271713009351A0015A3AF /* PendingStreamState.h in Headers */ = {isa = PBXBuildFile; fileRef = 41E271723009352A0015A3AF /* PendingStreamState.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		41E2F199274FAECF00A089EE /* NavigationPreloadManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 41E2F197274FAECB00A089EE /* NavigationPreloadManager.h */; };
 		41E4C3E729A3D03300EA6B3A /* BackgroundFetch.h in Headers */ = {isa = PBXBuildFile; fileRef = 418B491D29A3CF80007B3135 /* BackgroundFetch.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		41E4C3E829A3D03900EA6B3A /* BackgroundFetchEngine.h in Headers */ = {isa = PBXBuildFile; fileRef = 418B491E29A3CF81007B3135 /* BackgroundFetchEngine.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -11541,6 +11542,8 @@
 		41E2716F300934A20015A3AF /* PendingStreamIdentifier.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PendingStreamIdentifier.h; sourceTree = "<group>"; };
 		41E2806D300A37F90015A3AF /* FetchRequestDuplex.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FetchRequestDuplex.h; sourceTree = "<group>"; };
 		41E2806E300A37F90015A3AF /* FetchRequestDuplex.idl */ = {isa = PBXFileReference; lastKnownFileType = text; path = FetchRequestDuplex.idl; sourceTree = "<group>"; };
+		41E271723009352A0015A3AF /* PendingStreamState.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PendingStreamState.h; sourceTree = "<group>"; };
+		41E271733009353A0015A3AF /* PendingStreamState.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = PendingStreamState.cpp; sourceTree = "<group>"; };
 		41E2F195274FAECA00A089EE /* NavigationPreloadManager.idl */ = {isa = PBXFileReference; lastKnownFileType = text; path = NavigationPreloadManager.idl; sourceTree = "<group>"; };
 		41E2F197274FAECB00A089EE /* NavigationPreloadManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NavigationPreloadManager.h; sourceTree = "<group>"; };
 		41E2F198274FAECB00A089EE /* NavigationPreloadManager.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = NavigationPreloadManager.cpp; sourceTree = "<group>"; };
@@ -30852,6 +30855,8 @@
 				447958021643B47B001E0A7F /* ParsedContentType.cpp */,
 				447958031643B47B001E0A7F /* ParsedContentType.h */,
 				41E2716F300934A20015A3AF /* PendingStreamIdentifier.h */,
+				41E271733009353A0015A3AF /* PendingStreamState.cpp */,
+				41E271723009352A0015A3AF /* PendingStreamState.h */,
 				37BAAE571980D1DD005DFE71 /* ProtectionSpace.h */,
 				514C765F0CE923A1007EF3CD /* ProtectionSpaceBase.cpp */,
 				514C76600CE923A1007EF3CD /* ProtectionSpaceBase.h */,
@@ -47798,6 +47803,7 @@
 				8A7CC96B12076D73001D4588 /* PendingScript.h in Headers */,
 				E3FA38641D71812D00AA5950 /* PendingScriptClient.h in Headers */,
 				41E27170300934A90015A3AF /* PendingStreamIdentifier.h in Headers */,
+				41E271713009351A0015A3AF /* PendingStreamState.h in Headers */,
 				8A844D0511D3C18E0014065C /* Performance.h in Headers */,
 				86BE340115058CB200CE0FD8 /* PerformanceEntry.h in Headers */,
 				4822FD232E2A8058004CAFF9 /* PerformanceEventTiming.h in Headers */,

--- a/Source/WebCore/platform/network/FormData.cpp
+++ b/Source/WebCore/platform/network/FormData.cpp
@@ -30,6 +30,7 @@
 #include "FormDataBuilder.h"
 #include "MIMETypeRegistry.h"
 #include "Page.h"
+#include "PendingStreamState.h"
 #include "SharedBuffer.h"
 #include <pal/text/TextEncoding.h>
 #include "ThreadableBlobRegistry.h"
@@ -101,6 +102,13 @@ Ref<FormData> FormData::create(PendingStreamIdentifier identifier)
     auto result = create();
     result->m_elements.append(FormDataElement { FormDataElement::PendingStreamData { identifier } });
     return result;
+}
+
+void FormData::setPendingStreamState(Ref<PendingStreamState>&& state)
+{
+    ASSERT(isPendingStream());
+    ASSERT(!m_pendingStreamState);
+    m_pendingStreamState = WTF::move(state);
 }
 
 Ref<FormData> FormData::createMultiPart(const DOMFormData& formData)

--- a/Source/WebCore/platform/network/FormData.h
+++ b/Source/WebCore/platform/network/FormData.h
@@ -40,6 +40,7 @@ namespace WebCore {
 class BlobRegistryImpl;
 class DOMFormData;
 class File;
+class PendingStreamState;
 class SharedBuffer;
 
 struct FormDataElement {
@@ -154,7 +155,10 @@ public:
     // If the FormData has no blob references to resolve, this is returned.
     WEBCORE_EXPORT Ref<FormData> resolveBlobReferences(BlobRegistryImpl* = nullptr);
     bool NODELETE containsBlobElement() const;
+
     WEBCORE_EXPORT bool isPendingStream() const;
+    WEBCORE_EXPORT void setPendingStreamState(Ref<PendingStreamState>&&);
+    PendingStreamState* pendingStreamState() const { return m_pendingStreamState.get(); }
 
     WEBCORE_EXPORT FormDataForUpload prepareForUpload();
 
@@ -203,6 +207,7 @@ private:
     bool m_alwaysStream { false };
     Vector<uint8_t> m_boundary;
     mutable std::optional<uint64_t> m_lengthInBytes;
+    RefPtr<PendingStreamState> m_pendingStreamState;
 };
 
 inline bool operator==(const FormData& a, const FormData& b)

--- a/Source/WebCore/platform/network/PendingStreamState.cpp
+++ b/Source/WebCore/platform/network/PendingStreamState.cpp
@@ -1,0 +1,177 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "PendingStreamState.h"
+
+#include "SharedBuffer.h"
+#include <wtf/Locker.h>
+#include <wtf/StdLibExtras.h>
+
+namespace WebCore {
+
+class PendingStreamState::DataAvailableHandler : public ThreadSafeRefCounted<DataAvailableHandler> {
+public:
+    static Ref<DataAvailableHandler> create(Function<void()>&& function) { return adoptRef(*new DataAvailableHandler(WTF::move(function))); }
+
+    void invoke()
+    {
+        if (m_function)
+            m_function();
+    }
+
+private:
+    explicit DataAvailableHandler(Function<void()>&& function)
+        : m_function(WTF::move(function))
+    {
+    }
+
+    Function<void()> m_function;
+};
+
+Ref<PendingStreamState> PendingStreamState::create()
+{
+    return adoptRef(*new PendingStreamState());
+}
+
+PendingStreamState::PendingStreamState() = default;
+
+PendingStreamState::~PendingStreamState() = default;
+
+void PendingStreamState::setHTTPVersionProbe(HTTPVersionProbe&& probe)
+{
+    Locker locker { m_lock };
+    ASSERT(!m_httpVersionProbe);
+    m_httpVersionProbe = WTF::move(probe);
+}
+
+void PendingStreamState::invokeHandlerIfNeeded(NOESCAPE const std::function<RefPtr<DataAvailableHandler>()>& function)
+{
+    if (RefPtr handler = function())
+        handler->invoke();
+}
+
+void PendingStreamState::appendData(Ref<SharedBuffer>&& buffer)
+{
+    invokeHandlerIfNeeded([&] -> RefPtr<DataAvailableHandler> {
+        Locker locker { m_lock };
+        if (m_ended || m_errorCode)
+            return nullptr;
+        m_chunks.append(WTF::move(buffer));
+        return m_dataAvailableHandler;
+    });
+}
+
+void PendingStreamState::endStream()
+{
+    invokeHandlerIfNeeded([&] -> RefPtr<DataAvailableHandler> {
+        Locker locker { m_lock };
+        if (m_ended || m_errorCode)
+            return nullptr;
+        m_ended = true;
+        return m_dataAvailableHandler;
+    });
+}
+
+void PendingStreamState::errorStream(int errorCode)
+{
+    invokeHandlerIfNeeded([&] -> RefPtr<DataAvailableHandler> {
+        Locker locker { m_lock };
+        if (m_ended || m_errorCode)
+            return nullptr;
+        m_errorCode = errorCode ? errorCode : -1;
+        return m_dataAvailableHandler;
+    });
+}
+
+void PendingStreamState::setDataAvailableHandler(Function<void()>&& handler)
+{
+    if (!handler) {
+        Locker locker { m_lock };
+        m_dataAvailableHandler = nullptr;
+        return;
+    }
+
+    invokeHandlerIfNeeded([&] -> RefPtr<DataAvailableHandler> {
+        Locker locker { m_lock };
+        ASSERT(!m_dataAvailableHandler);
+        m_dataAvailableHandler = DataAvailableHandler::create(WTF::move(handler));
+        if (!m_chunks.isEmpty() || m_ended || m_errorCode)
+            return m_dataAvailableHandler;
+        return nullptr;
+    });
+}
+
+void PendingStreamState::clearDataAvailableHandler()
+{
+    Locker locker { m_lock };
+    m_dataAvailableHandler = nullptr;
+}
+
+PendingStreamState::HTTPVersion PendingStreamState::currentHTTPVersion()
+{
+    Locker locker { m_lock };
+    if (!m_httpVersionProbe)
+        return HTTPVersion::Unknown;
+    return m_httpVersionProbe();
+}
+
+size_t PendingStreamState::read(std::span<uint8_t> outBuffer, bool& atEOF, int& errorCode)
+{
+    Locker locker { m_lock };
+    errorCode = m_errorCode;
+    atEOF = false;
+
+    if (errorCode)
+        return 0;
+
+    size_t written = 0;
+    while (written < outBuffer.size() && !m_chunks.isEmpty()) {
+        auto chunkSpan = protect(m_chunks.first())->span();
+        size_t available = chunkSpan.size() - m_frontChunkOffset;
+        size_t remaining = outBuffer.size() - written;
+        size_t toCopy = std::min(available, remaining);
+        memcpySpan(outBuffer.subspan(written, toCopy), chunkSpan.subspan(m_frontChunkOffset, toCopy));
+        written += toCopy;
+        m_frontChunkOffset += toCopy;
+        if (m_frontChunkOffset >= chunkSpan.size()) {
+            m_chunks.removeFirst();
+            m_frontChunkOffset = 0;
+        }
+    }
+
+    if (m_chunks.isEmpty() && m_ended)
+        atEOF = true;
+
+    return written;
+}
+
+bool PendingStreamState::hasReadyData()
+{
+    Locker locker { m_lock };
+    return !m_chunks.isEmpty() || m_ended || m_errorCode;
+}
+
+} // namespace WebCore

--- a/Source/WebCore/platform/network/PendingStreamState.h
+++ b/Source/WebCore/platform/network/PendingStreamState.h
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <WebCore/PendingStreamIdentifier.h>
+#include <span>
+#include <wtf/Deque.h>
+#include <wtf/Forward.h>
+#include <wtf/Function.h>
+#include <wtf/Lock.h>
+#include <wtf/Ref.h>
+#include <wtf/ThreadSafeRefCounted.h>
+
+namespace WebCore {
+
+class SharedBuffer;
+
+class PendingStreamState : public ThreadSafeRefCounted<PendingStreamState> {
+public:
+    enum class HTTPVersion : uint8_t {
+        Unknown,
+        HTTP1,
+        HTTP2OrLater,
+    };
+
+    using HTTPVersionProbe = Function<HTTPVersion()>;
+    WEBCORE_EXPORT static Ref<PendingStreamState> create();
+    WEBCORE_EXPORT ~PendingStreamState();
+
+    WEBCORE_EXPORT void appendData(Ref<SharedBuffer>&&);
+    WEBCORE_EXPORT void endStream();
+    WEBCORE_EXPORT void errorStream(int errorCode);
+
+    WEBCORE_EXPORT void setHTTPVersionProbe(HTTPVersionProbe&&);
+
+    void setDataAvailableHandler(Function<void()>&&);
+    void clearDataAvailableHandler();
+
+    HTTPVersion currentHTTPVersion();
+
+    size_t read(std::span<uint8_t> outBuffer, bool& atEOF, int& errorCode);
+    bool hasReadyData();
+
+private:
+    class DataAvailableHandler;
+    PendingStreamState();
+
+    static void invokeHandlerIfNeeded(NOESCAPE const std::function<RefPtr<DataAvailableHandler>()>&);
+
+    Lock m_lock;
+    Deque<Ref<SharedBuffer>> m_chunks WTF_GUARDED_BY_LOCK(m_lock);
+    size_t m_frontChunkOffset WTF_GUARDED_BY_LOCK(m_lock) { 0 };
+    bool m_ended WTF_GUARDED_BY_LOCK(m_lock) { false };
+    int m_errorCode WTF_GUARDED_BY_LOCK(m_lock) { 0 };
+    RefPtr<DataAvailableHandler> m_dataAvailableHandler WTF_GUARDED_BY_LOCK(m_lock);
+    HTTPVersionProbe m_httpVersionProbe WTF_GUARDED_BY_LOCK(m_lock);
+};
+
+} // namespace WebCore

--- a/Source/WebCore/platform/network/cf/FormDataStreamCFNet.mm
+++ b/Source/WebCore/platform/network/cf/FormDataStreamCFNet.mm
@@ -31,6 +31,7 @@
 
 #include "BlobRegistryImpl.h"
 #include "FormData.h"
+#include "PendingStreamState.h"
 #include "PlatformStrategies.h"
 #include <sys/stat.h>
 #include <sys/types.h>
@@ -91,7 +92,7 @@ CFStringRef formDataStreamLengthPropertyNameSingleton()
 
 struct FormCreationContext {
     FormDataForUpload data;
-    std::optional<unsigned long long> streamLength;
+    unsigned long long streamLength { 0 };
 };
 
 struct FormStreamFields {
@@ -110,7 +111,7 @@ struct FormStreamFields {
     long long currentStreamRangeLength { BlobDataItem::toEndOfFile };
     MallocSpan<uint8_t, WTF::VectorBufferMalloc> currentData;
     WeakObjCPtr<NSInputStream> formStream;
-    std::optional<unsigned long long> streamLength;
+    unsigned long long streamLength { 0 };
     unsigned long long bytesSent { 0 };
     Lock streamIsBeingOpenedOrClosedLock;
 };
@@ -249,12 +250,6 @@ static Boolean formOpen(CFReadStreamRef, CFStreamError* error, Boolean* openComp
 {
     FormStreamFields* form = static_cast<FormStreamFields*>(context);
 
-    if (!form->streamLength) {
-        *openComplete = TRUE;
-        error->error = 0;
-        return TRUE;
-    }
-
     bool opened = openNextStream(form);
 
     *openComplete = opened;
@@ -265,14 +260,6 @@ static Boolean formOpen(CFReadStreamRef, CFStreamError* error, Boolean* openComp
 static CFIndex formRead(CFReadStreamRef, UInt8* buffer, CFIndex bufferLength, CFStreamError* error, Boolean* atEOF, void* context)
 {
     FormStreamFields* form = static_cast<FormStreamFields*>(context);
-
-    if (!form->streamLength) {
-        // FIXME: Add support for stream upload.
-        error->domain = kCFStreamErrorDomainMacOSStatus;
-        error->error = -1;
-        *atEOF = FALSE;
-        return -1;
-    }
 
     while (form->currentStream) {
         CFIndex bytesToRead = bufferLength;
@@ -304,9 +291,6 @@ static Boolean formCanRead(CFReadStreamRef stream, void* context)
 {
     FormStreamFields* form = static_cast<FormStreamFields*>(context);
 
-    if (!form->streamLength)
-        return TRUE;
-
     while (form->currentStream && CFReadStreamGetStatus(form->currentStream.get()) == kCFStreamStatusAtEnd)
         openNextStream(form);
 
@@ -334,11 +318,8 @@ static CFTypeRef formCopyProperty(CFReadStreamRef, CFStringRef propertyName, voi
         return CFNumberCreate(0, kCFNumberLongLongType, &formDataAsNumber);
     }
 
-    if (kCFCompareEqualTo == CFStringCompare(propertyName, formDataStreamLengthPropertyNameSingleton(), 0)) {
-        if (!form->streamLength)
-            return 0;
-        return CFStringCreateWithFormat(0, 0, CFSTR("%llu"), *form->streamLength);
-    }
+    if (kCFCompareEqualTo == CFStringCompare(propertyName, formDataStreamLengthPropertyNameSingleton(), 0))
+        return CFStringCreateWithFormat(0, 0, CFSTR("%llu"), form->streamLength);
 
     return 0;
 }
@@ -392,26 +373,147 @@ static void formEventCallback(CFReadStreamRef stream, CFStreamEventType type, vo
     }
 }
 
+struct PendingStreamCreationContext {
+    Ref<PendingStreamState> state;
+};
+
+struct PendingStreamFields {
+    explicit PendingStreamFields(Ref<PendingStreamState>&& state)
+        : state(WTF::move(state)) { }
+
+    RetainPtr<CFReadStreamRef> cfFormStream()
+    {
+        return bridge_cast(formStream.get());
+    }
+
+    Ref<PendingStreamState> state;
+    WeakObjCPtr<NSInputStream> formStream;
+    std::optional<bool> isHTTP2OrLater;
+};
+
+static void* pendingStreamCreate(CFReadStreamRef stream, void* context)
+{
+    auto* creationContext = static_cast<PendingStreamCreationContext*>(context);
+
+    auto* fields = new PendingStreamFields(WTF::move(creationContext->state));
+    fields->formStream = bridge_cast(stream);
+
+    callOnMainThread([creationContext] {
+        delete creationContext;
+    });
+
+    return fields;
+}
+
+static void pendingStreamFinalize(CFReadStreamRef stream, void* context)
+{
+    auto* fields = static_cast<PendingStreamFields*>(context);
+    ASSERT_UNUSED(stream, !fields->cfFormStream() || fields->cfFormStream() == stream);
+
+    callOnMainThread([fields] {
+        delete fields;
+    });
+}
+
+static Boolean pendingStreamOpen(CFReadStreamRef, CFStreamError* error, Boolean* openComplete, void*)
+{
+    *openComplete = TRUE;
+    error->error = 0;
+    return TRUE;
+}
+
+static CFIndex pendingStreamRead(CFReadStreamRef, UInt8* buffer, CFIndex bufferLength, CFStreamError* error, Boolean* atEOF, void* context)
+{
+    auto* fields = static_cast<PendingStreamFields*>(context);
+
+    if (!fields->isHTTP2OrLater.value_or(false)) {
+        error->domain = kCFStreamErrorDomainMacOSStatus;
+        error->error = -1;
+        *atEOF = FALSE;
+        return -1;
+    }
+
+    bool pendingAtEOF = false;
+    int pendingError = 0;
+    auto output = unsafeMakeSpan(buffer, static_cast<size_t>(bufferLength));
+    size_t bytesCopied = fields->state->read(output, pendingAtEOF, pendingError);
+
+    if (pendingError) {
+        error->domain = kCFStreamErrorDomainMacOSStatus;
+        error->error = pendingError;
+        *atEOF = FALSE;
+        return -1;
+    }
+
+    error->error = 0;
+    *atEOF = pendingAtEOF ? TRUE : FALSE;
+    return static_cast<CFIndex>(bytesCopied);
+}
+
+static Boolean pendingStreamCanRead(CFReadStreamRef, void* context)
+{
+    auto* fields = static_cast<PendingStreamFields*>(context);
+
+    if (!fields->isHTTP2OrLater)
+        fields->isHTTP2OrLater = protect(fields->state)->currentHTTPVersion() == PendingStreamState::HTTPVersion::HTTP2OrLater;
+
+    // Under HTTP/1 we fail immediately in pendingStreamRead.
+    return !*fields->isHTTP2OrLater || protect(fields->state)->hasReadyData();
+}
+
+static void pendingStreamClose(CFReadStreamRef, void* context)
+{
+    auto* fields = static_cast<PendingStreamFields*>(context);
+    protect(fields->state)->clearDataAvailableHandler();
+}
+
+static CFTypeRef pendingStreamCopyProperty(CFReadStreamRef, CFStringRef, void*)
+{
+    // Deliberately do not answer WebKitFormDataStreamLength — length is unknown for a pending stream.
+    return 0;
+}
+
+static void pendingStreamSchedule(CFReadStreamRef, CFRunLoopRef, CFStringRef, void* context)
+{
+    auto* fields = static_cast<PendingStreamFields*>(context);
+    RetainPtr<CFReadStreamRef> outerStream = fields->cfFormStream();
+    protect(fields->state)->setDataAvailableHandler([outerStream = WTF::move(outerStream)] {
+        if (outerStream)
+            CFReadStreamSignalEvent(outerStream.get(), kCFStreamEventHasBytesAvailable, nullptr);
+    });
+}
+
+static void pendingStreamUnschedule(CFReadStreamRef, CFRunLoopRef, CFStringRef, void*)
+{
+}
+
 RetainPtr<CFReadStreamRef> createHTTPBodyCFReadStream(FormData& formData)
 {
     if (!hasPlatformStrategies() && formData.containsBlobElement())
         return nullptr;
 
+    ASSERT(isMainThread());
+
+    if (formData.isPendingStream()) {
+        RefPtr state = formData.pendingStreamState();
+        if (!state)
+            return nullptr;
+        auto* context = new PendingStreamCreationContext { state.releaseNonNull() };
+        CFReadStreamCallBacksV1 pendingStreamCallBacks = { 1, pendingStreamCreate, pendingStreamFinalize, nullptr, pendingStreamOpen, nullptr, pendingStreamRead, nullptr, pendingStreamCanRead, pendingStreamClose, pendingStreamCopyProperty, nullptr, nullptr, pendingStreamSchedule, pendingStreamUnschedule };
+        return adoptCF(CFReadStreamCreate(nullptr, static_cast<const void*>(&pendingStreamCallBacks), context));
+    }
+
     auto resolvedFormData = formData.resolveBlobReferences();
     auto dataForUpload = resolvedFormData->prepareForUpload();
 
-    // Precompute the content length so CFNetwork doesn't use chunked mode, except for readable stream
-    // uploads (HTTP/2+ only) where we leave the length unset so no Content-Length header is added to the request.
-    std::optional<unsigned long long> length;
-    if (!dataForUpload.data().isPendingStream()) {
-        length = 0;
-        for (auto& element : dataForUpload.data().elements()) {
-            *length += element.lengthInBytes([](auto& url) {
-                return blobRegistry()->blobRegistryImpl()->blobSize(url);
-            });
-        }
+    // Precompute the content length so CFNetwork doesn't use chunked mode.
+    unsigned long long length = 0;
+    for (auto& element : dataForUpload.data().elements()) {
+        length += element.lengthInBytes([](auto& url) {
+            return blobRegistry()->blobRegistryImpl()->blobSize(url);
+        });
     }
-    ASSERT(isMainThread());
+
     FormCreationContext* formContext = new FormCreationContext { WTF::move(dataForUpload), length };
     CFReadStreamCallBacksV1 callBacks = { 1, formCreate, formFinalize, nullptr, formOpen, nullptr, formRead, nullptr, formCanRead, formClose, formCopyProperty, nullptr, nullptr, formSchedule, formUnschedule };
     return adoptCF(CFReadStreamCreate(nullptr, static_cast<const void*>(&callBacks), formContext));

--- a/Source/WebKit/NetworkProcess/NetworkDataTask.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkDataTask.cpp
@@ -91,9 +91,6 @@ NetworkDataTask::NetworkDataTask(NetworkSession& session, NetworkDataTaskClient&
 {
     ASSERT(RunLoop::isMain());
 
-    if (RefPtr body = requestWithCredentials.httpBody())
-        m_hasPendingStreamBody = body->isPendingStream();
-
     if (!requestWithCredentials.url().isValid()) {
         scheduleFailure(FailureType::InvalidURL);
         return;
@@ -120,6 +117,12 @@ NetworkDataTask::~NetworkDataTask()
 
     if (CheckedPtr session = m_session.get())
         session->unregisterNetworkDataTask(*this);
+}
+
+bool NetworkDataTask::hasPendingStreamBody() const
+{
+    RefPtr body = m_firstRequest.httpBody();
+    return body && body->isPendingStream();
 }
 
 void NetworkDataTask::scheduleFailure(FailureType type)

--- a/Source/WebKit/NetworkProcess/NetworkDataTask.h
+++ b/Source/WebKit/NetworkProcess/NetworkDataTask.h
@@ -32,6 +32,7 @@
 #include <WebCore/Credential.h>
 #include <WebCore/FrameLoaderTypes.h>
 #include <WebCore/NetworkLoadMetrics.h>
+#include <WebCore/PendingStreamIdentifier.h>
 #include <WebCore/ResourceLoaderOptions.h>
 #include <WebCore/ResourceRequest.h>
 #include <WebCore/StoredCredentialsPolicy.h>
@@ -157,6 +158,8 @@ public:
 
     size_t bytesTransferredOverNetwork() const { return m_bytesTransferredOverNetwork; }
 
+    bool hasPendingStreamBody() const;
+
 protected:
     NetworkDataTask(NetworkSession&, NetworkDataTaskClient&, const WebCore::ResourceRequest&, WebCore::StoredCredentialsPolicy, bool shouldClearReferrerOnHTTPSToHTTPRedirect, bool dataTaskIsForMainFrameNavigation, bool isInitiatedByDedicatedWorker);
 
@@ -170,7 +173,6 @@ protected:
 
     void restrictRequestReferrerToOriginIfNeeded(WebCore::ResourceRequest&);
     void setBytesTransferredOverNetwork(size_t bytes) { m_bytesTransferredOverNetwork = bytes; }
-    bool hasPendingStreamBody() const { return m_hasPendingStreamBody; }
 
     const WeakPtr<NetworkSession> m_session;
     WeakPtr<NetworkDataTaskClient> m_client;
@@ -186,7 +188,6 @@ protected:
     WebCore::ResourceRequest m_firstRequest;
     WebCore::ResourceRequest m_previousRequest;
     String m_suggestedFilename;
-    bool m_hasPendingStreamBody { false };
     size_t m_bytesTransferredOverNetwork { 0 };
     bool m_shouldClearReferrerOnHTTPSToHTTPRedirect { true };
     bool m_dataTaskIsForMainFrameNavigation { false };

--- a/Source/WebKit/NetworkProcess/NetworkLoad.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkLoad.cpp
@@ -37,6 +37,7 @@
 #include "NetworkSession.h"
 #include "WebErrors.h"
 #include <WebCore/AuthenticationChallenge.h>
+#include <WebCore/HTTPStatusCodes.h>
 #include <WebCore/ResourceRequest.h>
 #include <WebCore/SharedBuffer.h>
 #include <wtf/NeverDestroyed.h>
@@ -185,14 +186,23 @@ void NetworkLoad::willPerformHTTPRedirection(ResourceResponse&& redirectResponse
     ASSERT(!redirectResponse.isNull());
     ASSERT(RunLoop::isMain());
 
-    if (!m_networkProcess->ftpEnabled() && request.url().protocolIsInFTPFamily()) {
+    auto errorCallback = [&](ResourceError&& error) {
         m_task->clearClient();
         m_task = nullptr;
         WebCore::NetworkLoadMetrics emptyMetrics;
-        didCompleteWithError(ResourceError { errorDomainWebKitInternal, 0, url(), "FTP URLs are disabled"_s, ResourceError::Type::AccessControl }, emptyMetrics);
+        didCompleteWithError(WTF::move(error), emptyMetrics);
 
         if (completionHandler)
             completionHandler({ });
+    };
+
+    if (!m_networkProcess->ftpEnabled() && request.url().protocolIsInFTPFamily()) {
+        errorCallback({ errorDomainWebKitInternal, 0, url(), "FTP URLs are disabled"_s, ResourceError::Type::AccessControl });
+        return;
+    }
+
+    if (redirectResponse.httpStatusCode() != httpStatus303SeeOther && protect(m_task)->hasPendingStreamBody()) {
+        errorCallback({ errorDomainWebKitInternal, 0, url(), "Fetch upload streams cannot handle redirections other than 303"_s, ResourceError::Type::Cancellation });
         return;
     }
 

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
@@ -74,6 +74,7 @@
 #include <WebCore/NetworkLoadMetrics.h>
 #include <WebCore/NetworkStorageSession.h>
 #include <WebCore/OriginAccessPatterns.h>
+#include <WebCore/PendingStreamState.h>
 #include <WebCore/RegistrableDomain.h>
 #include <WebCore/ReportingScope.h>
 #include <WebCore/SWServer.h>
@@ -180,6 +181,15 @@ NetworkResourceLoader::NetworkResourceLoader(NetworkResourceLoadParameters&& par
 #endif
     if (synchronousReply)
         m_synchronousLoadData = makeUnique<SynchronousLoadData>(WTF::move(synchronousReply));
+
+    if (RefPtr body = m_parameters.request.httpBody()) {
+        if (body->isPendingStream()) {
+            m_pendingStreamState = PendingStreamState::create();
+            // FIXME: Until we add support for getting data from web process, we pretend the body is empty.
+            protect(m_pendingStreamState)->endStream();
+            body->setPendingStreamState(*m_pendingStreamState);
+        }
+    }
 }
 
 NetworkResourceLoader::~NetworkResourceLoader()

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.h
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.h
@@ -55,6 +55,7 @@ class ContentFilter;
 class FormData;
 class LinkHeader;
 class NetworkStorageSession;
+class PendingStreamState;
 class Report;
 class ResourceRequest;
 }
@@ -319,6 +320,8 @@ private:
 
     std::unique_ptr<SynchronousLoadData> m_synchronousLoadData;
     Vector<Ref<WebCore::BlobDataFileReference>> m_fileReferences;
+
+    RefPtr<WebCore::PendingStreamState> m_pendingStreamState;
 
     bool m_wasStarted { false };
     bool m_didConsumeSandboxExtensions { false };

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.h
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.h
@@ -38,6 +38,7 @@ OBJC_CLASS NSURLSessionDataTask;
 OBJC_CLASS NSMutableURLRequest;
 
 namespace WebCore {
+class PendingStreamState;
 class RegistrableDomain;
 class SharedBuffer;
 enum class AdvancedPrivacyProtections : uint16_t;
@@ -110,6 +111,8 @@ private:
     WebCore::StoredCredentialsPolicy storedCredentialsPolicy() const final { return m_storedCredentialsPolicy; }
 
     void setTimingAllowFailedFlag() final;
+
+    void installPendingStreamProbe(WebCore::PendingStreamState&);
 
     WeakPtr<SessionWrapper> m_sessionWrapper;
     RefPtr<SandboxExtension> m_sandboxExtension;

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm
@@ -42,6 +42,7 @@
 #import <WebCore/NetworkStorageSession.h>
 #import <WebCore/NotImplemented.h>
 #import <WebCore/OriginAccessPatterns.h>
+#import <WebCore/PendingStreamState.h>
 #import <WebCore/RegistrableDomain.h>
 #import <WebCore/ResourceError.h>
 #import <WebCore/ResourceRequest.h>
@@ -188,6 +189,21 @@ void NetworkDataTaskCocoa::updateFirstPartyInfoForSession(const URL& requestURL)
         session->setFirstPartyHostIPAddress(requestURL.host().toString(), ipAddress.get());
 }
 
+void NetworkDataTaskCocoa::installPendingStreamProbe(WebCore::PendingStreamState& state)
+{
+    state.setHTTPVersionProbe([weakThis = ThreadSafeWeakPtr { *this }] {
+        RefPtr task = weakThis.get();
+        if (!task || !task->m_task)
+            return WebCore::PendingStreamState::HTTPVersion::Unknown;
+        auto protocolName = retainPtr([task->m_task _incompleteTaskMetrics].transactionMetrics.lastObject.networkProtocolName);
+        if (!protocolName)
+            return WebCore::PendingStreamState::HTTPVersion::Unknown;
+        if ([protocolName isEqualToString:@"h2"] || [protocolName isEqualToString:@"h2c"] || [protocolName isEqualToString:@"h3"])
+            return WebCore::PendingStreamState::HTTPVersion::HTTP2OrLater;
+        return WebCore::PendingStreamState::HTTPVersion::HTTP1;
+    });
+}
+
 NetworkDataTaskCocoa::NetworkDataTaskCocoa(NetworkSession& session, NetworkDataTaskClient& client, const NetworkLoadParameters& parameters)
     : NetworkDataTask(session, client, parameters.request, parameters.storedCredentialsPolicy, parameters.shouldClearReferrerOnHTTPSToHTTPRedirect, parameters.isMainFrameNavigation, parameters.isInitiatedByDedicatedWorker)
     , NetworkTaskCocoa(session)
@@ -228,6 +244,11 @@ NetworkDataTaskCocoa::NetworkDataTaskCocoa(NetworkSession& session, NetworkDataT
 
     auto thirdPartyCookieBlockingDecision = requestThirdPartyCookieBlockingDecision(request);
     restrictRequestReferrerToOriginIfNeeded(request);
+
+    if (RefPtr body = request.httpBody()) {
+        if (RefPtr state = body->pendingStreamState())
+            installPendingStreamProbe(*state);
+    }
 
     RetainPtr<NSURLRequest> nsRequest = request.nsURLRequest(WebCore::HTTPBodyUpdatePolicy::UpdateHTTPBody);
     ASSERT(nsRequest);

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -2782,6 +2782,7 @@ enum class WebCore::IncludeSecureCookies : bool;
     bool m_alwaysStream;
     Vector<uint8_t> m_boundary;
     [NotSerialized] std::optional<uint64_t> m_lengthInBytes;
+    [NotSerialized] RefPtr<WebCore::PendingStreamState> m_pendingStreamState;
 };
 
 #if ENABLE(ASYNC_SCROLLING)


### PR DESCRIPTION
#### 538ad3aecfc8ee20c27bbd0126d855337c202df4
<pre>
FormData upload should be able to dereference the stream from its identifier in networking process
<a href="https://rdar.apple.com/182523406">rdar://182523406</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=319677">https://bugs.webkit.org/show_bug.cgi?id=319677</a>

Reviewed by Alex Christensen.

We add to FormData a RefPtr&lt;PendingStreamState&gt; member.
It is set by NetworkResourceLoader so that NetworkResourceLoader will be able to feed the PendingStreamState with data coming from web process via IPC.

NetworkDataTaskCocoa is setting the probe callback which allows to determine whether the upload connection is HTTP2+ or not.
This is used in FormDataStreamCFNet at the time of creating CFNetwork stream upload.
At that time, the NetworkDataTaskCocoa task is tied to a specific connection, which allows to know whether the connection is HTTP2+ or not.
If connection is not HTTP2+, we fail the load as per fetch spec.

For cocoa, we no longer fail stream uploads for HTTP2+, even though there is no data being uploaded yet.
We rebase WPT fetch/api/redirect/redirect-upload.h2.any.xxx.html tests as now Fetch upload streams are accepted.
To keep the 301/302/307/308 test passings, we make sure that these uploads fail except for 303, as per fetch specification in NetworkLoad.

For Glib, since we still fail stream uploads, we have to keep previous expected.txt files for glib as is, hence the newly added LayoutTests/platform/glib expectations.

Covered by existing and rebased tests.

* LayoutTests/imported/w3c/web-platform-tests/fetch/api/redirect/redirect-upload.h2.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fetch/api/redirect/redirect-upload.h2.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fetch/api/redirect/redirect-upload.h2.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fetch/api/redirect/redirect-upload.h2.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/fetch-event.https.h2-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/fetch/api/redirect/redirect-upload.h2.any-expected.txt: Copied from LayoutTests/imported/w3c/web-platform-tests/fetch/api/redirect/redirect-upload.h2.any-expected.txt.
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/fetch/api/redirect/redirect-upload.h2.any.serviceworker-expected.txt: Copied from LayoutTests/imported/w3c/web-platform-tests/fetch/api/redirect/redirect-upload.h2.any.serviceworker-expected.txt.
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/fetch/api/redirect/redirect-upload.h2.any.sharedworker-expected.txt: Copied from LayoutTests/imported/w3c/web-platform-tests/fetch/api/redirect/redirect-upload.h2.any.sharedworker-expected.txt.
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/fetch/api/redirect/redirect-upload.h2.any.worker-expected.txt: Copied from LayoutTests/imported/w3c/web-platform-tests/fetch/api/redirect/redirect-upload.h2.any.worker-expected.txt.
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/service-workers/service-worker/fetch-event.https.h2-expected.txt: Copied from LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/fetch-event.https.h2-expected.txt.
* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/network/FormData.cpp:
(WebCore::FormData::setPendingStreamState):
* Source/WebCore/platform/network/FormData.h:
* Source/WebCore/platform/network/PendingStreamState.cpp: Added.
(WebCore::PendingStreamState::DataAvailableHandler::create):
(WebCore::PendingStreamState::DataAvailableHandler::invoke):
(WebCore::PendingStreamState::DataAvailableHandler::DataAvailableHandler):
(WebCore::PendingStreamState::create):
(WebCore::PendingStreamState::setHTTPVersionProbe):
(WebCore::PendingStreamState::invokeHandlerIfNeeded):
(WebCore::PendingStreamState::appendData):
(WebCore::PendingStreamState::endStream):
(WebCore::PendingStreamState::errorStream):
(WebCore::PendingStreamState::setDataAvailableHandler):
(WebCore::PendingStreamState::clearDataAvailableHandler):
(WebCore::PendingStreamState::currentHTTPVersion):
(WebCore::PendingStreamState::read):
(WebCore::PendingStreamState::hasReadyData):
* Source/WebCore/platform/network/PendingStreamState.h: Added.
(WebCore::PendingStreamState::WTF_GUARDED_BY_LOCK):
* Source/WebCore/platform/network/cf/FormDataStreamCFNet.mm:
(WebCore::formOpen):
(WebCore::formRead):
(WebCore::formCanRead):
(WebCore::formCopyProperty):
(WebCore::PendingStreamFields::PendingStreamFields):
(WebCore::PendingStreamFields::cfFormStream):
(WebCore::pendingStreamCreate):
(WebCore::pendingStreamFinalize):
(WebCore::pendingStreamOpen):
(WebCore::pendingStreamRead):
(WebCore::pendingStreamCanRead):
(WebCore::pendingStreamClose):
(WebCore::pendingStreamCopyProperty):
(WebCore::pendingStreamSchedule):
(WebCore::pendingStreamUnschedule):
(WebCore::createHTTPBodyCFReadStream):
* Source/WebKit/NetworkProcess/NetworkDataTask.cpp:
(WebKit::NetworkDataTask::NetworkDataTask):
(WebKit::NetworkDataTask::hasPendingStreamBody const):
* Source/WebKit/NetworkProcess/NetworkDataTask.h:
(WebKit::NetworkDataTask::setBytesTransferredOverNetwork):
(WebKit::NetworkDataTask::hasPendingStreamBody const):
* Source/WebKit/NetworkProcess/NetworkLoad.cpp:
(WebKit::NetworkLoad::willPerformHTTPRedirection):
* Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp:
* Source/WebKit/NetworkProcess/NetworkResourceLoader.h:
* Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.h:
* Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm:
(WebKit::NetworkDataTaskCocoa::installPendingStreamProbe):
(WebKit::NetworkDataTaskCocoa::NetworkDataTaskCocoa):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/317791@main">https://commits.webkit.org/317791@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1291d6014029121049e28b33e8fa2f78d6caf0ea

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176374 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50309 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44099 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185973 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/138631 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4a58e6ba-cd43-492b-9e6a-209bcba46990) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178237 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51601 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49993 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/137378 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/138631 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179330 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40867 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/158165 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117853 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c1e0402c-0c64-4cd0-b2c8-5f2a1ae1bb62) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39516 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/37879 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149932 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37663 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34441 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/42038 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/42090 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188396 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49974 "Built successfully") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/146422 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39375 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50658 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/34281 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146235 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41011 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/122862 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/116911 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49162 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12638 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48564 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48798 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48623 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->