### PR TITLE
Media query parser: serialize <general-enclosed> as verbatim as possible

### DIFF
--- a/LayoutTests/fast/media/mq-color-index-02.html
+++ b/LayoutTests/fast/media/mq-color-index-02.html
@@ -24,7 +24,7 @@
     var rules = document.styleSheets[0].cssRules;
 
     test(function(){
-      assert_equals(rules[0].media.mediaText, "(color-index: 0)");
+      assert_equals(rules[0].media.mediaText, "(color-index: 0.0)");
     }, "(color-index: 0.0) is invalid");
 
     test(function(){

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/container-queries/at-container-anchored-serialization-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/container-queries/at-container-anchored-serialization-expected.txt
@@ -1,7 +1,7 @@
 
-FAIL Normalize spaces assert_equals: expected "anchored(fallback: --foo)" but got "anchored( fallback:--foo)"
-FAIL No value - invalid, serializes as <general-enclosed> assert_equals: expected "ANChoreD(fallback:    )" but got "ANChoreD(fallback: )"
+FAIL Normalize spaces assert_equals: expected "anchored(fallback: --foo)" but got "anchored(        fallback:--foo)"
+PASS No value - invalid, serializes as <general-enclosed>
 FAIL Boolean context assert_equals: expected "anchored(fallback)" but got "anchoRed(fallback)"
-FAIL Logical with 'or' assert_equals: expected "anchored((fallback: flip-inline) or (fallback: --bar))" but got "anchored( ( fallback: flip-INLINE) OR ( FALLBACK : --bar ) )"
+FAIL Logical with 'or' assert_equals: expected "anchored((fallback: flip-inline) or (fallback: --bar))" but got "anchored(  ( fallback: flip-INLINE) OR ( FALLBACK : --bar  ) )"
 PASS Not an anchored() function with space before '('
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/at-container-style-serialization-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/at-container-style-serialization-expected.txt
@@ -3,7 +3,7 @@ PASS Normalize spaces
 PASS Empty declaration value - spaces
 PASS Empty declaration value
 PASS No declaration value
-FAIL Unknown CSS property after 'or' assert_equals: expected "style((--FOO: BAR) or ( prop: val  ))" but got "style((--FOO: BAR) or ( prop: val ))"
+PASS Unknown CSS property after 'or'
 PASS Not a style function with space before '('
 PASS Spaces preserved in custom property value
 PASS Original string number in custom property value

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/scroll-state/at-container-scrollable-serialization-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/scroll-state/at-container-scrollable-serialization-expected.txt
@@ -1,6 +1,6 @@
 
 PASS Normalize spaces
-FAIL No value - invalid, serializes as <general-enclosed> assert_equals: expected "scroll-STate(scrollable:    )" but got "scroll-state(scrollable: )"
+FAIL No value - invalid, serializes as <general-enclosed> assert_equals: expected "scroll-STate(scrollable:    )" but got "scroll-state(scrollable:    )"
 PASS Boolean context
 PASS Logical with 'or'
 PASS Not a scroll-state function with space before '('

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/scroll-state/at-container-scrolled-serialization-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/scroll-state/at-container-scrolled-serialization-expected.txt
@@ -1,6 +1,6 @@
 
 PASS Normalize spaces
-FAIL No value - invalid, serializes as <general-enclosed> assert_equals: expected "scroll-STate(scrolled:    )" but got "scroll-state(scrolled: )"
+FAIL No value - invalid, serializes as <general-enclosed> assert_equals: expected "scroll-STate(scrolled:    )" but got "scroll-state(scrolled:    )"
 PASS Boolean context
 PASS Logical with 'or'
 PASS Not a scroll-state function with space before '('

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/scroll-state/at-container-snapped-serialization-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/scroll-state/at-container-snapped-serialization-expected.txt
@@ -1,6 +1,6 @@
 
 PASS Normalize spaces
-FAIL No value - invalid, serializes as <general-enclosed> assert_equals: expected "scroll-STate(snapped:    )" but got "scroll-state(snapped: )"
+FAIL No value - invalid, serializes as <general-enclosed> assert_equals: expected "scroll-STate(snapped:    )" but got "scroll-state(snapped:    )"
 PASS Boolean context
 PASS Logical with 'or'
 PASS Not a scroll-state function with space before '('

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/scroll-state/at-container-stuck-serialization-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/scroll-state/at-container-stuck-serialization-expected.txt
@@ -1,6 +1,6 @@
 
 PASS Normalize spaces
-FAIL No value - invalid, serializes as <general-enclosed> assert_equals: expected "scroll-STate(stuck:    )" but got "scroll-state(stuck: )"
+FAIL No value - invalid, serializes as <general-enclosed> assert_equals: expected "scroll-STate(stuck:    )" but got "scroll-state(stuck:    )"
 PASS Boolean context
 PASS Logical with 'or'
 PASS Not a scroll-state function with space before '('

--- a/Source/WebCore/css/query/GenericMediaQueryParser.h
+++ b/Source/WebCore/css/query/GenericMediaQueryParser.h
@@ -146,7 +146,7 @@ std::optional<QueryInParens> GenericMediaQueryParser<ConcreteParser>::consumeQue
             if (!validationRange.consumeAnyValue())
                 return { };
 
-            return GeneralEnclosed { name.toString(), functionRange.serialize() };
+            return GeneralEnclosed { name.toString(), functionRange.serialize(CSSParserToken::SerializationMode::CustomProperty) };
         }
     }
 
@@ -181,7 +181,7 @@ std::optional<QueryInParens> GenericMediaQueryParser<ConcreteParser>::consumeQue
     if (!validationRange.consumeAnyValue())
         return { };
 
-    return GeneralEnclosed { functionId ? nameString(*functionId) : nullAtom(), originalBlockRange.serialize() };
+    return GeneralEnclosed { functionId ? nameString(*functionId) : nullAtom(), originalBlockRange.serialize(CSSParserToken::SerializationMode::CustomProperty) };
 }
 
 template<typename ConcreteParser>


### PR DESCRIPTION
#### 7d2766db51cb1386ce0e5fbb3e63c83a8b138094
<pre>
Media query parser: serialize &lt;general-enclosed&gt; as verbatim as possible
<a href="https://rdar.apple.com/182958311">rdar://182958311</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=320025">https://bugs.webkit.org/show_bug.cgi?id=320025</a>

Reviewed by Antti Koivisto.

This test:
imported/w3c/web-platform-tests/css/css-conditional/container-queries/at-container-style-serialization.html
suggests that serializing &lt;general-enclosed&gt; should result in exactly the
same string as the input. For example, &quot;prop:var       &quot; is serialized to
the same string with the trailing whitespaces preserved.

The media query parser (also used for @container query parser) uses
CSSParserTokenRange::serialize to serialize &lt;general-enclosed&gt; back to
string, but it doesn&apos;t specify the serialization mode. The default mode
collapses consecutive whitespaces into one, so the example above is
serialized as &quot;prop:var &quot;.

Fix this by using CSSParserToken::SerializationMode::CustomProperty mode,
which preserves consecutive whitespaces, among other things.

Test: imported/w3c/web-platform-tests/css/css-conditional/container-queries/at-container-style-serialization.html

* LayoutTests/fast/media/mq-color-index-02.html:
    - Fix the expected serialization. This test now passes in all three browsers
      (Chrome, Firefox, WebKit)

* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/container-queries/at-container-anchored-serialization-expected.txt:
    - Test progression.

* LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/at-container-style-serialization-expected.txt:
    - Test progression.

* LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/scroll-state/at-container-scrollable-serialization-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/scroll-state/at-container-scrolled-serialization-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/scroll-state/at-container-snapped-serialization-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/scroll-state/at-container-stuck-serialization-expected.txt:
    - Test progression. The subtests still fail, but at least this fixes
      the trailing whitespaces issue.

* Source/WebCore/css/query/GenericMediaQueryParser.h:
(WebCore::MQ::GenericMediaQueryParser&lt;ConcreteParser&gt;::consumeQueryInParens):

Canonical link: <a href="https://commits.webkit.org/318627@main">https://commits.webkit.org/318627@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/acf408e6b6a10765ec17daedd2859c301ae94d47

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178860 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52798 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46593 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188476 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/143169 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/dba77610-545a-4f52-a8b6-6a1dc1aedb9a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/180723 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54092 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52509 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139472 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/143169 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2322e119-8402-4e92-8caf-5e53344f65cb) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181817 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43046 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160208 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119921 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6e1c919b-791d-4079-8afb-f3ffa4fa188e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41717 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40061 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152116 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39711 "Passed tests") | [⏳ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/GTK-GTK3-GCC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45408 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/44307 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190905 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52468 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/159725 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148663 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39897 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53148 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/36335 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148421 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43119 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125422 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/120099 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51666 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14684 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51051 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51291 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51113 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->