### PR TITLE
Implement WebTransport.exportKeyingMaterial

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/interfaces/webtransport.idl
+++ b/LayoutTests/imported/w3c/web-platform-tests/interfaces/webtransport.idl
@@ -27,7 +27,7 @@ interface WebTransport {
   constructor(USVString url, optional WebTransportOptions options = {});
 
   Promise<WebTransportConnectionStats> getStats();
-  [NewObject] Promise<ArrayBuffer> exportKeyingMaterial(BufferSource label, optional BufferSource context);
+  [NewObject] Promise<Uint8Array> exportKeyingMaterial(BufferSource label, BufferSource context, unsigned long outputLength);
   readonly attribute Promise<undefined> ready;
   readonly attribute WebTransportReliabilityMode reliability;
   readonly attribute WebTransportCongestionControl congestionControl;

--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/export-keying-material.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/export-keying-material.https.any-expected.txt
@@ -1,0 +1,10 @@
+
+PASS WebTransport exportKeyingMaterial returns keying material of the requested length
+PASS WebTransport exportKeyingMaterial honors the requested output length
+PASS WebTransport exportKeyingMaterial is deterministic for identical inputs
+PASS WebTransport exportKeyingMaterial returns different material for different labels
+PASS WebTransport exportKeyingMaterial returns different material for different contexts
+PASS WebTransport exportKeyingMaterial rejects out-of-range arguments with RangeError
+PASS WebTransport exportKeyingMaterial rejects with InvalidStateError after the session is closed
+PASS WebTransport exportKeyingMaterial rejects with InvalidStateError for a failed session
+

--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/export-keying-material.https.any.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/export-keying-material.https.any.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/export-keying-material.https.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/export-keying-material.https.any.js
@@ -1,0 +1,140 @@
+// META: global=window,worker
+// META: script=resources/webtransport-test-helpers.sub.js
+
+// Tests for WebTransport.exportKeyingMaterial(), which exports keying material
+// derived from the underlying TLS 1.3 connection (RFC 5705 style exporters).
+// https://www.w3.org/TR/webtransport/#dom-webtransport-exportkeyingmaterial
+
+const encoder = new TextEncoder();
+
+// exportKeyingMaterial() resolves with the derived bytes. Normalize the result
+// to a Uint8Array so the tests work whether an ArrayBuffer or a typed array
+// view is returned.
+function toBytes(result) {
+  return new Uint8Array(result);
+}
+
+function arraysEqual(a, b) {
+  if (a.length !== b.length)
+    return false;
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i])
+      return false;
+  }
+  return true;
+}
+
+promise_test(async t => {
+  const wt = new WebTransport(webtransport_url('echo.py'));
+  await wt.ready;
+  t.add_cleanup(() => wt.close());
+
+  const label = encoder.encode('EXPORTER-webtransport');
+  const context = encoder.encode('context');
+  const result = await wt.exportKeyingMaterial(label, context, 32);
+  assert_equals(result.byteLength, 32,
+      'result length should match the requested outputLength');
+}, 'WebTransport exportKeyingMaterial returns keying material of the requested length');
+
+promise_test(async t => {
+  const wt = new WebTransport(webtransport_url('echo.py'));
+  await wt.ready;
+  t.add_cleanup(() => wt.close());
+
+  const label = encoder.encode('EXPORTER-lengths');
+  const context = encoder.encode('context');
+  for (const length of [1, 16, 64, 4096]) {
+    const result = await wt.exportKeyingMaterial(label, context, length);
+    assert_equals(result.byteLength, length,
+        `result length should be ${length}`);
+  }
+}, 'WebTransport exportKeyingMaterial honors the requested output length');
+
+promise_test(async t => {
+  const wt = new WebTransport(webtransport_url('echo.py'));
+  await wt.ready;
+  t.add_cleanup(() => wt.close());
+
+  const label = encoder.encode('EXPORTER-determinism');
+  const context = encoder.encode('context');
+  const first = toBytes(await wt.exportKeyingMaterial(label, context, 32));
+  const second = toBytes(await wt.exportKeyingMaterial(label, context, 32));
+  assert_array_equals(second, first,
+      'identical label, context, and length should produce identical output');
+}, 'WebTransport exportKeyingMaterial is deterministic for identical inputs');
+
+promise_test(async t => {
+  const wt = new WebTransport(webtransport_url('echo.py'));
+  await wt.ready;
+  t.add_cleanup(() => wt.close());
+
+  const context = encoder.encode('context');
+  const a = toBytes(await wt.exportKeyingMaterial(
+      encoder.encode('EXPORTER-label-a'), context, 32));
+  const b = toBytes(await wt.exportKeyingMaterial(
+      encoder.encode('EXPORTER-label-b'), context, 32));
+  assert_false(arraysEqual(a, b),
+      'different labels should produce different keying material');
+}, 'WebTransport exportKeyingMaterial returns different material for different labels');
+
+promise_test(async t => {
+  const wt = new WebTransport(webtransport_url('echo.py'));
+  await wt.ready;
+  t.add_cleanup(() => wt.close());
+
+  const label = encoder.encode('EXPORTER-context');
+  const a = toBytes(await wt.exportKeyingMaterial(
+      label, encoder.encode('context-a'), 32));
+  const b = toBytes(await wt.exportKeyingMaterial(
+      label, encoder.encode('context-b'), 32));
+  assert_false(arraysEqual(a, b),
+      'different contexts should produce different keying material');
+}, 'WebTransport exportKeyingMaterial returns different material for different contexts');
+
+promise_test(async t => {
+  const wt = new WebTransport(webtransport_url('echo.py'));
+  await wt.ready;
+  t.add_cleanup(() => wt.close());
+
+  const label = encoder.encode('EXPORTER-range');
+  const context = encoder.encode('context');
+
+  // A label longer than 255 bytes is out of range.
+  await promise_rejects_js(t, RangeError,
+      wt.exportKeyingMaterial(new Uint8Array(256), context, 32),
+      'label longer than 255 bytes');
+  // A context longer than 255 bytes is out of range.
+  await promise_rejects_js(t, RangeError,
+      wt.exportKeyingMaterial(label, new Uint8Array(256), 32),
+      'context longer than 255 bytes');
+  // An outputLength of 0 is out of range.
+  await promise_rejects_js(t, RangeError,
+      wt.exportKeyingMaterial(label, context, 0),
+      'outputLength of 0');
+  // An outputLength greater than 4096 is out of range.
+  await promise_rejects_js(t, RangeError,
+      wt.exportKeyingMaterial(label, context, 4097),
+      'outputLength greater than 4096');
+}, 'WebTransport exportKeyingMaterial rejects out-of-range arguments with RangeError');
+
+promise_test(async t => {
+  const wt = new WebTransport(webtransport_url('echo.py'));
+  await wt.ready;
+  wt.close();
+  await wt.closed;
+
+  await promise_rejects_dom(t, 'InvalidStateError',
+      wt.exportKeyingMaterial(
+          encoder.encode('EXPORTER-closed'), encoder.encode('context'), 32));
+}, 'WebTransport exportKeyingMaterial rejects with InvalidStateError after the session is closed');
+
+promise_test(async t => {
+  const wt = new WebTransport('https://webtransport.invalid/');
+  wt.closed.catch(() => {});
+  // Wait for the connection to fail before exporting keying material.
+  await wt.ready.catch(() => {});
+
+  await promise_rejects_dom(t, 'InvalidStateError',
+      wt.exportKeyingMaterial(
+          encoder.encode('EXPORTER-failed'), encoder.encode('context'), 32));
+}, 'WebTransport exportKeyingMaterial rejects with InvalidStateError for a failed session');

--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/export-keying-material.https.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/export-keying-material.https.any.serviceworker-expected.txt
@@ -1,0 +1,10 @@
+
+PASS WebTransport exportKeyingMaterial returns keying material of the requested length
+PASS WebTransport exportKeyingMaterial honors the requested output length
+PASS WebTransport exportKeyingMaterial is deterministic for identical inputs
+PASS WebTransport exportKeyingMaterial returns different material for different labels
+PASS WebTransport exportKeyingMaterial returns different material for different contexts
+PASS WebTransport exportKeyingMaterial rejects out-of-range arguments with RangeError
+PASS WebTransport exportKeyingMaterial rejects with InvalidStateError after the session is closed
+PASS WebTransport exportKeyingMaterial rejects with InvalidStateError for a failed session
+

--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/export-keying-material.https.any.serviceworker.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/export-keying-material.https.any.serviceworker.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/export-keying-material.https.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/export-keying-material.https.any.sharedworker-expected.txt
@@ -1,0 +1,10 @@
+
+PASS WebTransport exportKeyingMaterial returns keying material of the requested length
+PASS WebTransport exportKeyingMaterial honors the requested output length
+PASS WebTransport exportKeyingMaterial is deterministic for identical inputs
+PASS WebTransport exportKeyingMaterial returns different material for different labels
+PASS WebTransport exportKeyingMaterial returns different material for different contexts
+PASS WebTransport exportKeyingMaterial rejects out-of-range arguments with RangeError
+PASS WebTransport exportKeyingMaterial rejects with InvalidStateError after the session is closed
+PASS WebTransport exportKeyingMaterial rejects with InvalidStateError for a failed session
+

--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/export-keying-material.https.any.sharedworker.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/export-keying-material.https.any.sharedworker.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/export-keying-material.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/export-keying-material.https.any.worker-expected.txt
@@ -1,0 +1,10 @@
+
+PASS WebTransport exportKeyingMaterial returns keying material of the requested length
+PASS WebTransport exportKeyingMaterial honors the requested output length
+PASS WebTransport exportKeyingMaterial is deterministic for identical inputs
+PASS WebTransport exportKeyingMaterial returns different material for different labels
+PASS WebTransport exportKeyingMaterial returns different material for different contexts
+PASS WebTransport exportKeyingMaterial rejects out-of-range arguments with RangeError
+PASS WebTransport exportKeyingMaterial rejects with InvalidStateError after the session is closed
+PASS WebTransport exportKeyingMaterial rejects with InvalidStateError for a failed session
+

--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/export-keying-material.https.any.worker.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/export-keying-material.https.any.worker.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/idlharness.https.sub.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/idlharness.https.sub.any-expected.txt
@@ -29,7 +29,7 @@ PASS WebTransport interface: existence and properties of interface prototype obj
 PASS WebTransport interface: existence and properties of interface prototype object's "constructor" property
 PASS WebTransport interface: existence and properties of interface prototype object's @@unscopables property
 PASS WebTransport interface: operation getStats()
-PASS WebTransport interface: operation exportKeyingMaterial(BufferSource, optional BufferSource)
+PASS WebTransport interface: operation exportKeyingMaterial(BufferSource, BufferSource, unsigned long)
 PASS WebTransport interface: attribute ready
 PASS WebTransport interface: attribute reliability
 PASS WebTransport interface: attribute congestionControl
@@ -49,8 +49,8 @@ PASS WebTransport interface: attribute supportsReliableOnly
 PASS WebTransport must be primary interface of webTransport
 PASS Stringification of webTransport
 PASS WebTransport interface: webTransport must inherit property "getStats()" with the proper type
-PASS WebTransport interface: webTransport must inherit property "exportKeyingMaterial(BufferSource, optional BufferSource)" with the proper type
-PASS WebTransport interface: calling exportKeyingMaterial(BufferSource, optional BufferSource) on webTransport with too few arguments must throw TypeError
+PASS WebTransport interface: webTransport must inherit property "exportKeyingMaterial(BufferSource, BufferSource, unsigned long)" with the proper type
+PASS WebTransport interface: calling exportKeyingMaterial(BufferSource, BufferSource, unsigned long) on webTransport with too few arguments must throw TypeError
 PASS WebTransport interface: webTransport must inherit property "ready" with the proper type
 PASS WebTransport interface: webTransport must inherit property "reliability" with the proper type
 PASS WebTransport interface: webTransport must inherit property "congestionControl" with the proper type

--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/idlharness.https.sub.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/idlharness.https.sub.any.serviceworker-expected.txt
@@ -29,7 +29,7 @@ PASS WebTransport interface: existence and properties of interface prototype obj
 PASS WebTransport interface: existence and properties of interface prototype object's "constructor" property
 PASS WebTransport interface: existence and properties of interface prototype object's @@unscopables property
 PASS WebTransport interface: operation getStats()
-PASS WebTransport interface: operation exportKeyingMaterial(BufferSource, optional BufferSource)
+PASS WebTransport interface: operation exportKeyingMaterial(BufferSource, BufferSource, unsigned long)
 PASS WebTransport interface: attribute ready
 PASS WebTransport interface: attribute reliability
 PASS WebTransport interface: attribute congestionControl
@@ -49,8 +49,8 @@ PASS WebTransport interface: attribute supportsReliableOnly
 PASS WebTransport must be primary interface of webTransport
 PASS Stringification of webTransport
 PASS WebTransport interface: webTransport must inherit property "getStats()" with the proper type
-PASS WebTransport interface: webTransport must inherit property "exportKeyingMaterial(BufferSource, optional BufferSource)" with the proper type
-PASS WebTransport interface: calling exportKeyingMaterial(BufferSource, optional BufferSource) on webTransport with too few arguments must throw TypeError
+PASS WebTransport interface: webTransport must inherit property "exportKeyingMaterial(BufferSource, BufferSource, unsigned long)" with the proper type
+PASS WebTransport interface: calling exportKeyingMaterial(BufferSource, BufferSource, unsigned long) on webTransport with too few arguments must throw TypeError
 PASS WebTransport interface: webTransport must inherit property "ready" with the proper type
 PASS WebTransport interface: webTransport must inherit property "reliability" with the proper type
 PASS WebTransport interface: webTransport must inherit property "congestionControl" with the proper type

--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/idlharness.https.sub.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/idlharness.https.sub.any.sharedworker-expected.txt
@@ -29,7 +29,7 @@ PASS WebTransport interface: existence and properties of interface prototype obj
 PASS WebTransport interface: existence and properties of interface prototype object's "constructor" property
 PASS WebTransport interface: existence and properties of interface prototype object's @@unscopables property
 PASS WebTransport interface: operation getStats()
-PASS WebTransport interface: operation exportKeyingMaterial(BufferSource, optional BufferSource)
+PASS WebTransport interface: operation exportKeyingMaterial(BufferSource, BufferSource, unsigned long)
 PASS WebTransport interface: attribute ready
 PASS WebTransport interface: attribute reliability
 PASS WebTransport interface: attribute congestionControl
@@ -49,8 +49,8 @@ PASS WebTransport interface: attribute supportsReliableOnly
 PASS WebTransport must be primary interface of webTransport
 PASS Stringification of webTransport
 PASS WebTransport interface: webTransport must inherit property "getStats()" with the proper type
-PASS WebTransport interface: webTransport must inherit property "exportKeyingMaterial(BufferSource, optional BufferSource)" with the proper type
-PASS WebTransport interface: calling exportKeyingMaterial(BufferSource, optional BufferSource) on webTransport with too few arguments must throw TypeError
+PASS WebTransport interface: webTransport must inherit property "exportKeyingMaterial(BufferSource, BufferSource, unsigned long)" with the proper type
+PASS WebTransport interface: calling exportKeyingMaterial(BufferSource, BufferSource, unsigned long) on webTransport with too few arguments must throw TypeError
 PASS WebTransport interface: webTransport must inherit property "ready" with the proper type
 PASS WebTransport interface: webTransport must inherit property "reliability" with the proper type
 PASS WebTransport interface: webTransport must inherit property "congestionControl" with the proper type

--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/idlharness.https.sub.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/idlharness.https.sub.any.worker-expected.txt
@@ -29,7 +29,7 @@ PASS WebTransport interface: existence and properties of interface prototype obj
 PASS WebTransport interface: existence and properties of interface prototype object's "constructor" property
 PASS WebTransport interface: existence and properties of interface prototype object's @@unscopables property
 PASS WebTransport interface: operation getStats()
-PASS WebTransport interface: operation exportKeyingMaterial(BufferSource, optional BufferSource)
+PASS WebTransport interface: operation exportKeyingMaterial(BufferSource, BufferSource, unsigned long)
 PASS WebTransport interface: attribute ready
 PASS WebTransport interface: attribute reliability
 PASS WebTransport interface: attribute congestionControl
@@ -49,8 +49,8 @@ PASS WebTransport interface: attribute supportsReliableOnly
 PASS WebTransport must be primary interface of webTransport
 PASS Stringification of webTransport
 PASS WebTransport interface: webTransport must inherit property "getStats()" with the proper type
-PASS WebTransport interface: webTransport must inherit property "exportKeyingMaterial(BufferSource, optional BufferSource)" with the proper type
-PASS WebTransport interface: calling exportKeyingMaterial(BufferSource, optional BufferSource) on webTransport with too few arguments must throw TypeError
+PASS WebTransport interface: webTransport must inherit property "exportKeyingMaterial(BufferSource, BufferSource, unsigned long)" with the proper type
+PASS WebTransport interface: calling exportKeyingMaterial(BufferSource, BufferSource, unsigned long) on webTransport with too few arguments must throw TypeError
 PASS WebTransport interface: webTransport must inherit property "ready" with the proper type
 PASS WebTransport interface: webTransport must inherit property "reliability" with the proper type
 PASS WebTransport interface: webTransport must inherit property "congestionControl" with the proper type

--- a/Source/WebCore/Modules/webtransport/WebTransport.cpp
+++ b/Source/WebCore/Modules/webtransport/WebTransport.cpp
@@ -381,10 +381,33 @@ void WebTransport::getStats(ScriptExecutionContext& context, Ref<DeferredPromise
     });
 }
 
-void WebTransport::exportKeyingMaterial(BufferSource&&, std::optional<BufferSource>&&, Ref<DeferredPromise>&& promise)
+void WebTransport::exportKeyingMaterial(ScriptExecutionContext& scriptExecutionContext, BufferSource&& label, BufferSource&& context, uint32_t outputLength, Ref<DeferredPromise>&& promise)
 {
-    // FIXME: Implement once libnetcore exposes a keying-material export SPI (rdar://167646346).
-    promise->reject(ExceptionCode::NotSupportedError);
+    // https://www.w3.org/TR/webtransport/#dom-webtransport-exportkeyingmaterial
+    size_t labelLength = label.byteLength();
+    if (labelLength > 255)
+        return promise->reject(ExceptionCode::RangeError);
+
+    size_t contextLength = context.byteLength();
+    if (contextLength > 255)
+        return promise->reject(ExceptionCode::RangeError);
+
+    if (!outputLength || outputLength > 4096)
+        return promise->reject(ExceptionCode::RangeError);
+
+    if (m_state == State::Closed || m_state == State::Failed)
+        return promise->reject(ExceptionCode::InvalidStateError);
+
+    RefPtr session = m_session;
+    if (!session)
+        return promise->reject(ExceptionCode::InvalidStateError);
+
+    scriptExecutionContext.enqueueTaskWhenSettled(session->exportKeyingMaterial(label.span(), context.span(), outputLength), WebCore::TaskSource::Networking, [promise = WTF::move(promise)] (auto&& keyingMaterial) mutable {
+        if (keyingMaterial)
+            fulfillPromiseWithUint8ArrayFromSpan(WTF::move(promise), keyingMaterial->span());
+        else
+            promise->reject(ExceptionCode::InvalidStateError);
+    });
 }
 
 DOMPromise& WebTransport::ready()

--- a/Source/WebCore/Modules/webtransport/WebTransport.h
+++ b/Source/WebCore/Modules/webtransport/WebTransport.h
@@ -82,7 +82,7 @@ public:
     void deref() const final { WebTransportSessionClient::deref(); }
 
     void getStats(ScriptExecutionContext&, Ref<DeferredPromise>&&);
-    void exportKeyingMaterial(BufferSource&& label, std::optional<BufferSource>&& context, Ref<DeferredPromise>&&);
+    void exportKeyingMaterial(ScriptExecutionContext&, BufferSource&& label, BufferSource&& context, uint32_t outputLength, Ref<DeferredPromise>&&);
     DOMPromise& NODELETE ready();
     WebTransportReliabilityMode NODELETE reliability();
     WebTransportCongestionControl NODELETE congestionControl();

--- a/Source/WebCore/Modules/webtransport/WebTransport.idl
+++ b/Source/WebCore/Modules/webtransport/WebTransport.idl
@@ -32,7 +32,7 @@
     [CallWith=CurrentScriptExecutionContext] constructor(USVString url, optional WebTransportOptions options = {});
 
     [CallWith=CurrentScriptExecutionContext] Promise<WebTransportConnectionStats> getStats();
-    Promise<ArrayBuffer> exportKeyingMaterial(BufferSource label, optional BufferSource context);
+    [CallWith=CurrentScriptExecutionContext] Promise<Uint8Array> exportKeyingMaterial(BufferSource label, BufferSource context, unsigned long outputLength);
     readonly attribute Promise<undefined> ready;
     readonly attribute WebTransportReliabilityMode reliability;
     readonly attribute WebTransportCongestionControl congestionControl;

--- a/Source/WebCore/Modules/webtransport/WebTransportSession.h
+++ b/Source/WebCore/Modules/webtransport/WebTransportSession.h
@@ -52,6 +52,7 @@ using WebTransportSendPromise = NativePromise<std::optional<Exception>, void>;
 using WebTransportConnectionStatsPromise = NativePromise<WebTransportConnectionStats, void>;
 using WebTransportSendStreamStatsPromise = NativePromise<WebTransportSendStreamStats, void>;
 using WebTransportReceiveStreamStatsPromise = NativePromise<WebTransportReceiveStreamStats, void>;
+using WebTransportExportKeyingMaterialPromise = NativePromise<Vector<uint8_t>, void>;
 
 using WebTransportSessionErrorCode = uint32_t;
 using WebTransportStreamErrorCode = uint64_t;
@@ -68,6 +69,7 @@ public:
     virtual Ref<WebTransportSendStreamStatsPromise> getSendStreamStats(WebTransportStreamIdentifier) = 0;
     virtual Ref<WebTransportReceiveStreamStatsPromise> getReceiveStreamStats(WebTransportStreamIdentifier) = 0;
     virtual Ref<WebTransportSendStreamStatsPromise> getSendGroupStats(WebTransportSendGroupIdentifier) = 0;
+    virtual Ref<WebTransportExportKeyingMaterialPromise> exportKeyingMaterial(std::span<const uint8_t>, std::span<const uint8_t>, uint32_t) = 0;
 
     virtual void cancelReceiveStream(WebTransportStreamIdentifier, std::optional<WebTransportStreamErrorCode>) = 0;
     virtual void cancelSendStream(WebTransportStreamIdentifier, std::optional<WebTransportStreamErrorCode>) = 0;

--- a/Source/WebCore/Modules/webtransport/WorkerWebTransportSession.cpp
+++ b/Source/WebCore/Modules/webtransport/WorkerWebTransportSession.cpp
@@ -216,6 +216,15 @@ Ref<WebTransportSendStreamStatsPromise> WorkerWebTransportSession::getSendGroupS
     return WebTransportSendStreamStatsPromise::createAndReject();
 }
 
+Ref<WebTransportExportKeyingMaterialPromise> WorkerWebTransportSession::exportKeyingMaterial(std::span<const uint8_t> label, std::span<const uint8_t> context, uint32_t outputLength)
+{
+    ASSERT(!RunLoop::isMain());
+    if (RefPtr session = m_session)
+        return session->exportKeyingMaterial(label, context, outputLength);
+    ASSERT_NOT_REACHED_WITH_MESSAGE("Session should be set up before use then never removed.");
+    return WebTransportExportKeyingMaterialPromise::createAndReject();
+}
+
 void WorkerWebTransportSession::terminate(WebTransportSessionErrorCode code, CString&& reason)
 {
     ASSERT(!RunLoop::isMain());

--- a/Source/WebCore/Modules/webtransport/WorkerWebTransportSession.h
+++ b/Source/WebCore/Modules/webtransport/WorkerWebTransportSession.h
@@ -62,6 +62,7 @@ private:
     Ref<WebTransportSendStreamStatsPromise> getSendStreamStats(WebTransportStreamIdentifier) final;
     Ref<WebTransportReceiveStreamStatsPromise> getReceiveStreamStats(WebTransportStreamIdentifier) final;
     Ref<WebTransportSendStreamStatsPromise> getSendGroupStats(WebTransportSendGroupIdentifier) final;
+    Ref<WebTransportExportKeyingMaterialPromise> exportKeyingMaterial(std::span<const uint8_t>, std::span<const uint8_t>, uint32_t) final;
 
     void cancelReceiveStream(WebTransportStreamIdentifier, std::optional<WebTransportStreamErrorCode>) final;
     void cancelSendStream(WebTransportStreamIdentifier, std::optional<WebTransportStreamErrorCode>) final;

--- a/Source/WebCore/PAL/pal/spi/cocoa/NetworkSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/NetworkSPI.h
@@ -147,6 +147,7 @@ void nw_connection_abort_writes(nw_connection_t, uint64_t);
 
 
 void nw_http_fields_access_value_by_name(nw_http_fields_t, const char*, NW_NOESCAPE nw_http_optional_string_accessor_t);
+sec_protocol_metadata_t nw_webtransport_metadata_copy_sec_protocol_metadata(nw_protocol_metadata_t);
 
 WTF_EXTERN_C_END
 

--- a/Source/WebKit/Configurations/AllowedSPI.toml
+++ b/Source/WebKit/Configurations/AllowedSPI.toml
@@ -108,6 +108,7 @@ symbols = [
     "nw_webtransport_metadata_set_remote_receive_error_handler",
     "nw_webtransport_metadata_set_remote_send_error_handler",
     "nw_webtransport_metadata_copy_connect_response",
+    "nw_webtransport_metadata_copy_sec_protocol_metadata",
     "nw_webtransport_metadata_get_transport_mode",
     "nw_webtransport_options_add_connect_request_header",
     "nw_webtransport_options_set_allow_joining_before_ready",

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkSoftLink.h
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkSoftLink.h
@@ -88,6 +88,8 @@ SOFT_LINK_FUNCTION_MAY_FAIL_FOR_HEADER(WebKit, Network, nw_connection_abort_writ
 
 SOFT_LINK_FUNCTION_MAY_FAIL_FOR_HEADER(WebKit, Network, nw_http_fields_access_value_by_name, void, (nw_http_fields_t fields, const char* name, NW_NOESCAPE nw_http_optional_string_accessor_t accessor), (fields, name, accessor))
 
+SOFT_LINK_FUNCTION_MAY_FAIL_FOR_HEADER(WebKit, Network, nw_webtransport_metadata_copy_sec_protocol_metadata, sec_protocol_metadata_t, (nw_protocol_metadata_t metadata), (metadata));
+
 #if HAVE(NWSETTINGS_UNIFIED_HTTP_WEBKIT)
 
 SOFT_LINK_FUNCTION_MAY_FAIL_FOR_HEADER(WebKit, Network, nw_settings_get_unified_http_enabled_webkit, bool, (), ())

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkSoftLink.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkSoftLink.mm
@@ -80,6 +80,8 @@ SOFT_LINK_FUNCTION_MAY_FAIL_FOR_SOURCE(WebKit, Network, nw_connection_abort_writ
 
 SOFT_LINK_FUNCTION_MAY_FAIL_FOR_SOURCE(WebKit, Network, nw_http_fields_access_value_by_name, void, (nw_http_fields_t fields, const char* name, NS_NOESCAPE nw_http_optional_string_accessor_t accessor), (fields, name, accessor))
 
+SOFT_LINK_FUNCTION_MAY_FAIL_FOR_SOURCE(WebKit, Network, nw_webtransport_metadata_copy_sec_protocol_metadata, sec_protocol_metadata_t, (nw_protocol_metadata_t metadata), (metadata));
+
 #if HAVE(NWSETTINGS_UNIFIED_HTTP_WEBKIT)
 
 SOFT_LINK_FUNCTION_MAY_FAIL_FOR_SOURCE(WebKit, Network, nw_settings_get_unified_http_enabled_webkit, bool, (), ())

--- a/Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.cpp
+++ b/Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.cpp
@@ -272,6 +272,11 @@ bool NetworkTransportSession::isSessionClosed() const
 {
     return false;
 }
+
+void NetworkTransportSession::exportKeyingMaterial(std::span<const uint8_t>, std::span<const uint8_t>, uint32_t, CompletionHandler<void(std::optional<Vector<uint8_t>>)>&& completionHandler)
+{
+    completionHandler(std::nullopt);
+}
 #endif
 
 }

--- a/Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.h
+++ b/Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.h
@@ -84,6 +84,7 @@ public:
     void getSendStreamStats(WebCore::WebTransportStreamIdentifier, CompletionHandler<void(std::optional<WebCore::WebTransportSendStreamStats>&&)>&&);
     void getReceiveStreamStats(WebCore::WebTransportStreamIdentifier, CompletionHandler<void(std::optional<WebCore::WebTransportReceiveStreamStats>&&)>&&);
     void getSendGroupStats(WebCore::WebTransportSendGroupIdentifier, CompletionHandler<void(std::optional<WebCore::WebTransportSendStreamStats>&&)>&&);
+    void exportKeyingMaterial(std::span<const uint8_t> label, std::span<const uint8_t> context, uint32_t outputLength, CompletionHandler<void(std::optional<Vector<uint8_t>>)>&&);
     void destroyOutgoingUnidirectionalStream(WebCore::WebTransportStreamIdentifier);
     void destroyBidirectionalStream(WebCore::WebTransportStreamIdentifier);
     void streamSendBytes(WebCore::WebTransportStreamIdentifier, std::span<const uint8_t>, bool withFin, CompletionHandler<void(std::optional<WebCore::Exception>&&)>&&);
@@ -107,10 +108,20 @@ public:
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
     std::optional<SharedPreferencesForWebProcess> NODELETE sharedPreferencesForWebProcess() const;
     bool isSessionClosed() const;
+#if PLATFORM(COCOA)
+    class SecurityProtocolMetadata : public RefCounted<SecurityProtocolMetadata> {
+    public:
+        static RefPtr<SecurityProtocolMetadata> create() { return adoptRef(new SecurityProtocolMetadata()); }
+        void receivedMetadata(sec_protocol_metadata_t metadata) { m_metadata = metadata; }
+        sec_protocol_metadata_t metadata() const { return m_metadata.get(); }
+    private:
+        RetainPtr<sec_protocol_metadata_t> m_metadata;
+    };
+#endif
 private:
 #if PLATFORM(COCOA)
-    static Ref<NetworkTransportSession> create(NetworkConnectionToWebProcess&, WebTransportSessionIdentifier, WebCore::WebTransportOptions&&, nw_connection_group_t, nw_endpoint_t);
-    NetworkTransportSession(NetworkConnectionToWebProcess&, WebTransportSessionIdentifier, WebCore::WebTransportOptions&&, nw_connection_group_t, nw_endpoint_t);
+    static Ref<NetworkTransportSession> create(NetworkConnectionToWebProcess&, WebTransportSessionIdentifier, WebCore::WebTransportOptions&&, nw_connection_group_t, nw_endpoint_t, RefPtr<SecurityProtocolMetadata>&&);
+    NetworkTransportSession(NetworkConnectionToWebProcess&, WebTransportSessionIdentifier, WebCore::WebTransportOptions&&, nw_connection_group_t, nw_endpoint_t, RefPtr<SecurityProtocolMetadata>&&);
 #else
     NetworkTransportSession();
 #endif
@@ -143,6 +154,7 @@ private:
 #if PLATFORM(COCOA)
     const RetainPtr<nw_connection_group_t> m_connectionGroup;
     const RetainPtr<nw_endpoint_t> m_endpoint;
+    const RefPtr<SecurityProtocolMetadata> m_securityProtocolMetadata;
     RetainPtr<nw_connection_t> m_datagramConnection;
     RetainPtr<nw_protocol_metadata_t> m_sessionMetadata;
 #endif

--- a/Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.messages.in
+++ b/Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.messages.in
@@ -33,6 +33,7 @@ messages -> NetworkTransportSession {
     GetSendStreamStats(WebCore::WebTransportStreamIdentifier identifier) -> (struct std::optional<WebCore::WebTransportSendStreamStats> stats)
     GetReceiveStreamStats(WebCore::WebTransportStreamIdentifier identifier) -> (struct std::optional<WebCore::WebTransportReceiveStreamStats> stats)
     GetSendGroupStats(WebCore::WebTransportSendGroupIdentifier identifier) -> (struct std::optional<WebCore::WebTransportSendStreamStats> stats)
+    ExportKeyingMaterial(std::span<const uint8_t> label, std::span<const uint8_t> context, uint32_t outputLength) -> (std::optional<Vector<uint8_t>> keyingMaterial)
     StreamSendBytes(WebCore::WebTransportStreamIdentifier identifier, std::span<const uint8_t> bytes, bool withFin) -> (std::optional<WebCore::Exception> exception)
     CancelReceiveStream(WebCore::WebTransportStreamIdentifier identifier, std::optional<uint64_t> errorCode)
     CancelSendStream(WebCore::WebTransportStreamIdentifier identifier, std::optional<uint64_t> errorCode)

--- a/Source/WebKit/NetworkProcess/webtransport/cocoa/NetworkTransportSessionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/webtransport/cocoa/NetworkTransportSessionCocoa.mm
@@ -56,17 +56,18 @@
 
 namespace WebKit {
 
-Ref<NetworkTransportSession> NetworkTransportSession::create(NetworkConnectionToWebProcess& connection, WebTransportSessionIdentifier identifier, WebCore::WebTransportOptions&& options, nw_connection_group_t group, nw_endpoint_t endpoint)
+Ref<NetworkTransportSession> NetworkTransportSession::create(NetworkConnectionToWebProcess& connection, WebTransportSessionIdentifier identifier, WebCore::WebTransportOptions&& options, nw_connection_group_t group, nw_endpoint_t endpoint, RefPtr<SecurityProtocolMetadata>&& metadata)
 {
-    return adoptRef(*new NetworkTransportSession(connection, identifier, WTF::move(options), group, endpoint));
+    return adoptRef(*new NetworkTransportSession(connection, identifier, WTF::move(options), group, endpoint, WTF::move(metadata)));
 }
 
-NetworkTransportSession::NetworkTransportSession(NetworkConnectionToWebProcess& connection, WebTransportSessionIdentifier identifier, WebCore::WebTransportOptions&& options, nw_connection_group_t connectionGroup, nw_endpoint_t endpoint)
+NetworkTransportSession::NetworkTransportSession(NetworkConnectionToWebProcess& connection, WebTransportSessionIdentifier identifier, WebCore::WebTransportOptions&& options, nw_connection_group_t connectionGroup, nw_endpoint_t endpoint, RefPtr<SecurityProtocolMetadata>&& metadata)
     : m_connectionToWebProcess(connection)
     , m_identifier(identifier)
     , m_options(WTF::move(options))
     , m_connectionGroup(connectionGroup)
     , m_endpoint(endpoint)
+    , m_securityProtocolMetadata(WTF::move(metadata))
 {
     setupConnectionHandler();
 }
@@ -194,7 +195,7 @@ static String joinProtocolStrings(const Vector<String>& protocols)
     return builder.toString();
 }
 
-static RetainPtr<nw_parameters_t> createParameters(NetworkConnectionToWebProcess& connectionToWebProcess, URL&& url, WebCore::WebTransportOptions& options, WebKit::WebPageProxyIdentifier&& pageID, WebCore::ClientOrigin&& clientOrigin)
+static RetainPtr<nw_parameters_t> createParameters(NetworkConnectionToWebProcess& connectionToWebProcess, URL&& url, WebCore::WebTransportOptions& options, WebKit::WebPageProxyIdentifier&& pageID, WebCore::ClientOrigin&& clientOrigin, RefPtr<NetworkTransportSession::SecurityProtocolMetadata> securityMetadata)
 {
     // https://www.w3.org/TR/webtransport/#web-transport-configuration
     auto configureWebTransport = [
@@ -219,6 +220,7 @@ static RetainPtr<nw_parameters_t> createParameters(NetworkConnectionToWebProcess
         url = WTF::move(url),
         pageID = WTF::move(pageID),
         hashes = std::exchange(options.serverCertificateHashes, { }),
+        securityMetadata = WTF::move(securityMetadata),
         clientOrigin = WTF::move(clientOrigin)
     ](nw_protocol_options_t options) mutable {
         RetainPtr securityOptions = adoptNS(nw_tls_copy_sec_protocol_options(options));
@@ -232,8 +234,11 @@ static RetainPtr<nw_parameters_t> createParameters(NetworkConnectionToWebProcess
             url,
             pageID,
             hashes,
+            securityMetadata,
             clientOrigin
         ] (sec_protocol_metadata_t metadata, sec_trust_t trust, sec_protocol_verify_complete_t completion) mutable {
+            if (securityMetadata)
+                securityMetadata->receivedMetadata(metadata);
             RefPtr connectionToWebProcess = weakConnection.get();
             if (!connectionToWebProcess) {
                 completion(false);
@@ -268,7 +273,10 @@ RefPtr<NetworkTransportSession> NetworkTransportSession::create(NetworkConnectio
         return nullptr;
     }
 
-    RetainPtr parameters = createParameters(connectionToWebProcess, WTF::move(url), options, WTF::move(pageID), WTF::move(clientOrigin));
+    // FIXME: Remove SecurityProtocolMetadata once we no longer support platforms without nw_webtransport_metadata_copy_sec_protocol_metadata.
+    RefPtr metadata = canLoad_Network_nw_webtransport_metadata_copy_sec_protocol_metadata() ? nullptr : SecurityProtocolMetadata::create();
+
+    RetainPtr parameters = createParameters(connectionToWebProcess, WTF::move(url), options, WTF::move(pageID), WTF::move(clientOrigin), metadata);
     if (!parameters) {
         ASSERT_NOT_REACHED();
         return nullptr;
@@ -286,7 +294,7 @@ RefPtr<NetworkTransportSession> NetworkTransportSession::create(NetworkConnectio
         return nullptr;
     }
 
-    return NetworkTransportSession::create(connectionToWebProcess, identifier, WTF::move(options), connectionGroup.get(), endpoint.get());
+    return NetworkTransportSession::create(connectionToWebProcess, identifier, WTF::move(options), connectionGroup.get(), endpoint.get(), WTF::move(metadata));
 }
 
 void NetworkTransportSession::initialize(CompletionHandler<void(std::optional<WebCore::WebTransportConnectionInfo>&&)>&& completionHandler)
@@ -590,4 +598,31 @@ bool NetworkTransportSession::isSessionClosed() const
         return softLink_Network_nw_webtransport_metadata_get_session_closed(m_sessionMetadata.get());
     return false;
 }
+
+void NetworkTransportSession::exportKeyingMaterial(std::span<const uint8_t> label, std::span<const uint8_t> context, uint32_t outputLength, CompletionHandler<void(std::optional<Vector<uint8_t>>)>&& completionHandler)
+{
+    if (!m_sessionMetadata)
+        return completionHandler(std::nullopt);
+
+    RetainPtr securityMetadata = canLoad_Network_nw_webtransport_metadata_copy_sec_protocol_metadata() ? adoptNS(softLink_Network_nw_webtransport_metadata_copy_sec_protocol_metadata(m_sessionMetadata.get())) : RetainPtr { m_securityProtocolMetadata->metadata() };
+    if (!securityMetadata)
+        return completionHandler(std::nullopt);
+    RetainPtr data = adoptNS(sec_protocol_metadata_create_secret_with_context(securityMetadata.get(), label.size(), reinterpret_cast<const char*>(label.data()), context.size(), context.data(), outputLength));
+    if (!data)
+        return completionHandler(std::nullopt);
+
+    // FIXME: This is something that should probably be in WTF, and it's duplicate code.
+    auto vectorFromData = [](dispatch_data_t content) {
+        Vector<uint8_t> request;
+        if (content) {
+            dispatch_data_apply_span(content, [&](std::span<const uint8_t> buffer) {
+                request.append(buffer);
+                return true;
+            });
+        }
+        return request;
+    };
+    completionHandler(vectorFromData(data.get()));
+}
+
 }

--- a/Source/WebKit/Scripts/webkit/opaque_ipc_types.tracking.in
+++ b/Source/WebKit/Scripts/webkit/opaque_ipc_types.tracking.in
@@ -559,3 +559,7 @@
 [Legacy] StructureParam WebCore::CertificateInfo.certificateChain() Vector<Vector<uint8_t>>
 [Legacy] MessageParam RiceBackend.SendData data WebCore::SharedMemory::Handle
 [Legacy] MessageParam RiceBackendProxy.NotifyIncomingData data WebCore::SharedMemory::Handle
+
+[NeedsReview] MessageParam NetworkTransportSession.ExportKeyingMaterial label std::span<const uint8_t>
+[NeedsReview] MessageParam NetworkTransportSession.ExportKeyingMaterial context std::span<const uint8_t>
+[NeedsReview] MessageParamReply NetworkTransportSession.ExportKeyingMaterial keyingMaterial std::optional<Vector<uint8_t>>

--- a/Source/WebKit/WebProcess/Network/WebTransportSession.cpp
+++ b/Source/WebKit/WebProcess/Network/WebTransportSession.cpp
@@ -206,6 +206,16 @@ Ref<WebCore::WebTransportSendStreamStatsPromise> WebTransportSession::getSendGro
     });
 }
 
+Ref<WebCore::WebTransportExportKeyingMaterialPromise> WebTransportSession::exportKeyingMaterial(std::span<const uint8_t> label, std::span<const uint8_t> context, uint32_t outputLength)
+{
+    return sendWithPromisedReply(Messages::NetworkTransportSession::ExportKeyingMaterial(label, context, outputLength))->whenSettled(RunLoop::mainSingleton(), [] (auto&& keyingMaterial) mutable {
+        ASSERT(RunLoop::isMain());
+        if (!keyingMaterial || !*keyingMaterial)
+            return WebCore::WebTransportExportKeyingMaterialPromise::createAndReject();
+        return WebCore::WebTransportExportKeyingMaterialPromise::createAndResolve(WTF::move(**keyingMaterial));
+    });
+}
+
 Ref<WebCore::WebTransportSendPromise> WebTransportSession::streamSendBytes(WebCore::WebTransportStreamIdentifier identifier, std::span<const uint8_t> bytes, bool withFin)
 {
     return sendWithPromisedReply(Messages::NetworkTransportSession::StreamSendBytes(identifier, bytes, withFin))->whenSettled(RunLoop::mainSingleton(), [] (auto&& exception) {

--- a/Source/WebKit/WebProcess/Network/WebTransportSession.h
+++ b/Source/WebKit/WebProcess/Network/WebTransportSession.h
@@ -94,6 +94,7 @@ private:
     Ref<WebCore::WebTransportSendStreamStatsPromise> getSendStreamStats(WebCore::WebTransportStreamIdentifier) final;
     Ref<WebCore::WebTransportReceiveStreamStatsPromise> getReceiveStreamStats(WebCore::WebTransportStreamIdentifier) final;
     Ref<WebCore::WebTransportSendStreamStatsPromise> getSendGroupStats(WebCore::WebTransportSendGroupIdentifier) final;
+    Ref<WebCore::WebTransportExportKeyingMaterialPromise> exportKeyingMaterial(std::span<const uint8_t>, std::span<const uint8_t>, uint32_t) final;
 
     void cancelReceiveStream(WebCore::WebTransportStreamIdentifier, std::optional<WebCore::WebTransportStreamErrorCode>);
     void cancelSendStream(WebCore::WebTransportStreamIdentifier, std::optional<WebCore::WebTransportStreamErrorCode>);


### PR DESCRIPTION
#### 832fafdf37776762c2c98d44541e14b0b3838899
<pre>
Implement WebTransport.exportKeyingMaterial
<a href="https://bugs.webkit.org/show_bug.cgi?id=320030">https://bugs.webkit.org/show_bug.cgi?id=320030</a>
<a href="https://rdar.apple.com/182965348">rdar://182965348</a>

Reviewed by Basuke Suzuki.

This works on platforms with the accessor for the security metadata from webtransport metadata,
nw_webtransport_metadata_copy_sec_protocol_metadata.

* LayoutTests/imported/w3c/web-platform-tests/interfaces/webtransport.idl:
* LayoutTests/imported/w3c/web-platform-tests/webtransport/export-keying-material.https.any-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/webtransport/export-keying-material.https.any.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/webtransport/export-keying-material.https.any.js: Added.
(toBytes):
(arraysEqual):
(promise_test.async t):
* LayoutTests/imported/w3c/web-platform-tests/webtransport/export-keying-material.https.any.serviceworker-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/webtransport/export-keying-material.https.any.serviceworker.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/webtransport/export-keying-material.https.any.sharedworker-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/webtransport/export-keying-material.https.any.sharedworker.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/webtransport/export-keying-material.https.any.worker-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/webtransport/export-keying-material.https.any.worker.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/webtransport/idlharness.https.sub.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webtransport/idlharness.https.sub.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webtransport/idlharness.https.sub.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webtransport/idlharness.https.sub.any.worker-expected.txt:
* Source/WebCore/Modules/webtransport/WebTransport.cpp:
(WebCore::WebTransport::exportKeyingMaterial):
* Source/WebCore/Modules/webtransport/WebTransport.h:
* Source/WebCore/Modules/webtransport/WebTransport.idl:
* Source/WebCore/Modules/webtransport/WebTransportSession.h:
* Source/WebCore/Modules/webtransport/WorkerWebTransportSession.cpp:
(WebCore::WorkerWebTransportSession::exportKeyingMaterial):
* Source/WebCore/Modules/webtransport/WorkerWebTransportSession.h:
* Source/WebCore/PAL/pal/spi/cocoa/NetworkSPI.h:
* Source/WebKit/Configurations/AllowedSPI.toml:
* Source/WebKit/NetworkProcess/cocoa/NetworkSoftLink.h:
* Source/WebKit/NetworkProcess/cocoa/NetworkSoftLink.mm:
* Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.cpp:
(WebKit::NetworkTransportSession::exportKeyingMaterial):
* Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.h:
(WebKit::NetworkTransportSession::SecurityProtocolMetadata::create):
(WebKit::NetworkTransportSession::SecurityProtocolMetadata::receivedMetadata):
(WebKit::NetworkTransportSession::SecurityProtocolMetadata::metadata const):
* Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.messages.in:
* Source/WebKit/NetworkProcess/webtransport/cocoa/NetworkTransportSessionCocoa.mm:
(WebKit::NetworkTransportSession::create):
(WebKit::NetworkTransportSession::NetworkTransportSession):
(WebKit::createParameters):
(WebKit::NetworkTransportSession::exportKeyingMaterial):
* Source/WebKit/Scripts/webkit/opaque_ipc_types.tracking.in:
* Source/WebKit/WebProcess/Network/WebTransportSession.cpp:
(WebKit::WebTransportSession::exportKeyingMaterial):
* Source/WebKit/WebProcess/Network/WebTransportSession.h:

Canonical link: <a href="https://commits.webkit.org/317835@main">https://commits.webkit.org/317835@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ff15188789aff721476d67be3be68fd6b244b2dc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176471 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50406 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44196 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186072 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/138742 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/440bba92-cbd7-49e2-bdaf-efcb040a7fb5) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178334 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51698 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50090 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137463 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/138742 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c875fffa-b3c1-45fa-b0f5-2c4d1a540509) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179427 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40946 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158239 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117938 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/84cd8bf6-3a40-4b56-971c-8d24f13dfceb) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/175794 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39596 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37962 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150011 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37737 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34540 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/42163 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/42173 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188495 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50071 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/157784 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146506 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50755 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/34355 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146316 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26789 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41080 "Passed tests") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122959 "Found 1 new failure in NetworkProcess/webtransport/cocoa/NetworkTransportSessionCocoa.mm") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117018 "Build is in progress. Recent messages:Printed configuration; Checked out pull request; Compiled WebKit") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49259 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12712 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48661 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48895 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48720 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->