### PR TITLE
Improve the Immersive API documentation

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKImmersiveEnvironment.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKImmersiveEnvironment.h
@@ -30,7 +30,7 @@
 
 NS_HEADER_AUDIT_BEGIN(nullability, sendability)
 
-/*! @abstract An object representing a website-provided immersive environment that is ready for presentation.
+/*! @abstract An object that represents a website-provided immersive environment ready for presentation.
  */
 NS_SWIFT_UI_ACTOR
 NS_SWIFT_SENDABLE
@@ -41,7 +41,7 @@ WK_API_UNAVAILABLE(macos, ios)
 + (instancetype)new NS_UNAVAILABLE;
 - (instancetype)init NS_UNAVAILABLE;
 
-/*! @abstract The frame information of the website that provided this immersive environment.
+/*! @abstract The frame information of the website that provides this immersive environment.
  */
 @property (nonatomic, readonly) WKFrameInfo *sourceFrame WK_API_AVAILABLE(visionos(27.0));
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKImmersiveEnvironmentDelegate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKImmersiveEnvironmentDelegate.h
@@ -32,9 +32,8 @@
 
 NS_HEADER_AUDIT_BEGIN(nullability, sendability)
 
-/*! @abstract A protocol for managing immersive environment presentation in a web view.
- @discussion Implement the methods of this protocol to control authorization, presentation,
- and dismissal of immersive environments requested by websites.
+/*! @abstract A protocol that manages the authorization, presentation, and dismissal of immersive environments in a web view.
+ @discussion Assign an object that adopts this protocol to the `immersiveEnvironmentDelegate` property of a `WKWebView`.
  */
 NS_SWIFT_UI_ACTOR
 WK_API_AVAILABLE(visionos(27.0))
@@ -44,7 +43,7 @@ WK_API_UNAVAILABLE(macos, ios)
 /*! @abstract Asks the delegate whether to allow an immersive environment from the specified frame.
  @param webView The web view that received the immersive environment request.
  @param frame The frame information from the website requesting the immersive environment.
- @param completionHandler The completion handler you must invoke with the request's answer. `YES` to allow
+ @param completionHandler The completion handler to invoke with the result of the authorization request. Pass `YES` to allow
  the environment presentation, or `NO` to deny it.
  */
 - (void)webView:(WKWebView *)webView shouldAllowImmersiveEnvironmentFromFrame:(WKFrameInfo *)frame completionHandler:(void (^)(BOOL allow))completionHandler NS_SWIFT_ASYNC_NAME(webView(_:shouldAllowImmersiveEnvironmentFrom:)) WK_API_AVAILABLE(visionos(27.0));
@@ -52,15 +51,15 @@ WK_API_UNAVAILABLE(macos, ios)
 /*! @abstract Asks the delegate to present an immersive environment.
  @param webView The web view requesting presentation.
  @param environment The immersive environment to present.
- @param completionHandler The completion handler you must invoke once the presentation transition has completed.
- The error argument should be used in case the presentation failed and the environment couldn't be presented.
+ @param completionHandler The completion handler to invoke after the presentation transition completes.
+ Pass an error if the presentation fails; otherwise, pass `nil`.
  */
 - (void)webView:(WKWebView *)webView presentImmersiveEnvironment:(WKImmersiveEnvironment *)environment completionHandler:(void (^)(NSError * _Nullable error))completionHandler NS_SWIFT_ASYNC_NAME(webView(_:presentImmersiveEnvironment:)) WK_API_AVAILABLE(visionos(27.0));
 
 /*! @abstract Asks the delegate to dismiss an immersive environment.
  @param webView The web view requesting dismissal.
  @param environment The immersive environment to dismiss.
- @param completionHandler The completion handler you must invoke once the dismissal transition has completed.
+ @param completionHandler The completion handler to invoke after the dismissal transition completes.
  */
 - (void)webView:(WKWebView *)webView dismissImmersiveEnvironment:(WKImmersiveEnvironment *)environment completionHandler:(void (^)(void))completionHandler NS_SWIFT_ASYNC_NAME(webView(_:dismissImmersiveEnvironment:)) WK_API_AVAILABLE(visionos(27.0));
 

--- a/Source/WebKit/UIProcess/API/Swift/WebPage+Configuration.swift
+++ b/Source/WebKit/UIProcess/API/Swift/WebPage+Configuration.swift
@@ -100,7 +100,7 @@ extension WebPage {
 
         private var backingAllowsImmersiveEnvironments = false
 
-        /// Indicates whether website immersive environments are allowed.
+        /// A Boolean value that indicates whether website immersive environments are allowed.
         ///
         /// Set this property to `true` to enable support for website immersive environments.
         /// If `false`, requests to present immersive environments are ignored.

--- a/Source/WebKit/UIProcess/API/Swift/WebPage+ImmersiveEnvironment.swift
+++ b/Source/WebKit/UIProcess/API/Swift/WebPage+ImmersiveEnvironment.swift
@@ -26,7 +26,7 @@
 public import Foundation
 
 extension WebPage {
-    /// An object representing a website-provided immersive environment that is ready for presentation.
+    /// An object that represents a website-provided immersive environment ready for presentation.
     @MainActor
     @available(anyAppleOSAndDownlevels 27.0, *)
     @available(iOS, unavailable)
@@ -40,7 +40,7 @@ extension WebPage {
             self.wrapped = wrapped
         }
 
-        /// The frame information of the website that provided this immersive environment.
+        /// The frame information of the website that provides this immersive environment.
         public var sourceFrame: WebPage.FrameInfo {
             WebPage.FrameInfo(wrapped.sourceFrame)
         }

--- a/Source/WebKit/_WebKit_SwiftUI/API/View+WebViewModifiers.swift
+++ b/Source/WebKit/_WebKit_SwiftUI/API/View+WebViewModifiers.swift
@@ -179,19 +179,22 @@ extension View {
     /// Use this modifier to control authorization, presentation, and dismissal of
     /// immersive environments from websites.
     ///
+    /// - Important: Set ``WebPage/Configuration/allowsImmersiveEnvironments`` to `true` before
+    ///   loading a page, or none of the callbacks will fire.
+    ///
     /// - Parameters:
     ///   - shouldAllow: An async closure called when a website requests an immersive environment.
-    ///     This can be used to request user consent or apply custom authorization logic.
-    ///     It receives the source `WebPage.FrameInfo` and should return `true` to allow
+    ///     Use this closure to request user consent or apply custom authorization logic.
+    ///     It receives the source ``WebPage/FrameInfo``. Return `true` to allow
     ///     the environment presentation, or `false` to deny it.
     ///   - present: An async throwing closure called after the environment has loaded and is ready
-    ///     for presentation. It receives the `WebPage.ImmersiveEnvironment`. Use this to
-    ///     open an Immersive Space containing a `WebViewImmersiveEnvironmentView` initialized
+    ///     for presentation. It receives the ``WebPage/ImmersiveEnvironment``. Use this to
+    ///     open an Immersive Space containing a ``WebViewImmersiveEnvironmentView`` initialized
     ///     with this environment. If another immersive space is already being presented,
-    ///     dismiss it first. This closure should return after the presentation transition completes.
-    ///   - dismiss: An async closure called when the website or the application asks to dismiss
-    ///     the immersive environment. It receives the `WebPage.ImmersiveEnvironment` to dismiss.
-    ///     This closure should return after the dismissal transition completes.
+    ///     dismiss it first. Return after the presentation transition completes.
+    ///   - dismiss: An async closure called when the website or the app asks to dismiss
+    ///     the immersive environment. It receives the ``WebPage/ImmersiveEnvironment`` to dismiss.
+    ///     Return after the dismissal transition completes.
     /// - Returns: A modified view that manages immersive environment lifecycle.
     @available(anyAppleOSAndDownlevels 27.0, *)
     @available(iOS, unavailable)

--- a/Source/WebKit/_WebKit_SwiftUI/API/WebViewImmersiveEnvironmentView.swift
+++ b/Source/WebKit/_WebKit_SwiftUI/API/WebViewImmersiveEnvironmentView.swift
@@ -30,7 +30,7 @@ import WebKit_Private
 /// A SwiftUI view that renders a specific website-provided immersive environment.
 ///
 /// Place this view in your app's Immersive Space hierarchy. Initialize it with the
-/// `WebPage.ImmersiveEnvironment` received from the presentation callback to render
+/// ``WebPage/ImmersiveEnvironment`` that the presentation callback provides to render
 /// that specific environment.
 @MainActor
 @available(anyAppleOSAndDownlevels 27.0, *)
@@ -46,7 +46,7 @@ public struct WebViewImmersiveEnvironmentView: View {
         self.init(environment.wrapped)
     }
 
-    /// Creates an immersive environment view from a `WKImmersiveEnvironment`.
+    /// Creates an immersive environment view from a ``WKImmersiveEnvironment``.
     public init(_ environment: WKImmersiveEnvironment) {
         self.environment = environment
     }


### PR DESCRIPTION
#### 1fa786a6d5aa6b5854d06233485bec44fe16c7d7
<pre>
Improve the Immersive API documentation
<a href="https://bugs.webkit.org/show_bug.cgi?id=319983">https://bugs.webkit.org/show_bug.cgi?id=319983</a>
<a href="https://rdar.apple.com/179862957">rdar://179862957</a>

Reviewed by Etienne Segonzac.

Align the immersive documentation syntax with the other API documentations.

* Source/WebKit/UIProcess/API/Cocoa/WKImmersiveEnvironment.h:
* Source/WebKit/UIProcess/API/Cocoa/WKImmersiveEnvironmentDelegate.h:
* Source/WebKit/UIProcess/API/Swift/WebPage+Configuration.swift:
* Source/WebKit/UIProcess/API/Swift/WebPage+ImmersiveEnvironment.swift:
* Source/WebKit/_WebKit_SwiftUI/API/View+WebViewModifiers.swift:
* Source/WebKit/_WebKit_SwiftUI/API/WebViewImmersiveEnvironmentView.swift:

Canonical link: <a href="https://commits.webkit.org/317711@main">https://commits.webkit.org/317711@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6385af5fb254723ed8cb049afcc39f7a96df7b04

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176089 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50024 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43814 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185685 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/138319 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51316 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49708 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137144 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/138319 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179045 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40615 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157916 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117619 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39264 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37633 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149680 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37413 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34153 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41740 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/41844 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188108 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49689 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146158 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39319 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50372 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/34031 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145987 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40772 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122575 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/116513 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48877 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12385 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48278 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48513 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48337 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->