### PR TITLE
Consolidate os_variant_is_basesystem() callers to a common WTF wrapper

### DIFF
--- a/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h
+++ b/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h
@@ -176,6 +176,8 @@ WTF_EXPORT_PRIVATE void setApplicationAuditToken(audit_token_t);
 WTF_EXPORT_PRIVATE std::optional<audit_token_t> applicationAuditToken();
 #endif
 
+WTF_EXPORT_PRIVATE bool isInBaseSystem();
+
 namespace CocoaApplication {
 
 WTF_EXPORT_PRIVATE bool isAppleApplication();
@@ -261,5 +263,7 @@ using WTF::setSDKAlignedBehaviors;
 using WTF::applicationAuditToken;
 using WTF::setApplicationAuditToken;
 #endif
+
+using WTF::isInBaseSystem;
 
 #endif // PLATFORM(COCOA)

--- a/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.mm
+++ b/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.mm
@@ -385,6 +385,16 @@ std::optional<audit_token_t> applicationAuditToken()
 
 #endif
 
+bool isInBaseSystem()
+{
+#if PLATFORM(MAC)
+    static bool isBaseSystem = os_variant_is_basesystem("WebKit");
+    return isBaseSystem;
+#else
+    return false;
+#endif
+}
+
 static bool applicationBundleIsEqualTo(const String& bundleIdentifierString)
 {
     return applicationBundleIdentifier() == bundleIdentifierString;

--- a/Source/WebKit/UIProcess/PDF/WKAlternatePDFHUDView.swift
+++ b/Source/WebKit/UIProcess/PDF/WKAlternatePDFHUDView.swift
@@ -27,6 +27,7 @@ import AppKit
 public import Foundation
 import WebKit_Internal
 @_weakLinked @_spi(Private) import SwiftUI
+private import wtf.Core.cocoa.RuntimeApplicationChecksCocoa
 
 private struct Controls: View {
     private static let autoHideDelay: Duration = .seconds(3)
@@ -104,7 +105,7 @@ extension WKAlternatePDFHUDView {
 
         super.init(frame: frame)
 
-        let controls = Controls(showSystemActions: !isInRecoveryOS(), action: actionHandler)
+        let controls = Controls(showSystemActions: !WTF.isInBaseSystem(), action: actionHandler)
 
         let hostingView = NSHostingView(rootView: controls)
         hostingView.translatesAutoresizingMaskIntoConstraints = false

--- a/Source/WebKit/UIProcess/PDF/WKDefaultPDFHUDView.swift
+++ b/Source/WebKit/UIProcess/PDF/WKDefaultPDFHUDView.swift
@@ -27,7 +27,7 @@ import AppKit
 public import Foundation
 internal import WebKit_Internal
 private import pal.spi.mac.NSImageSPI
-private import wtf.SPI.darwin.OSVariantSPI
+private import wtf.Core.cocoa.RuntimeApplicationChecksCocoa
 
 private let barVerticalOffset: CGFloat = 40
 private let barHorizontalPadding: CGFloat = 16
@@ -49,11 +49,6 @@ private let fadeInDuration: TimeInterval = 0.25
 private let fadeOutDuration: TimeInterval = 0.5
 private let autoHideDelay: TimeInterval = 3.0
 private let hoverInset: CGFloat = -16.0
-
-// FIXME: (rdar://164559261) understand/document/remove unsafety
-func isInRecoveryOS() -> Bool {
-    unsafe os_variant_is_basesystem("WebKit")
-}
 
 @objc
 @implementation
@@ -106,7 +101,7 @@ extension WKDefaultPDFHUDView {
         zoomGroup.alignment = .centerY
 
         self.stackView = NSStackView(views: [zoomGroup])
-        if !isInRecoveryOS() {
+        if !WTF.isInBaseSystem() {
             stackView.addArrangedSubview(separatorView)
             let fileGroup = NSStackView(views: [openInPreviewButton, saveButton])
             fileGroup.orientation = .horizontal

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -184,10 +184,10 @@
 #import <wtf/SoftLinking.h>
 #import <wtf/TZoneMallocInlines.h>
 #import <wtf/cf/TypeCastsCF.h>
+#import <wtf/cocoa/RuntimeApplicationChecksCocoa.h>
 #import <wtf/cocoa/TypeCastsCocoa.h>
 #import <wtf/cocoa/VectorCocoa.h>
 #import <wtf/darwin/DispatchExtras.h>
-#import <wtf/spi/darwin/OSVariantSPI.h>
 #import <wtf/text/MakeString.h>
 
 #if ENABLE(WEB_AUTHN)
@@ -1349,7 +1349,7 @@ WebViewImpl::WebViewImpl(WKWebView *view, WebProcessPool& processPool, Ref<API::
     [NSApp registerServicesMenuSendTypes:PasteboardTypes::forSelectionSingleton() returnTypes:PasteboardTypes::forEditingSingleton()];
 
     // Occlusion notifications are not always sent in the base system, and stale occlusion state can result in various misbehaviors.
-    if (os_variant_is_basesystem("WebKit"))
+    if (isInBaseSystem())
         setWindowOcclusionDetectionEnabled(false);
 
 #if ENABLE(TILED_CA_DRAWING_AREA)

--- a/Source/WebKit/WebProcess/Model/WebModelPlayerProvider.cpp
+++ b/Source/WebKit/WebProcess/Model/WebModelPlayerProvider.cpp
@@ -36,7 +36,7 @@
 
 #if PLATFORM(COCOA)
 #include <sys/sysctl.h>
-#include <wtf/spi/darwin/OSVariantSPI.h>
+#include <wtf/cocoa/RuntimeApplicationChecksCocoa.h>
 #endif
 
 #if ENABLE(MODEL_PROCESS)
@@ -47,18 +47,6 @@
 namespace WebKit {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(WebModelPlayerProvider);
-
-#if PLATFORM(COCOA)
-static bool isRunningInRecoveryOS()
-{
-#if PLATFORM(MAC)
-    static bool isBaseSystem = os_variant_is_basesystem("WebKit");
-    return isBaseSystem;
-#else
-    return false;
-#endif
-}
-#endif
 
 Ref<WebModelPlayerProvider> WebModelPlayerProvider::create(WebPage& webPage)
 {
@@ -77,7 +65,7 @@ WebModelPlayerProvider::~WebModelPlayerProvider() = default;
 bool WebModelPlayerProvider::isAvailable() const
 {
 #if PLATFORM(COCOA)
-    return !isRunningInRecoveryOS();
+    return !isInBaseSystem();
 #else
     return true;
 #endif

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
@@ -120,8 +120,8 @@
 #include <wtf/Scope.h>
 #include <wtf/SetForScope.h>
 #include <wtf/TZoneMallocInlines.h>
+#include <wtf/cocoa/RuntimeApplicationChecksCocoa.h>
 #include <wtf/cocoa/TypeCastsCocoa.h>
-#include <wtf/spi/darwin/OSVariantSPI.h>
 #include <wtf/text/MakeString.h>
 #include <wtf/text/StringBuilder.h>
 #include <wtf/text/StringToIntegerConversion.h>
@@ -2555,11 +2555,6 @@ auto UnifiedPDFPlugin::toContextMenuItemTag(int tagValue) -> ContextMenuItemTag
     return isKnownContextMenuItemTag ? static_cast<ContextMenuItemTag>(tagValue) : ContextMenuItemTag::Unknown;
 }
 
-static bool isInRecoveryOS()
-{
-    return os_variant_is_basesystem("WebKit");
-}
-
 std::optional<PDFContextMenu> UnifiedPDFPlugin::createContextMenu(const WebMouseEvent& contextMenuEvent) const
 {
     ASSERT(isContextMenuEvent(contextMenuEvent));
@@ -2581,13 +2576,13 @@ std::optional<PDFContextMenu> UnifiedPDFPlugin::createContextMenu(const WebMouse
     };
 
     if ([m_pdfDocument allowsCopying] && hasSelection()) {
-        bool shouldPresentLookupAndSearchOptions = !isInRecoveryOS();
+        bool shouldPresentLookupAndSearchOptions = !isInBaseSystem();
         menuItems.appendVector(selectionContextMenuItems(contextMenuEventRootViewPoint, shouldPresentLookupAndSearchOptions));
         addSeparator();
     }
 
     std::optional<int> openInDefaultViewerTag;
-    bool shouldPresentOpenWithDefaultViewerOption = !isInRecoveryOS();
+    bool shouldPresentOpenWithDefaultViewerOption = !isInBaseSystem();
     if (shouldPresentOpenWithDefaultViewerOption) {
         menuItems.append(contextMenuItem(ContextMenuItemTag::OpenWithDefaultViewer));
         openInDefaultViewerTag = std::to_underlying(ContextMenuItemTag::OpenWithDefaultViewer);


### PR DESCRIPTION
#### c17b54571809190c1c4607e91afca5a5d3807e72
<pre>
Consolidate os_variant_is_basesystem() callers to a common WTF wrapper
<a href="https://bugs.webkit.org/show_bug.cgi?id=320072">https://bugs.webkit.org/show_bug.cgi?id=320072</a>
<a href="https://rdar.apple.com/182995822">rdar://182995822</a>

Reviewed by Richard Robinson, Mike Wyrzykowski, Tim Horton, and Aditya Keerthi.

`os_variant_is_basesystem(&quot;WebKit&quot;)` is found 5 times in the codebase.
Each caller needed to remember the `&quot;WebKit&quot;` magic string; the method
name is not necessarily the most intuitive, either.

This patch introduces a WTF::isInBaseSystem() wrapper, that lives in
wtf/cooca/RuntimeApplicationChecksCococa.h, providing callers an easy
and intuitive way to query if the application is running in macOS
BaseSystem.

* Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h:
* Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.mm:
(WTF::isInBaseSystem):
* Source/WebKit/UIProcess/PDF/WKPDFHUDView.swift:
(isInRecoveryOS): Deleted.
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::m_flagsChangedEventMonitorTrackingArea):
* Source/WebKit/WebProcess/Model/WebModelPlayerProvider.cpp:
(WebKit::WebModelPlayerProvider::isAvailable const):
(WebKit::isRunningInRecoveryOS): Deleted.
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::createContextMenu const):
(WebKit::isInRecoveryOS): Deleted.

Canonical link: <a href="https://commits.webkit.org/318471@main">https://commits.webkit.org/318471@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5cf73dfea8010ce7a823cec98f5abec9fd73545b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178371 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52309 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46104 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187986 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/141619 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5d11b8a9-11ff-472a-91b9-484bee43192b) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53603 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52019 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139051 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96550 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ae1bca26-c7ef-4dea-ab99-cf689844721b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181328 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42614 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159813 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119506 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d6bf7eb2-eeac-4f8a-8bcf-5c55381bdea8) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41280 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39630 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/1475 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/8301 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151680 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39312 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36442 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/39644 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44909 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43872 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190414 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51978 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148207 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52659 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35935 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147981 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27061 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42694 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124924 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119533 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51177 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14286 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50562 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50802 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50624 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->