### PR TITLE
[Site Isolation] Validate frame page membership before dispatching WebFrameProxy messages, DidCreateSubframe, and DidDestroyFrame

### DIFF
--- a/Source/WebKit/UIProcess/WebFrameProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFrameProxy.cpp
@@ -491,7 +491,7 @@ bool WebFrameProxy::didHandleContentFilterUnblockNavigation(const ResourceReques
 #endif
             };
             protect(protect(page->websiteDataStore())->networkProcess())->allowEvaluatedURL(parameters, [page](bool unblocked) {
-            if (unblocked)
+                if (unblocked)
                     page->reload({ });
             });
             return true;
@@ -1068,6 +1068,27 @@ void WebFrameProxy::updateScrollingMode(WebCore::ScrollbarMode scrollingMode)
     m_scrollingMode = scrollingMode;
     if (RefPtr page = m_page.get())
         page->sendToProcessContainingFrame(m_frameID, Messages::WebPage::UpdateFrameScrollingMode(m_frameID, scrollingMode));
+}
+
+bool WebFrameProxy::isProcessAllowedToAccessFrame(WebProcessProxy& process) const
+{
+    if (&this->process() == &process)
+        return true;
+    RefPtr page = m_page.get();
+    if (!page)
+        return false;
+    if (&page->legacyMainFrameProcess() == &process)
+        return true;
+    if (isMainFrame()) {
+        if (RefPtr provisionalPage = page->provisionalPageProxy(); provisionalPage && &provisionalPage->process() == &process)
+            return true;
+    }
+    if (m_provisionalFrame && &m_provisionalFrame->process() == &process)
+        return true;
+    // A process joining the browsing context group gets a remote page for every cross-process page
+    // in the group (BrowsingContextGroup::addFrameProcessAndInjectPageContextIf), so this also
+    // covers a page this one opened, its opener, and openers further up the chain.
+    return protect(page->browsingContextGroup())->remotePageInProcess(*page, process);
 }
 
 void WebFrameProxy::setAppBadge(const WebCore::SecurityOriginData& origin, std::optional<uint64_t> badge)

--- a/Source/WebKit/UIProcess/WebFrameProxy.h
+++ b/Source/WebKit/UIProcess/WebFrameProxy.h
@@ -285,6 +285,15 @@ public:
     bool isShowingInitialAboutBlank() const { return m_isShowingInitialAboutBlank; }
 
     WebCore::LayerHostingContextIdentifier layerHostingContextIdentifier() const { return m_layerHostingContextIdentifier; }
+
+    // Whether |process| legitimately participates in this frame's page and may therefore
+    // send IPC that acts on this frame. Under site isolation a frame is reachable from its
+    // own process, any process participating in its page (the main-frame process or a
+    // remote-page process), and a process running a provisional navigation of the page or
+    // frame. Used to gate handlers that resolve a frame from the global WebFrameProxy
+    // registry so a process cannot manipulate a frame belonging to a different page.
+    bool isProcessAllowedToAccessFrame(WebProcessProxy&) const;
+
     void setAppBadge(const WebCore::SecurityOriginData&, std::optional<uint64_t> badge);
     void didChangeCSPOriginsThatUpgradeInsecureNavigations(HashSet<WebCore::SecurityOriginData>&&);
     void findFocusableElementDescendingIntoRemoteFrame(WebCore::FocusDirection, const WebCore::FocusEventData&, WebCore::ShouldFocusElement, CompletionHandler<void(WebCore::FoundElementInRemoteFrame)>&&);

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -7772,11 +7772,17 @@ void WebPageProxy::preferencesDidChange()
     protect(websiteDataStore())->propagateSettingUpdates();
 }
 
-void WebPageProxy::didCreateSubframe(FrameIdentifier parentID, FrameIdentifier newFrameID, String&& frameName, SandboxFlags sandboxFlags, ReferrerPolicy referrerPolicy, ScrollbarMode scrollingMode)
+void WebPageProxy::didCreateSubframe(IPC::Connection& connection, FrameIdentifier parentID, FrameIdentifier newFrameID, String&& frameName, SandboxFlags sandboxFlags, ReferrerPolicy referrerPolicy, ScrollbarMode scrollingMode)
 {
     RefPtr parent = WebFrameProxy::webFrame(parentID);
     if (!parent)
         return;
+    Ref process = WebProcessProxy::fromConnection(connection);
+    if (&parent->process() != process.ptr()) {
+        // Ignore rather than terminate the sender: the process that hosted the parent a moment ago
+        // can still have an in-flight subframe creation for it after a cross-site navigation.
+        return;
+    }
     parent->didCreateSubframe(newFrameID, WTF::move(frameName), sandboxFlags, referrerPolicy, scrollingMode);
 }
 
@@ -7787,8 +7793,18 @@ void WebPageProxy::didDestroyFrame(IPC::Connection& connection, FrameIdentifier 
 #endif
     if (RefPtr automationSession = m_configuration->processPool().automationSession())
         automationSession->didDestroyFrame(frameID);
-    if (RefPtr frame = WebFrameProxy::webFrame(frameID))
+    if (RefPtr frame = WebFrameProxy::webFrame(frameID)) {
+        // DidDestroyFrame is driven by whichever process currently hosts, is committing, or
+        // is tearing down this frame; under site isolation that is any process participating
+        // in the frame's page. A process that does not participate must not disconnect a frame
+        // belonging to a different page it merely names by identifier. Drop the message rather
+        // than terminate: a frame mid-transition between processes can still have an in-flight
+        // teardown message from a process that no longer participates in its page.
+        Ref process = WebProcessProxy::fromConnection(connection);
+        if (!frame->isProcessAllowedToAccessFrame(process))
+            return;
         frame->disconnect();
+    }
 
     bool didRemove = m_framesWithSubresourceLoadingForPageLoadTiming.remove(frameID);
 #if PLATFORM(COCOA)

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -3097,7 +3097,7 @@ private:
     static bool hasMouseDevice();
 #endif
 
-    void didCreateSubframe(WebCore::FrameIdentifier parent, WebCore::FrameIdentifier newFrameID, String&& frameName, WebCore::SandboxFlags, WebCore::ReferrerPolicy, WebCore::ScrollbarMode);
+    void didCreateSubframe(IPC::Connection&, WebCore::FrameIdentifier parent, WebCore::FrameIdentifier newFrameID, String&& frameName, WebCore::SandboxFlags, WebCore::ReferrerPolicy, WebCore::ScrollbarMode);
 
     void didStartProvisionalLoadForFrame(IPC::Connection&, WebCore::FrameIdentifier, FrameInfoData&&, WebCore::ResourceRequest&&, std::optional<WebCore::NavigationIdentifier>, URL&&, URL&& unreachableURL, const UserData&, WallTime);
     void didReceiveServerRedirectForProvisionalLoadForFrame(IPC::Connection&, WebCore::FrameIdentifier, std::optional<WebCore::NavigationIdentifier>, WebCore::ResourceRequest&&, const UserData&);

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -1414,7 +1414,15 @@ bool WebProcessProxy::dispatchMessage(IPC::Connection& connection, IPC::Decoder&
         return handleRemoteObjectRegistryMessage(connection, decoder);
 #endif
     if (messageName == Messages::WebFrameProxy::messageReceiverName()) {
-        if (RefPtr frame = FrameIdentifier::isValidIdentifier(decoder.destinationID()) ? WebFrameProxy::webFrame(FrameIdentifier(decoder.destinationID())) : nullptr)
+        // WebFrameProxy::webFrame() is a global registry shared across every page and
+        // WebContent process, so gate the resolved frame on the sending process actually
+        // participating in the frame's page before dispatching. This blocks a compromised
+        // process from manipulating a WebFrameProxy owned by a different page it merely
+        // names by identifier, while allowing legitimate site-isolation IPC between the
+        // processes participating in a page. Drop the message rather than terminate the
+        // sender: a frame mid-transition between processes can still have in-flight messages
+        // from a process that no longer participates in its page.
+        if (RefPtr frame = FrameIdentifier::isValidIdentifier(decoder.destinationID()) ? WebFrameProxy::webFrame(FrameIdentifier(decoder.destinationID())) : nullptr; frame && frame->isProcessAllowedToAccessFrame(*this))
             frame->didReceiveMessage(connection, decoder);
         else
             WebFrameProxy::sendCancelReply(connection, decoder);

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
@@ -12217,4 +12217,249 @@ TEST(SiteIsolation, WebsitePoliciesAppliedToCrossOriginSubframeDocumentLoader)
     EXPECT_WK_STREQ([webView stringByEvaluatingJavaScript:check inFrame:[webView firstChildFrame]], "available");
 }
 
+#if ENABLE(IPC_TESTING_API)
+
+// A compromised WebContent process must not be able to manipulate a WebFrameProxy
+// owned by a *different* page by naming its FrameIdentifier in UIProcess IPC, since
+// WebFrameProxy::webFrame() is a global registry shared across every page and process
+// (rdar://171983356). Under site isolation the processes participating in one page
+// legitimately exchange frame IPC, so the enforced boundary is the page, not the
+// individual frame's owning process: WebProcessProxy::dispatchMessage gates every
+// WebFrameProxy message on the sender participating in the target frame's page, and
+// WebPageProxy::didCreateSubframe / didDestroyFrame apply the equivalent check when
+// they resolve a frame from the registry. A message from a process outside the target
+// frame's page records a MESSAGE_CHECK failure; legitimate same-page cross-process IPC
+// is accepted. None crash the UIProcess.
+
+static std::pair<RetainPtr<TestWKWebView>, RetainPtr<TestNavigationDelegate>> siteIsolatedIPCTestingViewAndDelegate(const HTTPServer& server)
+{
+    RetainPtr configuration = server.httpsProxyConfiguration();
+    enableFeature(configuration.get(), @"SiteIsolationEnabled");
+    enableFeature(configuration.get(), @"IPCTestingAPIEnabled");
+    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    [navigationDelegate allowAnyTLSCertificate];
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
+    webView.get().navigationDelegate = navigationDelegate.get();
+    return { WTF::move(webView), WTF::move(navigationDelegate) };
+}
+
+// Loads a main frame (example.com) containing a cross-origin iframe
+// (webkit.org). The iframe reports its own FrameIdentifier via alert. Returns
+// that identifier as a decimal string and asserts the iframe really is hosted
+// in a different WebContent process than the main frame.
+static RetainPtr<NSString> loadMainFrameWithCrossProcessChild(TestWKWebView *webView)
+{
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/main"]]];
+    RetainPtr childAlert = [webView _test_waitForAlert];
+    EXPECT_TRUE([childAlert hasPrefix:@"child:"]);
+
+    RetainPtr<_WKFrameTreeNode> mainFrame = [webView mainFrame];
+    RetainPtr<_WKFrameTreeNode> childFrame = mainFrame.get().childFrames.firstObject;
+    EXPECT_NE(mainFrame.get().info._processIdentifier, 0);
+    EXPECT_NE(childFrame.get().info._processIdentifier, 0);
+    EXPECT_NE(mainFrame.get().info._processIdentifier, childFrame.get().info._processIdentifier);
+
+    return [childAlert substringFromIndex:[@"child:" length]];
+}
+
+// Reads (and clears) the last MESSAGE_CHECK-failure string recorded on the main
+// frame's WebContent connection. Empty when no message check fired.
+static RetainPtr<NSString> takeInvalidMessageStringForTesting(TestWKWebView *webView)
+{
+    return [webView stringByEvaluatingJavaScript:@"(() => { const r = window.IPC.sendSyncMessage('UI', 0, window.IPC.messages.WebProcessProxy_TakeInvalidMessageStringForTesting.name, 100, []); return (r && r.arguments && r.arguments[0]) ? String(r.arguments[0].value) : ''; })()"];
+}
+
+static HTTPServer mainAndCrossOriginChildServer()
+{
+    return HTTPServer({
+        { "/main"_s, { "<iframe src='https://webkit.org/child'></iframe>"_s } },
+        { "/child"_s, { "<script>alert('child:' + (window.IPC ? window.IPC.frameID[0] : 'NO_IPC'))</script>"_s } }
+    }, HTTPServer::Protocol::HttpsProxy);
+}
+
+// The process that hosts a frame's <iframe> element -- here the main frame's
+// process, which owns the cross-origin child -- participates in the frame's page
+// and legitimately drives its teardown. DidDestroyFrame naming that child must be
+// accepted, not flagged as a forged cross-process message. (This is the positive
+// counterpart of the over-strict check that regressed cross-origin subframe
+// teardown; see also SiteIsolation.RemoveFrames / RemoveFrameFromRemoteFrame.)
+TEST(SiteIsolation, DidDestroyFrameFromPageMemberProcessAccepted)
+{
+    auto server = mainAndCrossOriginChildServer();
+    auto [webView, navigationDelegate] = siteIsolatedIPCTestingViewAndDelegate(server);
+    RetainPtr childFrameID = loadMainFrameWithCrossProcessChild(webView.get());
+    EXPECT_EQ(1u, [webView mainFrame].childFrames.count);
+
+    [webView stringByEvaluatingJavaScript:[NSString stringWithFormat:@"window.IPC.sendMessage('UI', window.IPC.webPageProxyID, window.IPC.messages.WebPageProxy_DidDestroyFrame.name, [{ type: 'FrameID', value: [%@n] }])", childFrameID.get()]];
+
+    RetainPtr invalidMessage = takeInvalidMessageStringForTesting(webView.get());
+    EXPECT_FALSE([invalidMessage containsString:@"Message check failed"]);
+    // The main-frame process participates in the child's page, so its DidDestroyFrame must be
+    // HONORED, not merely un-rejected: assert the child frame is actually disconnected.
+    // WebPageProxy::didDestroyFrame returns early (no disconnect()) when isProcessAllowedToAccessFrame
+    // is false, so a silently-dropped message leaves the child in place -- which the "Message check
+    // failed" assertion alone cannot detect (it catches only a hard MESSAGE_CHECK termination). This
+    // guards the legacyMainFrameProcess accept branch: without it the message is silently dropped.
+    EXPECT_EQ(0u, [webView mainFrame].childFrames.count);
+}
+
+// A process belonging to a *different* page must not disconnect a frame it does
+// not participate in by naming its FrameIdentifier in the global WebFrameProxy
+// registry. Page 1 hosts the target cross-origin child; page 2 loads an unrelated
+// origin (apple.com), so its process is outside page 1's process set. Page 2
+// forges DidDestroyFrame naming page 1's child -- didDestroyFrame resolves the
+// frame's owning page via frame->page() (page 1), finds page 2 does not
+// participate, and drops the message without disconnecting the frame or
+// terminating page 2 (a frame mid-transition between processes can still have an
+// in-flight teardown message from a non-participating process).
+TEST(SiteIsolation, DidDestroyFrameFromNonParticipatingProcessDropped)
+{
+    HTTPServer server({
+        { "/main"_s, { "<iframe src='https://webkit.org/child'></iframe>"_s } },
+        { "/child"_s, { "<script>alert('child:' + (window.IPC ? window.IPC.frameID[0] : 'NO_IPC'))</script>"_s } },
+        { "/other"_s, { "<script>alert('other:' + (window.IPC ? 'IPC' : 'NO_IPC'))</script>"_s } }
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto [pageOneView, pageOneDelegate] = siteIsolatedIPCTestingViewAndDelegate(server);
+    RetainPtr childFrameID = loadMainFrameWithCrossProcessChild(pageOneView.get());
+    EXPECT_EQ(1u, [pageOneView mainFrame].childFrames.count);
+
+    // A second, unrelated page (apple.com) whose process is not in page 1's set.
+    auto [pageTwoView, pageTwoDelegate] = siteIsolatedIPCTestingViewAndDelegate(server);
+    [pageTwoView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://apple.com/other"]]];
+    RetainPtr pageTwoAlert = [pageTwoView _test_waitForAlert];
+    EXPECT_TRUE([pageTwoAlert hasPrefix:@"other:"]);
+
+    // Forge from page 2's process (its own webPageProxyID), naming page 1's
+    // cross-origin child frame. The handler still resolves the frame's page as
+    // page 1 via frame->page(), so page 2 is a non-participating sender.
+    [pageTwoView stringByEvaluatingJavaScript:[NSString stringWithFormat:@"window.IPC.sendMessage('UI', window.IPC.webPageProxyID, window.IPC.messages.WebPageProxy_DidDestroyFrame.name, [{ type: 'FrameID', value: [%@n] }])", childFrameID.get()]];
+
+    RetainPtr invalidMessage = takeInvalidMessageStringForTesting(pageTwoView.get());
+    EXPECT_FALSE([invalidMessage containsString:@"Message check failed"]);
+    // Dropped, not honored: page 1's child must still be present. A wrongful accept would disconnect it
+    // (count -> 0) with no MESSAGE_CHECK, which the message-check assertion alone cannot detect.
+    EXPECT_EQ(1u, [pageOneView mainFrame].childFrames.count);
+}
+
+// Only the parent frame's current process may add a child to it; anything else is ignored and the
+// sender is not terminated. The IPC testing API has no SandboxFlags / ReferrerPolicy / ScrollbarMode
+// encoders, so those arguments go as their on-the-wire integer widths (uint16_t, uint8_t, uint8_t).
+TEST(SiteIsolation, DidCreateSubframeFromNonHostingProcessIgnored)
+{
+    auto server = mainAndCrossOriginChildServer();
+    auto [webView, navigationDelegate] = siteIsolatedIPCTestingViewAndDelegate(server);
+    RetainPtr childFrameID = loadMainFrameWithCrossProcessChild(webView.get());
+
+    // Name the cross-process child as the parent, which the sending main process does not host.
+    [webView stringByEvaluatingJavaScript:[NSString stringWithFormat:@"window.IPC.sendMessage('UI', window.IPC.webPageProxyID, window.IPC.messages.WebPageProxy_DidCreateSubframe.name, ["
+        "{ type: 'FrameID', value: [%@n] },"
+        "{ type: 'FrameID', value: [(0xFFFFn << 32n) | 777n] },"
+        "{ type: 'String', value: 'forged' },"
+        "{ type: 'uint16_t', value: 0 },"
+        "{ type: 'uint8_t', value: 0 },"
+        "{ type: 'uint8_t', value: 0 }])", childFrameID.get()]];
+
+    RetainPtr invalidMessage = takeInvalidMessageStringForTesting(webView.get());
+    EXPECT_FALSE([invalidMessage containsString:@"Message check failed"]);
+    EXPECT_EQ(0u, [webView mainFrame].childFrames.firstObject.childFrames.count);
+}
+
+// A page and the page it opens share a BrowsingContextGroup, so the opened page's process
+// participates in the opener's frames and its DidDestroyFrame for one must be honored --
+// the opener's cross-origin child really goes away. Page membership alone would drop it.
+TEST(SiteIsolation, DidDestroyFrameFromOpenedPageProcessAccepted)
+{
+    HTTPServer server({
+        { "/main"_s, { "<iframe src='https://webkit.org/child'></iframe>"_s } },
+        { "/child"_s, { "<script>alert('child:' + (window.IPC ? window.IPC.frameID[0] : 'NO_IPC'))</script>"_s } },
+        { "/opened"_s, { "<script>alert('opened:' + (window.IPC ? 'IPC' : 'NO_IPC'))</script>"_s } }
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto [openerView, openerDelegate] = siteIsolatedIPCTestingViewAndDelegate(server);
+    RetainPtr childFrameID = loadMainFrameWithCrossProcessChild(openerView.get());
+
+    // Install the UI delegate only now: _test_waitForAlert above asserts none is set and
+    // clears it on the way out, which would drop the createWebView hook.
+    __block RetainPtr<TestWKWebView> openedView;
+    __block RetainPtr<TestNavigationDelegate> openedDelegate;
+    RetainPtr openerUIDelegate = adoptNS([TestUIDelegate new]);
+    openerUIDelegate.get().createWebViewWithConfiguration = ^(WKWebViewConfiguration *configuration, WKNavigationAction *, WKWindowFeatures *) {
+        enableFeature(configuration, @"SiteIsolationEnabled");
+        enableFeature(configuration, @"IPCTestingAPIEnabled");
+        openedDelegate = adoptNS([TestNavigationDelegate new]);
+        [openedDelegate allowAnyTLSCertificate];
+        openedView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration]);
+        openedView.get().navigationDelegate = openedDelegate.get();
+        return openedView.get();
+    };
+    [openerView setUIDelegate:openerUIDelegate.get()];
+    openerView.get().configuration.preferences.javaScriptCanOpenWindowsAutomatically = YES;
+
+    // Open a third site, so the opened page gets its own process inside the shared group.
+    [openerView evaluateJavaScript:@"window.open('https://apple.com/opened')" completionHandler:nil];
+    while (!openedView)
+        Util::spinRunLoop();
+    [openerView setUIDelegate:nil];
+    RetainPtr openedAlert = [openedView _test_waitForAlert];
+    EXPECT_TRUE([openedAlert hasPrefix:@"opened:"]);
+
+    // The opened page must be in its own process, distinct from BOTH the opener's main frame and
+    // the target child frame -- otherwise an earlier branch of the predicate would accept it and
+    // this test would say nothing about cross-page access.
+    pid_t openedPid = [openedView mainFrame].info._processIdentifier;
+    pid_t openerMainPid = [openerView mainFrame].info._processIdentifier;
+    pid_t childPid = [openerView mainFrame].childFrames.firstObject.info._processIdentifier;
+    EXPECT_NE(openedPid, 0);
+    EXPECT_NE(openedPid, openerMainPid);
+    EXPECT_NE(openedPid, childPid);
+
+    [openedView stringByEvaluatingJavaScript:[NSString stringWithFormat:@"window.IPC.sendMessage('UI', window.IPC.webPageProxyID, window.IPC.messages.WebPageProxy_DidDestroyFrame.name, [{ type: 'FrameID', value: [%@n] }])", childFrameID.get()]];
+
+    RetainPtr invalidMessage = takeInvalidMessageStringForTesting(openedView.get());
+    EXPECT_FALSE([invalidMessage containsString:@"Message check failed"]);
+    while ([openerView mainFrame].childFrames.count)
+        Util::spinRunLoop();
+    EXPECT_EQ(0u, [openerView mainFrame].childFrames.count);
+}
+
+// A process belonging to a *different* page must not act on a frame it does not
+// participate in by routing a WebFrameProxy message at its FrameIdentifier through
+// the global WebFrameProxy registry. WebProcessProxy::dispatchMessage gates every
+// WebFrameProxy message on the sending process participating in the target frame's
+// page, before the message is decoded or dispatched to the handler -- so this
+// drops the forgery (via sendCancelReply, without terminating the sender) regardless
+// of the specific message or its payload (here SetAppBadge with empty arguments,
+// which never has to decode). Page 1 hosts the target cross-origin child; page 2
+// loads an unrelated origin (apple.com), so its process is outside page 1's process
+// set. Dropping rather than terminating tolerates a frame mid-transition between
+// processes still receiving in-flight messages from a non-participating process.
+TEST(SiteIsolation, WebFrameProxyMessageFromNonParticipatingProcessDropped)
+{
+    HTTPServer server({
+        { "/main"_s, { "<iframe src='https://webkit.org/child'></iframe>"_s } },
+        { "/child"_s, { "<script>alert('child:' + (window.IPC ? window.IPC.frameID[0] : 'NO_IPC'))</script>"_s } },
+        { "/other"_s, { "<script>alert('other:' + (window.IPC ? 'IPC' : 'NO_IPC'))</script>"_s } }
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto [pageOneView, pageOneDelegate] = siteIsolatedIPCTestingViewAndDelegate(server);
+    RetainPtr childFrameID = loadMainFrameWithCrossProcessChild(pageOneView.get());
+
+    // A second, unrelated page (apple.com) whose process is not in page 1's set.
+    auto [pageTwoView, pageTwoDelegate] = siteIsolatedIPCTestingViewAndDelegate(server);
+    [pageTwoView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://apple.com/other"]]];
+    RetainPtr pageTwoAlert = [pageTwoView _test_waitForAlert];
+    EXPECT_TRUE([pageTwoAlert hasPrefix:@"other:"]);
+
+    // Forge a WebFrameProxy message from page 2's process, naming page 1's cross-origin
+    // child frame as the destination. dispatchMessage resolves that frame from the global
+    // registry and drops the message from page 2 as a non-participating sender.
+    [pageTwoView stringByEvaluatingJavaScript:[NSString stringWithFormat:@"window.IPC.sendMessage('UI', %@n, window.IPC.messages.WebFrameProxy_SetAppBadge.name, [])", childFrameID.get()]];
+
+    RetainPtr invalidMessage = takeInvalidMessageStringForTesting(pageTwoView.get());
+    EXPECT_FALSE([invalidMessage containsString:@"Message check failed"]);
+}
+
+#endif // ENABLE(IPC_TESTING_API)
+
 }


### PR DESCRIPTION
#### 919df044d95fa7bef686d6ba89fb0dcf7468a172
<pre>
[Site Isolation] Validate frame page membership before dispatching WebFrameProxy messages, DidCreateSubframe, and DidDestroyFrame
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=320002">https://bugs.webkit.org/show_bug.cgi?id=320002</a>&gt;
&lt;<a href="https://rdar.apple.com/182939909">rdar://182939909</a>&gt;

Reviewed by NOBODY (OOPS!).

WebFrameProxy::webFrame() resolves a FrameIdentifier through a global
registry shared across every page and WebContent process, so UIProcess
IPC handlers that look a frame up in it act on the result without
confirming the sending process has any relationship to that frame.

Under site isolation the several processes that host a page&apos;s frames
legitimately exchange IPC about those frames, so the boundary to enforce
is the page, not the individual frame&apos;s hosting process.  Gate a frame
resolved from the registry on the sending process participating in that
frame&apos;s page: its own process, the page&apos;s main-frame process, a process
holding a remote view of the page, or a process running a provisional
navigation of the page or frame.  A process outside that set is naming a
frame it takes no part in, so its message must not act on that frame.

Enforce this for every WebFrameProxy message in
WebProcessProxy::dispatchMessage(), where the global lookup happens, so
one check covers the whole message surface, and reuse it in
WebPageProxy::didDestroyFrame().  In both, drop the message rather than
terminate the sender: a frame mid-transition between processes can still
have an in-flight message from a process that no longer participates in
its page, and doing nothing in that case is correct.

WebPageProxy::didCreateSubframe() resolves the parent from the same
registry and already ignored a creation from a process that does not host
it; stop additionally terminating a sender whose new frame identifier
falls outside its own namespace.  Both cases are the same in-flight race
seen from the UI process, and neither is worth killing a WebContent
process over -- so no path here terminates the sender any more.

Note that a process joining the browsing context group is given a remote
page for every cross-process page in the group
(BrowsingContextGroup::addFrameProcessAndInjectPageContextIf), so the
remote-page branch already admits a page this one opened, its opener, and
openers further up that chain; no separate opener walk is needed.

Tests:
    TestWebKitAPI.SiteIsolation.DidDestroyFrameFromPageMemberProcessAccepted
    TestWebKitAPI.SiteIsolation.DidDestroyFrameFromOpenedPageProcessAccepted
    TestWebKitAPI.SiteIsolation.DidDestroyFrameFromNonParticipatingProcessDropped
    TestWebKitAPI.SiteIsolation.DidCreateSubframeFromNonHostingProcessIgnored
    TestWebKitAPI.SiteIsolation.WebFrameProxyMessageFromNonParticipatingProcessDropped

* Source/WebKit/UIProcess/WebFrameProxy.h:
(WebKit::WebFrameProxy::isProcessAllowedToAccessFrame): Add.
* Source/WebKit/UIProcess/WebFrameProxy.cpp:
(WebKit::WebFrameProxy::isProcessAllowedToAccessFrame): Add.
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::dispatchMessage):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::didCreateSubframe):
(WebKit::WebPageProxy::didDestroyFrame):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm:
(TestWebKitAPI::TEST(SiteIsolation, DidDestroyFrameFromPageMemberProcessAccepted)): Add.
(TestWebKitAPI::TEST(SiteIsolation, DidDestroyFrameFromOpenedPageProcessAccepted)): Add.
(TestWebKitAPI::TEST(SiteIsolation, DidDestroyFrameFromNonParticipatingProcessDropped)): Add.
(TestWebKitAPI::TEST(SiteIsolation, DidCreateSubframeFromNonHostingProcessIgnored)): Add.
(TestWebKitAPI::TEST(SiteIsolation, WebFrameProxyMessageFromNonParticipatingProcessDropped)): Add.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/919df044d95fa7bef686d6ba89fb0dcf7468a172

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179058 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52997 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46792 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188887 "Built successfully") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/143367 "Failed to checkout and rebase branch from PR 69969") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ebb8ecad-dfce-4d3f-938d-28a9b85fc05c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/180921 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54290 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52707 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139632 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/143367 "Failed to checkout and rebase branch from PR 69969") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/131d111c-5f90-4b02-8e9d-d13dfee6386f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182015 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43231 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160389 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120078 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/58f3384c-4cff-4161-92c1-7ca4ed0e1932) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41902 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40243 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152302 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39892 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/194 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45603 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44488 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191107 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52667 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148863 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53347 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36518 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/bfcache/held.tentative.https.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148608 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43300 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125618 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/120432 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51865 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14871 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51250 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51491 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51311 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->