### PR TITLE
OpenSSL 3.x compatibility improvements

### DIFF
--- a/Source/WebCore/crypto/openssl/CryptoAlgorithmAESGCMOpenSSL.cpp
+++ b/Source/WebCore/crypto/openssl/CryptoAlgorithmAESGCMOpenSSL.cpp
@@ -64,12 +64,12 @@ static std::optional<Vector<uint8_t>> cryptEncrypt(const Vector<uint8_t>& key, c
     if (!(ctx = EvpCipherCtxPtr(EVP_CIPHER_CTX_new())))
         return std::nullopt;
 
-    // Disable padding
-    if (1 != EVP_CIPHER_CTX_set_padding(ctx.get(), 0))
-        return std::nullopt;
-
     // Initialize the encryption operation
     if (1 != EVP_EncryptInit_ex(ctx.get(), algorithm, nullptr, nullptr, nullptr))
+        return std::nullopt;
+
+    // Disable padding
+    if (1 != EVP_CIPHER_CTX_set_padding(ctx.get(), 0))
         return std::nullopt;
 
     // Set IV length
@@ -120,12 +120,12 @@ static std::optional<Vector<uint8_t>> cryptDecrypt(const Vector<uint8_t>& key, c
     if (!(ctx = EvpCipherCtxPtr(EVP_CIPHER_CTX_new())))
         return std::nullopt;
 
-    // Disable padding
-    if (1 != EVP_CIPHER_CTX_set_padding(ctx.get(), 0))
-        return std::nullopt;
-
     // Initialize the encryption operation
     if (1 != EVP_DecryptInit_ex(ctx.get(), algorithm, nullptr, nullptr, nullptr))
+        return std::nullopt;
+
+    // Disable padding
+    if (1 != EVP_CIPHER_CTX_set_padding(ctx.get(), 0))
         return std::nullopt;
 
     // Set IV length

--- a/Source/WebCore/crypto/openssl/CryptoAlgorithmRSA_OAEPOpenSSL.cpp
+++ b/Source/WebCore/crypto/openssl/CryptoAlgorithmRSA_OAEPOpenSSL.cpp
@@ -36,7 +36,6 @@ namespace WebCore {
 
 ExceptionOr<Vector<uint8_t>> CryptoAlgorithmRSA_OAEP::platformEncrypt(const CryptoAlgorithmRsaOaepParams& parameters, const CryptoKeyRSA& key, const Vector<uint8_t>& plainText)
 {
-#if defined(EVP_PKEY_CTX_set_rsa_oaep_md) && defined(EVP_PKEY_CTX_set_rsa_mgf1_md) && defined(EVP_PKEY_CTX_set0_rsa_oaep_label)
     const EVP_MD* md = digestAlgorithm(key.hashAlgorithmIdentifier());
     if (!md)
         return Exception { ExceptionCode::NotSupportedError };
@@ -78,14 +77,10 @@ ExceptionOr<Vector<uint8_t>> CryptoAlgorithmRSA_OAEP::platformEncrypt(const Cryp
     cipherText.shrink(cipherTextLen);
 
     return cipherText;
-#else
-    return Exception { ExceptionCode::NotSupportedError };
-#endif
 }
 
 ExceptionOr<Vector<uint8_t>> CryptoAlgorithmRSA_OAEP::platformDecrypt(const CryptoAlgorithmRsaOaepParams& parameters, const CryptoKeyRSA& key, const Vector<uint8_t>& cipherText)
 {
-#if defined(EVP_PKEY_CTX_set_rsa_oaep_md) && defined(EVP_PKEY_CTX_set_rsa_mgf1_md) && defined(EVP_PKEY_CTX_set0_rsa_oaep_label)
     const EVP_MD* md = digestAlgorithm(key.hashAlgorithmIdentifier());
     if (!md)
         return Exception { ExceptionCode::NotSupportedError };
@@ -127,9 +122,6 @@ ExceptionOr<Vector<uint8_t>> CryptoAlgorithmRSA_OAEP::platformDecrypt(const Cryp
     plainText.shrink(plainTextLen);
 
     return plainText;
-#else
-    return Exception { ExceptionCode::NotSupportedError };
-#endif
 }
 
 } // namespace WebCore

--- a/Source/WebCore/crypto/openssl/CryptoAlgorithmRSA_PSSOpenSSL.cpp
+++ b/Source/WebCore/crypto/openssl/CryptoAlgorithmRSA_PSSOpenSSL.cpp
@@ -37,7 +37,6 @@ namespace WebCore {
 
 ExceptionOr<Vector<uint8_t>> CryptoAlgorithmRSA_PSS::platformSign(const CryptoAlgorithmRsaPssParams& parameters, const CryptoKeyRSA& key, const Vector<uint8_t>& data)
 {
-#if defined(EVP_PKEY_CTX_set_rsa_pss_saltlen) && defined(EVP_PKEY_CTX_set_rsa_mgf1_md)
     const EVP_MD* md = digestAlgorithm(key.hashAlgorithmIdentifier());
     if (!md)
         return Exception { ExceptionCode::NotSupportedError };
@@ -75,14 +74,10 @@ ExceptionOr<Vector<uint8_t>> CryptoAlgorithmRSA_PSS::platformSign(const CryptoAl
     signature.shrink(signatureLen);
 
     return signature;
-#else
-    return Exception { ExceptionCode::NotSupportedError };
-#endif
 }
 
 ExceptionOr<bool> CryptoAlgorithmRSA_PSS::platformVerify(const CryptoAlgorithmRsaPssParams& parameters, const CryptoKeyRSA& key, const Vector<uint8_t>& signature, const Vector<uint8_t>& data)
 {
-#if defined(EVP_PKEY_CTX_set_rsa_pss_saltlen) && defined(EVP_PKEY_CTX_set_rsa_mgf1_md)
     const EVP_MD* md = digestAlgorithm(key.hashAlgorithmIdentifier());
     if (!md)
         return Exception { ExceptionCode::NotSupportedError };
@@ -113,9 +108,6 @@ ExceptionOr<bool> CryptoAlgorithmRSA_PSS::platformVerify(const CryptoAlgorithmRs
     int ret = EVP_PKEY_verify(ctx.get(), signature.span().data(), signature.size(), digest->span().data(), digest->size());
 
     return ret == 1;
-#else
-    return Exception { ExceptionCode::NotSupportedError };
-#endif
 }
 
 } // namespace WebCore

--- a/Source/WebCore/crypto/openssl/CryptoKeyRSAOpenSSL.cpp
+++ b/Source/WebCore/crypto/openssl/CryptoKeyRSAOpenSSL.cpp
@@ -37,7 +37,7 @@
 
 namespace WebCore {
 
-static size_t getRSAModulusLength(RSA* rsa)
+static size_t getRSAModulusLength(const RSA* rsa)
 {
     if (!rsa)
         return 0;
@@ -164,7 +164,7 @@ bool CryptoKeyRSA::isRestrictedToHash(CryptoAlgorithmIdentifier& identifier) con
 
 size_t CryptoKeyRSA::keySizeInBits() const
 {
-    RSA* rsa = EVP_PKEY_get0_RSA(m_platformKey.get());
+    const RSA* rsa = EVP_PKEY_get0_RSA(m_platformKey.get());
     if (!rsa)
         return 0;
 
@@ -297,7 +297,7 @@ ExceptionOr<Vector<uint8_t>> CryptoKeyRSA::exportPkcs8() const
 
 auto CryptoKeyRSA::algorithm() const -> KeyAlgorithm
 {
-    RSA* rsa = EVP_PKEY_get0_RSA(platformKey());
+    const RSA* rsa = EVP_PKEY_get0_RSA(platformKey());
 
     // FIXME: `CryptoRsaKeyAlgorithm` stores `modulusLength` as an `unsigned` requiring us to cast below. We should find a way to remove the need for a cast / ensure the cast is safe and doesn't overflow.
 
@@ -330,7 +330,7 @@ auto CryptoKeyRSA::algorithm() const -> KeyAlgorithm
 
 std::unique_ptr<CryptoKeyRSAComponents> CryptoKeyRSA::exportData() const
 {
-    RSA* rsa = EVP_PKEY_get0_RSA(platformKey());
+    const RSA* rsa = EVP_PKEY_get0_RSA(platformKey());
     if (!rsa)
         return nullptr;
 


### PR DESCRIPTION
#### 86b93412c2ed0729569d01cef74410c689827f2e
<pre>
OpenSSL 3.x compatibility improvements
<a href="https://bugs.webkit.org/show_bug.cgi?id=319982">https://bugs.webkit.org/show_bug.cgi?id=319982</a>

Reviewed by Patrick Griffis.

Problems fixed:

1)
const usage in Source/WebCore/crypto/openssl/CryptoKeyRSAOpenSSL.cpp
<a href="https://docs.openssl.org/3.0/man7/migration_guide/#functions-that-return-an-internal-key-should-be-treated-as-read-only">https://docs.openssl.org/3.0/man7/migration_guide/#functions-that-return-an-internal-key-should-be-treated-as-read-only</a>
&quot;the value returned from EVP_PKEY_get0_RSA(3), ... have been made const&quot;

2)
Feature test ifdefs in Source/WebCore/crypto/openssl/CryptoAlgorithmRSA_OAEPOpenSSL.cpp no longer work
<a href="https://github.com/WebKit/WebKit/blob/6d8ca7e79a097c2013cf960c16489930cad90f11/Source/WebCore/crypto/openssl/CryptoAlgorithmRSA_OAEPOpenSSL.cpp#L39">https://github.com/WebKit/WebKit/blob/6d8ca7e79a097c2013cf960c16489930cad90f11/Source/WebCore/crypto/openssl/CryptoAlgorithmRSA_OAEPOpenSSL.cpp#L39</a>
These were macros in OpenSSL 1.x, but are now real functions in OpenSSL 3.x:
<a href="https://docs.openssl.org/3.0/man3/EVP_PKEY_CTX_ctrl/#history">https://docs.openssl.org/3.0/man3/EVP_PKEY_CTX_ctrl/#history</a> &quot;In OpenSSL 1.1.1 and below the functions were mostly macros. From OpenSSL 3.0 they are all functions.&quot;
So the ifdefs do not see the macros defined (because they are now functions), so the code incorrectly returns ExceptionCode::NotSupportedError.
The solution is to remove these feature checks, surely no one is still using OpenSSL 0.x from before these were added as macros.

3)
Runtime GCM failures. In Source/WebCore/crypto/openssl/CryptoAlgorithmAESGCMOpenSSL.cpp EVP_CIPHER_CTX_set_padding() is called *before*
EVP_EncryptInit_ex() and EVP_DecryptInit_ex().
The OpenSSL documentation says:
&quot;This function should be called after the context is set up for encryption or decryption&quot;
<a href="https://docs.openssl.org/3.0/man3/EVP_EncryptInit/#description">https://docs.openssl.org/3.0/man3/EVP_EncryptInit/#description</a> .
In OpenSSL 1.x this did not matter because EVP_EncryptInit_ex() always returned 1:
<a href="https://github.com/openssl/openssl/blob/OpenSSL_1_1_1-stable/crypto/evp/evp_enc.c#L650">https://github.com/openssl/openssl/blob/OpenSSL_1_1_1-stable/crypto/evp/evp_enc.c#L650</a> ,
but in OpenSSL 3.x it can return 0 if it is called incorrectly, as here with a null ctx-&gt;cipher.
The solution is to move the function calls after the init functions.

No new tests: fixes behaviour in non default configuration

* Source/WebCore/crypto/openssl/CryptoAlgorithmAESGCMOpenSSL.cpp: move EVP_CIPHER_CTX_set_padding() calls
(WebCore::cryptEncrypt): move EVP_CIPHER_CTX_set_padding() call after EVP_EncryptInit_ex()
(WebCore::cryptDecrypt): move EVP_CIPHER_CTX_set_padding() call after EVP_DecryptInit_ex()
* Source/WebCore/crypto/openssl/CryptoAlgorithmRSA_OAEPOpenSSL.cpp: delete broken feature check #ifs
(WebCore::CryptoAlgorithmRSA_OAEP::platformEncrypt): delete broken feature check #if
(WebCore::CryptoAlgorithmRSA_OAEP::platformDecrypt): delete broken feature check #if
* Source/WebCore/crypto/openssl/CryptoAlgorithmRSA_PSSOpenSSL.cpp: delete broken feature check #ifs
(WebCore::CryptoAlgorithmRSA_PSS::platformSign): delete broken feature check #if
(WebCore::CryptoAlgorithmRSA_PSS::platformVerify): delete broken feature check #if
* Source/WebCore/crypto/openssl/CryptoKeyRSAOpenSSL.cpp: Add const to match OpenSSL 3.x API changes
(WebCore::getRSAModulusLength): add const
(WebCore::CryptoKeyRSA::keySizeInBits const): add const
(WebCore::CryptoKeyRSA::algorithm const): add const
(WebCore::CryptoKeyRSA::exportData const): add const

Canonical link: <a href="https://commits.webkit.org/317719@main">https://commits.webkit.org/317719@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/be008b6d00c493827d03559a5c20ec77d5c2f668

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176100 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50035 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43825 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185696 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/138330 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/177963 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51327 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49719 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137153 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/138330 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179056 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40625 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157926 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117628 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39274 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37645 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149690 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37423 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34164 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41751 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/41856 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188119 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49700 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146169 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39323 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50383 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/34041 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145998 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40777 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122586 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/116530 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48888 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12395 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48289 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48524 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48348 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->