### PR TITLE
[WebTransport] Add WebTransportWriter IDL interface and WebTransportSendStream.getWriter()

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6778,7 +6778,7 @@ imported/w3c/web-platform-tests/webtransport/streams-close.https.any.servicework
 imported/w3c/web-platform-tests/webtransport/streams-close.https.any.sharedworker.html [ Skip ]
 imported/w3c/web-platform-tests/webtransport/streams-close.https.any.worker.html [ Skip ]
 
-# Backend gaps (datagram flow-control, getStats, close, historical, idlharness exportKeyingMaterial).
+# Backend gaps (datagram flow-control, getStats, close, historical).
 imported/w3c/web-platform-tests/webtransport/datagrams.https.any.html [ Skip ]
 imported/w3c/web-platform-tests/webtransport/datagrams.https.any.serviceworker.html [ Skip ]
 imported/w3c/web-platform-tests/webtransport/datagrams.https.any.sharedworker.html [ Skip ]
@@ -6795,10 +6795,6 @@ imported/w3c/web-platform-tests/webtransport/historical.https.sub.any.html [ Ski
 imported/w3c/web-platform-tests/webtransport/historical.https.sub.any.serviceworker.html [ Skip ]
 imported/w3c/web-platform-tests/webtransport/historical.https.sub.any.sharedworker.html [ Skip ]
 imported/w3c/web-platform-tests/webtransport/historical.https.sub.any.worker.html [ Skip ]
-imported/w3c/web-platform-tests/webtransport/idlharness.https.sub.any.html [ Skip ]
-imported/w3c/web-platform-tests/webtransport/idlharness.https.sub.any.serviceworker.html [ Skip ]
-imported/w3c/web-platform-tests/webtransport/idlharness.https.sub.any.sharedworker.html [ Skip ]
-imported/w3c/web-platform-tests/webtransport/idlharness.https.sub.any.worker.html [ Skip ]
 
 # Some of Canvas Layer API features are not supported yet.
 imported/w3c/web-platform-tests/html/canvas/element/layers/2d.layer.anisotropic-blur.isotropic.html [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/idlharness.https.sub.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/idlharness.https.sub.any-expected.txt
@@ -79,7 +79,7 @@ PASS WebTransportSendStream interface: existence and properties of interface pro
 PASS WebTransportSendStream interface: attribute sendGroup
 PASS WebTransportSendStream interface: attribute sendOrder
 PASS WebTransportSendStream interface: operation getStats()
-FAIL WebTransportSendStream interface: operation getWriter() assert_own_property: interface prototype object missing non-static operation expected property "getWriter" missing
+PASS WebTransportSendStream interface: operation getWriter()
 PASS WebTransportSendGroup interface: existence and properties of interface object
 PASS WebTransportSendGroup interface object length
 PASS WebTransportSendGroup interface object name
@@ -102,14 +102,14 @@ PASS WebTransportBidirectionalStream interface: existence and properties of inte
 PASS WebTransportBidirectionalStream interface: existence and properties of interface prototype object's @@unscopables property
 PASS WebTransportBidirectionalStream interface: attribute readable
 PASS WebTransportBidirectionalStream interface: attribute writable
-FAIL WebTransportWriter interface: existence and properties of interface object assert_own_property: self does not have own property "WebTransportWriter" expected property "WebTransportWriter" missing
-FAIL WebTransportWriter interface object length assert_own_property: self does not have own property "WebTransportWriter" expected property "WebTransportWriter" missing
-FAIL WebTransportWriter interface object name assert_own_property: self does not have own property "WebTransportWriter" expected property "WebTransportWriter" missing
-FAIL WebTransportWriter interface: existence and properties of interface prototype object assert_own_property: self does not have own property "WebTransportWriter" expected property "WebTransportWriter" missing
-FAIL WebTransportWriter interface: existence and properties of interface prototype object's "constructor" property assert_own_property: self does not have own property "WebTransportWriter" expected property "WebTransportWriter" missing
-FAIL WebTransportWriter interface: existence and properties of interface prototype object's @@unscopables property assert_own_property: self does not have own property "WebTransportWriter" expected property "WebTransportWriter" missing
-FAIL WebTransportWriter interface: operation atomicWrite(optional any) assert_own_property: self does not have own property "WebTransportWriter" expected property "WebTransportWriter" missing
-FAIL WebTransportWriter interface: operation commit() assert_own_property: self does not have own property "WebTransportWriter" expected property "WebTransportWriter" missing
+PASS WebTransportWriter interface: existence and properties of interface object
+PASS WebTransportWriter interface object length
+PASS WebTransportWriter interface object name
+PASS WebTransportWriter interface: existence and properties of interface prototype object
+PASS WebTransportWriter interface: existence and properties of interface prototype object's "constructor" property
+PASS WebTransportWriter interface: existence and properties of interface prototype object's @@unscopables property
+PASS WebTransportWriter interface: operation atomicWrite(optional any)
+PASS WebTransportWriter interface: operation commit()
 PASS WebTransportError interface: existence and properties of interface object
 PASS WebTransportError interface object length
 PASS WebTransportError interface object name

--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/idlharness.https.sub.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/idlharness.https.sub.any.serviceworker-expected.txt
@@ -79,7 +79,7 @@ PASS WebTransportSendStream interface: existence and properties of interface pro
 PASS WebTransportSendStream interface: attribute sendGroup
 PASS WebTransportSendStream interface: attribute sendOrder
 PASS WebTransportSendStream interface: operation getStats()
-FAIL WebTransportSendStream interface: operation getWriter() assert_own_property: interface prototype object missing non-static operation expected property "getWriter" missing
+PASS WebTransportSendStream interface: operation getWriter()
 PASS WebTransportSendGroup interface: existence and properties of interface object
 PASS WebTransportSendGroup interface object length
 PASS WebTransportSendGroup interface object name
@@ -102,14 +102,14 @@ PASS WebTransportBidirectionalStream interface: existence and properties of inte
 PASS WebTransportBidirectionalStream interface: existence and properties of interface prototype object's @@unscopables property
 PASS WebTransportBidirectionalStream interface: attribute readable
 PASS WebTransportBidirectionalStream interface: attribute writable
-FAIL WebTransportWriter interface: existence and properties of interface object assert_own_property: self does not have own property "WebTransportWriter" expected property "WebTransportWriter" missing
-FAIL WebTransportWriter interface object length assert_own_property: self does not have own property "WebTransportWriter" expected property "WebTransportWriter" missing
-FAIL WebTransportWriter interface object name assert_own_property: self does not have own property "WebTransportWriter" expected property "WebTransportWriter" missing
-FAIL WebTransportWriter interface: existence and properties of interface prototype object assert_own_property: self does not have own property "WebTransportWriter" expected property "WebTransportWriter" missing
-FAIL WebTransportWriter interface: existence and properties of interface prototype object's "constructor" property assert_own_property: self does not have own property "WebTransportWriter" expected property "WebTransportWriter" missing
-FAIL WebTransportWriter interface: existence and properties of interface prototype object's @@unscopables property assert_own_property: self does not have own property "WebTransportWriter" expected property "WebTransportWriter" missing
-FAIL WebTransportWriter interface: operation atomicWrite(optional any) assert_own_property: self does not have own property "WebTransportWriter" expected property "WebTransportWriter" missing
-FAIL WebTransportWriter interface: operation commit() assert_own_property: self does not have own property "WebTransportWriter" expected property "WebTransportWriter" missing
+PASS WebTransportWriter interface: existence and properties of interface object
+PASS WebTransportWriter interface object length
+PASS WebTransportWriter interface object name
+PASS WebTransportWriter interface: existence and properties of interface prototype object
+PASS WebTransportWriter interface: existence and properties of interface prototype object's "constructor" property
+PASS WebTransportWriter interface: existence and properties of interface prototype object's @@unscopables property
+PASS WebTransportWriter interface: operation atomicWrite(optional any)
+PASS WebTransportWriter interface: operation commit()
 PASS WebTransportError interface: existence and properties of interface object
 PASS WebTransportError interface object length
 PASS WebTransportError interface object name

--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/idlharness.https.sub.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/idlharness.https.sub.any.sharedworker-expected.txt
@@ -79,7 +79,7 @@ PASS WebTransportSendStream interface: existence and properties of interface pro
 PASS WebTransportSendStream interface: attribute sendGroup
 PASS WebTransportSendStream interface: attribute sendOrder
 PASS WebTransportSendStream interface: operation getStats()
-FAIL WebTransportSendStream interface: operation getWriter() assert_own_property: interface prototype object missing non-static operation expected property "getWriter" missing
+PASS WebTransportSendStream interface: operation getWriter()
 PASS WebTransportSendGroup interface: existence and properties of interface object
 PASS WebTransportSendGroup interface object length
 PASS WebTransportSendGroup interface object name
@@ -102,14 +102,14 @@ PASS WebTransportBidirectionalStream interface: existence and properties of inte
 PASS WebTransportBidirectionalStream interface: existence and properties of interface prototype object's @@unscopables property
 PASS WebTransportBidirectionalStream interface: attribute readable
 PASS WebTransportBidirectionalStream interface: attribute writable
-FAIL WebTransportWriter interface: existence and properties of interface object assert_own_property: self does not have own property "WebTransportWriter" expected property "WebTransportWriter" missing
-FAIL WebTransportWriter interface object length assert_own_property: self does not have own property "WebTransportWriter" expected property "WebTransportWriter" missing
-FAIL WebTransportWriter interface object name assert_own_property: self does not have own property "WebTransportWriter" expected property "WebTransportWriter" missing
-FAIL WebTransportWriter interface: existence and properties of interface prototype object assert_own_property: self does not have own property "WebTransportWriter" expected property "WebTransportWriter" missing
-FAIL WebTransportWriter interface: existence and properties of interface prototype object's "constructor" property assert_own_property: self does not have own property "WebTransportWriter" expected property "WebTransportWriter" missing
-FAIL WebTransportWriter interface: existence and properties of interface prototype object's @@unscopables property assert_own_property: self does not have own property "WebTransportWriter" expected property "WebTransportWriter" missing
-FAIL WebTransportWriter interface: operation atomicWrite(optional any) assert_own_property: self does not have own property "WebTransportWriter" expected property "WebTransportWriter" missing
-FAIL WebTransportWriter interface: operation commit() assert_own_property: self does not have own property "WebTransportWriter" expected property "WebTransportWriter" missing
+PASS WebTransportWriter interface: existence and properties of interface object
+PASS WebTransportWriter interface object length
+PASS WebTransportWriter interface object name
+PASS WebTransportWriter interface: existence and properties of interface prototype object
+PASS WebTransportWriter interface: existence and properties of interface prototype object's "constructor" property
+PASS WebTransportWriter interface: existence and properties of interface prototype object's @@unscopables property
+PASS WebTransportWriter interface: operation atomicWrite(optional any)
+PASS WebTransportWriter interface: operation commit()
 PASS WebTransportError interface: existence and properties of interface object
 PASS WebTransportError interface object length
 PASS WebTransportError interface object name

--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/idlharness.https.sub.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/idlharness.https.sub.any.worker-expected.txt
@@ -79,7 +79,7 @@ PASS WebTransportSendStream interface: existence and properties of interface pro
 PASS WebTransportSendStream interface: attribute sendGroup
 PASS WebTransportSendStream interface: attribute sendOrder
 PASS WebTransportSendStream interface: operation getStats()
-FAIL WebTransportSendStream interface: operation getWriter() assert_own_property: interface prototype object missing non-static operation expected property "getWriter" missing
+PASS WebTransportSendStream interface: operation getWriter()
 PASS WebTransportSendGroup interface: existence and properties of interface object
 PASS WebTransportSendGroup interface object length
 PASS WebTransportSendGroup interface object name
@@ -102,14 +102,14 @@ PASS WebTransportBidirectionalStream interface: existence and properties of inte
 PASS WebTransportBidirectionalStream interface: existence and properties of interface prototype object's @@unscopables property
 PASS WebTransportBidirectionalStream interface: attribute readable
 PASS WebTransportBidirectionalStream interface: attribute writable
-FAIL WebTransportWriter interface: existence and properties of interface object assert_own_property: self does not have own property "WebTransportWriter" expected property "WebTransportWriter" missing
-FAIL WebTransportWriter interface object length assert_own_property: self does not have own property "WebTransportWriter" expected property "WebTransportWriter" missing
-FAIL WebTransportWriter interface object name assert_own_property: self does not have own property "WebTransportWriter" expected property "WebTransportWriter" missing
-FAIL WebTransportWriter interface: existence and properties of interface prototype object assert_own_property: self does not have own property "WebTransportWriter" expected property "WebTransportWriter" missing
-FAIL WebTransportWriter interface: existence and properties of interface prototype object's "constructor" property assert_own_property: self does not have own property "WebTransportWriter" expected property "WebTransportWriter" missing
-FAIL WebTransportWriter interface: existence and properties of interface prototype object's @@unscopables property assert_own_property: self does not have own property "WebTransportWriter" expected property "WebTransportWriter" missing
-FAIL WebTransportWriter interface: operation atomicWrite(optional any) assert_own_property: self does not have own property "WebTransportWriter" expected property "WebTransportWriter" missing
-FAIL WebTransportWriter interface: operation commit() assert_own_property: self does not have own property "WebTransportWriter" expected property "WebTransportWriter" missing
+PASS WebTransportWriter interface: existence and properties of interface object
+PASS WebTransportWriter interface object length
+PASS WebTransportWriter interface object name
+PASS WebTransportWriter interface: existence and properties of interface prototype object
+PASS WebTransportWriter interface: existence and properties of interface prototype object's "constructor" property
+PASS WebTransportWriter interface: existence and properties of interface prototype object's @@unscopables property
+PASS WebTransportWriter interface: operation atomicWrite(optional any)
+PASS WebTransportWriter interface: operation commit()
 PASS WebTransportError interface: existence and properties of interface object
 PASS WebTransportError interface object length
 PASS WebTransportError interface object name

--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -925,6 +925,7 @@ set(WebCore_NON_SVG_IDL_FILES
     Modules/webtransport/WebTransportSendStream.idl
     Modules/webtransport/WebTransportSendStreamOptions.idl
     Modules/webtransport/WebTransportSendStreamStats.idl
+    Modules/webtransport/WebTransportWriter.idl
 
 
     animation/AnimationEffect.idl

--- a/Source/WebCore/DerivedSources-input.xcfilelist
+++ b/Source/WebCore/DerivedSources-input.xcfilelist
@@ -1122,6 +1122,7 @@ $(PROJECT_DIR)/Modules/webtransport/WebTransportSendOptions.idl
 $(PROJECT_DIR)/Modules/webtransport/WebTransportSendStream.idl
 $(PROJECT_DIR)/Modules/webtransport/WebTransportSendStreamOptions.idl
 $(PROJECT_DIR)/Modules/webtransport/WebTransportSendStreamStats.idl
+$(PROJECT_DIR)/Modules/webtransport/WebTransportWriter.idl
 $(PROJECT_DIR)/Modules/webxr/Navigator+WebXR.idl
 $(PROJECT_DIR)/Modules/webxr/WebXRBoundedReferenceSpace.idl
 $(PROJECT_DIR)/Modules/webxr/WebXRFrame+HandInput.idl

--- a/Source/WebCore/DerivedSources-output.xcfilelist
+++ b/Source/WebCore/DerivedSources-output.xcfilelist
@@ -3499,6 +3499,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWebTransportSendStreamOptions.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWebTransportSendStreamOptions.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWebTransportSendStreamStats.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWebTransportSendStreamStats.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWebTransportWriter.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWebTransportWriter.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWebXRBoundedReferenceSpace.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWebXRBoundedReferenceSpace.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWebXRFrame+HandInput.cpp

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -856,6 +856,7 @@ JS_BINDING_IDLS := \
     $(WebCore)/Modules/webtransport/WebTransportSendStream.idl \
     $(WebCore)/Modules/webtransport/WebTransportSendStreamOptions.idl \
     $(WebCore)/Modules/webtransport/WebTransportSendStreamStats.idl \
+    $(WebCore)/Modules/webtransport/WebTransportWriter.idl \
     $(WebCore)/Modules/webxr/Navigator+WebXR.idl \
     $(WebCore)/Modules/webxr/WebXRBoundedReferenceSpace.idl \
     $(WebCore)/Modules/webxr/WebXRFrame+HandInput.idl \

--- a/Source/WebCore/Modules/streams/WritableStreamDefaultWriter.h
+++ b/Source/WebCore/Modules/streams/WritableStreamDefaultWriter.h
@@ -41,6 +41,9 @@ public:
 
     virtual ~WritableStreamDefaultWriter();
 
+    enum class Type : bool { Default, WebTransport };
+    virtual Type type() const { return Type::Default; }
+
     ExceptionOr<std::optional<double>> desiredSize(JSDOMGlobalObject&);
     ExceptionOr<void> releaseLock(JSDOMGlobalObject&);
 

--- a/Source/WebCore/Modules/webtransport/WebTransportSendStream.cpp
+++ b/Source/WebCore/Modules/webtransport/WebTransportSendStream.cpp
@@ -38,6 +38,7 @@
 #include "WebTransportSendStreamSink.h"
 #include "WebTransportSendStreamStats.h"
 #include "WebTransportSession.h"
+#include "WebTransportWriter.h"
 #include <wtf/CompletionHandler.h>
 
 namespace WebCore {
@@ -64,6 +65,11 @@ WebTransportSendStream::WebTransportSendStream(WebTransportStreamIdentifier iden
     , m_transport(transport) { }
 
 WebTransportSendStream::~WebTransportSendStream() = default;
+
+ExceptionOr<Ref<WebTransportWriter>> WebTransportSendStream::getWriter(JSDOMGlobalObject& globalObject)
+{
+    return WebTransportWriter::create(globalObject, *this);
+}
 
 void WebTransportSendStream::getStats(ScriptExecutionContext& context, Ref<DeferredPromise>&& promise)
 {

--- a/Source/WebCore/Modules/webtransport/WebTransportSendStream.h
+++ b/Source/WebCore/Modules/webtransport/WebTransportSendStream.h
@@ -39,6 +39,8 @@ struct WebTransportSendStreamOptions;
 struct WebTransportSendStreamStats;
 struct WebTransportStreamIdentifierType;
 
+class WebTransportWriter;
+
 using WebTransportStreamIdentifier = ObjectIdentifier<WebTransportStreamIdentifierType>;
 
 class WebTransportSendStream : public WritableStream {
@@ -47,6 +49,7 @@ public:
     ~WebTransportSendStream();
 
     void getStats(ScriptExecutionContext&, Ref<DeferredPromise>&&);
+    ExceptionOr<Ref<WebTransportWriter>> getWriter(JSDOMGlobalObject&);
     WebTransportSendGroup* NODELETE sendGroup();
     ExceptionOr<void> setSendGroup(WebTransportSendGroup*);
     int64_t sendOrder() { return m_sendOrder; }

--- a/Source/WebCore/Modules/webtransport/WebTransportWriter.cpp
+++ b/Source/WebCore/Modules/webtransport/WebTransportWriter.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,14 +23,39 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-[
-    EnabledBySetting=WebTransportEnabled,
-    Exposed=(Window,Worker),
-    SecureContext,
-    Transferable
-] interface WebTransportSendStream : WritableStream {
-    attribute WebTransportSendGroup? sendGroup;
-    attribute long long sendOrder;
-    [CallWith=CurrentScriptExecutionContext] Promise<WebTransportSendStreamStats> getStats();
-    [CallWith=CurrentGlobalObject] WebTransportWriter getWriter();
-};
+#include "config.h"
+#include "WebTransportWriter.h"
+
+#include "InternalWritableStreamWriter.h"
+#include "JSDOMGlobalObject.h"
+#include "JSDOMPromiseDeferred.h"
+#include "WritableStream.h"
+
+namespace WebCore {
+
+ExceptionOr<Ref<WebTransportWriter>> WebTransportWriter::create(JSDOMGlobalObject& globalObject, WritableStream& stream)
+{
+    auto result = acquireWritableStreamDefaultWriter(globalObject, stream);
+    if (result.hasException())
+        return result.releaseException();
+
+    return adoptRef(*new WebTransportWriter(result.releaseReturnValue()));
+}
+
+WebTransportWriter::WebTransportWriter(Ref<InternalWritableStreamWriter>&& internalWriter)
+    : WritableStreamDefaultWriter(WTF::move(internalWriter))
+{
+}
+
+void WebTransportWriter::atomicWrite(JSC::JSValue, Ref<DeferredPromise>&& promise)
+{
+    // FIXME: Implement WebTransport atomic writes once the send-stream commit API exists (rdar://164169921).
+    promise->reject(ExceptionCode::NotSupportedError);
+}
+
+void WebTransportWriter::commit()
+{
+    // FIXME: Implement WebTransport commit once the send-stream commit API exists (rdar://164169921).
+}
+
+} // namespace WebCore

--- a/Source/WebCore/Modules/webtransport/WebTransportWriter.h
+++ b/Source/WebCore/Modules/webtransport/WebTransportWriter.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,14 +23,36 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-[
-    EnabledBySetting=WebTransportEnabled,
-    Exposed=(Window,Worker),
-    SecureContext,
-    Transferable
-] interface WebTransportSendStream : WritableStream {
-    attribute WebTransportSendGroup? sendGroup;
-    attribute long long sendOrder;
-    [CallWith=CurrentScriptExecutionContext] Promise<WebTransportSendStreamStats> getStats();
-    [CallWith=CurrentGlobalObject] WebTransportWriter getWriter();
+#pragma once
+
+#include "WritableStreamDefaultWriter.h"
+#include <JavaScriptCore/JSCJSValue.h>
+#include <wtf/TypeCasts.h>
+
+namespace WebCore {
+
+class DeferredPromise;
+class JSDOMGlobalObject;
+class WritableStream;
+
+template<typename> class ExceptionOr;
+
+class WebTransportWriter final : public WritableStreamDefaultWriter {
+public:
+    static ExceptionOr<Ref<WebTransportWriter>> create(JSDOMGlobalObject&, WritableStream&);
+
+    void atomicWrite(JSC::JSValue chunk, Ref<DeferredPromise>&&);
+    void commit();
+
+private:
+    explicit WebTransportWriter(Ref<InternalWritableStreamWriter>&&);
+
+    Type type() const final { return Type::WebTransport; }
 };
+
+} // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::WebTransportWriter)
+static bool isType(const WebCore::WritableStreamDefaultWriter& writer) { return writer.type() == WebCore::WritableStreamDefaultWriter::Type::WebTransport; }
+SPECIALIZE_TYPE_TRAITS_END()
+

--- a/Source/WebCore/Modules/webtransport/WebTransportWriter.idl
+++ b/Source/WebCore/Modules/webtransport/WebTransportWriter.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,11 +26,8 @@
 [
     EnabledBySetting=WebTransportEnabled,
     Exposed=(Window,Worker),
-    SecureContext,
-    Transferable
-] interface WebTransportSendStream : WritableStream {
-    attribute WebTransportSendGroup? sendGroup;
-    attribute long long sendOrder;
-    [CallWith=CurrentScriptExecutionContext] Promise<WebTransportSendStreamStats> getStats();
-    [CallWith=CurrentGlobalObject] WebTransportWriter getWriter();
+    SecureContext
+] interface WebTransportWriter : WritableStreamDefaultWriter {
+    Promise<undefined> atomicWrite(optional any chunk);
+    undefined commit();
 };

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -540,6 +540,7 @@ Modules/webtransport/WebTransportSendGroup.cpp
 Modules/webtransport/WebTransportSendStream.cpp
 Modules/webtransport/WebTransportSendStreamSink.cpp
 Modules/webtransport/WebTransportSession.cpp
+Modules/webtransport/WebTransportWriter.cpp
 Modules/webtransport/WorkerWebTransportSession.cpp
 Modules/webxr/NavigatorWebXR.cpp
 Modules/webxr/WebGLOpaqueTexture.cpp
@@ -5309,6 +5310,7 @@ JSWebTransportSendOptions.cpp
 JSWebTransportSendStream.cpp
 JSWebTransportSendStreamOptions.cpp
 JSWebTransportSendStreamStats.cpp
+JSWebTransportWriter.cpp
 JSWebXRBoundedReferenceSpace.cpp
 JSWebXRFrame.cpp
 JSWebXRHand.cpp

--- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
+++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
@@ -23619,6 +23619,9 @@
 		FAC8497A2A9E68E900D407EF /* WebTransportSession.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebTransportSession.h; sourceTree = "<group>"; };
 		FAC8497E2A9E6CEF00D407EF /* WebTransportSessionClient.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebTransportSessionClient.h; sourceTree = "<group>"; };
 		FAC849912A9EB85F00D407EF /* WebTransportSession.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WebTransportSession.cpp; sourceTree = "<group>"; };
+		BA5EC0DE2C0000000000AA01 /* WebTransportWriter.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebTransportWriter.cpp; sourceTree = "<group>"; };
+		BA5EC0DE2C0000000000AA02 /* WebTransportWriter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebTransportWriter.h; sourceTree = "<group>"; };
+		BA5EC0DE2C0000000000AA03 /* WebTransportWriter.idl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = WebTransportWriter.idl; sourceTree = "<group>"; };
 		FAC849922A9FD85F00D407EF /* WebTransportBidirectionalStreamSource.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WebTransportBidirectionalStreamSource.cpp; sourceTree = "<group>"; };
 		FAC849932A9FD86000D407EF /* WebTransportBidirectionalStreamSource.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebTransportBidirectionalStreamSource.h; sourceTree = "<group>"; };
 		FAC849942A9FD86000D407EF /* WebTransportReceiveStreamSource.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebTransportReceiveStreamSource.h; sourceTree = "<group>"; };
@@ -43395,6 +43398,9 @@
 				FAC849912A9EB85F00D407EF /* WebTransportSession.cpp */,
 				FAC8497A2A9E68E900D407EF /* WebTransportSession.h */,
 				FAC8497E2A9E6CEF00D407EF /* WebTransportSessionClient.h */,
+				BA5EC0DE2C0000000000AA01 /* WebTransportWriter.cpp */,
+				BA5EC0DE2C0000000000AA02 /* WebTransportWriter.h */,
+				BA5EC0DE2C0000000000AA03 /* WebTransportWriter.idl */,
 				5CC66DB92D122C8F00479139 /* WorkerWebTransportSession.cpp */,
 				5CC66DB82D122C8F00479139 /* WorkerWebTransportSession.h */,
 			);

--- a/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
+++ b/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
@@ -524,6 +524,7 @@ namespace WebCore {
     macro(WebTransportReceiveStream) \
     macro(WebTransportSendGroup) \
     macro(WebTransportSendStream) \
+    macro(WebTransportWriter) \
     macro(WindowClient) \
     macro(Worker) \
     macro(Worklet) \


### PR DESCRIPTION
#### e2f2241ebf93fa77d5e47b6d91371d606bc8edbd
<pre>
[WebTransport] Add WebTransportWriter IDL interface and WebTransportSendStream.getWriter()
<a href="https://bugs.webkit.org/show_bug.cgi?id=320009">https://bugs.webkit.org/show_bug.cgi?id=320009</a>
<a href="https://rdar.apple.com/182947195">rdar://182947195</a>

Reviewed by Alex Christensen.

Add the WebTransportWriter IDL interface (a subclass of WritableStreamDefaultWriter
exposing atomicWrite() and commit()) and WebTransportSendStream.getWriter(), so the
WebTransport idlharness WPT test passes and can be un-skipped.

This adds the interface shape only. atomicWrite() rejects with NotSupportedError and
commit() is a no-op for now: neither is exercised by any functional WPT test (only
idlharness checks the interface shape), and the functional implementation is tracked
separately by <a href="https://rdar.apple.com/167646357">rdar://167646357</a> (WebTransportWriter) and <a href="https://rdar.apple.com/164169921">rdar://164169921</a> (commit). This
is enabled by the recently subclassable C++ WritableStreamDefaultWriter; a small type
discriminator is added there so bindings can dispatch to the WebTransportWriter wrapper.

This clears the final 9 idlharness FAILs, so the four
imported/w3c/web-platform-tests/webtransport/idlharness.https.sub.any variants are
un-skipped and now pass.

* LayoutTests/TestExpectations: Un-skip the four webtransport idlharness variants.
* LayoutTests/imported/w3c/web-platform-tests/webtransport/idlharness.https.sub.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webtransport/idlharness.https.sub.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webtransport/idlharness.https.sub.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webtransport/idlharness.https.sub.any.worker-expected.txt:
* Source/WebCore/CMakeLists.txt:
* Source/WebCore/DerivedSources-input.xcfilelist:
* Source/WebCore/DerivedSources-output.xcfilelist:
* Source/WebCore/DerivedSources.make:
* Source/WebCore/Modules/streams/WritableStreamDefaultWriter.h:
(WebCore::WritableStreamDefaultWriter::type const):
* Source/WebCore/Modules/webtransport/WebTransportSendStream.cpp:
(WebCore::WebTransportSendStream::getWriter):
* Source/WebCore/Modules/webtransport/WebTransportSendStream.h:
* Source/WebCore/Modules/webtransport/WebTransportSendStream.idl:
* Source/WebCore/Modules/webtransport/WebTransportWriter.cpp: Added.
(WebCore::WebTransportWriter::create):
(WebCore::WebTransportWriter::WebTransportWriter):
(WebCore::WebTransportWriter::atomicWrite):
(WebCore::WebTransportWriter::commit):
* Source/WebCore/Modules/webtransport/WebTransportWriter.h: Added.
* Source/WebCore/Modules/webtransport/WebTransportWriter.idl: Added.
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/bindings/js/WebCoreBuiltinNames.h:

Canonical link: <a href="https://commits.webkit.org/317810@main">https://commits.webkit.org/317810@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/43a08ed50735673b7f27d420686dbe8aac48805e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176197 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50132 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43922 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185793 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/138435 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178060 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51424 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49816 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137236 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/138435 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179153 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40716 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158012 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117711 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f71809c3-8b17-4341-aa2c-9503293fd98e) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39365 "Found 4 new test failures: imported/w3c/web-platform-tests/webtransport/idlharness.https.sub.any.html imported/w3c/web-platform-tests/webtransport/idlharness.https.sub.any.serviceworker.html imported/w3c/web-platform-tests/webtransport/idlharness.https.sub.any.sharedworker.html imported/w3c/web-platform-tests/webtransport/idlharness.https.sub.any.worker.html (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37728 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149781 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37509 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34262 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41851 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41939 "Found 4 new test failures: imported/w3c/web-platform-tests/webtransport/idlharness.https.sub.any.html imported/w3c/web-platform-tests/webtransport/idlharness.https.sub.any.serviceworker.html imported/w3c/web-platform-tests/webtransport/idlharness.https.sub.any.sharedworker.html imported/w3c/web-platform-tests/webtransport/idlharness.https.sub.any.worker.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188217 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49797 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146259 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39386 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50480 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34127 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146080 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40863 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122685 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/116661 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48985 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12481 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48387 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48621 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48445 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->