### PR TITLE
Stream IPC message receivers can call directly into Swift

### DIFF
--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -774,6 +774,9 @@ def forward_declarations_and_headers(receiver):
         '<wtf/ThreadSafeRefCounted.h>',
     ])
 
+    if (receiver.swift_receiver or receiver.swift_receiver_build_enabled_by) and receiver.has_attribute(STREAM_ATTRIBUTE):
+        headers.add('"StreamMessageReceiver.h"')
+
     non_template_wtf_types = frozenset([
         'MachSendRight',
         'MediaType',
@@ -874,18 +877,29 @@ def generate_messages_header(receiver):
                 sync_messages.append(message)
 
         result.append('namespace ' + handler_namespace + ' {\n\n')
-        result.append('class ' + forwarder_class + ': public RefCounted<' + forwarder_class + '>, public IPC::MessageReceiver {\n')
+        is_stream = receiver.has_attribute(STREAM_ATTRIBUTE)
+        if is_stream:
+            result.append('class ' + forwarder_class + ' final : public IPC::StreamMessageReceiver {\n')
+        else:
+            result.append('class ' + forwarder_class + ': public RefCounted<' + forwarder_class + '>, public IPC::MessageReceiver {\n')
         result.append('public:\n')
         result.append('    static Ref<' + forwarder_class + '> createFromWeak(' + handler_namespace + '::' + weak_ref_class + '* _Nonnull handler)\n')
         result.append('    {\n')
         result.append('        return adoptRef(*new ' + forwarder_class + '(handler));\n')
         result.append('    }\n')
         result.append('    ~' + forwarder_class + '();\n')
-        result.append('    void didReceiveMessage(IPC::Connection&, IPC::Decoder&);\n')
-        if not receiver.has_attribute(STREAM_ATTRIBUTE) and (sync_messages or receiver.has_attribute(WANTS_DISPATCH_MESSAGE_ATTRIBUTE)):
+        if is_stream:
+            result.append('    void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;\n')
+        else:
+            result.append('    void didReceiveMessage(IPC::Connection&, IPC::Decoder&);\n')
+        if not is_stream and (sync_messages or receiver.has_attribute(WANTS_DISPATCH_MESSAGE_ATTRIBUTE)):
             result.append('    void didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&);\n')
-        result.append('    void ref() const final { RefCounted::ref(); }\n')
-        result.append('    void deref() const final { RefCounted::deref(); }\n')
+        if is_stream:
+            result.append('    void ref() const { StreamMessageReceiver::ref(); }\n')
+            result.append('    void deref() const { StreamMessageReceiver::deref(); }\n')
+        else:
+            result.append('    void ref() const final { RefCounted::ref(); }\n')
+            result.append('    void deref() const final { RefCounted::deref(); }\n')
         result.append('private:\n')
         result.append('    ' + forwarder_class + '(' + handler_namespace + '::' + weak_ref_class + '* _Nonnull);\n')
         result.append('    std::unique_ptr<' + handler_namespace + '::' + class_name + '> getMessageTarget();\n')
@@ -1823,17 +1837,26 @@ def generate_get_target_statements(receiver):
 
     def append_swift_get_target_statements(result):
         result.append('    auto target = getMessageTarget();\n')
-        # If target is a nullptr, this means the Swift message receiver has been destroyed.
-        # This makes no sense, since that Swift message receiver owns this class, the C++
-        # message forwarder, so we should also have been destroyed. If this happens,
-        # something somewhere is keeping an unexpected reference alive.
-        # In debug builds, crash. In release builds, attempt to survive by behaving as if
-        # corrupted data was received from the sender.
-        result.append('    if (!target) {\n')
-        result.append('        FATAL("Something is keeping a reference to the message forwarder");\n')
-        result.append('        decoder.markInvalid();\n')
-        result.append('        return;\n')
-        result.append('    }\n')
+        if receiver.has_attribute(STREAM_ATTRIBUTE):
+            # Stream receivers hold the target weakly and dispatch off the main thread, so a null
+            # target is a benign teardown race that must not crash the process. Mark the message
+            # invalid, which tears the stream connection down cleanly.
+            result.append('    if (!target) {\n')
+            result.append('        decoder.markInvalid();\n')
+            result.append('        return;\n')
+            result.append('    }\n')
+        else:
+            # If target is a nullptr, this means the Swift message receiver has been destroyed.
+            # This makes no sense, since that Swift message receiver owns this class, the C++
+            # message forwarder, so we should also have been destroyed. If this happens,
+            # something somewhere is keeping an unexpected reference alive.
+            # In debug builds, crash. In release builds, attempt to survive by behaving as if
+            # corrupted data was received from the sender.
+            result.append('    if (!target) {\n')
+            result.append('        FATAL("Something is keeping a reference to the message forwarder");\n')
+            result.append('        decoder.markInvalid();\n')
+            result.append('        return;\n')
+            result.append('    }\n')
 
     if_swift_enabled(receiver, result, append_swift_get_target_statements, None)
     return result

--- a/Source/WebKit/Scripts/webkit/messages_unittest.py
+++ b/Source/WebKit/Scripts/webkit/messages_unittest.py
@@ -59,6 +59,7 @@ _test_receiver_names = [
     'TestWithStreamBatched',
     'TestWithStreamBuffer',
     'TestWithStreamServerConnectionHandle',
+    'TestWithStreamSwift',
     'TestWithSuperclass',
     'TestWithSuperclassAndWantsAsyncDispatch',
     'TestWithSuperclassAndWantsDispatch',

--- a/Source/WebKit/Scripts/webkit/tests/Makefile
+++ b/Source/WebKit/Scripts/webkit/tests/Makefile
@@ -18,6 +18,7 @@ TESTS = \
     TestWithStreamBatched \
     TestWithStreamBuffer \
     TestWithStreamServerConnectionHandle \
+    TestWithStreamSwift \
     TestWithSuperclass \
     TestWithSuperclassAndWantsAsyncDispatch \
     TestWithSuperclassAndWantsDispatch \

--- a/Source/WebKit/Scripts/webkit/tests/MessageArgumentDescriptions.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/MessageArgumentDescriptions.cpp
@@ -287,6 +287,8 @@ std::optional<JSC::JSValue> jsValueForArguments(JSC::JSGlobalObject* globalObjec
         return jsValueForDecodedMessage<MessageName::TestWithStreamBuffer_SendStreamBuffer>(globalObject, decoder);
     case MessageName::TestWithStreamServerConnectionHandle_SendStreamServerConnection:
         return jsValueForDecodedMessage<MessageName::TestWithStreamServerConnectionHandle_SendStreamServerConnection>(globalObject, decoder);
+    case MessageName::TestWithStreamSwift_SendString:
+        return jsValueForDecodedMessage<MessageName::TestWithStreamSwift_SendString>(globalObject, decoder);
     case MessageName::TestWithSuperclass_LoadURL:
         return jsValueForDecodedMessage<MessageName::TestWithSuperclass_LoadURL>(globalObject, decoder);
 #if ENABLE(TEST_FEATURE)
@@ -1064,6 +1066,10 @@ std::optional<Vector<ArgumentDescription>> messageArgumentDescriptions(MessageNa
     case MessageName::TestWithStreamServerConnectionHandle_SendStreamServerConnection:
         return Vector<ArgumentDescription> {
             { "handle"_s, "IPC::StreamServerConnectionHandle"_s },
+        };
+    case MessageName::TestWithStreamSwift_SendString:
+        return Vector<ArgumentDescription> {
+            { "url"_s, "String"_s },
         };
     case MessageName::TestWithSuperclass_LoadURL:
         return Vector<ArgumentDescription> {

--- a/Source/WebKit/Scripts/webkit/tests/MessageNames.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/MessageNames.cpp
@@ -99,6 +99,7 @@ const MessageDescriptionsArray messageDescriptions {
     MessageDescription { "TestWithStreamBatched_SendString"_s, ReceiverName::TestWithStreamBatched, true, false, false, ProcessName::Unknown, ProcessName::Unknown },
     MessageDescription { "TestWithStreamBuffer_SendStreamBuffer"_s, ReceiverName::TestWithStreamBuffer, false, false, false, ProcessName::Unknown, ProcessName::Unknown },
     MessageDescription { "TestWithStreamServerConnectionHandle_SendStreamServerConnection"_s, ReceiverName::TestWithStreamServerConnectionHandle, false, false, false, ProcessName::Unknown, ProcessName::Unknown },
+    MessageDescription { "TestWithStreamSwift_SendString"_s, ReceiverName::TestWithStreamSwift, true, false, false, ProcessName::Unknown, ProcessName::Unknown },
     MessageDescription { "TestWithStream_CallWithIdentifier"_s, ReceiverName::TestWithStream, true, false, false, ProcessName::Unknown, ProcessName::Unknown },
     MessageDescription { "TestWithStream_CallWithIdentifierReply"_s, ReceiverName::TestWithStream, false, false, true, ProcessName::Unknown, ProcessName::Unknown },
 #if PLATFORM(COCOA)

--- a/Source/WebKit/Scripts/webkit/tests/MessageNames.h
+++ b/Source/WebKit/Scripts/webkit/tests/MessageNames.h
@@ -58,19 +58,20 @@ enum class ReceiverName : uint8_t {
     , TestWithStreamBatched = 14
     , TestWithStreamBuffer = 15
     , TestWithStreamServerConnectionHandle = 16
-    , TestWithSuperclass = 17
-    , TestWithSuperclassAndWantsAsyncDispatch = 18
-    , TestWithSuperclassAndWantsDispatch = 19
-    , TestWithSwift = 20
-    , TestWithSwiftConditionally = 21
-    , TestWithValidator = 22
-    , TestWithWantsAsyncDispatch = 23
-    , TestWithWantsDispatch = 24
-    , TestWithWantsDispatchNoSyncMessages = 25
-    , TestWithoutAttributes = 26
-    , TestWithoutUsingIPCConnection = 27
-    , IPC = 28
-    , Invalid = 29
+    , TestWithStreamSwift = 17
+    , TestWithSuperclass = 18
+    , TestWithSuperclassAndWantsAsyncDispatch = 19
+    , TestWithSuperclassAndWantsDispatch = 20
+    , TestWithSwift = 21
+    , TestWithSwiftConditionally = 22
+    , TestWithValidator = 23
+    , TestWithWantsAsyncDispatch = 24
+    , TestWithWantsDispatch = 25
+    , TestWithWantsDispatchNoSyncMessages = 26
+    , TestWithoutAttributes = 27
+    , TestWithoutUsingIPCConnection = 28
+    , IPC = 29
+    , Invalid = 30
 };
 
 enum class MessageName : uint16_t {
@@ -145,6 +146,7 @@ enum class MessageName : uint16_t {
     TestWithStreamBatched_SendString,
     TestWithStreamBuffer_SendStreamBuffer,
     TestWithStreamServerConnectionHandle_SendStreamServerConnection,
+    TestWithStreamSwift_SendString,
     TestWithStream_CallWithIdentifier,
     TestWithStream_CallWithIdentifierReply,
 #if PLATFORM(COCOA)

--- a/Source/WebKit/Scripts/webkit/tests/TestWithStreamSwift.messages.in
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithStreamSwift.messages.in
@@ -1,0 +1,31 @@
+# Copyright (C) 2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+[
+    ExceptionForEnabledBy,
+    ExceptionForDispatchedFrom,
+    ExceptionForDispatchedTo,
+    SwiftReceiver
+]
+messages -> TestWithStreamSwift Stream {
+    void SendString(String url)
+}

--- a/Source/WebKit/Scripts/webkit/tests/TestWithStreamSwiftMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithStreamSwiftMessageReceiver.cpp
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "Shared/WebKit-Swift.h" // NOLINT
+#include "ArgumentCoders.h" // NOLINT
+#include "Decoder.h" // NOLINT
+#include "HandleMessage.h" // NOLINT
+#include "TestWithStreamSwiftMessages.h" // NOLINT
+#include <wtf/text/WTFString.h> // NOLINT
+
+#if ENABLE(IPC_TESTING_API)
+#include "JSIPCBinding.h"
+#endif
+
+namespace WebKit {
+
+void TestWithStreamSwiftMessageForwarder::didReceiveStreamMessage(IPC::StreamServerConnection& connection, IPC::Decoder& decoder)
+{
+    auto target = getMessageTarget();
+    if (!target) {
+        decoder.markInvalid();
+        return;
+    }
+    if (decoder.messageName() == Messages::TestWithStreamSwift::SendString::name()) {
+        IPC::handleMessage<Messages::TestWithStreamSwift::SendString>(connection, decoder, target.get(), &TestWithStreamSwift::sendString);
+        return;
+    }
+    RELEASE_LOG_ERROR(IPC, "Unhandled stream message %s to %" PRIu64, IPC::description(decoder.messageName()).characters(), decoder.destinationID());
+    decoder.markInvalid();
+}
+
+static std::unique_ptr<TestWithStreamSwiftWeakRef> makeTestWithStreamSwiftWeakRefUniquePtr(TestWithStreamSwiftWeakRef* _Nonnull handler)
+{
+    auto newRef = _impl::_impl_TestWithStreamSwiftWeakRef::makeRetained(handler);
+    return WTF::makeUniqueWithoutFastMallocCheck<TestWithStreamSwiftWeakRef>(newRef);
+}
+
+TestWithStreamSwiftMessageForwarder::TestWithStreamSwiftMessageForwarder(TestWithStreamSwiftWeakRef* _Nonnull target)
+    : m_handler(makeTestWithStreamSwiftWeakRefUniquePtr(target))
+{
+}
+
+std::unique_ptr<TestWithStreamSwift> TestWithStreamSwiftMessageForwarder::getMessageTarget()
+{
+    auto target = m_handler->getMessageTarget();
+    if (target)
+        return WTF::makeUniqueWithoutFastMallocCheck<TestWithStreamSwift>(target.get());
+    return nullptr;
+}
+
+TestWithStreamSwiftMessageForwarder::~TestWithStreamSwiftMessageForwarder()
+{
+}
+
+
+} // namespace WebKit
+
+#if ENABLE(IPC_TESTING_API)
+
+namespace IPC {
+
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithStreamSwift_SendString>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+{
+    return jsValueForDecodedArguments<Messages::TestWithStreamSwift::SendString::Arguments>(globalObject, decoder);
+}
+
+}
+
+#endif
+

--- a/Source/WebKit/Scripts/webkit/tests/TestWithStreamSwiftMessageReceiver.swift
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithStreamSwiftMessageReceiver.swift
@@ -1,0 +1,51 @@
+//
+// Copyright (C) 2021-2023 Apple Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1.  Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+// 2.  Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+// ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+import WebKit_Internal
+
+final class TestWithStreamSwiftWeakRef {
+    private weak var target: TestWithStreamSwift?
+    init(target: TestWithStreamSwift) {
+        self.target = target
+    }
+
+    @used
+    func getMessageTarget() -> TestWithStreamSwift? {
+        target
+    }
+}
+
+extension WebKit.TestWithStreamSwiftMessageForwarder {
+    static func create(target: TestWithStreamSwift) -> RefTestWithStreamSwiftMessageForwarder {
+        let weakRefContainer = TestWithStreamSwiftWeakRef(target: target)
+        // Safety: we're creating a pointer which will immediately be stored in a
+        // proper ref-counted reference on the C++ side before this call returns.
+        // Workaround for rdar://163107752.
+        return unsafe WebKit.TestWithStreamSwiftMessageForwarder.createFromWeak(
+            OpaquePointer(
+                Unmanaged.passRetained(weakRefContainer).toOpaque()
+            )
+        )
+    }
+}

--- a/Source/WebKit/Scripts/webkit/tests/TestWithStreamSwiftMessages.h
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithStreamSwiftMessages.h
@@ -1,0 +1,107 @@
+/*
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "ArgumentCoders.h"
+#include "Connection.h"
+#include "MessageNames.h"
+#include "StreamMessageReceiver.h"
+#include <wtf/Forward.h>
+#include <wtf/RuntimeApplicationChecks.h>
+#include <wtf/ThreadSafeRefCounted.h>
+#include <wtf/text/WTFString.h>
+
+namespace WebKit {
+class TestWithStreamSwift;
+class TestWithStreamSwiftMessageForwarder;
+class TestWithStreamSwiftWeakRef;
+}
+
+namespace WebKit {
+
+class TestWithStreamSwiftMessageForwarder final : public IPC::StreamMessageReceiver {
+public:
+    static Ref<TestWithStreamSwiftMessageForwarder> createFromWeak(WebKit::TestWithStreamSwiftWeakRef* _Nonnull handler)
+    {
+        return adoptRef(*new TestWithStreamSwiftMessageForwarder(handler));
+    }
+    ~TestWithStreamSwiftMessageForwarder();
+    void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
+    void ref() const { StreamMessageReceiver::ref(); }
+    void deref() const { StreamMessageReceiver::deref(); }
+private:
+    TestWithStreamSwiftMessageForwarder(WebKit::TestWithStreamSwiftWeakRef* _Nonnull);
+    std::unique_ptr<WebKit::TestWithStreamSwift> getMessageTarget();
+    std::unique_ptr<WebKit::TestWithStreamSwiftWeakRef> m_handler;
+} SWIFT_SHARED_REFERENCE(.ref, .deref);
+
+}
+
+using RefTestWithStreamSwiftMessageForwarder = Ref<WebKit::TestWithStreamSwiftMessageForwarder>;
+
+namespace Messages {
+namespace TestWithStreamSwift {
+
+static inline IPC::ReceiverName messageReceiverName()
+{
+    return IPC::ReceiverName::TestWithStreamSwift;
+}
+
+class SendString {
+public:
+    using Arguments = std::tuple<String>;
+
+    static IPC::MessageName name() { return IPC::MessageName::TestWithStreamSwift_SendString; }
+    static constexpr bool isSync = false;
+    static constexpr bool canDispatchOutOfOrder = false;
+    static constexpr bool replyCanDispatchOutOfOrder = false;
+    static constexpr bool deferSendingIfSuspended = false;
+    static constexpr bool isStreamEncodable = true;
+    static constexpr bool isStreamBatched = false;
+
+    explicit SendString(const String& url)
+        : m_url(url)
+    {
+    }
+
+    template<typename Encoder>
+    void encode(Encoder& encoder)
+    {
+        encoder << m_url;
+    }
+
+private:
+    const String& m_url;
+};
+
+} // namespace TestWithStreamSwift
+} // namespace Messages
+
+namespace CompletionHandlers {
+namespace TestWithStreamSwift {
+
+} // namespace TestWithStreamSwift
+} // namespace CompletionHandlers
+


### PR DESCRIPTION
#### 85ec3f6980f7fd9767bf955bb851f9b93d5d499c
<pre>
Stream IPC message receivers can call directly into Swift

<a href="https://bugs.webkit.org/show_bug.cgi?id=320035">https://bugs.webkit.org/show_bug.cgi?id=320035</a>
<a href="https://rdar.apple.com/182967586">rdar://182967586</a>

Reviewed by Adrian Taylor.

The IPC code generator can already emit a Swift message receiver for
non-stream receivers (as used by WebBackForwardList), but not for Stream
receivers. A Stream receiver dispatches off the main thread and uses a
different base class (IPC::StreamMessageReceiver) and entry point
(didReceiveStreamMessage), so a receiver marked both Stream and SwiftReceiver
was generated with the wrong shape. Supporting it is a prerequisite for moving
stream-based receivers such as RemoteMesh to Swift.

Teach the generator to emit the stream-shaped forwarder: it inherits
IPC::StreamMessageReceiver (itself ThreadSafeRefCounted, so its refcount is
atomic for the off-main work queue), overrides didReceiveStreamMessage, and
forwards ref()/deref() to the stream base. If the weakly-held Swift target has
already been destroyed (a benign off-main teardown race), the forwarder marks
the message invalid so the stream connection tears down cleanly instead of
leaving the shared buffer mis-framed.

Covered by a new fixture, TestWithStreamSwift, added to the IPC
message-generator test messages_unittest.py.

* Source/WebKit/Scripts/webkit/messages.py:
(forward_declarations_and_headers):
(generate_messages_header):
(generate_get_target_statements.append_swift_get_target_statements):
* Source/WebKit/Scripts/webkit/messages_unittest.py:
* Source/WebKit/Scripts/webkit/tests/Makefile:
* Source/WebKit/Scripts/webkit/tests/MessageArgumentDescriptions.cpp:
* Source/WebKit/Scripts/webkit/tests/MessageNames.cpp:
* Source/WebKit/Scripts/webkit/tests/MessageNames.h:
* Source/WebKit/Scripts/webkit/tests/TestWithStreamSwift.messages.in: Added.
* Source/WebKit/Scripts/webkit/tests/TestWithStreamSwiftMessageReceiver.cpp: Added.
* Source/WebKit/Scripts/webkit/tests/TestWithStreamSwiftMessageReceiver.swift: Added.
* Source/WebKit/Scripts/webkit/tests/TestWithStreamSwiftMessages.h: Added.

Canonical link: <a href="https://commits.webkit.org/317984@main">https://commits.webkit.org/317984@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2bb0bd43f743539303146e07f10a331e97b7295d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176242 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50177 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43967 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185838 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/138486 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8db20c1a-d2a3-406f-a23d-9ea4bf4cf2d2) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51469 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49861 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137264 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/138486 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179198 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40747 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158041 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117739 "Passed tests") | | ⏳ 🛠 vision-apple 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/175565 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39396 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37759 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/6550 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149812 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37538 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34307 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/37510 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41898 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41970 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188262 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49842 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146299 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39501 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50526 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34278 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146119 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40894 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122730 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/116706 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49030 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12510 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48432 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48666 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48491 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->