### PR TITLE
Add results database API endpoints to upload and query EWS test results

### DIFF
--- a/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/controller/api_routes.py
+++ b/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/controller/api_routes.py
@@ -25,6 +25,7 @@ import traceback
 
 from flask import abort, jsonify
 from resultsdbpy.controller.archive_controller import ArchiveController
+from resultsdbpy.controller.ews_controller import EWSController
 from resultsdbpy.controller.commit_controller import CommitController
 from resultsdbpy.controller.ci_controller import CIController
 from resultsdbpy.controller.failure_controller import FailureController
@@ -50,6 +51,7 @@ class APIRoutes(AuthedBlueprint):
 
         self.ci_controller = CIController(ci_context=model.ci_context, upload_context=model.upload_context)
         self.archive_controller = ArchiveController(commit_controller=self.commit_controller, archive_context=model.archive_context, upload_context=model.upload_context)
+        self.ews_controller = EWSController(commit_controller=self.commit_controller, ews_context=model.ews_context)
 
         self.bug_tracker_configs = [WebKitBugzilla()] if not len(bug_tracker_configs) else bug_tracker_configs
         self.bug_tracker_controller = BugTrackerController(bug_tracker_configs=self.bug_tracker_configs, commit_context=model.commit_context)
@@ -70,6 +72,7 @@ class APIRoutes(AuthedBlueprint):
 
         self.add_url_rule('/upload', 'upload', self.upload_controller.upload, methods=('GET', 'POST'))
         self.add_url_rule('/upload/archive', 'upload_archive', self.archive_controller.endpoint, methods=('GET', 'POST'))
+        self.add_url_rule('/upload/ews', 'upload_ews', self.ews_controller.upload, methods=('POST',))
         self.add_url_rule('/upload/process', 'process', self.upload_controller.process, methods=('POST',))
         self.add_url_rule('/suites', 'suites', self.upload_controller.suites, methods=('GET',))
         self.add_url_rule('/<path:suite>/tests', 'tests-in-suite', self.test_controller.list_tests, methods=('GET',))
@@ -77,6 +80,8 @@ class APIRoutes(AuthedBlueprint):
         self.add_url_rule('/results/<path:suite>', 'suite-results', self.suite_controller.find_run_results, methods=('GET',))
         self.add_url_rule('/results/<path:suite>/<path:test>', 'test-results', self.test_controller.find_test_result, methods=('GET',))
         self.add_url_rule('/results-summary/<path:suite>/<path:test>', 'test-aggregate-results', self.test_controller.summarize_test_results, methods=('GET',))
+        self.add_url_rule('/results-ews', 'results-ews', self.ews_controller.find, methods=('GET',))
+        self.add_url_rule('/results-ews/tests', 'tests-ews', self.ews_controller.list_tests, methods=('GET',))
 
         self.add_url_rule('/failures/<path:suite>', 'suite-failures', self.failure_controller.failures, methods=('GET',))
 

--- a/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/controller/ews_controller.py
+++ b/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/controller/ews_controller.py
@@ -1,0 +1,153 @@
+# Copyright (C) 2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import json
+import time
+
+from flask import abort, jsonify, request
+from resultsdbpy.controller.commit_controller import HasCommitContext
+from resultsdbpy.controller.configuration import Configuration
+from resultsdbpy.controller.configuration_controller import configuration_for_query
+from resultsdbpy.controller.suite_controller import time_range_for_query
+from webkitflaskpy.util import AssertRequest, query_as_kwargs, limit_for_query, boolean_query
+
+
+class EWSController(HasCommitContext):
+    DEFAULT_LIMIT = 100
+    TIMESTAMP_TOLERANCE_SECONDS = 5 * 60
+
+    def __init__(self, commit_controller, ews_context):
+        super().__init__(commit_controller.commit_context)
+        self.commit_controller = commit_controller
+        self.ews_context = ews_context
+
+    def upload(self):
+        AssertRequest.is_type(['POST'])
+        AssertRequest.no_query()
+
+        try:
+            data = json.loads(request.get_data())
+        except ValueError:
+            abort(400, description='Expected uploaded data to be json')
+        if not isinstance(data, dict):
+            abort(400, description='Expected uploaded data to be a json object')
+
+        try:
+            configuration = Configuration.from_json(data.get('configuration', {}))
+        except (ValueError, TypeError):
+            abort(400, description='Invalid configuration')
+
+        suite = data.get('suite')
+        if not suite or not isinstance(suite, str):
+            abort(400, description='Invalid suite')
+
+        test_results = data.get('test_results')
+        results = test_results.get('results') if isinstance(test_results, dict) else None
+        if not results or not isinstance(results, dict) or any(not isinstance(result, dict) for result in results.values()):
+            abort(400, description='Invalid test results')
+
+        timestamp = data.get('timestamp', time.time())
+        if isinstance(timestamp, bool) or not isinstance(timestamp, (int, float)):
+            abort(400, description='Invalid timestamp')
+        if not 0 < timestamp < time.time() + self.TIMESTAMP_TOLERANCE_SECONDS:
+            abort(400, description=f'Unrealistic timestamp: {timestamp}')
+
+        flaky_type = data.get('flaky_type')
+        if flaky_type is not None and not isinstance(flaky_type, str):
+            abort(400, description='Invalid flaky_type')
+
+        details = data.get('details')
+        if details is not None and not isinstance(details, dict):
+            abort(400, description='Invalid details')
+
+        commits = data.get('commits')
+        if not commits or not isinstance(commits, list) or any(not isinstance(commit, dict) for commit in commits):
+            abort(400, description='Invalid commits')
+        commits = [self.commit_controller.register(commit=commit, fast=True) for commit in commits]
+
+        try:
+            stored = self.ews_context.record_results(
+                configuration, commits, suite, test_results,
+                timestamp=timestamp, flaky_type=flaky_type, details=details,
+            )
+        except (TypeError, ValueError) as error:
+            abort(400, description=str(error))
+
+        # Naming the tests that were stored lets a caller log the write instead of assuming it.
+        return jsonify({'status': 'ok', 'tests': stored})
+
+    @query_as_kwargs()
+    @limit_for_query(DEFAULT_LIMIT)
+    @configuration_for_query()
+    @time_range_for_query()
+    def find(
+        self, configurations=None, suite=None, test=None, recent=None, flaky=None,
+        branch=None, begin_query_time=None, end_query_time=None,
+        limit=None, **kwargs
+    ):
+        AssertRequest.is_type(['GET'])
+        AssertRequest.query_kwargs_empty(**kwargs)
+
+        if not suite or not suite[0]:
+            abort(400, description='No valid test suite specified')
+        if not test or not test[0]:
+            abort(400, description='No valid test specified')
+
+        recent = boolean_query(*recent)[0] if recent else True
+        flaky = boolean_query(*flaky)[0] if flaky else False
+
+        results = self.ews_context.find_for_test(
+            configurations=configurations, suite=suite[0], branch=branch[0] if branch else None,
+            begin_query_time=begin_query_time, end_query_time=end_query_time, limit=limit,
+            test=test[0], flaky=flaky, recent=recent,
+        )
+        if not results:
+            abort(404, description='No EWS results matching the specified criteria')
+
+        response = []
+        for config, entries in results.items():
+            response.append({
+                'configuration': Configuration.Encoder().default(config),
+                'results': sorted(entries, key=lambda result: (result['uuid'], result['start_time'])),
+            })
+        return jsonify(response)
+
+    @query_as_kwargs()
+    @limit_for_query(DEFAULT_LIMIT)
+    def list_tests(self, suite=None, test=None, flaky=None, limit=None, **kwargs):
+        """Names recorded in the EWS tables by any configuration & branch."""
+        AssertRequest.is_type(['GET'])
+        AssertRequest.query_kwargs_empty(**kwargs)
+
+        if not suite or not suite[0]:
+            abort(400, description='No valid test suite specified')
+
+        flaky = boolean_query(*flaky)[0] if flaky else False
+
+        names = set()
+        for prefix in test or [None]:
+            if len(names) >= limit:
+                break
+            names.update(self.ews_context.names(
+                suite=suite[0], flaky=flaky, test=prefix, limit=limit - len(names),
+            ))
+        return jsonify(sorted(names))

--- a/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/controller/ews_controller_unittest.py
+++ b/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/controller/ews_controller_unittest.py
@@ -1,0 +1,394 @@
+# Copyright (C) 2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import json
+import time
+
+from fakeredis import FakeStrictRedis
+from redis import StrictRedis
+from resultsdbpy.controller.api_routes import APIRoutes
+from resultsdbpy.controller.configuration import Configuration
+from resultsdbpy.flask_support.flask_testcase import FlaskTestCase
+from resultsdbpy.model.cassandra_context import CassandraContext
+from resultsdbpy.model.mock_model_factory import MockModelFactory
+from resultsdbpy.model.mock_cassandra_context import MockCassandraContext
+from resultsdbpy.model.wait_for_docker_test_case import WaitForDockerTestCase
+from resultsdbpy.model.configuration_context_unittest import ConfigurationContextTest
+from urllib.parse import quote
+
+
+class EWSControllerTest(FlaskTestCase, WaitForDockerTestCase):
+    KEYSPACE = 'ews_controller_test_keyspace'
+    EWS_UPLOAD_ENDPOINT = 'api/upload/ews'
+    EWS_RESULTS_ENDPOINT = 'api/results-ews'
+    EWS_TESTS_ENDPOINT = 'api/results-ews/tests'
+    COMMITS_ENDPOINT = 'api/commits'
+    DEFAULT_COMMITS = [
+        {'repository_id': 'safari', 'hash': 'd8bce26fa65c6fc8f39c17927abb77f69fab82fc'},
+        {'repository_id': 'webkit', 'hash': '75eaef1c9242f92a8d7694e8ccd310f69cf9683b'},
+    ]
+    DEFAULT_TEST_RESULTS = dict(
+        results={
+            'fast/encoding/css-cached-bom.html': {'report': 'REGRESSION', 'expected': 'PASS', 'actual': 'TEXT'},
+            'fast/encoding/css-charset.html': {'report': 'FLAKY', 'expected': 'PASS', 'actual': 'TIMEOUT PASS', 'has_stderr': True},
+            'fast/encoding/css-link-charset.html': {'report': 'MISSING', 'expected': 'PASS', 'actual': 'MISSING', 'is_missing_text': True},
+        },
+    )
+    REGRESSION_TEST = 'fast/encoding/css-cached-bom.html'
+
+    @classmethod
+    def setup_webserver(cls, app, redis=StrictRedis, cassandra=CassandraContext):
+        with MockModelFactory.safari(), MockModelFactory.webkit():
+            cassandra.drop_keyspace(keyspace=cls.KEYSPACE)
+            model = MockModelFactory.create(redis=redis(), cassandra=cassandra(keyspace=cls.KEYSPACE, create_keyspace=True))
+            app.register_blueprint(APIRoutes(model))
+
+    @classmethod
+    def upload_ews_results(cls, client, configuration=None, suite=None, commits=None, test_results=None, flaky_type=None, details=None, timestamp=None):
+        if configuration is None:
+            configuration = ConfigurationContextTest.CONFIGURATIONS[0]
+        data = {
+            'configuration': json.dumps(configuration, cls=Configuration.Encoder),
+            'suite': suite if suite is not None else 'layout-tests',
+            'commits': commits if commits is not None else cls.DEFAULT_COMMITS,
+            'test_results': test_results if test_results is not None else cls.DEFAULT_TEST_RESULTS,
+        }
+        if flaky_type is not None:
+            data['flaky_type'] = flaky_type
+        if details is not None:
+            data['details'] = details
+        if timestamp is not None:
+            data['timestamp'] = timestamp
+        return client.post(f'{cls.URL}/{cls.EWS_UPLOAD_ENDPOINT}', data=json.dumps(data))
+
+    @classmethod
+    def find_ews_results(cls, client, configuration=None, suite='layout-tests', test=..., flaky=None, recent=None, after_time=None, before_time=None):
+        if configuration is None:
+            configuration = ConfigurationContextTest.CONFIGURATIONS[0]
+        if test is ...:
+            test = cls.REGRESSION_TEST
+        params = {
+            'suite': suite, 'test': test, 'flaky': flaky, 'recent': recent,
+            'after_time': after_time, 'before_time': before_time,
+            'platform': configuration.platform, 'style': configuration.style, 'flavor': configuration.flavor,
+        }
+        query = '&'.join(
+            f'{key}={str(value).lower() if isinstance(value, bool) else value}'
+            for key, value in params.items() if value is not None
+        )
+        return client.get(f'{cls.URL}/{cls.EWS_RESULTS_ENDPOINT}?{query}')
+
+    @WaitForDockerTestCase.mock_if_no_docker(mock_redis=FakeStrictRedis, mock_cassandra=MockCassandraContext)
+    @FlaskTestCase.run_with_webserver()
+    def test_upload_and_find(self, client, **kwargs):
+        response = self.upload_ews_results(
+            client,
+            details={
+                'remote': 'github.com/WebKit/WebKit', 'pr_number': 12345, 'commit_hash': 'abc123def456',
+                'build_number': 678, 'link': 'https://ews.example.com/build/1',
+            },
+        )
+        self.assertEqual(response.status_code, 200, response.json())
+
+        response = self.find_ews_results(client)
+        self.assertEqual(response.status_code, 200, response.json())
+        entries = response.json()[0]['results']
+        self.assertGreater(len(entries), 0)
+
+        result = entries[0]
+        self.assertEqual(result['result']['report'], 'REGRESSION')
+        self.assertEqual(result['result']['actual'], 'TEXT')
+        self.assertEqual(result['result']['expected'], 'PASS')
+
+        details = result.get('details') or {}
+        self.assertEqual(details.get('remote'), 'github.com/WebKit/WebKit')
+        self.assertEqual(details.get('pr_number'), 12345)
+        self.assertEqual(details.get('commit_hash'), 'abc123def456')
+        self.assertEqual(details.get('build_number'), 678)
+        self.assertEqual(details.get('link'), 'https://ews.example.com/build/1')
+
+        response = self.find_ews_results(client, test='fast/encoding/css-charset.html')
+        self.assertEqual(response.status_code, 200, response.json())
+
+    @WaitForDockerTestCase.mock_if_no_docker(mock_redis=FakeStrictRedis, mock_cassandra=MockCassandraContext)
+    @FlaskTestCase.run_with_webserver()
+    def test_flaky_upload_and_find(self, client, **kwargs):
+        response = self.upload_ews_results(
+            client,
+            test_results={'results': {
+                self.REGRESSION_TEST: {'report': 'FLAKY', 'expected': 'PASS', 'actual': 'TIMEOUT PASS'},
+            }},
+            flaky_type='BetweenStepsDirtyTree',
+            details={'pr_number': 12345},
+        )
+        self.assertEqual(response.status_code, 200, response.json())
+
+        # The flaky test we reported is queryable with its flaky_type.
+        response = self.find_ews_results(client, flaky=True)
+        self.assertEqual(response.status_code, 200, response.json())
+        result = response.json()[0]['results'][0]
+        self.assertEqual(result['result']['actual'], 'TIMEOUT PASS')
+        self.assertEqual(result['flaky_type'], 'BetweenStepsDirtyTree')
+        self.assertEqual((result.get('details') or {}).get('pr_number'), 12345)
+
+        # A test that wasn't reported flaky is not in the flaky table.
+        response = self.find_ews_results(client, test='fast/encoding/css-charset.html', flaky=True)
+        self.assertEqual(response.status_code, 404)
+
+    @WaitForDockerTestCase.mock_if_no_docker(mock_redis=FakeStrictRedis, mock_cassandra=MockCassandraContext)
+    @FlaskTestCase.run_with_webserver()
+    def test_invalid_upload_body_is_not_an_object(self, client, **kwargs):
+        # Every field check below reads data.get(...), so a non-object body would raise
+        # AttributeError, which is neither a TypeError nor a ValueError, and answer 500.
+        for body in ('[]', '5', '"a string"', 'null', 'not json at all'):
+            response = client.post(f'{self.URL}/{self.EWS_UPLOAD_ENDPOINT}', data=body)
+            self.assertEqual(response.status_code, 400, f'{body} gave {response.status_code}')
+
+    @WaitForDockerTestCase.mock_if_no_docker(mock_redis=FakeStrictRedis, mock_cassandra=MockCassandraContext)
+    @FlaskTestCase.run_with_webserver()
+    def test_invalid_upload_missing_suite(self, client, **kwargs):
+        response = client.post(f'{self.URL}/{self.EWS_UPLOAD_ENDPOINT}', data=json.dumps({
+            'configuration': json.dumps(ConfigurationContextTest.CONFIGURATIONS[0], cls=Configuration.Encoder),
+            'commits': [{'repository_id': 'webkit', 'id': '6'}],
+            'test_results': {'results': {}},
+        }))
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json()['description'], 'Invalid suite')
+
+    @WaitForDockerTestCase.mock_if_no_docker(mock_redis=FakeStrictRedis, mock_cassandra=MockCassandraContext)
+    @FlaskTestCase.run_with_webserver()
+    def test_invalid_upload_malformed_columns(self, client, **kwargs):
+        # These reach cqlengine columns or a commit lookup directly, and neither a ValidationError nor
+        # an AttributeError is a TypeError or a ValueError, so anything unchecked here answers 500 with
+        # the raw exception instead of 400.
+        for field, value in (
+            ('timestamp', 'yesterday'), ('timestamp', 0), ('timestamp', 1e300), ('timestamp', time.time() + 86400),
+            ('flaky_type', 5), ('details', 'a string'),
+            ('commits', 'webkit@main'), ('commits', {'repository_id': 'webkit'}), ('commits', ['webkit@main']),
+            ('test_results', {'results': {}}), ('test_results', {'no_results': {}}),
+            ('test_results', {'results': ['fast/a.html']}), ('test_results', {'results': {'fast/a.html': 'TEXT'}}),
+        ):
+            response = self.upload_ews_results(client, **{field: value})
+            self.assertEqual(response.status_code, 400, f'{field}={value!r} gave {response.status_code}')
+
+    @WaitForDockerTestCase.mock_if_no_docker(mock_redis=FakeStrictRedis, mock_cassandra=MockCassandraContext)
+    @FlaskTestCase.run_with_webserver()
+    def test_invalid_upload_missing_commits(self, client, **kwargs):
+        response = self.upload_ews_results(client, commits=[])
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json()['description'], 'Invalid commits')
+
+    @WaitForDockerTestCase.mock_if_no_docker(mock_redis=FakeStrictRedis, mock_cassandra=MockCassandraContext)
+    @FlaskTestCase.run_with_webserver()
+    def test_invalid_upload_missing_test_results(self, client, **kwargs):
+        response = self.upload_ews_results(client, test_results={})
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json()['description'], 'Invalid test results')
+
+    @WaitForDockerTestCase.mock_if_no_docker(mock_redis=FakeStrictRedis, mock_cassandra=MockCassandraContext)
+    @FlaskTestCase.run_with_webserver()
+    def test_no_results(self, client, **kwargs):
+        response = self.find_ews_results(client)
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.json()['description'], 'No EWS results matching the specified criteria')
+
+    @WaitForDockerTestCase.mock_if_no_docker(mock_redis=FakeStrictRedis, mock_cassandra=MockCassandraContext)
+    @FlaskTestCase.run_with_webserver()
+    def test_find_rejects_a_commit_range(self, client, **kwargs):
+        # Results are clustered by start_time, so a commit range could only be honored as a
+        # client-side filter over rows Cassandra already truncated with LIMIT. Reject it instead.
+        for param in ('ref=6', 'uuid=153802947300000', 'timestamp=1538029473', 'begin=5', 'end=7'):
+            response = client.get(f'{self.URL}/{self.EWS_RESULTS_ENDPOINT}?suite=layout-tests&test={self.REGRESSION_TEST}&{param}')
+            self.assertEqual(response.status_code, 400, f'{param} gave {response.status_code}')
+            self.assertIn('not supported in queries by this endpoint', response.json()['description'])
+
+    @WaitForDockerTestCase.mock_if_no_docker(mock_redis=FakeStrictRedis, mock_cassandra=MockCassandraContext)
+    @FlaskTestCase.run_with_webserver()
+    def test_find_without_test(self, client, **kwargs):
+        response = self.find_ews_results(client, test=None)
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json()['description'], 'No valid test specified')
+
+    @WaitForDockerTestCase.mock_if_no_docker(mock_redis=FakeStrictRedis, mock_cassandra=MockCassandraContext)
+    @FlaskTestCase.run_with_webserver()
+    def test_upload_omitting_optional_fields(self, client, **kwargs):
+        response = self.upload_ews_results(client)
+        self.assertEqual(response.status_code, 200, response.json())
+        response = self.find_ews_results(client)
+        self.assertEqual(response.status_code, 200, response.json())
+        result = response.json()[0]['results'][0]
+        self.assertEqual(result['result']['actual'], 'TEXT')
+        self.assertIsNone(result.get('details'))
+        self.assertNotIn('flaky_type', result)
+
+    @WaitForDockerTestCase.mock_if_no_docker(mock_redis=FakeStrictRedis, mock_cassandra=MockCassandraContext)
+    @FlaskTestCase.run_with_webserver()
+    def test_invalid_upload_non_string_suite(self, client, **kwargs):
+        response = self.upload_ews_results(client, suite=123)
+        self.assertEqual(response.status_code, 400, response.json())
+
+    @WaitForDockerTestCase.mock_if_no_docker(mock_redis=FakeStrictRedis, mock_cassandra=MockCassandraContext)
+    @FlaskTestCase.run_with_webserver()
+    def test_upload_preserves_commit_metadata(self, client, **kwargs):
+        # EWS knows the hash, branch and timestamp but never the author or message, and uploading
+        # must not drop what a post-commit upload already stored.
+        with MockModelFactory.webkit() as webkit:
+            commit = webkit.commits['main'][-1]
+
+        response = self.upload_ews_results(client, commits=[{
+            'repository_id': 'webkit', 'hash': commit.hash,
+            'branch': 'main', 'timestamp': commit.timestamp, 'identifier': str(commit),
+        }])
+        self.assertEqual(response.status_code, 200, response.json())
+
+        response = client.get(f'{self.URL}/{self.COMMITS_ENDPOINT}?repository_id=webkit&ref={commit.hash}')
+        self.assertEqual(response.status_code, 200, response.json())
+        found = response.json()[0]
+        self.assertIsNotNone(found.get('author'))
+        self.assertTrue(found.get('message', '').startswith(commit.message))
+
+    @WaitForDockerTestCase.mock_if_no_docker(mock_redis=FakeStrictRedis, mock_cassandra=MockCassandraContext)
+    @FlaskTestCase.run_with_webserver()
+    def test_upload_registers_an_unsynced_commit(self, client, **kwargs):
+        hash = 'e1c8f9d3a24b5670bd91a2f4e6c8037b5da91e42'
+        response = self.upload_ews_results(client, commits=[{
+            'repository_id': 'webkit', 'hash': hash,
+            'branch': 'main', 'timestamp': int(time.time()), 'identifier': '999999@main',
+        }])
+        self.assertEqual(response.status_code, 200, response.json())
+
+        response = client.get(f'{self.URL}/{self.COMMITS_ENDPOINT}?repository_id=webkit&ref={hash}')
+        self.assertEqual(response.status_code, 200, response.json())
+        self.assertEqual(response.json()[0]['hash'], hash)
+
+    @WaitForDockerTestCase.mock_if_no_docker(mock_redis=FakeStrictRedis, mock_cassandra=MockCassandraContext)
+    @FlaskTestCase.run_with_webserver()
+    def test_upload_reports_the_tests_it_stored(self, client, **kwargs):
+        response = self.upload_ews_results(client)
+        self.assertEqual(response.status_code, 200, response.json())
+        self.assertEqual(response.json(), {
+            'status': 'ok', 'tests': sorted(self.DEFAULT_TEST_RESULTS['results']),
+        })
+
+    @WaitForDockerTestCase.mock_if_no_docker(mock_redis=FakeStrictRedis, mock_cassandra=MockCassandraContext)
+    @FlaskTestCase.run_with_webserver()
+    def test_invalid_upload_partial_configuration(self, client, **kwargs):
+        # A configuration missing a required member cannot be written, so the upload is refused
+        # rather than answered with a success the caller would believe.
+        response = self.upload_ews_results(client, configuration=Configuration(platform='mac', style='release'))
+        self.assertEqual(response.status_code, 400, response.json())
+        self.assertIn('partial configuration', response.json()['description'])
+
+    @WaitForDockerTestCase.mock_if_no_docker(mock_redis=FakeStrictRedis, mock_cassandra=MockCassandraContext)
+    @FlaskTestCase.run_with_webserver()
+    def test_time_window_query(self, client, **kwargs):
+        HOUR = 60 * 60
+        now = int(time.time())
+        recent, day_old, old = now - HOUR, now - 30 * HOUR, now - 72 * HOUR
+        for timestamp in (recent, day_old, old):
+            response = self.upload_ews_results(
+                client,
+                test_results={'results': {self.REGRESSION_TEST: {'report': 'REGRESSION', 'expected': 'PASS', 'actual': 'TEXT'}}},
+                timestamp=timestamp,
+            )
+            self.assertEqual(response.status_code, 200, response.json())
+
+        def start_times_after(cutoff):
+            response = self.find_ews_results(client, recent=False, after_time=cutoff)
+            self.assertEqual(response.status_code, 200, response.json())
+            return {entry['start_time'] for config in response.json() for entry in config['results']}
+
+        self.assertEqual(start_times_after(now - 24 * HOUR), {recent})
+        self.assertEqual(start_times_after(now - 48 * HOUR), {recent, day_old})
+        self.assertEqual(start_times_after(now - 96 * HOUR), {recent, day_old, old})
+
+        # A window that ends before every upload yields no results.
+        response = self.find_ews_results(client, recent=False, before_time=old - HOUR)
+        self.assertEqual(response.status_code, 404)
+
+    @WaitForDockerTestCase.mock_if_no_docker(mock_redis=FakeStrictRedis, mock_cassandra=MockCassandraContext)
+    @FlaskTestCase.run_with_webserver()
+    def test_list_tests(self, client, **kwargs):
+        self.assertEqual(self.upload_ews_results(client).status_code, 200)
+
+        response = client.get(f'{self.URL}/{self.EWS_TESTS_ENDPOINT}?suite=layout-tests')
+        self.assertEqual(response.status_code, 200, response.json())
+        self.assertEqual(response.json(), sorted(self.DEFAULT_TEST_RESULTS['results']))
+
+    @WaitForDockerTestCase.mock_if_no_docker(mock_redis=FakeStrictRedis, mock_cassandra=MockCassandraContext)
+    @FlaskTestCase.run_with_webserver()
+    def test_list_tests_flaky(self, client, **kwargs):
+        self.assertEqual(self.upload_ews_results(client, flaky_type='WithinStepDirtyTree').status_code, 200)
+
+        response = client.get(f'{self.URL}/{self.EWS_TESTS_ENDPOINT}?suite=layout-tests&flaky=true')
+        self.assertEqual(response.status_code, 200, response.json())
+        self.assertEqual(response.json(), sorted(self.DEFAULT_TEST_RESULTS['results']))
+        # The failed-table index must stay empty when everything was reported flaky.
+        response = client.get(f'{self.URL}/{self.EWS_TESTS_ENDPOINT}?suite=layout-tests')
+        self.assertEqual(response.json(), [])
+
+    @WaitForDockerTestCase.mock_if_no_docker(mock_redis=FakeStrictRedis, mock_cassandra=MockCassandraContext)
+    @FlaskTestCase.run_with_webserver()
+    def test_list_tests_prefix(self, client, **kwargs):
+        self.assertEqual(self.upload_ews_results(client).status_code, 200)
+
+        response = client.get(f'{self.URL}/{self.EWS_TESTS_ENDPOINT}?suite=layout-tests&test=fast/encoding/css-c')
+        self.assertEqual(response.status_code, 200, response.json())
+        self.assertEqual(response.json(), ['fast/encoding/css-cached-bom.html', 'fast/encoding/css-charset.html'])
+
+    @WaitForDockerTestCase.mock_if_no_docker(mock_redis=FakeStrictRedis, mock_cassandra=MockCassandraContext)
+    @FlaskTestCase.run_with_webserver()
+    def test_list_tests_honours_the_limit_across_prefixes(self, client, **kwargs):
+        # Each prefix is a separate query, so the limit has to be spent down rather than reapplied.
+        # cqlengine reads a limit of 0 as no limit, so exhausting it must stop the loop.
+        self.assertEqual(self.upload_ews_results(client).status_code, 200)
+
+        prefixes = '&'.join(f'test={name}' for name in sorted(self.DEFAULT_TEST_RESULTS['results']))
+        response = client.get(f'{self.URL}/{self.EWS_TESTS_ENDPOINT}?suite=layout-tests&limit=2&{prefixes}')
+        self.assertEqual(response.status_code, 200, response.json())
+        self.assertEqual(len(response.json()), 2)
+
+    @WaitForDockerTestCase.mock_if_no_docker(mock_redis=FakeStrictRedis, mock_cassandra=MockCassandraContext)
+    @FlaskTestCase.run_with_webserver()
+    def test_list_tests_percent_encoded_name(self, client, **kwargs):
+        # A '?' in a test name is percent-encoded by the client and decoded by Flask before we see it.
+        test = 'http/tests/cache/disk-cache/disk-cache-validation.html?bar'
+        results = {test: {'report': 'REGRESSION', 'expected': 'PASS', 'actual': 'TEXT'}}
+        self.assertEqual(self.upload_ews_results(client, test_results=dict(results=results)).status_code, 200)
+
+        response = client.get(f'{self.URL}/{self.EWS_TESTS_ENDPOINT}?suite=layout-tests&test={quote(test, safe="")}')
+        self.assertEqual(response.status_code, 200, response.json())
+        self.assertEqual(response.json(), list(results))
+
+    @WaitForDockerTestCase.mock_if_no_docker(mock_redis=FakeStrictRedis, mock_cassandra=MockCassandraContext)
+    @FlaskTestCase.run_with_webserver()
+    def test_list_tests_without_suite(self, client, **kwargs):
+        response = client.get(f'{self.URL}/{self.EWS_TESTS_ENDPOINT}')
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json()['description'], 'No valid test suite specified')
+
+    @WaitForDockerTestCase.mock_if_no_docker(mock_redis=FakeStrictRedis, mock_cassandra=MockCassandraContext)
+    @FlaskTestCase.run_with_webserver()
+    def test_list_tests_empty(self, client, **kwargs):
+        response = client.get(f'{self.URL}/{self.EWS_TESTS_ENDPOINT}?suite=layout-tests')
+        self.assertEqual(response.status_code, 200, response.json())
+        self.assertEqual(response.json(), [])

--- a/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/model/ews_context.py
+++ b/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/model/ews_context.py
@@ -25,9 +25,9 @@ import json
 import time
 
 from cassandra.cqlengine import columns
+from cassandra.cqlengine.models import Model
 from datetime import datetime
 
-from resultsdbpy.model.commit_context import CommitContext
 from resultsdbpy.model.configuration_context import ClusteredByConfiguration
 from resultsdbpy.model.upload_context import UploadCallbackContext
 
@@ -61,12 +61,19 @@ class EWSContext(UploadCallbackContext):
 
     class EWSFlakyTestsByStartTime(EWSResultsBase):
         __table_name__ = 'ews_flaky_tests_by_start_time'
-        flaky_type = columns.Text(required=True)  # WithChangeStep, WithoutChangeStep, WithChangeInterStep, InterBuild
+        flaky_type = columns.Text(required=True)  # WithinStepDirtyTree, BetweenStepsDirtyTree, WithinStepCleanTree
 
         def unpack(self):
             results = super().unpack()
             results['flaky_type'] = self.flaky_type
             return results
+
+    class EWSTestNameBySuite(Model):
+        """Which tests each table holds, across every configuration and branch."""
+        __table_name__ = 'ews_test_names_by_suite'
+        suite = columns.Text(partition_key=True, required=True)
+        flaky = columns.Boolean(partition_key=True, required=True)
+        test = columns.Text(primary_key=True, required=True)
 
     def __init__(self, *args, **kwargs):
         super(EWSContext, self).__init__('ews-results', *args, **kwargs)
@@ -74,51 +81,55 @@ class EWSContext(UploadCallbackContext):
         with self:
             self.cassandra.create_table(self.EWSFailedTestsByStartTime)
             self.cassandra.create_table(self.EWSFlakyTestsByStartTime)
+            self.cassandra.create_table(self.EWSTestNameBySuite)
 
-    def register(self, configuration, commits, suite, test_results, timestamp=None, flaky_type=None, details=None):
-        try:
-            if not isinstance(suite, str):
-                raise TypeError(f'Expected type {str}, got {type(suite)}')
+    def record_results(self, configuration, commits, suite, test_results, timestamp=None, flaky_type=None, details=None):
+        stored = set()
+        uuid = self.commit_context.uuid_for_commits(commits)
+        timestamp = timestamp or time.time()
+        if isinstance(timestamp, datetime):
+            timestamp = calendar.timegm(timestamp.timetuple())
 
-            uuid = self.commit_context.uuid_for_commits(commits)
-            timestamp = timestamp or time.time()
-            if isinstance(timestamp, datetime):
-                timestamp = calendar.timegm(timestamp.timetuple())
+        # Not relative to commit timestamp since an old commit may cause the short FLAKY TTL to expire immediately.
+        ttl = self.FLAKY_TTL_SECONDS if flaky_type is not None else self.ttl_seconds
+        ttl = int(ttl) if ttl else None
 
-            table = self.EWSFlakyTestsByStartTime if flaky_type is not None else self.EWSFailedTestsByStartTime
-            ttl = self.FLAKY_TTL_SECONDS if flaky_type is not None else self.ttl_seconds
-            extra = dict(flaky_type=flaky_type) if flaky_type is not None else {}
+        extra = dict(flaky_type=flaky_type) if flaky_type is not None else {}
+        table = self.EWSFlakyTestsByStartTime if flaky_type is not None else self.EWSFailedTestsByStartTime
 
-            with self, self.cassandra.batch_query_context():
-                for branch in self.commit_context.branch_keys_for_commits(commits):
-                    for test, result in (test_results.get('results') or {}).items():
-                        self.configuration_context.insert_row_with_configuration(
-                            table.__table_name__, configuration=configuration, suite=suite, branch=branch,
-                            test=test, result=json.dumps(result),
-                            uuid=uuid, start_time=timestamp, ttl=ttl,
-                            details=json.dumps(details) if details else None,
-                            **extra,
-                        )
-                    self.configuration_context.register_configuration(configuration, branch=branch, timestamp=timestamp)
+        with self, self.cassandra.batch_query_context():
+            for branch in self.commit_context.branch_keys_for_commits(commits):
+                for test, result in (test_results.get('results') or {}).items():
+                    self.configuration_context.insert_row_with_configuration(
+                        table.__table_name__, configuration=configuration, suite=suite, branch=branch,
+                        test=test, result=json.dumps(result),
+                        uuid=uuid, start_time=timestamp, ttl=ttl,
+                        details=json.dumps(details) if details else None,
+                        **extra,
+                    )
+                    stored.add(test)
+                self.configuration_context.register_configuration(configuration, branch=branch, timestamp=timestamp)
 
-        except Exception as e:
-            return self.partial_status(e)
-        return self.partial_status()
+            for test in stored:
+                self.cassandra.insert_row(
+                    self.EWSTestNameBySuite.__table_name__,
+                    suite=suite, flaky=flaky_type is not None, test=test, ttl=ttl,
+                )
+        return sorted(stored)
 
-    def find_for_test(self, configurations, suite, test, flaky=True, branch=None, recent=True, begin=None, end=None, begin_query_time=None, end_query_time=None, limit=100):
-        if not isinstance(suite, str):
-            raise TypeError(f'Expected type {str} for suite, got {type(suite)}')
-        if not isinstance(test, str):
-            raise TypeError(f'Expected type {str} for test, got {type(test)}')
+    def names(self, suite, flaky, test=None, limit=100):
+        """Test names recorded for a suite, optionally restricted to a name prefix."""
+        with self:
+            args = {'suite': suite, 'flaky': flaky, 'limit': limit}
+            if test:
+                args.update(test__gte=test, test__lte=test + '~')
+            return [row.test for row in self.cassandra.select_from_table(self.EWSTestNameBySuite.__table_name__, **args)]
 
+    def find_for_test(self, configurations, suite, test, flaky, branch=None, recent=True, begin_query_time=None, end_query_time=None, limit=100):
         table = self.EWSFlakyTestsByStartTime if flaky else self.EWSFailedTestsByStartTime
 
         def get_time(time):
-            if isinstance(time, datetime):
-                return time
-            elif time:
-                return datetime.utcfromtimestamp(int(time))
-            return None
+            return time if isinstance(time, datetime) else datetime.utcfromtimestamp(int(time)) if time else None
 
         with self:
             return {
@@ -126,10 +137,7 @@ class EWSContext(UploadCallbackContext):
                 for config, rows in self.configuration_context.select_from_table_with_configurations(
                     table.__table_name__, configurations=configurations,
                     suite=suite, branch=branch or self.commit_context.DEFAULT_BRANCH_KEY, test=test,
-                    recent=recent,
-                    uuid__gte=CommitContext.convert_to_uuid(begin),
-                    uuid__lte=CommitContext.convert_to_uuid(end, CommitContext.timestamp_to_uuid()),
                     start_time__gte=get_time(begin_query_time), start_time__lte=get_time(end_query_time),
-                    limit=limit,
+                    recent=recent, limit=limit,
                 ).items()
             }

--- a/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/model/ews_context_unittest.py
+++ b/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/model/ews_context_unittest.py
@@ -64,6 +64,37 @@ class EWSContextTest(WaitForDockerTestCase):
         )
 
     @WaitForDockerTestCase.mock_if_no_docker(mock_redis=FakeStrictRedis, mock_cassandra=MockCassandraContext)
+    def test_ttl_is_an_integer(self, redis=StrictRedis, cassandra=CassandraContext):
+        """cqlengine formats the TTL into the CQL verbatim, so a float reaches Cassandra as an InvalidRequest."""
+        self.init_database(redis=redis, cassandra=cassandra)
+
+        ttls = []
+        context = self.model.ews_context
+        originals = [
+            (context.cassandra, 'insert_row'),
+            (context.configuration_context, 'insert_row_with_configuration'),
+        ]
+
+        def record(original):
+            def wrapper(*args, ttl=None, **kwargs):
+                ttls.append(ttl)
+                return original(*args, ttl=ttl, **kwargs)
+            return wrapper
+
+        try:
+            for owner, name in originals:
+                setattr(owner, name, record(getattr(owner, name)))
+            MockModelFactory.add_mock_ews_results(test_results=self.DEFAULT_TEST_RESULTS, model=self.model)
+        finally:
+            for owner, name in originals:
+                delattr(owner, name)
+
+        self.assertTrue(ttls)
+        for ttl in ttls:
+            self.assertIsInstance(ttl, (int, type(None)))
+            self.assertNotIsInstance(ttl, bool)
+
+    @WaitForDockerTestCase.mock_if_no_docker(mock_redis=FakeStrictRedis, mock_cassandra=MockCassandraContext)
     def test_stores_all_reported_results(self, redis=StrictRedis, cassandra=CassandraContext):
         self.init_database(redis=redis, cassandra=cassandra)
 
@@ -86,14 +117,14 @@ class EWSContextTest(WaitForDockerTestCase):
     @WaitForDockerTestCase.mock_if_no_docker(mock_redis=FakeStrictRedis, mock_cassandra=MockCassandraContext)
     def test_flaky_results_stored(self, redis=StrictRedis, cassandra=CassandraContext):
         """Flaky results land in a separate table, tagged with their flaky_type. These should not be stored in the failure table."""
-        self.init_database(redis=redis, cassandra=cassandra, flaky_type='InterStep')
+        self.init_database(redis=redis, cassandra=cassandra, flaky_type='BetweenStepsDirtyTree')
 
         results = self._find(self.REGRESSION_TEST, flaky=True)
         self.assertGreater(len(results), 0)
 
         entry = list(results.values())[0][0]
         self.assertEqual(entry['result']['actual'], 'TEXT')
-        self.assertEqual(entry['flaky_type'], 'InterStep')
+        self.assertEqual(entry['flaky_type'], 'BetweenStepsDirtyTree')
         self.assertEqual(len(self._find(self.REGRESSION_TEST, flaky=False)), 0)
 
     @WaitForDockerTestCase.mock_if_no_docker(mock_redis=FakeStrictRedis, mock_cassandra=MockCassandraContext)
@@ -136,3 +167,68 @@ class EWSContextTest(WaitForDockerTestCase):
             cassandra.drop_keyspace(keyspace=self.KEYSPACE)
             self.model = MockModelFactory.create(redis=redis(), cassandra=cassandra(keyspace=self.KEYSPACE, create_keyspace=True))
         self.assertEqual(len(self._find(self.REGRESSION_TEST)), 0)
+
+    @WaitForDockerTestCase.mock_if_no_docker(mock_redis=FakeStrictRedis, mock_cassandra=MockCassandraContext)
+    def test_record_results_reports_the_tests_it_stored(self, redis=StrictRedis, cassandra=CassandraContext):
+        """Callers cannot see the write, so registering has to tell them which tests it recorded."""
+        with MockModelFactory.safari(), MockModelFactory.webkit() as webkit:
+            cassandra.drop_keyspace(keyspace=self.KEYSPACE)
+            self.model = MockModelFactory.create(redis=redis(), cassandra=cassandra(keyspace=self.KEYSPACE, create_keyspace=True))
+
+            stored = self.model.ews_context.record_results(
+                Configuration(platform='Mac', version='13.0.0', is_simulator=False, architecture='arm64', style='Release', flavor='wk1'),
+                [webkit.commits['main'][-1]], 'layout-tests', self.DEFAULT_TEST_RESULTS,
+            )
+
+        self.assertEqual(stored, sorted(self.DEFAULT_TEST_RESULTS['results']))
+
+    @WaitForDockerTestCase.mock_if_no_docker(mock_redis=FakeStrictRedis, mock_cassandra=MockCassandraContext)
+    def test_record_results_raises_when_the_write_is_rejected(self, redis=StrictRedis, cassandra=CassandraContext):
+        with MockModelFactory.safari(), MockModelFactory.webkit() as webkit:
+            cassandra.drop_keyspace(keyspace=self.KEYSPACE)
+            self.model = MockModelFactory.create(redis=redis(), cassandra=cassandra(keyspace=self.KEYSPACE, create_keyspace=True))
+
+            # A partial configuration cannot be written, and must not be reported as stored.
+            with self.assertRaises(TypeError):
+                self.model.ews_context.record_results(
+                    Configuration(platform='Mac', style='Release'),
+                    [webkit.commits['main'][-1]], 'layout-tests', self.DEFAULT_TEST_RESULTS,
+                )
+
+    @WaitForDockerTestCase.mock_if_no_docker(mock_redis=FakeStrictRedis, mock_cassandra=MockCassandraContext)
+    def test_names_enumerates_reported_tests(self, redis=StrictRedis, cassandra=CassandraContext):
+        """Results can only be read back by exact test name, so registering must record the names."""
+        self.init_database(redis=redis, cassandra=cassandra)
+
+        self.assertEqual(
+            sorted(self.model.ews_context.names(suite='layout-tests', flaky=False)),
+            sorted(self.DEFAULT_TEST_RESULTS['results']),
+        )
+        self.assertEqual(sorted(self.model.ews_context.names(suite='layout-tests', flaky=True)), [])
+        self.assertEqual(sorted(self.model.ews_context.names(suite='javascriptcore-tests', flaky=False)), [])
+
+    @WaitForDockerTestCase.mock_if_no_docker(mock_redis=FakeStrictRedis, mock_cassandra=MockCassandraContext)
+    def test_names_separates_flaky_from_failed(self, redis=StrictRedis, cassandra=CassandraContext):
+        self.init_database(redis=redis, cassandra=cassandra, flaky_type='WithinStepDirtyTree')
+
+        expected = sorted(self.DEFAULT_TEST_RESULTS['results'])
+        self.assertEqual(sorted(self.model.ews_context.names(suite='layout-tests', flaky=True)), expected)
+        self.assertEqual(sorted(self.model.ews_context.names(suite='layout-tests', flaky=False)), [])
+
+    @WaitForDockerTestCase.mock_if_no_docker(mock_redis=FakeStrictRedis, mock_cassandra=MockCassandraContext)
+    def test_names_filters_by_prefix(self, redis=StrictRedis, cassandra=CassandraContext):
+        self.init_database(redis=redis, cassandra=cassandra, test_results=dict(results={
+            'fast/encoding/css-cached-bom.html': {'expected': 'PASS', 'actual': 'TEXT'},
+            'fast/forms/submit.html': {'expected': 'PASS', 'actual': 'TEXT'},
+            'http/tests/xhr/basic.html': {'expected': 'PASS', 'actual': 'TIMEOUT'},
+        }))
+
+        self.assertEqual(
+            sorted(self.model.ews_context.names(suite='layout-tests', test='fast/', flaky=False)),
+            ['fast/encoding/css-cached-bom.html', 'fast/forms/submit.html'],
+        )
+        self.assertEqual(
+            sorted(self.model.ews_context.names(suite='layout-tests', test='http/', flaky=False)),
+            ['http/tests/xhr/basic.html'],
+        )
+        self.assertEqual(sorted(self.model.ews_context.names(suite='layout-tests', test='nonexistent/', flaky=False)), [])

--- a/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/model/mock_model_factory.py
+++ b/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/model/mock_model_factory.py
@@ -226,7 +226,7 @@ class MockModelFactory(object):
             if complete_configuration != configuration:
                 continue
 
-            cls.iterate_all_commits(model, lambda commits: model.ews_context.register(
+            cls.iterate_all_commits(model, lambda commits: model.ews_context.record_results(
                 complete_configuration, commits, suite='layout-tests',
                 test_results=test_results, flaky_type=flaky_type,
                 timestamp=timestamp, details=details,

--- a/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/model/model.py
+++ b/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/model/model.py
@@ -106,6 +106,7 @@ class Model(object):
         self.ews_context = EWSContext(
             configuration_context=self.configuration_context,
             commit_context=self.commit_context,
+            ttl_seconds=self.default_ttl_seconds,
         )
 
     def healthy(self, writable=True):


### PR DESCRIPTION
#### 363100839eacb5718060931341fde67887fbe01d
<pre>
Add results database API endpoints to upload and query EWS test results
<a href="https://bugs.webkit.org/show_bug.cgi?id=320031">https://bugs.webkit.org/show_bug.cgi?id=320031</a>
<a href="https://rdar.apple.com/182965776">rdar://182965776</a>

Reviewed by Aakash Jain.

resultsdbpy can store EWS test results, but exposes no HTTP interface for
clients to write or read them. Add an EWSController with three endpoints:
POST /api/upload/ews to register a run&apos;s per-test results (optionally tagged
with a flaky_type), GET /api/results-ews to query a single test&apos;s history for
one or more configurations, selecting either the failure or flaky table and
windowing by time, and GET /api/results-ews/tests to enumerate the recorded
test names. Wire the routes into APIRoutes.

The read endpoints sit beside /api/results-summary rather than under
/api/results/, whose grammar is /results/&lt;path:suite&gt;, so a static rule there
would claim URLs out of a namespace that accepts any suite name.

Results are clustered by start_time, so a commit range could only be honored
as a filter applied in Python to rows Cassandra had already truncated with
LIMIT. Rather than answer such a query wrongly, find rejects ref, uuid,
timestamp, begin and end with a 400 and windows by time alone. Serving them
needs a by-commit table, as suite_results_by_commit is to
suite_results_by_start_time.

Results are partitioned by configuration and test name, so they can only be
read back for a test whose name is already known. Nothing recorded those
names: the shared test_names_by_suite belongs to TestContext and is not
written by EWSContext. Each reported name is now recorded in an index
partitioned by suite and by which of the two tables it belongs to, written in
the same batch as its results and sharing the same TTL, so a name never
outlives the data it points at. Like test_names_by_suite, that index is not
keyed by configuration or branch.

EWSContext was constructed without ttl_seconds, so rows in
ews_failed_tests_by_start_time were written with no TTL and would never
expire; it now inherits default_ttl_seconds while flaky rows keep the shorter
FLAKY_TTL_SECONDS. A TTL is applied per write, so this changes rows written
from now on rather than anything already stored.

* Tools/Scripts/libraries/resultsdbpy/resultsdbpy/controller/api_routes.py:
(APIRoutes.__init__): Construct an EWSController and register the /upload/ews
(POST), /results-ews (GET) and /results-ews/tests (GET) routes.
* Tools/Scripts/libraries/resultsdbpy/resultsdbpy/controller/ews_controller.py: Added.
(EWSController):
(EWSController.__init__): Hold the commit controller and EWS context.
(EWSController.upload): Handle POST /api/upload/ews; validate the payload
(configuration, suite, test_results, timestamp, flaky_type, details, commits),
aborting 400 on anything missing or malformed, then record the results via
ews_context. Commits are registered only once every check that can abort has
passed.
(EWSController.find): Handle GET /api/results-ews; query a test&apos;s results for
the requested configurations from the failure or flaky table, honoring recent
and time bounds, and return them grouped by configuration (404 when none
match).
(EWSController.list_tests): Handle GET /api/results-ews/tests; return the
recorded test names for a suite, optionally filtered by table and name prefix.
* Tools/Scripts/libraries/resultsdbpy/resultsdbpy/controller/ews_controller_unittest.py: Added.
(EWSControllerTest):
(EWSControllerTest.setup_webserver): Stand up a mock model and register the
API routes.
(EWSControllerTest.upload_ews_results): Helper that POSTs a results payload to
the upload endpoint.
(EWSControllerTest.find_ews_results): Helper that GETs the results endpoint
with the default configuration.
(EWSControllerTest.test_upload_and_find): Upload failures with metadata and
read them back, asserting details round-trip.
(EWSControllerTest.test_flaky_upload_and_find): Upload a flaky result and
confirm it is queryable via flaky=true, separate from the failure table.
(EWSControllerTest.test_invalid_upload_body_is_not_an_object): A body that is
not a json object is rejected with 400 rather than raising AttributeError.
(EWSControllerTest.test_invalid_upload_missing_suite): A payload without a
suite is rejected with 400.
(EWSControllerTest.test_invalid_upload_malformed_columns): Values that would
otherwise reach a cqlengine column or a commit lookup are rejected with 400.
(EWSControllerTest.test_invalid_upload_missing_commits): A payload without
commits is rejected with 400.
(EWSControllerTest.test_invalid_upload_missing_test_results): A payload
without test results is rejected with 400.
(EWSControllerTest.test_no_results): Querying a test with no stored results
returns 404.
(EWSControllerTest.test_find_rejects_a_commit_range): Commit-range parameters
are rejected with 400.
(EWSControllerTest.test_find_without_test): A query missing the test parameter
is rejected with 400.
(EWSControllerTest.test_upload_omitting_optional_fields): Optional fields may
be omitted from the payload.
(EWSControllerTest.test_invalid_upload_non_string_suite): A payload whose
suite is not a string is rejected with 400.
(EWSControllerTest.test_upload_preserves_commit_metadata): Uploading against a
registered commit leaves its author and message intact.
(EWSControllerTest.test_upload_registers_an_unsynced_commit): A commit the
database has not seen is registered by the upload.
(EWSControllerTest.test_upload_reports_the_tests_it_stored): The response
names the tests that were written.
(EWSControllerTest.test_invalid_upload_partial_configuration): A configuration
that cannot be written is rejected with 400.
(EWSControllerTest.test_time_window_query):
(EWSControllerTest.test_time_window_query.start_times_after): Results are
windowed by after_time and before_time.
(EWSControllerTest.test_list_tests): Recorded test names are enumerable.
(EWSControllerTest.test_list_tests_flaky): The flaky and failure indices are
separate.
(EWSControllerTest.test_list_tests_prefix): Names can be filtered by prefix.
(EWSControllerTest.test_list_tests_honours_the_limit_across_prefixes): The
limit applies to the whole response, not to each prefix.
(EWSControllerTest.test_list_tests_percent_encoded_name): A name containing a
query character survives percent-encoding.
(EWSControllerTest.test_list_tests_without_suite): A query missing the suite
parameter is rejected with 400.
(EWSControllerTest.test_list_tests_empty): Finding no tests returns an empty
list rather than 404.
* Tools/Scripts/libraries/resultsdbpy/resultsdbpy/model/ews_context.py:
(EWSContext):
(EWSContext.EWSTestNameBySuite): Index of test names by suite and table.
(EWSContext.__init__): Create the index table.
(EWSContext.record_results): Renamed from register, which named a callback
contract this does not keep: it returns the stored test names and raises
rather than returning partial_status. Record each reported name once per
table, with the same TTL as its results, coercing that TTL to an int since
cqlengine formats it straight into the CQL.
(EWSContext.names): Return the recorded names, optionally restricted to a name
prefix, as a list rather than a generator built inside the keyspace context.
(EWSContext.find_for_test): Query a test&apos;s results, bounded by start time.
* Tools/Scripts/libraries/resultsdbpy/resultsdbpy/model/ews_context_unittest.py:
(EWSContextTest):
(EWSContextTest.test_ttl_is_an_integer): Every TTL reaching Cassandra is an
int.
(EWSContextTest.test_record_results_reports_the_tests_it_stored):
(EWSContextTest.test_record_results_raises_when_the_write_is_rejected):
(EWSContextTest.test_names_enumerates_reported_tests):
(EWSContextTest.test_names_separates_flaky_from_failed):
(EWSContextTest.test_names_filters_by_prefix): Cover the index.
* Tools/Scripts/libraries/resultsdbpy/resultsdbpy/model/mock_model_factory.py:
(MockModelFactory.add_mock_ews_results): Follow the rename.
* Tools/Scripts/libraries/resultsdbpy/resultsdbpy/model/model.py:
(Model.__init__): Pass default_ttl_seconds to EWSContext.

Canonical link: <a href="https://commits.webkit.org/319085@main">https://commits.webkit.org/319085@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/579c2c7f830376a98fb72192779b0a81aebb6636

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180302 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54247 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48045 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190513 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144623 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182164 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55545 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53963 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140628 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97409 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183257 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44285 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161404 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121080 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/179626 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42958 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41260 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153361 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40933 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1672 "Built successfully") | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45513 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192448 "Built successfully") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/179703 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53913 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149980 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40181 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54601 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37545 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149703 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44340 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122025 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53118 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15922 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52500 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52737 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52565 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->