### PR TITLE
Text translated from an RTL language keeps RTL selection behavior

### DIFF
--- a/Source/WebCore/editing/TextManipulationController.cpp
+++ b/Source/WebCore/editing/TextManipulationController.cpp
@@ -55,6 +55,7 @@
 #include "Text.h"
 #include "TextIterator.h"
 #include "TextManipulationItem.h"
+#include "UnicodeHelpers.h"
 #include "VisibleUnits.h"
 #include <algorithm>
 #include <wtf/TZoneMallocInlines.h>
@@ -806,6 +807,26 @@ void TextManipulationController::updateInsertions(Vector<NodeEntry>& lastTopDown
         insertions.append(NodeInsertion { lastTopDownPath.size() ? lastTopDownPath.last().second.ptr() : nullptr, *currentNode });
 }
 
+static void updateEnclosingBlockDirectionAfterReplacement(Node& replacedContentContainer, StringView replacementText)
+{
+    auto newDirection = baseTextDirection(replacementText);
+    if (!newDirection)
+        return;
+
+    RefPtr block = enclosingBlock(&replacedContentContainer);
+    if (!block)
+        return;
+
+    if (equalLettersIgnoringASCIICase(block->attributeWithoutSynchronization(HTMLNames::dirAttr), "auto"_s))
+        return;
+
+    CheckedPtr renderer = block->renderer();
+    if (!renderer || renderer->writingMode().bidiDirection() == *newDirection)
+        return;
+
+    block->setAttribute(HTMLNames::dirAttr, *newDirection == TextDirection::RTL ? "rtl"_s : "ltr"_s);
+}
+
 auto TextManipulationController::replace(const ManipulationItemData& item, const Vector<TextManipulationToken>& replacementTokens, NodeSet& containersWithoutVisualOverflowBeforeReplacement) -> std::optional<ManipulationFailure::Type>
 {
     if (item.start.isOrphan() || item.end.isOrphan())
@@ -833,6 +854,9 @@ auto TextManipulationController::replace(const ManipulationItemData& item, const
             input->setValue(newValue.toString());
         else
             element->setAttribute(item.attributeName, newValue.toAtomString());
+
+        if (item.attributeName == nullQName())
+            updateEnclosingBlockDirectionAfterReplacement(*element, newValue.toString());
 
         m_manipulatedNodes.add(*element);
         return std::nullopt;
@@ -991,6 +1015,18 @@ auto TextManipulationController::replace(const ManipulationItemData& item, const
 
         if (insertion.isChildManipulated == IsNodeManipulated::Yes)
             m_manipulatedNodes.add(insertion.child.get());
+    }
+
+    if (commonAncestor) {
+        StringBuilder replacementText;
+        for (auto& token : replacementTokens) {
+            if (token.content.isNull())
+                continue;
+            if (!replacementText.isEmpty())
+                replacementText.append(' ');
+            replacementText.append(token.content);
+        }
+        updateEnclosingBlockDirectionAfterReplacement(*commonAncestor, replacementText.toString());
     }
 
     return std::nullopt;

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/TextManipulation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/TextManipulation.mm
@@ -1570,6 +1570,63 @@ TEST(TextManipulation, CompleteTextManipulationReplaceSimpleSingleParagraph)
     EXPECT_WK_STREQ("<p>hello, world</p>", [webView stringByEvaluatingJavaScript:@"document.body.innerHTML"]);
 }
 
+static NSString *selectionDirectionProbe(TestWKWebView *webView, NSString *elementID)
+{
+    return [webView stringByEvaluatingJavaScript:[NSString stringWithFormat:@""
+        "(function() {"
+        "    var p = document.getElementById('%@');"
+        "    var t = p.firstChild;"
+        "    var sel = getSelection();"
+        "    var r = document.createRange();"
+        "    r.setStart(t, 10);"
+        "    r.collapse(true);"
+        "    sel.removeAllRanges();"
+        "    sel.addRange(r);"
+        "    sel.modify('extend', 'right', 'character');"
+        "    if (sel.focusNode !== t) return 'other';"
+        "    if (sel.focusOffset > 10) return 'forward';"
+        "    if (sel.focusOffset < 10) return 'backward';"
+        "    return 'none';"
+        "})()", elementID]];
+}
+
+TEST(TextManipulation, CompleteTextManipulationTranslatedRTLParagraphUsesStaleSelectionDirection)
+{
+    RetainPtr delegate = adoptNS([[TextManipulationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    [webView _setTextManipulationDelegate:delegate.get()];
+
+    [webView synchronouslyLoadHTMLString:@"<!DOCTYPE html>"
+        "<html><body>"
+        "<p id='translated' dir='rtl'>الثعلب البني السريع يقفز فوق الكلب الكسول</p>"
+        "<p id='control' dir='ltr'>The quick brown fox jumps over the lazy dog</p>"
+        "</body></html>"];
+
+    done = false;
+    [webView _startTextManipulationsWithConfiguration:nil completion:^{
+        done = true;
+    }];
+    TestWebKitAPI::Util::run(&done);
+
+    auto *items = [delegate items];
+    EXPECT_EQ(items.count, 2UL);
+
+    EXPECT_WK_STREQ("backward", selectionDirectionProbe(webView.get(), @"translated"));
+
+    done = false;
+    [webView _completeTextManipulationForItems:@[(_WKTextManipulationItem *)createItem(items[0].identifier, {
+        { items[0].tokens[0].identifier, @"The quick brown fox jumps over the lazy dog" },
+    })] completion:^(NSArray<NSError *> *errors) {
+        EXPECT_EQ(errors, nil);
+        done = true;
+    }];
+    TestWebKitAPI::Util::run(&done);
+
+    EXPECT_WK_STREQ("The quick brown fox jumps over the lazy dog", [webView stringByEvaluatingJavaScript:@"document.getElementById('translated').textContent"]);
+    EXPECT_WK_STREQ("forward", selectionDirectionProbe(webView.get(), @"control"));
+    EXPECT_WK_STREQ("forward", selectionDirectionProbe(webView.get(), @"translated"));
+}
+
 TEST(TextManipulation, LegacyCompleteTextManipulationReplaceSimpleSingleParagraph)
 {
     RetainPtr delegate = adoptNS([[TextManipulationDelegate alloc] init]);


### PR DESCRIPTION
#### 5d309c9d1cb5cb215cf9764e1aad513afaf7c6ba
<pre>
Text translated from an RTL language keeps RTL selection behavior
<a href="https://bugs.webkit.org/show_bug.cgi?id=320005">https://bugs.webkit.org/show_bug.cgi?id=320005</a>
<a href="https://rdar.apple.com/182944889">rdar://182944889</a>

Reviewed by Wenson Hsieh.

Translation replaces an element&apos;s text via TextManipulationController without touching its writing
direction. Since caret and selection direction come from the enclosing block&apos;s direction (not the
script of the characters), text translated from Arabic (RTL) to English (LTR) stayed in an RTL
block, so the caret moved backwards and selection extended the wrong way.

After a replacement, update the enclosing block&apos;s direction to match the base direction of the new
text when they disagree, mirroring how pasted content updates its direction in
ReplaceSelectionCommand. dir=auto blocks are left alone since they already recompute direction from
content.

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/TextManipulation.mm

* Source/WebCore/editing/TextManipulationController.cpp:
(WebCore::updateEnclosingBlockDirectionAfterReplacement):
(WebCore::TextManipulationController::replace):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/TextManipulation.mm:
(TestWebKitAPI::selectionDirectionProbe):
(TestWebKitAPI::TEST(TextManipulation, CompleteTextManipulationTranslatedRTLParagraphUsesStaleSelectionDirection)):

Canonical link: <a href="https://commits.webkit.org/317745@main">https://commits.webkit.org/317745@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e6a07fdcb7062593aa2f0f0d8ebe4b4610a5ba50

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176156 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50091 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43881 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185752 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/138391 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178019 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51383 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49775 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137203 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/138391 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/edbb1ef5-a7cc-4998-b34b-61a16ee27cbd) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179112 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40682 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157995 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117678 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b4824bd0-c077-4ec4-a452-6f9690e0fcc5) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39331 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37697 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149747 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37492 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34221 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41807 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/41908 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188175 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49756 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146223 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50439 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/34110 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146047 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26766 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40827 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122644 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/116614 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48944 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12464 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48346 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48580 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48404 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->