### PR TITLE
[WebTransport] Add exportKeyingMaterial() IDL interface

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/idlharness.https.sub.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/idlharness.https.sub.any-expected.txt
@@ -29,7 +29,7 @@ PASS WebTransport interface: existence and properties of interface prototype obj
 PASS WebTransport interface: existence and properties of interface prototype object's "constructor" property
 PASS WebTransport interface: existence and properties of interface prototype object's @@unscopables property
 PASS WebTransport interface: operation getStats()
-FAIL WebTransport interface: operation exportKeyingMaterial(BufferSource, optional BufferSource) assert_own_property: interface prototype object missing non-static operation expected property "exportKeyingMaterial" missing
+PASS WebTransport interface: operation exportKeyingMaterial(BufferSource, optional BufferSource)
 PASS WebTransport interface: attribute ready
 PASS WebTransport interface: attribute reliability
 PASS WebTransport interface: attribute congestionControl
@@ -49,8 +49,8 @@ PASS WebTransport interface: attribute supportsReliableOnly
 PASS WebTransport must be primary interface of webTransport
 PASS Stringification of webTransport
 PASS WebTransport interface: webTransport must inherit property "getStats()" with the proper type
-FAIL WebTransport interface: webTransport must inherit property "exportKeyingMaterial(BufferSource, optional BufferSource)" with the proper type assert_inherits: property "exportKeyingMaterial" not found in prototype chain
-FAIL WebTransport interface: calling exportKeyingMaterial(BufferSource, optional BufferSource) on webTransport with too few arguments must throw TypeError assert_inherits: property "exportKeyingMaterial" not found in prototype chain
+PASS WebTransport interface: webTransport must inherit property "exportKeyingMaterial(BufferSource, optional BufferSource)" with the proper type
+PASS WebTransport interface: calling exportKeyingMaterial(BufferSource, optional BufferSource) on webTransport with too few arguments must throw TypeError
 PASS WebTransport interface: webTransport must inherit property "ready" with the proper type
 PASS WebTransport interface: webTransport must inherit property "reliability" with the proper type
 PASS WebTransport interface: webTransport must inherit property "congestionControl" with the proper type

--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/idlharness.https.sub.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/idlharness.https.sub.any.serviceworker-expected.txt
@@ -29,7 +29,7 @@ PASS WebTransport interface: existence and properties of interface prototype obj
 PASS WebTransport interface: existence and properties of interface prototype object's "constructor" property
 PASS WebTransport interface: existence and properties of interface prototype object's @@unscopables property
 PASS WebTransport interface: operation getStats()
-FAIL WebTransport interface: operation exportKeyingMaterial(BufferSource, optional BufferSource) assert_own_property: interface prototype object missing non-static operation expected property "exportKeyingMaterial" missing
+PASS WebTransport interface: operation exportKeyingMaterial(BufferSource, optional BufferSource)
 PASS WebTransport interface: attribute ready
 PASS WebTransport interface: attribute reliability
 PASS WebTransport interface: attribute congestionControl
@@ -49,8 +49,8 @@ PASS WebTransport interface: attribute supportsReliableOnly
 PASS WebTransport must be primary interface of webTransport
 PASS Stringification of webTransport
 PASS WebTransport interface: webTransport must inherit property "getStats()" with the proper type
-FAIL WebTransport interface: webTransport must inherit property "exportKeyingMaterial(BufferSource, optional BufferSource)" with the proper type assert_inherits: property "exportKeyingMaterial" not found in prototype chain
-FAIL WebTransport interface: calling exportKeyingMaterial(BufferSource, optional BufferSource) on webTransport with too few arguments must throw TypeError assert_inherits: property "exportKeyingMaterial" not found in prototype chain
+PASS WebTransport interface: webTransport must inherit property "exportKeyingMaterial(BufferSource, optional BufferSource)" with the proper type
+PASS WebTransport interface: calling exportKeyingMaterial(BufferSource, optional BufferSource) on webTransport with too few arguments must throw TypeError
 PASS WebTransport interface: webTransport must inherit property "ready" with the proper type
 PASS WebTransport interface: webTransport must inherit property "reliability" with the proper type
 PASS WebTransport interface: webTransport must inherit property "congestionControl" with the proper type

--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/idlharness.https.sub.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/idlharness.https.sub.any.sharedworker-expected.txt
@@ -29,7 +29,7 @@ PASS WebTransport interface: existence and properties of interface prototype obj
 PASS WebTransport interface: existence and properties of interface prototype object's "constructor" property
 PASS WebTransport interface: existence and properties of interface prototype object's @@unscopables property
 PASS WebTransport interface: operation getStats()
-FAIL WebTransport interface: operation exportKeyingMaterial(BufferSource, optional BufferSource) assert_own_property: interface prototype object missing non-static operation expected property "exportKeyingMaterial" missing
+PASS WebTransport interface: operation exportKeyingMaterial(BufferSource, optional BufferSource)
 PASS WebTransport interface: attribute ready
 PASS WebTransport interface: attribute reliability
 PASS WebTransport interface: attribute congestionControl
@@ -49,8 +49,8 @@ PASS WebTransport interface: attribute supportsReliableOnly
 PASS WebTransport must be primary interface of webTransport
 PASS Stringification of webTransport
 PASS WebTransport interface: webTransport must inherit property "getStats()" with the proper type
-FAIL WebTransport interface: webTransport must inherit property "exportKeyingMaterial(BufferSource, optional BufferSource)" with the proper type assert_inherits: property "exportKeyingMaterial" not found in prototype chain
-FAIL WebTransport interface: calling exportKeyingMaterial(BufferSource, optional BufferSource) on webTransport with too few arguments must throw TypeError assert_inherits: property "exportKeyingMaterial" not found in prototype chain
+PASS WebTransport interface: webTransport must inherit property "exportKeyingMaterial(BufferSource, optional BufferSource)" with the proper type
+PASS WebTransport interface: calling exportKeyingMaterial(BufferSource, optional BufferSource) on webTransport with too few arguments must throw TypeError
 PASS WebTransport interface: webTransport must inherit property "ready" with the proper type
 PASS WebTransport interface: webTransport must inherit property "reliability" with the proper type
 PASS WebTransport interface: webTransport must inherit property "congestionControl" with the proper type

--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/idlharness.https.sub.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/idlharness.https.sub.any.worker-expected.txt
@@ -29,7 +29,7 @@ PASS WebTransport interface: existence and properties of interface prototype obj
 PASS WebTransport interface: existence and properties of interface prototype object's "constructor" property
 PASS WebTransport interface: existence and properties of interface prototype object's @@unscopables property
 PASS WebTransport interface: operation getStats()
-FAIL WebTransport interface: operation exportKeyingMaterial(BufferSource, optional BufferSource) assert_own_property: interface prototype object missing non-static operation expected property "exportKeyingMaterial" missing
+PASS WebTransport interface: operation exportKeyingMaterial(BufferSource, optional BufferSource)
 PASS WebTransport interface: attribute ready
 PASS WebTransport interface: attribute reliability
 PASS WebTransport interface: attribute congestionControl
@@ -49,8 +49,8 @@ PASS WebTransport interface: attribute supportsReliableOnly
 PASS WebTransport must be primary interface of webTransport
 PASS Stringification of webTransport
 PASS WebTransport interface: webTransport must inherit property "getStats()" with the proper type
-FAIL WebTransport interface: webTransport must inherit property "exportKeyingMaterial(BufferSource, optional BufferSource)" with the proper type assert_inherits: property "exportKeyingMaterial" not found in prototype chain
-FAIL WebTransport interface: calling exportKeyingMaterial(BufferSource, optional BufferSource) on webTransport with too few arguments must throw TypeError assert_inherits: property "exportKeyingMaterial" not found in prototype chain
+PASS WebTransport interface: webTransport must inherit property "exportKeyingMaterial(BufferSource, optional BufferSource)" with the proper type
+PASS WebTransport interface: calling exportKeyingMaterial(BufferSource, optional BufferSource) on webTransport with too few arguments must throw TypeError
 PASS WebTransport interface: webTransport must inherit property "ready" with the proper type
 PASS WebTransport interface: webTransport must inherit property "reliability" with the proper type
 PASS WebTransport interface: webTransport must inherit property "congestionControl" with the proper type

--- a/Source/WebCore/Modules/webtransport/WebTransport.cpp
+++ b/Source/WebCore/Modules/webtransport/WebTransport.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "WebTransport.h"
 
+#include "BufferSource.h"
 #include "ContextDestructionObserverInlines.h"
 #include "ContentSecurityPolicy.h"
 #include "DatagramByteSource.h"
@@ -378,6 +379,12 @@ void WebTransport::getStats(ScriptExecutionContext& context, Ref<DeferredPromise
             return promise->reject(ExceptionCode::InvalidStateError);
         promise->resolve<IDLDictionary<WebTransportConnectionStats>>(*stats);
     });
+}
+
+void WebTransport::exportKeyingMaterial(BufferSource&&, std::optional<BufferSource>&&, Ref<DeferredPromise>&& promise)
+{
+    // FIXME: Implement once libnetcore exposes a keying-material export SPI (rdar://167646346).
+    promise->reject(ExceptionCode::NotSupportedError);
 }
 
 DOMPromise& WebTransport::ready()

--- a/Source/WebCore/Modules/webtransport/WebTransport.h
+++ b/Source/WebCore/Modules/webtransport/WebTransport.h
@@ -41,6 +41,7 @@ namespace WebCore {
 
 enum class WebTransportCongestionControl : uint8_t;
 
+class BufferSource;
 class DOMException;
 class DOMPromise;
 class DatagramSource;
@@ -81,6 +82,7 @@ public:
     void deref() const final { WebTransportSessionClient::deref(); }
 
     void getStats(ScriptExecutionContext&, Ref<DeferredPromise>&&);
+    void exportKeyingMaterial(BufferSource&& label, std::optional<BufferSource>&& context, Ref<DeferredPromise>&&);
     DOMPromise& NODELETE ready();
     WebTransportReliabilityMode NODELETE reliability();
     WebTransportCongestionControl NODELETE congestionControl();

--- a/Source/WebCore/Modules/webtransport/WebTransport.idl
+++ b/Source/WebCore/Modules/webtransport/WebTransport.idl
@@ -32,6 +32,7 @@
     [CallWith=CurrentScriptExecutionContext] constructor(USVString url, optional WebTransportOptions options = {});
 
     [CallWith=CurrentScriptExecutionContext] Promise<WebTransportConnectionStats> getStats();
+    Promise<ArrayBuffer> exportKeyingMaterial(BufferSource label, optional BufferSource context);
     readonly attribute Promise<undefined> ready;
     readonly attribute WebTransportReliabilityMode reliability;
     readonly attribute WebTransportCongestionControl congestionControl;


### PR DESCRIPTION
#### 0c4a8543bea68b7d8743d046e5113bbf67b1125d
<pre>
[WebTransport] Add exportKeyingMaterial() IDL interface
<a href="https://bugs.webkit.org/show_bug.cgi?id=319994">https://bugs.webkit.org/show_bug.cgi?id=319994</a>
<a href="https://rdar.apple.com/182925790">rdar://182925790</a>

Reviewed by Alex Christensen.

Add the WebTransport.exportKeyingMaterial() IDL surface so the WebTransport
idlharness WPT conformance checks pass. This covers the interface shape only:
the IDL operation, the prototype property, and argument-arity behavior. The
implementation rejects the returned promise with NotSupportedError because
deriving TLS keying material requires a Network.framework SPI that libnetcore
does not yet expose; the functional implementation remains tracked by
<a href="https://rdar.apple.com/167646346">rdar://167646346</a>.

Clears 3 idlharness subtest FAILs per variant across the 4 webtransport
idlharness variants. No IPC or network-process changes.

* LayoutTests/imported/w3c/web-platform-tests/webtransport/idlharness.https.sub.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webtransport/idlharness.https.sub.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webtransport/idlharness.https.sub.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webtransport/idlharness.https.sub.any.worker-expected.txt:
* Source/WebCore/Modules/webtransport/WebTransport.cpp:
(WebCore::WebTransport::exportKeyingMaterial):
* Source/WebCore/Modules/webtransport/WebTransport.h:
* Source/WebCore/Modules/webtransport/WebTransport.idl:

Canonical link: <a href="https://commits.webkit.org/317720@main">https://commits.webkit.org/317720@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b66f94d237a9e93a403ce624e12f97dcc2081146

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176117 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50052 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43842 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185713 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/138350 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b62ac6b1-d7d0-4a05-81e7-802a4c208bc9) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/177980 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51344 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49736 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/137171 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/138350 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/05b51ac8-f5d1-450b-b20e-488008c2cd7d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179073 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40642 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/157943 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117646 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b1fbe718-f51b-474f-b4d8-8d39f428ea0a) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/39291 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/37661 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149707 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37440 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34181 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41768 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/41872 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188136 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49717 "Built successfully") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/146188 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39324 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50400 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/34058 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146015 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40794 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122603 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/116570 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48905 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12412 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48306 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48541 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48365 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->