### PR TITLE
[WPE] WebKitWebView created without an explicit display ignores the primary display

### DIFF
--- a/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
@@ -927,6 +927,17 @@ static void webkitWebViewCreatePage(WebKitWebView* webView, Ref<API::PageConfigu
 #endif
 }
 
+#if PLATFORM(WPE) && ENABLE(WPE_PLATFORM)
+static WPEDisplay* webkitWebViewDefaultDisplay()
+{
+    // If the application has already created a display it is the primary display, and web views
+    // should be created there rather than implicitly connecting to the platform default display.
+    if (auto* primaryDisplay = wpe_display_get_primary())
+        return primaryDisplay;
+    return wpe_display_get_default();
+}
+#endif
+
 static void webkitWebViewConstructed(GObject* object)
 {
     G_OBJECT_CLASS(webkit_web_view_parent_class)->constructed(object);
@@ -964,7 +975,7 @@ static void webkitWebViewConstructed(GObject* object)
 #if PLATFORM(WPE) && ENABLE(WPE_PLATFORM)
 #if USE(LIBWPE)
     if (!priv->display && !priv->backend)
-        priv->display = wpe_display_get_default();
+        priv->display = webkitWebViewDefaultDisplay();
     else if (priv->backend) {
         if (priv->display) {
             g_critical("WebKitWebView backend can't be set when display is set too, passed backend is ignored.");
@@ -972,12 +983,12 @@ static void webkitWebViewConstructed(GObject* object)
         } else if (WKWPE::isUsingWPEPlatformAPI()) {
             g_critical("WebKitWebView backend can't be set when WPE platform API is already in use, passed backend is ignored.");
             priv->backend = nullptr;
-            priv->display = wpe_display_get_default();
+            priv->display = webkitWebViewDefaultDisplay();
         }
     }
 #else
     if (!priv->display)
-        priv->display = wpe_display_get_default();
+        priv->display = webkitWebViewDefaultDisplay();
 #endif
 
     if (priv->display)

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/glib/TestWebKitWebView.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/glib/TestWebKitWebView.cpp
@@ -202,13 +202,24 @@ static void testWebViewDisplay(WebViewTest* test, gconstpointer)
     auto* display = webkit_web_view_get_display(test->webView());
     g_assert_true(WPE_IS_DISPLAY_HEADLESS(display));
 
-    // A web view created without a display uses the default one (mock display for the tests).
+    // A web view created without a display uses the primary display (the one created by the
+    // application, in this case the test headless display), falling back to the default display
+    // only when the application didn't create any.
     GRefPtr<WebKitWebView> webView = adoptGRef(WEBKIT_WEB_VIEW(g_object_new(WEBKIT_TYPE_WEB_VIEW, nullptr)));
     test->assertObjectIsDeletedWhenTestFinishes(G_OBJECT(webView.get()));
     display = webkit_web_view_get_display(webView.get());
     g_assert_true(WPE_IS_DISPLAY(display));
+    g_assert_true(display == wpe_display_get_primary());
+    g_assert_true(display == test->m_display.get());
+
+    // A web view created with the default display still uses it instead of the primary display.
+    auto* defaultDisplay = wpe_display_get_default();
+    GRefPtr<WebKitWebView> defaultWebView = adoptGRef(WEBKIT_WEB_VIEW(g_object_new(WEBKIT_TYPE_WEB_VIEW, "display", defaultDisplay, nullptr)));
+    test->assertObjectIsDeletedWhenTestFinishes(G_OBJECT(defaultWebView.get()));
+    display = webkit_web_view_get_display(defaultWebView.get());
+    g_assert_true(WPE_IS_DISPLAY(display));
     g_assert_cmpstr(G_OBJECT_TYPE_NAME(display), ==, "WPEDisplayMock");
-    g_assert_true(display == wpe_display_get_default());
+    g_assert_true(display == defaultDisplay);
 }
 
 static void testWebViewWPEView(WebViewTest* test, gconstpointer)
@@ -223,10 +234,19 @@ static void testWebViewWPEView(WebViewTest* test, gconstpointer)
     g_assert_true(WPE_IS_VIEW_HEADLESS(view));
     g_assert_true(wpe_view_get_display(view) == test->m_display.get());
 
-    // A web view created without a display uses the default one (mock display for the tests).
+    // A web view created without a display uses the primary one (headless display for the tests).
     GRefPtr<WebKitWebView> webView = adoptGRef(WEBKIT_WEB_VIEW(g_object_new(WEBKIT_TYPE_WEB_VIEW, nullptr)));
     test->assertObjectIsDeletedWhenTestFinishes(G_OBJECT(webView.get()));
     view = webkit_web_view_get_wpe_view(webView.get());
+    test->assertObjectIsDeletedWhenTestFinishes(G_OBJECT(view));
+    g_assert_true(WPE_IS_VIEW_HEADLESS(view));
+    g_assert_true(wpe_view_get_display(view) == wpe_display_get_primary());
+    g_assert_true(wpe_view_get_display(view) == test->m_display.get());
+
+    // A web view created with the default display still creates a mock WPE view.
+    GRefPtr<WebKitWebView> defaultWebView = adoptGRef(WEBKIT_WEB_VIEW(g_object_new(WEBKIT_TYPE_WEB_VIEW, "display", wpe_display_get_default(), nullptr)));
+    test->assertObjectIsDeletedWhenTestFinishes(G_OBJECT(defaultWebView.get()));
+    view = webkit_web_view_get_wpe_view(defaultWebView.get());
     test->assertObjectIsDeletedWhenTestFinishes(G_OBJECT(view));
     g_assert_true(WPE_IS_VIEW(view));
     g_assert_cmpstr(G_OBJECT_TYPE_NAME(view), ==, "WPEViewMock");


### PR DESCRIPTION
#### 9e251a3eea0a530f16f7d3e1c39fef1fd99e82fc
<pre>
[WPE] WebKitWebView created without an explicit display ignores the primary display
<a href="https://bugs.webkit.org/show_bug.cgi?id=320001">https://bugs.webkit.org/show_bug.cgi?id=320001</a>

Reviewed by NOBODY (OOPS!).

Use the primary WPE display when creating a WebKitWebView without an
explicit display, falling back to the default display when no primary
display exists.

Test: Tools/TestWebKitAPI/Tests/WebKit/WKPage/glib/TestWebKitWebView.cpp

* Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp:
(webkitWebViewDefaultDisplay):
(webkitWebViewConstructed):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/glib/TestWebKitWebView.cpp:
(testWebViewDisplay):
(testWebViewWPEView):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9e251a3eea0a530f16f7d3e1c39fef1fd99e82fc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176253 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50188 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43978 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185849 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/138497 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178116 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51480 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49872 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137279 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/138497 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179209 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40764 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158051 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117754 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39413 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37771 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149829 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37548 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34318 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41910 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41982 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188273 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49853 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146327 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50537 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34166 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146132 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40899 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122741 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/116717 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49041 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12520 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48443 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48677 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48502 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->