### PR TITLE
[JSC][Wasm] Fix OMG inlined stack origin lookup skipping deeper frames

### DIFF
--- a/JSTests/wasm/stress/nested-inline-stacktrace-omg.js
+++ b/JSTests/wasm/stress/nested-inline-stacktrace-omg.js
@@ -1,0 +1,49 @@
+//@ skip if $addressBits <= 32
+//@ runDefaultWasm("--useBBQJIT=0", "--useConcurrentJIT=0", "--wasmInliningMaximumDepth=10", "--wasmInliningMaximumWasmCalleeSize=10000000", "--wasmInliningBudget=100000", "--thresholdForOMGOptimizeAfterWarmUp=0", "--thresholdForOMGOptimizeSoon=0")
+//@ runDefaultWasm("--useBBQJIT=0", "--useConcurrentJIT=1", "--wasmInliningMaximumDepth=10", "--wasmInliningMaximumWasmCalleeSize=10000000", "--wasmInliningBudget=100000", "--thresholdForOMGOptimizeAfterWarmUp=0", "--thresholdForOMGOptimizeSoon=0")
+var wasm_code = read('simple-inline-stacktrace-with-catch.wasm', 'binary');
+var wasm_module = new WebAssembly.Module(wasm_code);
+let throwCounter = 0;
+let throwAt = 0;
+var wasm_instance = new WebAssembly.Instance(wasm_module, { a: { doThrow: () => {
+    if (throwCounter == throwAt)
+        throw new Error();
+    ++throwCounter;
+} } });
+var f = wasm_instance.exports.main;
+
+function verifyStack(stack, e) {
+    let trace = e.stack.toString().split('\n');
+    let expected = ["*"];
+    for (let i of stack)
+        expected.push(`${i}@wasm-function[${i}]`);
+    expected.push("*");
+
+    if (trace.length != expected.length)
+        throw "unexpected length, got:\n" + e.stack + "\nExpected:\n" + expected.join("\n");
+    for (let i = 0; i < trace.length; ++i) {
+        if (expected[i] == "*")
+            continue;
+        if (expected[i] != trace[i].trim())
+            throw "mismatch at " + i + ", got:\n" + e.stack + "\nExpected:\n" + expected.join("\n");
+    }
+}
+
+const cases = [
+    { throwAt: 8, stack: [14, 15, 16] },
+    { throwAt: 9, stack: [11, 12, 13, 14, 15, 16] },
+    { throwAt: 11, stack: [14, 15, 16] },
+];
+
+const warmups = 20;
+for (let c of cases) {
+    for (let i = 0; i < warmups; ++i) {
+        try {
+            throwCounter = 0;
+            throwAt = c.throwAt;
+            f();
+        } catch (e) {
+            verifyStack(c.stack, e);
+        }
+    }
+}

--- a/Source/JavaScriptCore/wasm/WasmCallee.cpp
+++ b/Source/JavaScriptCore/wasm/WasmCallee.cpp
@@ -443,19 +443,18 @@ void OptimizingJITCallee::addCodeOrigin(unsigned firstInlineCSI, unsigned lastIn
 const WasmCodeOrigin* OptimizingJITCallee::getCodeOrigin(unsigned csi, unsigned depth, bool& isInlined) const
 {
     isInlined = false;
-    auto iter = std::lower_bound(codeOrigins.begin(), codeOrigins.end(), WasmCodeOrigin { 0, csi, 0, 0 }, [&](const auto& a, const auto& b) {
-        return b.lastInlineCSI - a.lastInlineCSI;
+    auto iter = std::lower_bound(codeOrigins.begin(), codeOrigins.end(), csi, [](const WasmCodeOrigin& origin, unsigned value) {
+        return origin.lastInlineCSI < value;
     });
-    if (!iter || iter == codeOrigins.end())
-        iter = codeOrigins.begin();
-    while (iter != codeOrigins.end()) {
-        if (iter->firstInlineCSI <= csi && iter->lastInlineCSI >= csi && !(depth--)) {
+    for (; iter != codeOrigins.end(); ++iter) {
+        if (iter->firstInlineCSI > csi)
+            continue;
+        if (!depth) {
             isInlined = true;
             return iter;
         }
-        ++iter;
+        --depth;
     }
-
     return nullptr;
 }
 


### PR DESCRIPTION
#### 4bfd6c750726a25617c844de7be79c4400f3c088
<pre>
[JSC][Wasm] Fix OMG inlined stack origin lookup skipping deeper frames
<a href="https://bugs.webkit.org/show_bug.cgi?id=270832">https://bugs.webkit.org/show_bug.cgi?id=270832</a>

Reviewed by Yusuke Suzuki.

getCodeOrigin used a broken lower_bound comparator on lastInlineCSI
(integer subtraction coerced to bool), so it could start mid-list and
skip deeper postorder origins that still contain the call site.
Error.stack then dropped nested inlined frames (seen as a flaky wasm
stress failure on x86/EWS). Use a proper lower_bound for the first
origin with lastInlineCSI &gt;= csi, then walk only that suffix matching
firstInlineCSI and depth.

Add a focused OMG-inlining stress test for nested catch/throw stacks.

* Source/JavaScriptCore/wasm/WasmCallee.cpp:
(JSC::Wasm::OptimizingJITCallee::getCodeOrigin):
* JSTests/wasm/stress/nested-inline-stacktrace-omg.js: Added.

Canonical link: <a href="https://commits.webkit.org/317800@main">https://commits.webkit.org/317800@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/08e572ee1e4eff865e7f3216161eb20841f5e71c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176323 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50258 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44048 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185919 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/138578 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51550 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49942 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137338 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/138578 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179279 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40821 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158117 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117813 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39470 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37831 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/6626 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149886 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37615 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34388 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/37591 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42002 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42042 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188343 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49923 "Built successfully") | | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146375 "Found 1 new test failure: fast/flexbox/002.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50607 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34232 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146193 "Passed tests") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26779 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Checked out pull request; Reviewed by Yusuke Suzuki; Canonicalized commit; Pushed commit to WebKit repository") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40965 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122811 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/116826 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49111 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12590 "") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48513 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48747 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48572 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->