### PR TITLE
RealtimeIncomingAudioSourceCocoa::OnData rescales the frame counter against the already-updated sample rate, making it a no-op

### DIFF
--- a/Source/WebCore/platform/mediastream/cocoa/RealtimeIncomingAudioSourceCocoa.cpp
+++ b/Source/WebCore/platform/mediastream/cocoa/RealtimeIncomingAudioSourceCocoa.cpp
@@ -123,6 +123,7 @@ void RealtimeIncomingAudioSourceCocoa::OnData(const void* audioData, int bitsPer
         m_audioFormatChanged = true;
 #endif
 
+        auto previousSampleRate = m_sampleRate;
         m_sampleRate = sampleRate;
         m_numberOfChannels = numberOfChannels;
         m_streamDescription = streamDescription(sampleRate, numberOfChannels);
@@ -131,8 +132,8 @@ void RealtimeIncomingAudioSourceCocoa::OnData(const void* audioData, int bitsPer
             DisableMallocRestrictionsForCurrentThreadScope scope;
             m_audioBufferList = makeUnique<WebAudioBufferList>(m_streamDescription);
         }
-        if (m_sampleRate && m_numberOfFrames)
-            m_numberOfFrames = m_numberOfFrames * sampleRate / m_sampleRate;
+        if (previousSampleRate && m_numberOfFrames)
+            m_numberOfFrames = m_numberOfFrames * sampleRate / previousSampleRate;
         else
             m_numberOfFrames = 0;
     }


### PR DESCRIPTION
#### c2c858a8f87c1ac084b5bf77b8b463585073d71c
<pre>
RealtimeIncomingAudioSourceCocoa::OnData rescales the frame counter against the already-updated sample rate, making it a no-op
<a href="https://bugs.webkit.org/show_bug.cgi?id=320049">https://bugs.webkit.org/show_bug.cgi?id=320049</a>
<a href="https://rdar.apple.com/182986735">rdar://182986735</a>

Reviewed by Youenn Fablet.

m_sampleRate was overwritten with the new sampleRate before it was
used as the divisor in the frame-count rebase, so the computation
became m_numberOfFrames * r / r — always equal to the original value
instead of rescaling the fallback frame counter across a sample-rate
change. This only affects the timestamp computed when no audio
module is attached yet.

Capture the previous sample rate before overwriting m_sampleRate and
use it as the divisor.

* Source/WebCore/platform/mediastream/cocoa/RealtimeIncomingAudioSourceCocoa.cpp:
(WebCore::RealtimeIncomingAudioSourceCocoa::OnData):

Canonical link: <a href="https://commits.webkit.org/318050@main">https://commits.webkit.org/318050@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dc2abe9d1737364370b98e5b86e80cbff49d4667

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176279 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50214 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44004 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185875 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/138526 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/df613084-14e2-4a24-884a-ecdae0239e42) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178142 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51506 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49898 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137297 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/138526 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3253eb33-dbb2-436c-ac92-1b0c8d34eada) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179235 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40780 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158077 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117772 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/01dec8e2-dc8b-4b77-8dfd-8cd9917f1611) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39429 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37794 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149845 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37574 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34344 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41937 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42005 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188299 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49879 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146335 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39539 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50563 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34192 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146153 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40924 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122767 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/116755 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49067 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12547 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48469 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48703 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48528 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->