### PR TITLE
NumericConstraint::valueForCapabilityRange() ignores a valid current value when both min and max constraints are set

### DIFF
--- a/LayoutTests/fast/mediastream/apply-constraints-framerate-range-expected.txt
+++ b/LayoutTests/fast/mediastream/apply-constraints-framerate-range-expected.txt
@@ -1,0 +1,31 @@
+Tests applyConstraints with frame rate min/max range constraints on a video stream track.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS stream.getVideoTracks().length is 1
+
+** Constraint: {"width":1280,"height":720,"frameRate":20} - set width, height, and frame rate to valid values.
+PASS settings['width'] is 1280
+PASS settings['height'] is 720
+PASS settings['frameRate'] is 20
+
+** Constraint: {"frameRate":{"min":10,"max":25}} - frame rate 'min' and 'max' set, current value already satisfies both and there is no 'ideal', frame rate should not change.
+PASS settings['frameRate'] is 20
+
+** Constraint: {"frameRate":{"max":25}} - frame rate 'max' only set, current value already satisfies it and there is no 'ideal', frame rate should not change.
+PASS settings['frameRate'] is 20
+
+** Constraint: {"frameRate":{"max":15}} - frame rate 'max' only set, current value exceeds it, frame rate should be clamped down.
+PASS settings['frameRate'] is 15
+
+** Constraint: {"frameRate":{"min":10}} - frame rate 'min' only set, current value already satisfies it and there is no 'ideal', frame rate should not change.
+PASS settings['frameRate'] is 15
+
+** Constraint: {"frameRate":{"min":20}} - frame rate 'min' only set, current value is below it, frame rate should be clamped up.
+PASS settings['frameRate'] is 20
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/mediastream/apply-constraints-framerate-range.html
+++ b/LayoutTests/fast/mediastream/apply-constraints-framerate-range.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <script src="../../resources/js-test.js"></script>
+        <script src="resources/apply-constraints-utils.js"></script>
+        <script>
+
+            let tests = [
+                {
+                    message: "set width, height, and frame rate to valid values.",
+                    constraint: { width: 1280, height: 720, frameRate: 20 },
+                    expected: { width: 1280, height: 720, frameRate: 20 },
+                },
+                {
+                    message: "frame rate 'min' and 'max' set, current value already satisfies both and there is no 'ideal', frame rate should not change.",
+                    constraint: { frameRate: { min: 10, max: 25 } },
+                    expected: { frameRate: 20 },
+                },
+                {
+                    message: "frame rate 'max' only set, current value already satisfies it and there is no 'ideal', frame rate should not change.",
+                    constraint: { frameRate: { max: 25 } },
+                    expected: { frameRate: 20 },
+                },
+                {
+                    message: "frame rate 'max' only set, current value exceeds it, frame rate should be clamped down.",
+                    constraint: { frameRate: { max: 15 } },
+                    expected: { frameRate: 15 },
+                },
+                {
+                    message: "frame rate 'min' only set, current value already satisfies it and there is no 'ideal', frame rate should not change.",
+                    constraint: { frameRate: { min: 10 } },
+                    expected: { frameRate: 15 },
+                },
+                {
+                    message: "frame rate 'min' only set, current value is below it, frame rate should be clamped up.",
+                    constraint: { frameRate: { min: 20 } },
+                    expected: { frameRate: 20 },
+                },
+            ];
+
+            let tester = new ConstraintsTest({ video: true }, tests, "Tests applyConstraints with frame rate min/max range constraints on a video stream track.")
+                .onStreamReady((s) => {
+                    stream = s;
+                    shouldBe('stream.getVideoTracks().length', '1');
+                    tester.setStreamTrack(stream.getVideoTracks()[0]);
+                })
+                .onVideoReady((v) => {
+                    video = v;
+                })
+                .start();
+
+        </script>
+    </head>
+    <body>
+        <video controls id="video"</video>
+        <br>
+        <div id="div"></div>
+
+    </body>
+</html>

--- a/Source/WebCore/platform/mediastream/MediaConstraints.h
+++ b/Source/WebCore/platform/mediastream/MediaConstraints.h
@@ -263,12 +263,23 @@ public:
         }
 
         if (m_max) {
-            value = m_max.value();
-            ASSERT(validForRange(capabilityMin, value));
-            if (value < max)
-                max = value;
-            if (value > max)
-                value = max;
+            auto constraintMax = m_max.value();
+            ASSERT(validForRange(capabilityMin, constraintMax));
+            if (constraintMax < max)
+                max = constraintMax;
+
+            if (m_min) {
+                if (value > max)
+                    value = max;
+            } else {
+                value = constraintMax;
+                if (value > max)
+                    value = max;
+
+                // If there is no ideal, don't change if maximum is larger than current, as long as current is a valid value for this capability.
+                if (!m_ideal && current >= min && current < value)
+                    value = current;
+            }
         }
 
         if (m_ideal)

--- a/Tools/TestWebKitAPI/CMakeLists.txt
+++ b/Tools/TestWebKitAPI/CMakeLists.txt
@@ -245,6 +245,7 @@ if (ENABLE_WEBCORE)
         Tests/WebCore/LayoutUnitTests.cpp
         Tests/WebCore/MIMESniffer.cpp
         Tests/WebCore/MIMETypeRegistry.cpp
+        Tests/WebCore/MediaConstraintsTests.cpp
         Tests/WebCore/MediaReorderQueue.cpp
         Tests/WebCore/MixedContentChecker.cpp
         Tests/WebCore/MonospaceFontTests.cpp

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -775,6 +775,7 @@
 				WebCore/Logging.cpp,
 				WebCore/LoginStatus.cpp,
 				WebCore/MarkedText.cpp,
+				WebCore/MediaConstraintsTests.cpp,
 				WebCore/MediaReorderQueue.cpp,
 				WebCore/MIMESniffer.cpp,
 				WebCore/MIMETypeRegistry.cpp,

--- a/Tools/TestWebKitAPI/Tests/WebCore/MediaConstraintsTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/MediaConstraintsTests.cpp
@@ -1,0 +1,114 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#if ENABLE(MEDIA_STREAM)
+
+#include <WebCore/MediaConstraints.h>
+
+namespace TestWebKitAPI {
+
+TEST(MediaConstraintsTest, ValueForCapabilityRangeMinMaxPreservesValidCurrent)
+{
+    WebCore::IntConstraint constraint;
+    constraint.setMin(640);
+    constraint.setMax(1920);
+
+    // Current value already satisfies [min, max] and there is no ideal, so it
+    // should be left unchanged rather than jumping to max.
+    EXPECT_EQ(constraint.valueForCapabilityRange(1280, 0, 4096), 1280);
+}
+
+TEST(MediaConstraintsTest, ValueForCapabilityRangeMinMaxClampsAboveMax)
+{
+    WebCore::IntConstraint constraint;
+    constraint.setMin(640);
+    constraint.setMax(1920);
+
+    EXPECT_EQ(constraint.valueForCapabilityRange(2000, 0, 4096), 1920);
+}
+
+TEST(MediaConstraintsTest, ValueForCapabilityRangeMinMaxClampsBelowMin)
+{
+    WebCore::IntConstraint constraint;
+    constraint.setMin(640);
+    constraint.setMax(1920);
+
+    EXPECT_EQ(constraint.valueForCapabilityRange(100, 0, 4096), 640);
+}
+
+TEST(MediaConstraintsTest, ValueForCapabilityRangeMaxOnlyClampsAboveMax)
+{
+    WebCore::IntConstraint constraint;
+    constraint.setMax(1920);
+
+    EXPECT_EQ(constraint.valueForCapabilityRange(2000, 0, 4096), 1920);
+}
+
+TEST(MediaConstraintsTest, ValueForCapabilityRangeMaxOnlyPreservesValidCurrent)
+{
+    WebCore::IntConstraint constraint;
+    constraint.setMax(1920);
+
+    // Current value already satisfies max and there is no ideal, so it
+    // should be left unchanged rather than jumping to max.
+    EXPECT_EQ(constraint.valueForCapabilityRange(1280, 0, 4096), 1280);
+}
+
+TEST(MediaConstraintsTest, ValueForCapabilityRangeMaxOnlyIgnoresCurrentBelowCapabilityMin)
+{
+    WebCore::IntConstraint constraint;
+    constraint.setMax(1920);
+
+    // Current value is below the capability's own minimum (e.g. an unset/default
+    // value before the source has produced any frames), so it is not a valid current
+    // value and must not be preserved; the constraint should still clamp to max.
+    EXPECT_EQ(constraint.valueForCapabilityRange(0, 1, 4096), 1920);
+}
+
+TEST(MediaConstraintsTest, ValueForCapabilityRangeMinOnlyPreservesValidCurrent)
+{
+    WebCore::IntConstraint constraint;
+    constraint.setMin(640);
+
+    // Current value already satisfies min and there is no ideal, so it
+    // should be left unchanged rather than jumping to min.
+    EXPECT_EQ(constraint.valueForCapabilityRange(1280, 0, 4096), 1280);
+}
+
+TEST(MediaConstraintsTest, ValueForCapabilityRangeMinMaxIdealIsUnaffected)
+{
+    WebCore::IntConstraint constraint;
+    constraint.setMin(640);
+    constraint.setMax(1920);
+    constraint.setIdeal(1024);
+
+    EXPECT_EQ(constraint.valueForCapabilityRange(1280, 0, 4096), 1024);
+}
+
+} // namespace TestWebKitAPI
+
+#endif // ENABLE(MEDIA_STREAM)


### PR DESCRIPTION
#### fdc1fa6d65eadd301ae44497e2dce31645437fe1
<pre>
NumericConstraint::valueForCapabilityRange() ignores a valid current value when both min and max constraints are set
<a href="https://bugs.webkit.org/show_bug.cgi?id=320037">https://bugs.webkit.org/show_bug.cgi?id=320037</a>
<a href="https://rdar.apple.com/problem/182968516">rdar://problem/182968516</a>

Reviewed by Youenn Fablet.

When a numeric constraint (width, height, frameRate, zoom, aspectRatio, ...)
has both min and max set but no ideal, valueForCapabilityRange() first computes
a value that preserves the current setting if it already satisfies the min
constraint, then unconditionally overwrites that value with the max constraint
in the following block. This forces applyConstraints() to jump the setting to
the max bound even when the current value already lies within [min, max],
e.g. applyConstraints({width: {min: 640, max: 1920}}) with a current width of
1280 incorrectly changes width to 1920 instead of leaving it unchanged.

Fix the max block to clamp the already-computed value down to max only when
it exceeds max, instead of always replacing it with the max constraint value.

The same problem also existed when only max is set (no min): the max block
unconditionally set the value to the max constraint, ignoring a current value
that already satisfied it. Apply the same current-preserving fix there. The
min-only case was already correct, since the min block has always preserved
a valid current value independently of the max block.

In the max-only case, only preserve current when it is itself a valid value
for the capability (current &gt;= capabilityMin). Otherwise a sentinel/default
current of 0, such as the RealtimeMediaSource width/height before any frame
has been produced, is always less than a positive max constraint and would be
incorrectly preserved as the resolved value, collapsing width/height to 0.
This was caught by fast/mediastream/getDisplayMedia-max-constraints2.html,
getDisplayMedia-max-constraints4.html, and getDisplayMedia-max-constraints5.html,
which asserted in RealtimeMediaSource::addVideoFrameObserver() because the
zeroed size threw off UserMediaCaptureManagerProxySourceProxy&apos;s observer
bookkeeping. The min-only case does not need the same guard, since a current
of 0 is never greater than a positive min constraint.

* Source/WebCore/platform/mediastream/MediaConstraints.h:
(WebCore::NumericConstraint::valueForCapabilityRange const):
* Tools/TestWebKitAPI/CMakeLists.txt:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebCore/MediaConstraintsTests.cpp: Added.
(TestWebKitAPI::TEST(MediaConstraintsTest, ValueForCapabilityRangeMinMaxPreservesValidCurrent)):
(TestWebKitAPI::TEST(MediaConstraintsTest, ValueForCapabilityRangeMinMaxClampsAboveMax)):
(TestWebKitAPI::TEST(MediaConstraintsTest, ValueForCapabilityRangeMinMaxClampsBelowMin)):
(TestWebKitAPI::TEST(MediaConstraintsTest, ValueForCapabilityRangeMaxOnlyClampsAboveMax)):
(TestWebKitAPI::TEST(MediaConstraintsTest, ValueForCapabilityRangeMaxOnlyPreservesValidCurrent)):
(TestWebKitAPI::TEST(MediaConstraintsTest, ValueForCapabilityRangeMaxOnlyIgnoresCurrentBelowCapabilityMin)):
(TestWebKitAPI::TEST(MediaConstraintsTest, ValueForCapabilityRangeMinOnlyPreservesValidCurrent)):
(TestWebKitAPI::TEST(MediaConstraintsTest, ValueForCapabilityRangeMinMaxIdealIsUnaffected)):
* LayoutTests/fast/mediastream/apply-constraints-framerate-range.html: Added.
* LayoutTests/fast/mediastream/apply-constraints-framerate-range-expected.txt: Added.

Canonical link: <a href="https://commits.webkit.org/318046@main">https://commits.webkit.org/318046@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c6e5588144023344e52a7df7ad078fd0d393ab57

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176546 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50481 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44271 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186147 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/138832 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7a0d0682-3f6d-4cca-b4ef-b78b496eb376) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178409 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51773 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50165 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137522 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/138832 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ba1859aa-eefa-470c-941f-68c5ed0c3973) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179502 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41008 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158300 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117997 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/35b5707c-d92c-40dc-a359-1db1273e571b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39658 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38029 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150073 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37798 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34615 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42214 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42240 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188570 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50146 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/157845 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146577 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39540 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50830 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34421 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146386 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41145 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123034 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117107 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49334 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12773 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48736 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48970 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48795 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->