### PR TITLE
Web Inspector: Network: disabling resource cache always sets `Cache-Control: no-cache`

### DIFF
--- a/LayoutTests/http/tests/cache/disable-resource-caching-preserves-request-cache-control-expected.txt
+++ b/LayoutTests/http/tests/cache/disable-resource-caching-preserves-request-cache-control-expected.txt
@@ -1,0 +1,3 @@
+caching enabled, page sets max-age=12345: max-age=12345
+caching disabled, no page header: no-cache
+caching disabled, page sets max-age=12345: max-age=12345

--- a/LayoutTests/http/tests/cache/disable-resource-caching-preserves-request-cache-control.html
+++ b/LayoutTests/http/tests/cache/disable-resource-caching-preserves-request-cache-control.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html>
+<body>
+<div id="console"></div>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+function log(message)
+{
+    const line = document.createElement("div");
+    line.textContent = message;
+    document.getElementById("console").appendChild(line);
+}
+
+async function cacheControlSentToServer(options)
+{
+    const response = await fetch("/xmlhttprequest/resources/print-cache-control-header.cgi?" + Math.random(), options);
+    const text = (await response.text()).trim();
+    return text ? text.replace(/^HTTP_CACHE_CONTROL:\s*/, "") : "(none)";
+}
+
+async function run()
+{
+    try {
+        log("caching enabled, page sets max-age=12345: " + await cacheControlSentToServer({ headers: { "cache-control": "max-age=12345" } }));
+
+        if (window.internals)
+            internals.setResourceCachingDisabledByWebInspector(true);
+
+        log("caching disabled, no page header: " + await cacheControlSentToServer({ }));
+        log("caching disabled, page sets max-age=12345: " + await cacheControlSentToServer({ headers: { "cache-control": "max-age=12345" } }));
+
+        if (window.internals)
+            internals.setResourceCachingDisabledByWebInspector(false);
+    } catch (exception) {
+        log("threw " + exception);
+    }
+
+    if (window.testRunner)
+        testRunner.notifyDone();
+}
+
+run();
+</script>
+</body>
+</html>

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -3558,7 +3558,8 @@ void FrameLoader::updateRequestAndAddExtraFields(Frame& targetFrame, ResourceReq
         request.setIsTopSite(isMainFrameMainResource);
 
     bool hasSpecificCachePolicy = request.cachePolicy() != ResourceRequestCachePolicy::UseProtocolCachePolicy;
-    if (page && page->isResourceCachingDisabledByWebInspector()) {
+    bool cachingDisabledByWebInspector = page && page->isResourceCachingDisabledByWebInspector();
+    if (cachingDisabledByWebInspector) {
         request.setCachePolicy(ResourceRequestCachePolicy::ReloadIgnoringCacheData);
         loadType = FrameLoadType::ReloadFromOrigin;
     } else if (!hasSpecificCachePolicy)
@@ -3569,11 +3570,18 @@ void FrameLoader::updateRequestAndAddExtraFields(Frame& targetFrame, ResourceReq
         return;
 
     if (!hasSpecificCachePolicy && request.cachePolicy() == ResourceRequestCachePolicy::ReloadIgnoringCacheData) {
+        auto overrideHeaderIfNeeded = [&] (HTTPHeaderName name, const String& value) {
+            if (cachingDisabledByWebInspector)
+                request.addHTTPHeaderFieldIfNotPresent(name, value);
+            else
+                request.setHTTPHeaderField(name, value);
+        };
+
         if (loadType == FrameLoadType::Reload)
-            request.setHTTPHeaderField(HTTPHeaderName::CacheControl, HTTPHeaderValues::maxAge0());
+            overrideHeaderIfNeeded(HTTPHeaderName::CacheControl, HTTPHeaderValues::maxAge0());
         else if (loadType == FrameLoadType::ReloadFromOrigin) {
-            request.setHTTPHeaderField(HTTPHeaderName::CacheControl, HTTPHeaderValues::noCache());
-            request.setHTTPHeaderField(HTTPHeaderName::Pragma, HTTPHeaderValues::noCache());
+            overrideHeaderIfNeeded(HTTPHeaderName::CacheControl, HTTPHeaderValues::noCache());
+            overrideHeaderIfNeeded(HTTPHeaderName::Pragma, HTTPHeaderValues::noCache());
         }
     }
 


### PR DESCRIPTION
#### 96437189e7eecba977fe0a452b7e35fecc6ea776
<pre>
Web Inspector: Network: disabling resource cache always sets `Cache-Control: no-cache`
<a href="https://bugs.webkit.org/show_bug.cgi?id=320033">https://bugs.webkit.org/show_bug.cgi?id=320033</a>

Reviewed by Basuke Suzuki.

When Web Inspector disables the resource cache, `FrameLoader::updateRequestAndAddExtraFields` forces every request to `ReloadIgnoringCacheData` and `ReloadFromOrigin`, then overwrites `Cache-Control` and `Pragma` with `no-cache`.
That discards a `Cache-Control` the page set itself (for example through `fetch()`), so the value the page asked for never reaches the network.

Only synthesize the `no-cache` headers when the request does not already carry them, using `addHTTPHeaderFieldIfNotPresent` instead of `setHTTPHeaderField`.
The cache policy is still forced to `ReloadIgnoringCacheData`, so disabling the cache keeps bypassing the local cache and only the header write changes.

* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::updateRequestAndAddExtraFields):

* LayoutTests/http/tests/cache/disable-resource-caching-preserves-request-cache-control.html: Added.
* LayoutTests/http/tests/cache/disable-resource-caching-preserves-request-cache-control-expected.txt: Added.

Canonical link: <a href="https://commits.webkit.org/317814@main">https://commits.webkit.org/317814@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f2ef3a3e4f10238b4344a8691916b5157ac55d82

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176270 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50205 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43995 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185866 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/138517 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178133 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51497 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49889 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137285 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/138517 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179226 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40771 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158065 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117760 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39420 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37785 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149836 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37562 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34335 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41928 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41996 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188290 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49870 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/157610 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146323 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39390 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50554 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34180 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146144 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40913 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122758 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/116737 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49058 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12535 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48460 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48694 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48519 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->