### PR TITLE
[Site Isolation] Dark mode is not disabled for printing when the main frame is remote

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7597,7 +7597,6 @@ http/tests/ipc/write-web-archive-frame-ancestry-check.html [ Skip ]
 
 http/tests/site-isolation/touch-events [ Skip ]
 http/tests/site-isolation/ios [ Skip ]
-http/tests/site-isolation/iframe-dark-mode-print.html [ ImageOnlyFailure ]
 
 # CSS syntax
 imported/w3c/web-platform-tests/css/css-scoping/scoped-reference-animation-002.html [ ImageOnlyFailure ]

--- a/LayoutTests/http/tests/site-isolation/iframe-dark-mode-print-expected.html
+++ b/LayoutTests/http/tests/site-isolation/iframe-dark-mode-print-expected.html
@@ -1,3 +1,0 @@
-<body bgcolor=blue>
-    <div style="width:300px;height:150px;background-color:red;">
-</body>

--- a/LayoutTests/http/tests/site-isolation/iframe-dark-mode-print-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/iframe-dark-mode-print-expected.txt
@@ -1,0 +1,13 @@
+layer at (0,0) size 1000x170
+  RenderView at (0,0) size 1000x170
+layer at (0,0) size 1000x170
+  RenderBlock {HTML} at (0,0) size 1000x170
+    RenderBody {BODY} at (8,8) size 984x154 [bgcolor=#0000FF]
+      RenderText {#text} at (0,0) size 0x0
+layer at (8,8) size 300x150
+  RenderIFrame {IFRAME} at (0,0) size 300x150
+    layer at (0,0) size 300x150
+      RenderView at (0,0) size 300x150
+    layer at (0,0) size 300x150
+      RenderBlock {HTML} at (0,0) size 300x150
+        RenderBody {BODY} at (8,8) size 284x134 [bgcolor=#FF0000]

--- a/LayoutTests/http/tests/site-isolation/iframe-dark-mode-print.html
+++ b/LayoutTests/http/tests/site-isolation/iframe-dark-mode-print.html
@@ -1,17 +1,20 @@
 <!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
-<body bgcolor=blue>
-    <iframe onload="test()" src="http://localhost:8000/site-isolation/resources/dark-mode-background.html" frameborder=0></iframe>
-    <script>
-        if (window.testRunner) {
-            testRunner.setPrinting();
-            testRunner.waitUntilDone();
-        }
+<!DOCTYPE HTML>
+<head>
+<script>
+if (window.testRunner) {
+    testRunner.waitUntilDone();
+    testRunner.setPrinting();
+}
 
-        function test() {
-            if (window.testRunner) {
-                testRunner.setUseDarkAppearanceForTesting(true);
-                testRunner.notifyDone();
-            }
-        }
-    </script>
+onmessage = (event) => {
+    if (window.testRunner && event.data == "onload") {
+        testRunner.setUseDarkAppearanceForTesting(true);
+        testRunner.notifyDone();
+    }
+}
+</script>
+</head>
+<body bgcolor=blue>
+<iframe src="http://localhost:8000/site-isolation/resources/dark-mode-background.html" frameborder=0></iframe>
 </body>

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -4455,9 +4455,11 @@ bool Page::useDarkAppearance() const
     if (m_useDarkAppearanceOverride)
         return m_useDarkAppearanceOverride.value();
 
+    if (mainFrame().isPrinting())
+        return false;
+
     if (RefPtr localMainFrame = this->localMainFrame()) {
-        // Printed page should always use light appearance (i.e return false)
-        // FIXME: implement this logic for remote main frames.
+        // Media type can be non-screen without printing (Inspector emulation, client override).
         RefPtr view = localMainFrame->view();
         if (!view || view->mediaType() != screenAtom())
             return false;


### PR DESCRIPTION
#### a1a50b098fc374d17ffdaa715cdd949d5a659e88
<pre>
[Site Isolation] Dark mode is not disabled for printing when the main frame is remote
<a href="https://bugs.webkit.org/show_bug.cgi?id=320020">https://bugs.webkit.org/show_bug.cgi?id=320020</a>
<a href="https://rdar.apple.com/182952197">rdar://182952197</a>

Reviewed by Kiet Ho.

Page::useDarkAppearance() only applied the &quot;printing uses light appearance&quot;
rule inside an `if (localMainFrame())` block, so under site isolation a
cross-origin iframe (whose process has a RemoteFrame as its main frame)
kept using dark appearance while printing. prefers-color-scheme: dark then
still matched inside the iframe and it painted with its dark background.

The printing flag is synced to remote main frames via SetFramePrinting, so
consult mainFrame().isPrinting() before the localMainFrame()-only logic.

iframe-dark-mode-print.html was an image-only reftest, which cannot work for a
printing test under site isolation. WebKitTestRunner captures the pixel result
of a printing test in the main frame&apos;s WebContent process (a printing snapshot
taken in the injected bundle), and that process paints nothing for a remote
frame; printing also forces backgrounds to white unless ShouldPrintBackgrounds
is enabled, so the snapshot is blank white with or without this change. Convert
it into a render tree dump test, following print-with-iframe.html: a remote
frame&apos;s render tree is collected across processes, so the used background color
inside the cross-origin iframe is visible in the dump (red for light appearance
rather than green for dark).

* LayoutTests/TestExpectations:
* LayoutTests/http/tests/site-isolation/iframe-dark-mode-print-expected.html: Removed.
* LayoutTests/http/tests/site-isolation/iframe-dark-mode-print-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/iframe-dark-mode-print.html:
* Source/WebCore/page/Page.cpp:
(WebCore::Page::useDarkAppearance const):

Canonical link: <a href="https://commits.webkit.org/319122@main">https://commits.webkit.org/319122@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c00ae8d8e186b34eedb1628c60a7b5a5fba01ac3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180477 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54422 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48220 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190688 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144798 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f1230b9b-424c-4a92-8978-3ea60a38d766) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182339 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55720 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54138 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140764 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97499 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/42abd151-12b3-4e09-9d32-078ee3f50190) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183432 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44426 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161533 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121216 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43099 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41386 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153503 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41062 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1847 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47021 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45640 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192623 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54088 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/161051 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150125 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40205 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54776 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37676 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149848 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44472 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127039 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122207 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53293 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16051 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52675 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52912 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52740 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->