### PR TITLE
Anchor positioning: retry when an anchor candidate has no renderer yet

### DIFF
--- a/Source/WebCore/style/AnchorPositionEvaluator.cpp
+++ b/Source/WebCore/style/AnchorPositionEvaluator.cpp
@@ -1203,7 +1203,11 @@ static RefPtr<Element> findImplicitAnchor(const Styleable& anchorPositioned)
         // "If [a spec] defines is an implicit anchor element for query el which is an acceptable anchor element for query el, return that element."
         // https://drafts.csswg.org/css-anchor-position-1/#target
         CheckedPtr anchor = dynamicDowncast<RenderBoxModelObject>(implicitAnchorElement->renderer());
-        if (anchor && isAcceptableAnchorElement(*anchor, anchorPositioned))
+        if (!anchor) {
+            // Not yet rendered isn't the same as "no anchor" -- return it so the caller can retry.
+            return implicitAnchorElement;
+        }
+        if (isAcceptableAnchorElement(*anchor, anchorPositioned))
             return implicitAnchorElement;
     }
 
@@ -1306,12 +1310,26 @@ void AnchorPositionEvaluator::updateAnchorPositioningStatesAfterInterleavedLayou
                     renderer->setNeedsLayout();
 
                 Vector<ResolvedAnchor> anchors;
+                bool anchorCandidateMissingRenderer = false;
                 for (auto& anchorNameAndElement : state->anchorElements) {
                     CheckedPtr anchorElement = anchorNameAndElement.value.get();
+                    auto* anchorRenderer = anchorElement ? dynamicDowncast<RenderBoxModelObject>(anchorElement->renderer()) : nullptr;
+                    if (anchorElement && !anchorRenderer)
+                        anchorCandidateMissingRenderer = true;
                     anchors.append(ResolvedAnchor {
-                        .renderer = anchorElement ? dynamicDowncast<RenderBoxModelObject>(anchorElement->renderer()) : nullptr,
+                        .renderer = anchorRenderer,
                         .name = anchorNameAndElement.key
                     });
+                }
+
+                // Retry a bounded number of times before giving up on a candidate with no
+                // renderer yet. Don't publish anchorPositionedToAnchorMap until then -- the
+                // loop below treats a null anchor renderer as "nothing to wait for" and would
+                // prematurely force this element's stage to Resolved.
+                static constexpr uint8_t maxPendingAnchorRendererRetries = 4;
+                if (anchorCandidateMissingRenderer && state->pendingAnchorRendererRetryCount < maxPendingAnchorRendererRetries) {
+                    ++state->pendingAnchorRendererRetryCount;
+                    break;
                 }
 
                 anchorPositionedToAnchorMap.set(*anchorPositioned, AnchorPositionedToAnchorEntry {

--- a/Source/WebCore/style/AnchorPositionEvaluator.h
+++ b/Source/WebCore/style/AnchorPositionEvaluator.h
@@ -158,6 +158,10 @@ struct AnchorPositionedState {
     HashSet<ResolvedScopedName> anchorNames;
     AnchorPositionResolutionStage stage;
 
+    // Bounds retries when a found anchor candidate has no renderer yet, so a
+    // permanently unrendered candidate can't hang style resolution forever.
+    uint8_t pendingAnchorRendererRetryCount { 0 };
+
     WTF_MAKE_STRUCT_TZONE_ALLOCATED(AnchorPositionedState);
 };
 


### PR DESCRIPTION
#### f2a5611a92a30f7dac932bb2ed7945e8fcb98c8e
<pre>
Anchor positioning: retry when an anchor candidate has no renderer yet
<a href="https://bugs.webkit.org/show_bug.cgi?id=320026">https://bugs.webkit.org/show_bug.cgi?id=320026</a>
<a href="https://rdar.apple.com/182959023">rdar://182959023</a>

Reviewed by NOBODY (OOPS!).

Split out from Bug 319691. During interleaved layout an implicit or named
anchor element may be found before it has been rendered. Previously such a
candidate was treated as &quot;no anchor&quot;, which could force the anchor-positioned
element&apos;s resolution stage to Resolved prematurely.

Return the not-yet-rendered implicit anchor so the caller can retry, and bound
the number of retries when a resolved anchor candidate still lacks a renderer
so that a permanently unrendered candidate cannot hang style resolution.

* Source/WebCore/style/AnchorPositionEvaluator.cpp:
(WebCore::Style::findImplicitAnchor):
(WebCore::Style::AnchorPositionEvaluator::updateAnchorPositioningStatesAfterInterleavedLayout):
* Source/WebCore/style/AnchorPositionEvaluator.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f2a5611a92a30f7dac932bb2ed7945e8fcb98c8e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176205 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50140 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43930 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185801 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/138443 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178068 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51432 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49824 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137244 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96236 "1 flakes 4 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179161 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40717 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158016 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117719 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39366 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37732 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149782 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37513 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34270 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41860 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41943 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188225 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49805 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146268 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50488 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34131 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146089 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40868 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122693 "Built successfully") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/116669 "Hash f2a5611a for PR 69977 does not build (failure)") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48993 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12485 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48395 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48629 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48486 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->