### PR TITLE
[JSC] Inline `String#substring` in DFG/FTL

### DIFF
--- a/JSTests/microbenchmarks/string-substring-empty.js
+++ b/JSTests/microbenchmarks/string-substring-empty.js
@@ -1,0 +1,8 @@
+function substring(string, start, end)
+{
+    return string.substring(start, end);
+}
+noInline(substring);
+
+for (var i = 0; i < 1e6; ++i)
+    substring("Cocoa", 3, 3);

--- a/JSTests/microbenchmarks/string-substring-multi-chars.js
+++ b/JSTests/microbenchmarks/string-substring-multi-chars.js
@@ -1,0 +1,8 @@
+function substring(string, start, end)
+{
+    return string.substring(start, end);
+}
+noInline(substring);
+
+for (var i = 0; i < 1e6; ++i)
+    substring("Hello, World", 2, 9);

--- a/JSTests/microbenchmarks/string-substring-no-end.js
+++ b/JSTests/microbenchmarks/string-substring-no-end.js
@@ -1,0 +1,8 @@
+function substring(string, start)
+{
+    return string.substring(start);
+}
+noInline(substring);
+
+for (var i = 0; i < 1e6; ++i)
+    substring("Cocoa", 2);

--- a/JSTests/microbenchmarks/string-substring-one-char.js
+++ b/JSTests/microbenchmarks/string-substring-one-char.js
@@ -1,0 +1,8 @@
+function substring(string, start, end)
+{
+    return string.substring(start, end);
+}
+noInline(substring);
+
+for (var i = 0; i < 1e6; ++i)
+    substring("Cocoa", 2, 3);

--- a/JSTests/microbenchmarks/string-substring-reversed.js
+++ b/JSTests/microbenchmarks/string-substring-reversed.js
@@ -1,0 +1,8 @@
+function substring(string, start, end)
+{
+    return string.substring(start, end);
+}
+noInline(substring);
+
+for (var i = 0; i < 1e6; ++i)
+    substring("Cocoa", 4, 1);

--- a/JSTests/stress/string-substring-jit-constant-indices.js
+++ b/JSTests/stress/string-substring-jit-constant-indices.js
@@ -1,0 +1,60 @@
+function shouldBe(actual, expected) {
+    if (!Object.is(actual, expected))
+        throw new Error(`Bad value: ${actual}!`);
+}
+
+function head(string)
+{
+    return string.substring(0, 5);
+}
+noInline(head);
+
+function reversed(string)
+{
+    return string.substring(5, 1);
+}
+noInline(reversed);
+
+function negative(string)
+{
+    return string.substring(-3, 2);
+}
+noInline(negative);
+
+function huge(string)
+{
+    return string.substring(3, 1000);
+}
+noInline(huge);
+
+function tail(string)
+{
+    return string.substring(4);
+}
+noInline(tail);
+
+for (var i = 0; i < testLoopCount; ++i) {
+    shouldBe(head(""), "");
+    shouldBe(reversed(""), "");
+    shouldBe(negative(""), "");
+    shouldBe(huge(""), "");
+    shouldBe(tail(""), "");
+
+    shouldBe(head("AB"), "AB");
+    shouldBe(reversed("AB"), "B");
+    shouldBe(negative("AB"), "AB");
+    shouldBe(huge("AB"), "");
+    shouldBe(tail("AB"), "");
+
+    shouldBe(head("ABCDE"), "ABCDE");
+    shouldBe(reversed("ABCDE"), "BCDE");
+    shouldBe(negative("ABCDE"), "AB");
+    shouldBe(huge("ABCDE"), "DE");
+    shouldBe(tail("ABCDE"), "E");
+
+    shouldBe(head("ABCDEFGHIJ"), "ABCDE");
+    shouldBe(reversed("ABCDEFGHIJ"), "BCDE");
+    shouldBe(negative("ABCDEFGHIJ"), "AB");
+    shouldBe(huge("ABCDEFGHIJ"), "DEFGHIJ");
+    shouldBe(tail("ABCDEFGHIJ"), "EFGHIJ");
+}

--- a/JSTests/stress/string-substring-jit.js
+++ b/JSTests/stress/string-substring-jit.js
@@ -1,0 +1,61 @@
+function shouldBe(actual, expected) {
+    if (!Object.is(actual, expected))
+        throw new Error(`Bad value: ${actual}!`);
+}
+
+function referenceSubstring(string, start, end)
+{
+    var length = string.length;
+    start = Math.min(Math.max(start, 0), length);
+    end = end === undefined ? length : Math.min(Math.max(end, 0), length);
+    if (start > end) {
+        var swap = start;
+        start = end;
+        end = swap;
+    }
+    var result = "";
+    for (var i = start; i < end; ++i)
+        result += string[i];
+    return result;
+}
+
+function substring(string, start, end)
+{
+    return string.substring(start, end);
+}
+noInline(substring);
+
+function substringNoEnd(string, start)
+{
+    return string.substring(start);
+}
+noInline(substringNoEnd);
+
+function makeRope(tail)
+{
+    var result = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+    result += "0123456789";
+    result += tail;
+    return result;
+}
+noInline(makeRope);
+
+var strings = ["", "A", "ABCDE", "ABCDEFGHIJKLMN", "\u3042\u3044\u3046\u3048\u304A", "\uD842\uDFB7\u91CE\u5BB6"];
+var indices = [-100, -5, -1, 0, 1, 2, 3, 5, 13, 14, 100];
+
+for (var i = 0; i < testLoopCount; ++i) {
+    for (var string of strings) {
+        for (var start of indices) {
+            shouldBe(substringNoEnd(string, start), referenceSubstring(string, start, undefined));
+            for (var end of indices)
+                shouldBe(substring(string, start, end), referenceSubstring(string, start, end));
+        }
+    }
+
+    shouldBe(substring(makeRope("XY"), 26, 30), "0123");
+    shouldBe(substring(makeRope("XY"), 30, 26), "0123");
+    shouldBe(substring(makeRope("XY"), 36, 37), "X");
+    shouldBe(substring(makeRope("XY"), 36, 36), "");
+    shouldBe(substring(makeRope("XY"), -1, 100), "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789XY");
+    shouldBe(substringNoEnd(makeRope("XY"), 34), "89XY");
+}

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -1547,7 +1547,7 @@ void SpeculativeJIT::compilePeepHoleBooleanBranch(Node* node, Node* branchNode, 
     jump(notTaken);
 }
 
-void SpeculativeJIT::compileStringSlice(Node* node)
+void SpeculativeJIT::compileStringSliceOrSubstring(Node* node)
 {
     SpeculateCellOperand string(this, node->child1());
 
@@ -1580,12 +1580,25 @@ void SpeculativeJIT::compileStringSlice(Node* node)
     {
         load32(Address(tempGPR, StringImpl::lengthMemoryOffset()), temp2GPR);
 
-        emitPopulateSliceIndex(node->child2(), startGPR, temp2GPR, startIndexGPR);
+        if (node->op() == StringSubstring) {
+            emitPopulateSubstringIndex(node->child2(), startGPR, temp2GPR, startIndexGPR);
 
-        if (node->child3())
-            emitPopulateSliceIndex(node->child3(), endGPR.value(), temp2GPR, tempGPR);
-        else
-            move(temp2GPR, tempGPR);
+            if (node->child3()) {
+                emitPopulateSubstringIndex(node->child3(), endGPR.value(), temp2GPR, tempGPR);
+
+                move(startIndexGPR, temp2GPR);
+                moveConditionally32(Above, startIndexGPR, tempGPR, tempGPR, startIndexGPR, startIndexGPR);
+                moveConditionally32(Above, temp2GPR, tempGPR, temp2GPR, tempGPR, tempGPR);
+            } else
+                move(temp2GPR, tempGPR);
+        } else {
+            emitPopulateSliceIndex(node->child2(), startGPR, temp2GPR, startIndexGPR);
+
+            if (node->child3())
+                emitPopulateSliceIndex(node->child3(), endGPR.value(), temp2GPR, tempGPR);
+            else
+                move(temp2GPR, tempGPR);
+        }
     }
 
     JumpList doneCases;
@@ -1628,48 +1641,26 @@ void SpeculativeJIT::compileStringSlice(Node* node)
     addSlowPathGenerator(slowPathCall(slowCases, this, operationStringSubstr, tempGPR, LinkableConstant::globalObject(*this, node), stringGPR, startIndexGPR, tempGPR));
 
     if (isRope.isSet()) {
-        if (endGPR)
-            addSlowPathGenerator(slowPathCall(isRope, this, operationStringSliceWithEnd, tempGPR, LinkableConstant::globalObject(*this, node), stringGPR, startGPR, *endGPR));
-        else
-            addSlowPathGenerator(slowPathCall(isRope, this, operationStringSlice, tempGPR, LinkableConstant::globalObject(*this, node), stringGPR, startGPR));
+        switch (node->op()) {
+        case StringSlice:
+            if (endGPR)
+                addSlowPathGenerator(slowPathCall(isRope, this, operationStringSliceWithEnd, tempGPR, LinkableConstant::globalObject(*this, node), stringGPR, startGPR, *endGPR));
+            else
+                addSlowPathGenerator(slowPathCall(isRope, this, operationStringSlice, tempGPR, LinkableConstant::globalObject(*this, node), stringGPR, startGPR));
+            break;
+        case StringSubstring:
+            if (endGPR)
+                addSlowPathGenerator(slowPathCall(isRope, this, operationStringSubstringWithEnd, tempGPR, LinkableConstant::globalObject(*this, node), stringGPR, startGPR, *endGPR));
+            else
+                addSlowPathGenerator(slowPathCall(isRope, this, operationStringSubstring, tempGPR, LinkableConstant::globalObject(*this, node), stringGPR, startGPR));
+            break;
+        default:
+            RELEASE_ASSERT_NOT_REACHED();
+        }
     }
 
     doneCases.link(this);
     cellResult(tempGPR, node);
-}
-
-void SpeculativeJIT::compileStringSubstring(Node* node)
-{
-    SpeculateCellOperand string(this, node->child1());
-
-    SpeculateInt32Operand start(this, node->child2());
-    if (node->child3()) {
-        SpeculateInt32Operand end(this, node->child3());
-
-        GPRReg stringGPR = string.gpr();
-        GPRReg startGPR = start.gpr();
-        GPRReg endGPR = end.gpr();
-
-        speculateString(node->child1(), stringGPR);
-
-        flushRegisters();
-        GPRFlushedCallResult result(this);
-        GPRReg resultGPR = result.gpr();
-        callOperation(operationStringSubstringWithEnd, resultGPR, LinkableConstant::globalObject(*this, node), stringGPR, startGPR, endGPR);
-        cellResult(resultGPR, node);
-        return;
-    }
-
-    GPRReg stringGPR = string.gpr();
-    GPRReg startGPR = start.gpr();
-
-    speculateString(node->child1(), stringGPR);
-
-    flushRegisters();
-    GPRFlushedCallResult result(this);
-    GPRReg resultGPR = result.gpr();
-    callOperation(operationStringSubstring, resultGPR, LinkableConstant::globalObject(*this, node), stringGPR, startGPR);
-    cellResult(resultGPR, node);
 }
 
 void SpeculativeJIT::compileStringSubstr(Node* node)
@@ -9528,6 +9519,24 @@ void SpeculativeJIT::emitPopulateSliceIndex(Edge& target, std::optional<GPRReg> 
     move(lengthGPR, resultGPR);
 
     done.link(this);
+}
+
+void SpeculativeJIT::emitPopulateSubstringIndex(Edge& target, GPRReg indexGPR, GPRReg lengthGPR, GPRReg resultGPR)
+{
+    if (target->isInt32Constant()) {
+        int32_t value = target->asInt32();
+        if (value <= 0) {
+            move(TrustedImm32(0), resultGPR);
+            return;
+        }
+
+        move(TrustedImm32(value), resultGPR);
+        moveConditionally32(Above, resultGPR, lengthGPR, lengthGPR, resultGPR, resultGPR);
+        return;
+    }
+
+    moveConditionally32(GreaterThan, indexGPR, lengthGPR, lengthGPR, indexGPR, resultGPR);
+    moveConditionally32(LessThan, resultGPR, TrustedImm32(0), TrustedImm32(0), resultGPR, resultGPR);
 }
 
 void SpeculativeJIT::compileArraySlice(Node* node)

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
@@ -1626,8 +1626,7 @@ public:
     void compileDefineAccessorProperty(Node*);
     void compileObjectDefineProperty(Node*);
     void compileObjectDefinePropertyFromFields(Node*);
-    void compileStringSlice(Node*);
-    void compileStringSubstring(Node*);
+    void compileStringSliceOrSubstring(Node*);
     void compileStringSubstr(Node*);
     void compileToUpperCase(Node*);
     void compileToLowerCase(Node*);
@@ -1788,6 +1787,7 @@ public:
     void emitGetCallee(CodeOrigin, GPRReg calleeGPR);
     void emitGetArgumentStart(CodeOrigin, GPRReg startGPR);
     void emitPopulateSliceIndex(Edge&, std::optional<GPRReg> indexGPR, GPRReg lengthGPR, GPRReg resultGPR);
+    void emitPopulateSubstringIndex(Edge&, GPRReg indexGPR, GPRReg lengthGPR, GPRReg resultGPR);
     
     // Generate an OSR exit fuzz check. Returns Jump() if OSR exit fuzz is not enabled, or if
     // it's in training mode.

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
@@ -5843,13 +5843,9 @@ void SpeculativeJIT::compile(Node* node)
         compileWeakMapSet(node);
         break;
 
-    case StringSlice: {
-        compileStringSlice(node);
-        break;
-    }
-
+    case StringSlice:
     case StringSubstring: {
-        compileStringSubstring(node);
+        compileStringSliceOrSubstring(node);
         break;
     }
 

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -1927,10 +1927,8 @@ private:
             compileUnreachable();
             break;
         case StringSlice:
-            compileStringSlice();
-            break;
         case StringSubstring:
-            compileStringSubstring();
+            compileStringSliceOrSubstring();
             break;
         case StringSubstr:
             compileStringSubstr();
@@ -8457,6 +8455,25 @@ IGNORE_CLANG_WARNINGS_END
             endBoundary = pickIndex(end);
         LValue startIndex = pickIndex(start);
         return std::make_pair(startIndex, endBoundary);
+    }
+
+    std::pair<LValue, LValue> populateSubstringRange(LValue start, LValue end, LValue length)
+    {
+        // end can be nullptr.
+        ASSERT(start);
+        ASSERT(length);
+
+        auto clampIndex = [&] (LValue index) {
+            return m_out.select(m_out.lessThan(index, m_out.int32Zero), m_out.int32Zero,
+                m_out.select(m_out.greaterThan(index, length), length, index));
+        };
+
+        if (!end)
+            return std::make_pair(clampIndex(start), length);
+
+        // Clamping is monotonic, so the indices can be ordered before it.
+        LValue isReversed = m_out.greaterThan(start, end);
+        return std::make_pair(clampIndex(m_out.select(isReversed, end, start)), clampIndex(m_out.select(isReversed, start, end)));
     }
 
     void compileArraySlice()
@@ -20776,7 +20793,7 @@ IGNORE_CLANG_WARNINGS_END
         genericJSValueCompare(intFunctor, fallbackFunction);
     }
 
-    void compileStringSlice()
+    void compileStringSliceOrSubstring()
     {
         JSGlobalObject* globalObject = m_graph.globalObjectFor(m_origin.semantic);
         LBasicBlock lengthCheckCase = m_out.newBlock();
@@ -20808,7 +20825,7 @@ IGNORE_CLANG_WARNINGS_END
             length = m_out.constInt32(*stringLength);
         else
             length = m_out.load32NonNegative(stringImpl, m_heaps.StringImpl_length);
-        auto range = populateSliceRange(start, end, length);
+        auto range = m_node->op() == StringSubstring ? populateSubstringRange(start, end, length) : populateSliceRange(start, end, length);
         LValue from = range.first;
         LValue to = range.second;
         LValue span = m_out.sub(to, from);
@@ -20878,23 +20895,26 @@ IGNORE_CLANG_WARNINGS_END
         m_out.jump(continuation);
 
         m_out.appendTo(ropeSlowCase, continuation);
-        if (end)
-            results.append(m_out.anchor(vmCall(pointerType(), operationStringSliceWithEnd, weakPointer(globalObject), string, start, end)));
-        else
-            results.append(m_out.anchor(vmCall(pointerType(), operationStringSlice, weakPointer(globalObject), string, start)));
+        switch (m_node->op()) {
+        case StringSlice:
+            if (end)
+                results.append(m_out.anchor(vmCall(pointerType(), operationStringSliceWithEnd, weakPointer(globalObject), string, start, end)));
+            else
+                results.append(m_out.anchor(vmCall(pointerType(), operationStringSlice, weakPointer(globalObject), string, start)));
+            break;
+        case StringSubstring:
+            if (end)
+                results.append(m_out.anchor(vmCall(pointerType(), operationStringSubstringWithEnd, weakPointer(globalObject), string, start, end)));
+            else
+                results.append(m_out.anchor(vmCall(pointerType(), operationStringSubstring, weakPointer(globalObject), string, start)));
+            break;
+        default:
+            RELEASE_ASSERT_NOT_REACHED();
+        }
         m_out.jump(continuation);
 
         m_out.appendTo(continuation, lastNext);
         setJSValue(m_out.phi(pointerType(), results));
-    }
-
-    void compileStringSubstring()
-    {
-        JSGlobalObject* globalObject = m_graph.globalObjectFor(m_origin.semantic);
-        if (m_node->child3())
-            setJSValue(vmCall(pointerType(), operationStringSubstringWithEnd, weakPointer(globalObject), lowString(m_node->child1()), lowInt32(m_node->child2()), lowInt32(m_node->child3())));
-        else
-            setJSValue(vmCall(pointerType(), operationStringSubstring, weakPointer(globalObject), lowString(m_node->child1()), lowInt32(m_node->child2())));
     }
 
     void compileStringSubstr()


### PR DESCRIPTION
#### 465d5ab28c60bc2521fb30cdce3c68dc289f5d71
<pre>
[JSC] Inline `String#substring` in DFG/FTL
<a href="https://bugs.webkit.org/show_bug.cgi?id=320045">https://bugs.webkit.org/show_bug.cgi?id=320045</a>

Reviewed by Yusuke Suzuki.

StringSubstring was always lowered to operationStringSubstring(WithEnd) in
both tiers, while its siblings StringSlice and StringSubstr have inline fast
paths.

substring only differs from slice in how the range is computed: a negative
index clamps to 0 instead of counting from the end, and the range is reversed
when start is greater than end. Clamping is monotonic, so the indices can be
ordered before it, which lets B3 fold the ordering away for constant indices.

This patch computes that range inline and shares the rest of the lowering with
StringSlice in compileStringSliceOrSubstring, so substring now gets the empty
string, single character, whole string and inline substring rope fast paths
that slice already had.

                                     Baseline                  Patched

    string-substring-one-char     6.2668+-0.1659     ^      3.0261+-0.0439        ^ definitely 2.0709x faster
    string-substring-no-end       6.6585+-0.1495     ^      3.8226+-0.0724        ^ definitely 1.7419x faster
    string-substring-multi-chars  6.9944+-0.1302     ^      4.1724+-0.0762        ^ definitely 1.6763x faster
    string-substring-reversed     6.9336+-0.1514     ^      4.2162+-0.0876        ^ definitely 1.6445x faster
    string-substring-empty        4.1059+-0.0706     ^      2.5331+-0.0572        ^ definitely 1.6209x faster

Tests: JSTests/microbenchmarks/string-substring-empty.js
       JSTests/microbenchmarks/string-substring-multi-chars.js
       JSTests/microbenchmarks/string-substring-no-end.js
       JSTests/microbenchmarks/string-substring-one-char.js
       JSTests/microbenchmarks/string-substring-reversed.js
       JSTests/stress/string-substring-jit-constant-indices.js
       JSTests/stress/string-substring-jit.js

* JSTests/microbenchmarks/string-substring-empty.js: Added.
(substring):
* JSTests/microbenchmarks/string-substring-multi-chars.js: Added.
(substring):
* JSTests/microbenchmarks/string-substring-no-end.js: Added.
(substring):
* JSTests/microbenchmarks/string-substring-one-char.js: Added.
(substring):
* JSTests/microbenchmarks/string-substring-reversed.js: Added.
(substring):
* JSTests/stress/string-substring-jit-constant-indices.js: Added.
(shouldBe):
(reversed):
(negative):
(huge):
(tail):
* JSTests/stress/string-substring-jit.js: Added.
(shouldBe):
(substring):
(substringNoEnd):
(makeRope):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
(JSC::DFG::SpeculativeJIT::compileStringSliceOrSubstring):
(JSC::DFG::SpeculativeJIT::compileStringSlice): Deleted.
(JSC::DFG::SpeculativeJIT::compileStringSubstring): Deleted.
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp:
(JSC::DFG::SpeculativeJIT::compile):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp:
(JSC::DFG::SpeculativeJIT::compile):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileNode):
(JSC::FTL::DFG::LowerDFGToB3::populateSubstringRange):
(JSC::FTL::DFG::LowerDFGToB3::compileCompareStrictEq):

Canonical link: <a href="https://commits.webkit.org/318448@main">https://commits.webkit.org/318448@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/81b7fc8311d80ccbc6cfd475ab371b9307f4eee1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178269 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52207 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46002 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187883 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/141517 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53501 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51916 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138971 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96484 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181226 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42529 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159737 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119426 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41195 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39549 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/1395 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/8225 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151595 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39234 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36340 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/39542 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44807 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43792 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190310 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51875 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148122 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39788 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52557 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35859 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147896 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42611 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124821 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119409 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51075 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14209 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50460 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50700 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50522 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->