### PR TITLE
[JSC] Materialize .length/.name for bound^2 functions

### DIFF
--- a/JSTests/stress/function-bind-bound-target-tainted-structure-transition.js
+++ b/JSTests/stress/function-bind-bound-target-tainted-structure-transition.js
@@ -1,0 +1,42 @@
+//@ requireOptions("--forceDiskCache=0")
+// $vm doesn't have a source provider that can cache to disk. Skip that testing configuration.
+
+$vm.runTaintedString(`
+    function shouldBe(actual, expected) {
+        if (actual !== expected)
+            throw new Error("bad value: " + actual);
+    }
+
+    function target() { }
+
+    function test(mode, count) {
+        var result = null;
+        for (var i = 0; i < count; ++i) {
+            var o;
+            if (mode === 0)
+                o = { a: 1, b: 2, c: 3, d: 4, e: 5, f: 6, g: 7, h: 8, i: 9, j: 10, k: 11 };
+            else {
+                o = target.bind();
+                if (mode === 2)
+                    o.bind();
+            }
+            o.x = 42;
+            if (mode === 2)
+                result = o;
+        }
+        return result;
+    }
+
+    for (var i = 0; i < 80; ++i) {
+        test(1, 1000);
+        test(0, 1000);
+        test(2, 100);
+    }
+    test(1, 80000);
+
+    var boundFunction = test(2, 1);
+    shouldBe(typeof boundFunction, "function");
+    shouldBe(boundFunction.name, "bound target");
+    shouldBe(boundFunction.hasOwnProperty("a"), false);
+    shouldBe(boundFunction.x, 42);
+`);

--- a/Source/JavaScriptCore/runtime/JSBoundFunction.cpp
+++ b/Source/JavaScriptCore/runtime/JSBoundFunction.cpp
@@ -398,8 +398,13 @@ bool JSBoundFunction::canSkipNameAndLengthMaterialization(JSGlobalObject* global
     if (structure->realm() != globalObject)
         return false;
 
+    // Bound functions cannot assume their .length/.name are unchanged, and so cannot skip
+    // materializing them.
+    //
+    // This must be synced with JSFunction::canAssumeNameAndLengthAreOriginal().
     if (structure->classInfoForCells()->isSubClassOf(JSBoundFunction::info()))
-        return true;
+        return false;
+
     if (structure == globalObject->arrowFunctionStructure(true) || structure == globalObject->arrowFunctionStructure(false))
         return true;
     if (structure == globalObject->strictFunctionStructure(true) || structure == globalObject->strictFunctionStructure(false))

--- a/Source/JavaScriptCore/runtime/JSFunctionInlines.h
+++ b/Source/JavaScriptCore/runtime/JSFunctionInlines.h
@@ -230,6 +230,8 @@ inline bool JSFunction::canAssumeNameAndLengthAreOriginal(VM&)
     // FunctionExecutable for JS), so the only thing we have to refuse is bound functions
     // (which set their length/name at bind time, not via FunctionRareData tracking) and any
     // function whose length or name has since been user-mutated.
+    //
+    // This must be synced with JSBoundFunction::canSkipNameAndLengthMaterialization().
     if (this->inherits<JSBoundFunction>())
         return false;
     FunctionRareData* rareData = this->rareData();


### PR DESCRIPTION
#### 259d2999018347dae277c3b7041abbcb4fd16a86
<pre>
[JSC] Materialize .length/.name for bound^2 functions
<a href="https://bugs.webkit.org/show_bug.cgi?id=320017">https://bugs.webkit.org/show_bug.cgi?id=320017</a>
<a href="https://rdar.apple.com/182269995">rdar://182269995</a>

Reviewed by Marcus Plutowski.

314682@main unified handling of bound functions (i.e. functions returned by
F.p.bind) with native functions for .length/.name materialization. This
materialization is controlled by two predicates that must be in sync:
JSBoundFunction::canSkipNameAndLengthMaterialization() used at compile-time and
JSFunction::canAssumeNameAndLengthAreOriginal() used at runtime. 314682@main
de-synced them by making JSFunction::canAssumeNameAndLengthAreOriginal() return
false for bound functions, while
JSBoundFunction::canSkipNameAndLengthMaterialization() kept returning true.

This PR re-syncs the predicates to return false for bound functions in both.

Test: JSTests/stress/function-bind-bound-target-tainted-structure-transition.js

* JSTests/stress/function-bind-bound-target-tainted-structure-transition.js: Added.
(vm.runTaintedString.shouldBe):
(target):
(test):
* Source/JavaScriptCore/runtime/JSBoundFunction.cpp:
(JSC::JSBoundFunction::canSkipNameAndLengthMaterialization):
* Source/JavaScriptCore/runtime/JSFunctionInlines.h:
(JSC::JSFunction::canAssumeNameAndLengthAreOriginal):

Canonical link: <a href="https://commits.webkit.org/317813@main">https://commits.webkit.org/317813@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0c571d4e730524e2300580b37adb7c8be937540d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176411 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50346 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44136 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186010 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/138674 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/dad796eb-1314-4e61-93b3-82dfd94f6a48) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51638 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50030 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137416 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/138674 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6ccec869-6cf4-4893-a95b-3f79a693801b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179367 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40897 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158195 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117891 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9da21166-666a-4264-ae0d-1efe3f79a024) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39546 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37913 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/6704 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149962 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37693 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34478 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/37679 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42075 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/42124 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188433 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50011 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146461 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39391 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50695 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/34311 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146272 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41040 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122899 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/116952 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49199 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12668 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48601 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48835 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48660 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->