### PR TITLE
[JSC] Add VectorZipX(a, all-zeros) strength reduction

### DIFF
--- a/Source/JavaScriptCore/b3/B3ReduceStrength.cpp
+++ b/Source/JavaScriptCore/b3/B3ReduceStrength.cpp
@@ -119,6 +119,16 @@ namespace B3ReduceStrengthInternal {
 static constexpr bool verbose = false;
 }
 
+static inline std::optional<SIMDLane> wideningLaneFor(SIMDLane lane)
+{
+    switch (lane) {
+    case SIMDLane::i8x16: return SIMDLane::i16x8;
+    case SIMDLane::i16x8: return SIMDLane::i32x4;
+    case SIMDLane::i32x4: return SIMDLane::i64x2;
+    default: return std::nullopt;
+    }
+}
+
 struct CanonicalShuffleInfo {
     B3::Opcode opcode;
     SIMDLane lane;
@@ -3923,6 +3933,20 @@ private:
         }
 
         case VectorZipLower: {
+            // Turn this: VectorZipLower(x, zeroConstant) with a widenable integer lane
+            // Into this: VectorExtendLow(x, widerLane, Unsigned)
+            //
+            // zip1(x, 0) interleaves each narrow element of x's low half with a zero
+            // element, which is exactly an unsigned widening of the low half (uxtl / pmovzx).
+            //   zip i8x16  -> i8 ->i16 zero extension
+            //   zip i16x8  -> i16->i32 zero extension
+            //   zip i32x4  -> i32->i64 zero extension
+            if (SIMDValue* zip = m_value->as<SIMDValue>(); zip->child(1)->isV128(vectorAllZeros())) {
+                if (auto widerLane = wideningLaneFor(zip->simdLane())) {
+                    replaceWithNew<SIMDValue>(m_value->origin(), VectorExtendLow, B3::V128, *widerLane, SIMDSignMode::Unsigned, zip->child(0));
+                    break;
+                }
+            }
             // Turn this: VectorZipLower(i64x2, i64x2)
             // Into this: VectorDupElement(i64x2, 0)
             if (tryReduceSameInputShuffleToDup(0))
@@ -3931,6 +3955,14 @@ private:
         }
 
         case VectorZipHigher: {
+            // Turn this: VectorZipHigher(x, zeroConstant) with a widenable integer lane
+            // Into this: VectorExtendHigh(x, widerLane, Unsigned)
+            if (SIMDValue* zip = m_value->as<SIMDValue>(); zip->child(1)->isV128(vectorAllZeros())) {
+                if (auto widerLane = wideningLaneFor(zip->simdLane())) {
+                    replaceWithNew<SIMDValue>(m_value->origin(), VectorExtendHigh, B3::V128, *widerLane, SIMDSignMode::Unsigned, zip->child(0));
+                    break;
+                }
+            }
             // Turn this: VectorZipHigher(i64x2, i64x2)
             // Into this: VectorDupElement(i64x2, 1)
             if (tryReduceSameInputShuffleToDup(1))

--- a/Source/JavaScriptCore/b3/testb3.h
+++ b/Source/JavaScriptCore/b3/testb3.h
@@ -1566,6 +1566,7 @@ void testVectorShlByOne();
 // SIMD vector shift by immediate
 void testVectorShlImmediate();
 void testVectorShrImmediate();
+void testVectorZipWithZeroIsZeroExtend();
 
 // SIMD shuffle → canonical instruction strength reduction
 void testVectorSwizzleToUnzipEven();

--- a/Source/JavaScriptCore/b3/testb3_1.cpp
+++ b/Source/JavaScriptCore/b3/testb3_1.cpp
@@ -1486,6 +1486,7 @@ void run(const TestConfig* config)
         RUN(testVectorXor3());
         RUN(testVectorShlImmediate());
         RUN(testVectorShrImmediate());
+        RUN(testVectorZipWithZeroIsZeroExtend());
         RUN(testVectorUnzipEven());
         RUN(testVectorUnzipOdd());
         RUN(testVectorZipLower());

--- a/Source/JavaScriptCore/b3/testb3_7.cpp
+++ b/Source/JavaScriptCore/b3/testb3_7.cpp
@@ -4571,6 +4571,57 @@ void testVectorShrImmediate()
     testVectorShrImmediateForLane<uint64_t, int64_t>(SIMDLane::i64x2, SIMDSignMode::Signed, 32, 0xFFFFFFFF00000000ull);
     testVectorShrImmediateForLane<uint64_t, int64_t>(SIMDLane::i64x2, SIMDSignMode::Signed, 63, 0x8000000000000000ull);
 }
+
+// Verifies the B3ReduceStrength peephole that rewrites VectorZip{Lower,Higher}(x, zeroConstant)
+// into an unsigned VectorExtend{Low,High}(x): zip-with-zero interleaves each narrow lane with a
+// zero lane, which is exactly a zero-extension (uxtl / uxtl2). NarrowT/WideT are the source and
+// destination lane element types.
+template<typename NarrowT, typename WideT>
+static void testVectorZipZeroExtendForLane(SIMDLane narrowLane, bool high)
+{
+    if constexpr (!isARM64())
+        return;
+
+    alignas(16) v128_t vectors[2];
+    Procedure proc;
+    BasicBlock* root = proc.addBlock();
+    auto arguments = cCallArgumentValues<void*>(proc, root);
+    Value* address = arguments[0];
+    Value* input = root->appendNew<MemoryValue>(proc, Load, V128, Origin(), address);
+    Value* zero = root->appendNew<Const128Value>(proc, Origin(), vectorAllZeros());
+    B3::Opcode zipOp = high ? VectorZipHigher : VectorZipLower;
+    Value* result = root->appendNew<SIMDValue>(proc, Origin(), zipOp, B3::V128, narrowLane, SIMDSignMode::None, input, zero);
+    root->appendNew<MemoryValue>(proc, Store, Origin(), result, address, static_cast<int32_t>(sizeof(v128_t)));
+    root->appendNewControlValue(proc, Return, Origin());
+
+    auto code = compileProc(proc);
+
+    constexpr unsigned narrowLanes = sizeof(v128_t) / sizeof(NarrowT);
+    constexpr unsigned wideLanes = sizeof(v128_t) / sizeof(WideT);
+    for (unsigned i = 0; i < narrowLanes; ++i)
+        reinterpret_cast<NarrowT*>(&vectors[0])[i] = static_cast<NarrowT>(0x80 + i * 0x11);
+    invoke<void>(*code, vectors);
+
+    // Lower zips the low half of the input; higher zips the high half.
+    unsigned base = high ? wideLanes : 0;
+    for (unsigned i = 0; i < wideLanes; ++i) {
+        WideT expected = static_cast<WideT>(reinterpret_cast<NarrowT*>(&vectors[0])[base + i]);
+        CHECK(reinterpret_cast<WideT*>(&vectors[1])[i] == expected);
+    }
+}
+
+void testVectorZipWithZeroIsZeroExtend()
+{
+    if constexpr (!isARM64())
+        return;
+
+    for (bool high : { false, true }) {
+        testVectorZipZeroExtendForLane<uint8_t, uint16_t>(SIMDLane::i8x16, high);
+        testVectorZipZeroExtendForLane<uint16_t, uint32_t>(SIMDLane::i16x8, high);
+        testVectorZipZeroExtendForLane<uint32_t, uint64_t>(SIMDLane::i32x4, high);
+    }
+}
+
 // Helper: build a 3-child (binary) VectorSwizzle with the given byte pattern, verify result.
 static void testBinarySwizzlePattern(const char*, const uint8_t pattern[16], v128_t inputA, v128_t inputB, v128_t expected)
 {


### PR DESCRIPTION
#### d8082ccd8788955200b95084e2bad3e933fdff05
<pre>
[JSC] Add VectorZipX(a, all-zeros) strength reduction
<a href="https://bugs.webkit.org/show_bug.cgi?id=319991">https://bugs.webkit.org/show_bug.cgi?id=319991</a>
<a href="https://rdar.apple.com/182920842">rdar://182920842</a>

Reviewed by Yijia Huang.

This patch adds strength reduction rules for

    VectorZipHigher(a, all-zeros)
    VectorZipLower(a, all-zeros)

Taking low / high part of each narrow lane and extending it with zeros,
so this is VectorExtendHigh / VectorExtendLow.

Tests: Source/JavaScriptCore/b3/testb3_1.cpp
       Source/JavaScriptCore/b3/testb3_7.cpp

* Source/JavaScriptCore/b3/B3ReduceStrength.cpp:
* Source/JavaScriptCore/b3/testb3.h:
* Source/JavaScriptCore/b3/testb3_1.cpp:
(run):
* Source/JavaScriptCore/b3/testb3_7.cpp:
(testVectorZipZeroExtendForLane):
(testVectorZipWithZeroIsZeroExtend):

Canonical link: <a href="https://commits.webkit.org/317726@main">https://commits.webkit.org/317726@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f808cfa7bb64350192da82d5762f779af65cf0cb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176108 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50043 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43833 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185704 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/138338 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6ad1285c-e1f0-4f6b-8129-0dc2d9d9d5eb) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51335 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49727 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137161 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/138338 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ffccb01a-7529-47d4-9d1d-1fec50bed916) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179064 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40636 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157934 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117636 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/95ed8bc1-39aa-43ea-8d15-250f1ce5d0d6) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39285 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37651 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/6443 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149701 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37431 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34172 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/37376 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41759 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41862 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188127 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49708 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146178 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50391 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/34049 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146006 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26757 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40784 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122594 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/116549 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48896 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12403 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48297 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48532 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48356 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->