### PR TITLE
[JSC] Skew small function's OMG tierup call counts

### DIFF
--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -577,6 +577,7 @@ bool hasCapacityToUseLargeGigacage();
     v(Unsigned, maximumOMGCandidateCost, 100000, Normal, nullptr) \
     v(Int32, omgTierUpCounterIncrementForLoop, 1, Normal, "The amount the tier up counter is incremented on each loop backedge."_s) \
     v(Int32, omgTierUpCounterIncrementForEntry, 15, Normal, "The amount the tier up counter is incremented on each function entry."_s) \
+    v(Int32, wasmOMGEntryIncrementSizeReference, 128, Normal, "If non-zero, the BBQ->OMG function-entry tier-up increment is scaled down for functions whose bytecode size is below this reference (work-proportional tier-up): increment = clamp(entryIncrement * size / reference, 1, entryIncrement). 0 disables (flat increment)."_s) \
     v(Bool, useWasmFastMemory, true, Normal, "If true, we will try to use a 32-bit address space with a signal handler to bounds check wasm memory."_s) \
     v(Bool, logWasmMemory, false, Normal, nullptr) \
     v(Unsigned, wasmFastMemoryRedzonePages, 128, Normal, "Wasm fast memories use 4GiB virtual allocations, plus a redzone (counted as multiple of 64KiB Wasm pages) at the end to catch reg+imm accesses which exceed 32-bit, anything beyond the redzone is explicitly bounds-checked"_s) \

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
@@ -3219,8 +3219,38 @@ void BBQJIT::emitEntryTierUpCheck()
 
 #if ENABLE(WEBASSEMBLY_OMGJIT)
     static_assert(GPRInfo::nonPreservedNonArgumentGPR0 == wasmScratchGPR);
+
+    // By default every function entry bumps the BBQ->OMG tier-up counter by a flat amount, so tier-up
+    // is driven purely by call count. That over-optimizes tiny straight-line functions that are called
+    // often but do little work per call: they are cheap in BBQ yet still pay a full OMG compile,
+    // flooding the compiler threads during warm-up. Furthermore, they do not get significant benefit
+    // typically because (1) BBQ and OMG both needs to pay the same function prologue / epilogue cost
+    // so if the body is tiny, progression is small, and (2) tiny functions will be inlined from the
+    // hot callers and they will fully inline them. After that, compiled tiny functions will not be called.
+    //
+    // When wasmOMGEntryIncrementSizeReference is set we make the entry increment work-proportional by
+    // scaling it down for functions smaller than the reference size (never above the flat increment,
+    // so medium/large functions tier up exactly as before). Loop back-edges already increment per
+    // iteration, so genuinely hot small functions still reach OMG.
+    //
+    // Per-entry increment vs the default flat +15 (defaults: functionEntryIncrement 15, reference 128):
+    //
+    //   function size |  count
+    //   --------------+-------
+    //        8 B      |   +1
+    //       32 B      |   +3
+    //       64 B      |   +7
+    //      100 B      |  +11
+    //      128 B      |  +15   (cutover)
+    //      256 B      |  +15
+    //
+    int32_t entryIncrement = TierUpCount::functionEntryIncrement();
+    if (int32_t reference = Options::wasmOMGEntryIncrementSizeReference()) {
+        int32_t size = static_cast<int32_t>(std::min<size_t>(m_function.data.size(), std::numeric_limits<int32_t>::max()));
+        entryIncrement = std::clamp<int32_t>((static_cast<int64_t>(size) * TierUpCount::functionEntryIncrement()) / reference, 1, TierUpCount::functionEntryIncrement());
+    }
     m_jit.move(TrustedImmPtr(std::bit_cast<uintptr_t>(&m_callee.tierUpCounter().m_counter)), wasmScratchGPR);
-    Jump tierUp = m_jit.branchAdd32(CCallHelpers::PositiveOrZero, TrustedImm32(TierUpCount::functionEntryIncrement()), Address(wasmScratchGPR));
+    Jump tierUp = m_jit.branchAdd32(CCallHelpers::PositiveOrZero, TrustedImm32(entryIncrement), Address(wasmScratchGPR));
     MacroAssembler::Label tierUpResume = m_jit.label();
     addLatePath(origin(), [tierUp, tierUpResume](BBQJIT& generator, CCallHelpers& jit) {
         tierUp.link(&jit);


### PR DESCRIPTION
#### 02d16b1d8e1a8fe076e354412936c1af5a07f675
<pre>
[JSC] Skew small function&apos;s OMG tierup call counts
<a href="https://bugs.webkit.org/show_bug.cgi?id=320046">https://bugs.webkit.org/show_bug.cgi?id=320046</a>
<a href="https://rdar.apple.com/182981673">rdar://182981673</a>

Reviewed by Mark Lam.

When tiering up from BBQ to OMG, we would like to deprioritize very small
functions.

1. Very small functions are not having meaningful improvements from the
   tiering up. BBQ is fast enough and BBQ &amp; OMG both has prologue and
   epilogue as they are the functions. If body size is small, then
   improvement effect is small.
2. OMG compilation has fix-sized cost offset, so regardless of the size
   of the function, compile requires some time. For very small functions,
   compile time is too long compared to the benefit we can get.
3. Very small functions will be inlined from the callers eventually. And
   in that case, callers will fully inline it, and remove the use of
   this very small functions completely. Then the compiled code becomes
   useless since the caller is covering it via inlining.

This patch adds a threshold and step function which reduces function
entry tier up count increment. Right now, focusing on entry increment
since we are focusing function invocation count, and loop would have
different stories. This patch sets 128 as a threshold, which is
empirically obtained from the measurement.

* Source/JavaScriptCore/runtime/OptionsList.h:
* Source/JavaScriptCore/wasm/WasmBBQJIT.cpp:
(JSC::Wasm::BBQJITImpl::BBQJIT::emitEntryTierUpCheck):

Canonical link: <a href="https://commits.webkit.org/317759@main">https://commits.webkit.org/317759@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8471fca39ac2fc44fbb66e28ff1c892ae9c66e33

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176272 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50207 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43997 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185868 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/138519 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a11ca33b-8c8f-4c57-bc22-3ef9a6be87d4) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51499 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49891 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137299 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/138519 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/09434039-0f34-4628-ac20-64c7abb60bcd) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179228 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40777 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/158074 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117774 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/32c1cd72-5eb6-48cf-a725-c2c73fcf1817) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39426 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/37788 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/6583 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/149842 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37571 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34337 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/37540 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/41930 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/41999 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188292 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49872 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146330 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50556 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/34189 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146148 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26771 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40918 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/122760 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/116739 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49060 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12544 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48462 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48696 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48521 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->