### PR TITLE
charactersToFloat() reports success even when a value fits a double but overflows a float

### DIFF
--- a/Source/WTF/wtf/text/WTFString.cpp
+++ b/Source/WTF/wtf/text/WTFString.cpp
@@ -22,6 +22,7 @@
 #include "config.h"
 #include <wtf/text/WTFString.h>
 
+#include <cmath>
 #include <wtf/ASCIICType.h>
 #include <wtf/DataLog.h>
 #include <wtf/Function.h>
@@ -576,30 +577,38 @@ double charactersToFixedDouble(std::span<const char16_t> data, bool* ok)
     return toDoubleType<char16_t, TrailingJunkPolicy::Disallow, WhitespacePolicy::Preserve, ParseMode::Fixed>(data, ok, parsedLength);
 }
 
+static inline float doubleToFloatCheckingOverflow(double number, bool* isValid)
+{
+    float result = static_cast<float>(number);
+    if (isValid && *isValid && std::isfinite(number) && !std::isfinite(result))
+        *isValid = false;
+    return result;
+}
+
 float charactersToFloat(std::span<const Latin1Character> data, bool* ok)
 {
-    // FIXME: This will return ok even when the string fits into a double but not a float.
     size_t parsedLength;
-    return static_cast<float>(toDoubleType<Latin1Character, TrailingJunkPolicy::Disallow, WhitespacePolicy::Skip, ParseMode::General>(data, ok, parsedLength));
+    double number = toDoubleType<Latin1Character, TrailingJunkPolicy::Disallow, WhitespacePolicy::Skip, ParseMode::General>(data, ok, parsedLength);
+    return doubleToFloatCheckingOverflow(number, ok);
 }
 
 float charactersToFloat(std::span<const char16_t> data, bool* ok)
 {
-    // FIXME: This will return ok even when the string fits into a double but not a float.
     size_t parsedLength;
-    return static_cast<float>(toDoubleType<char16_t, TrailingJunkPolicy::Disallow, WhitespacePolicy::Skip, ParseMode::General>(data, ok, parsedLength));
+    double number = toDoubleType<char16_t, TrailingJunkPolicy::Disallow, WhitespacePolicy::Skip, ParseMode::General>(data, ok, parsedLength);
+    return doubleToFloatCheckingOverflow(number, ok);
 }
 
 float charactersToFloat(std::span<const Latin1Character> data, size_t& parsedLength)
 {
-    // FIXME: This will return ok even when the string fits into a double but not a float.
-    return static_cast<float>(toDoubleType<Latin1Character, TrailingJunkPolicy::Allow, WhitespacePolicy::Skip, ParseMode::General>(data, nullptr, parsedLength));
+    double number = toDoubleType<Latin1Character, TrailingJunkPolicy::Allow, WhitespacePolicy::Skip, ParseMode::General>(data, nullptr, parsedLength);
+    return static_cast<float>(number);
 }
 
 float charactersToFloat(std::span<const char16_t> data, size_t& parsedLength)
 {
-    // FIXME: This will return ok even when the string fits into a double but not a float.
-    return static_cast<float>(toDoubleType<char16_t, TrailingJunkPolicy::Allow, WhitespacePolicy::Skip, ParseMode::General>(data, nullptr, parsedLength));
+    double number = toDoubleType<char16_t, TrailingJunkPolicy::Allow, WhitespacePolicy::Skip, ParseMode::General>(data, nullptr, parsedLength);
+    return static_cast<float>(number);
 }
 
 const StaticString nullStringData { nullptr };

--- a/Tools/TestWebKitAPI/Tests/WTF/WTFString.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/WTFString.cpp
@@ -331,6 +331,54 @@ TEST(WTF, StringToDouble)
     EXPECT_FALSE(ok);
 }
 
+TEST(WTF, StringToFloat)
+{
+    bool succeeded = false;
+
+    EXPECT_EQ(0.0f, String().toFloat());
+    EXPECT_EQ(0.0f, String().toFloat(&succeeded));
+    EXPECT_FALSE(succeeded);
+
+    EXPECT_EQ(0.0f, emptyString().toFloat());
+    EXPECT_EQ(0.0f, emptyString().toFloat(&succeeded));
+    EXPECT_FALSE(succeeded);
+
+    EXPECT_EQ(0.0f, String("0"_s).toFloat());
+    EXPECT_EQ(0.0f, String("0"_s).toFloat(&succeeded));
+    EXPECT_TRUE(succeeded);
+
+    EXPECT_EQ(1.0f, String("1"_s).toFloat());
+    EXPECT_EQ(1.0f, String("1"_s).toFloat(&succeeded));
+    EXPECT_TRUE(succeeded);
+
+    // fail if we see leading junk
+    EXPECT_EQ(0.0f, String("x1"_s).toFloat());
+    EXPECT_EQ(0.0f, String("x1"_s).toFloat(&succeeded));
+    EXPECT_FALSE(succeeded);
+
+    // succeed if we see leading spaces
+    EXPECT_EQ(1.0f, String(" 1"_s).toFloat());
+    EXPECT_EQ(1.0f, String(" 1"_s).toFloat(&succeeded));
+    EXPECT_TRUE(succeeded);
+
+    // ignore trailing junk, but return false for "succeeded"
+    EXPECT_EQ(1.0f, String("1x"_s).toFloat());
+    EXPECT_EQ(1.0f, String("1x"_s).toFloat(&succeeded));
+    EXPECT_FALSE(succeeded);
+
+    // fits in a double, but overflows a float: succeeded should be false
+    EXPECT_TRUE(std::isinf(String("1e300"_s).toFloat()));
+    EXPECT_TRUE(std::isinf(String("1e300"_s).toFloat(&succeeded)));
+    EXPECT_FALSE(succeeded);
+
+    EXPECT_TRUE(std::isinf(String("-1e300"_s).toFloat(&succeeded)));
+    EXPECT_FALSE(succeeded);
+
+    // a value that fits comfortably in both double and float should still report success
+    EXPECT_FLOAT_EQ(1e30f, String("1e30"_s).toFloat(&succeeded));
+    EXPECT_TRUE(succeeded);
+}
+
 TEST(WTF, StringhasInfixStartingAt)
 {
     EXPECT_TRUE(String("Test"_s).is8Bit());


### PR DESCRIPTION
#### 44592cdcc791dd1e6fb2ce283834b34ad4722013
<pre>
charactersToFloat() reports success even when a value fits a double but overflows a float
<a href="https://bugs.webkit.org/show_bug.cgi?id=320069">https://bugs.webkit.org/show_bug.cgi?id=320069</a>
<a href="https://rdar.apple.com/182991785">rdar://182991785</a>

Reviewed by Chris Dumez.

charactersToFloat() parses into a double and then narrows the result to
float with a plain static_cast, but the &quot;ok&quot; flag it reports back was set
purely from whether the double parse succeeded. A string like &quot;1e300&quot;
parses to a finite double, so ok was reported true, even though casting
that double to float overflows to infinity. Callers had no way to tell
the float result was bogus.

Added doubleToFloatCheckingOverflow(), which clears the out-param when
the double was finite but the narrowed float is not, and use it from
both bool*-returning overloads of charactersToFloat(). The two
parsedLength-returning overloads take no ok out-param, so there is
nothing for them to report and they are unchanged aside from dropping
the now-inaccurate FIXME.

Test: Tools/TestWebKitAPI/Tests/WTF/WTFString.cpp

* Source/WTF/wtf/text/WTFString.cpp:
(WTF::doubleToFloatCheckingOverflow):
(WTF::charactersToFloat):
* Tools/TestWebKitAPI/Tests/WTF/WTFString.cpp:
(TestWebKitAPI::TEST(WTF, StringToFloat)):

Canonical link: <a href="https://commits.webkit.org/317828@main">https://commits.webkit.org/317828@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7cebbc46bf68f54c3598c28599e388d4148c9c75

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176288 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50223 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44013 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185884 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/138535 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b9cc0025-c991-4b58-8c5d-32b80032e0f9) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178151 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51515 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49907 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137306 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/138535 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/387cdfc0-3910-4974-8521-d129a78a4050) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179244 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40790 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158086 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117781 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9c039b75-d790-4089-a679-38541cb58844) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39439 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37803 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/6595 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149855 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37584 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34353 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/37556 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41947 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42014 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188308 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49888 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146342 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39401 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50572 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34201 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146160 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40933 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122776 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/116769 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49076 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12557 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48478 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48712 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48537 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->