### PR TITLE
[GFC] Implement initial logic for automatic sizes of replaced elements

### DIFF
--- a/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.cpp
@@ -288,6 +288,14 @@ LayoutUnit inlinePreferredSize(const PlacedGridItem& placedGridItem, LayoutUnit 
             return fitContentSize(minContentBorderBoxWidth, maxContentBorderBoxWidth, stretchFitBorderBoxWidth);
         }
 
+        // Otherwise, a replaced grid item with an automatic size uses its natural size in the axis
+        // (i.e. it is sized consistent with the block-level replaced element sizing rules).
+        auto& layoutBox = placedGridItem.layoutBox();
+        if (placedGridItem.isReplacedElement() && layoutBox.hasNaturalWidth())
+            return BorderBoxSize { ContentBoxSize { layoutBox.naturalWidth() }, borderAndPadding }.value;
+
+        // FIXME: Handle replaced elements with no natural size in the axis and non-replaced items
+        // with a preferred aspect ratio.
         ASSERT_NOT_IMPLEMENTED_YET();
         return { };
     }
@@ -437,6 +445,14 @@ LayoutUnit blockPreferredSize(const PlacedGridItem& placedGridItem, LayoutUnit b
             return fitContentSize(minContentBorderBoxHeight, maxContentBorderBoxHeight, stretchFitBorderBoxHeight);
         }
 
+        // Otherwise, a replaced grid item with an automatic size uses its natural size in the axis
+        // (i.e. it is sized consistent with the block-level replaced element sizing rules).
+        auto& layoutBox = placedGridItem.layoutBox();
+        if (placedGridItem.isReplacedElement() && layoutBox.hasNaturalHeight())
+            return BorderBoxSize { ContentBoxSize { layoutBox.naturalHeight() }, borderAndPadding }.value;
+
+        // FIXME: Handle replaced elements with no natural size in the axis and non-replaced items
+        // with a preferred aspect ratio.
         ASSERT_NOT_IMPLEMENTED_YET();
         return { };
     }

--- a/Source/WebCore/layout/layouttree/LayoutElementBox.cpp
+++ b/Source/WebCore/layout/layouttree/LayoutElementBox.cpp
@@ -201,6 +201,28 @@ bool ElementBox::hasIntrinsicRatio() const
     return m_replacedData && (m_replacedData->intrinsicSize || m_replacedData->intrinsicRatio);
 }
 
+bool ElementBox::hasNaturalWidth() const
+{
+    return m_replacedData && m_replacedData->intrinsicSize;
+}
+
+bool ElementBox::hasNaturalHeight() const
+{
+    return m_replacedData && m_replacedData->intrinsicSize;
+}
+
+LayoutUnit ElementBox::naturalWidth() const
+{
+    ASSERT(hasNaturalWidth());
+    return m_replacedData->intrinsicSize->width();
+}
+
+LayoutUnit ElementBox::naturalHeight() const
+{
+    ASSERT(hasNaturalHeight());
+    return m_replacedData->intrinsicSize->height();
+}
+
 LayoutUnit ElementBox::intrinsicWidth() const
 {
     ASSERT(hasIntrinsicWidth());

--- a/Source/WebCore/layout/layouttree/LayoutElementBox.h
+++ b/Source/WebCore/layout/layouttree/LayoutElementBox.h
@@ -89,6 +89,10 @@ public:
     bool NODELETE hasIntrinsicWidth() const;
     bool NODELETE hasIntrinsicHeight() const;
     bool NODELETE hasIntrinsicRatio() const;
+    bool NODELETE hasNaturalWidth() const;
+    bool NODELETE hasNaturalHeight() const;
+    LayoutUnit NODELETE naturalWidth() const;
+    LayoutUnit NODELETE naturalHeight() const;
     LayoutUnit NODELETE intrinsicWidth() const;
     LayoutUnit NODELETE intrinsicHeight() const;
     LayoutUnit NODELETE intrinsicRatio() const;


### PR DESCRIPTION
#### ae45cfcca596a58a0202e585a88ce6dfcba4147a
<pre>
[GFC] Implement initial logic for automatic sizes of replaced elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=319995">https://bugs.webkit.org/show_bug.cgi?id=319995</a>
<a href="https://rdar.apple.com/182927210">rdar://182927210</a>

Reviewed by Alan Baradlay.

<a href="https://drafts.csswg.org/css-grid-1/#grid-item-sizing">https://drafts.csswg.org/css-grid-1/#grid-item-sizing</a>

When a replaced element is not being stretched due to its alignment then
we try to size it to its natrual sizes. This falls into the logic that
comes from the rules of block-level elements from CSS2. There is extra
work that is needed for the case where a repalced element does not have
a natural size, but we defer to do that in a later patch since this
should be the common case.

After this there should only be two cases left that we need to figure
out in terms of computing the automatic sizes for grid items. These are
the replaced elements without a natural size and non-replaced elements
with a preferred aspect ratio that are documented in the FIXME.

Also, we work with the assumption that the content is all horizontal-tb
since that is the only thing allowed into GFC. Incorporating other
writing modes will ideally just be a small API changing to make sure the
mapping is done correctly and the core logic this patch introduces
should remain the same.

* Source/WebCore/layout/layouttree/LayoutElementBox.cpp:
(WebCore::Layout::ElementBox::hasNaturalWidth const):
(WebCore::Layout::ElementBox::hasNaturalHeight const):
(WebCore::Layout::ElementBox::naturalWidth const):
(WebCore::Layout::ElementBox::naturalHeight const):
We had an API that checked the box for an intrinsic width/height, but
those also handle cases where the box is a non-replaced element which is
something we are not concerned with for this portion of the spec. I
added a set of natural size APIs that is similar but is targeted only
boxes which are replaced elements since that is the type of content that
has natural sizes.

<a href="https://www.w3.org/TR/css-images-3/#natural-size">https://www.w3.org/TR/css-images-3/#natural-size</a>
Canonical link: <a href="https://commits.webkit.org/317874@main">https://commits.webkit.org/317874@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/39f4c02b24297316d24048f1b3290b1797325de5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176131 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50066 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43856 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185727 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/138364 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f6720384-785b-4762-9349-9fc2e9d743b3) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/177994 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51358 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49750 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137179 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/138364 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5357031a-fa79-4b75-9f03-6824b93bdb16) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179087 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40659 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157957 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117654 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c7f403c2-2e87-49fe-864d-2966885905be) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39308 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37674 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149724 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37454 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34195 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41782 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41885 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188150 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49731 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146201 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39431 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50414 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34072 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146027 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40808 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122617 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/116586 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48919 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12426 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48321 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48555 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48379 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->