### PR TITLE
AX: Setting AXSelectedTextMarkerRange to an empty non-text element moves the selection into an adjacent editable, potentially causing navigation loops

### DIFF
--- a/LayoutTests/accessibility/mac/set-selected-text-marker-range-on-non-text-element-expected.txt
+++ b/LayoutTests/accessibility/mac/set-selected-text-marker-range-on-non-text-element-expected.txt
@@ -1,0 +1,9 @@
+This test verifies that setting the accessibility selected-text-marker range to an empty non-text element (e.g. an icon button with no text of its own) does not walk the selection forward into a following contenteditable and steal DOM focus into it.
+
+PASS: selectionEnteredComposer === false
+PASS: focusEnteredComposer === false
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/mac/set-selected-text-marker-range-on-non-text-element.html
+++ b/LayoutTests/accessibility/mac/set-selected-text-marker-range-on-non-text-element.html
@@ -1,0 +1,62 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+
+<div id="content">
+    <p>Message text</p>
+    <button id="more" aria-label="More actions"></button>
+    <div id="composer" contenteditable="true">Composer text</div>
+</div>
+
+<script>
+var output = "This test verifies that setting the accessibility selected-text-marker range to an empty non-text element (e.g. an icon button with no text of its own) does not walk the selection forward into a following contenteditable and steal DOM focus into it.\n\n";
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    setTimeout(async () => {
+        const webArea = accessibilityController.rootElement.childAtIndex(0);
+        const more = accessibilityController.accessibleElementById("more");
+        const composer = document.getElementById("composer");
+
+        // As VoiceOver navigates (with "Synchronize keyboard focus and VoiceOver cursor" on), it
+        // sets a collapsed text marker range to represent the "cursor" or insertion point position.
+        // Emulate that.
+        const moreRange = more.textMarkerRangeForElement(more);
+        const startMarker = webArea.startTextMarkerForTextMarkerRange(moreRange);
+        const collapsedRange = webArea.textMarkerRangeForMarkers(startMarker, startMarker);
+        webArea.setSelectedTextMarkerRange(collapsedRange);
+
+        // The set is applied asynchronously, so wait until it has taken effect (the web area reports a
+        // selected range whose start marker resolves to an element).
+        await waitFor(() => {
+            const range = webArea.selectedTextMarkerRange();
+            if (!range)
+                return false;
+            const start = webArea.startTextMarkerForTextMarkerRange(range);
+            return start && webArea.accessibilityElementForTextMarker(start);
+        });
+
+        // Setting the "cursor" to a position should not jump into the adjacent editable. This would
+        // result in navigation loops in a real browser environment, since the focus-changed notification
+        // that would be generated would jump VoiceOver to the editable every time you tried to move to
+        // the button.
+        const anchorNode = window.getSelection().anchorNode;
+        window.selectionEnteredComposer = !!(anchorNode && composer.contains(anchorNode));
+        output += expect("selectionEnteredComposer", "false");
+
+        window.focusEnteredComposer = document.activeElement === composer;
+        output += expect("focusEnteredComposer", "false");
+
+        debug(output);
+        document.getElementById("content").style.display = "none";
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/Source/WebCore/accessibility/AXTextMarker.cpp
+++ b/Source/WebCore/accessibility/AXTextMarker.cpp
@@ -663,8 +663,25 @@ AXTextMarker AXTextMarker::convertToDomOffset() const
 
     if (!isValid())
         return { };
-    if (!isInTextRun())
-        return toTextRunMarker().convertToDomOffset();
+    if (!isInTextRun()) {
+        // This marker is anchored to a non-text object, so to compute a DOM offset we normalize it to
+        // the text run its offset points into. A non-text *container* (e.g. a group) legitimately
+        // resolves to a descendant text run, but an empty non-text *leaf* (e.g. a button with no text
+        // of its own) has none, and the forward walk can then escape into unrelated downstream text. If
+        // that text is inside an editable, applying the result as the selection steals DOM focus into
+        // the editable, which can cause adverse side effects like navigation loops.
+        //
+        // So, when the resolved text run lies outside this object's own subtree, anchor at the object
+        // itself. Return a normalized element-anchored offset (0) so we maintain the invariant of this
+        // function always returning a DOM-offset marker.
+        auto textRunMarker = toTextRunMarker();
+        RefPtr object = isolatedObject();
+        RefPtr textRunObject = textRunMarker.isolatedObject();
+        if (!textRunMarker.isValid() || !object || !textRunObject || !object->isAncestorOfObject(*textRunObject))
+            return { treeID(), objectID(), 0 };
+
+        return textRunMarker.convertToDomOffset();
+    }
 
     auto newData = m_data;
     newData.offset = runs()->domOffset(offset());


### PR DESCRIPTION
#### d9f55c1ea18059d105464a271fd8173f0ebcd7f2
<pre>
AX: Setting AXSelectedTextMarkerRange to an empty non-text element moves the selection into an adjacent editable, potentially causing navigation loops
<a href="https://bugs.webkit.org/show_bug.cgi?id=320010">https://bugs.webkit.org/show_bug.cgi?id=320010</a>
<a href="https://rdar.apple.com/182947669">rdar://182947669</a>

Reviewed by Andres Gonzalez.

When an assistive technology sets AXSelectedTextMarkerRange on the isolated tree,
-[WebAccessibilityObjectWrapper accessibilitySetValue:forAttribute:] converts the
incoming marker range to DOM offsets via AXTextMarkerRange::convertToDomOffsetRange(),
which calls AXTextMarker::convertToDomOffset() on each endpoint.

For a marker anchored to a non-text object, convertToDomOffset() normalizes it to a
text-run marker with toTextRunMarker(), which walks forward in pre-order to the nearest
object that has text runs. For an empty non-text *leaf* (e.g. an icon button with no
text of its own), that walk escapes the element&apos;s own subtree and lands on unrelated
downstream text. When that text is inside an editable, applying the resulting position
as the selection moves DOM focus into the editable.

Concretely: with &quot;Synchronize keyboard focus and VoiceOver cursor&quot; enabled, moving the
VoiceOver cursor onto a hover-only button (e.g. Slack&apos;s &quot;More actions&quot;) jumped the cursor
and focus into the message composer, because the button&apos;s marker was walked forward to
the composer&apos;s text on set.

Fix convertToDomOffset() to keep the marker anchored at the object itself when the
normalized text run lies outside the object&apos;s own subtree — i.e. when the object has no
text of its own. A non-text container that genuinely wraps descendant text is unchanged,
since its text run is within its subtree.

* LayoutTests/accessibility/mac/set-selected-text-marker-range-on-non-text-element-expected.txt: Added.
* LayoutTests/accessibility/mac/set-selected-text-marker-range-on-non-text-element.html: Added.
* Source/WebCore/accessibility/AXTextMarker.cpp:
(WebCore::AXTextMarker::convertToDomOffset const):

Canonical link: <a href="https://commits.webkit.org/317824@main">https://commits.webkit.org/317824@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d293e71669f98f6409fc1ad909827d1af0152b9a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176390 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50325 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44115 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185989 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/138650 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178253 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51617 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50009 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137392 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/138650 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179346 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40878 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158178 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117867 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39527 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37893 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149943 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37676 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34457 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42054 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42104 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188412 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49990 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/157723 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146444 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39397 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50674 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34294 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/bfcache/abort.tentative.https.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146250 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41020 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122878 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/116928 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49178 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12651 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48580 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48814 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48639 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->