### PR TITLE
[WPE Platform] New internal API to create a touch event with multiple touch points

### DIFF
--- a/LayoutTests/platform/wpe/TestExpectations
+++ b/LayoutTests/platform/wpe/TestExpectations
@@ -918,21 +918,11 @@ webkit.org/b/228311 imported/w3c/web-platform-tests/css/css-scoping/css-scoping-
 fast/events/mouse-cursor-pseudo-elements.html [ Failure Pass ]
 
 webkit.org/b/278719 fast/events/touch/touch-event-frames.html [ Failure ]
-
-webkit.org/b/278719 fast/events/touch/basic-multi-touch-events.html [ Failure ]
-webkit.org/b/278719 fast/events/touch/basic-multi-touch-events-limited.html [ Failure ]
 webkit.org/b/278719 fast/events/touch/frame-hover-update.html [ Failure ]
-
-webkit.org/b/278719 fast/events/touch/multi-touch-grouped-targets.html [ Failure ]
-webkit.org/b/278719 fast/events/touch/multi-touch-inside-nested-iframes.html [ Failure ]
 webkit.org/b/278719 fast/events/touch/multi-touch-some-without-handlers.html [ Failure ]
 webkit.org/b/278719 fast/events/touch/ontouchstart-active-selector.html [ Failure  ]
 webkit.org/b/278719 fast/events/touch/send-oncancel-event.html [ Pass ]
 webkit.org/b/278719 fast/events/touch/touch-event-pageXY.html [ Failure ]
-webkit.org/b/278719 fast/events/touch/touch-target.html [ Timeout ]
-webkit.org/b/278719 fast/events/touch/touch-target-limited.html [ Failure ]
-
-webkit.org/b/278719 fast/events/touch/input-touch-target.html [ Failure ]
 webkit.org/b/278719 fast/events/touch/zoomed-touch-event-pageXY.html [ Failure ]
 
 # The assertion failure occurs to WPE only.

--- a/Source/WebKit/UIProcess/API/wpe/WPEWebViewPlatform.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/WPEWebViewPlatform.cpp
@@ -43,6 +43,10 @@
 #include <WebCore/SystemSettings.h>
 #include <wtf/glib/GUniquePtr.h>
 
+#if ENABLE(DEVELOPER_MODE)
+#include "WPEEventInternal.h"
+#endif
+
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
 #include <skia/core/SkPixmap.h>
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
@@ -324,6 +328,37 @@ void ViewPlatform::toplevelStateChanged(WPEToplevelState previousState, WPETople
 }
 
 #if ENABLE(TOUCH_EVENTS)
+#if ENABLE(DEVELOPER_MODE)
+static Vector<WebKit::WebPlatformTouchPoint> platformTouchPoints(const Vector<WPETouchPoint>& touchPoints)
+{
+    Vector<WebPlatformTouchPoint> points;
+    points.reserveInitialCapacity(touchPoints.size());
+    for (const auto& touchPoint : touchPoints) {
+        WebCore::IntPoint position(touchPoint.x, touchPoint.y);
+        WebPlatformTouchPoint::State state = WebPlatformTouchPoint::State::Stationary;
+        switch (touchPoint.state) {
+        case WPETouchPointState::Stationary:
+            state = WebPlatformTouchPoint::State::Stationary;
+            break;
+        case WPETouchPointState::Pressed:
+            state = WebPlatformTouchPoint::State::Pressed;
+            break;
+        case WPETouchPointState::Moved:
+            state = WebPlatformTouchPoint::State::Moved;
+            break;
+        case WPETouchPointState::Released:
+            state = WebPlatformTouchPoint::State::Released;
+            break;
+        case WPETouchPointState::Cancelled:
+            state = WebPlatformTouchPoint::State::Cancelled;
+            break;
+        }
+        points.append(WebPlatformTouchPoint(touchPoint.sequenceID, state, position, position));
+    }
+    return points;
+}
+#endif // ENABLE(DEVELOPER_MODE)
+
 Vector<WebKit::WebPlatformTouchPoint> ViewPlatform::touchPointsForEvent(WPEEvent* event)
 {
     auto stateForEvent = [](uint32_t id, WPEEvent* event) -> WebPlatformTouchPoint::State {
@@ -361,6 +396,12 @@ Vector<WebKit::WebPlatformTouchPoint> ViewPlatform::touchPointsForEvent(WPEEvent
 
 gboolean ViewPlatform::handleEvent(WPEEvent* event)
 {
+#if ENABLE(TOUCH_EVENTS) && ENABLE(DEVELOPER_MODE)
+    if (wpeEventIsTouchForTesting(event)) {
+        page().handleTouchEvent(nullptr, NativeWebTouchEvent(event, platformTouchPoints(wpeEventTouchPointsForTesting(event))));
+        return TRUE;
+    }
+#endif
     switch (wpe_event_get_event_type(event)) {
     case WPE_EVENT_NONE:
         RELEASE_ASSERT_NOT_REACHED();

--- a/Source/WebKit/WPEPlatform/wpe/WPEEvent.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEEvent.cpp
@@ -30,6 +30,11 @@
 #include <wtf/StdLibExtras.h>
 #include <wtf/glib/GRefPtr.h>
 
+#if ENABLE(DEVELOPER_MODE)
+#include "WPEEventInternal.h"
+#include <wtf/Vector.h>
+#endif
+
 struct WPEEventPointerButton {
     WPEModifiers modifiers { static_cast<WPEModifiers>(0) };
     unsigned button { 0 };
@@ -69,6 +74,13 @@ struct WPEEventTouch {
     double y { 0 };
 };
 
+#if ENABLE(DEVELOPER_MODE)
+struct WPEEventTouchForTesting {
+    WPEModifiers modifiers { static_cast<WPEModifiers>(0) };
+    Vector<WPETouchPoint> touchPoints;
+};
+#endif
+
 /**
  * WPEEvent: (ref-func wpe_event_ref) (unref-func wpe_event_unref)
  *
@@ -92,7 +104,11 @@ struct _WPEEvent {
         GDestroyNotify destroyFunction { nullptr };
     } userData;
 
+#if ENABLE(DEVELOPER_MODE)
+    Variant<WPEEventPointerButton, WPEEventPointerMove, WPEEventScroll, WPEEventKeyboard, WPEEventTouch, WPEEventTouchForTesting> variant;
+#else
     Variant<WPEEventPointerButton, WPEEventPointerMove, WPEEventScroll, WPEEventKeyboard, WPEEventTouch> variant;
+#endif
 
     int referenceCount { 1 };
 };
@@ -247,6 +263,9 @@ WPEModifiers wpe_event_get_modifiers(WPEEvent* event)
         [](const WPEEventScroll& scroll) { return scroll.modifiers; },
         [](const WPEEventKeyboard& keyboard) { return keyboard.modifiers; },
         [](const WPEEventTouch& touch) { return touch.modifiers; },
+#if ENABLE(DEVELOPER_MODE)
+        [](const WPEEventTouchForTesting& touch) { return touch.modifiers; },
+#endif
         [](const auto&) { return static_cast<WPEModifiers>(0); }
     );
 }
@@ -577,3 +596,24 @@ guint32 wpe_event_touch_get_sequence_id(WPEEvent* event)
 
     return std::get<WPEEventTouch>(event->variant).sequenceID;
 }
+
+#if ENABLE(DEVELOPER_MODE)
+WPEEvent* wpeEventTouchCreateForTesting(WPEEventType type, WPEView* view, WPEInputSource source, guint32 time, WPEModifiers modifiers, Vector<WPETouchPoint>&& touchPoints)
+{
+    ASSERT(type == WPE_EVENT_TOUCH_DOWN || type == WPE_EVENT_TOUCH_UP || type == WPE_EVENT_TOUCH_MOVE || type == WPE_EVENT_TOUCH_CANCEL);
+    return new _WPEEvent { view, type, source, time, { nullptr, nullptr }, WPEEventTouchForTesting { modifiers,  WTF::move(touchPoints) }, 1 };
+}
+
+bool wpeEventIsTouchForTesting(WPEEvent* event)
+{
+    if (!(event->type == WPE_EVENT_TOUCH_DOWN || event->type == WPE_EVENT_TOUCH_UP || event->type == WPE_EVENT_TOUCH_MOVE || event->type == WPE_EVENT_TOUCH_CANCEL))
+        return false;
+    return std::holds_alternative<WPEEventTouchForTesting>(event->variant);
+}
+
+const Vector<WPETouchPoint>& wpeEventTouchPointsForTesting(WPEEvent* event)
+{
+    ASSERT(wpeEventIsTouchForTesting(event));
+    return std::get<WPEEventTouchForTesting>(event->variant).touchPoints;
+}
+#endif

--- a/Source/WebKit/WPEPlatform/wpe/WPEEventInternal.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPEEventInternal.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2026 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "WPEEvent.h"
+#include <wtf/Forward.h>
+
+enum class WPETouchPointState : uint8_t {
+    Stationary,
+    Pressed,
+    Moved,
+    Released,
+    Cancelled,
+};
+
+struct WPETouchPoint {
+    uint32_t sequenceID;
+    WPETouchPointState state;
+    double x;
+    double y;
+};
+
+WPE_API WPEEvent* wpeEventTouchCreateForTesting(WPEEventType, WPEView*, WPEInputSource, guint32 time, WPEModifiers, Vector<WPETouchPoint>&&);
+
+WPE_API bool wpeEventIsTouchForTesting(WPEEvent*);
+
+WPE_API const Vector<WPETouchPoint>& wpeEventTouchPointsForTesting(WPEEvent*);

--- a/Tools/WebKitTestRunner/wpe/EventSenderProxyClientWPE.cpp
+++ b/Tools/WebKitTestRunner/wpe/EventSenderProxyClientWPE.cpp
@@ -31,6 +31,7 @@
 #include "PlatformWebView.h"
 #include "PlatformWebViewClientWPE.h"
 #include "TestController.h"
+#include <wpe/WPEEventInternal.h>
 #include <wpe/wpe-platform.h>
 #include <wtf/MonotonicTime.h>
 #include <wtf/UniqueArray.h>
@@ -396,59 +397,67 @@ void EventSenderProxyClientWPE::clearTouchPoints()
     m_touchPoints.clear();
 }
 
-struct EventSenderProxyClientWPE::TouchPointContext {
-    const TouchPoint::State targetState;
-    const std::optional<TouchPoint::State> newState;
-    const WPEEventType eventType;
-    const double time;
-    const WPEModifiers modifiers;
-    WPEView* view;
-};
-
-std::function<bool(EventSenderProxyClientWPE::TouchPoint&)> EventSenderProxyClientWPE::pointProcessor(const TouchPointContext& context)
+void EventSenderProxyClientWPE::sendTouchEvent(int type, double time)
 {
-    return [context](TouchPoint& point) -> bool {
-        if (point.state != context.targetState)
-            return false;
-
-        if (context.newState)
-            point.state = *context.newState;
-
-        auto* event = wpe_event_touch_new(context.eventType, context.view, WPE_INPUT_SOURCE_TOUCHSCREEN, secToMsTimestamp(context.time), context.modifiers, point.id, point.x, point.y);
-        wpe_view_event(context.view, event);
-        wpe_event_unref(event);
-        return true;
+    auto toWPETouchPointState = [](EventSenderProxyClientWPE::TouchPoint::State state) -> WPETouchPointState {
+        switch (state) {
+        case EventSenderProxyClientWPE::TouchPoint::State::Down:
+            return WPETouchPointState::Pressed;
+        case EventSenderProxyClientWPE::TouchPoint::State::Up:
+            return WPETouchPointState::Released;
+        case EventSenderProxyClientWPE::TouchPoint::State::Move:
+            return WPETouchPointState::Moved;
+        case EventSenderProxyClientWPE::TouchPoint::State::Cancel:
+            return WPETouchPointState::Cancelled;
+        case EventSenderProxyClientWPE::TouchPoint::State::Stationary:
+            return WPETouchPointState::Stationary;
+        }
+        ASSERT_NOT_REACHED();
+        return WPETouchPointState::Stationary;
     };
+
+    auto* view = WKViewGetView(m_testController.mainWebView()->platformView());
+    auto points = m_touchPoints.map([&](const auto& point) {
+        return WPETouchPoint(point.id, toWPETouchPointState(point.state), point.x, point.y);
+    });
+
+    auto* event = wpeEventTouchCreateForTesting(static_cast<WPEEventType>(type), view, WPE_INPUT_SOURCE_TOUCHSCREEN, secToMsTimestamp(time), static_cast<WPEModifiers>(m_touchModifiers), WTF::move(points));
+    wpe_view_event(view, event);
+    wpe_event_unref(event);
 }
 
 void EventSenderProxyClientWPE::touchStart(double time)
 {
-    auto* view = WKViewGetView(m_testController.mainWebView()->platformView());
-    auto downPointProcessor = pointProcessor(TouchPointContext { TouchPoint::State::Down, TouchPoint::State::Stationary, WPE_EVENT_TOUCH_DOWN, time, static_cast<WPEModifiers>(m_touchModifiers), view });
+    sendTouchEvent(WPE_EVENT_TOUCH_DOWN, time);
     for (auto& point : m_touchPoints)
-        downPointProcessor(point);
+        point.state = TouchPoint::State::Stationary;
 }
 
 void EventSenderProxyClientWPE::touchMove(double time)
 {
-    auto* view = WKViewGetView(m_testController.mainWebView()->platformView());
-    auto movePointProcessor = pointProcessor(TouchPointContext { TouchPoint::State::Move, TouchPoint::State::Stationary, WPE_EVENT_TOUCH_MOVE, time, static_cast<WPEModifiers>(m_touchModifiers), view });
+    sendTouchEvent(WPE_EVENT_TOUCH_MOVE, time);
     for (auto& point : m_touchPoints)
-        movePointProcessor(point);
+        point.state = TouchPoint::State::Stationary;
 }
 
 void EventSenderProxyClientWPE::touchEnd(double time)
 {
-    auto* view = WKViewGetView(m_testController.mainWebView()->platformView());
-    auto upPointProcessor = pointProcessor(TouchPointContext { TouchPoint::State::Up, std::nullopt, WPE_EVENT_TOUCH_UP, time, static_cast<WPEModifiers>(0), view });
-    m_touchPoints.removeAllMatching(upPointProcessor);
+    sendTouchEvent(WPE_EVENT_TOUCH_UP, time);
+    m_touchPoints.removeAllMatching([](const auto& point) {
+        return point.state == TouchPoint::State::Up;
+    });
+    for (auto& point : m_touchPoints)
+        point.state = TouchPoint::State::Stationary;
 }
 
 void EventSenderProxyClientWPE::touchCancel(double time)
 {
-    auto* view = WKViewGetView(m_testController.mainWebView()->platformView());
-    auto cancelPointProcessor = pointProcessor(TouchPointContext { TouchPoint::State::Cancel, std::nullopt, WPE_EVENT_TOUCH_CANCEL, time, static_cast<WPEModifiers>(0), view });
-    m_touchPoints.removeAllMatching(cancelPointProcessor);
+    sendTouchEvent(WPE_EVENT_TOUCH_CANCEL, time);
+    m_touchPoints.removeAllMatching([](const auto& point) {
+        return point.state == TouchPoint::State::Cancel;
+    });
+    for (auto& point : m_touchPoints)
+        point.state = TouchPoint::State::Stationary;
 }
 
 void EventSenderProxyClientWPE::setTouchModifier(WKEventModifiers wkModifiers, bool enable)

--- a/Tools/WebKitTestRunner/wpe/EventSenderProxyClientWPE.h
+++ b/Tools/WebKitTestRunner/wpe/EventSenderProxyClientWPE.h
@@ -60,6 +60,7 @@ private:
     void touchEnd(double) override;
     void touchCancel(double) override;
     void setTouchModifier(WKEventModifiers, bool);
+    void sendTouchEvent(int type, double time);
 
     struct TouchPoint {
         enum class State { Down, Up, Move, Cancel, Stationary };
@@ -71,8 +72,6 @@ private:
     };
 
     struct TouchPointContext;
-
-    std::function<bool(TouchPoint&)> pointProcessor(const TouchPointContext&);
 
     Vector<TouchPoint> m_touchPoints;
     unsigned m_touchModifiers { 0 };


### PR DESCRIPTION
#### 103ad17fab7bb625a285a8f785e7a1bc709ccb6d
<pre>
[WPE Platform] New internal API to create a touch event with multiple touch points
<a href="https://bugs.webkit.org/show_bug.cgi?id=319941">https://bugs.webkit.org/show_bug.cgi?id=319941</a>

Reviewed by Carlos Garcia Campos.

WPE Platform API wpe_event_touch_new takes only a single touch point. This is
not a problem for normal usecases. If two fingers touch the screen, the
application calls wpe_event_touch_new twice with a single touch point each
time. WPEWebViewPlatform class memorizes all touch points in m_touchEvents
member variable.

However, this causes two problems for layout tests. Some layout tests expect a
touch event with multiple touch points at a time. For example,
fast/events/touch/touch-target.html has this code.

&gt;     eventSender.clearTouchPoints();
&gt;     eventSender.addTouchPoint(50, 150);
&gt;     eventSender.addTouchPoint(50, 250);
&gt;     eventSender.touchStart();

This should dispatch a touchstart event with two touch points at a time.
However, WPE WebKitTestRunner dispatched two touchstart events because
wpe_event_touch_new accepts only a single touch point at a time.

The second problem is that some layout tests don&apos;t release all touch points.
For example, fast/events/touch/touch-target.html has this code at the end of
the test.

&gt;    eventSender.releaseTouchPoint(1);
&gt;    eventSender.touchEnd();

Only the 1st touch point is released. The 0th touch point isn&apos;t released. This
caused a problme for the next test because WPEWebViewPlatform memorizes touch
points in m_touchEvents.

Added new internal API wpeEventTouchCreateForTesting, wpeEventIsTouchForTesting
and wpeEventTouchTouchPoints.

* Source/WebKit/UIProcess/API/wpe/WPEWebViewPlatform.cpp:
(WKWPE::platformTouchPoints):
(WKWPE::ViewPlatform::handleEvent):
* Source/WebKit/WPEPlatform/wpe/WPEEvent.cpp:
(wpe_event_get_modifiers):
(wpe_event_touch_get_sequence_id):
(wpeEventTouchCreateForTesting):
(wpeEventTouchTouchPoints):
(wpeEventTouchPointsForTesting):
(wpeEventIsTouchForTesting):
* Tools/WebKitTestRunner/wpe/EventSenderProxyClientWPE.cpp:
(WTR::EventSenderProxyClientWPE::sendTouchEvent):
(WTR::EventSenderProxyClientWPE::touchStart):
(WTR::EventSenderProxyClientWPE::touchMove):
(WTR::EventSenderProxyClientWPE::touchEnd):
(WTR::EventSenderProxyClientWPE::touchCancel):
(WTR::std::function&lt;bool): Deleted.
* Tools/WebKitTestRunner/wpe/EventSenderProxyClientWPE.h:
* LayoutTests/platform/wpe/TestExpectations:
* Source/WebKit/WPEPlatform/wpe/WPEEventInternal.h: Added.

Canonical link: <a href="https://commits.webkit.org/318003@main">https://commits.webkit.org/318003@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3670cf1d91b249d76f768171e24a57879ea15aba

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177029 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50966 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/44761 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186632 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140265 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178892 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/52259 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50652 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/137932 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140265 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179985 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/52259 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/44761 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118401 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/52259 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/38472 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/44761 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/52259 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/44761 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35100 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/42732 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/42690 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189055 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/50633 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/44761 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/147019 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/51316 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/44761 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146811 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26846 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/51316 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/123530 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117817 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/49821 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/44761 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/49220 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/49457 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/49281 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->