### PR TITLE
[Memory64] Implement Table64 in the OMG tier

### DIFF
--- a/JSTests/wasm/stress/table64-bulk.js
+++ b/JSTests/wasm/stress/table64-bulk.js
@@ -1,5 +1,5 @@
 //@ skip if $addressBits <= 32
-//@ runDefaultWasm("-m", "--useWasmMemory64=1", "--useOMGJIT=0")
+//@ runDefaultWasm("-m", "--useWasmMemory64=1")
 import { instantiate } from "../wabt-wrapper.js";
 import * as assert from "../assert.js";
 

--- a/JSTests/wasm/stress/table64-call-indirect.js
+++ b/JSTests/wasm/stress/table64-call-indirect.js
@@ -1,5 +1,5 @@
 //@ skip if $addressBits <= 32
-//@ runDefaultWasm("-m", "--useWasmMemory64=1", "--useOMGJIT=0")
+//@ runDefaultWasm("-m", "--useWasmMemory64=1")
 import { instantiate } from "../wabt-wrapper.js";
 import * as assert from "../assert.js";
 

--- a/JSTests/wasm/stress/table64-get-and-set.js
+++ b/JSTests/wasm/stress/table64-get-and-set.js
@@ -1,5 +1,5 @@
 //@ skip if $addressBits <= 32
-//@ runDefaultWasm("-m", "--useWasmMemory64=1", "--useOMGJIT=0")
+//@ runDefaultWasm("-m", "--useWasmMemory64=1")
 import { instantiate } from "../wabt-wrapper.js";
 import * as assert from "../assert.js";
 

--- a/JSTests/wasm/stress/table64-grow-and-size.js
+++ b/JSTests/wasm/stress/table64-grow-and-size.js
@@ -1,5 +1,5 @@
 //@ skip if $addressBits <= 32
-//@ runDefaultWasm("-m", "--useWasmMemory64=1", "--useOMGJIT=0")
+//@ runDefaultWasm("-m", "--useWasmMemory64=1")
 import { instantiate } from "../wabt-wrapper.js";
 import * as assert from "../assert.js";
 

--- a/JSTests/wasm/stress/table64-overflow.js
+++ b/JSTests/wasm/stress/table64-overflow.js
@@ -1,5 +1,5 @@
 //@ skip if $addressBits <= 32
-//@ runDefaultWasm("-m", "--useWasmMemory64=1", "--useOMGJIT=0")
+//@ runDefaultWasm("-m", "--useWasmMemory64=1")
 import { instantiate } from "../wabt-wrapper.js";
 import * as assert from "../assert.js";
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/js/memory64/table64.wast.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/js/memory64/table64.wast.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWasmMemory64=1", "--useOMGJIT=0", "--useWasmIPInt=1")
+//@ requireOptions("--useWasmMemory64=1")
 (function table64_wast_js() {
 
 // table64.wast:1

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/js/memory64/table_copy64.wast.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/js/memory64/table_copy64.wast.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWasmMemory64=1", "--useOMGJIT=0", "--useWasmIPInt=1")
+//@ requireOptions("--useWasmMemory64=1")
 (function table_copy64_wast_js() {
 
 // table_copy64.wast:6

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/js/memory64/table_fill64.wast.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/js/memory64/table_fill64.wast.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWasmMemory64=1", "--useOMGJIT=0", "--useWasmIPInt=1")
+//@ requireOptions("--useWasmMemory64=1")
 (function table_fill64_wast_js() {
 
 // table_fill64.wast:1

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/js/memory64/table_get64.wast.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/js/memory64/table_get64.wast.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWasmMemory64=1", "--useOMGJIT=0", "--useWasmIPInt=1")
+//@ requireOptions("--useWasmMemory64=1")
 (function table_get64_wast_js() {
 
 // table_get64.wast:1

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/js/memory64/table_grow64.wast.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/js/memory64/table_grow64.wast.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWasmMemory64=1", "--useOMGJIT=0", "--useWasmIPInt=1")
+//@ requireOptions("--useWasmMemory64=1")
 (function table_grow64_wast_js() {
 
 // table_grow64.wast:1

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/js/memory64/table_init64.wast.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/js/memory64/table_init64.wast.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWasmMemory64=1", "--useOMGJIT=0", "--useWasmIPInt=1")
+//@ requireOptions("--useWasmMemory64=1")
 (function table_init64_wast_js() {
 
 // table_init64.wast:6

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/js/memory64/table_set64.wast.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/js/memory64/table_set64.wast.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWasmMemory64=1", "--useOMGJIT=0", "--useWasmIPInt=1")
+//@ requireOptions("--useWasmMemory64=1")
 (function table_set64_wast_js() {
 
 // table_set64.wast:1

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/js/memory64/table_size64.wast.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/js/memory64/table_size64.wast.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWasmMemory64=1", "--useOMGJIT=0", "--useWasmIPInt=1")
+//@ requireOptions("--useWasmMemory64=1")
 (function table_size64_wast_js() {
 
 // table_size64.wast:1

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/address64.wast.js.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/address64.wast.js.html
@@ -1,4 +1,4 @@
-<!doctype html><!-- webkit-test-runner [ jscOptions=--useOMGJIT=false ] -->
+<!doctype html>
 <html>
     <head>
         <meta charset="UTF-8">

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/align64.wast.js.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/align64.wast.js.html
@@ -1,4 +1,4 @@
-<!doctype html><!-- webkit-test-runner [ jscOptions=--useOMGJIT=false ] -->
+<!doctype html>
 <html>
     <head>
         <meta charset="UTF-8">

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/binary_leb128_64.wast.js.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/binary_leb128_64.wast.js.html
@@ -1,4 +1,4 @@
-<!doctype html><!-- webkit-test-runner [ jscOptions=--useOMGJIT=false ] -->
+<!doctype html>
 <html>
     <head>
         <meta charset="UTF-8">

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/bulk64.wast.js.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/bulk64.wast.js.html
@@ -1,4 +1,4 @@
-<!doctype html><!-- webkit-test-runner [ jscOptions=--useOMGJIT=false ] -->
+<!doctype html>
 <html>
     <head>
         <meta charset="UTF-8">

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/call_indirect64.wast.js.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/call_indirect64.wast.js.html
@@ -1,4 +1,4 @@
-<!doctype html><!-- webkit-test-runner [ jscOptions=--useOMGJIT=false ] -->
+<!doctype html>
 <html>
     <head>
         <meta charset="UTF-8">

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/endianness64.wast.js.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/endianness64.wast.js.html
@@ -1,4 +1,4 @@
-<!doctype html><!-- webkit-test-runner [ jscOptions=--useOMGJIT=false ] -->
+<!doctype html>
 <html>
     <head>
         <meta charset="UTF-8">

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/float_memory64.wast.js.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/float_memory64.wast.js.html
@@ -1,4 +1,4 @@
-<!doctype html><!-- webkit-test-runner [ jscOptions=--useOMGJIT=false ] -->
+<!doctype html>
 <html>
     <head>
         <meta charset="UTF-8">

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/load64.wast.js.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/load64.wast.js.html
@@ -1,4 +1,4 @@
-<!doctype html><!-- webkit-test-runner [ jscOptions=--useOMGJIT=false ] -->
+<!doctype html>
 <html>
     <head>
         <meta charset="UTF-8">

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/memory64-imports.wast.js.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/memory64-imports.wast.js.html
@@ -1,4 +1,4 @@
-<!doctype html><!-- webkit-test-runner [ jscOptions=--useOMGJIT=false ] -->
+<!doctype html>
 <html>
     <head>
         <meta charset="UTF-8">

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/memory64.wast.js.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/memory64.wast.js.html
@@ -1,4 +1,4 @@
-<!doctype html><!-- webkit-test-runner [ jscOptions=--useOMGJIT=false ] -->
+<!doctype html>
 <html>
     <head>
         <meta charset="UTF-8">

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/memory_copy64.wast.js.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/memory_copy64.wast.js.html
@@ -1,4 +1,4 @@
-<!doctype html><!-- webkit-test-runner [ jscOptions=--useOMGJIT=false ] -->
+<!doctype html>
 <html>
     <head>
         <meta charset="UTF-8">

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/memory_fill64.wast.js.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/memory_fill64.wast.js.html
@@ -1,4 +1,4 @@
-<!doctype html><!-- webkit-test-runner [ jscOptions=--useOMGJIT=false ] -->
+<!doctype html>
 <html>
     <head>
         <meta charset="UTF-8">

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/memory_grow64.wast.js.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/memory_grow64.wast.js.html
@@ -1,4 +1,4 @@
-<!doctype html><!-- webkit-test-runner [ jscOptions=--useOMGJIT=false ] -->
+<!doctype html>
 <html>
     <head>
         <meta charset="UTF-8">

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/memory_init64.wast.js.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/memory_init64.wast.js.html
@@ -1,4 +1,4 @@
-<!doctype html><!-- webkit-test-runner [ jscOptions=--useOMGJIT=false ] -->
+<!doctype html>
 <html>
     <head>
         <meta charset="UTF-8">

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/memory_redundancy64.wast.js.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/memory_redundancy64.wast.js.html
@@ -1,4 +1,4 @@
-<!doctype html><!-- webkit-test-runner [ jscOptions=--useOMGJIT=false ] -->
+<!doctype html>
 <html>
     <head>
         <meta charset="UTF-8">

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/memory_trap64.wast.js.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/memory_trap64.wast.js.html
@@ -1,4 +1,4 @@
-<!doctype html><!-- webkit-test-runner [ jscOptions=--useOMGJIT=false ] -->
+<!doctype html>
 <html>
     <head>
         <meta charset="UTF-8">

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table64.wast.js.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table64.wast.js.html
@@ -1,4 +1,4 @@
-<!doctype html><!-- webkit-test-runner [ jscOptions=--useOMGJIT=false ] -->
+<!doctype html>
 <html>
     <head>
         <meta charset="UTF-8">

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table_copy64.wast.js.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table_copy64.wast.js.html
@@ -1,4 +1,4 @@
-<!doctype html><!-- webkit-test-runner [ jscOptions=--useOMGJIT=false ] -->
+<!doctype html>
 <html>
     <head>
         <meta charset="UTF-8">

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table_copy_mixed.wast.js.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table_copy_mixed.wast.js.html
@@ -1,4 +1,4 @@
-<!doctype html><!-- webkit-test-runner [ jscOptions=--useOMGJIT=false ] -->
+<!doctype html>
 <html>
     <head>
         <meta charset="UTF-8">

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table_fill64.wast.js.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table_fill64.wast.js.html
@@ -1,4 +1,4 @@
-<!doctype html><!-- webkit-test-runner [ jscOptions=--useOMGJIT=false ] -->
+<!doctype html>
 <html>
     <head>
         <meta charset="UTF-8">

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table_get64.wast.js.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table_get64.wast.js.html
@@ -1,4 +1,4 @@
-<!doctype html><!-- webkit-test-runner [ jscOptions=--useOMGJIT=false ] -->
+<!doctype html>
 <html>
     <head>
         <meta charset="UTF-8">

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table_grow64.wast.js.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table_grow64.wast.js.html
@@ -1,4 +1,4 @@
-<!doctype html><!-- webkit-test-runner [ jscOptions=--useOMGJIT=false ] -->
+<!doctype html>
 <html>
     <head>
         <meta charset="UTF-8">

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table_init64.wast.js.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table_init64.wast.js.html
@@ -1,4 +1,4 @@
-<!doctype html><!-- webkit-test-runner [ jscOptions=--useOMGJIT=false ] -->
+<!doctype html>
 <html>
     <head>
         <meta charset="UTF-8">

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table_set64.wast.js.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table_set64.wast.js.html
@@ -1,4 +1,4 @@
-<!doctype html><!-- webkit-test-runner [ jscOptions=--useOMGJIT=false ] -->
+<!doctype html>
 <html>
     <head>
         <meta charset="UTF-8">

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table_size64.wast.js.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table_size64.wast.js.html
@@ -1,4 +1,4 @@
-<!doctype html><!-- webkit-test-runner [ jscOptions=--useOMGJIT=false ] -->
+<!doctype html>
 <html>
     <head>
         <meta charset="UTF-8">

--- a/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
@@ -25,6 +25,7 @@
 
 #include "config.h"
 #include "WasmOMGIRGenerator.h"
+#include "B3Opcode.h"
 
 #if ENABLE(WEBASSEMBLY_OMGJIT)
 
@@ -1788,7 +1789,7 @@ auto OMGIRGenerator::addElemDrop(unsigned elementIndex) -> PartialResult
 auto OMGIRGenerator::addTableSize(unsigned tableIndex, ExpressionType& result) -> PartialResult
 {
     // FIXME: Emit this inline <https://bugs.webkit.org/show_bug.cgi?id=198506>.
-    result = push(callWasmOperation(m_currentBlock, toB3Type(Types::I32), operationGetWasmTableSize,
+    result = push(callWasmOperation(m_currentBlock, toB3Type(m_info.table(tableIndex).addressType().asWasmType()), operationGetWasmTableSize,
         instanceValue(), constant(Int32, tableIndex)));
 
     return { };
@@ -1796,7 +1797,7 @@ auto OMGIRGenerator::addTableSize(unsigned tableIndex, ExpressionType& result) -
 
 auto OMGIRGenerator::addTableGrow(unsigned tableIndex, ExpressionType fill, ExpressionType delta, ExpressionType& result) -> PartialResult
 {
-    result = push(callWasmOperation(m_currentBlock, toB3Type(Types::I32), operationWasmTableGrow,
+    result = push(callWasmOperation(m_currentBlock, toB3Type(m_info.table(tableIndex).addressType().asWasmType()), operationWasmTableGrow,
         instanceValue(), constant(Int32, tableIndex), get(fill), get(delta)));
 
     return { };
@@ -6397,17 +6398,22 @@ auto OMGIRGenerator::addCallIndirect(unsigned callProfileIndex, unsigned tableIn
         }
     }
 
-    // Check the index we are looking for is valid.
+    const bool isTable64 = m_info.table(tableIndex).addressType().is64Bit();
     {
+        Value* comparableLength = callableFunctionBufferLength;
+        if (isTable64)
+            comparableLength = m_currentBlock->appendNew<Value>(m_proc, ZExt32, origin(), callableFunctionBufferLength);
+
         CheckValue* check = m_currentBlock->appendNew<CheckValue>(m_proc, Check, origin(),
-            m_currentBlock->appendNew<Value>(m_proc, AboveEqual, origin(), calleeIndex, callableFunctionBufferLength));
+            m_currentBlock->appendNew<Value>(m_proc, AboveEqual, origin(), calleeIndex, comparableLength));
 
         check->setGenerator([=, this, origin = this->origin()] (CCallHelpers& jit, const B3::StackmapGenerationParams&) {
             this->emitExceptionCheck(jit, origin, ExceptionType::OutOfBoundsCallIndirect);
         });
     }
 
-    calleeIndex = pointerOfInt32(calleeIndex);
+    if (!isTable64)
+        calleeIndex = pointerOfInt32(calleeIndex);
 
     BasicBlock* continuation = m_proc.addBlock();
 


### PR DESCRIPTION
#### 184ee4c654bdc0653e57c7aefd6c4b90a8dd9269
<pre>
[Memory64] Implement Table64 in the OMG tier
<a href="https://bugs.webkit.org/show_bug.cgi?id=320014">https://bugs.webkit.org/show_bug.cgi?id=320014</a>
<a href="https://rdar.apple.com/182949083">rdar://182949083</a>

Reviewed by Keith Miller.

This patch adds support for Table64 in the OMG tier.

* JSTests/wasm/stress/table64-bulk.js:
* JSTests/wasm/stress/table64-call-indirect.js:
* JSTests/wasm/stress/table64-get-and-set.js:
* JSTests/wasm/stress/table64-grow-and-size.js:
* JSTests/wasm/stress/table64-overflow.js:
* LayoutTests/imported/w3c/web-platform-tests/wasm/core/js/memory64/table64.wast.js:
* LayoutTests/imported/w3c/web-platform-tests/wasm/core/js/memory64/table_copy64.wast.js:
* LayoutTests/imported/w3c/web-platform-tests/wasm/core/js/memory64/table_fill64.wast.js:
* LayoutTests/imported/w3c/web-platform-tests/wasm/core/js/memory64/table_get64.wast.js:
* LayoutTests/imported/w3c/web-platform-tests/wasm/core/js/memory64/table_grow64.wast.js:
* LayoutTests/imported/w3c/web-platform-tests/wasm/core/js/memory64/table_init64.wast.js:
* LayoutTests/imported/w3c/web-platform-tests/wasm/core/js/memory64/table_set64.wast.js:
* LayoutTests/imported/w3c/web-platform-tests/wasm/core/js/memory64/table_size64.wast.js:
* LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/address64.wast.js.html:
* LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/align64.wast.js.html:
* LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/binary_leb128_64.wast.js.html:
* LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/bulk64.wast.js.html:
* LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/call_indirect64.wast.js.html:
* LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/endianness64.wast.js.html:
* LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/float_memory64.wast.js.html:
* LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/load64.wast.js.html:
* LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/memory64-imports.wast.js.html:
* LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/memory64.wast.js.html:
* LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/memory_copy64.wast.js.html:
* LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/memory_fill64.wast.js.html:
* LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/memory_grow64.wast.js.html:
* LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/memory_init64.wast.js.html:
* LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/memory_redundancy64.wast.js.html:
* LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/memory_trap64.wast.js.html:
* LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table64.wast.js.html:
* LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table_copy64.wast.js.html:
* LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table_copy_mixed.wast.js.html:
* LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table_fill64.wast.js.html:
* LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table_get64.wast.js.html:
* LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table_grow64.wast.js.html:
* LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table_init64.wast.js.html:
* LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table_set64.wast.js.html:
* LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table_size64.wast.js.html:
* Source/JavaScriptCore/wasm/WasmBBQJIT.cpp:
(JSC::Wasm::BBQJITImpl::BBQJIT::addTableSet):
(JSC::Wasm::BBQJITImpl::BBQJIT::addTableInit):
(JSC::Wasm::BBQJITImpl::BBQJIT::addTableSize):
(JSC::Wasm::BBQJITImpl::BBQJIT::addTableGrow):
(JSC::Wasm::BBQJITImpl::BBQJIT::addTableFill):
(JSC::Wasm::BBQJITImpl::BBQJIT::addTableCopy):
(JSC::Wasm::BBQJITImpl::BBQJIT::addCallIndirect):
* Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp:
(JSC::Wasm::BBQJITImpl::BBQJIT::addTableGet):
* Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp:
(JSC::IPInt::WASM_IPINT_EXTERN_CPP_DECL):
* Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp:
(JSC::Wasm::OMGIRGenerator::addTableSize):
(JSC::Wasm::OMGIRGenerator::addTableGrow):
(JSC::Wasm::OMGIRGenerator::addCallIndirect):
* Source/JavaScriptCore/wasm/WasmOperations.cpp:
(JSC::Wasm::JSC_DEFINE_NOEXCEPT_JIT_OPERATION):
* Source/JavaScriptCore/wasm/WasmOperations.h:
* Source/JavaScriptCore/wasm/WasmOperationsInlines.h:
(JSC::Wasm::tableGet):
(JSC::Wasm::tableSet):
(JSC::Wasm::tableInit):
(JSC::Wasm::tableFill):
(JSC::Wasm::tableGrow):
(JSC::Wasm::tableCopy):
* Source/JavaScriptCore/wasm/WasmTable.cpp:
(JSC::Wasm::Table::grow):
* Source/JavaScriptCore/wasm/WasmTable.h:
(JSC::Wasm::Table::isValidLength):

Canonical link: <a href="https://commits.webkit.org/318092@main">https://commits.webkit.org/318092@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/beaf163f9d60c4a464f4ffcb8979b48335b6133e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177282 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51220 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45014 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186885 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140518 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f93dc23d-77f9-4047-a8e3-fbafedff4dd4) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52512 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50908 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138144 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140518 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b2a78d1a-9946-4219-ab9b-506506dd7905) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180238 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41648 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/158912 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118609 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d89313bd-810d-417c-8699-755aafb0b8d4) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40309 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/38686 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/251/builds/578 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/7412 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150717 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38410 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35353 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/38553 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/43005 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/42900 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189314 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50886 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/158447 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147234 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39564 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51569 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/35036 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147026 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41751 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123784 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118118 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50077 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13388 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49473 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49713 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49535 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->