### PR TITLE
[css-values-5 random-item()] random-item() should be disallowed in @container style() queries

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-item-in-container-query.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-item-in-container-query.tentative-expected.txt
@@ -1,0 +1,6 @@
+
+PASS Query condition should be valid but unknown: (width: random-item(--foo, 10px, 30px))
+PASS random-item() is disallowed in a @container style() query
+PASS random-item() is disallowed in a @container style() range query (custom property = random-item())
+PASS random-item() is disallowed in a @container style() range query (random-item() = random-item())
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-item-in-container-query.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-item-in-container-query.tentative.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<title>CSS Values and Units Test: random-item() in container queries</title>
+<link rel="help" href="https://drafts.csswg.org/css-values-5/#funcdef-random-item">
+<link rel="help" href="https://github.com/w3c/csswg-drafts/issues/10982">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/css-conditional/container-queries/support/cq-testcommon.js"></script>
+<style>
+  @property --length {
+    syntax: "<length>";
+    inherits: true;
+    initial-value: 30px;
+  }
+  #container { container-type: size; --length: 30px; }
+  #target { --test1: true; --test2: true; --test3: true; }
+
+  /* Every random-item() item is 30px and --length is 30px. So if random-item() were (wrongly)
+     evaluated in the query, it would resolve to 30px and the condition WOULD match — flipping the
+     --testN guard to false, no matter which item is picked. With random-item() correctly rejected
+     (guaranteed-invalid), the condition never matches and --testN stays true. Deterministic in both
+     directions — no dependence on the random selection. */
+  @container style(--length: random-item(--foo, 30px, 30px)) { #target { --test1: false; } }
+  @container style(--length = random-item(--foo, 30px, 30px)) { #target { --test2: false; } }
+  @container style(random-item(--foo, 30px, 30px) = random-item(--foo, 30px, 30px)) { #target { --test3: false; } }
+</style>
+<div style="container-name:name">
+  <main id="cq-main"></main>
+</div>
+<div id="container">
+  <div id="target"></div>
+</div>
+<script>
+  // random functions are disallowed outside an element context, so random-item() in a @container
+  // query is rejected like random(). Whether they should be allowed here is an open question:
+  // https://github.com/w3c/csswg-drafts/issues/10982
+
+  // Size-feature form: random-item() isn't a valid <length> feature value, so the condition is
+  // valid-but-unknown (roll-independent, parse-level).
+  test_cq_condition_unknown("(width: random-item(--foo, 10px, 30px))");
+
+  // style() forms: random-item() is rejected at evaluation, so the condition never matches. Each
+  // guard stays "true" iff random-item() was rejected (see the note in the stylesheet — this is
+  // deterministic regardless of which item random-item() would pick).
+  test(() => {
+    assert_equals(getComputedStyle(target).getPropertyValue("--test1"), "true");
+  }, "random-item() is disallowed in a @container style() query");
+  test(() => {
+    assert_equals(getComputedStyle(target).getPropertyValue("--test2"), "true");
+  }, "random-item() is disallowed in a @container style() range query (custom property = random-item())");
+  test(() => {
+    assert_equals(getComputedStyle(target).getPropertyValue("--test3"), "true");
+  }, "random-item() is disallowed in a @container style() range query (random-item() = random-item())");
+
+  // Note: a custom property that merely *holds* random-item() (e.g.
+  //   #container { --v: random-item(--foo, 30px, 30px); }  @container style(--length: var(--v)) {})
+  // is intentionally not tested. random-item() is an arbitrary substitution function, so it resolves
+  // in the container element's own context (where it is allowed) before the query runs — no
+  // random-item() reaches the query. That is the open element-context question above, not a property
+  // of the @container feature; see https://github.com/w3c/csswg-drafts/issues/10982
+</script>

--- a/Source/WebCore/style/StyleBuilder.cpp
+++ b/Source/WebCore/style/StyleBuilder.cpp
@@ -621,6 +621,8 @@ Ref<CSSValue> Builder::resolveSubstitutionFunctions(CSSPropertyID propertyID, CS
 
 RefPtr<const CustomProperty> Builder::resolveCustomPropertyForContainerQueries(const CSSCustomPropertyValue& value)
 {
+    m_state->setIsResolvingContainerQueries();
+
     auto resolvedValue = resolveCustomPropertyValue(const_cast<CSSCustomPropertyValue&>(value));
     if (!resolvedValue)
         return CustomProperty::createForGuaranteedInvalid(value.name());

--- a/Source/WebCore/style/StyleBuilderState.h
+++ b/Source/WebCore/style/StyleBuilderState.h
@@ -167,6 +167,9 @@ public:
     void setIsBuildingKeyframeStyle() { m_isBuildingKeyframeStyle = true; }
     bool hasRevertRuleOrLayerInKeyframeStyle() const { return m_hasRevertRuleOrLayerInKeyframeStyle; }
 
+    void setIsResolvingContainerQueries() { m_isResolvingContainerQueries = true; }
+    bool isResolvingContainerQueries() const { return m_isResolvingContainerQueries; }
+
     bool isAuthorOrigin() const
     {
         return m_currentProperty && m_currentProperty->origin == PropertyCascade::Origin::Author;
@@ -276,6 +279,7 @@ private:
 
     bool m_isBuildingKeyframeStyle { false };
     bool m_hasRevertRuleOrLayerInKeyframeStyle { false };
+    bool m_isResolvingContainerQueries { false };
 };
 
 } // namespace Style

--- a/Source/WebCore/style/StyleSubstitutionResolver.cpp
+++ b/Source/WebCore/style/StyleSubstitutionResolver.cpp
@@ -823,6 +823,12 @@ bool SubstitutionResolver::substituteRandomItemFunction(CSSParserTokenRange rang
 {
     // https://drafts.csswg.org/css-values-5/#funcdef-random-item
 
+    // Reject random-item() when resolving a @container style() query value: random functions are
+    // disallowed outside an element context. (random() is rejected via a separate parse-time guard.)
+    // Whether they should be allowed here is an open question: https://github.com/w3c/csswg-drafts/issues/10982
+    if (m_styleBuilder.state().isResolvingContainerQueries())
+        return false;
+
     // <random-item-args> = random-item( <declaration-value>, [ <declaration-value>? ]# )
     auto randomItemArgs = substituteRandomItemArgumentGrammar(range, context);
     if (!randomItemArgs)


### PR DESCRIPTION
#### b817f195c95ec4f50962f01dfe31c808803f46b8
<pre>
[css-values-5 random-item()] random-item() should be disallowed in @container style() queries
<a href="https://bugs.webkit.org/show_bug.cgi?id=319929">https://bugs.webkit.org/show_bug.cgi?id=319929</a>
<a href="https://rdar.apple.com/182854362">rdar://182854362</a>

Reviewed by Antti Koivisto.

random() is rejected in @container style() query values, but random-item() was not, so
it leaked into a context where random() is blocked. random-item() is an arbitrary
substitution function resolved in StyleSubstitutionResolver rather than a math function
rejected at parse time, so it bypassed the guard that stops random().

Reject random-item() while resolving a @container style() query value. Builder sets a
BuilderState::isResolvingContainerQueries() flag around resolveCustomPropertyForContainerQueries()
(a per-evaluation throwaway builder, so the flag cannot leak into normal style resolution),
and substituteRandomItemFunction() bails when it is set.

Whether random functions should be allowed outside an element context is an open question
(<a href="https://github.com/w3c/csswg-drafts/issues/10982)">https://github.com/w3c/csswg-drafts/issues/10982)</a>; this matches random()&apos;s current
behavior pending a CSSWG resolution.

Test: imported/w3c/web-platform-tests/css/css-values/random-item-in-container-query.tentative.html

* LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-item-in-container-query.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-item-in-container-query.tentative.html: Added.
* Source/WebCore/style/StyleBuilder.cpp:
(WebCore::Style::Builder::resolveCustomPropertyForContainerQueries):
* Source/WebCore/style/StyleBuilderState.h:
(WebCore::Style::BuilderState::setIsResolvingContainerQueries):
(WebCore::Style::BuilderState::isResolvingContainerQueries const):
* Source/WebCore/style/StyleSubstitutionResolver.cpp:
(WebCore::Style::SubstitutionResolver::substituteRandomItemFunction):

Canonical link: <a href="https://commits.webkit.org/318550@main">https://commits.webkit.org/318550@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ffc74adb2c5c7d8c86ed1b495fade69f51b9f95d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176114 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50049 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43839 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185710 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/138344 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f0c434be-df81-4a4c-8ca1-c0801b21fec0) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/177977 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51341 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49733 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137168 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96259 "1 flakes 5 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/39958093-b963-45b7-9199-62a1ce22ea18) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179070 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40641 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157942 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117643 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/dfcacf73-4a0e-4a06-b306-18ed1d0aab4e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39290 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37657 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149706 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37439 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34178 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41765 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41868 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188133 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49714 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/157487 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146184 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39858 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50397 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34057 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146012 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40792 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122600 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/116561 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48902 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12411 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48303 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48538 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48362 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->