### PR TITLE
[WebGPU] setPipeline fails for depth-only pipeline in a render bundle

### DIFF
--- a/LayoutTests/fast/webgpu/render-bundle-depth-only-pipeline-expected.txt
+++ b/LayoutTests/fast/webgpu/render-bundle-depth-only-pipeline-expected.txt
@@ -1,0 +1,2 @@
+CONSOLE MESSAGE: no validation error
+

--- a/LayoutTests/fast/webgpu/render-bundle-depth-only-pipeline.html
+++ b/LayoutTests/fast/webgpu/render-bundle-depth-only-pipeline.html
@@ -1,0 +1,36 @@
+<script>
+globalThis.testRunner?.waitUntilDone();
+globalThis.testRunner?.dumpAsText();
+const log = console.debug;
+
+onload = async () => {
+    let adapter = await navigator.gpu.requestAdapter({});
+    let device = await adapter.requestDevice({});
+    device.pushErrorScope('validation');
+
+    // A render pipeline with no fragment stage (depth-only) should be compatible with a render
+    // bundle encoder that declares no color formats and a matching depthStencilFormat.
+    let module = device.createShaderModule({
+        code: '@vertex fn v() -> @builtin(position) vec4f { return vec4f(); }',
+    });
+    let pipeline = device.createRenderPipeline({
+        layout: 'auto',
+        vertex: { module },
+        depthStencil: { format: 'depth24plus', depthWriteEnabled: true, depthCompare: 'less' },
+    });
+    let encoder = device.createRenderBundleEncoder({
+        colorFormats: [],
+        depthStencilFormat: 'depth24plus',
+    });
+    encoder.setPipeline(pipeline);
+    encoder.draw(3);
+    encoder.finish();
+
+    let error = await device.popErrorScope();
+    if (error)
+        log(error.message);
+    else
+        log('no validation error');
+    globalThis.testRunner?.notifyDone();
+};
+</script>

--- a/Source/WebGPU/WebGPU/RenderPipeline.mm
+++ b/Source/WebGPU/WebGPU/RenderPipeline.mm
@@ -1946,15 +1946,8 @@ bool RenderPipeline::validateRenderBundle(const WGPURenderBundleEncoderDescripto
     if (descriptor.sampleCount != m_descriptor.multisample.count)
         return false;
 
-    if (!m_descriptor.fragment) {
-        if (descriptor.colorFormatCount || descriptor.depthStencilFormat != WGPUTextureFormat_Undefined)
-            return false;
-
-        return true;
-    }
-
-    auto& fragment = *m_descriptor.fragment;
-    for (size_t i = 0, maxTargetCount = std::max<size_t>(fragment.targetCount, descriptor.colorFormatCount); i < maxTargetCount; ++i) {
+    size_t fragmentTargetCount = m_descriptor.fragment ? m_descriptor.fragment->targetCount : 0;
+    for (size_t i = 0, maxTargetCount = std::max<size_t>(fragmentTargetCount, descriptor.colorFormatCount); i < maxTargetCount; ++i) {
         auto colorFormat = i < descriptor.colorFormatCount ? descriptor.colorFormatsSpan()[i] : WGPUTextureFormat_Undefined;
         auto descriptorFormat = i < m_descriptorTargets.size() ? m_descriptorTargets[i].format : WGPUTextureFormat_Undefined;
         if (descriptorFormat != colorFormat)


### PR DESCRIPTION
#### eefdc13c0e17cb0f37b0b272b482ed598f0b8c61
<pre>
[WebGPU] setPipeline fails for depth-only pipeline in a render bundle
<a href="https://bugs.webkit.org/show_bug.cgi?id=319980">https://bugs.webkit.org/show_bug.cgi?id=319980</a>
<a href="https://rdar.apple.com/182926317">rdar://182926317</a>

Reviewed by Taher Ali.

Correct validation of depth only passes in render bundles, which are allowed
per the spec but we rejected them.

Test: fast/webgpu/render-bundle-depth-only-pipeline.html

* LayoutTests/fast/webgpu/render-bundle-depth-only-pipeline-expected.txt: Added.
* LayoutTests/fast/webgpu/render-bundle-depth-only-pipeline.html: Added.
* Source/WebGPU/WebGPU/RenderPipeline.mm:
(WebGPU::RenderPipeline::validateRenderBundle const):

Canonical link: <a href="https://commits.webkit.org/317736@main">https://commits.webkit.org/317736@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c84793621ceea022776d771da47fe1c87f93349e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176135 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50070 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43860 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185731 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/138370 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/569052ba-4f21-4b71-9701-c6d5062871d2) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51362 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49754 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137184 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/138370 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/52204529-edb4-41d5-859e-be4c91291f1a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179091 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40656 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157962 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117659 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/858b3a9d-c8d5-4254-aa70-6bd44ef72d9b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39305 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37675 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149721 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37459 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34199 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41786 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41886 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188154 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49735 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/157507 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146206 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39336 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50418 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/34077 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146031 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40818 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122621 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/116590 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48923 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12431 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48325 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48559 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48383 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->