### PR TITLE
REGRESSION(317427@main): [GLIB] Wheel events crash with an assertion in EventDispatcher::dispatchWheelEvent

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -5303,10 +5303,6 @@ webkit.org/b/319950 imported/w3c/web-platform-tests/css/css-pseudo/marker-hit-te
 # WebTransport is Cocoa-only (non-Cocoa ports are a stub). https://bugs.webkit.org/show_bug.cgi?id=319008
 imported/w3c/web-platform-tests/webtransport/ [ Skip ]
 
-# Crashes on both GLib ports since 317427@main (Remove DidReceiveEventIPC): thread-affinity assertion (threadLikeAssertion.isCurrent()) in EventDispatcher::dispatchWheelEvent.
-webkit.org/b/319949 fast/events/wheel/wheel-event-destroys-frame.html [ Crash ]
-webkit.org/b/319949 fast/events/wheel/wheelevent-basic.html [ Crash ]
-
 # End: Common failures between GTK and WPE.
 
 #////////////////////////////////////////////////////////////////////////////////////////

--- a/LayoutTests/platform/gtk/TestExpectations
+++ b/LayoutTests/platform/gtk/TestExpectations
@@ -1325,8 +1325,3 @@ webkit.org/b/319319 [ Debug ] imported/w3c/web-platform-tests/css/css-contain/co
 webkit.org/b/319323 imported/w3c/web-platform-tests/css/css-scroll-snap/input/keyboard-snap-interruption.html [ Failure Pass ]
 webkit.org/b/319324 inspector/canvas/create-context-webgl.html [ Failure Pass ]
 webkit.org/b/319325 fast/body-propagation/background-color/010.html [ ImageOnlyFailure Pass ]
-
-# crash since 317427@main (Remove DidReceiveEventIPC), thread-affinity assertion in EventDispatcher::dispatchWheelEvent. Same root cause as the glib wheel entries.
-webkit.org/b/319949 pointer-lock/mouse-event-delivery.html [ Crash ]
-webkit.org/b/319949 swipe/swipe-back-with-active-wheel-listener-and-scroller.html [ Crash ]
-webkit.org/b/319949 swipe/swipe-back-with-passive-wheel-listener-and-scroller.html [ Crash ]

--- a/LayoutTests/platform/wpe/TestExpectations
+++ b/LayoutTests/platform/wpe/TestExpectations
@@ -681,8 +681,7 @@ webkit.org/b/173419 fast/events/wheel/platform-wheelevent-paging-y-in-non-scroll
 webkit.org/b/173419 fast/events/wheel/platform-wheelevent-paging-y-in-scrolling-div.html [ Failure ]
 webkit.org/b/173419 fast/events/wheel/platform-wheelevent-paging-y-in-scrolling-page.html [ Failure ]
 webkit.org/b/173419 fast/events/wheel/wheel-event-destroys-overflow.html [ Timeout ]
-# Uncomment when webkit.org/b/319949 is fixed
-# webkit.org/b/173419 fast/events/wheel/wheelevent-basic.html [ Failure Timeout ]
+webkit.org/b/173419 fast/events/wheel/wheelevent-basic.html [ Failure Timeout ]
 webkit.org/b/173419 fast/events/wheel/wheelevent-in-horizontal-scrollbar-in-rtl.html [ Failure ]
 webkit.org/b/173419 fast/events/wheel/wheelevent-in-vertical-scrollbar-in-rtl.html [ Failure ]
 

--- a/Source/WebKit/WebProcess/WebPage/EventDispatcher.cpp
+++ b/Source/WebKit/WebProcess/WebPage/EventDispatcher.cpp
@@ -183,7 +183,7 @@ void EventDispatcher::internalWheelEvent(PageIdentifier pageID, const WebWheelEv
                     dispatchWheelEventViaMainThread(pageID, wheelEvent, result.steps, WTF::move(completionHandler));
                     return;
                 }
-                dispatchWheelEventViaMainThread(pageID, wheelEvent, result.steps, [](bool) { });
+                dispatchWheelEventViaMainThread(pageID, wheelEvent, result.steps, CompletionHandler<void(bool)>([](bool) { }, CompletionHandlerCallThread::AnyThread));
             }
 
             // If we scrolled on the scrolling thread (even if we send the event to the main thread for passive event handlers)


### PR DESCRIPTION
#### cfde6a8041f4af9029634f874e9c3816954b8054
<pre>
REGRESSION(317427@main): [GLIB] Wheel events crash with an assertion in EventDispatcher::dispatchWheelEvent
<a href="https://bugs.webkit.org/show_bug.cgi?id=319949">https://bugs.webkit.org/show_bug.cgi?id=319949</a>

Reviewed by Charlie Wolfe.

A wheel event is usually handled across several threads: a background thread
receives it, a scrolling thread can do the scroll on its own to keep scrolling
smooth, and the main thread runs the page JavaScript wheel listeners.

Since 317427@main the &quot;was the event handled&quot; answer is returned as an async
reply to the WheelEvent message via a CompletionHandler instead of as a
separate DidReceiveEventIPC message.

And every CompletionHandler asserts that it is executed on the thread where
it was created (unless specified otherwise via the AnyThread parameter).

The main reply handler (the one carrying the answer back to the UIProcess)
is already correctly created as AnyThread, because depending on the path
it gets called either from the scrolling thread or from the main thread.

The problem is in the passive scrolling path, there the reply is sent from
the scrolling thread as soon as the scrolling is done without waiting for
the main thread ACK, but the event still has to be forwarded to the main
thread after completed so the passive DOM listeners run.
The result of forwarding this to the main thread is not used because the
main reply handler already finished, so a no-op CompletionHandler is passed,
which is created on the scrolling thread but executed on the main thread,
therefore the assertion hits.
The fix is to simply mark this no-op CompletionHandler as AnyThread.

This is not a problem on the Mac port because it runs the scrolling thread
in the UIProcess and doesn&apos;t exercise this codepath, however in the GTK
and WPE case the scrolling thread runs in the WebProcess and wheel events
are routed through this EventDispatcher.

* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/gtk/TestExpectations:
* LayoutTests/platform/wpe/TestExpectations:
* Source/WebKit/WebProcess/WebPage/EventDispatcher.cpp:
  (WebKit::EventDispatcher::internalWheelEvent):

Canonical link: <a href="https://commits.webkit.org/317769@main">https://commits.webkit.org/317769@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/162b9cc4ced488e25b7bfaa10d09210ca4be8cdb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176259 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50194 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43984 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185855 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/138506 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51486 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49878 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137284 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/138506 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179215 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40763 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158057 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117759 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39412 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37776 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149828 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37554 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34324 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41916 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41987 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188279 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49859 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146316 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50543 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/34172 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146137 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26772 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40904 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122747 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/116723 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49047 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12527 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48449 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48683 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48508 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->