### PR TITLE
Add tests verifying cross-origin iframe window.alert() behavior

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
@@ -1554,6 +1554,75 @@ TEST(SiteIsolation, IframeWithPrompt)
     EXPECT_WK_STREQ(childFrame.info.securityOrigin.host, "webkit.org");
 }
 
+// Make sure the main frame remains responsive even while a cross origin iframe is
+// displaying an alert.
+TEST(SiteIsolation, MainFrameHeartbeatContinuesWhileCrossSiteIframeDialogShown)
+{
+    HTTPServer server({
+        { "/example"_s, { "<script>"
+            "window.__heartbeat = 0;"
+            "setInterval(() => { window.__heartbeat++; }, 10);"
+            "</script>"
+            "<iframe src='https://webkit.org/webkit'></iframe>"_s } },
+        { "/webkit"_s, { "<script>alert('subframe alert')</script>"_s } },
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto [webView, navigationDelegate] = siteIsolatedViewAndDelegate(server);
+    RetainPtr protectedWebView = webView;
+
+    // Hold the subframe's alert open; its WebContent process is now blocked in synchronous IPC.
+    __block bool receivedSubframeAlert = false;
+    __block BlockPtr<void()> heldCompletion;
+    RetainPtr uiDelegate = adoptNS([TestUIDelegate new]);
+    uiDelegate.get().runJavaScriptAlertPanelWithMessage = ^(WKWebView *, NSString *message, WKFrameInfo *frameInfo, void (^completionHandler)(void)) {
+        EXPECT_WK_STREQ(message, "subframe alert");
+        EXPECT_WK_STREQ(frameInfo.securityOrigin.host, "webkit.org");
+        heldCompletion = makeBlockPtr(completionHandler);
+        receivedSubframeAlert = true;
+    };
+    webView.get().UIDelegate = uiDelegate.get();
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/example"]]];
+    TestWebKitAPI::Util::run(&receivedSubframeAlert);
+
+    // Read window.__heartbeat from the main frame. Bounded wait: if the main frame's process were
+    // blocked by the subframe's dialog, evaluateJavaScript would not respond and this reports
+    // didRespond == false (a clean failure) rather than hanging.
+    auto readHeartbeat = [&](bool& didRespond) -> int {
+        __block bool done = false;
+        __block int value = -1;
+        [protectedWebView evaluateJavaScript:@"window.__heartbeat" completionHandler:^(id result, NSError *error) {
+            if (!error && [result isKindOfClass:[NSNumber class]])
+                value = [result intValue];
+            done = true;
+        }];
+        for (unsigned attempt = 0; attempt < 100 && !done; ++attempt)
+            TestWebKitAPI::Util::runFor(Seconds(0.05));
+        didRespond = done;
+        return value;
+    };
+
+    bool firstResponded = false;
+    int firstHeartbeat = readHeartbeat(firstResponded);
+    EXPECT_TRUE(firstResponded);
+
+    // The main frame's timer must keep firing while the dialog is held.
+    int laterHeartbeat = firstHeartbeat;
+    for (unsigned attempt = 0; laterHeartbeat <= firstHeartbeat && attempt < 40; ++attempt) {
+        TestWebKitAPI::Util::runFor(Seconds(0.05));
+        bool responded = false;
+        laterHeartbeat = readHeartbeat(responded);
+        if (!responded) {
+            EXPECT_TRUE(responded);
+            break;
+        }
+    }
+    EXPECT_GT(laterHeartbeat, firstHeartbeat);
+
+    if (heldCompletion)
+        heldCompletion();
+}
+
 TEST(SiteIsolation, GrandchildIframe)
 {
     HTTPServer server({


### PR DESCRIPTION
#### 2d50d7a754c72cf9ef44a64254bcf2b4e9d3b22d
<pre>
Add tests verifying cross-origin iframe window.alert() behavior
<a href="https://rdar.apple.com/182962288">rdar://182962288</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=320028">https://bugs.webkit.org/show_bug.cgi?id=320028</a>

Reviewed by Alex Christensen.

JavaScript dialog APIs (i.e. window.alert(), etc) currently work well with site isolation on.
These tests verify they continue to work well.

One notable difference with site isolation is that a cross-origin iframe stuck in a JS dialog no longer
blocks the main frame. This is web compatible and suggested by the specs. And these tests also confirm
that behavior remains as expected.

* LayoutTests/http/tests/site-isolation/javascript-dialogs-in-cross-origin-iframe-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/javascript-dialogs-in-cross-origin-iframe.html: Added.
* LayoutTests/http/tests/site-isolation/resources/javascript-dialogs-iframe.html: Added.
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm:
(TestWebKitAPI::testCrossSiteIframeCanShowAlert):
(TestWebKitAPI::TEST(SiteIsolation, CrossSiteIframeCanShowAlertWithSiteIsolation)):
(TestWebKitAPI::TEST(SiteIsolation, CrossSiteIframeCanShowAlertWithoutSiteIsolation)):
(TestWebKitAPI::TEST(SiteIsolation, MainFrameHeartbeatContinuesWhileCrossSiteIframeDialogShown)):

Canonical link: <a href="https://commits.webkit.org/318073@main">https://commits.webkit.org/318073@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dbcf6ce1a6379214645a736204c83ebd744b04cc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177146 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51083 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44878 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186749 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140382 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ddbe5757-1228-4bb3-84d7-35a25a31155b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179009 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52376 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50769 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138027 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140382 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/13e41c0d-9a5e-4687-9982-7ae6b7e3255b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180102 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41532 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158789 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118494 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6c8cb369-418f-4fa2-a05c-b24136f75d6e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40188 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38562 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150598 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38288 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35217 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42796 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189175 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50750 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147112 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39555 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51433 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34912 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146906 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41637 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117941 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49938 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13268 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49337 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49574 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49398 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->