### PR TITLE
Add FloatRect::edges() helper returning the rect's four edges as  directed segments

### DIFF
--- a/Source/WebCore/platform/graphics/BezierUtilities.cpp
+++ b/Source/WebCore/platform/graphics/BezierUtilities.cpp
@@ -235,12 +235,7 @@ Vector<BezierSegment> trimBezierToRect(const BezierSegment& curve, const FloatRe
         return { };
 
     FloatPoint center = rect.center();
-    RectEdges<std::pair<FloatPoint, FloatPoint>> edges {
-        { rect.minXMinYCorner(), rect.maxXMinYCorner() }, // top
-        { rect.maxXMinYCorner(), rect.maxXMaxYCorner() }, // right
-        { rect.maxXMaxYCorner(), rect.minXMaxYCorner() }, // bottom
-        { rect.minXMaxYCorner(), rect.minXMinYCorner() }, // left
-    };
+    auto edges = rect.edges();
 
     Vector<BezierSegment> curves;
     curves.append(curve);

--- a/Source/WebCore/platform/graphics/FloatRect.h
+++ b/Source/WebCore/platform/graphics/FloatRect.h
@@ -28,6 +28,7 @@
 
 #include <WebCore/BoxExtents.h>
 #include <WebCore/FloatPoint.h>
+#include <utility>
 #include <wtf/Platform.h>
 
 #if USE(CG)
@@ -181,6 +182,16 @@ public:
     constexpr FloatPoint maxXMinYCorner() const { return FloatPoint(m_location.x() + m_size.width(), m_location.y()); } // typically topRight
     constexpr FloatPoint minXMaxYCorner() const { return FloatPoint(m_location.x(), m_location.y() + m_size.height()); } // typically bottomLeft
     constexpr FloatPoint maxXMaxYCorner() const { return FloatPoint(m_location.x() + m_size.width(), m_location.y() + m_size.height()); } // typically bottomRight
+
+    RectEdges<std::pair<FloatPoint, FloatPoint>> edges() const
+    {
+        return {
+            { minXMinYCorner(), maxXMinYCorner() }, // top
+            { maxXMinYCorner(), maxXMaxYCorner() }, // right
+            { maxXMaxYCorner(), minXMaxYCorner() }, // bottom
+            { minXMaxYCorner(), minXMinYCorner() }, // left
+        };
+    }
 
     WEBCORE_EXPORT bool NODELETE intersects(const FloatRect&) const;
     WEBCORE_EXPORT bool NODELETE inclusivelyIntersects(const FloatRect&) const;


### PR DESCRIPTION
#### 37b50f4cc7736485389df1585332ea03621a3e5b
<pre>
Add FloatRect::edges() helper returning the rect&apos;s four edges as  directed segments
<a href="https://bugs.webkit.org/show_bug.cgi?id=319997">https://bugs.webkit.org/show_bug.cgi?id=319997</a>
<a href="https://rdar.apple.com/182933375">rdar://182933375</a>

Reviewed by Simon Fraser.

Add a FloatRect::edges() convenience accessor that returns the rectangle&apos;s
four edges as RectEdges&lt;std::pair&lt;FloatPoint, FloatPoint&gt;&gt;, each edge being
a {  start corner, end corner } pair wound clockwise (top -&gt; right -&gt; bottom -&gt; left)
and indexable by BoxSide. Utilized in BezierUtilities and will be utilized
in CornerShapeUtilities

New tests are not neccesary for this change

* Source/WebCore/platform/graphics/BezierUtilities.cpp:
(WebCore::trimBezierToRect):
* Source/WebCore/platform/graphics/FloatRect.h:
(WebCore::FloatRect::edges const):

Canonical link: <a href="https://commits.webkit.org/317739@main">https://commits.webkit.org/317739@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cec2047fa7ff4010b2cf5776c7c562b5424c37e1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176132 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50067 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43857 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185728 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/138367 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/177995 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51359 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49751 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137192 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/138367 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179088 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40655 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157958 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117667 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39304 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37676 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149720 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37455 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34196 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41783 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/41887 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188151 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49732 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146209 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50415 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/34073 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146033 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26763 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40807 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122618 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/116587 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48920 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12427 "") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48322 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48556 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48380 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->