### PR TITLE
Fix CMake build on arm64 broken by 317696@main (Enable ASM support in dav1d)

### DIFF
--- a/Source/ThirdParty/dav1d/CMakeLists.txt
+++ b/Source/ThirdParty/dav1d/CMakeLists.txt
@@ -1,7 +1,5 @@
 # Mirrors Source/WebCore/PAL/ThirdParty/dav1d/dav1d.xcodeproj.
-# Pre-committed config.h pins HAVE_ASM=0, so no .S/.asm files and no nasm/yasm/meson are needed.
-# Three OBJECT libs (generic + _8bpc + _16bpc) merge into one STATIC dav1d, matching the Xcode
-# libtool-merge of libdav1d_bitdepth_8.a + libdav1d_bitdepth_16.a + generic objects into libdav1d.a.
+# config.h sets HAVE_ASM=1 only on arm64; on every other arch there are no .S/.asm files to build.
 
 set(DAV1D_DIR "${CMAKE_SOURCE_DIR}/Source/WebCore/PAL/ThirdParty/dav1d")
 
@@ -49,6 +47,36 @@ set(dav1d_tmpl_SOURCES
     src/recon_tmpl.c
 )
 
+# arm64 assembly. The per-bitdepth arm init functions are static-inline in the arm/*.h headers, so
+# arm/cpu.c is the only extra C file. The .S files are compiled once (no BITDEPTH) and set their own
+# architecture via `.arch`, so no assembler flags are needed; the set matches src/meson.build.
+if (WTF_CPU_ARM64)
+    enable_language(ASM)
+    list(APPEND dav1d_generic_SOURCES src/arm/cpu.c)
+    set(dav1d_asm_SOURCES
+        src/arm/64/cdef.S
+        src/arm/64/cdef16.S
+        src/arm/64/filmgrain.S
+        src/arm/64/filmgrain16.S
+        src/arm/64/ipred.S
+        src/arm/64/ipred16.S
+        src/arm/64/itx.S
+        src/arm/64/itx16.S
+        src/arm/64/loopfilter.S
+        src/arm/64/loopfilter16.S
+        src/arm/64/looprestoration.S
+        src/arm/64/looprestoration16.S
+        src/arm/64/looprestoration_common.S
+        src/arm/64/mc.S
+        src/arm/64/mc16.S
+        src/arm/64/mc16_sve.S
+        src/arm/64/mc_dotprod.S
+        src/arm/64/msac.S
+        src/arm/64/refmvs.S
+    )
+    list(TRANSFORM dav1d_asm_SOURCES PREPEND "${DAV1D_DIR}/")
+endif ()
+
 list(TRANSFORM dav1d_generic_SOURCES PREPEND "${DAV1D_DIR}/")
 list(TRANSFORM dav1d_tmpl_SOURCES    PREPEND "${DAV1D_DIR}/")
 
@@ -59,7 +87,14 @@ add_library(dav1d_bitdepth_16 OBJECT ${dav1d_tmpl_SOURCES})
 target_compile_definitions(dav1d_bitdepth_8  PRIVATE BITDEPTH=8)
 target_compile_definitions(dav1d_bitdepth_16 PRIVATE BITDEPTH=16)
 
-foreach (_t dav1d_generic dav1d_bitdepth_8 dav1d_bitdepth_16)
+set(dav1d_OBJECT_LIBRARIES dav1d_generic dav1d_bitdepth_8 dav1d_bitdepth_16)
+
+if (WTF_CPU_ARM64)
+    add_library(dav1d_asm OBJECT ${dav1d_asm_SOURCES})
+    list(APPEND dav1d_OBJECT_LIBRARIES dav1d_asm)
+endif ()
+
+foreach (_t ${dav1d_OBJECT_LIBRARIES})
     target_include_directories(${_t} PRIVATE
         ${DAV1D_DIR}            # for #include "config.h" and "src/*.h"
         ${DAV1D_DIR}/include    # for #include <dav1d/dav1d.h>
@@ -69,10 +104,10 @@ foreach (_t dav1d_generic dav1d_bitdepth_8 dav1d_bitdepth_16)
 endforeach ()
 unset(_t)
 
-add_library(dav1d STATIC
-    $<TARGET_OBJECTS:dav1d_generic>
-    $<TARGET_OBJECTS:dav1d_bitdepth_8>
-    $<TARGET_OBJECTS:dav1d_bitdepth_16>
-)
+add_library(dav1d STATIC)
+foreach (_t ${dav1d_OBJECT_LIBRARIES})
+    target_sources(dav1d PRIVATE $<TARGET_OBJECTS:${_t}>)
+endforeach ()
+unset(_t)
 target_include_directories(dav1d INTERFACE ${DAV1D_DIR}/include)
 set_target_properties(dav1d PROPERTIES C_VISIBILITY_PRESET hidden)


### PR DESCRIPTION
#### 7baf27bd15e01df68926be1e9d36361e20a5fbdb
<pre>
Fix CMake build on arm64 broken by 317696@main (Enable ASM support in dav1d)
<a href="https://bugs.webkit.org/show_bug.cgi?id=319992">https://bugs.webkit.org/show_bug.cgi?id=319992</a>
<a href="https://rdar.apple.com/182923403">rdar://182923403</a>

Reviewed by Alex Christensen.

317696@main (&quot;Enable ASM support in dav1d&quot;) changed config.h so that
HAVE_ASM=1 on arm64 and updated the Xcode project to compile the arm64
.S assembly, but Source/ThirdParty/dav1d/CMakeLists.txt was left behind.
The ASM-enabled C then referenced dav1d_*_neon symbols with no assembly
compiled, breaking the arm64 CMake build.

Compile the arm64 .S files (and the generic arm/cpu.c) in the CMake build
when WTF_CPU_ARM64, mirroring the aarch64 source list in src/meson.build.
The .S files are compiled once into a dedicated OBJECT library (no BITDEPTH)
and set their own architecture via .arch, so no extra assembler flags are
needed. Other architectures keep HAVE_ASM=0 and build no assembly.

* Source/ThirdParty/dav1d/CMakeLists.txt:

Canonical link: <a href="https://commits.webkit.org/317725@main">https://commits.webkit.org/317725@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e065955230b96585ee1980b64c35be1941a3b1c1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176115 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50050 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43840 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185711 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/138346 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2ce5f3b5-0aac-4bfc-ba41-d00d44a5edef) 
| [⏳ 🧪 bindings](https://ews-build.webkit.org/#/builders/Bindings-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51342 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49734 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137169 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/138346 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/431c2680-5ee3-4101-b9ab-33baa8bb0270) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179071 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40640 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157941 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117644 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5f6b6387-312f-4732-9144-37c3b5edae31) 
| [⏳ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/WebKitPy-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39289 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37659 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149705 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37438 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34179 "Built successfully") | | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/41870 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188134 "Built successfully") | | 
| [⏳ 🧪 services](https://ews-build.webkit.org/#/builders/Services-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49715 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146185 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39329 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50398 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/34056 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146013 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40790 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/116562 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48903 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12410 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48304 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48539 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48363 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->