### PR TITLE
[EvaluationTimeZoom] Convert remaining grid/table properties to use unzoomed lengths

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/grid-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/grid-expected.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.group {
+  border: solid black 1px;
+  padding: 20px;
+  margin: 10px;
+  width: max-content;
+}
+.outer {
+  display: inline-block;
+  border: solid black 1px;
+}
+.container {
+  width: 100px;
+  height: 100px;
+  display: grid;
+  gap: 10px;
+}
+.container-zoom {
+  width: 200px;
+  height: 200px;
+  display: grid;
+  gap: 20px;
+}
+.item {
+  background: black;
+}
+.spacer {
+  display: inline-block;
+  width: 20px;
+}
+</style>
+</head>
+<body>
+<p>Each grouping below should have two matching boxes.</p>
+<div class="group">
+  <div class="outer">
+    <div class="container" style="grid-template-columns: 40px 1fr 20px; grid-template-rows: 10px 30px 40px;">
+      <div class="item"> </div>
+      <div class="item"> </div>
+      <div class="item"> </div>
+      <div class="item"> </div>
+      <div class="item"> </div>
+      <div class="item"> </div>
+      <div class="item"> </div>
+      <div class="item"> </div>
+      <div class="item"> </div>
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container" style="grid-template-columns: 40px 1fr 20px; grid-template-rows: 10px 30px 40px;">
+      <div class="item"> </div>
+      <div class="item"> </div>
+      <div class="item"> </div>
+      <div class="item"> </div>
+      <div class="item"> </div>
+      <div class="item"> </div>
+      <div class="item"> </div>
+      <div class="item"> </div>
+      <div class="item"> </div>
+    </div>
+  </div>
+</div>
+<div class="group">
+  <div class="outer">
+    <div class="container-zoom" style="grid-template-columns: 80px 1fr 40px; grid-template-rows: 20px 60px 80px;">
+      <div class="item"> </div>
+      <div class="item"> </div>
+      <div class="item"> </div>
+      <div class="item"> </div>
+      <div class="item"> </div>
+      <div class="item"> </div>
+      <div class="item"> </div>
+      <div class="item"> </div>
+      <div class="item"> </div>
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container-zoom" style="grid-template-columns: 80px 1fr 40px; grid-template-rows: 20px 60px 80px;">
+      <div class="item"> </div>
+      <div class="item"> </div>
+      <div class="item"> </div>
+      <div class="item"> </div>
+      <div class="item"> </div>
+      <div class="item"> </div>
+      <div class="item"> </div>
+      <div class="item"> </div>
+      <div class="item"> </div>
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/grid.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/grid.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>CSS Zoom applies to grid-template-columns/grid-template-rows</title>
+<link rel="author" title="Sam Weinig" href="mailto:sam@webkit.org">
+<link rel="help" href="https://drafts.csswg.org/css-viewport/">
+<link rel="match" href="reference/grid-ref.html">
+<style>
+.group {
+  border: solid black 1px;
+  padding: 20px;
+  margin: 10px;
+  width: max-content;
+}
+.outer {
+  display: inline-block;
+  border: solid black 1px;
+  grid-template-columns: 40px 1fr 20px;
+  grid-template-rows: 10px 30px 40px;
+}
+.container {
+  width: 100px;
+  height: 100px;
+  display: grid;
+  gap: 10px;
+}
+.item {
+  background: black;
+}
+.spacer {
+  display: inline-block;
+  width: 20px;
+}
+</style>
+</head>
+<body>
+<p>Each grouping below should have two matching boxes.</p>
+<div class="group">
+  <div class="outer">
+    <div class="container" style="grid-template-columns: 40px 1fr 20px; grid-template-rows: 10px 30px 40px; zoom: 1;">
+      <div class="item"> </div>
+      <div class="item"> </div>
+      <div class="item"> </div>
+      <div class="item"> </div>
+      <div class="item"> </div>
+      <div class="item"> </div>
+      <div class="item"> </div>
+      <div class="item"> </div>
+      <div class="item"> </div>
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container" style="grid-template-columns: inherit; grid-template-rows: inherit; zoom: 1;">
+      <div class="item"> </div>
+      <div class="item"> </div>
+      <div class="item"> </div>
+      <div class="item"> </div>
+      <div class="item"> </div>
+      <div class="item"> </div>
+      <div class="item"> </div>
+      <div class="item"> </div>
+      <div class="item"> </div>
+    </div>
+  </div>
+</div>
+<div class="group">
+  <div class="outer">
+    <div class="container" style="grid-template-columns: 40px 1fr 20px; grid-template-rows: 10px 30px 40px; zoom: 2;">
+      <div class="item"> </div>
+      <div class="item"> </div>
+      <div class="item"> </div>
+      <div class="item"> </div>
+      <div class="item"> </div>
+      <div class="item"> </div>
+      <div class="item"> </div>
+      <div class="item"> </div>
+      <div class="item"> </div>
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container" style="grid-template-columns: inherit; grid-template-rows: inherit; zoom: 2;">
+      <div class="item"> </div>
+      <div class="item"> </div>
+      <div class="item"> </div>
+      <div class="item"> </div>
+      <div class="item"> </div>
+      <div class="item"> </div>
+      <div class="item"> </div>
+      <div class="item"> </div>
+      <div class="item"> </div>
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/grid-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/grid-ref.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.group {
+  border: solid black 1px;
+  padding: 20px;
+  margin: 10px;
+  width: max-content;
+}
+.outer {
+  display: inline-block;
+  border: solid black 1px;
+}
+.container {
+  width: 100px;
+  height: 100px;
+  display: grid;
+  gap: 10px;
+}
+.container-zoom {
+  width: 200px;
+  height: 200px;
+  display: grid;
+  gap: 20px;
+}
+.item {
+  background: black;
+}
+.spacer {
+  display: inline-block;
+  width: 20px;
+}
+</style>
+</head>
+<body>
+<p>Each grouping below should have two matching boxes.</p>
+<div class="group">
+  <div class="outer">
+    <div class="container" style="grid-template-columns: 40px 1fr 20px; grid-template-rows: 10px 30px 40px;">
+      <div class="item"> </div>
+      <div class="item"> </div>
+      <div class="item"> </div>
+      <div class="item"> </div>
+      <div class="item"> </div>
+      <div class="item"> </div>
+      <div class="item"> </div>
+      <div class="item"> </div>
+      <div class="item"> </div>
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container" style="grid-template-columns: 40px 1fr 20px; grid-template-rows: 10px 30px 40px;">
+      <div class="item"> </div>
+      <div class="item"> </div>
+      <div class="item"> </div>
+      <div class="item"> </div>
+      <div class="item"> </div>
+      <div class="item"> </div>
+      <div class="item"> </div>
+      <div class="item"> </div>
+      <div class="item"> </div>
+    </div>
+  </div>
+</div>
+<div class="group">
+  <div class="outer">
+    <div class="container-zoom" style="grid-template-columns: 80px 1fr 40px; grid-template-rows: 20px 60px 80px;">
+      <div class="item"> </div>
+      <div class="item"> </div>
+      <div class="item"> </div>
+      <div class="item"> </div>
+      <div class="item"> </div>
+      <div class="item"> </div>
+      <div class="item"> </div>
+      <div class="item"> </div>
+      <div class="item"> </div>
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container-zoom" style="grid-template-columns: 80px 1fr 40px; grid-template-rows: 20px 60px 80px;">
+      <div class="item"> </div>
+      <div class="item"> </div>
+      <div class="item"> </div>
+      <div class="item"> </div>
+      <div class="item"> </div>
+      <div class="item"> </div>
+      <div class="item"> </div>
+      <div class="item"> </div>
+      <div class="item"> </div>
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
+++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
@@ -19666,6 +19666,8 @@
 		BC4F32CA2E8C518300F6AEC1 /* StyleAccentColor.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StyleAccentColor.h; sourceTree = "<group>"; };
 		BC4F32CB2E8C518300F6AEC1 /* StyleAccentColor.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = StyleAccentColor.cpp; sourceTree = "<group>"; };
 		BC51156D12B1749C00C96754 /* ScrollAnimatorMac.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ScrollAnimatorMac.mm; sourceTree = "<group>"; };
+		BC51496330111DE2003E6266 /* StyleZoomResolvable.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StyleZoomResolvable.h; sourceTree = "<group>"; };
+		BC514965301120A9003E6266 /* StyleZoomResolved.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StyleZoomResolved.h; sourceTree = "<group>"; };
 		BC5238112F82BE2000316BBC /* StyleCounterStyle.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = StyleCounterStyle.cpp; sourceTree = "<group>"; };
 		BC53C5F40DA56B920021EB5D /* Gradient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Gradient.h; sourceTree = "<group>"; };
 		BC53C6070DA56C570021EB5D /* Gradient.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Gradient.cpp; sourceTree = "<group>"; };
@@ -38392,6 +38394,8 @@
 				BC913AE02EE1FA36009E3349 /* StyleZoom.h */,
 				BC913AE12EE1FA36009E3349 /* StyleZoomPrimitives.h */,
 				BC1778102F4908C500E318C5 /* StyleZoomPrimitivesInlines.h */,
+				BC51496330111DE2003E6266 /* StyleZoomResolvable.h */,
+				BC514965301120A9003E6266 /* StyleZoomResolved.h */,
 			);
 			path = viewport;
 			sourceTree = "<group>";

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Grid.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Grid.cpp
@@ -420,7 +420,7 @@ static std::optional<CSS::GridTrackBreadth> consumeUnresolvedGridInflexibleBread
         break;
     }
 
-    if (auto lengthPercentage = MetaConsumer<CSS::LengthPercentage<CSS::Nonnegative>>::consume(range, state)) {
+    if (auto lengthPercentage = MetaConsumer<CSS::LengthPercentage<CSS::NonnegativeUnzoomed>>::consume(range, state)) {
         guard.commit();
         return CSS::GridTrackBreadth { WTF::move(*lengthPercentage) };
     }
@@ -461,7 +461,7 @@ static std::optional<CSS::GridTrackBreadth> consumeUnresolvedGridTrackBreadth(CS
         guard.commit();
         return CSS::GridTrackBreadth { WTF::move(*flex) };
     }
-    if (auto lengthPercentage = MetaConsumer<CSS::LengthPercentage<CSS::Nonnegative>>::consume(range, state)) {
+    if (auto lengthPercentage = MetaConsumer<CSS::LengthPercentage<CSS::NonnegativeUnzoomed>>::consume(range, state)) {
         guard.commit();
         return CSS::GridTrackBreadth { WTF::move(*lengthPercentage) };
     }
@@ -511,7 +511,7 @@ static std::optional<GridInflexibleOrFixedBreadth> consumeUnresolvedGridInflexib
         break;
     }
 
-    if (auto lengthPercentage = MetaConsumer<CSS::LengthPercentage<CSS::Nonnegative>>::consume(range, state)) {
+    if (auto lengthPercentage = MetaConsumer<CSS::LengthPercentage<CSS::NonnegativeUnzoomed>>::consume(range, state)) {
         guard.commit();
         return GridInflexibleOrFixedBreadth {
             .value = CSS::GridTrackBreadth { WTF::move(*lengthPercentage) },
@@ -571,7 +571,7 @@ static std::optional<GridTrackOrFixedBreadth> consumeUnresolvedGridTrackOrFixedB
             .hasConsumedNonFixed = true,
         };
     }
-    if (auto lengthPercentage = MetaConsumer<CSS::LengthPercentage<CSS::Nonnegative>>::consume(range, state)) {
+    if (auto lengthPercentage = MetaConsumer<CSS::LengthPercentage<CSS::NonnegativeUnzoomed>>::consume(range, state)) {
         guard.commit();
         return GridTrackOrFixedBreadth {
             .value = CSS::GridTrackBreadth { WTF::move(*lengthPercentage) },
@@ -591,7 +591,7 @@ static std::optional<CSS::GridFitContentFunction> consumeUnresolvedGridFitConten
     CSSParserTokenRangeGuard guard { range };
     auto args = consumeFunction(range);
 
-    auto lengthPercentage = MetaConsumer<CSS::LengthPercentage<CSS::Nonnegative>>::consume(args, state);
+    auto lengthPercentage = MetaConsumer<CSS::LengthPercentage<CSS::NonnegativeUnzoomed>>::consume(args, state);
     if (!lengthPercentage || !args.atEnd())
         return std::nullopt;
 

--- a/Source/WebCore/css/values/grid/CSSGridTrackBreadth.h
+++ b/Source/WebCore/css/values/grid/CSSGridTrackBreadth.h
@@ -32,13 +32,13 @@ namespace CSS {
 // <track-breadth> = <length-percentage [0,∞]> | <flex [0,∞]> | min-content | max-content | auto
 // https://drafts.csswg.org/css-grid/#typedef-track-breadth
 struct GridTrackBreadth {
-    GridTrackBreadth(LengthPercentage<Nonnegative>&& lengthPercentage) : m_value { WTF::move(lengthPercentage) } { }
+    GridTrackBreadth(LengthPercentage<NonnegativeUnzoomed>&& lengthPercentage) : m_value { WTF::move(lengthPercentage) } { }
     GridTrackBreadth(Flex<Nonnegative>&& flex) : m_value { WTF::move(flex) } { }
     GridTrackBreadth(Keyword::MinContent keyword) : m_value { keyword } { }
     GridTrackBreadth(Keyword::MaxContent keyword) : m_value { keyword } { }
     GridTrackBreadth(Keyword::Auto keyword) : m_value { keyword } { }
 
-    bool isLengthPercentage() const { return WTF::holdsAlternative<LengthPercentage<Nonnegative>>(m_value); }
+    bool isLengthPercentage() const { return WTF::holdsAlternative<LengthPercentage<NonnegativeUnzoomed>>(m_value); }
     bool isFlex() const { return WTF::holdsAlternative<Flex<Nonnegative>>(m_value); }
     bool isMinContent() const { return WTF::holdsAlternative<Keyword::MinContent>(m_value); }
     bool isMaxContent() const { return WTF::holdsAlternative<Keyword::MaxContent>(m_value); }
@@ -52,7 +52,7 @@ struct GridTrackBreadth {
     bool operator==(const GridTrackBreadth&) const = default;
 
 private:
-    Variant<LengthPercentage<Nonnegative>, Flex<Nonnegative>, Keyword::MinContent, Keyword::MaxContent, Keyword::Auto> m_value;
+    Variant<LengthPercentage<NonnegativeUnzoomed>, Flex<Nonnegative>, Keyword::MinContent, Keyword::MaxContent, Keyword::Auto> m_value;
 };
 
 } // namespace CSS

--- a/Source/WebCore/css/values/grid/CSSGridTrackSize.h
+++ b/Source/WebCore/css/values/grid/CSSGridTrackSize.h
@@ -51,7 +51,7 @@ template<size_t I> const auto& get(const GridMinMaxFunctionParameters& value)
 
 // <fit-content()> = fit-content( <length-percentage [0,∞]> )
 struct GridFitContentFunctionParameters {
-    LengthPercentage<Nonnegative> value;
+    LengthPercentage<NonnegativeUnzoomed> value;
 
     bool operator==(const GridFitContentFunctionParameters&) const = default;
 };

--- a/Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.cpp
@@ -190,7 +190,7 @@ UsedTrackSizes GridFormattingContext::layout(GridLayoutConstraints layoutConstra
     auto gridTemplateColumns = inlineAxisDependsOnTracks ? gridTemplateListWithPercentagesConvertedToAuto(gridStyle->gridTemplateColumns()) : gridStyle->gridTemplateColumns();
     auto gridTemplateRows = blockAxisDependsOnTracks ? gridTemplateListWithPercentagesConvertedToAuto(gridStyle->gridTemplateRows()) : gridStyle->gridTemplateRows();
 
-    GridDefinition gridDefinition { gridTemplateColumns, gridTemplateRows, gridStyle->gridAutoColumns(), gridStyle->gridAutoRows(), autoFlowOptions };
+    GridDefinition gridDefinition { gridTemplateColumns, gridTemplateRows, gridStyle->gridAutoColumns(), gridStyle->gridAutoRows(), autoFlowOptions, gridStyle->usedZoomForLength() };
 
     auto usedJustifyContent = gridStyle->justifyContent().resolve();
     auto usedAlignContent = gridStyle->alignContent().resolve();
@@ -298,7 +298,8 @@ GridFormattingContext::IntrinsicWidths GridFormattingContext::computeIntrinsicWi
         gridTemplateListWithPercentagesConvertedToAuto(gridStyle->gridTemplateRows()),
         gridStyle->gridAutoColumns(),
         gridStyle->gridAutoRows(),
-        autoFlowOptions
+        autoFlowOptions,
+        gridStyle->usedZoomForLength(),
     };
 
     auto usedJustifyContent = gridStyle->justifyContent().resolve();

--- a/Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.h
+++ b/Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.h
@@ -32,6 +32,7 @@
 #include <WebCore/StyleGridTemplateList.h>
 #include <WebCore/StyleGridTrackSizes.h>
 #include <WebCore/StylePrimitiveNumericTypes+Evaluation.h>
+#include <WebCore/StyleZoomPrimitives.h>
 #include <wtf/CheckedRef.h>
 
 namespace WebCore {
@@ -68,6 +69,7 @@ struct GridDefinition {
     Style::GridTrackSizes gridAutoColumns;
     Style::GridTrackSizes gridAutoRows;
     GridAutoFlowOptions autoFlowOptions;
+    Style::ZoomFactor zoom;
 };
 
 // Static classification of how much grid-sizing work is required to compute

--- a/Source/WebCore/layout/formattingContexts/grid/GridLayout.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayout.cpp
@@ -210,8 +210,8 @@ GridLayoutResult GridLayout::layout(UnplacedGridItems& unplacedGridItems, const 
     auto [ gridAreas, columnsCount, rowsCount ] = placeGridItems(unplacedGridItems, gridTemplateColumnsTrackSizes, gridTemplateRowsTrackSizes, gridDefinition.autoFlowOptions);
     auto placedGridItems = formattingContext.constructPlacedGridItems(gridAreas);
 
-    auto columnTrackSizingFunctionsList = trackSizingFunctions(columnsCount, gridTemplateColumnsTrackSizes, gridDefinition.gridAutoColumns);
-    auto rowTrackSizingFunctionsList = trackSizingFunctions(rowsCount, gridTemplateRowsTrackSizes, gridDefinition.gridAutoRows);
+    auto columnTrackSizingFunctionsList = trackSizingFunctions(columnsCount, gridTemplateColumnsTrackSizes, gridDefinition.gridAutoColumns, gridDefinition.zoom);
+    auto rowTrackSizingFunctionsList = trackSizingFunctions(rowsCount, gridTemplateRowsTrackSizes, gridDefinition.gridAutoRows, gridDefinition.zoom);
 
     // https://drafts.csswg.org/css-grid-1/#algo-grid-sizing
     // Fast path: the caller only needs the column sizes resolved by step 1 of the grid sizing
@@ -315,7 +315,7 @@ BorderBoxPositions GridLayout::performBlockAxisSelfAlignment(const PlacedGridIte
     return borderBoxPositions;
 }
 
-TrackSizingFunctions GridLayout::convertGridTrackSizeToTrackSizingFunctions(const Style::GridTrackSize& gridTrackSize)
+TrackSizingFunctions GridLayout::convertGridTrackSizeToTrackSizingFunctions(const Style::GridTrackSize& gridTrackSize, const Style::ZoomFactor& zoom)
 {
     auto minTrackSizingFunction = [&]() {
         // If the track was sized with a minmax() function, this is the first argument to that function.
@@ -341,12 +341,12 @@ TrackSizingFunctions GridLayout::convertGridTrackSizeToTrackSizingFunctions(cons
         return gridTrackSize.maxTrackBreadth();
     };
 
-    return TrackSizingFunctions { minTrackSizingFunction(), maxTrackSizingFunction() };
+    return TrackSizingFunctions { minTrackSizingFunction(), maxTrackSizingFunction(), zoom };
 }
 
 // Generates track sizing functions for implicit tracks using grid-auto-{columns,rows}
 // FIXME: This function only supports appended tracks but not prepended tracks.
-TrackSizingFunctionsList GridLayout::generateImplicitTrackSizingFunctions(size_t explicitTracksCount, size_t totalTracksCount, const Style::GridTrackSizes& gridAutoTrackSizes)
+TrackSizingFunctionsList GridLayout::generateImplicitTrackSizingFunctions(size_t explicitTracksCount, size_t totalTracksCount, const Style::GridTrackSizes& gridAutoTrackSizes, const Style::ZoomFactor& zoom)
 {
     // https://drafts.csswg.org/css-grid-1/#auto-tracks
     size_t implicitTracksCount = totalTracksCount - explicitTracksCount;
@@ -357,13 +357,13 @@ TrackSizingFunctionsList GridLayout::generateImplicitTrackSizingFunctions(size_t
     // Cycle through grid-auto-{columns,rows} values using modulo.
     for (size_t i = 0; i < implicitTracksCount; ++i) {
         size_t autoTrackIndex = i % gridAutoTrackSizes.size();
-        trackSizingFunctionsForImplicitGrid.append(convertGridTrackSizeToTrackSizingFunctions(gridAutoTrackSizes[autoTrackIndex]));
+        trackSizingFunctionsForImplicitGrid.append(convertGridTrackSizeToTrackSizingFunctions(gridAutoTrackSizes[autoTrackIndex], zoom));
     }
 
     return trackSizingFunctionsForImplicitGrid;
 }
 
-TrackSizingFunctionsList GridLayout::trackSizingFunctions(size_t totalTracksCount, const Vector<Style::GridTrackSize>& gridTemplateTrackSizes, const Style::GridTrackSizes& gridAutoTrackSizes)
+TrackSizingFunctionsList GridLayout::trackSizingFunctions(size_t totalTracksCount, const Vector<Style::GridTrackSize>& gridTemplateTrackSizes, const Style::GridTrackSizes& gridAutoTrackSizes, const Style::ZoomFactor& zoom)
 {
     // FIXME: This function only supports appended tracks but not prepended tracks.
     // Per spec, we should support both forward and backward implicit tracks.
@@ -375,12 +375,12 @@ TrackSizingFunctionsList GridLayout::trackSizingFunctions(size_t totalTracksCoun
     // https://drafts.csswg.org/css-grid-1/#algo-terms
     // Map explicit tracks from grid-template-{columns,rows}
     for (auto& gridTrackSize : gridTemplateTrackSizes)
-        trackSizingFunctions.append(convertGridTrackSizeToTrackSizingFunctions(gridTrackSize));
+        trackSizingFunctions.append(convertGridTrackSizeToTrackSizingFunctions(gridTrackSize, zoom));
 
     // Generate implicit tracks using grid-auto-{columns,rows}
     // https://drafts.csswg.org/css-grid-1/#auto-tracks
     // "The first track after the last explicitly-sized track receives the first specified size, and so on forwards"
-    auto implicitTrackSizingFunctions = generateImplicitTrackSizingFunctions(gridTemplateTrackSizes.size(), totalTracksCount, gridAutoTrackSizes);
+    auto implicitTrackSizingFunctions = generateImplicitTrackSizingFunctions(gridTemplateTrackSizes.size(), totalTracksCount, gridAutoTrackSizes, zoom);
     trackSizingFunctions.appendVector(implicitTrackSizingFunctions);
 
     ASSERT(trackSizingFunctions.size() == totalTracksCount);
@@ -394,16 +394,16 @@ static Vector<LayoutUnit> rowSizesForFirstIterationColumnSizing(const TrackSizin
 {
     return rowTrackSizingFunctionsList.map([&gridContainerInnerInlineSize](const TrackSizingFunctions& trackSizingFunctions) {
         return WTF::switchOn(trackSizingFunctions.max,
-            [](const Style::GridTrackBreadthLength::Fixed& fixedValue) {
-                return Style::evaluate<LayoutUnit>(fixedValue, Style::ZoomNeeded { });
+            [&](const Style::GridTrackBreadthLength::Fixed& fixedValue) {
+                return Style::evaluate<LayoutUnit>(fixedValue, trackSizingFunctions.zoom);
             },
-            [&gridContainerInnerInlineSize](const Style::GridTrackBreadthLength::Percentage& percentageValue) {
+            [&](const Style::GridTrackBreadthLength::Percentage& percentageValue) {
                 ASSERT(gridContainerInnerInlineSize, "The formatting context should have transformed this track size to auto");
                 return Style::evaluate<LayoutUnit>(percentageValue, *gridContainerInnerInlineSize);
             },
-            [&gridContainerInnerInlineSize](const Style::GridTrackBreadth::Calc calculatedValue) -> LayoutUnit {
+            [&](const Style::GridTrackBreadth::Calc calculatedValue) -> LayoutUnit {
                 ASSERT(gridContainerInnerInlineSize, "The formatting context should have transformed this track size to auto");
-                return Style::evaluate<LayoutUnit>(calculatedValue, *gridContainerInnerInlineSize, Style::ZoomNeeded { });
+                return Style::evaluate<LayoutUnit>(calculatedValue, *gridContainerInnerInlineSize, trackSizingFunctions.zoom);
             },
             [](const CSS::Keyword::MinContent&) -> LayoutUnit {
                 return LayoutUnit::max();

--- a/Source/WebCore/layout/formattingContexts/grid/GridLayout.h
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayout.h
@@ -77,9 +77,9 @@ private:
     GridDimensions calculateInitialImplicitGridDimensions(const UnplacedGridItems&, size_t explicitColumnsCount, size_t explicitRowsCount);
     ImplicitGrid constructInitialImplicitGrid(UnplacedGridItems&, size_t explicitColumnsCount, size_t explicitRowsCount);
 
-    static TrackSizingFunctions convertGridTrackSizeToTrackSizingFunctions(const Style::GridTrackSize&);
-    static TrackSizingFunctionsList generateImplicitTrackSizingFunctions(size_t explicitTracksCount, size_t totalTracksCount, const Style::GridTrackSizes& gridAutoTrackSizes);
-    static TrackSizingFunctionsList trackSizingFunctions(size_t totalTracksCount, const Vector<Style::GridTrackSize>& gridTemplateTrackSizes, const Style::GridTrackSizes& gridAutoTrackSizes);
+    static TrackSizingFunctions convertGridTrackSizeToTrackSizingFunctions(const Style::GridTrackSize&, const Style::ZoomFactor&);
+    static TrackSizingFunctionsList generateImplicitTrackSizingFunctions(size_t explicitTracksCount, size_t totalTracksCount, const Style::GridTrackSizes& gridAutoTrackSizes, const Style::ZoomFactor&);
+    static TrackSizingFunctionsList trackSizingFunctions(size_t totalTracksCount, const Vector<Style::GridTrackSize>& gridTemplateTrackSizes, const Style::GridTrackSizes& gridAutoTrackSizes, const Style::ZoomFactor&);
 
     UsedTrackSizes performGridSizingAlgorithm(const GridLayoutState&, const PlacedGridItems&, const TrackSizingFunctionsList&, const TrackSizingFunctionsList&) const;
     TrackSizes sizeColumnTracks(const PlacedGridItems&, const TrackSizingFunctionsList& columnTrackSizingFunctions, const TrackSizingFunctionsList& rowTrackSizingFunctions, const GridLayoutState&) const;

--- a/Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.cpp
@@ -249,13 +249,14 @@ static std::optional<LayoutUnit> fixedMaxTrackSizingFunctionSum(const WTF::Range
 {
     LayoutUnit sum;
     for (size_t trackIndex = itemSpan.begin(); trackIndex < itemSpan.end(); ++trackIndex) {
-        auto& maxTrackSizingFunction = unsizedTracks[trackIndex].trackSizingFunction.max;
+        auto& trackSizingFunction = unsizedTracks[trackIndex].trackSizingFunction;
+        auto& maxTrackSizingFunction = trackSizingFunction.max;
         if (!maxTrackSizingFunction.isLength())
             return { };
         auto fixedValue = maxTrackSizingFunction.length().tryFixed();
         if (!fixedValue)
             return { };
-        sum += LayoutUnit { fixedValue->resolveZoom(Style::ZoomNeeded { }) };
+        sum += Style::evaluate<LayoutUnit>(*fixedValue, trackSizingFunction.zoom);
     }
     return sum;
 }
@@ -689,10 +690,9 @@ static UnsizedTracks initializeTrackSizes(const TrackSizingFunctionsList& trackS
             if (minTrackSizingFunction.isLength()) {
                 auto& trackBreadthLength = minTrackSizingFunction.length();
                 if (auto fixedValue = trackBreadthLength.tryFixed())
-                    return LayoutUnit { fixedValue->resolveZoom(Style::ZoomNeeded { }) };
+                    return Style::evaluate<LayoutUnit>(*fixedValue, trackSizingFunctions.zoom);
                 if (trackBreadthLength.isPercentOrCalculated())
-                    return Style::evaluate<LayoutUnit>(trackBreadthLength, availableGridSpace, Style::ZoomNeeded { });
-
+                    return Style::evaluate<LayoutUnit>(trackBreadthLength, availableGridSpace, trackSizingFunctions.zoom);
             }
 
             // An intrinsic sizing function
@@ -713,9 +713,9 @@ static UnsizedTracks initializeTrackSizes(const TrackSizingFunctionsList& trackS
             if (maxTrackSizingFunction.isLength()) {
                 auto trackBreadthLength = maxTrackSizingFunction.length();
                 if (auto fixedValue = trackBreadthLength.tryFixed())
-                    return LayoutUnit { fixedValue->resolveZoom(Style::ZoomNeeded { }) };
+                    return Style::evaluate<LayoutUnit>(*fixedValue, trackSizingFunctions.zoom);
                 if (trackBreadthLength.isPercentOrCalculated())
-                    return Style::evaluate<LayoutUnit>(trackBreadthLength, availableGridSpace, Style::ZoomNeeded { });
+                    return Style::evaluate<LayoutUnit>(trackBreadthLength, availableGridSpace, trackSizingFunctions.zoom);
             }
 
             // An intrinsic sizing function

--- a/Source/WebCore/layout/formattingContexts/grid/TrackSizingFunctions.h
+++ b/Source/WebCore/layout/formattingContexts/grid/TrackSizingFunctions.h
@@ -26,12 +26,16 @@
 #pragma once
 
 #include "StyleGridTrackBreadth.h"
+#include "StyleZoomPrimitives.h"
 
 namespace WebCore {
 namespace Layout {
+
 struct TrackSizingFunctions {
     Style::GridTrackBreadth min { CSS::Keyword::Auto { } };
     Style::GridTrackBreadth max { CSS::Keyword::Auto { } };
+    Style::ZoomFactor zoom;
 };
-}
-}
+
+} // namespace Layout
+} // namespace WebCore

--- a/Source/WebCore/layout/formattingContexts/table/TableFormattingContext.cpp
+++ b/Source/WebCore/layout/formattingContexts/table/TableFormattingContext.cpp
@@ -329,8 +329,11 @@ IntrinsicWidthConstraints TableFormattingContext::computedIntrinsicWidthForColum
                     return width;
                 return formattingGeometry.computedColumnWidth(*columnBox);
             }();
-        if (fixedWidth)
-            column.setComputedLogicalWidth(Style::Length<CSS::Nonnegative, float> { *fixedWidth });
+            if (fixedWidth) {
+                column.setComputedLogicalWidth(TableGrid::Column::ComputedLogicalWidthFixed {
+                    Style::Length<CSS::NonnegativeUnzoomed, float> { *fixedWidth }
+                });
+            }
         }
     };
     collectColsFixedWidth();
@@ -445,8 +448,11 @@ IntrinsicWidthConstraints TableFormattingContext::computedIntrinsicWidthForColum
 
         if (hasColumnWithFixedWidth && !hasColumnWithPercentWidth) {
             for (size_t columnIndex = 0; columnIndex < columnList.size(); ++columnIndex) {
-                if (auto fixedWidth = maximumFixedColumnWidths[columnIndex])
-                    columnList[columnIndex].setComputedLogicalWidth(Style::Length<CSS::Nonnegative, float> { *fixedWidth });
+                if (auto fixedWidth = maximumFixedColumnWidths[columnIndex]) {
+                    columnList[columnIndex].setComputedLogicalWidth(TableGrid::Column::ComputedLogicalWidthFixed {
+                        Style::Length<CSS::NonnegativeUnzoomed, float> { *fixedWidth }
+                    });
+                }
             }
             return;
         } 
@@ -462,7 +468,9 @@ IntrinsicWidthConstraints TableFormattingContext::computedIntrinsicWidthForColum
         for (size_t columnIndex = 0; columnIndex < columnList.size(); ++columnIndex) {
             auto nonPercentColumnWidth = columnIntrinsicWidths[columnIndex].maximum;
             if (auto fixedWidth = maximumFixedColumnWidths[columnIndex]) {
-                columnList[columnIndex].setComputedLogicalWidth(Style::Length<CSS::Nonnegative, float> { *fixedWidth });
+                columnList[columnIndex].setComputedLogicalWidth(TableGrid::Column::ComputedLogicalWidthFixed {
+                    Style::Length<CSS::NonnegativeUnzoomed, float> { *fixedWidth }
+                });
                 nonPercentColumnWidth = std::max(nonPercentColumnWidth, *fixedWidth);
             }
             if (!maximumPercentColumnWidths[columnIndex]) {
@@ -470,7 +478,9 @@ IntrinsicWidthConstraints TableFormattingContext::computedIntrinsicWidthForColum
                 continue;
             }
             auto percent = std::min(*maximumPercentColumnWidths[columnIndex], remainingPercent);
-            columnList[columnIndex].setComputedLogicalWidth(Style::Percentage<CSS::Nonnegative, float> { percent });
+            columnList[columnIndex].setComputedLogicalWidth(TableGrid::Column::ComputedLogicalWidthPercentage {
+                percent
+            });
             percentMaximumWidth = std::max(percentMaximumWidth, LayoutUnit { nonPercentColumnWidth * 100.0f / percent });
             remainingPercent -= percent;
         }

--- a/Source/WebCore/layout/formattingContexts/table/TableGrid.h
+++ b/Source/WebCore/layout/formattingContexts/table/TableGrid.h
@@ -30,6 +30,7 @@
 #include "LayoutBoxGeometry.h"
 #include "LayoutUnits.h"
 #include "StylePrimitiveNumericTypes.h"
+#include "StyleZoomResolved.h"
 #include <wtf/HashMap.h>
 #include <wtf/ListHashSet.h>
 #include <wtf/Variant.h>
@@ -93,10 +94,17 @@ public:
     std::optional<IntrinsicWidthConstraints> widthConstraints() const { return m_intrinsicWidthConstraints; }
 
     bool isEmpty() const { return m_slotMap.isEmpty(); }
+
     // Column represents a vertical set of slots in the grid. A column has horizontal position and width.
     class Column {
     public:
-        using ComputedLogicalWidth = Variant<CSS::Keyword::Auto, Style::Length<CSS::Nonnegative, float>, Style::Percentage<CSS::Nonnegative, float>>;
+        using ComputedLogicalWidthFixed = Style::ZoomResolved<Style::Length<CSS::NonnegativeUnzoomed, float>>;
+        using ComputedLogicalWidthPercentage = Style::Percentage<CSS::Nonnegative, float>;
+        using ComputedLogicalWidth = Variant<
+            CSS::Keyword::Auto,
+            ComputedLogicalWidthFixed,
+            ComputedLogicalWidthPercentage
+        >;
 
         Column(const ElementBox*);
 

--- a/Source/WebCore/layout/formattingContexts/table/TableLayout.cpp
+++ b/Source/WebCore/layout/formattingContexts/table/TableLayout.cpp
@@ -338,10 +338,10 @@ TableFormattingContext::TableLayout::DistributedSpaces TableFormattingContext::T
             [&](const CSS::Keyword::Auto&) -> std::pair<std::optional<float>, GridSpace::Type> {
                 return { std::nullopt, GridSpace::Type::Auto };
             },
-            [&](const Style::Length<CSS::Nonnegative, float>& fixed) -> std::pair<std::optional<float>, GridSpace::Type> {
-                return { fixed.resolveZoom(Style::ZoomNeeded { }), GridSpace::Type::Fixed };
+            [&](const TableGrid::Column::ComputedLogicalWidthFixed& fixed) -> std::pair<std::optional<float>, GridSpace::Type> {
+                return { Style::evaluate<float>(fixed), GridSpace::Type::Fixed };
             },
-            [&](const Style::Percentage<CSS::Nonnegative, float>& percentage) -> std::pair<std::optional<float>, GridSpace::Type> {
+            [&](const TableGrid::Column::ComputedLogicalWidthPercentage& percentage) -> std::pair<std::optional<float>, GridSpace::Type> {
                 return { Style::evaluate<float>(percentage, availableHorizontalSpace), GridSpace::Type::Percent };
             }
         );

--- a/Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp
+++ b/Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp
@@ -158,13 +158,13 @@ void GridTrack::setGrowthLimitCap(std::optional<LayoutUnit> growthLimitCap)
     m_growthLimitCap = growthLimitCap;
 }
 
-const Style::GridTrackSize& GridTrack::cachedTrackSize() const
+const Style::ZoomResolvable<Style::GridTrackSize>& GridTrack::cachedTrackSize() const
 {
     RELEASE_ASSERT(m_cachedTrackSize);
     return *m_cachedTrackSize;
 }
 
-void GridTrack::setCachedTrackSize(const Style::GridTrackSize& cachedTrackSize)
+void GridTrack::setCachedTrackSize(const Style::ZoomResolvable<Style::GridTrackSize>& cachedTrackSize)
 {
     m_cachedTrackSize = cachedTrackSize;
 }
@@ -256,29 +256,29 @@ LayoutUnit GridTrackSizingAlgorithm::computeTrackBasedSize() const
     return size;
 }
 
-LayoutUnit GridTrackSizingAlgorithm::initialBaseSize(const Style::GridTrackSize& trackSize) const
+LayoutUnit GridTrackSizingAlgorithm::initialBaseSize(const Style::ZoomResolvable<Style::GridTrackSize>& trackSize) const
 {
-    auto& gridLength = trackSize.minTrackBreadth();
+    auto& gridLength = trackSize.value.minTrackBreadth();
     if (gridLength.isFlex())
         return 0;
 
     auto& trackLength = gridLength.length();
     if (trackLength.isSpecified())
-        return Style::evaluate<LayoutUnit>(trackLength, std::max<LayoutUnit>(availableSpace().value_or(0), 0), Style::ZoomNeeded { });
+        return Style::evaluate<LayoutUnit>(trackLength, std::max<LayoutUnit>(availableSpace().value_or(0), 0), trackSize.zoom);
 
     ASSERT(trackLength.isMinContent() || trackLength.isAuto() || trackLength.isMaxContent());
     return 0;
 }
 
-LayoutUnit GridTrackSizingAlgorithm::initialGrowthLimit(const Style::GridTrackSize& trackSize, LayoutUnit baseSize) const
+LayoutUnit GridTrackSizingAlgorithm::initialGrowthLimit(const Style::ZoomResolvable<Style::GridTrackSize>& trackSize, LayoutUnit baseSize) const
 {
-    auto& gridLength = trackSize.maxTrackBreadth();
+    auto& gridLength = trackSize.value.maxTrackBreadth();
     if (gridLength.isFlex())
-        return trackSize.minTrackBreadth().isContentSized() ? LayoutUnit(infinity) : baseSize;
+        return trackSize.value.minTrackBreadth().isContentSized() ? LayoutUnit(infinity) : baseSize;
 
     auto& trackLength = gridLength.length();
     if (trackLength.isSpecified())
-        return Style::evaluate<LayoutUnit>(trackLength, std::max<LayoutUnit>(availableSpace().value_or(0), 0), Style::ZoomNeeded { });
+        return Style::evaluate<LayoutUnit>(trackLength, std::max<LayoutUnit>(availableSpace().value_or(0), 0), trackSize.zoom);
 
     ASSERT(trackLength.isMinContent() || trackLength.isAuto() || trackLength.isMaxContent());
     return infinity;
@@ -289,19 +289,19 @@ void GridTrackSizingAlgorithm::sizeTrackToFitSingleSpanMasonryGroup(const GridSp
     auto trackPosition = span.startLine();
     const auto& trackSize = tracks(m_direction)[trackPosition]->cachedTrackSize();
 
-    if (trackSize.hasMinContentMinTrackBreadth())
+    if (trackSize.value.hasMinContentMinTrackBreadth())
         track.setBaseSize(std::max(track.baseSize(), masonryIndefiniteItems.minContentSize));
-    else if (trackSize.hasMaxContentMinTrackBreadth())
+    else if (trackSize.value.hasMaxContentMinTrackBreadth())
         track.setBaseSize(std::max(track.baseSize(), masonryIndefiniteItems.maxContentSize));
-    else if (trackSize.hasAutoMinTrackBreadth())
+    else if (trackSize.value.hasAutoMinTrackBreadth())
         track.setBaseSize(std::max(track.baseSize(), masonryIndefiniteItems.minSize));
 
-    if (trackSize.hasMinContentMaxTrackBreadth())
+    if (trackSize.value.hasMinContentMaxTrackBreadth())
         track.setGrowthLimit(std::max(track.growthLimit(), masonryIndefiniteItems.minContentSize));
-    else if (trackSize.hasMaxContentOrAutoMaxTrackBreadth()) {
+    else if (trackSize.value.hasMaxContentOrAutoMaxTrackBreadth()) {
         auto growthLimit = masonryIndefiniteItems.maxContentSize;
-        if (trackSize.isFitContent())
-            growthLimit = std::min(growthLimit, Style::evaluate<LayoutUnit>(trackSize.fitContentTrackLength(), availableSpace().value_or(0), Style::ZoomNeeded { }));
+        if (trackSize.value.isFitContent())
+            growthLimit = std::min(growthLimit, Style::evaluate<LayoutUnit>(trackSize.value.fitContentTrackLength(), availableSpace().value_or(0), trackSize.zoom));
         track.setGrowthLimit(std::max(track.growthLimit(), growthLimit));
     }
 }
@@ -311,20 +311,20 @@ void GridTrackSizingAlgorithm::sizeTrackToFitNonSpanningItem(const GridSpan& spa
     unsigned trackPosition = span.startLine();
     const auto& trackSize = tracks(m_direction)[trackPosition]->cachedTrackSize();
 
-    if (trackSize.hasMinContentMinTrackBreadth()) {
+    if (trackSize.value.hasMinContentMinTrackBreadth()) {
         track.setBaseSize(std::max(track.baseSize(), m_strategy->minContentContributionForGridItem(gridItem, gridLayoutState)));
-    } else if (trackSize.hasMaxContentMinTrackBreadth()) {
+    } else if (trackSize.value.hasMaxContentMinTrackBreadth()) {
         track.setBaseSize(std::max(track.baseSize(), m_strategy->maxContentContributionForGridItem(gridItem, gridLayoutState)));
-    } else if (trackSize.hasAutoMinTrackBreadth()) {
+    } else if (trackSize.value.hasAutoMinTrackBreadth()) {
         track.setBaseSize(std::max(track.baseSize(), m_strategy->minContributionForGridItem(gridItem, gridLayoutState)));
     }
 
-    if (trackSize.hasMinContentMaxTrackBreadth()) {
+    if (trackSize.value.hasMinContentMaxTrackBreadth()) {
         track.setGrowthLimit(std::max(track.growthLimit(), m_strategy->minContentContributionForGridItem(gridItem, gridLayoutState)));
-    } else if (trackSize.hasMaxContentOrAutoMaxTrackBreadth()) {
+    } else if (trackSize.value.hasMaxContentOrAutoMaxTrackBreadth()) {
         LayoutUnit growthLimit = m_strategy->maxContentContributionForGridItem(gridItem, gridLayoutState);
-        if (trackSize.isFitContent())
-            growthLimit = std::min(growthLimit, Style::evaluate<LayoutUnit>(trackSize.fitContentTrackLength(), availableSpace().value_or(0), Style::ZoomNeeded { }));
+        if (trackSize.value.isFitContent())
+            growthLimit = std::min(growthLimit, Style::evaluate<LayoutUnit>(trackSize.value.fitContentTrackLength(), availableSpace().value_or(0), trackSize.zoom));
         track.setGrowthLimit(std::max(track.growthLimit(), growthLimit));
     }
 }
@@ -334,7 +334,7 @@ bool GridTrackSizingAlgorithm::spanningItemCrossesFlexibleSizedTracks(const Grid
     auto& trackList = tracks(m_direction);
     for (auto trackPosition : itemSpan) {
         const auto& trackSize = trackList[trackPosition]->cachedTrackSize();
-        if (trackSize.minTrackBreadth().isFlex() || trackSize.maxTrackBreadth().isFlex())
+        if (trackSize.value.minTrackBreadth().isFlex() || trackSize.value.maxTrackBreadth().isFlex())
             return true;
     }
 
@@ -404,19 +404,19 @@ LayoutUnit GridTrackSizingAlgorithm::itemSizeForTrackSizeComputationPhaseMasonry
     return 0;
 }
 
-static bool NODELETE shouldProcessTrackForTrackSizeComputationPhase(TrackSizeComputationPhase phase, const Style::GridTrackSize& trackSize)
+static bool NODELETE shouldProcessTrackForTrackSizeComputationPhase(TrackSizeComputationPhase phase, const Style::ZoomResolvable<Style::GridTrackSize>& trackSize)
 {
     switch (phase) {
     case TrackSizeComputationPhase::ResolveIntrinsicMinimums:
-        return trackSize.hasIntrinsicMinTrackBreadth();
+        return trackSize.value.hasIntrinsicMinTrackBreadth();
     case TrackSizeComputationPhase::ResolveContentBasedMinimums:
-        return trackSize.hasMinOrMaxContentMinTrackBreadth();
+        return trackSize.value.hasMinOrMaxContentMinTrackBreadth();
     case TrackSizeComputationPhase::ResolveMaxContentMinimums:
-        return trackSize.hasMaxContentMinTrackBreadth();
+        return trackSize.value.hasMaxContentMinTrackBreadth();
     case TrackSizeComputationPhase::ResolveIntrinsicMaximums:
-        return trackSize.hasIntrinsicMaxTrackBreadth();
+        return trackSize.value.hasIntrinsicMaxTrackBreadth();
     case TrackSizeComputationPhase::ResolveMaxContentMaximums:
-        return trackSize.hasMaxContentOrAutoMaxTrackBreadth();
+        return trackSize.value.hasMaxContentOrAutoMaxTrackBreadth();
     case TrackSizeComputationPhase::MaximizeTracks:
         ASSERT_NOT_REACHED();
         return false;
@@ -463,14 +463,14 @@ static void updateTrackSizeForTrackSizeComputationPhase(TrackSizeComputationPhas
     ASSERT_NOT_REACHED();
 }
 
-static bool NODELETE trackShouldGrowBeyondGrowthLimitsForTrackSizeComputationPhase(TrackSizeComputationPhase phase, const Style::GridTrackSize& trackSize)
+static bool NODELETE trackShouldGrowBeyondGrowthLimitsForTrackSizeComputationPhase(TrackSizeComputationPhase phase, const Style::ZoomResolvable<Style::GridTrackSize>& trackSize)
 {
     switch (phase) {
     case TrackSizeComputationPhase::ResolveIntrinsicMinimums:
     case TrackSizeComputationPhase::ResolveContentBasedMinimums:
-        return trackSize.hasAutoOrMinContentMinTrackBreadthAndIntrinsicMaxTrackBreadth();
+        return trackSize.value.hasAutoOrMinContentMinTrackBreadthAndIntrinsicMaxTrackBreadth();
     case TrackSizeComputationPhase::ResolveMaxContentMinimums:
-        return trackSize.hasMaxContentMinTrackBreadthAndMaxContentMaxTrackBreadth();
+        return trackSize.value.hasMaxContentMinTrackBreadthAndMaxContentMaxTrackBreadth();
     case TrackSizeComputationPhase::ResolveIntrinsicMaximums:
     case TrackSizeComputationPhase::ResolveMaxContentMaximums:
         return true;
@@ -528,7 +528,7 @@ void GridTrackSizingAlgorithm::increaseSizesToAccommodateSpanningItems(GridItems
             GridTrack& track = allTracks[trackPosition];
             const auto& trackSize = track.cachedTrackSize();
             spanningTracksSize += trackSizeForTrackSizeComputationPhase(phase, track, TrackSizeRestriction::ForbidInfinity);
-            if (variant == TrackSizeComputationVariant::CrossingFlexibleTracks && !trackSize.maxTrackBreadth().isFlex())
+            if (variant == TrackSizeComputationVariant::CrossingFlexibleTracks && !trackSize.value.maxTrackBreadth().isFlex())
                 continue;
             if (!shouldProcessTrackForTrackSizeComputationPhase(phase, trackSize))
                 continue;
@@ -655,7 +655,7 @@ void GridTrackSizingAlgorithm::increaseSizesToAccommodateSpanningItemsMasonryWit
                 auto& track = allTracks[trackPosition];
                 const auto& trackSize = track->cachedTrackSize();
                 spanningTracksSize += trackSizeForTrackSizeComputationPhase(phase, track, TrackSizeRestriction::ForbidInfinity);
-                if (!trackSize.maxTrackBreadth().isFlex())
+                if (!trackSize.value.maxTrackBreadth().isFlex())
                     continue;
                 if (!shouldProcessTrackForTrackSizeComputationPhase(phase, trackSize))
                     continue;
@@ -718,8 +718,8 @@ static double NODELETE getSizeDistributionWeight(const GridTrack& track)
 {
     if (variant != TrackSizeComputationVariant::CrossingFlexibleTracks)
         return 0;
-    ASSERT(track.cachedTrackSize().maxTrackBreadth().isFlex());
-    return track.cachedTrackSize().maxTrackBreadth().flex().value;
+    ASSERT(track.cachedTrackSize().value.maxTrackBreadth().isFlex());
+    return track.cachedTrackSize().value.maxTrackBreadth().flex().value;
 }
 
 static bool sortByGridTrackGrowthPotential(const CheckedRef<GridTrack>& track1, const CheckedRef<GridTrack>& track2)
@@ -824,12 +824,21 @@ std::optional<LayoutUnit> GridTrackSizingAlgorithm::estimatedGridAreaBreadthForG
         // We may need to estimate the grid area size before running the track sizing algorithm in order to perform the pre-layout of orthogonal items.
         // We cannot use tracks(direction)[trackPosition].cachedTrackSize() because tracks(direction) is empty, since we are either performing pre-layout
         // or are running the track sizing algorithm in the opposite direction and haven't run it in the desired direction yet.
-        const auto& trackSize = wasSetup() ? calculateGridTrackSize(direction, trackPosition) : GridLayoutFunctions::rawGridTrackSize(m_renderGrid->style(), direction, trackPosition, m_grid.autoRepeatTracks(direction), m_grid.explicitGridStart(direction));
-        auto& maxTrackSize = trackSize.maxTrackBreadth();
-        if (maxTrackSize.isContentSized() || maxTrackSize.isFlex() || GridLayoutFunctions::isRelativeGridTrackBreadthAsAuto(maxTrackSize, availableSpace(direction)))
-            gridAreaIsIndefinite = true;
-        else
-            gridAreaSize += Style::evaluate<LayoutUnit>(maxTrackSize.length(), availableSize.value_or(0_lu), Style::ZoomNeeded { });
+        auto process = [&](const auto& trackSize, const auto& zoom) {
+            auto& maxTrackSize = trackSize.maxTrackBreadth();
+            if (maxTrackSize.isContentSized() || maxTrackSize.isFlex() || GridLayoutFunctions::isRelativeGridTrackBreadthAsAuto(maxTrackSize, availableSpace(direction)))
+                gridAreaIsIndefinite = true;
+            else
+                gridAreaSize += Style::evaluate<LayoutUnit>(maxTrackSize.length(), availableSize.value_or(0_lu), zoom);
+        };
+
+        if (wasSetup()) {
+            const auto& trackSize = calculateGridTrackSize(direction, trackPosition);
+            process(trackSize.value, trackSize.zoom);
+        } else {
+            const auto& rawTrackSize = GridLayoutFunctions::rawGridTrackSize(m_renderGrid->style(), direction, trackPosition, m_grid.autoRepeatTracks(direction), m_grid.explicitGridStart(direction));
+            process(rawTrackSize, m_renderGrid->style().usedZoomForLength());
+        }
     }
 
     gridAreaSize += m_renderGrid->guttersSize(direction, span.startLine(), span.integerSpan(), availableSize);
@@ -902,18 +911,22 @@ bool GridTrackSizingAlgorithm::isIntrinsicSizedGridArea(const RenderBox& gridIte
     return false;
 }
 
-Style::GridTrackSize GridTrackSizingAlgorithm::calculateGridTrackSize(Style::GridTrackSizingDirection direction, unsigned translatedIndex) const
+Style::ZoomResolvable<Style::GridTrackSize> GridTrackSizingAlgorithm::calculateGridTrackSize(Style::GridTrackSizingDirection direction, unsigned translatedIndex) const
 {
     ASSERT(wasSetup());
+
+    auto trackSizeZoom = m_renderGrid->style().usedZoomForLength();
+
     // Collapse empty auto repeat tracks if auto-fit.
     if (m_grid.hasAutoRepeatEmptyTracks(direction) && m_grid.isEmptyAutoRepeatTrack(direction, translatedIndex))
-        return 0_css_px;
+        return { .value = 0_css_px, .zoom = trackSizeZoom };
 
     auto& trackSize = GridLayoutFunctions::rawGridTrackSize(m_renderGrid->style(), direction, translatedIndex, m_grid.autoRepeatTracks(direction), m_grid.explicitGridStart(direction));
+
     if (trackSize.isFitContent()) {
         if (GridLayoutFunctions::isRelativeGridTrackBreadthAsAuto(trackSize.fitContentTrackLength(), availableSpace(direction)))
-            return Style::GridTrackSize::MinMax { CSS::Keyword::Auto { }, CSS::Keyword::MaxContent { } };
-        return trackSize;
+            return { .value = Style::GridTrackSize::MinMax { CSS::Keyword::Auto { }, CSS::Keyword::MaxContent { } }, .zoom = trackSizeZoom };
+        return { .value = trackSize, .zoom = trackSizeZoom };
     }
 
     auto minTrackBreadth = trackSize.minTrackBreadth();
@@ -930,7 +943,7 @@ Style::GridTrackSize GridTrackSizingAlgorithm::calculateGridTrackSize(Style::Gri
     if (minTrackBreadth.isFlex())
         minTrackBreadth = CSS::Keyword::Auto { };
 
-    return Style::GridTrackSize::MinMax { WTF::move(minTrackBreadth), WTF::move(maxTrackBreadth) };
+    return { .value = Style::GridTrackSize::MinMax { WTF::move(minTrackBreadth), WTF::move(maxTrackBreadth) }, .zoom = trackSizeZoom };
 }
 
 double GridTrackSizingAlgorithm::computeFlexFactorUnitSize(const Vector<UniqueRef<GridTrack>>& tracks, double flexFactorSum, LayoutUnit& leftOverSpace, const Vector<unsigned, 8>& flexibleTracksIndexes, std::unique_ptr<TrackIndexSet> tracksToTreatAsInflexible) const
@@ -944,7 +957,7 @@ double GridTrackSizingAlgorithm::computeFlexFactorUnitSize(const Vector<UniqueRe
         if (tracksToTreatAsInflexible && tracksToTreatAsInflexible->contains(index))
             continue;
         auto baseSize = tracks[index]->baseSize();
-        auto flexFactor = tracks[index]->cachedTrackSize().maxTrackBreadth().flex().value;
+        auto flexFactor = tracks[index]->cachedTrackSize().value.maxTrackBreadth().flex().value;
         // treating all such tracks as inflexible.
         if (baseSize > hypotheticalFactorUnitSize * flexFactor) {
             leftOverSpace -= baseSize;
@@ -972,9 +985,9 @@ void GridTrackSizingAlgorithm::computeFlexSizedTracksGrowth(double flexFraction,
     for (size_t i = 0; i < numFlexTracks; ++i) {
         unsigned trackIndex = m_flexibleSizedTracksIndex[i];
         const auto& trackSize = allTracks[trackIndex]->cachedTrackSize();
-        ASSERT(trackSize.maxTrackBreadth().isFlex());
+        ASSERT(trackSize.value.maxTrackBreadth().isFlex());
         LayoutUnit oldBaseSize = allTracks[trackIndex]->baseSize();
-        auto frShare = flexFraction * trackSize.maxTrackBreadth().flex().value + leftOverSize;
+        auto frShare = flexFraction * trackSize.value.maxTrackBreadth().flex().value + leftOverSize;
         auto stretchedSize = LayoutUnit(frShare);
         LayoutUnit newBaseSize = std::max(oldBaseSize, stretchedSize);
         increments[i] = newBaseSize - oldBaseSize;
@@ -994,10 +1007,10 @@ double GridTrackSizingAlgorithm::findFrUnitSize(const GridSpan& tracksSpan, Layo
     Vector<unsigned, 8> flexibleTracksIndexes;
     for (auto trackIndex : tracksSpan) {
         const auto& trackSize = allTracks[trackIndex]->cachedTrackSize();
-        if (!trackSize.maxTrackBreadth().isFlex())
+        if (!trackSize.value.maxTrackBreadth().isFlex())
             leftOverSpace -= allTracks[trackIndex]->baseSize();
         else {
-            auto flexFactor = trackSize.maxTrackBreadth().flex().value;
+            auto flexFactor = trackSize.value.maxTrackBreadth().flex().value;
             flexibleTracksIndexes.append(trackIndex);
             flexFactorSum += flexFactor;
         }
@@ -1238,12 +1251,12 @@ LayoutUnit GridTrackSizingAlgorithmStrategy::minContributionForGridItem(RenderBo
         bool allFixed = true;
         for (auto trackPosition : span) {
             const auto& trackSize = allTracks[trackPosition]->cachedTrackSize();
-            if (trackSize.maxTrackBreadth().isFlex() && span.integerSpan() > 1)
+            if (trackSize.value.maxTrackBreadth().isFlex() && span.integerSpan() > 1)
                 return { };
-            if (!trackSize.hasFixedMaxTrackBreadth())
+            if (!trackSize.value.hasFixedMaxTrackBreadth())
                 allFixed = false;
             else if (allFixed)
-                maxBreadth += Style::evaluate<LayoutUnit>(trackSize.maxTrackBreadth().length(), availableSpace().value_or(0_lu), Style::ZoomNeeded { });
+                maxBreadth += Style::evaluate<LayoutUnit>(trackSize.value.maxTrackBreadth().length(), availableSpace().value_or(0_lu), trackSize.zoom);
         }
         if (!allFixed)
             return minSize;
@@ -1439,7 +1452,7 @@ void IndefiniteSizeStrategy::maximizeTracks(Vector<UniqueRef<GridTrack>>& tracks
 
 static inline double normalizedFlexFraction(const GridTrack& track)
 {
-    auto flexFactor = track.cachedTrackSize().maxTrackBreadth().flex().value;
+    auto flexFactor = track.cachedTrackSize().value.maxTrackBreadth().flex().value;
     return track.baseSize() / std::max<double>(1, flexFactor);
 }
 
@@ -1693,13 +1706,13 @@ void GridTrackSizingAlgorithm::initializeTrackSizes()
         track.setGrowthLimit(initialGrowthLimit(trackSize, track.baseSize()));
         track.setInfinitelyGrowable(false);
 
-        if (trackSize.isFitContent())
-            track.setGrowthLimitCap(Style::evaluate<LayoutUnit>(trackSize.fitContentTrackLength(), maxSize, Style::ZoomNeeded { }));
-        if (trackSize.isContentSized())
+        if (trackSize.value.isFitContent())
+            track.setGrowthLimitCap(Style::evaluate<LayoutUnit>(trackSize.value.fitContentTrackLength(), maxSize, trackSize.zoom));
+        if (trackSize.value.isContentSized())
             m_contentSizedTracksIndex.append(i);
-        if (trackSize.maxTrackBreadth().isFlex())
+        if (trackSize.value.maxTrackBreadth().isFlex())
             m_flexibleSizedTracksIndex.append(i);
-        if (trackSize.hasAutoMaxTrackBreadth() && !trackSize.isFitContent())
+        if (trackSize.value.hasAutoMaxTrackBreadth() && !trackSize.value.isFitContent())
             m_autoSizedTracksForStretchIndex.append(i);
 
         if (indefiniteHeight) {
@@ -1734,12 +1747,12 @@ static LayoutUnit computeSubgridMarginBorderPadding(const RenderGrid* outermost,
     bool reversed = GridLayoutFunctions::isSubgridReversedDirection(*outermost, outermostDirection, *subgrid);
 
     LayoutUnit subgridMbp;
-    if (trackIndex == span.startLine() && track.cachedTrackSize().hasIntrinsicMinTrackBreadth()) {
+    if (trackIndex == span.startLine() && track.cachedTrackSize().value.hasIntrinsicMinTrackBreadth()) {
         // If the subgrid has a reversed flow direction relative to the outermost grid, then
         // we want the MBP from the end edge in its local coordinate space.
         subgridMbp = marginAndBorderAndPaddingForEdge(*subgrid, direction, !reversed);
     }
-    if (trackIndex == span.endLine() - 1 && track.cachedTrackSize().hasIntrinsicMinTrackBreadth())
+    if (trackIndex == span.endLine() - 1 && track.cachedTrackSize().value.hasIntrinsicMinTrackBreadth())
         subgridMbp += marginAndBorderAndPaddingForEdge(*subgrid, direction, reversed);
     return subgridMbp;
 }

--- a/Source/WebCore/rendering/GridTrackSizingAlgorithm.h
+++ b/Source/WebCore/rendering/GridTrackSizingAlgorithm.h
@@ -33,6 +33,7 @@
 #include "RenderGridLayoutState.h"
 #include "StyleGridTrackSize.h"
 #include "StyleGridTrackSizingDirection.h"
+#include "StyleZoomResolvable.h"
 #include <wtf/StdMap.h>
 #include <wtf/TZoneMalloc.h>
 
@@ -94,8 +95,8 @@ public:
     void NODELETE setGrowthLimitCap(std::optional<LayoutUnit>);
     std::optional<LayoutUnit> growthLimitCap() const { return m_growthLimitCap; }
 
-    const Style::GridTrackSize& NODELETE cachedTrackSize() const LIFETIME_BOUND;
-    void setCachedTrackSize(const Style::GridTrackSize&);
+    const Style::ZoomResolvable<Style::GridTrackSize>& NODELETE cachedTrackSize() const LIFETIME_BOUND;
+    void setCachedTrackSize(const Style::ZoomResolvable<Style::GridTrackSize>&);
 
 private:
     bool isGrowthLimitBiggerThanBaseSize() const { return growthLimitIsInfinite() || m_growthLimit >= std::max(m_baseSize, 0_lu); }
@@ -108,7 +109,7 @@ private:
     LayoutUnit m_tempSize { 0 };
     std::optional<LayoutUnit> m_growthLimitCap;
     bool m_infinitelyGrowable { false };
-    std::optional<Style::GridTrackSize> m_cachedTrackSize;
+    std::optional<Style::ZoomResolvable<Style::GridTrackSize>> m_cachedTrackSize;
 };
 
 class GridTrackSizingAlgorithm final {
@@ -177,11 +178,11 @@ private:
     };
 
     std::optional<LayoutUnit> NODELETE availableSpace() const;
-    Style::GridTrackSize calculateGridTrackSize(Style::GridTrackSizingDirection, unsigned translatedIndex) const;
+    Style::ZoomResolvable<Style::GridTrackSize> calculateGridTrackSize(Style::GridTrackSizingDirection, unsigned translatedIndex) const;
 
     // Helper methods for step 1. initializeTrackSizes().
-    LayoutUnit initialBaseSize(const Style::GridTrackSize&) const;
-    LayoutUnit initialGrowthLimit(const Style::GridTrackSize&, LayoutUnit baseSize) const;
+    LayoutUnit initialBaseSize(const Style::ZoomResolvable<Style::GridTrackSize>&) const;
+    LayoutUnit initialGrowthLimit(const Style::ZoomResolvable<Style::GridTrackSize>&, LayoutUnit baseSize) const;
 
     // Helper methods for step 2. resolveIntrinsicTrackSizes().
     void sizeTrackToFitNonSpanningItem(const GridSpan&, RenderBox& gridItem, GridTrack&, RenderGridLayoutState&);

--- a/Source/WebCore/rendering/RenderGrid.cpp
+++ b/Source/WebCore/rendering/RenderGrid.cpp
@@ -997,6 +997,7 @@ unsigned RenderGrid::computeAutoRepeatTracksCount(Style::GridTrackSizingDirectio
             availableSize = std::max(availableMinSize, availableMaxSize);
     }
 
+    auto usedZoomForLength = style().usedZoomForLength();
     LayoutUnit autoRepeatTracksSize;
     for (auto& autoTrackSize : autoRepeatTracks) {
         ASSERT(autoTrackSize.minTrackBreadth().isLength());
@@ -1009,8 +1010,8 @@ unsigned RenderGrid::computeAutoRepeatTracksCount(Style::GridTrackSizingDirectio
 
         auto contributingTrackSize = [&] {
             if (hasDefiniteMaxTrackSizingFunction && hasDefiniteMinTrackSizingFunction)
-                return std::max(Style::evaluate<LayoutUnit>(minTrackSizingFunction.length(), *availableSize, Style::ZoomNeeded { }), Style::evaluate<LayoutUnit>(maxTrackSizingFunction.length(), *availableSize, Style::ZoomNeeded { }));
-            return hasDefiniteMaxTrackSizingFunction ? Style::evaluate<LayoutUnit>(maxTrackSizingFunction.length(), *availableSize, Style::ZoomNeeded { }) : Style::evaluate<LayoutUnit>(minTrackSizingFunction.length(), *availableSize, Style::ZoomNeeded { });
+                return std::max(Style::evaluate<LayoutUnit>(minTrackSizingFunction.length(), *availableSize, usedZoomForLength), Style::evaluate<LayoutUnit>(maxTrackSizingFunction.length(), *availableSize, usedZoomForLength));
+            return hasDefiniteMaxTrackSizingFunction ? Style::evaluate<LayoutUnit>(maxTrackSizingFunction.length(), *availableSize, usedZoomForLength) : Style::evaluate<LayoutUnit>(minTrackSizingFunction.length(), *availableSize, usedZoomForLength);
         };
         autoRepeatTracksSize += contributingTrackSize();
     }
@@ -1025,7 +1026,7 @@ unsigned RenderGrid::computeAutoRepeatTracksCount(Style::GridTrackSizingDirectio
     for (const auto& track : trackSizes) {
         bool hasDefiniteMaxTrackBreadth = track.maxTrackBreadth().isLength() && !track.maxTrackBreadth().isContentSized();
         ASSERT(hasDefiniteMaxTrackBreadth || (track.minTrackBreadth().isLength() && !track.minTrackBreadth().isContentSized()));
-        tracksSize += Style::evaluate<LayoutUnit>(hasDefiniteMaxTrackBreadth ? track.maxTrackBreadth().length() : track.minTrackBreadth().length(), availableSize.value(), Style::ZoomNeeded { });
+        tracksSize += Style::evaluate<LayoutUnit>(hasDefiniteMaxTrackBreadth ? track.maxTrackBreadth().length() : track.minTrackBreadth().length(), availableSize.value(), usedZoomForLength);
     }
 
     // Add gutters as if auto repeat tracks were only repeated once. Gaps between different repetitions will be added later when

--- a/Source/WebCore/style/StyleExtractorCustom.h
+++ b/Source/WebCore/style/StyleExtractorCustom.h
@@ -284,9 +284,9 @@ public:
     static void extractMarkerShorthandSerialization(ExtractorState&, StringBuilder&, const CSS::SerializationContext&);
 };
 
-template<typename T> Length<CSS::AllUnzoomed> unzoomedLengthIfEvaluationTimeZoomEnabled(ExtractorState& state, T value)
+template<typename T, typename U> auto unzoomedIfEvaluationTimeZoomEnabled(ExtractorState& state, U value) -> T
 {
-    return Length<CSS::AllUnzoomed> { value / state.style.usedZoomForLength().value };
+    return T { value / state.style.usedZoomForLength().value };
 }
 
 // MARK: - Shared Adaptor
@@ -327,7 +327,7 @@ template<CSSPropertyID propertyID> struct InsetEdgeSharedAdaptor {
                         containingBlockSize = box->containingBlockLogicalWidthForContent();
                 }
             }
-            return functor(unzoomedLengthIfEvaluationTimeZoomEnabled(state, evaluate<LayoutUnit>(value, containingBlockSize, state.style.usedZoomForLength())));
+            return functor(unzoomedIfEvaluationTimeZoomEnabled<Length<CSS::AllUnzoomed>>(state, evaluate<LayoutUnit>(value, containingBlockSize, state.style.usedZoomForLength())));
         }
 
         // Return a "computed value" length.
@@ -360,7 +360,7 @@ template<CSSPropertyID propertyID> struct InsetEdgeSharedAdaptor {
 
         // The property won't be over-constrained if its computed value is "auto", so the "used value" can be returned.
         if (box->isRelativelyPositioned())
-            return functor(unzoomedLengthIfEvaluationTimeZoomEnabled(state, insetUsedStyleRelative(*box)));
+            return functor(unzoomedIfEvaluationTimeZoomEnabled<Length<CSS::AllUnzoomed>>(state, insetUsedStyleRelative(*box)));
 
         auto insetUsedStyleOutOfFlowPositioned = [&](auto& container, auto& box) {
             // For out-of-flow positioned boxes, the inset is how far an box's margin
@@ -402,7 +402,7 @@ template<CSSPropertyID propertyID> struct InsetEdgeSharedAdaptor {
         };
 
         if (containingBlock && box->isOutOfFlowPositioned())
-            return functor(unzoomedLengthIfEvaluationTimeZoomEnabled(state, insetUsedStyleOutOfFlowPositioned(*containingBlock, *box)));
+            return functor(unzoomedIfEvaluationTimeZoomEnabled<Length<CSS::AllUnzoomed>>(state, insetUsedStyleOutOfFlowPositioned(*containingBlock, *box)));
 
         return functor(CSS::Keyword::Auto { });
     }
@@ -496,7 +496,7 @@ template<CSSPropertyID propertyID> struct MarginEdgeSharedAdaptor {
 
         if constexpr (propertyID == CSSPropertyMarginRight) {
             if (rendererCanHaveTrimmedMargin(*box) && box->hasTrimmedMargin(toMarginTrimSide(*box)))
-                return functor(unzoomedLengthIfEvaluationTimeZoomEnabled(state, usedValue(*box)));
+                return functor(unzoomedIfEvaluationTimeZoomEnabled<Length<CSS::AllUnzoomed>>(state, usedValue(*box)));
 
             if (value.isFixed())
                 return functor(value);
@@ -505,11 +505,11 @@ template<CSSPropertyID propertyID> struct MarginEdgeSharedAdaptor {
                 // RenderBox gives a marginRight() that is the distance between the right-edge of the child box
                 // and the right-edge of the containing box, when display == DisplayType::BlockFlow. Let's calculate the absolute
                 // value of the specified margin-right % instead of relying on RenderBox's marginRight() value.
-                return functor(unzoomedLengthIfEvaluationTimeZoomEnabled(state, evaluateMinimum<float>(value, box->containingBlockLogicalWidthForContent(), state.style.usedZoomForLength())));
+                return functor(unzoomedIfEvaluationTimeZoomEnabled<Length<CSS::AllUnzoomed>>(state, evaluateMinimum<float>(value, box->containingBlockLogicalWidthForContent(), state.style.usedZoomForLength())));
             }
         }
 
-        return functor(unzoomedLengthIfEvaluationTimeZoomEnabled(state, usedValue(*box)));
+        return functor(unzoomedIfEvaluationTimeZoomEnabled<Length<CSS::AllUnzoomed>>(state, usedValue(*box)));
     }
 };
 
@@ -531,7 +531,7 @@ template<CSSPropertyID propertyID> struct PaddingEdgeSharedAdaptor {
                 return box.computedCSSPaddingLeft();
         };
 
-        return functor(unzoomedLengthIfEvaluationTimeZoomEnabled(state, usedValue(*box)));
+        return functor(unzoomedIfEvaluationTimeZoomEnabled<Length<CSS::AllUnzoomed>>(state, usedValue(*box)));
     }
 };
 
@@ -590,9 +590,9 @@ template<CSSPropertyID propertyID> struct PreferredSizeSharedAdaptor {
                 // not apply for non-replaced inline elements.
                 if (!isNonReplacedInline(*state.renderer)) {
                     if constexpr (propertyID == CSSPropertyHeight)
-                        return functor(unzoomedLengthIfEvaluationTimeZoomEnabled(state, sizingBox(*state.renderer).height()));
+                        return functor(unzoomedIfEvaluationTimeZoomEnabled<Length<CSS::AllUnzoomed>>(state, sizingBox(*state.renderer).height()));
                     else if constexpr (propertyID == CSSPropertyWidth)
-                        return functor(unzoomedLengthIfEvaluationTimeZoomEnabled(state, sizingBox(*state.renderer).width()));
+                        return functor(unzoomedIfEvaluationTimeZoomEnabled<Length<CSS::AllUnzoomed>>(state, sizingBox(*state.renderer).width()));
                 }
             }
         }
@@ -1201,8 +1201,8 @@ template<> struct PropertyExtractorAdaptor<CSSPropertyPerspectiveOrigin> {
             auto box = state.renderer->transformReferenceBoxRect(state.style);
             auto zoom = state.style.usedZoomForLength();
 
-            auto perspectiveOriginX = unzoomedLengthIfEvaluationTimeZoomEnabled(state, evaluate<float>(state.style.perspectiveOriginX(), box.width(), zoom));
-            auto perspectiveOriginY = unzoomedLengthIfEvaluationTimeZoomEnabled(state, evaluate<float>(state.style.perspectiveOriginY(), box.height(), zoom));
+            auto perspectiveOriginX = unzoomedIfEvaluationTimeZoomEnabled<Length<CSS::AllUnzoomed>>(state, evaluate<float>(state.style.perspectiveOriginX(), box.width(), zoom));
+            auto perspectiveOriginY = unzoomedIfEvaluationTimeZoomEnabled<Length<CSS::AllUnzoomed>>(state, evaluate<float>(state.style.perspectiveOriginY(), box.height(), zoom));
 
             return functor(SpaceSeparatedTuple { perspectiveOriginX, perspectiveOriginY });
         }
@@ -1288,8 +1288,8 @@ template<> struct PropertyExtractorAdaptor<CSSPropertyTransformOrigin> {
             auto box = state.renderer->transformReferenceBoxRect(state.style);
             auto zoom = state.style.usedZoomForLength();
 
-            auto transformOriginX = unzoomedLengthIfEvaluationTimeZoomEnabled(state, evaluate<float>(state.style.transformOriginX(), box.width(), zoom));
-            auto transformOriginY = unzoomedLengthIfEvaluationTimeZoomEnabled(state, evaluate<float>(state.style.transformOriginY(), box.height(), zoom));
+            auto transformOriginX = unzoomedIfEvaluationTimeZoomEnabled<Length<CSS::AllUnzoomed>>(state, evaluate<float>(state.style.transformOriginX(), box.width(), zoom));
+            auto transformOriginY = unzoomedIfEvaluationTimeZoomEnabled<Length<CSS::AllUnzoomed>>(state, evaluate<float>(state.style.transformOriginY(), box.height(), zoom));
 
             if (auto transformOriginZ = state.style.transformOriginZ(); !transformOriginZ.isZero())
                 return functor(SpaceSeparatedTuple { transformOriginX, transformOriginY, transformOriginZ });
@@ -1456,7 +1456,9 @@ template<GridTrackSizingDirection direction> Ref<CSSValue> extractGridTemplateVa
                 addValuesForNamedGridLinesAtIndex(trackList.value.value, collector, i + offset, false);
 
             trackList.value.value.append(CSS::GridTrackSize { CSS::GridTrackBreadth {
-                toCSS(LengthPercentage<CSS::Nonnegative> { Length<CSS::Nonnegative> { computedTrackSizes[i] } }, state.style)
+                toCSS(LengthPercentage<CSS::NonnegativeUnzoomed> {
+                    unzoomedIfEvaluationTimeZoomEnabled<Length<CSS::NonnegativeUnzoomed>>(state, computedTrackSizes[i])
+                }, state.style)
             } });
         }
         if (end + offset >= 0)

--- a/Source/WebCore/style/values/grid/StyleGridTrackBreadth.cpp
+++ b/Source/WebCore/style/values/grid/StyleGridTrackBreadth.cpp
@@ -42,7 +42,7 @@ namespace Style {
 auto ToCSS<GridTrackBreadth>::operator()(const GridTrackBreadth& value, const Style::ComputedStyle& style) -> CSS::GridTrackBreadth
 {
     return value.switchOnUsingNumeric(
-        [&](const LengthPercentage<CSS::Nonnegative>& lengthPercentage) -> CSS::GridTrackBreadth {
+        [&](const LengthPercentage<CSS::NonnegativeUnzoomed>& lengthPercentage) -> CSS::GridTrackBreadth {
             return toCSS(lengthPercentage, style);
         },
         [&](const Flex<CSS::Nonnegative>& flex) -> CSS::GridTrackBreadth {
@@ -63,7 +63,7 @@ auto ToCSS<GridTrackBreadth>::operator()(const GridTrackBreadth& value, const St
 auto ToStyle<CSS::GridTrackBreadth>::operator()(const CSS::GridTrackBreadth& value, const BuilderState& state) -> GridTrackBreadth
 {
     return WTF::switchOn(value,
-        [&](const CSS::LengthPercentage<CSS::Nonnegative>& lengthPercentage) -> GridTrackBreadth {
+        [&](const CSS::LengthPercentage<CSS::NonnegativeUnzoomed>& lengthPercentage) -> GridTrackBreadth {
             return GridTrackBreadthLength { toStyle(lengthPercentage, state) };
         },
         [&](const CSS::Flex<CSS::Nonnegative>& flex) -> GridTrackBreadth {

--- a/Source/WebCore/style/values/grid/StyleGridTrackBreadth.h
+++ b/Source/WebCore/style/values/grid/StyleGridTrackBreadth.h
@@ -46,7 +46,7 @@ namespace Style {
 
 // FIXME: Make PrimitiveNumericOrKeyword support additional numeric types in addition to the <length-percentage> one and then replace GridTrackBreadth with that.
 
-struct GridTrackBreadthLength : PrimitiveNumericOrKeyword<LengthPercentage<CSS::Nonnegative>, CSS::Keyword::MinContent, CSS::Keyword::MaxContent, CSS::Keyword::Auto> {
+struct GridTrackBreadthLength : PrimitiveNumericOrKeyword<LengthPercentage<CSS::NonnegativeUnzoomed>, CSS::Keyword::MinContent, CSS::Keyword::MaxContent, CSS::Keyword::Auto> {
     using Base::Base;
 
     ALWAYS_INLINE bool isMinContent() const { return holdsAlternative<CSS::Keyword::MinContent>(); }

--- a/Source/WebCore/style/values/grid/StyleGridTrackSize.h
+++ b/Source/WebCore/style/values/grid/StyleGridTrackSize.h
@@ -59,7 +59,7 @@ template<size_t I> const auto& get(const GridMinMaxFunctionParameters& value)
         return value.max;
 }
 
-DEFINE_PRIMITIVE_NUMERIC_TYPE_WRAPPER(GridTrackFitContentLength, LengthPercentage<CSS::Nonnegative>);
+DEFINE_PRIMITIVE_NUMERIC_TYPE_WRAPPER(GridTrackFitContentLength, LengthPercentage<CSS::NonnegativeUnzoomed>);
 
 struct GridFitContentFunctionParameters {
     GridTrackFitContentLength value;

--- a/Source/WebCore/style/values/viewport/StyleZoomResolvable.h
+++ b/Source/WebCore/style/values/viewport/StyleZoomResolvable.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2026 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "StyleValueTypes.h"
+#include "StyleZoomPrimitives.h"
+
+namespace WebCore {
+namespace Style {
+
+// Utility used to store a numeric type along with the zoom to apply during
+// evaluation. Useful when storing numeric values outside of `Style::ComputedStyle`.
+template<typename T>
+struct ZoomResolvable {
+    T value;
+    ZoomFactor zoom;
+
+    constexpr bool operator==(const ZoomResolvable&) const = default;
+};
+
+template<typename T, typename Result> struct Evaluation<ZoomResolvable<T>, Result> {
+    template<typename... Rest>
+    constexpr auto operator()(const ZoomResolvable<T>& value, Rest&&... rest) -> Result
+    {
+        return evaluate<Result>(value.value, value.zoom, std::forward<Rest>(rest)...);
+    }
+};
+
+} // namespace Style
+} // namespace WebCore

--- a/Source/WebCore/style/values/viewport/StyleZoomResolved.h
+++ b/Source/WebCore/style/values/viewport/StyleZoomResolved.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2026 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "StyleValueTypes.h"
+#include "StyleZoomPrimitives.h"
+
+namespace WebCore {
+namespace Style {
+
+// Utility used to store a numeric type that has had zoom already resolved.
+template<typename T>
+struct ZoomResolved {
+    T value;
+
+    constexpr bool operator==(const ZoomResolved&) const = default;
+};
+
+template<typename T, typename Result> struct Evaluation<ZoomResolved<T>, Result> {
+    template<typename... Rest>
+    constexpr auto operator()(const ZoomResolved<T>& value, Rest&&... rest) -> Result
+    {
+        return evaluate<Result>(value.value, ZoomFactor::none(), std::forward<Rest>(rest)...);
+    }
+};
+
+} // namespace Style
+} // namespace WebCore


### PR DESCRIPTION
#### 6446909a3615d2f33b406c4ad1c4aceabfd90e83
<pre>
[EvaluationTimeZoom] Convert remaining grid/table properties to use unzoomed lengths
<a href="https://bugs.webkit.org/show_bug.cgi?id=319996">https://bugs.webkit.org/show_bug.cgi?id=319996</a>

Reviewed by Sammy Gill.

Converts the remaining grid/table CSS properties to use unzoomed lengths.

New test added showing properties working properly with inherited + zoomed values.

Added helpers Style::ZoomResolved and Style::ZoomResolvable to annotate types with
zoom related context to make some bundling simpler.

Tests: imported/w3c/web-platform-tests/css/css-viewport/zoom/grid.html
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/grid-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/grid.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/grid-ref.html: Added.
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Grid.cpp:
* Source/WebCore/css/values/grid/CSSGridTrackBreadth.h:
* Source/WebCore/css/values/grid/CSSGridTrackSize.h:
* Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.cpp:
* Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.h:
* Source/WebCore/layout/formattingContexts/grid/GridLayout.cpp:
* Source/WebCore/layout/formattingContexts/grid/GridLayout.h:
* Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.cpp:
* Source/WebCore/layout/formattingContexts/grid/TrackSizingFunctions.h:
* Source/WebCore/layout/formattingContexts/table/TableFormattingContext.cpp:
* Source/WebCore/layout/formattingContexts/table/TableGrid.h:
* Source/WebCore/layout/formattingContexts/table/TableLayout.cpp:
* Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp:
* Source/WebCore/rendering/GridTrackSizingAlgorithm.h:
* Source/WebCore/rendering/RenderGrid.cpp:
* Source/WebCore/style/StyleExtractorCustom.h:
* Source/WebCore/style/values/grid/StyleGridTrackBreadth.cpp:
* Source/WebCore/style/values/grid/StyleGridTrackBreadth.h:
* Source/WebCore/style/values/grid/StyleGridTrackSize.h:
* Source/WebCore/style/values/viewport/StyleZoomResolvable.h: Added.
* Source/WebCore/style/values/viewport/StyleZoomResolved.h: Added.

Canonical link: <a href="https://commits.webkit.org/317807@main">https://commits.webkit.org/317807@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1e6cd1268b93864e581ad8fe262f877a62fb4b3b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176391 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50326 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44116 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185990 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/138651 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178254 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51618 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50010 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137397 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/138651 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179347 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40884 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158177 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117872 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39533 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37894 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149949 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37675 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34458 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42055 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42105 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188413 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49991 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/157722 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146437 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39385 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50675 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/34293 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146249 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41024 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122879 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/116929 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49179 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12650 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48581 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48815 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48640 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->