### PR TITLE
REGRESSION(317690@main): A label-for relation is not re-resolved when the target control's id changes

### DIFF
--- a/LayoutTests/accessibility/label-for-control-id-change-expected.txt
+++ b/LayoutTests/accessibility/label-for-control-id-change-expected.txt
@@ -1,0 +1,12 @@
+This tests that a label-for association updates when a control's id attribute changes to (or away from) the label's for value.
+
+PASS: hasNoTitleUIElement('control') === true
+document.getElementById('control').id = 'target';
+PASS: isLabelledBy('target', 'label') === true
+document.getElementById('target').id = 'control';
+PASS: hasNoTitleUIElement('control') === true
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/label-for-control-id-change.html
+++ b/LayoutTests/accessibility/label-for-control-id-change.html
@@ -1,0 +1,53 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../resources/accessibility-helper.js"></script>
+<script src="../resources/js-test.js"></script>
+</head>
+<body>
+
+<div id="container">
+    <label id="label" for="target">Label</label>
+    <input id="control" type="text">
+</div>
+
+<script>
+var output = "This tests that a label-for association updates when a control's id attribute changes to (or away from) the label's for value.\n\n";
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    function isLabelledBy(controlId, labelId) {
+        var control = accessibilityController.accessibleElementById(controlId);
+        if (!control)
+            return false;
+        var title = control.titleUIElement();
+        return title != null && title.isEqual(accessibilityController.accessibleElementById(labelId));
+    }
+
+    function hasNoTitleUIElement(controlId) {
+        var control = accessibilityController.accessibleElementById(controlId);
+        return control != null && control.titleUIElement() == null;
+    }
+
+    // Force the initial relations build. The label's for="target" matches no control yet.
+    output += expect("hasNoTitleUIElement('control')", "true");
+
+    setTimeout(async function() {
+        // Give the control the id the label points at. This is an id-attribute change (not a change to
+        // the label's for attribute), which must still re-resolve the label -> control relation.
+        output += evalAndReturn("document.getElementById('control').id = 'target';");
+        output += await expectAsync("isLabelledBy('target', 'label')", "true");
+
+        // Change the id away again. The association must be removed.
+        output += evalAndReturn("document.getElementById('target').id = 'control';");
+        output += await expectAsync("hasNoTitleUIElement('control')", "true");
+
+        document.getElementById('container').style.display = 'none';
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -6896,6 +6896,13 @@ bool AXObjectCache::addRelation(Element& origin, const QualifiedName& attribute)
 
 void AXObjectCache::addLabelForRelation(Element& origin)
 {
+    RefPtr label = dynamicDowncast<HTMLLabelElement>(origin);
+
+    if (label) {
+        if (const auto& controlID = label->attributeWithoutSynchronization(forAttr); !controlID.isEmpty())
+            m_referencedRelationTargetIds.add(controlID);
+    }
+
     // A detached label has no accessibility object, so its label relations have no consumer. Skipping
     // it here also avoids HTMLLabelElement::control()'s scan of the label's descendants.
     if (!origin.isInTreeScope())
@@ -6904,7 +6911,7 @@ void AXObjectCache::addLabelForRelation(Element& origin)
     bool addedRelation = false;
 
     // LabelFor relations are established for <label for=...>.
-    if (RefPtr label = dynamicDowncast<HTMLLabelElement>(origin)) {
+    if (label) {
         if (RefPtr control = Accessibility::controlForLabelElement(*label)) {
             // Always add NativeLabelFor for geometry purposes.
             addedRelation = addRelation(origin, *control, AXRelation::NativeLabelFor);


### PR DESCRIPTION
#### 67bc63c03450d4128c2a12d2f750776a020ae8bd
<pre>
REGRESSION(317690@main): A label-for relation is not re-resolved when the target control&apos;s id changes
<a href="https://bugs.webkit.org/show_bug.cgi?id=319990">https://bugs.webkit.org/show_bug.cgi?id=319990</a>
<a href="https://rdar.apple.com/182918982">rdar://182918982</a>

Reviewed by Andres Gonzalez.

Relations are only re-resolved on an id-attribute change when the changed id is
referenced by a relation (AXObjectCache::idChangeCanAffectRelations, backed by
m_referencedRelationTargetIds). That set was populated only from relation attribute
values (relationAttributes()), which does not include the label `for` attribute.
NativeLabelFor/LabelFor relations are established separately in addLabelForRelation()
via HTMLLabelElement::control(). As a result, giving an element the id that an
existing label-for points at no longer associated the label with the control.

Record a label&apos;s `for` target id in addLabelForRelation() (resolved or not, and
before the not-in-tree-scope bail so the set stays a complete superset) so that an
id change to or from that id re-resolves the label&apos;s control relation.

* LayoutTests/accessibility/label-for-control-id-change-expected.txt: Added.
* LayoutTests/accessibility/label-for-control-id-change.html: Added.
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::addLabelForRelation):

Canonical link: <a href="https://commits.webkit.org/317751@main">https://commits.webkit.org/317751@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fe61c8727ac9079d900750e2bac5ce8820193035

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176139 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50074 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43864 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185735 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/138374 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/31a77f28-fca3-4cf0-b2ae-c373e9cd65eb) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178002 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51366 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49758 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137188 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/138374 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179095 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40662 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157965 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117663 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ebbcb0e8-618c-494b-916f-e1540ff5aad5) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39311 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37683 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149727 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37462 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34204 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41790 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41894 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188158 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49739 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/157510 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146212 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39343 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50422 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34080 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146036 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40814 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122625 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/116595 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48927 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12434 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48329 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48563 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48387 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->