### PR TITLE
WKWebViewTestingIOS.mm's dumpUIView() is using point.x instead of point.y

### DIFF
--- a/LayoutTests/platform/visionos/transforms/separated-image-animated-expected.txt
+++ b/LayoutTests/platform/visionos/transforms/separated-image-animated-expected.txt
@@ -1,7 +1,7 @@
 
 (UIView tree root view [class: WKCompositingView]
   (layer bounds [x: 0 y: 0 width: 800 height: 200])
-  (layer position [x: 400 y: 400])
+  (layer position [x: 400 y: 100])
   (subviews
     (view [class: WKCompositingView]
       (layer bounds [x: 0 y: 0 width: 200 height: 200])

--- a/LayoutTests/platform/visionos/transforms/separated-image-downgrade-content-expected.txt
+++ b/LayoutTests/platform/visionos/transforms/separated-image-downgrade-content-expected.txt
@@ -1,7 +1,7 @@
 
 (UIView tree root view [class: WKCompositingView]
   (layer bounds [x: 0 y: 0 width: 800 height: 3200])
-  (layer position [x: 400 y: 400])
+  (layer position [x: 400 y: 1600])
   (subviews
     (view [class: WKCompositingView]
       (layer bounds [x: 0 y: 0 width: 200 height: 200])
@@ -10,6 +10,6 @@
       (separated))
     (view [class: WKCompositingView]
       (layer bounds [x: 0 y: 0 width: 3000 height: 3000])
-      (layer position [x: 1500 y: 1500])
+      (layer position [x: 1500 y: 1700])
       (layer cornerRadius 24)
       (separated))))

--- a/LayoutTests/platform/visionos/transforms/separated-image-downgrade-expected.txt
+++ b/LayoutTests/platform/visionos/transforms/separated-image-downgrade-expected.txt
@@ -1,7 +1,7 @@
 
 (UIView tree root view [class: WKCompositingView]
   (layer bounds [x: 0 y: 0 width: 800 height: 3200])
-  (layer position [x: 400 y: 400])
+  (layer position [x: 400 y: 1600])
   (subviews
     (view [class: WKCompositingView]
       (layer bounds [x: 0 y: 0 width: 200 height: 200])
@@ -13,7 +13,7 @@
           (layer cornerRadius 24))))
     (view [class: WKCompositingView]
       (layer bounds [x: 0 y: 0 width: 3000 height: 3000])
-      (layer position [x: 1500 y: 1500])
+      (layer position [x: 1500 y: 1700])
       (layer cornerRadius 24)
       (subviews
         (view [class: WKCompositingView]

--- a/LayoutTests/platform/visionos/transforms/separated-image-downgrade-tiled-expected.txt
+++ b/LayoutTests/platform/visionos/transforms/separated-image-downgrade-tiled-expected.txt
@@ -1,7 +1,7 @@
 
 (UIView tree root view [class: WKCompositingView]
   (layer bounds [x: 0 y: 0 width: 800 height: 3000])
-  (layer position [x: 400 y: 400])
+  (layer position [x: 400 y: 1500])
   (subviews
     (view [class: WKCompositingView]
       (layer bounds [x: 0 y: 0 width: 3000 height: 3000])

--- a/LayoutTests/platform/visionos/transforms/separated-image-upgrade-expected.txt
+++ b/LayoutTests/platform/visionos/transforms/separated-image-upgrade-expected.txt
@@ -1,7 +1,7 @@
 
 (UIView tree root view [class: WKCompositingView]
   (layer bounds [x: 0 y: 0 width: 800 height: 3200])
-  (layer position [x: 400 y: 400])
+  (layer position [x: 400 y: 1600])
   (subviews
     (view [class: WKSeparatedImageView]
       (layer bounds [x: 0 y: 0 width: 200 height: 200])
@@ -10,6 +10,6 @@
       (separated))
     (view [class: WKCompositingView]
       (layer bounds [x: 0 y: 0 width: 3000 height: 3000])
-      (layer position [x: 1500 y: 1500])
+      (layer position [x: 1500 y: 1700])
       (layer cornerRadius 12)
       (separated))))

--- a/LayoutTests/platform/visionos/transforms/separated-image-upgrade-tiled-expected.txt
+++ b/LayoutTests/platform/visionos/transforms/separated-image-upgrade-tiled-expected.txt
@@ -1,7 +1,7 @@
 
 (UIView tree root view [class: WKCompositingView]
   (layer bounds [x: 0 y: 0 width: 800 height: 200])
-  (layer position [x: 400 y: 400])
+  (layer position [x: 400 y: 100])
   (subviews
     (view [class: WKSeparatedImageView]
       (layer bounds [x: 0 y: 0 width: 200 height: 200])

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewTestingIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewTestingIOS.mm
@@ -242,7 +242,7 @@ static void dumpUIView(TextStream& ts, UIView *view, bool traverse)
     };
 
     auto pointToString = [] (auto point) {
-        return makeString("[x: "_s, point.x, " y: "_s, point.x, ']');
+        return makeString("[x: "_s, point.x, " y: "_s, point.y, ']');
     };
 
 

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -980,6 +980,7 @@
 				WebKit/WKWebView/ios/TouchEventTests.mm,
 				WebKit/WKWebView/ios/UIFocusTests.mm,
 				WebKit/WKWebView/ios/UIPasteboardTests.mm,
+				WebKit/WKWebView/ios/UIViewTreeAsText.mm,
 				WebKit/WKWebView/ios/UIWKInteractionViewProtocol.mm,
 				WebKit/WKWebView/ios/UserInterfaceIdiomUpdate.mm,
 				WebKit/WKWebView/ios/Viewport.mm,

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/UIViewTreeAsText.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/UIViewTreeAsText.mm
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+
+#if PLATFORM(IOS_FAMILY)
+
+#import "Helpers/Test.h"
+#import <WebKit/WKWebView.h>
+#import <WebKit/WKWebViewPrivateForTesting.h>
+#import <wtf/RetainPtr.h>
+
+TEST(WebKit, UIViewTreeAsTextDumpsLayerPositionYCoordinate)
+{
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 480)]);
+
+    RetainPtr subview = adoptNS([[UIView alloc] initWithFrame:CGRectMake(0, 0, 10, 10)]);
+    [webView addSubview:subview];
+    [subview layer].position = CGPointMake(123, 456);
+
+    RetainPtr treeText = [webView _uiViewTreeAsText];
+
+    EXPECT_TRUE([treeText containsString:@"[x: 123 y: 456]"]);
+    EXPECT_FALSE([treeText containsString:@"[x: 123 y: 123]"]);
+}
+
+#endif // PLATFORM(IOS_FAMILY)


### PR DESCRIPTION
#### 30a61de7cfcf92cb352672472512cc97c6bbf492
<pre>
WKWebViewTestingIOS.mm&apos;s dumpUIView() is using point.x instead of point.y
<a href="https://bugs.webkit.org/show_bug.cgi?id=320075">https://bugs.webkit.org/show_bug.cgi?id=320075</a>

Reviewed by Aditya Keerthi and Abrar Rahman Protyasha.

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/UIViewTreeAsText.mm

* Source/WebKit/UIProcess/API/ios/WKWebViewTestingIOS.mm:
(dumpUIView):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/UIViewTreeAsText.mm: Added.
(TEST(WebKit, UIViewTreeAsTextDumpsLayerPositionYCoordinate)):
* LayoutTests/platform/visionos/transforms/separated-image-animated-expected.txt:
* LayoutTests/platform/visionos/transforms/separated-image-downgrade-content-expected.txt:
* LayoutTests/platform/visionos/transforms/separated-image-downgrade-expected.txt:
* LayoutTests/platform/visionos/transforms/separated-image-downgrade-tiled-expected.txt:
* LayoutTests/platform/visionos/transforms/separated-image-upgrade-expected.txt:
* LayoutTests/platform/visionos/transforms/separated-image-upgrade-tiled-expected.txt:

Canonical link: <a href="https://commits.webkit.org/317839@main">https://commits.webkit.org/317839@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3811f51a8dcd72c8f43fba4b6895e9d7fdcf165d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176489 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50424 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44214 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186090 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/138760 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8d12658a-42a6-4608-bdcd-b47bb4b240ae) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178352 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51716 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50108 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137474 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/138760 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9269a6c7-0c54-40fb-9e24-41f5b7c9704a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179445 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40960 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158255 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117949 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/216f8b9f-47cf-45b2-a8bd-aa1accc09027) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39610 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37980 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150025 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37753 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34558 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42154 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42191 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188513 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50089 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146524 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39410 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50773 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/34371 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146334 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41097 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122977 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117037 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49277 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12728 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48679 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48913 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48738 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->