### PR TITLE
ParkingLot::ensureHashtable() has dead always-true check and variable shadowing

### DIFF
--- a/Source/WTF/wtf/ParkingLot.cpp
+++ b/Source/WTF/wtf/ParkingLot.cpp
@@ -266,13 +266,11 @@ Hashtable* ensureHashtable()
         if (currentHashtable)
             return currentHashtable;
 
-        if (!currentHashtable) {
-            auto currentHashtable = makeUnique<Hashtable>(maxLoadFactor);
-            if (hashtable.compareExchangeWeak(nullptr, currentHashtable.get())) {
-                if (verbose)
-                    dataLogForCurrentThread(": created initial hashtable ", RawPointer(currentHashtable.get()), "\n");
-                return currentHashtable.release(); // Leak the hash table.
-            }
+        auto newHashtable = makeUnique<Hashtable>(maxLoadFactor);
+        if (hashtable.compareExchangeWeak(nullptr, newHashtable.get())) {
+            if (verbose)
+                dataLogForCurrentThread(": created initial hashtable ", RawPointer(newHashtable.get()), "\n");
+            return newHashtable.release(); // Leak the hash table.
         }
     }
 }


### PR DESCRIPTION
#### 0a9ad7da36c554b99b55d3064b1a405fecac32d6
<pre>
ParkingLot::ensureHashtable() has dead always-true check and variable shadowing
<a href="https://bugs.webkit.org/show_bug.cgi?id=320050">https://bugs.webkit.org/show_bug.cgi?id=320050</a>
<a href="https://rdar.apple.com/182987373">rdar://182987373</a>

Reviewed by Chris Dumez.

The `if (!currentHashtable)` check was always true at that point, since
the preceding `if (currentHashtable) return currentHashtable;` already
established it was null. The inner scope then declared a new local
also named `currentHashtable`, shadowing the outer one. Removed the
dead check and renamed the local to `newHashtable` to avoid the
shadowing; no behavior change.

* Source/WTF/wtf/ParkingLot.cpp:

Canonical link: <a href="https://commits.webkit.org/317829@main">https://commits.webkit.org/317829@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/61ca83040445b7984b49c04b75e37c06aec2698c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176280 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50215 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44005 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185876 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/138527 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0cce12a8-5824-46de-984b-08fe1e1187bf) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51507 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49899 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137300 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/138527 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5bff4b7e-530c-4b36-a404-4c1470735142) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179236 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40785 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158082 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117775 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5e780ccc-abc9-4903-af3f-d20d3f4f1eda) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39434 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37795 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/6591 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149850 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37580 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34345 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/37548 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41938 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42006 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188300 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49880 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146336 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39400 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50564 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34197 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146154 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40925 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122768 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/116756 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49068 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12553 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48470 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48704 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48529 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->