### PR TITLE
Cache Find in Page Text Markers

### DIFF
--- a/Source/WebCore/editing/CachedMatchFinder.cpp
+++ b/Source/WebCore/editing/CachedMatchFinder.cpp
@@ -272,6 +272,7 @@ Expected<Vector<SimpleRange>, CachedMatchFinder::CacheUnusable> CachedMatchFinde
 
     m_matchCache = results;
     m_countCache = results.size();
+    m_matchesMarked = false;
     m_searchResultCacheKeys.targetString = target;
     m_searchResultCacheKeys.limit = limit;
     m_searchResultCacheKeys.options = matchAffectingOptions(options);
@@ -364,6 +365,7 @@ bool CachedMatchFinder::clearTextBufferCache()
         m_searchResultCacheKeys.options = std::nullopt;
         m_matchCache = std::nullopt;
         m_countCache = std::nullopt;
+        m_matchesMarked = false;
         return false;
     }
 
@@ -376,6 +378,7 @@ bool CachedMatchFinder::clearTextBufferCache()
     m_docBuffer.dirty = true;
     m_matchCache = std::nullopt;
     m_countCache = std::nullopt;
+    m_matchesMarked = false;
     return true;
 }
 
@@ -460,6 +463,21 @@ bool CachedMatchFinder::isSearchResultCacheValid(const String& target, FindOptio
         && target == *m_searchResultCacheKeys.targetString
         && m_searchResultCacheKeys.limit == limit
         && m_searchResultCacheKeys.options == matchAffectingOptions(options);
+}
+
+void CachedMatchFinder::setMatchesMarked()
+{
+    m_matchesMarked = true;
+}
+
+void CachedMatchFinder::clearMatchesMarked()
+{
+    m_matchesMarked = false;
+}
+
+bool CachedMatchFinder::matchesAreMarked(const String& target, FindOptions options, std::optional<unsigned> limit) const
+{
+    return m_matchesMarked && isSearchResultCacheValid(target, options, limit);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/editing/CachedMatchFinder.h
+++ b/Source/WebCore/editing/CachedMatchFinder.h
@@ -50,6 +50,10 @@ public:
     WEBCORE_EXPORT Expected<Vector<SimpleRange>, CacheUnusable> findMatches(const std::optional<SimpleRange>&, const String& target, FindOptions, std::optional<unsigned> limit = std::nullopt);
     WEBCORE_EXPORT Expected<unsigned, CacheUnusable> countMatches(const std::optional<SimpleRange>&, const String& target, FindOptions, std::optional<unsigned> limit = std::nullopt);
 
+    WEBCORE_EXPORT bool matchesAreMarked(const String& target, FindOptions, std::optional<unsigned> limit) const;
+    WEBCORE_EXPORT void setMatchesMarked();
+    WEBCORE_EXPORT void clearMatchesMarked();
+
     WEBCORE_EXPORT static void setMaximumRunCountForTesting(std::optional<unsigned>);
 
 private:
@@ -85,6 +89,7 @@ private:
     TextRunCache m_docBuffer;
     std::optional<Vector<SimpleRange>> m_matchCache;
     std::optional<size_t> m_countCache;
+    bool m_matchesMarked { false };
 
     struct TextBufferCacheKeys {
         uint64_t domTreeVersion { 0 };

--- a/Source/WebCore/editing/Editor.cpp
+++ b/Source/WebCore/editing/Editor.cpp
@@ -4170,9 +4170,23 @@ static bool isFrameInRange(LocalFrame& frame, const SimpleRange& range)
     return false;
 }
 
-unsigned Editor::countMatchesForText(const String& target, const std::optional<SimpleRange>& range, FindOptions options, unsigned limit, bool markMatches, Vector<SimpleRange>* matches)
+Vector<SimpleRange> Editor::findAllMatches(const String& searchText, const std::optional<SimpleRange>& searchRange, FindOptions searchOptions, std::optional<unsigned> optionalLimit)
 {
-    if (target.isEmpty())
+    if (!m_matchFinder)
+        m_matchFinder = WTF::makeUnique<CachedMatchFinder>(this->document());
+
+    auto cachedMatches = m_matchFinder->findMatches(searchRange, searchText, searchOptions, optionalLimit);
+    if (cachedMatches.has_value())
+        return *cachedMatches;
+
+    ASSERT(cachedMatches.error() == CachedMatchFinder::CacheUnusable::Oversized);
+    auto fallbackRange = searchRange.has_value() ? *searchRange : makeRangeSelectingNodeContents(this->document());
+    return findAllPlainText(fallbackRange, searchText, searchOptions, optionalLimit.has_value() ? *optionalLimit : 0);
+}
+
+unsigned Editor::countMatchesForText(const String& searchText, const std::optional<SimpleRange>& range, FindOptions options, unsigned limit, bool markMatches, Vector<SimpleRange>* matches)
+{
+    if (searchText.isEmpty())
         return 0;
 
     Ref document = this->document();
@@ -4187,40 +4201,52 @@ unsigned Editor::countMatchesForText(const String& target, const std::optional<S
     if (!searchRange)
         searchRange = makeRangeSelectingNodeContents(document);
 
+    auto searchOptions = options - FindOption::Backwards;
+    std::optional<unsigned> optionalLimit = limit ? std::make_optional(limit) : std::nullopt;
+
+    auto allMatches = findAllMatches(searchText, searchRange, searchOptions, optionalLimit);
+
+    if (matches)
+        matches->appendVector(allMatches);
+
+    if (markMatches) {
+        for (const auto& match : allMatches)
+            addMarker(match, DocumentMarkerType::TextMatch);
+    }
+
+    return allMatches.size();
+}
+
+unsigned Editor::markAllMatchesForText(const String& searchText, FindOptions options, unsigned limit)
+{
+    if (searchText.isEmpty())
+        return 0;
+
+    Ref document = this->document();
+
     if (!m_matchFinder)
         m_matchFinder = WTF::makeUnique<CachedMatchFinder>(document);
 
     auto searchOptions = options - FindOption::Backwards;
     std::optional<unsigned> optionalLimit = limit ? std::make_optional(limit) : std::nullopt;
 
-    auto collectAndMark = [&](const Vector<SimpleRange>& allMatches) {
-        if (matches)
-            matches->appendVector(allMatches);
+    auto allMatches = findAllMatches(searchText, std::nullopt, searchOptions, optionalLimit);
 
-        if (markMatches) {
-            for (const auto& match : allMatches)
-                addMarker(match, DocumentMarkerType::TextMatch);
-        }
-    };
+    if (CheckedPtr markers = document->markersIfExists())
+        markers->removeMarkers(DocumentMarkerType::TextMatch);
+    for (const auto& match : allMatches)
+        addMarker(match, DocumentMarkerType::TextMatch);
 
-    if (matches || markMatches) {
-        auto cachedMatches = m_matchFinder->findMatches(searchRange, target, searchOptions, optionalLimit);
-        if (cachedMatches.has_value()) {
-            collectAndMark(*cachedMatches);
-            return cachedMatches->size();
-        }
-        ASSERT(cachedMatches.error() == CachedMatchFinder::CacheUnusable::Oversized);
-    } else {
-        auto cachedCount = m_matchFinder->countMatches(searchRange, target, searchOptions, optionalLimit);
-        if (cachedCount.has_value())
-            return *cachedCount;
-        ASSERT(cachedCount.error() == CachedMatchFinder::CacheUnusable::Oversized);
-    }
+    if (!m_matchFinder->matchesAreMarked(searchText, searchOptions, optionalLimit))
+        m_matchFinder->setMatchesMarked();
 
-    // The cached buffer was oversized; fall back to an uncached search.
-    auto allMatches = findAllPlainText(*searchRange, target, searchOptions, limit);
-    collectAndMark(allMatches);
     return allMatches.size();
+}
+
+void Editor::textMatchMarkersWereCleared()
+{
+    if (m_matchFinder)
+        m_matchFinder->clearMatchesMarked();
 }
 
 void Editor::setMarkedTextMatchesAreHighlighted(bool flag)

--- a/Source/WebCore/editing/Editor.h
+++ b/Source/WebCore/editing/Editor.h
@@ -526,6 +526,8 @@ public:
     WEBCORE_EXPORT void updateEditorUINowIfScheduled();
     bool shouldChangeSelection(const VisibleSelection& oldSelection, const VisibleSelection& newSelection, Affinity, bool stillSelecting) const;
     WEBCORE_EXPORT unsigned countMatchesForText(const String&, const std::optional<SimpleRange>&, FindOptions, unsigned limit, bool markMatches, Vector<SimpleRange>*);
+    WEBCORE_EXPORT unsigned markAllMatchesForText(const String&, FindOptions, unsigned limit);
+    WEBCORE_EXPORT void textMatchMarkersWereCleared();
     bool markedTextMatchesAreHighlighted() const;
     WEBCORE_EXPORT void setMarkedTextMatchesAreHighlighted(bool);
 
@@ -734,6 +736,8 @@ private:
     void postTextStateChangeNotificationForCut(const String&, const VisibleSelection&);
 
     void removeWritingSuggestionIfNeeded();
+
+    Vector<SimpleRange> findAllMatches(const String& searchText, const std::optional<SimpleRange>&, FindOptions searchOptions, std::optional<unsigned> limit);
 
     WeakPtr<EditorClient> m_client;
     WeakRef<Document, WeakPtrImplWithEventTargetData> m_document;

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -1360,9 +1360,11 @@ unsigned Page::findMatchesForText(const String& target, FindOptions options, uns
             frame = incrementFrame(frame.get(), true, CanWrap::No);
             continue;
         }
-        if (shouldMarkMatches == MarkMatches)
+        if (shouldMarkMatches == MarkMatches) {
             protect(localFrame->editor())->setMarkedTextMatchesAreHighlighted(shouldHighlightMatches == HighlightMatches);
-        matchCount += protect(localFrame->editor())->countMatchesForText(target, std::nullopt, options, maxMatchCount ? (maxMatchCount - matchCount) : 0, shouldMarkMatches == MarkMatches, nullptr);
+            matchCount += protect(localFrame->editor())->markAllMatchesForText(target, options, maxMatchCount ? (maxMatchCount - matchCount) : 0);
+        } else
+            matchCount += protect(localFrame->editor())->countMatchesForText(target, std::nullopt, options, maxMatchCount ? (maxMatchCount - matchCount) : 0, false, nullptr);
         frame = incrementFrame(frame.get(), true, CanWrap::No);
     } while (frame);
 
@@ -1488,6 +1490,8 @@ void Page::unmarkAllTextMatches()
     forEachDocument([] (Document& document) {
         if (CheckedPtr markers = document.markersIfExists())
             markers->removeMarkers(DocumentMarkerType::TextMatch);
+        if (RefPtr frame = document.frame())
+            protect(frame->editor())->textMatchMarkersWereCleared();
     });
 }
 

--- a/Source/WebKit/WebProcess/WebPage/FindController.cpp
+++ b/Source/WebKit/WebProcess/WebPage/FindController.cpp
@@ -223,7 +223,6 @@ void FindController::countStringMatches(const String& string, OptionSet<FindOpti
         if (shouldShowOverlay || shouldShowHighlight) {
             auto result = protect(webPage->corePage())->findTextMatches(string, core(options), maxMatchCount);
             matchCount = result.ranges.size();
-            protect(webPage->corePage())->unmarkAllTextMatches();
             protect(webPage->corePage())->markAllMatchesForText(string, core(options), shouldShowHighlight, maxMatchCount + 1);
         } else {
             matchCount = protect(webPage->corePage())->countFindMatches(string, core(options), maxMatchCount + 1);
@@ -374,7 +373,6 @@ unsigned FindController::markMatches(const String& string, OptionSet<FindOptions
     RefPtr webPage { m_webPage.get() };
     bool shouldShowHighlight = options.contains(FindOptions::ShowHighlight);
 
-    protect(webPage->corePage())->unmarkAllTextMatches();
     unsigned matchCount = protect(webPage->corePage())->markAllMatchesForText(string, core(options), shouldShowHighlight, maxMatchCount + 1);
     return matchCount + cueMatchCount;
 }
@@ -438,10 +436,8 @@ void FindController::updateFindUIAfterFindingAllMatches(bool found, const String
 
     bool shouldShowOverlay = found && options.contains(FindOptions::ShowOverlay);
     bool shouldShowHighlight = options.contains(FindOptions::ShowHighlight);
-    if (shouldShowOverlay || shouldShowHighlight) {
-        protect(webPage->corePage())->unmarkAllTextMatches();
+    if (shouldShowOverlay || shouldShowHighlight)
         protect(webPage->corePage())->markAllMatchesForText(string, core(options), shouldShowHighlight, maxMatchCount + 1);
-    }
 
     updateFindPageOverlay(shouldShowOverlay);
     updateFindIndicatorIfNeeded(found, options, shouldShowOverlay);


### PR DESCRIPTION
#### dca7909abc1adcba44fa11379ae05c0833513ed4
<pre>
Cache Find in Page Text Markers
<a href="https://bugs.webkit.org/show_bug.cgi?id=320032">https://bugs.webkit.org/show_bug.cgi?id=320032</a>
<a href="https://rdar.apple.com/182967087">rdar://182967087</a>

Reviewed by Sammy Gill.

Find in Page text markers are removed and readded every time the
user finds a new match. We improve performance by only removing
and readding if the DOM or search criteria has changed.

Note that I had to decouple the counting and matching in Editor.h
for this to work. Editor::countMatchesForText and
Editor::markAllMatchesForText both use a common helper
Editor::findAllMatches, which calls into
CachedMatchFinder::findMatches. This simplifies the code, and
allows us the benefit of caching the markers, which out weighs
the cost of calling CachedMatchFinder::findMatches in the case
we that only count.

* Source/WebCore/editing/CachedMatchFinder.cpp:
(WebCore::CachedMatchFinder::findMatches):
(WebCore::CachedMatchFinder::clearTextBufferCache):
(WebCore::CachedMatchFinder::setMatchesMarked):
(WebCore::CachedMatchFinder::clearMatchesMarked):
(WebCore::CachedMatchFinder::matchesAreMarked const):
* Source/WebCore/editing/CachedMatchFinder.h:
* Source/WebCore/editing/Editor.cpp:
(WebCore::Editor::countMatchesForText):
(WebCore::Editor::textMatchMarkersWereCleared):
* Source/WebCore/editing/Editor.h:
* Source/WebCore/page/Page.cpp:
(WebCore::Page::unmarkAllTextMatches):
* Source/WebKit/WebProcess/WebPage/FindController.cpp:
(WebKit::FindController::countStringMatches):
(WebKit::FindController::markMatches):
(WebKit::FindController::updateFindUIAfterFindingAllMatches):

Canonical link: <a href="https://commits.webkit.org/317897@main">https://commits.webkit.org/317897@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6178fa92bac88ed023c7c54ce167bb919216eba6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176671 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50608 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/44400 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186273 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/139551 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ab6b1168-c91f-4aad-af91-0714f5853f7f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178534 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51901 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50294 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/137623 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/139551 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e5ab1990-99bf-4bff-9529-8a6b3d817c64) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179627 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41123 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/158410 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118097 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3b1d355a-f4f0-4e67-9924-24e9e093e6fd) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39778 "Passed tests") | [⏳ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-API-Tests-EWS "Waiting to run tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150190 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/37908 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34741 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42348 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/42364 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188697 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50275 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/157953 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/146687 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39447 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50958 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/34529 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146492 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41252 "Passed tests") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123164 "Found 1 new failure in wasm/WasmConstExprGenerator.cpp") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117294 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49463 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/12887 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48862 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49098 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48923 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->