### PR TITLE
WebProcessProxy::cacheMediaMIMETypes never broadcasts cached types to other web processes

### DIFF
--- a/Source/WebKit/UIProcess/Cocoa/WebProcessProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebProcessProxyCocoa.mm
@@ -125,17 +125,8 @@ void WebProcessProxy::cacheMediaMIMETypes(const Vector<String>& types)
     mediaTypeCache() = types;
     for (Ref process : processPool().processes()) {
         if (process.ptr() != this)
-            cacheMediaMIMETypesInternal(types);
+            process->send(Messages::WebProcess::SetMediaMIMETypes(types), 0);
     }
-}
-
-void WebProcessProxy::cacheMediaMIMETypesInternal(const Vector<String>& types)
-{
-    if (!mediaTypeCache().isEmpty())
-        return;
-
-    mediaTypeCache() = types;
-    send(Messages::WebProcess::SetMediaMIMETypes(types), 0);
 }
 
 const Vector<String>& WebProcessProxy::mediaMIMETypes()

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -664,8 +664,6 @@ private:
 
 #if PLATFORM(COCOA)
     bool handleRemoteObjectRegistryMessage(IPC::Connection&, IPC::Decoder&);
-
-    void cacheMediaMIMETypesInternal(const Vector<String>&);
 #endif
 
     // ProcessLauncher::Client


### PR DESCRIPTION
#### 75c66e5982a9258fa7019336c884473a1cabf393
<pre>
WebProcessProxy::cacheMediaMIMETypes never broadcasts cached types to other web processes
<a href="https://bugs.webkit.org/show_bug.cgi?id=320070">https://bugs.webkit.org/show_bug.cgi?id=320070</a>

Reviewed by Jean-Yves Avenard.

When a web process lazily computes the supported media MIME types (by loading
AVFoundation and querying [AVURLAsset audiovisualMIMETypes]), it reports them
back to the UI process via CacheMediaMIMETypes. The UI process caches them in a
process-global and is supposed to push them to every other existing web process
(via SetMediaMIMETypes) so those processes can avoid recomputing them.

This broadcast was broken in two ways, both present since the machinery was
introduced in 201372@main (2018):

  1. cacheMediaMIMETypes() iterated over the other processes but called
     cacheMediaMIMETypesInternal(types) on `this` rather than on the loop
     variable `process`, so the message would have targeted the wrong process.

  2. Even ignoring (1), cacheMediaMIMETypesInternal() guarded on
     `!mediaTypeCache().isEmpty()` and returned early. Since mediaTypeCache() is
     a UI-process global that cacheMediaMIMETypes() populates before the loop,
     that guard was always true by the time the helper ran, so the
     SetMediaMIMETypes IPC was never sent to any process.

The net effect was that already-running web processes never received the cached
types over IPC and had to recompute them independently on first use.

Fix this by inlining the broadcast into the loop so it sends SetMediaMIMETypes
directly to each peer process, and remove the now-unused
cacheMediaMIMETypesInternal() helper.

Note that the practical value of this broadcast is limited today:

  - New web processes were never affected: they already receive the cached types
    at launch via WebProcessCreationParameters (WebProcessPoolCocoa.mm), which
    seeds both AVAssetMIMETypeCache and RemoteMediaPlayerMIMETypeCache. That leg
    has always worked; only the broadcast to already-running peers was broken.

  - Since media playback moved to the GPU process (205763@main), the WebProcess
    no longer loads AVFoundation for playback type queries; those go through
    RemoteMediaPlayerMIMETypeCache to the GPU process instead. The original
    rationale (avoid loading AVFoundation in every web process) now mostly
    applies to the non-GPU-process fallback path and to RemoteImageDecoderAVF,
    which still consults AVAssetMIMETypeCache locally (see the TODOs there about
    removing that dependency).

So the concrete benefit is narrow: a long-lived, already-running web process
that later hits one of the remaining local AVAssetMIMETypeCache consumers avoids
an AVFoundation load, and its RemoteMediaPlayerMIMETypeCache avoids a sync IPC to
the GPU process. If RemoteImageDecoderAVF is eventually routed through the GPU
process, this whole broadcast/cache chain could be removed outright (modulo the
non-GPU-process fallback).

* Source/WebKit/UIProcess/Cocoa/WebProcessProxyCocoa.mm:
(WebKit::WebProcessProxy::cacheMediaMIMETypes):
(WebKit::WebProcessProxy::cacheMediaMIMETypesInternal): Deleted.
* Source/WebKit/UIProcess/WebProcessProxy.h:

Canonical link: <a href="https://commits.webkit.org/317848@main">https://commits.webkit.org/317848@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fae00aa4e5a4377ac3f09d457d1b614384e37144

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176558 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50493 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44283 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186159 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/138853 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/dc11cc74-5bee-4c62-af69-9aa27f2c034a) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51785 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50177 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137531 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/138853 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4c0f6436-fbdf-4b1c-99e3-18d0db013cc2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179514 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41021 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/158306 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118006 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/692511c4-8c81-4413-9f27-c9d2846c85d2) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39671 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/38038 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/150086 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37804 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34627 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/42226 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/42251 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188582 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50158 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146585 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39415 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50842 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/34427 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146394 "Found 1 new API test failure: WebKitGTK/TestWebViewEditor:/webkit/WebKitWebView/editable/editable (failure)") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41155 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123046 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117120 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49346 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12779 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48748 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48982 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48807 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->