### PR TITLE
CoreAudioCaptureDevice::getDeviceInfo() leaks a CFStringRef when the data source name is empty

### DIFF
--- a/Source/WebCore/platform/mediastream/cocoa/CoreAudioCaptureDevice.cpp
+++ b/Source/WebCore/platform/mediastream/cocoa/CoreAudioCaptureDevice.cpp
@@ -75,6 +75,10 @@ static bool getDeviceInfo(uint32_t deviceID, CaptureDevice::DeviceType type, Str
     }
 
     if (err || !localizedName || !CFStringGetLength(localizedName)) {
+        if (localizedName) {
+            CFRelease(localizedName);
+            localizedName = nullptr;
+        }
         address = {
             kAudioObjectPropertyName,
             kAudioObjectPropertyScopeGlobal,


### PR DESCRIPTION
#### b2779a1fffa063d660c9a78217e9ccea57ab9a3f
<pre>
CoreAudioCaptureDevice::getDeviceInfo() leaks a CFStringRef when the data source name is empty
<a href="https://bugs.webkit.org/show_bug.cgi?id=320007">https://bugs.webkit.org/show_bug.cgi?id=320007</a>
<a href="https://rdar.apple.com/182946069">rdar://182946069</a>

Reviewed by Youenn Fablet.

If the AudioObjectGetPropertyData() call for the data source name
succeeds but returns a non-null, zero-length CFStringRef,
getDeviceInfo() fell through to the kAudioObjectPropertyName fallback
and overwrote localizedName with a second string without releasing
the first one, leaking a CFStringRef.

Release localizedName before overwriting it in the fallback branch,
so the empty string returned by the data source name lookup is no
longer leaked.

No new tests, since this path only leaks memory and cannot be
detected by output-diffing LayoutTests/WPT; there&apos;s no mock layer
for the CoreAudio HAL calls exercised here.

* Source/WebCore/platform/mediastream/cocoa/CoreAudioCaptureDevice.cpp:
(WebCore::getDeviceInfo):

Canonical link: <a href="https://commits.webkit.org/317780@main">https://commits.webkit.org/317780@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/60c84a137dbb2c4584714c90e8959cb310240001

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176274 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50209 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43999 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185870 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/138521 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/33d9897d-8b37-496a-a677-7a8b35b636fe) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178137 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51501 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49893 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137292 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/138521 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/dd23242e-c397-40b3-82eb-fe27c5067873) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179230 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40774 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158069 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117767 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/103e9a29-aa8c-40df-a656-71a6efafbab1) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39423 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37789 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149839 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37566 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34339 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41932 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42000 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188294 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49874 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146329 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39367 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50558 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34184 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146147 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40919 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122762 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/116741 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49062 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12539 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48464 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48698 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48523 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->