### PR TITLE
[JSC][Wasm] Test Module.customSections returns independent ArrayBuffer copies

### DIFF
--- a/JSTests/wasm/js-api/Module.customSection.js
+++ b/JSTests/wasm/js-api/Module.customSection.js
@@ -75,3 +75,35 @@ assert.eq(WebAssembly.Module.customSections.length, 2);
         ++seen;
     }
 }
+
+{
+    const module = new WebAssembly.Module((new Builder())
+        .Unknown("copy").Byte(0x11).Byte(0x22).Byte(0x33).End()
+        .WebAssembly().get());
+
+    const first = WebAssembly.Module.customSections(module, "copy");
+    assert.eq(first.length, 1);
+    const second = WebAssembly.Module.customSections(module, "copy");
+    assert.eq(second.length, 1);
+
+    assert.eq(first[0] === second[0], false);
+    assert.eq(first === second, false);
+
+    const firstBytes = new Uint8Array(first[0]);
+    firstBytes[0] = 0xFF;
+    firstBytes[1] = 0xEE;
+    firstBytes[2] = 0xDD;
+
+    const again = WebAssembly.Module.customSections(module, "copy");
+    assert.eq(again.length, 1);
+    assert.eq(again[0] === first[0], false);
+    const againBytes = new Uint8Array(again[0]);
+    assert.eq(againBytes[0], 0x11);
+    assert.eq(againBytes[1], 0x22);
+    assert.eq(againBytes[2], 0x33);
+
+    const secondBytes = new Uint8Array(second[0]);
+    assert.eq(secondBytes[0], 0x11);
+    assert.eq(secondBytes[1], 0x22);
+    assert.eq(secondBytes[2], 0x33);
+}


### PR DESCRIPTION
#### 4517c96eee8667596c8e8db38520221837d3faa2
<pre>
[JSC][Wasm] Test Module.customSections returns independent ArrayBuffer copies
<a href="https://bugs.webkit.org/show_bug.cgi?id=166701">https://bugs.webkit.org/show_bug.cgi?id=166701</a>

Reviewed by Yusuke Suzuki.

customSections already allocates a new ArrayBuffer via tryCreate(span)
and memcpy. Cover the bug 166701 requirement that mutating a returned
buffer does not affect later customSections results or other returned
buffers, and that successive calls do not reuse the same objects.

* JSTests/wasm/js-api/Module.customSection.js:

Canonical link: <a href="https://commits.webkit.org/318396@main">https://commits.webkit.org/318396@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c24f1bfe2bcd872a40bd5323d933375de5c06aad

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176155 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50090 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43880 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185751 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/138390 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51382 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49774 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137202 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96235 "5 flakes 5 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179111 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40678 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157986 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117677 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39327 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37695 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/6495 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149743 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37483 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34220 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/37423 "Built successfully and passed tests") | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41906 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188174 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49755 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146233 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50438 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34101 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146048 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27024 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40826 "Passed tests") | | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/116613 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48943 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12455 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48345 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48579 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48403 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->