### PR TITLE
model-element-immersive-state-consistency.html test is flaky

### DIFF
--- a/LayoutTests/model-element/immersive/model-element-immersive-basic.html
+++ b/LayoutTests/model-element/immersive/model-element-immersive-basic.html
@@ -41,6 +41,8 @@ promise_test(async t => {
     await model.requestImmersive();
     
     assert_equals(document.immersiveElement, model, 'Document should reference immersive model');
+
+    await document.exitImmersive();
 }, 'Model enters immersive mode with user activation');
 
 promise_test(async t => {
@@ -94,6 +96,8 @@ promise_test(async t => {
 
     assert_equals(documentChangeEvents.length, 1, 'Document should fire one immersivechange event');
     assert_equals(documentChangeEvents[0], model, 'Document event should reference model');
+
+    await document.exitImmersive();
 }, 'Immersivechange events fire when entering immersive');
 
 promise_test(async t => {
@@ -109,6 +113,8 @@ promise_test(async t => {
     await model2.requestImmersive();
     
     assert_equals(document.immersiveElement, model2, 'Document should reference second model');
+
+    await document.exitImmersive();
 }, 'Only one model can be immersive at a time');
 
 
@@ -184,6 +190,8 @@ promise_test(async t => {
     await model.requestImmersive();
     
     assert_equals(model.complete, true, 'Model should be complete when immersive');
+
+    await document.exitImmersive();
 }, 'Model is complete once presented as immersive');
 
 promise_test(async t => {
@@ -200,6 +208,8 @@ promise_test(async t => {
     await Promise.all([promise1, promise2]);
     
     assert_equals(document.immersiveElement, model1, 'Model should be immersive after multiple requests');
+
+    await document.exitImmersive();
 }, 'Multiple concurrent requestImmersive calls are handled correctly');
 
 </script>

--- a/LayoutTests/model-element/immersive/model-element-immersive-bfcache.html
+++ b/LayoutTests/model-element/immersive/model-element-immersive-bfcache.html
@@ -33,6 +33,8 @@ window.addEventListener("pageshow", async (event) => {
         testFailed("Could not re-enter the immersive environment after restore: " + error);
     }
 
+    await document.exitImmersive();
+
     finishJSTest();
 });
 

--- a/LayoutTests/model-element/immersive/model-element-immersive-state-consistency.html
+++ b/LayoutTests/model-element/immersive/model-element-immersive-state-consistency.html
@@ -13,11 +13,10 @@ promise_test(async t => {
     const [model1, source1] = createModelAndSource(t, "../resources/cube.usdz");
     const [model2, source2] = createModelAndSource(t, "../resources/cube.usdz");
 
-    await test_driver.bless("immersive");
-    const promise1 = model1.requestImmersive();
 
-    await test_driver.bless("immersive");
-    const promise2 = model2.requestImmersive();
+    let promise1, promise2;
+    internals.withUserGesture(() => { promise1 = model1.requestImmersive(); });
+    internals.withUserGesture(() => { promise2 = model2.requestImmersive(); });
 
     await promise_rejects_dom(t, "AbortError", promise1,
         'First request should be superseded by second');
@@ -27,6 +26,7 @@ promise_test(async t => {
     assert_equals(document.immersiveElement, model2,
         'document.immersiveElement should match successful request');
 
+    await document.exitImmersive();
 }, 'Second request during first request completes correctly');
 
 promise_test(async t => {
@@ -40,8 +40,13 @@ promise_test(async t => {
     await test_driver.bless("immersive");
     const requestPromise = model2.requestImmersive();
 
-    await t.step_wait(() => document.immersiveElement === null, 'Waiting for immersive exit');
-    await t.step_wait(() => document.immersiveElement === model2, 'Waiting for new model to be immersive');
+    await exitPromise;
+    assert_equals(document.immersiveElement, null, 'Waiting for immersive exit');
+
+    await requestPromise;
+    assert_equals(document.immersiveElement, model2, 'Waiting for new model to be immersive');
+
+    await document.exitImmersive();
 }, 'Immersive request during immersive exit should first wait for exit and then proceeds');
 
 promise_test(async t => {
@@ -67,17 +72,18 @@ promise_test(async t => {
     await model3.requestImmersive();
     assert_equals(document.immersiveElement, model3);
 
+    await document.exitImmersive();
 }, 'Rapid request/exit cycles maintain consistent state');
 
 promise_test(async t => {
     const promises = [];
     const models = [];
 
-    // Create 5 models and start 5 concurrent requests
+    // Fire all 5 requests synchronously
     for (let i = 0; i < 5; i++) {
         const [model, source] = createModelAndSource(t, "../resources/teapot.usdz");
         models.push(model);
-        await test_driver.bless("immersive", () => {
+        internals.withUserGesture(() => {
             promises.push(model.requestImmersive());
         });
     }
@@ -97,6 +103,7 @@ promise_test(async t => {
 
     assert_equals(document.immersiveElement, models[4], 'Last request should be the one fulfilled');
 
+    await document.exitImmersive();
 }, 'Multiple concurrent requests - exactly one succeeds');
 
 promise_test(async t => {
@@ -115,6 +122,7 @@ promise_test(async t => {
 
     assert_equals(document.immersiveElement, model2, 'State should be clean for new request');
 
+    await document.exitImmersive();
 }, 'State remains clean after request aborted by element removal');
 
 promise_test(async t => {
@@ -125,12 +133,13 @@ promise_test(async t => {
     await model1.requestImmersive();
     const exitPromise = document.exitImmersive();
 
-    await test_driver.bless("immersive");
-    const requestPromise = model2.requestImmersive();
+    let requestPromise;
+    internals.withUserGesture(() => { requestPromise = model2.requestImmersive(); });
     model2.remove();
+    const requestRejection = promise_rejects_dom(t, "AbortError", requestPromise);
 
     await exitPromise;
-    await promise_rejects_dom(t, "AbortError", requestPromise);
+    await requestRejection;
     assert_equals(document.immersiveElement, null, 'State should be clean after removal during exit');
 
 }, 'Element removed while waiting for exit to complete');


### PR DESCRIPTION
#### 9fe6e62598e4062f19e4e6db6f7907a4c9a7fba8
<pre>
model-element-immersive-state-consistency.html test is flaky
<a href="https://bugs.webkit.org/show_bug.cgi?id=319989">https://bugs.webkit.org/show_bug.cgi?id=319989</a>
<a href="https://rdar.apple.com/177935542">rdar://177935542</a>

Reviewed by Etienne Segonzac.

Fire concurrent requestImmersive() calls synchronously via
internals.withUserGesture instead of test_driver.bless, so that races are
deterministic. Await document.exitImmersive() at the end of each test that entered immersive mode,
so cleanup doesn&apos;t tear down an active immersive element asynchronously and race the next test.
Attach promise_rejects_dom&apos;s rejection handler synchronously right after
removing the element, instead of after an intervening await, to avoid an
unhandled promise rejection.

* LayoutTests/model-element/immersive/model-element-immersive-state-consistency.html:
* LayoutTests/model-element/immersive/model-element-immersive-basic.html:
* LayoutTests/model-element/immersive/model-element-immersive-bfcache.html:

Canonical link: <a href="https://commits.webkit.org/317775@main">https://commits.webkit.org/317775@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8e33bd962362ec71c3e106dd77528bd7cf31b4be

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176330 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50265 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44055 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185926 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/138586 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51557 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49949 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137345 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/138586 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179286 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40826 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158120 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117820 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39475 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/37838 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/149891 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37618 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34395 "Built successfully") | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/42049 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188350 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49930 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/157665 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146381 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39363 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50614 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/34235 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146200 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40969 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/116839 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49118 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12593 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48520 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48754 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48579 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->