### PR TITLE
AX: Line APIs mishandle the trailing blank line of a textarea whose value ends in a newline

### DIFF
--- a/LayoutTests/accessibility/mac/range-for-line-trailing-blank-line-expected.txt
+++ b/LayoutTests/accessibility/mac/range-for-line-trailing-blank-line-expected.txt
@@ -1,0 +1,32 @@
+This tests the line APIs for the trailing blank line of a textarea whose value ends in a newline: rangeForLine reports it as an empty range at the document end, and lineForIndex reports indices there as out of range (matching a value without a trailing newline having no phantom line).
+
+PASS: axTrailingNewline.rangeForLine(0) === '{0, 4}'
+PASS: axTrailingNewline.rangeForLine(1) === '{4, 4}'
+PASS: axTrailingNewline.rangeForLine(2) === '{8, 0}'
+PASS: axTrailingNewline.lineForIndex(0) === 0
+PASS: axTrailingNewline.lineForIndex(4) === 1
+PASS: axTrailingNewline.lineForIndex(7) === 1
+PASS: axTrailingNewline.lineForIndex(8) === -1
+PASS: axThreeLine.rangeForLine(0) === '{0, 4}'
+PASS: axThreeLine.rangeForLine(1) === '{4, 4}'
+PASS: axThreeLine.rangeForLine(2) === '{8, 4}'
+PASS: axThreeLine.rangeForLine(3) === '{12, 0}'
+PASS: axThreeLine.lineForIndex(0) === 0
+PASS: axThreeLine.lineForIndex(4) === 1
+PASS: axThreeLine.lineForIndex(8) === 2
+PASS: axThreeLine.lineForIndex(11) === 2
+PASS: axThreeLine.lineForIndex(12) === -1
+PASS: axNoTrailingNewline.rangeForLine(0) === '{0, 4}'
+PASS: axNoTrailingNewline.rangeForLine(1) === '{4, 3}'
+PASS: axNoTrailingNewline.rangeForLine(2) === '{0, 0}'
+PASS: axNoTrailingNewline.lineForIndex(0) === 0
+PASS: axNoTrailingNewline.lineForIndex(4) === 1
+PASS: axNoTrailingNewline.lineForIndex(6) === 1
+PASS: axThreeLineNoNewline.rangeForLine(2) === '{8, 3}'
+PASS: axThreeLineNoNewline.lineForIndex(8) === 2
+PASS: axThreeLineNoNewline.lineForIndex(10) === 2
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/mac/range-for-line-trailing-blank-line.html
+++ b/LayoutTests/accessibility/mac/range-for-line-trailing-blank-line.html
@@ -1,0 +1,78 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+
+<textarea id="trailing-newline">abc
+def
+</textarea>
+
+<textarea id="three-line">abc
+def
+ghi
+</textarea>
+
+<textarea id="no-trailing-newline">abc
+def</textarea>
+
+<textarea id="three-line-no-newline">abc
+def
+ghi</textarea>
+
+<script>
+var output = "This tests the line APIs for the trailing blank line of a textarea whose value ends in a newline: rangeForLine reports it as an empty range at the document end, and lineForIndex reports indices there as out of range (matching a value without a trailing newline having no phantom line).\n\n";
+
+if (window.accessibilityController) {
+    // Value "abc\ndef\n": line 0 is "abc\n", line 1 is "def\n", and line 2 is the trailing
+    // blank line rendered by the placeholder <br>, an empty range at the document end (8). An
+    // index at a line start resolves to that line, not the previous one; the trailing blank
+    // line at the document end (index 8) is out of range.
+    var axTrailingNewline = accessibilityController.accessibleElementById("trailing-newline");
+    output += expect("axTrailingNewline.rangeForLine(0)", "'{0, 4}'");
+    output += expect("axTrailingNewline.rangeForLine(1)", "'{4, 4}'");
+    output += expect("axTrailingNewline.rangeForLine(2)", "'{8, 0}'");
+    output += expect("axTrailingNewline.lineForIndex(0)", "0");
+    output += expect("axTrailingNewline.lineForIndex(4)", "1");
+    output += expect("axTrailingNewline.lineForIndex(7)", "1");
+    output += expect("axTrailingNewline.lineForIndex(8)", "-1");
+
+    // Value "abc\ndef\nghi\n": the trailing blank line (line 3) is also an empty range at the
+    // document end, regardless of how many content lines precede it.
+    var axThreeLine = accessibilityController.accessibleElementById("three-line");
+    output += expect("axThreeLine.rangeForLine(0)", "'{0, 4}'");
+    output += expect("axThreeLine.rangeForLine(1)", "'{4, 4}'");
+    output += expect("axThreeLine.rangeForLine(2)", "'{8, 4}'");
+    output += expect("axThreeLine.rangeForLine(3)", "'{12, 0}'");
+    output += expect("axThreeLine.lineForIndex(0)", "0");
+    output += expect("axThreeLine.lineForIndex(4)", "1");
+    output += expect("axThreeLine.lineForIndex(8)", "2");
+    output += expect("axThreeLine.lineForIndex(11)", "2");
+    output += expect("axThreeLine.lineForIndex(12)", "-1");
+
+    // Value "abc\ndef" has no trailing newline, so line 1 is the last line ("def") and there is
+    // no trailing blank line to report. lineForIndex of the last content character (6, the "f")
+    // resolves to its line, not out of range.
+    var axNoTrailingNewline = accessibilityController.accessibleElementById("no-trailing-newline");
+    output += expect("axNoTrailingNewline.rangeForLine(0)", "'{0, 4}'");
+    output += expect("axNoTrailingNewline.rangeForLine(1)", "'{4, 3}'");
+    output += expect("axNoTrailingNewline.rangeForLine(2)", "'{0, 0}'");
+    output += expect("axNoTrailingNewline.lineForIndex(0)", "0");
+    output += expect("axNoTrailingNewline.lineForIndex(4)", "1");
+    output += expect("axNoTrailingNewline.lineForIndex(6)", "1");
+
+    // Value "abc\ndef\nghi" (no trailing newline, three content lines): lineForIndex at a later
+    // line's start (8, the "g") resolves to that line, not the previous one. This is the "type a
+    // character on the last line then pan" case; there is no trailing blank line.
+    var axThreeLineNoNewline = accessibilityController.accessibleElementById("three-line-no-newline");
+    output += expect("axThreeLineNoNewline.rangeForLine(2)", "'{8, 3}'");
+    output += expect("axThreeLineNoNewline.lineForIndex(8)", "2");
+    output += expect("axThreeLineNoNewline.lineForIndex(10)", "2");
+
+    debug(output);
+}
+</script>
+</body>
+</html>

--- a/Source/WebCore/accessibility/AXTextMarker.cpp
+++ b/Source/WebCore/accessibility/AXTextMarker.cpp
@@ -770,6 +770,35 @@ int AXTextMarker::lineIndex() const
     return index;
 }
 
+// A text control whose value ends in a line break renders an empty final line. Depending on
+// whether the control is being edited, that line's sole content, a single newline, is exposed
+// either as a placeholder <br> (role LineBreak, appended by HTMLTextFormControlElement::
+// setInnerTextValue) or as a text node (role StaticText). Detect it by content and position, a
+// lone newline with no following text runs within the text control (bounded by |stopAtID|),
+// rather than by object role, which differs between those two representations. |lineLength| is
+// the caller's already-computed length of |lineRange|; a lone newline is length 1, so checking it
+// first avoids building the range's string (and walking for following runs) on every other line.
+static bool isOnTrailingPlaceholderBlankLine(const AXTextMarkerRange& lineRange, unsigned lineLength, std::optional<AXID> stopAtID)
+{
+    if (lineLength != 1 || lineRange.toString() != "\n"_s)
+        return false;
+    RefPtr object = lineRange.start().isolatedObject();
+    return object && !findObjectWithRuns(*object, AXDirection::Next, stopAtID);
+}
+
+// Advances |lineRange| to the following line: the range from the start of the next line through
+// its end. Returns an invalid range when there is no next line (nextLineEnd does not advance),
+// which ends the line walks in characterRangeForLine, markerRangeForLineIndex, and
+// lineNumberForIndex. |includeTrailingLineBreak| and |stopAtID| select the caller's line semantics.
+static AXTextMarkerRange nextLineRange(const AXTextMarkerRange& lineRange, IncludeTrailingLineBreak includeTrailingLineBreak, std::optional<AXID> stopAtID)
+{
+    auto lineEnd = lineRange.end();
+    auto nextLineEndMarker = lineEnd.nextLineEnd(includeTrailingLineBreak, stopAtID);
+    if (nextLineEndMarker == lineEnd)
+        return { };
+    return { nextLineEndMarker.previousLineStart(stopAtID), WTF::move(nextLineEndMarker) };
+}
+
 CharacterRange AXTextMarker::characterRangeForLine(unsigned lineIndex) const
 {
     if (!isValid())
@@ -796,11 +825,17 @@ CharacterRange AXTextMarker::characterRangeForLine(unsigned lineIndex) const
     auto currentLineRange = textRunMarker.lineRange(LineRangeType::Current, IncludeTrailingLineBreak::Yes);
     while (lineIndex && currentLineRange) {
         precedingLength += currentLineRange.toString().length();
-        auto lineEndMarker = currentLineRange.end().nextLineEnd(IncludeTrailingLineBreak::Yes, stopAtID);
-        currentLineRange = { lineEndMarker.previousLineStart(stopAtID), WTF::move(lineEndMarker) };
+        currentLineRange = nextLineRange(currentLineRange, IncludeTrailingLineBreak::Yes, stopAtID);
         --lineIndex;
     }
-    return currentLineRange ? CharacterRange(precedingLength, currentLineRange.toString().length()) : CharacterRange();
+    if (!currentLineRange)
+        return { };
+    // Report the trailing blank line of a value ending in a line break as an empty range at the
+    // document end, so it reads as an empty line rather than a line whose content is a newline.
+    unsigned lineLength = currentLineRange.toString().length();
+    if (isOnTrailingPlaceholderBlankLine(currentLineRange, lineLength, stopAtID))
+        return CharacterRange(precedingLength, 0);
+    return CharacterRange(precedingLength, lineLength);
 }
 
 AXTextMarkerRange AXTextMarker::markerRangeForLineIndex(unsigned lineIndex) const
@@ -815,8 +850,7 @@ AXTextMarkerRange AXTextMarker::markerRangeForLineIndex(unsigned lineIndex) cons
 
     auto currentLineRange = lineRange(LineRangeType::Current);
     while (lineIndex && currentLineRange) {
-        auto lineEndMarker = currentLineRange.end().nextLineEnd();
-        currentLineRange = { lineEndMarker.previousLineStart(), WTF::move(lineEndMarker) };
+        currentLineRange = nextLineRange(currentLineRange, IncludeTrailingLineBreak::No, std::nullopt);
         --lineIndex;
     }
     return currentLineRange;
@@ -828,27 +862,33 @@ int AXTextMarker::lineNumberForIndex(unsigned index) const
     if (!object)
         return -1;
 
-    if (object->isTextControl() && index >= object->textMarkerRange().toString().length() - 1) {
-        // Mimic behavior of AccessibilityRenderObject::visiblePositionForIndex.
-        return -1;
-    }
-
     std::optional stopAtID = object->idOfNextSiblingIncludingIgnoredOrParent();
-    unsigned lineIndex = 0;
-    auto currentMarker = *this;
-    while (index) {
-        auto oldMarker = WTF::move(currentMarker);
-        currentMarker = oldMarker.findMarker(AXDirection::Next, CoalesceObjectBreaks::Yes, IgnoreBRs::Yes, stopAtID);
-        if (!currentMarker.isValid())
-            break;
+    auto textRunMarker = toTextRunMarker(stopAtID);
+    if (!textRunMarker.isValid())
+        return !index ? 0 : -1;
 
-        if (oldMarker.lineID() != currentMarker.lineID())
-            ++lineIndex;
-
-        --index;
+    // Walk lines with nextLineRange, the same helper characterRangeForLine uses, so the two APIs
+    // stay consistent: return the line whose [start, end) character range contains |index|, or -1
+    // if |index| is past the end.
+    unsigned lineStart = 0;
+    unsigned lineNumber = 0;
+    auto currentLineRange = textRunMarker.lineRange(LineRangeType::Current, IncludeTrailingLineBreak::Yes);
+    while (currentLineRange) {
+        unsigned lineLength = currentLineRange.toString().length();
+        if (index < lineStart + lineLength) {
+            // Report an index on the trailing blank line of a value ending in a line break as
+            // out of range, matching the non-isolated AccessibilityRenderObject path: that line
+            // sits at the document end and is surfaced by characterRangeForLine (an empty range)
+            // instead. A value with no trailing line break has no such line and is unaffected.
+            if (isOnTrailingPlaceholderBlankLine(currentLineRange, lineLength, stopAtID))
+                return -1;
+            return static_cast<int>(lineNumber);
+        }
+        lineStart += lineLength;
+        currentLineRange = nextLineRange(currentLineRange, IncludeTrailingLineBreak::Yes, stopAtID);
+        ++lineNumber;
     }
-    // Only return the line number if the index was a valid offset into our descendants.
-    return !index ? lineIndex : -1;
+    return -1;
 }
 
 bool AXTextMarker::atLineBoundaryForDirection(AXDirection direction) const

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
@@ -2192,8 +2192,16 @@ CharacterRange AccessibilityRenderObject::doAXRangeForLine(unsigned lineNumber) 
     if (isHardLineBreak(lineEnd))
         ++lineEndIndex;
 
-    if (lineStartIndex < 0 || lineEndIndex < 0 || lineEndIndex <= lineStartIndex)
+    if (lineStartIndex < 0 || lineEndIndex < 0 || lineEndIndex <= lineStartIndex) {
+        // A text control whose value ends in a line break has an empty final line at the document
+        // end, rendered by a placeholder <br>. Report it as an empty range there so it reads as an
+        // empty line, matching the isolated-tree path (AXTextMarker::characterRangeForLine).
+        auto value = text();
+        bool endsWithLineBreak = value.length() && value[value.length() - 1] == '\n';
+        if (lineStartIndex >= 0 && lineStartIndex == lineEndIndex && static_cast<unsigned>(lineStartIndex) == value.length() && endsWithLineBreak)
+            return { static_cast<unsigned>(lineStartIndex), 0 };
         return { };
+    }
 
     return { static_cast<unsigned>(lineStartIndex), static_cast<unsigned>(lineEndIndex - lineStartIndex) };
 }


### PR DESCRIPTION
#### 870b45452df25c3624ea8fc6341b5c2c1ce3d36f
<pre>
AX: Line APIs mishandle the trailing blank line of a textarea whose value ends in a newline
<a href="https://bugs.webkit.org/show_bug.cgi?id=319984">https://bugs.webkit.org/show_bug.cgi?id=319984</a>
<a href="https://rdar.apple.com/182912872">rdar://182912872</a>

Reviewed by Dominic Mazzoni and Tyler Wilcock.

When a text control&apos;s value ends in a line break, HTMLTextFormControlElement::
setInnerTextValue appends a placeholder &lt;br&gt; so the empty final line renders.
That placeholder contributes a &quot;\n&quot; text run, so the accessibility string is one
character longer than the value and the empty final line looks like a line whose
content is a newline. Both the isolated-tree and the legacy line APIs mishandled
it:

Isolated tree (AXTextMarker):
- characterRangeForLine reported the trailing blank line as {docEnd, 1} (the
  placeholder newline) instead of an empty range at the document end. VoiceOver
  then rendered the newline on the empty last line and, because the line looked
  non-empty, skipped the previous line when panning left in braille.
- lineNumberForIndex, which counted line-ID transitions with findMarker, resolved
  an index at a line&apos;s start (right after a hard line break) to the previous line.
  That made VoiceOver skip a line when panning through content lines. Its
  index &gt;= length - 1 clamp also rejected the last content character of a value
  that does not end in a newline.

Live tree (AccessibilityRenderObject):
- doAXRangeForLine returned an empty range {0, 0} for the trailing blank line,
  because its lineEndIndex &lt;= lineStartIndex guard treats an empty line at the
  document end as &quot;no such line&quot;.

Fix all three so the two trees agree and the trailing blank line reads as an empty
range at the document end:

- characterRangeForLine returns an empty range at the document end for that line,
  detecting it by content (a lone newline with no following text runs) rather than
  object role, which differs between the &lt;br&gt; (LineBreak) and text node
  (StaticText) representations.
- lineNumberForIndex walks line ranges the same way characterRangeForLine does, so
  an index at a line&apos;s start resolves to that line, and returns -1 for an index on
  the trailing blank line, matching the legacy contract.
- doAXRangeForLine reports the trailing blank line of a value ending in a line
  break as an empty range at the document end.

Because the isolated-tree and legacy paths now agree, the test passes with
IsAccessibilityIsolatedTreeEnabled on and off, so it no longer forces the isolated
tree on.

* Source/WebCore/accessibility/AXTextMarker.cpp:
(WebCore::isOnTrailingPlaceholderBlankLine):
(WebCore::nextLineRange):
(WebCore::AXTextMarker::characterRangeForLine):
(WebCore::AXTextMarker::markerRangeForLineIndex):
(WebCore::AXTextMarker::lineNumberForIndex):
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
(WebCore::AccessibilityRenderObject::doAXRangeForLine):
* LayoutTests/accessibility/mac/range-for-line-trailing-blank-line.html: Added.
* LayoutTests/accessibility/mac/range-for-line-trailing-blank-line-expected.txt: Added.

Canonical link: <a href="https://commits.webkit.org/317784@main">https://commits.webkit.org/317784@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/336de8e8562bb14b7884497d00ea2b0833d7fdf3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176252 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50187 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43977 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185848 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/138496 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/da8e2fc5-e03d-4e64-a8cd-eccb45c13872) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178115 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51479 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49871 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137278 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/138496 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4a68a638-4bd4-4988-abf5-86a4d17c8c27) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179208 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40759 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158049 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117753 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39408 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37770 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149824 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37546 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34317 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41909 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41981 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188272 "Built successfully") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49852 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/157594 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146310 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39370 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50536 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34164 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/held.https.any.sharedworker.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146131 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40900 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122740 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/116716 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49040 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12518 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48442 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48676 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48501 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->