### PR TITLE
[Digital Credentials] Start to parse OpenID4VP signed and multisigned requests in the web content process

### DIFF
--- a/LayoutTests/http/wpt/identity/digital-credential-openid4vp-request-parsing-disabled.https-expected.txt
+++ b/LayoutTests/http/wpt/identity/digital-credential-openid4vp-request-parsing-disabled.https-expected.txt
@@ -1,0 +1,3 @@
+
+PASS With the setting disabled, a malformed openid4vp-v1-signed request is skipped, so a valid mdoc request alongside it still passes filtering
+

--- a/LayoutTests/http/wpt/identity/digital-credential-openid4vp-request-parsing-disabled.https.html
+++ b/LayoutTests/http/wpt/identity/digital-credential-openid4vp-request-parsing-disabled.https.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<meta charset="utf-8" />
+<title>Digital Credentials: OpenID4VP requests are not parsed while the setting is disabled.</title>
+<link rel="help" href="https://w3c-fedid.github.io/digital-credentials/" />
+<link rel="author" href="mailto:pascoe@apple.com">
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body></body>
+<script>
+    promise_setup(async () => {
+        if (document.visibilityState === "hidden") {
+            await new Promise((resolve) => {
+                document.onvisibilitychange = resolve;
+                testRunner.setPageVisibility("visible");
+            });
+        }
+        assert_equals(document.visibilityState, "visible", "should be visible");
+    });
+
+    const validMDocRequest = {
+        protocol: "org-iso-mdoc",
+        data: {
+            deviceRequest:
+                "omd2ZXJzaW9uYzEuMGtkb2NSZXF1ZXN0c4GhbGl0ZW1zUmVxdWVzdNgYWIKiZ2RvY1R5cGV1b3JnLmlzby4xODAxMy41LjEubURMam5hbWVTcGFjZXOhcW9yZy5pc28uMTgwMTMuNS4x9pWthZ2Vfb3Zlcl8yMfRqZ2l2ZW5fbmFtZfRrZmFtaWx5X25hbWX0cmRyaXZpbmdfcHJpdmlsZWdlc_RocG9ydHJhaXT0",
+            encryptionInfo:
+                "gmVkY2FwaaJlbm9uY2VYICBetSsDkKlE_G9JSIHwPzr3ctt6Ol9GgmCH8iGdGQNJcnJlY2lwaWVudFB1YmxpY0tleaQBAiABIVggKKm1iPeuOb9bDJeeJEL4QldYlWvY7F_K8eZkmYdS9PwiWCCm9PLEmosiE_ildsE11lqq4kDkjhfQUKPpbX-Hm1ZSLg",
+        },
+    };
+
+    promise_test(async (t) => {
+        let error;
+        try {
+            await navigator.credentials.get({
+                digital: { requests: [validMDocRequest, { protocol: "openid4vp-v1-signed", data: {} }] },
+                mediation: "required",
+            });
+            assert_unreached("get() should not succeed in the test environment");
+        } catch (e) {
+            error = e;
+        }
+        assert_not_equals(error.name, "TypeError",
+            "the unsupported openid4vp-v1-signed request should be skipped, leaving the valid mdoc request");
+    }, "With the setting disabled, a malformed openid4vp-v1-signed request is skipped, so a valid mdoc request alongside it still passes filtering");
+</script>

--- a/LayoutTests/http/wpt/identity/digital-credential-openid4vp-request-parsing.https-expected.txt
+++ b/LayoutTests/http/wpt/identity/digital-credential-openid4vp-request-parsing.https-expected.txt
@@ -1,0 +1,5 @@
+
+PASS openid4vp-v1-signed missing the required 'request' member rejects with a TypeError
+PASS openid4vp-v1-multisigned missing the required 'payload'/'signatures' members rejects with a TypeError
+PASS A malformed openid4vp-v1-signed request is parsed and aborts a get() that also contains a valid mdoc request
+

--- a/LayoutTests/http/wpt/identity/digital-credential-openid4vp-request-parsing.https.html
+++ b/LayoutTests/http/wpt/identity/digital-credential-openid4vp-request-parsing.https.html
@@ -1,0 +1,59 @@
+<!-- webkit-test-runner [ DigitalCredentialsOpenID4VPEnabled=true ] -->
+<!DOCTYPE html>
+<meta charset="utf-8" />
+<title>Digital Credentials: OpenID4VP signed/multisigned requests are parsed when enabled.</title>
+<link rel="help" href="https://w3c-fedid.github.io/digital-credentials/" />
+<link rel="author" href="mailto:pascoe@apple.com">
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body></body>
+<script>
+    promise_setup(async () => {
+        if (document.visibilityState === "hidden") {
+            await new Promise((resolve) => {
+                document.onvisibilitychange = resolve;
+                testRunner.setPageVisibility("visible");
+            });
+        }
+        assert_equals(document.visibilityState, "visible", "should be visible");
+    });
+
+    const validMDocRequest = {
+        protocol: "org-iso-mdoc",
+        data: {
+            deviceRequest:
+                "omd2ZXJzaW9uYzEuMGtkb2NSZXF1ZXN0c4GhbGl0ZW1zUmVxdWVzdNgYWIKiZ2RvY1R5cGV1b3JnLmlzby4xODAxMy41LjEubURMam5hbWVTcGFjZXOhcW9yZy5pc28uMTgwMTMuNS4x9pWthZ2Vfb3Zlcl8yMfRqZ2l2ZW5fbmFtZfRrZmFtaWx5X25hbWX0cmRyaXZpbmdfcHJpdmlsZWdlc_RocG9ydHJhaXT0",
+            encryptionInfo:
+                "gmVkY2FwaaJlbm9uY2VYICBetSsDkKlE_G9JSIHwPzr3ctt6Ol9GgmCH8iGdGQNJcnJlY2lwaWVudFB1YmxpY0tleaQBAiABIVggKKm1iPeuOb9bDJeeJEL4QldYlWvY7F_K8eZkmYdS9PwiWCCm9PLEmosiE_ildsE11lqq4kDkjhfQUKPpbX-Hm1ZSLg",
+        },
+    };
+
+    // With the setting enabled, the OpenID4VP signed/multisigned requests are parsed
+    // via convertDictionary() in the web content process, which enforces the required
+    // dictionary members. A missing required member makes the whole get() reject.
+    promise_test(async (t) => {
+        await promise_rejects_js(t, TypeError, navigator.credentials.get({
+            digital: { requests: [{ protocol: "openid4vp-v1-signed", data: {} }] },
+            mediation: "required",
+        }));
+    }, "openid4vp-v1-signed missing the required 'request' member rejects with a TypeError");
+
+    promise_test(async (t) => {
+        await promise_rejects_js(t, TypeError, navigator.credentials.get({
+            digital: { requests: [{ protocol: "openid4vp-v1-multisigned", data: {} }] },
+            mediation: "required",
+        }));
+    }, "openid4vp-v1-multisigned missing the required 'payload'/'signatures' members rejects with a TypeError");
+
+    // A malformed signed request is parsed (not skipped): its conversion failure aborts
+    // the whole get(), even though a valid mdoc request is also present. (Contrast with
+    // the disabled case, where the unsupported request is skipped and the mdoc proceeds.)
+    promise_test(async (t) => {
+        await promise_rejects_js(t, TypeError, navigator.credentials.get({
+            digital: { requests: [validMDocRequest, { protocol: "openid4vp-v1-signed", data: {} }] },
+            mediation: "required",
+        }));
+    }, "A malformed openid4vp-v1-signed request is parsed and aborts a get() that also contains a valid mdoc request");
+</script>

--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -456,6 +456,9 @@ set(WebCore_NON_SVG_IDL_FILES
 
     Modules/identity/protocols/ISO18013/MobileDocumentRequest.idl
 
+    Modules/identity/protocols/openid/OpenID4VPMultisignedRequest.idl
+    Modules/identity/protocols/openid/OpenID4VPSignature.idl
+    Modules/identity/protocols/openid/OpenID4VPSignedRequest.idl
 
     Modules/indexeddb/IDBCursor.idl
     Modules/indexeddb/IDBCursorDirection.idl

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -383,6 +383,9 @@ JS_BINDING_IDLS := \
     $(WebCore)/Modules/identity/DigitalCredentialRequestOptions.idl \
     $(WebCore)/Modules/identity/DigitalCredentialPresentationProtocol.idl \
     $(WebCore)/Modules/identity/protocols/ISO18013/MobileDocumentRequest.idl \
+    $(WebCore)/Modules/identity/protocols/openid/OpenID4VPMultisignedRequest.idl \
+    $(WebCore)/Modules/identity/protocols/openid/OpenID4VPSignature.idl \
+    $(WebCore)/Modules/identity/protocols/openid/OpenID4VPSignedRequest.idl \
     $(WebCore)/Modules/indexeddb/IDBCursor.idl \
     $(WebCore)/Modules/indexeddb/IDBCursorDirection.idl \
     $(WebCore)/Modules/indexeddb/IDBCursorWithValue.idl \

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -490,6 +490,10 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     Modules/identity/protocols/ISO18013/MobileDocumentRequest.h
     Modules/identity/protocols/ISO18013/ValidatedMobileDocumentRequest.h
 
+    Modules/identity/protocols/openid/OpenID4VPMultisignedRequest.h
+    Modules/identity/protocols/openid/OpenID4VPSignature.h
+    Modules/identity/protocols/openid/OpenID4VPSignedRequest.h
+
     Modules/indexeddb/IDBActiveDOMObject.h
     Modules/indexeddb/IDBActiveDOMObjectInlines.h
     Modules/indexeddb/IDBCursor.h

--- a/Source/WebCore/Modules/identity/DigitalCredential.cpp
+++ b/Source/WebCore/Modules/identity/DigitalCredential.cpp
@@ -41,6 +41,8 @@
 #include "JSDOMConvertDictionary.h"
 #include "JSDOMConvertJSON.h"
 #include "JSDOMPromiseDeferred.h"
+#include "JSOpenID4VPMultisignedRequest.h"
+#include "JSOpenID4VPSignedRequest.h"
 #include "LocalDOMWindow.h"
 #include "LocalFrame.h"
 #include "MediationRequirement.h"
@@ -75,9 +77,7 @@ bool DigitalCredential::userAgentAllowsProtocol(const Document& document, const 
     if (protocol == "org-iso-mdoc"_s)
         return true;
 
-    // The OpenID4VP protocols are gated behind an off-by-default setting while their request
-    // validation and wallet plumbing are still under development, so that the API does not
-    // advertise support for a protocol it cannot yet fulfill.
+    // Off by default: the API must not advertise a protocol it cannot yet fulfill.
     if (document.settings().digitalCredentialsOpenID4VPEnabled()) {
         return protocol == "openid4vp-v1-unsigned"_s
             || protocol == "openid4vp-v1-signed"_s
@@ -87,16 +87,24 @@ bool DigitalCredential::userAgentAllowsProtocol(const Document& document, const 
     return false;
 }
 
-static std::optional<DigitalCredentialPresentationProtocol> convertProtocolString(const String& protocolString)
+static std::optional<DigitalCredentialPresentationProtocol> convertProtocolString(const Document& document, const String& protocolString)
 {
     if (protocolString == "org-iso-mdoc"_s)
         return DigitalCredentialPresentationProtocol::OrgIsoMdoc;
+
+    if (document.settings().digitalCredentialsOpenID4VPEnabled()) {
+        if (protocolString == "openid4vp-v1-signed"_s)
+            return DigitalCredentialPresentationProtocol::Openid4vpV1Signed;
+        if (protocolString == "openid4vp-v1-multisigned"_s)
+            return DigitalCredentialPresentationProtocol::Openid4vpV1Multisigned;
+    }
+
     return std::nullopt;
 }
 
 static ExceptionOr<std::optional<UnvalidatedDigitalCredentialRequest>> jsToCredentialRequest(const Document& document, const DigitalCredentialGetRequest& request)
 {
-    auto protocol = convertProtocolString(request.protocol);
+    auto protocol = convertProtocolString(document, request.protocol);
     if (!protocol)
         return std::optional<UnvalidatedDigitalCredentialRequest> { std::nullopt }; // Skip requests with an unsupported protocol.
 
@@ -108,14 +116,28 @@ static ExceptionOr<std::optional<UnvalidatedDigitalCredentialRequest>> jsToCrede
     if (scope.exception()) [[unlikely]]
         return Exception { ExceptionCode::ExistingExceptionError };
 
+    using enum DigitalCredentialPresentationProtocol;
     switch (*protocol) {
-    case DigitalCredentialPresentationProtocol::OrgIsoMdoc: {
+    case OrgIsoMdoc: {
         auto result = convertDictionary<MobileDocumentRequest>(*globalObject, request.data.get());
         if (result.hasException(scope)) [[unlikely]]
             return Exception { ExceptionCode::ExistingExceptionError };
         return std::make_optional<UnvalidatedDigitalCredentialRequest>(result.releaseReturnValue());
     }
+    case Openid4vpV1Signed: {
+        auto result = convertDictionary<OpenID4VPSignedRequest>(*globalObject, request.data.get());
+        if (result.hasException(scope)) [[unlikely]]
+            return Exception { ExceptionCode::ExistingExceptionError };
+        return std::make_optional<UnvalidatedDigitalCredentialRequest>(result.releaseReturnValue());
+    }
+    case Openid4vpV1Multisigned: {
+        auto result = convertDictionary<OpenID4VPMultisignedRequest>(*globalObject, request.data.get());
+        if (result.hasException(scope)) [[unlikely]]
+            return Exception { ExceptionCode::ExistingExceptionError };
+        return std::make_optional<UnvalidatedDigitalCredentialRequest>(result.releaseReturnValue());
+    }
     default:
+        // FIXME: Handle "openid4vp-v1-unsigned" once DCQL parsing lands (webkit.org/b/320207).
         ASSERT_NOT_REACHED();
         return Exception { ExceptionCode::TypeError, "Unsupported protocol."_s };
     }

--- a/Source/WebCore/Modules/identity/protocols/openid/OpenID4VPMultisignedRequest.h
+++ b/Source/WebCore/Modules/identity/protocols/openid/OpenID4VPMultisignedRequest.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,18 +25,15 @@
 
 #pragma once
 
-#include <WebCore/MobileDocumentRequest.h>
-#include <WebCore/OpenID4VPMultisignedRequest.h>
-#include <WebCore/OpenID4VPSignedRequest.h>
-#include <wtf/Variant.h>
+#include <WebCore/OpenID4VPSignature.h>
+#include <wtf/Vector.h>
+#include <wtf/text/WTFString.h>
 
 namespace WebCore {
 
-// Every alternative must be IPC-serializable; see WebCoreArgumentCodersAuth.serialization.in.
-using UnvalidatedDigitalCredentialRequest = Variant<
-    MobileDocumentRequest,
-    OpenID4VPSignedRequest,
-    OpenID4VPMultisignedRequest
->;
+struct OpenID4VPMultisignedRequest {
+    String payload;
+    Vector<OpenID4VPSignature> signatures;
+};
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/identity/protocols/openid/OpenID4VPMultisignedRequest.idl
+++ b/Source/WebCore/Modules/identity/protocols/openid/OpenID4VPMultisignedRequest.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,20 +23,7 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
-
-#include <WebCore/MobileDocumentRequest.h>
-#include <WebCore/OpenID4VPMultisignedRequest.h>
-#include <WebCore/OpenID4VPSignedRequest.h>
-#include <wtf/Variant.h>
-
-namespace WebCore {
-
-// Every alternative must be IPC-serializable; see WebCoreArgumentCodersAuth.serialization.in.
-using UnvalidatedDigitalCredentialRequest = Variant<
-    MobileDocumentRequest,
-    OpenID4VPSignedRequest,
-    OpenID4VPMultisignedRequest
->;
-
-} // namespace WebCore
+dictionary OpenID4VPMultisignedRequest {
+    required DOMString payload;
+    required sequence<OpenID4VPSignature> signatures;
+};

--- a/Source/WebCore/Modules/identity/protocols/openid/OpenID4VPSignature.h
+++ b/Source/WebCore/Modules/identity/protocols/openid/OpenID4VPSignature.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,18 +25,13 @@
 
 #pragma once
 
-#include <WebCore/MobileDocumentRequest.h>
-#include <WebCore/OpenID4VPMultisignedRequest.h>
-#include <WebCore/OpenID4VPSignedRequest.h>
-#include <wtf/Variant.h>
+#include <wtf/text/WTFString.h>
 
 namespace WebCore {
 
-// Every alternative must be IPC-serializable; see WebCoreArgumentCodersAuth.serialization.in.
-using UnvalidatedDigitalCredentialRequest = Variant<
-    MobileDocumentRequest,
-    OpenID4VPSignedRequest,
-    OpenID4VPMultisignedRequest
->;
+struct OpenID4VPSignature {
+    String protectedHeader;
+    String signature;
+};
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/identity/protocols/openid/OpenID4VPSignature.idl
+++ b/Source/WebCore/Modules/identity/protocols/openid/OpenID4VPSignature.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,20 +23,8 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
-
-#include <WebCore/MobileDocumentRequest.h>
-#include <WebCore/OpenID4VPMultisignedRequest.h>
-#include <WebCore/OpenID4VPSignedRequest.h>
-#include <wtf/Variant.h>
-
-namespace WebCore {
-
-// Every alternative must be IPC-serializable; see WebCoreArgumentCodersAuth.serialization.in.
-using UnvalidatedDigitalCredentialRequest = Variant<
-    MobileDocumentRequest,
-    OpenID4VPSignedRequest,
-    OpenID4VPMultisignedRequest
->;
-
-} // namespace WebCore
+dictionary OpenID4VPSignature {
+    // "protected" is a C++ reserved word, so the IDL name is escaped.
+    [ImplementedAs=protectedHeader] required DOMString _protected;
+    required DOMString signature;
+};

--- a/Source/WebCore/Modules/identity/protocols/openid/OpenID4VPSignedRequest.h
+++ b/Source/WebCore/Modules/identity/protocols/openid/OpenID4VPSignedRequest.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,18 +25,12 @@
 
 #pragma once
 
-#include <WebCore/MobileDocumentRequest.h>
-#include <WebCore/OpenID4VPMultisignedRequest.h>
-#include <WebCore/OpenID4VPSignedRequest.h>
-#include <wtf/Variant.h>
+#include <wtf/text/WTFString.h>
 
 namespace WebCore {
 
-// Every alternative must be IPC-serializable; see WebCoreArgumentCodersAuth.serialization.in.
-using UnvalidatedDigitalCredentialRequest = Variant<
-    MobileDocumentRequest,
-    OpenID4VPSignedRequest,
-    OpenID4VPMultisignedRequest
->;
+struct OpenID4VPSignedRequest {
+    String request;
+};
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/identity/protocols/openid/OpenID4VPSignedRequest.idl
+++ b/Source/WebCore/Modules/identity/protocols/openid/OpenID4VPSignedRequest.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,20 +23,6 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
-
-#include <WebCore/MobileDocumentRequest.h>
-#include <WebCore/OpenID4VPMultisignedRequest.h>
-#include <WebCore/OpenID4VPSignedRequest.h>
-#include <wtf/Variant.h>
-
-namespace WebCore {
-
-// Every alternative must be IPC-serializable; see WebCoreArgumentCodersAuth.serialization.in.
-using UnvalidatedDigitalCredentialRequest = Variant<
-    MobileDocumentRequest,
-    OpenID4VPSignedRequest,
-    OpenID4VPMultisignedRequest
->;
-
-} // namespace WebCore
+dictionary OpenID4VPSignedRequest {
+    required DOMString request;
+};

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -4704,6 +4704,9 @@ JSOfflineAudioContext.cpp
 JSOfflineAudioContextOptions.cpp
 JSOffscreenCanvas.cpp
 JSOffscreenCanvasRenderingContext2D.cpp
+JSOpenID4VPMultisignedRequest.cpp
+JSOpenID4VPSignature.cpp
+JSOpenID4VPSignedRequest.cpp
 JSOptionalEffectTiming.cpp
 JSOpusEncoderConfig.cpp
 JSOrigin.cpp

--- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
+++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
@@ -7124,6 +7124,9 @@
 		E868034828603E8900799EE3 /* JSWindowEventHandlers+Gamepad.h in Headers */ = {isa = PBXBuildFile; fileRef = E8FC9219285BFD5A004904B2 /* JSWindowEventHandlers+Gamepad.h */; };
 		E8744DA22D62BD0100E56B11 /* ValidatedMobileDocumentRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = E8744DA02D62BD0100E56B11 /* ValidatedMobileDocumentRequest.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E8744DA32D62BD0100E56B11 /* MobileDocumentRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = E8744D9D2D62BD0100E56B11 /* MobileDocumentRequest.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		EB08054AAEA4BB58328F5762 /* OpenID4VPMultisignedRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = 745C1E395EA6A30D6AE53DCB /* OpenID4VPMultisignedRequest.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		599DD0B0C2E2D658258CFA9A /* OpenID4VPSignature.h in Headers */ = {isa = PBXBuildFile; fileRef = 166FD29091573AE0071CC010 /* OpenID4VPSignature.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		34B3726E71963DE8E6D0A99B /* OpenID4VPSignedRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = 24318795E4EEC2337746A550 /* OpenID4VPSignedRequest.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E89BE8AC2DADBD2F0036B3A5 /* UnvalidatedDigitalCredentialRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = E89BE8AB2DADBD2F0036B3A5 /* UnvalidatedDigitalCredentialRequest.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E8BF3AE42D56005800E7ED0B /* DummyCredentialRequestCoordinatorClient.h in Headers */ = {isa = PBXBuildFile; fileRef = E8BF3AE12D56003700E7ED0B /* DummyCredentialRequestCoordinatorClient.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E8E7BDE32D94D20E0000A163 /* DigitalCredentialsProtocols.h in Headers */ = {isa = PBXBuildFile; fileRef = E8E7BDE22D94D2020000A163 /* DigitalCredentialsProtocols.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -23164,6 +23167,12 @@
 		E8744D9D2D62BD0100E56B11 /* MobileDocumentRequest.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MobileDocumentRequest.h; sourceTree = "<group>"; };
 		E8744D9F2D62BD0100E56B11 /* MobileDocumentRequest.idl */ = {isa = PBXFileReference; lastKnownFileType = text; path = MobileDocumentRequest.idl; sourceTree = "<group>"; };
 		E8744DA02D62BD0100E56B11 /* ValidatedMobileDocumentRequest.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ValidatedMobileDocumentRequest.h; sourceTree = "<group>"; };
+		745C1E395EA6A30D6AE53DCB /* OpenID4VPMultisignedRequest.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OpenID4VPMultisignedRequest.h; sourceTree = "<group>"; };
+		10DCBDE288D8DF09E9DE8095 /* OpenID4VPMultisignedRequest.idl */ = {isa = PBXFileReference; lastKnownFileType = text; path = OpenID4VPMultisignedRequest.idl; sourceTree = "<group>"; };
+		166FD29091573AE0071CC010 /* OpenID4VPSignature.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OpenID4VPSignature.h; sourceTree = "<group>"; };
+		DA1F1A26CC1A22F7F9E51921 /* OpenID4VPSignature.idl */ = {isa = PBXFileReference; lastKnownFileType = text; path = OpenID4VPSignature.idl; sourceTree = "<group>"; };
+		24318795E4EEC2337746A550 /* OpenID4VPSignedRequest.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OpenID4VPSignedRequest.h; sourceTree = "<group>"; };
+		99AC31211F38CFD6F2485E92 /* OpenID4VPSignedRequest.idl */ = {isa = PBXFileReference; lastKnownFileType = text; path = OpenID4VPSignedRequest.idl; sourceTree = "<group>"; };
 		E886AA61285AC5A5008FF9F7 /* WindowEventHandlers+Gamepad.idl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "WindowEventHandlers+Gamepad.idl"; sourceTree = "<group>"; };
 		E89BE8AB2DADBD2F0036B3A5 /* UnvalidatedDigitalCredentialRequest.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = UnvalidatedDigitalCredentialRequest.h; sourceTree = "<group>"; };
 		E8BF3AE12D56003700E7ED0B /* DummyCredentialRequestCoordinatorClient.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DummyCredentialRequestCoordinatorClient.h; sourceTree = "<group>"; };
@@ -41582,6 +41591,12 @@
 		E8E7BDE12D94D12A0000A163 /* openid */ = {
 			isa = PBXGroup;
 			children = (
+				745C1E395EA6A30D6AE53DCB /* OpenID4VPMultisignedRequest.h */,
+				10DCBDE288D8DF09E9DE8095 /* OpenID4VPMultisignedRequest.idl */,
+				166FD29091573AE0071CC010 /* OpenID4VPSignature.h */,
+				DA1F1A26CC1A22F7F9E51921 /* OpenID4VPSignature.idl */,
+				24318795E4EEC2337746A550 /* OpenID4VPSignedRequest.h */,
+				99AC31211F38CFD6F2485E92 /* OpenID4VPSignedRequest.idl */,
 			);
 			path = openid;
 			sourceTree = "<group>";
@@ -47692,6 +47707,9 @@
 				314877E31FAA8FE900C05759 /* OffscreenCanvas.h in Headers */,
 				3140C5201FDF151A00D2A873 /* OffscreenCanvasRenderingContext2D.h in Headers */,
 				07E4BDC42A3A6191000D5509 /* OpacityCaretAnimator.h in Headers */,
+				EB08054AAEA4BB58328F5762 /* OpenID4VPMultisignedRequest.h in Headers */,
+				599DD0B0C2E2D658258CFA9A /* OpenID4VPSignature.h in Headers */,
+				34B3726E71963DE8E6D0A99B /* OpenID4VPSignedRequest.h in Headers */,
 				B2D3DA650D006CD600EF6F3A /* OpenTypeCG.h in Headers */,
 				B2D3DA650D006CD600EF6F27 /* OpenTypeMathData.h in Headers */,
 				B2D3EA650D006CD600EF6F28 /* OpenTypeTypes.h in Headers */,

--- a/Source/WebKit/Shared/WebCoreArgumentCodersAuth.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCodersAuth.serialization.in
@@ -337,6 +337,26 @@ struct WebCore::MobileDocumentRequest {
     Vector<WebCore::ISO18013PresentmentRequest> presentmentRequests;
 };
 
+header: <WebCore/OpenID4VPSignedRequest.h>
+struct WebCore::OpenID4VPSignedRequest {
+    String request;
+};
+
+header: <WebCore/OpenID4VPSignature.h>
+struct WebCore::OpenID4VPSignature {
+    String protectedHeader;
+    String signature;
+};
+
+header: <WebCore/OpenID4VPMultisignedRequest.h>
+struct WebCore::OpenID4VPMultisignedRequest {
+    String payload;
+    Vector<WebCore::OpenID4VPSignature> signatures;
+};
+
+header: <WebCore/UnvalidatedDigitalCredentialRequest.h>
+using WebCore::UnvalidatedDigitalCredentialRequest = Variant<WebCore::MobileDocumentRequest, WebCore::OpenID4VPSignedRequest, WebCore::OpenID4VPMultisignedRequest>;
+
 header: <WebCore/DigitalCredentialsRequestData.h>
 [AdditionalEncoder=StreamConnectionEncoder] struct WebCore::DigitalCredentialsSecurityOriginData {
     [Validator='!topOrigin->isNull()'] WebCore::SecurityOriginData topOrigin;

--- a/Source/WebKit/UIProcess/DigitalCredentials/WKDigitalCredentialsPicker.mm
+++ b/Source/WebKit/UIProcess/DigitalCredentials/WKDigitalCredentialsPicker.mm
@@ -281,9 +281,14 @@ static RetainPtr<NSArray<NSArray<WKIdentityDocumentPresentmentRequestAuthenticat
                 RetainPtr<NSMutableArray<WKIdentityDocumentPresentmentRawRequest *>> rawRequests = adoptNS([[NSMutableArray alloc] init]);
 
                 for (auto &&unvalidatedRequest : unvalidatedRequests) {
-                    const auto &mobileDocumentRequest = unvalidatedRequest;
-                    RetainPtr deviceRequest = mobileDocumentRequest.deviceRequest.createNSString();
-                    RetainPtr encryptionInfo = mobileDocumentRequest.encryptionInfo.createNSString();
+                    auto* mobileDocumentRequest = std::get_if<WebCore::MobileDocumentRequest>(&unvalidatedRequest);
+                    if (!mobileDocumentRequest) {
+                        // FIXME: Hand off the OpenID4VP protocols once rdar://problem/183338719
+                        // is fulfilled.
+                        continue;
+                    }
+                    RetainPtr deviceRequest = mobileDocumentRequest->deviceRequest.createNSString();
+                    RetainPtr encryptionInfo = mobileDocumentRequest->encryptionInfo.createNSString();
 
                     RetainPtr<NSDictionary<NSString *, id>> jsonRequest = @{
                         @"deviceRequest" : deviceRequest.get(),

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -378,7 +378,9 @@ using RawDigitalCredentialsWithRequestInfo = Vector<String>;
 #endif
 
 struct MobileDocumentRequest;
-using UnvalidatedDigitalCredentialRequest = MobileDocumentRequest;
+struct OpenID4VPMultisignedRequest;
+struct OpenID4VPSignedRequest;
+using UnvalidatedDigitalCredentialRequest = Variant<MobileDocumentRequest, OpenID4VPSignedRequest, OpenID4VPMultisignedRequest>;
 using DigitalCredentialsRequestData = Variant<
     WebCore::DigitalCredentialsMobileDocumentRequestData
 #if ENABLE(ISO18013_DOCUMENT_REQUEST_INFO)

--- a/Source/WebKit/WebProcess/DigitalCredentials/DigitalCredentialsCoordinator.messages.in
+++ b/Source/WebKit/WebProcess/DigitalCredentials/DigitalCredentialsCoordinator.messages.in
@@ -30,10 +30,10 @@
 ]
 messages -> DigitalCredentialsCoordinator {
 #if ENABLE(ISO18013_DOCUMENT_REQUEST_INFO)
-    ProvideRawDigitalCredentialRequests() -> (Variant<Vector<WebCore::MobileDocumentRequest>, Vector<String>> rawRequests)
+    ProvideRawDigitalCredentialRequests() -> (Variant<Vector<WebCore::UnvalidatedDigitalCredentialRequest>, Vector<String>> rawRequests)
 #endif
 #if !ENABLE(ISO18013_DOCUMENT_REQUEST_INFO)
-    ProvideRawDigitalCredentialRequests() -> (Variant<Vector<WebCore::MobileDocumentRequest>> rawRequests)
+    ProvideRawDigitalCredentialRequests() -> (Variant<Vector<WebCore::UnvalidatedDigitalCredentialRequest>> rawRequests)
 #endif
 }
 

--- a/Source/WebKit/WebProcess/cocoa/IdentityDocumentServices/DigitalCredentialsRequestValidatorBridge.h
+++ b/Source/WebKit/WebProcess/cocoa/IdentityDocumentServices/DigitalCredentialsRequestValidatorBridge.h
@@ -28,6 +28,7 @@
 #if ENABLE(WEB_AUTHN)
 
 #include <WebCore/MobileDocumentRequest.h>
+#include <WebCore/UnvalidatedDigitalCredentialRequest.h>
 #include <WebCore/ValidatedMobileDocumentRequest.h>
 #include <wtf/Vector.h>
 
@@ -40,7 +41,7 @@ struct ValidatedMobileDocumentRequest;
 namespace WebKit {
 namespace DigitalCredentials {
 
-Vector<WebCore::ValidatedMobileDocumentRequest> validateRequests(const WebCore::SecurityOrigin&, const WebCore::Document&, const Vector<WebCore::MobileDocumentRequest>&);
+Vector<WebCore::ValidatedMobileDocumentRequest> validateRequests(const WebCore::SecurityOrigin&, const WebCore::Document&, const Vector<WebCore::UnvalidatedDigitalCredentialRequest>&);
 
 } // namespace DigitalCredentials
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/cocoa/IdentityDocumentServices/DigitalCredentialsRequestValidatorBridge.mm
+++ b/Source/WebKit/WebProcess/cocoa/IdentityDocumentServices/DigitalCredentialsRequestValidatorBridge.mm
@@ -164,17 +164,23 @@ static WebCore::ValidatedMobileDocumentRequest buildValidatedRequest(WKIdentityD
     return validatedRequest;
 }
 
-Vector<WebCore::ValidatedMobileDocumentRequest> DigitalCredentials::validateRequests(const SecurityOrigin &topOrigin, const Document &document, const Vector<WebCore::MobileDocumentRequest> &unvalidatedRequests)
+Vector<WebCore::ValidatedMobileDocumentRequest> DigitalCredentials::validateRequests(const SecurityOrigin &topOrigin, const Document &document, const Vector<WebCore::UnvalidatedDigitalCredentialRequest> &unvalidatedRequests)
 {
     RetainPtr convertedTopOrigin = topOrigin.toURL().createNSURL().get();
     RetainPtr validator = adoptNS([WebKit::allocWKIdentityDocumentRawRequestValidatorInstance() init]);
 
     Vector<WebCore::ValidatedMobileDocumentRequest> validatedRequests;
 
-    for (auto mobileDocumentRequest : unvalidatedRequests) {
+    for (auto& unvalidatedRequest : unvalidatedRequests) {
+        auto* mobileDocumentRequest = std::get_if<WebCore::MobileDocumentRequest>(&unvalidatedRequest);
+        if (!mobileDocumentRequest) {
+            // FIXME: Validate the OpenID4VP protocols once rdar://problem/183338719 is
+            // fulfilled.
+            continue;
+        }
 
-        RetainPtr convertedEncryptionInfo = mobileDocumentRequest.encryptionInfo.createNSString();
-        RetainPtr convertedDeviceRequest = mobileDocumentRequest.deviceRequest.createNSString();
+        RetainPtr convertedEncryptionInfo = mobileDocumentRequest->encryptionInfo.createNSString();
+        RetainPtr convertedDeviceRequest = mobileDocumentRequest->deviceRequest.createNSString();
 
         RetainPtr iso18013Request = adoptNS([WebKit::allocWKISO18013RequestInstance() initWithEncryptionInfo:convertedEncryptionInfo.get() deviceRequest:convertedDeviceRequest.get()]);
 


### PR DESCRIPTION
#### 18ea1bb6285663216d95a9cebfe72c6ee10fe88e
<pre>
[Digital Credentials] Start to parse OpenID4VP signed and multisigned requests in the web content process
<a href="https://bugs.webkit.org/show_bug.cgi?id=320038">https://bugs.webkit.org/show_bug.cgi?id=320038</a>
<a href="https://rdar.apple.com/problem/182968585">rdar://problem/182968585</a>

Reviewed by Abrar Rahman Protyasha.

Turn the unvalidated digital credential request into a variant so the
OpenID4VP presentation protocols can be represented alongside the
existing ISO 18013 mobile document request, and parse the signed and
multisigned variants entirely in the web content process.

Add IPC-serializable request structs under Modules/identity/protocols/openid/:
OpenID4VPSignedRequest ({ request }, a JWS Compact Serialization) and
OpenID4VPMultisignedRequest ({ payload, signatures }, a JWS JSON
Serialization, whose signatures are OpenID4VPSignature { protected,
signature }).  All members are strings/vectors so the unvalidated
request remains serializable across IPC; no JSObject crosses the process
boundary.  The &quot;openid4vp-v1-unsigned&quot; protocol is added once its DCQL
request parsing lands.

UnvalidatedDigitalCredentialRequest becomes
Variant&lt;MobileDocumentRequest, OpenID4VPSignedRequest,
OpenID4VPMultisignedRequest&gt;.  convertProtocolString() now takes the
document so it can gate the OpenID4VP protocols behind the off-by-default
DigitalCredentialsOpenID4VPEnabled setting, and jsToCredentialRequest()
converts each via convertDictionary() in the web content process.  The
request validator and the raw-request handoff to the picker switch over
the variant, handling the mobile document request and skipping the
OpenID4VP requests until their validation and wallet routing land.

Tests: http/wpt/identity/digital-credential-openid4vp-request-parsing.https.html
       http/wpt/identity/digital-credential-openid4vp-request-parsing-disabled.https.html

* Source/WebCore/CMakeLists.txt:
* Source/WebCore/DerivedSources.make:
* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/Modules/identity/DigitalCredential.cpp:
(WebCore::convertProtocolString):
(WebCore::jsToCredentialRequest):
* Source/WebCore/Modules/identity/protocols/UnvalidatedDigitalCredentialRequest.h:
* Source/WebCore/Modules/identity/protocols/openid/OpenID4VPMultisignedRequest.h: Added.
* Source/WebCore/Modules/identity/protocols/openid/OpenID4VPMultisignedRequest.idl: Added.
* Source/WebCore/Modules/identity/protocols/openid/OpenID4VPSignature.h: Added.
* Source/WebCore/Modules/identity/protocols/openid/OpenID4VPSignature.idl: Added.
* Source/WebCore/Modules/identity/protocols/openid/OpenID4VPSignedRequest.h: Added.
* Source/WebCore/Modules/identity/protocols/openid/OpenID4VPSignedRequest.idl: Added.
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebKit/Shared/WebCoreArgumentCodersAuth.serialization.in:
* Source/WebKit/UIProcess/DigitalCredentials/WKDigitalCredentialsPicker.mm:
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/WebProcess/DigitalCredentials/DigitalCredentialsCoordinator.messages.in:
* Source/WebKit/WebProcess/cocoa/IdentityDocumentServices/DigitalCredentialsRequestValidatorBridge.h:
* Source/WebKit/WebProcess/cocoa/IdentityDocumentServices/DigitalCredentialsRequestValidatorBridge.mm:
(WebKit::DigitalCredentials::validateRequests):
* LayoutTests/http/wpt/identity/digital-credential-openid4vp-request-parsing.https.html: Added.
* LayoutTests/http/wpt/identity/digital-credential-openid4vp-request-parsing.https-expected.txt: Added.
* LayoutTests/http/wpt/identity/digital-credential-openid4vp-request-parsing-disabled.https.html: Added.
* LayoutTests/http/wpt/identity/digital-credential-openid4vp-request-parsing-disabled.https-expected.txt: Added.

Canonical link: <a href="https://commits.webkit.org/318074@main">https://commits.webkit.org/318074@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f5e22acb4c71294dfdcc797c74f47220086adceb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177099 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51036 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44831 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186702 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140335 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/aea980d4-12a1-4905-9ed8-8887c1fe2aa0) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178962 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52329 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50722 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137988 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140335 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/db89237f-0b90-4823-adb6-eaa7e4e9597e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180055 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41493 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158764 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118456 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3d8ef440-226e-4818-bd38-2c983a94bac2) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40149 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38520 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150559 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38263 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35170 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42811 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42738 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189128 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50703 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/158303 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147074 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39556 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51386 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34887 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146866 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41605 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123600 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117887 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49891 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13243 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49290 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49527 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49351 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->