### PR TITLE
Show process ID label alongside frame process border indicators

### DIFF
--- a/Source/WebCore/PlatformCocoa.cmake
+++ b/Source/WebCore/PlatformCocoa.cmake
@@ -357,6 +357,7 @@ list(APPEND WebCore_SOURCES
     platform/graphics/avfoundation/objc/VideoTrackPrivateMediaSourceAVFObjC.mm
     platform/graphics/avfoundation/objc/WebCoreAVFResourceLoader.mm
 
+    platform/graphics/ca/FrameProcessIndicators.cpp
     platform/graphics/ca/GraphicsLayerCA.cpp
     platform/graphics/ca/LayerPool.cpp
     platform/graphics/ca/PlatformCAAnimation.cpp
@@ -1142,6 +1143,7 @@ list(APPEND WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/graphics/avfoundation/objc/MediaSampleAVFObjC.h
     platform/graphics/avfoundation/objc/VideoLayerManagerObjC.h
 
+    platform/graphics/ca/FrameProcessIndicators.h
     platform/graphics/ca/GraphicsLayerCA.h
     platform/graphics/ca/LayerPool.h
     platform/graphics/ca/PlatformCAAnimation.h

--- a/Source/WebCore/SourcesCocoa.txt
+++ b/Source/WebCore/SourcesCocoa.txt
@@ -400,6 +400,7 @@ platform/graphics/avfoundation/objc/VideoTrackPrivateAVFObjC.cpp
 platform/graphics/avfoundation/objc/VideoTrackPrivateMediaSourceAVFObjC.mm @nonARC
 platform/graphics/avfoundation/objc/WebAVContentKeyGroup.mm @nonARC @no-unify-when(bundle<=8)
 platform/graphics/avfoundation/objc/WebCoreAVFResourceLoader.mm @nonARC
+platform/graphics/ca/FrameProcessIndicators.cpp
 platform/graphics/ca/GraphicsLayerCA.cpp
 platform/graphics/ca/LayerPool.cpp
 platform/graphics/ca/PlatformCAAnimation.cpp

--- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
+++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
@@ -3127,6 +3127,7 @@
 		7AA3A69A194A64E7001CBD24 /* TileController.h in Headers */ = {isa = PBXBuildFile; fileRef = 7AA3A696194A64E7001CBD24 /* TileController.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		7AA3A69C194A64E7001CBD24 /* TileGrid.h in Headers */ = {isa = PBXBuildFile; fileRef = 7AA3A698194A64E7001CBD24 /* TileGrid.h */; };
 		7AA3A6A0194B59B6001CBD24 /* LayerPool.h in Headers */ = {isa = PBXBuildFile; fileRef = 7AA3A69E194B59B6001CBD24 /* LayerPool.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		0F1A2B3C4D5E6F7080910A01 /* FrameProcessIndicators.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F1A2B3C4D5E6F7080910A02 /* FrameProcessIndicators.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		7AA3A6A4194B5C22001CBD24 /* TileCoverageMap.h in Headers */ = {isa = PBXBuildFile; fileRef = 7AA3A6A2194B5C22001CBD24 /* TileCoverageMap.h */; };
 		7AAA32B6C6C7C1328978606C /* Ellipsis.svg in Copy Modern Media Controls Images */ = {isa = PBXBuildFile; fileRef = F3FB34D3C8B0041EA738900D /* Ellipsis.svg */; platformFilters = (macos, ); };
 		7AABA25A14BC613300AA9A11 /* DOMEditor.h in Headers */ = {isa = PBXBuildFile; fileRef = 7AABA25814BC613300AA9A11 /* DOMEditor.h */; };
@@ -12266,6 +12267,8 @@
 		4998AED013FB224D0090B1AA /* ScriptedAnimationController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ScriptedAnimationController.h; sourceTree = "<group>"; };
 		499B3EC3128CCC4700E726C2 /* PlatformCALayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PlatformCALayer.h; sourceTree = "<group>"; };
 		499B3ED4128CD31400E726C2 /* GraphicsLayerCA.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GraphicsLayerCA.cpp; sourceTree = "<group>"; };
+		0F1A2B3C4D5E6F7080910A03 /* FrameProcessIndicators.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = FrameProcessIndicators.cpp; sourceTree = "<group>"; };
+		0F1A2B3C4D5E6F7080910A02 /* FrameProcessIndicators.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FrameProcessIndicators.h; sourceTree = "<group>"; };
 		499B3ED5128CD31400E726C2 /* GraphicsLayerCA.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GraphicsLayerCA.h; sourceTree = "<group>"; };
 		499B3EDC128DB50100E726C2 /* PlatformCAAnimation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PlatformCAAnimation.h; sourceTree = "<group>"; };
 		49AE2D8C134EE50C0072920A /* CSSCalcValue.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CSSCalcValue.cpp; sourceTree = "<group>"; };
@@ -28579,6 +28582,8 @@
 			isa = PBXGroup;
 			children = (
 				4958781E12A57DBC007238AC /* cocoa */,
+				0F1A2B3C4D5E6F7080910A03 /* FrameProcessIndicators.cpp */,
+				0F1A2B3C4D5E6F7080910A02 /* FrameProcessIndicators.h */,
 				499B3ED4128CD31400E726C2 /* GraphicsLayerCA.cpp */,
 				499B3ED5128CD31400E726C2 /* GraphicsLayerCA.h */,
 				7AA3A69D194B59B6001CBD24 /* LayerPool.cpp */,
@@ -45593,6 +45598,7 @@
 				93B77A380ADD792500EA4B81 /* FrameLoaderTypes.h in Headers */,
 				658436860AE01B7400E53753 /* FrameLoadRequest.h in Headers */,
 				628D214E12131EF40055DCFC /* FrameNetworkingContext.h in Headers */,
+				0F1A2B3C4D5E6F7080910A01 /* FrameProcessIndicators.h in Headers */,
 				71FCB17027BAB3FE00E0631C /* FrameRateAligner.h in Headers */,
 				4190F3A524A0B4EE00531C57 /* FrameRateMonitor.h in Headers */,
 				5EAA0A2D2F47C803009CAB0D /* FrameRuntimeAgent.h in Headers */,

--- a/Source/WebCore/platform/graphics/GraphicsLayer.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsLayer.cpp
@@ -40,7 +40,6 @@
 #include <wtf/FileHandle.h>
 #include <wtf/HashMap.h>
 #include <wtf/NeverDestroyed.h>
-#include <wtf/ProcessID.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/CString.h>
 #include <wtf/text/MakeString.h>
@@ -781,20 +780,12 @@ void GraphicsLayer::getDebugBorderInfo(Color& color, float& width) const
         return;
     }
 
-    if (isShowingFrameProcessBorders()) {
-        auto hash = intHash(static_cast<uint32_t>(getCurrentProcessID()));
-        uint8_t r = (hash >>  0) & 0xFF, g = (hash >>  8) & 0xFF, b = (hash >> 16) & 0xFF;
-        color = SRGBA<uint8_t> { r, g, b }.colorWithAlphaByte(192);
-        width = 4;
-        return;
-    }
-
     color = Color::yellow.colorWithAlphaByte(192); // container: yellow
 }
 
 void GraphicsLayer::updateDebugIndicators()
 {
-    if (!isShowingDebugBorder() && !isShowingFrameProcessBorders())
+    if (!isShowingDebugBorder())
         return;
 
     Color borderColor;

--- a/Source/WebCore/platform/graphics/ca/FrameProcessIndicators.cpp
+++ b/Source/WebCore/platform/graphics/ca/FrameProcessIndicators.cpp
@@ -1,0 +1,152 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "FrameProcessIndicators.h"
+
+#if USE(CA)
+
+#include "ComplexTextController.h"
+#include "FontCascade.h"
+#include "FontCascadeDescription.h"
+#include "FontSelector.h"
+#include "GraphicsLayerCA.h"
+#include "TextRun.h"
+#include <wtf/ProcessID.h>
+#include <wtf/TZoneMallocInlines.h>
+
+namespace WebCore {
+
+static constexpr float padding = 3;
+static constexpr float fontSize = 12;
+static constexpr float borderWidth = 4;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(FrameProcessIndicators);
+
+FrameProcessIndicators::FrameProcessIndicators(GraphicsLayerCA& graphicsLayer)
+    : m_graphicsLayer(graphicsLayer)
+    , m_backgroundColor(borderColor())
+    , m_text(String::number(getCurrentProcessID()))
+    , m_borderLayer(graphicsLayer.createPlatformCALayer(PlatformCALayer::LayerType::LayerTypeLayer, nullptr))
+    , m_indicatorLayer(graphicsLayer.createPlatformCALayer(PlatformCALayer::LayerType::LayerTypeWebLayer, this))
+{
+    m_borderLayer->setName(MAKE_STATIC_STRING_IMPL("frame process border"));
+    m_borderLayer->setAnchorPoint({ });
+    m_borderLayer->setBorderColor(m_backgroundColor);
+    m_borderLayer->setBorderWidth(borderWidth);
+    m_borderLayer->setUserInteractionEnabled(false);
+
+    m_indicatorLayer->setName(MAKE_STATIC_STRING_IMPL("frame process indicator"));
+    m_indicatorLayer->setAnchorPoint({ });
+    m_indicatorLayer->setBounds({ { }, size() });
+    m_indicatorLayer->setContentsScale(graphicsLayer.m_layer->contentsScale());
+    m_indicatorLayer->setUserInteractionEnabled(false);
+    m_indicatorLayer->setNeedsDisplay();
+
+    updateGeometry(graphicsLayer.m_layer->bounds());
+}
+
+FrameProcessIndicators::~FrameProcessIndicators()
+{
+    m_indicatorLayer->setOwner(nullptr);
+}
+
+void FrameProcessIndicators::appendLayers(PlatformCALayerList& list) const
+{
+    list.append(m_borderLayer);
+    list.append(m_indicatorLayer);
+}
+
+void FrameProcessIndicators::updateGeometry(const FloatRect& bounds)
+{
+    auto location = bounds.location();
+    m_borderLayer->setPosition(location);
+    m_borderLayer->setBounds({ { }, bounds.size() });
+    m_indicatorLayer->setPosition({ bounds.maxX() - m_indicatorLayer->bounds().width(), location.y(), 1 });
+}
+
+void FrameProcessIndicators::updateContentsScale(float contentsScale)
+{
+    if (contentsScale == m_indicatorLayer->contentsScale())
+        return;
+
+    m_indicatorLayer->setContentsScale(contentsScale);
+    m_indicatorLayer->setNeedsDisplay();
+}
+
+Color FrameProcessIndicators::borderColor()
+{
+    auto hash = intHash(static_cast<uint32_t>(getCurrentProcessID()));
+    uint8_t r = (hash >> 0) & 0xFF;
+    uint8_t g = (hash >> 8) & 0xFF;
+    uint8_t b = (hash >> 16) & 0xFF;
+    return SRGBA<uint8_t> { r, g, b }.colorWithAlphaByte(192);
+}
+
+FontCascade FrameProcessIndicators::makeFont()
+{
+    FontCascadeDescription fontDescription;
+    fontDescription.setOneFamily("Helvetica"_s);
+    fontDescription.setSpecifiedSize(fontSize);
+    fontDescription.setComputedSize(fontSize);
+
+    FontCascade font(WTF::move(fontDescription));
+    font.update(nullptr);
+    return font;
+}
+
+FloatSize FrameProcessIndicators::size() const
+{
+    auto font = makeFont();
+    auto [textTop, textBottom] = textVerticalBounds(font);
+    return { 2 * padding + font.width(TextRun(m_text)), 2 * padding + textBottom - textTop };
+}
+
+std::pair<float, float> FrameProcessIndicators::textVerticalBounds(const FontCascade& font) const
+{
+    return ComplexTextController::enclosingGlyphBoundsForTextRun(font, TextRun(m_text));
+}
+
+void FrameProcessIndicators::platformCALayerPaintContents(PlatformCALayer* layer, GraphicsContext& context, const FloatRect&, OptionSet<GraphicsLayerPaintBehavior>)
+{
+    auto font = makeFont();
+    auto textTop = textVerticalBounds(font).first;
+    auto textColor = m_backgroundColor.luminance() > 0.5 ? Color::black : Color::white;
+    auto indicatorSize = layer->bounds().size();
+
+    context.setFillColor(m_backgroundColor);
+    context.fillRect(FloatRect { 0, borderWidth, indicatorSize.width() - borderWidth, indicatorSize.height() - borderWidth });
+    context.setFillColor(textColor);
+    context.drawText(font, TextRun(m_text), { padding, padding - textTop });
+}
+
+float FrameProcessIndicators::platformCALayerDeviceScaleFactor() const
+{
+    return m_graphicsLayer ? m_graphicsLayer->deviceScaleFactor() : 1;
+}
+
+} // namespace WebCore
+
+#endif // USE(CA)

--- a/Source/WebCore/platform/graphics/ca/FrameProcessIndicators.h
+++ b/Source/WebCore/platform/graphics/ca/FrameProcessIndicators.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <WebCore/PlatformCALayer.h>
+#include <WebCore/PlatformCALayerClient.h>
+
+namespace WebCore {
+
+class FontCascade;
+class GraphicsLayer;
+class GraphicsLayerCA;
+
+class FrameProcessIndicators final : public PlatformCALayerClient {
+    WTF_MAKE_TZONE_ALLOCATED(FrameProcessIndicators);
+public:
+    explicit FrameProcessIndicators(GraphicsLayerCA&);
+    ~FrameProcessIndicators();
+
+    void appendLayers(PlatformCALayerList&) const;
+    void updateGeometry(const FloatRect&);
+    void updateContentsScale(float);
+
+private:
+    static Color borderColor();
+    static FontCascade makeFont();
+
+    FloatSize size() const;
+    std::pair<float, float> textVerticalBounds(const FontCascade&) const;
+
+    PlatformLayerIdentifier platformCALayerIdentifier() const override { return m_layerIdentifier; }
+    void platformCALayerPaintContents(PlatformCALayer*, GraphicsContext&, const FloatRect&, OptionSet<GraphicsLayerPaintBehavior>) override;
+    bool platformCALayerContentsOpaque() const override { return false; }
+    bool platformCALayerDrawsContent() const override { return true; }
+    float platformCALayerDeviceScaleFactor() const override;
+    OptionSet<ContentsFormat> screenContentsFormats() const override { return { }; }
+
+    const PlatformLayerIdentifier m_layerIdentifier { PlatformLayerIdentifier::generate() };
+    const WeakPtr<GraphicsLayer> m_graphicsLayer;
+    const Color m_backgroundColor;
+    const String m_text;
+    const Ref<PlatformCALayer> m_borderLayer;
+    const Ref<PlatformCALayer> m_indicatorLayer;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
@@ -32,6 +32,7 @@
 #include "DisplayListRecorderImpl.h"
 #include "FloatConversion.h"
 #include "FloatRect.h"
+#include "FrameProcessIndicators.h"
 #include "GraphicsLayerAnimation.h"
 #include "GraphicsLayerAnimationValue.h"
 #include "GraphicsLayerAsyncContentsDisplayDelegateCocoa.h"
@@ -475,6 +476,8 @@ GraphicsLayerCA::~GraphicsLayerCA()
 
     if (m_backdropClippingLayer)
         protect(m_backdropClippingLayer)->setOwner(nullptr);
+
+    m_frameProcessIndicators = nullptr;
 
     removeCloneLayers();
 
@@ -2449,9 +2452,9 @@ void GraphicsLayerCA::updateSublayerList(bool maxLayerDepthReached)
 #ifdef VISIBLE_TILE_WASH
         if (m_visibleTileWashLayer)
             list.append(m_visibleTileWashLayer);
-#else
-        UNUSED_PARAM(list);
 #endif
+        if (m_frameProcessIndicators)
+            m_frameProcessIndicators->appendLayers(list);
     };
 
     auto buildChildLayerList = [&](PlatformCALayerList& list) {
@@ -2541,6 +2544,9 @@ void GraphicsLayerCA::updateGeometry(float pageScaleFactor, const FloatPoint& po
     FloatRect adjustedBounds = FloatRect(FloatPoint(m_boundsOrigin - pixelAlignmentOffset), m_size);
     layer->setBounds(adjustedBounds);
     layer->setAnchorPoint(scaledAnchorPoint);
+
+    if (m_frameProcessIndicators)
+        m_frameProcessIndicators->updateGeometry(adjustedBounds);
 
     if (m_layerClones) {
         for (auto& clone : m_layerClones->primaryLayerClones) {
@@ -3089,12 +3095,23 @@ static Color cloneLayerDebugBorderColor(bool showingBorders)
     return showingBorders ? SRGBA<uint8_t> { 255, 122, 251 } : Color { };
 }
 
+void GraphicsLayerCA::updateFrameProcessIndicators()
+{
+    if (isShowingFrameProcessBorders() && !m_frameProcessIndicators)
+        m_frameProcessIndicators = makeUnique<FrameProcessIndicators>(*this);
+    else if (!isShowingFrameProcessBorders() && m_frameProcessIndicators)
+        m_frameProcessIndicators = nullptr;
+    noteSublayersChanged(DontScheduleFlush);
+}
+
 void GraphicsLayerCA::updateDebugIndicators()
 {
+    updateFrameProcessIndicators();
+
     Color borderColor;
     float width = 0;
 
-    bool showDebugBorders = isShowingDebugBorder() || isShowingFrameProcessBorders();
+    bool showDebugBorders = isShowingDebugBorder();
     if (showDebugBorders)
         getDebugBorderInfo(borderColor, width);
 
@@ -4419,6 +4436,9 @@ void GraphicsLayerCA::updateContentsScale(float pageScaleFactor)
 
     if (auto customScale = client().customContentsScale(*this))
         contentsScale = *customScale;
+
+    if (m_frameProcessIndicators)
+        m_frameProcessIndicators->updateContentsScale(contentsScale);
 
     RefPtr layer = m_layer;
     if (contentsScale == layer->contentsScale())

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h
@@ -48,6 +48,7 @@ class DisplayList;
 }
 
 class FloatRoundedRect;
+class FrameProcessIndicators;
 class GraphicsLayerAnimationValue;
 class GraphicsLayerKeyframeValueList;
 class HTMLVideoElement;
@@ -247,6 +248,8 @@ public:
     WEBCORE_EXPORT void setShadowPath(const Path&) override;
 
 private:
+    friend class FrameProcessIndicators;
+
     bool isGraphicsLayerCA() const override { return true; }
 
     // PlatformCALayerClient overrides
@@ -525,6 +528,7 @@ private:
     void updateContentsNeedsDisplay();
     void updateAcceleratesDrawing();
     void updateDebugIndicators();
+    void updateFrameProcessIndicators();
     void updateTiles();
     void updateRootRelativeScale();
     void updateContentsScale(float pageScaleFactor);
@@ -728,6 +732,7 @@ private:
 #ifdef VISIBLE_TILE_WASH
     RefPtr<PlatformCALayer> m_visibleTileWashLayer;
 #endif
+    std::unique_ptr<FrameProcessIndicators> m_frameProcessIndicators;
     FloatRect m_visibleRect;
     FloatRect m_previousCommittedVisibleRect;
     FloatRect m_coverageRect; // Area for which we should maintain backing store, in the coordinate space of this layer.


### PR DESCRIPTION
#### 85b404d9be36a777d5765440185ace8e2fd7a600
<pre>
Show process ID label alongside frame process border indicators
<a href="https://bugs.webkit.org/show_bug.cgi?id=320012">https://bugs.webkit.org/show_bug.cgi?id=320012</a>
<a href="https://rdar.apple.com/182947796">rdar://182947796</a>

Reviewed by Simon Fraser.

Move the per-process debug border out of GraphicsLayer::getDebugBorderInfo into a new
FrameProcessIndicators class owned by GraphicsLayerCA. In addition to the PID-colored border, it
draws a text layer labeling each frame with its process ID, making it clearer which process a frame
is rendered in when debugging site isolation.

* Source/WebCore/PlatformCocoa.cmake:
* Source/WebCore/SourcesCocoa.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/graphics/GraphicsLayer.cpp:
(WebCore::GraphicsLayer::getDebugBorderInfo const):
(WebCore::GraphicsLayer::updateDebugIndicators):
* Source/WebCore/platform/graphics/ca/FrameProcessIndicators.cpp: Added.
(WebCore::FrameProcessIndicators::FrameProcessIndicators):
(WebCore::FrameProcessIndicators::~FrameProcessIndicators):
(WebCore::FrameProcessIndicators::appendLayers const):
(WebCore::FrameProcessIndicators::updateGeometry):
(WebCore::FrameProcessIndicators::updateContentsScale):
(WebCore::FrameProcessIndicators::borderColor):
(WebCore::FrameProcessIndicators::makeFont):
(WebCore::FrameProcessIndicators::size const):
(WebCore::FrameProcessIndicators::textVerticalBounds const):
(WebCore::FrameProcessIndicators::platformCALayerPaintContents):
* Source/WebCore/platform/graphics/ca/FrameProcessIndicators.h: Added.
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp:
(WebCore::GraphicsLayerCA::~GraphicsLayerCA):
(WebCore::GraphicsLayerCA::updateSublayerList):
(WebCore::GraphicsLayerCA::updateGeometry):
(WebCore::GraphicsLayerCA::ensureStructuralLayer):
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h:

Canonical link: <a href="https://commits.webkit.org/317746@main">https://commits.webkit.org/317746@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ed05e805bbe0c193dadd035e44ade738cfb060f1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176198 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50133 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43923 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185794 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/138436 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178061 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51425 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49817 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137237 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/138436 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179154 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40712 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158013 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117712 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1e2e4864-a07e-4fdc-b910-faf9a99939fb) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39361 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37727 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149777 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37510 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34263 "Built successfully") | | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41852 "Found 6 new failures in platform/graphics/ca/FrameProcessIndicators.cpp") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/41938 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188218 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49798 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146261 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50481 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/34128 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146082 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26767 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40867 "Passed tests") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122686 "Found 6 new failures in platform/graphics/ca/FrameProcessIndicators.cpp") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/116662 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48986 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12482 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48388 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48622 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48446 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->