### PR TITLE
appearance: base-select select styling lacks adequate polish and professionalism

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -680,6 +680,10 @@ imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-mode
 imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-accessibility-minimum-target-size.html [ Skip ]
 imported/w3c/web-platform-tests/html/rendering/replaced-elements/the-select-element/customizable-select/min-size-empty-001.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/html/rendering/replaced-elements/the-select-element/customizable-select/min-size-empty-002.html [ ImageOnlyFailure ]
+# Intrinsic sizing of a base-select inside a flex container differs from the reference.
+imported/w3c/web-platform-tests/html/rendering/replaced-elements/the-select-element/customizable-select/min-height-in-flex.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/html/rendering/replaced-elements/the-select-element/customizable-select/min-width-in-flex.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-sizing-in-flex.html [ ImageOnlyFailure ]
 
 # Picker fallback positioning failures (potentially related to the max-block-size).
 imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-fallback-bottom-left-scroller.html [ ImageOnlyFailure ]
@@ -698,6 +702,15 @@ imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customiz
 
 # Untriaged.
 imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/selectedcontent-restore.optional.html [ Skip ]
+
+# <optgroup label> renders bold + black rather than as a gray legend.
+imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-optgroup-rendering.html [ ImageOnlyFailure ]
+# Our selectedcontent avoids overflow, but test expects it.
+imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-button-text-and-icon-clipping.html [ ImageOnlyFailure ]
+# Overflow handling differences.
+imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/select-overflow-x.tentative.html [ ImageOnlyFailure ]
+# The picker-icon's negative margin glyph adjustment (margin-block-start: -0.25em) shifts the icon, which the reference doesn't account for.
+imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-display-block.tentative.html [ ImageOnlyFailure ]
 
 # List boxes/<select multiple>.
 imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select-listbox/ [ Skip ]

--- a/LayoutTests/fast/forms/select/base/option-focus-visible-outline-offset-expected.txt
+++ b/LayoutTests/fast/forms/select/base/option-focus-visible-outline-offset-expected.txt
@@ -4,8 +4,8 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 
 
 PASS outlineOffset == -3 || outlineOffset == -2 is true
-PASS internals.usedOutlineOffset(opt1) is 0
-PASS internals.usedOutlineOffset(opt1) is 0
+PASS internals.usedOutlineOffset(opt1) == 0 is true
+PASS internals.usedOutlineOffset(opt1) == 0 is true
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/forms/select/base/option-focus-visible-outline-offset.html
+++ b/LayoutTests/fast/forms/select/base/option-focus-visible-outline-offset.html
@@ -36,13 +36,13 @@ jsTestIsAsync = true;
     await UIHelper.keyDown("\x1B");
     await UIHelper.animationFrame();
 
-    shouldBeEqualToNumber('internals.usedOutlineOffset(opt1)', 0);
+    shouldBeTrue('internals.usedOutlineOffset(opt1) == 0');
 
     // Open via mouse click — option should not have focus-visible outline.
     await UIHelper.activateElement(select);
     await UIHelper.animationFrame();
 
-    shouldBeEqualToNumber('internals.usedOutlineOffset(opt1)', 0);
+    shouldBeTrue('internals.usedOutlineOffset(opt1) == 0');
 
     finishJSTest();
 })();

--- a/LayoutTests/fast/forms/select/base/select-pagedown-pageup.html
+++ b/LayoutTests/fast/forms/select/base/select-pagedown-pageup.html
@@ -192,7 +192,18 @@ jsTestIsAsync = true;
 
     // Test: With a non-evenly-divisible picker height, the partially visible item from
     // the current page remains visible after Page Down (overlap behavior).
-    pickerStyle.textContent = `select, ::picker(select) { appearance: base-select; }\n::picker(select) { max-height: 170px; }`;
+    // Derive the picker height from the measured option height so a partial row is
+    // always present regardless of UA spacing changes: 4 full rows + 1/7 of a row,
+    // plus 2px for the picker's 1px top/bottom border. The fraction is deliberately
+    // not 1/2: with a half row, two pages span an exact integer number of rows and
+    // the straddling row lands precisely on the page fold, so it can never become
+    // fully visible. A smaller fraction leaves a genuine one-row overlap.
+    await openPickerAt(1);
+    optionHeight = getOption(2).getBoundingClientRect().top - getOption(1).getBoundingClientRect().top;
+    await closePicker();
+
+    pickerMaxHeight = Math.round(4 * optionHeight + optionHeight / 7 + 2);
+    pickerStyle.textContent = `select, ::picker(select) { appearance: base-select; }\n::picker(select) { max-height: ${pickerMaxHeight}px; }`;
 
     await openPickerAt(1);
     picker = internals.shadowRoot(select).querySelector('[popover]');

--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/form-controls/resets-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/form-controls/resets-expected.txt
@@ -262,7 +262,7 @@ PASS <optgroup><option> (in <select>) - text-shadow
 PASS <optgroup><option> (in <select>) - text-align
 PASS <optgroup><option> (in <select>) - overflow
 PASS <optgroup><option> (in <select>) - overflow-clip-margin
-PASS <optgroup><option> (in <select>) - box-sizing
+FAIL <optgroup><option> (in <select>) - box-sizing assert_equals: expected "content-box" but got "border-box"
 PASS <option> (in <select><optgroup>) - letter-spacing
 PASS <option> (in <select><optgroup>) - word-spacing
 PASS <option> (in <select><optgroup>) - line-height
@@ -272,7 +272,7 @@ PASS <option> (in <select><optgroup>) - text-shadow
 PASS <option> (in <select><optgroup>) - text-align
 PASS <option> (in <select><optgroup>) - overflow
 PASS <option> (in <select><optgroup>) - overflow-clip-margin
-PASS <option> (in <select><optgroup>) - box-sizing
+FAIL <option> (in <select><optgroup>) - box-sizing assert_equals: expected "content-box" but got "border-box"
 PASS <select multiple=""> - letter-spacing
 PASS <select multiple=""> - word-spacing
 PASS <select multiple=""> - line-height
@@ -292,7 +292,7 @@ PASS <optgroup> - text-shadow
 PASS <optgroup> - text-align
 PASS <optgroup> - overflow
 PASS <optgroup> - overflow-clip-margin
-PASS <optgroup> - box-sizing
+FAIL <optgroup> - box-sizing assert_equals: expected "content-box" but got "border-box"
 PASS <option> - letter-spacing
 PASS <option> - word-spacing
 PASS <option> - line-height

--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/the-select-element/select-as-listbox-default-styles.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/the-select-element/select-as-listbox-default-styles.tentative-expected.txt
@@ -59,7 +59,7 @@ PASS <option>1 (in <select multiple="">) - text-transform
 PASS <option>1 (in <select multiple="">) - text-indent
 PASS <option>1 (in <select multiple="">) - text-shadow
 PASS <option>1 (in <select multiple="">) - appearance
-PASS <option>1 (in <select multiple="">) - box-sizing
+FAIL <option>1 (in <select multiple="">) - box-sizing assert_equals: expected "content-box" but got "border-box"
 PASS <option>1 (in <select multiple="">) - border-top-width
 PASS <option>1 (in <select multiple="">) - border-right-width
 PASS <option>1 (in <select multiple="">) - border-bottom-width
@@ -105,7 +105,7 @@ PASS <optgroup label="2"><option>3 (in <select multiple="">) - text-transform
 PASS <optgroup label="2"><option>3 (in <select multiple="">) - text-indent
 PASS <optgroup label="2"><option>3 (in <select multiple="">) - text-shadow
 PASS <optgroup label="2"><option>3 (in <select multiple="">) - appearance
-PASS <optgroup label="2"><option>3 (in <select multiple="">) - box-sizing
+FAIL <optgroup label="2"><option>3 (in <select multiple="">) - box-sizing assert_equals: expected "content-box" but got "border-box"
 PASS <optgroup label="2"><option>3 (in <select multiple="">) - border-top-width
 PASS <optgroup label="2"><option>3 (in <select multiple="">) - border-right-width
 PASS <optgroup label="2"><option>3 (in <select multiple="">) - border-bottom-width
@@ -151,7 +151,7 @@ PASS <option>3 (in <select multiple=""><optgroup label="2">) - text-transform
 PASS <option>3 (in <select multiple=""><optgroup label="2">) - text-indent
 PASS <option>3 (in <select multiple=""><optgroup label="2">) - text-shadow
 PASS <option>3 (in <select multiple=""><optgroup label="2">) - appearance
-PASS <option>3 (in <select multiple=""><optgroup label="2">) - box-sizing
+FAIL <option>3 (in <select multiple=""><optgroup label="2">) - box-sizing assert_equals: expected "content-box" but got "border-box"
 PASS <option>3 (in <select multiple=""><optgroup label="2">) - border-top-width
 PASS <option>3 (in <select multiple=""><optgroup label="2">) - border-right-width
 PASS <option>3 (in <select multiple=""><optgroup label="2">) - border-bottom-width

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/appearance-base-and-base-select.tentative-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/appearance-base-and-base-select.tentative-expected.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<style>select::picker(select), select::picker-icon { transition-duration: 0s !important; }</style>
 <html class=reftest-wait>
 <script src="/resources/testdriver.js"></script>
 <script src="/resources/testdriver-vendor.js"></script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/appearance-base-and-base-select.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/appearance-base-and-base-select.tentative.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html class=reftest-wait>
+<style>select::picker(select), select::picker-icon { transition-duration: 0s !important; }</style>
 <link rel=author href="mailto:jarhar@chromium.org">
 <link rel=help href="https://drafts.csswg.org/css-ui-4/#valdef-appearance-base-select">
 <link rel=match href="appearance-base-and-base-select-ref.html">

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/appearance-base-select-other-elements-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/appearance-base-select-other-elements-expected.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<link rel=stylesheet href="update.css">
 <h2>appearance:base-select should not affect the rendering of non-select elements.</h2>
 
 <button>button</button>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/appearance-base-select-other-elements.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/appearance-base-select-other-elements.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<style>select::picker(select), select::picker-icon { transition-duration: 0s !important; }</style>
 <link rel=author href="mailto:jarhar@chromium.org">
 <link rel=help href="https://github.com/whatwg/html/issues/9799">
 <link rel=match href="appearance-base-select-other-elements-ref.html">

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/border-rendering-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/border-rendering-expected.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <link rel=stylesheet href="resources/customizable-select-styles.css">
+<link rel=stylesheet href="update.css">
 
 <div class=customizable-select-button>
   <span class=customizable-select-selectedcontent>Option 1</span>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/border-rendering.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/border-rendering.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<style>select::picker(select), select::picker-icon { transition-duration: 0s !important; }</style>
 <meta name=fuzzy content="maxDifference=0-56;totalPixels=0-9">
 <link rel=help href="https://github.com/whatwg/html/issues/9799">
 <link rel=match href="border-rendering-ref.html">

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/checkmark-animation-002-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/checkmark-animation-002-expected.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
 <link rel=stylesheet href="resources/customizable-select-styles.css">
+<link rel=stylesheet href="update.css">
 
 <style>
 .customizable-select-option::before {

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/checkmark-animation-002.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/checkmark-animation-002.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html class=reftest-wait>
+<style>select::picker(select), select::picker-icon { transition-duration: 0s !important; }</style>
 <meta charset="utf-8">
 <title>CSS Test: Web Animations on ::checkmark</title>
 <link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/closed-listbox-rendering-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/closed-listbox-rendering-expected.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<style>select::picker(select), select::picker-icon { transition-duration: 0s !important; }</style>
 <style>
 select {
   appearance: base-select;

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/closed-listbox-rendering.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/closed-listbox-rendering.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<style>select::picker(select), select::picker-icon { transition-duration: 0s !important; }</style>
 <link rel=author href="mailto:jarhar@chromium.org">
 <link rel=help href="https://github.com/whatwg/html/issues/9799">
 <link rel=match href="closed-listbox-rendering-ref.html">

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/focus-ring-rendering-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/focus-ring-rendering-expected.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <link rel=stylesheet href="resources/customizable-select-styles.css">
+<link rel=stylesheet href="update.css">
 
 <div id="target" class="customizable-select-button" tabindex="0">
   <span>Option 1</span>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/focus-ring-rendering.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/focus-ring-rendering.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<style>select::picker(select), select::picker-icon { transition-duration: 0s !important; }</style>
 <link rel=help href="https://crbug.com/389729368">
 <link rel=match href="focus-ring-rendering-ref.html">
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/option-label-in-shadow-tree-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/option-label-in-shadow-tree-expected.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<style>select::picker(select), select::picker-icon { transition-duration: 0s !important; }</style>
 <html class=reftest-wait>
 <script src="/resources/testdriver.js"></script>
 <script src="/resources/testdriver-vendor.js"></script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/option-label-in-shadow-tree.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/option-label-in-shadow-tree.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html class=reftest-wait>
+<style>select::picker(select), select::picker-icon { transition-duration: 0s !important; }</style>
 <link rel=help href="https://html.spec.whatwg.org/multipage/form-elements.html#the-option-element">
 <link rel=match href="option-label-in-shadow-tree-ref.html">
 <script src="/resources/testdriver.js"></script>
@@ -14,6 +15,9 @@ host.attachShadow({ mode: "open" }).innerHTML = `
   <style>
     select, ::picker(select) {
       appearance: base-select;
+    }
+    select::picker(select), select::picker-icon {
+      transition-duration: 0s !important;
     }
     select:focus-visible {
       outline: none;

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/picker-and-slotted-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/picker-and-slotted-expected.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<style>select::picker(select), select::picker-icon { transition-duration: 0s !important; }</style>
 <html class=reftest-wait>
 <link rel="author" title="L. David Baron" href="https://dbaron.org/">
 <link rel="author" title="Google" href="http://www.google.com/">

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/picker-and-slotted-invalidation-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/picker-and-slotted-invalidation-expected.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<style>select::picker(select), select::picker-icon { transition-duration: 0s !important; }</style>
 <html class=reftest-wait>
 <script src="/resources/testdriver.js"></script>
 <script src="/resources/testdriver-vendor.js"></script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/picker-and-slotted-invalidation.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/picker-and-slotted-invalidation.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html class=reftest-wait>
+<style>select::picker(select), select::picker-icon { transition-duration: 0s !important; }</style>
 <title>Style invalidation for ::slotted(select)::picker(select)</title>
 <link rel=match href="picker-and-slotted-invalidation-ref.html">
 <script src="/resources/testdriver.js"></script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/picker-and-slotted.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/picker-and-slotted.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html class=reftest-wait>
+<style>select::picker(select), select::picker-icon { transition-duration: 0s !important; }</style>
 <link rel=match href="picker-and-slotted-ref.html">
 <link rel="author" title="L. David Baron" href="https://dbaron.org/">
 <link rel="author" title="Google" href="http://www.google.com/">

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/picker-icon-and-slotted-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/picker-icon-and-slotted-expected.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<style>select::picker(select), select::picker-icon { transition-duration: 0s !important; }</style>
 
 <style>
 select {

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/picker-icon-and-slotted.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/picker-icon-and-slotted.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<style>select::picker(select), select::picker-icon { transition-duration: 0s !important; }</style>
 <meta name=fuzzy content="maxDifference=0-41;totalPixels=0-6">
 <link rel=match href="picker-icon-and-slotted-ref.html">
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/picker-icon-animation-002-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/picker-icon-animation-002-expected.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
 <link rel=stylesheet href="resources/customizable-select-styles.css">
+<link rel=stylesheet href="update.css">
 
 <style>
 .customizable-select-button::after {

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/picker-icon-animation-002.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/picker-icon-animation-002.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<style>select::picker(select), select::picker-icon { transition-duration: 0s !important; }</style>
 <meta charset="utf-8">
 <title>CSS Test: Web Animations on ::picker-icon</title>
 <link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-active-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-active-expected.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <link rel=stylesheet href="resources/customizable-select-styles.css">
+<link rel=stylesheet href="update.css">
 
-<button class="customizable-select-button active" popovertarget=popover id=button>
+<button class="customizable-select-button active hover" popovertarget=popover id=button>
   <span class=customizable-select-selectedoption>option</span>
 </button>
 <div id=popover popover=auto class=customizable-select-popover>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-active.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-active.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html class=reftest-wait>
+<style>select::picker(select), select::picker-icon { transition-duration: 0s !important; }</style>
 <meta name=fuzzy content="maxDifference=0-33;totalPixels=0-1">
 <link rel=author href="mailto:jarhar@chromium.org">
 <link rel=help href="https://github.com/w3c/csswg-drafts/issues/10909">

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-button-after-option-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-button-after-option-expected.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <link rel=stylesheet href="resources/customizable-select-styles.css">
+<link rel=stylesheet href="update.css">
 
 <div class=customizable-select-button>
   <span class=customizable-select-selectedcontent>option 1</span>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-button-after-option.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-button-after-option.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html class=reftest-wait>
+<style>select::picker(select), select::picker-icon { transition-duration: 0s !important; }</style>
 <meta name=fuzzy content="maxDifference=0-100;totalPixels=0-50">
 <link rel=author href="mailto:masonf@chromium.org">
 <link rel=match href="select-appearance-button-after-option-ref.html">

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-button-after-span-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-button-after-span-expected.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <link rel=stylesheet href="resources/customizable-select-styles.css">
+<link rel=stylesheet href="update.css">
 
 <div class=customizable-select-button>
   <span class=customizable-select-selectedcontent>option 1</span>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-button-after-span.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-button-after-span.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html class=reftest-wait>
+<style>select::picker(select), select::picker-icon { transition-duration: 0s !important; }</style>
 <meta name=fuzzy content="maxDifference=0-100;totalPixels=0-50">
 <link rel=author href="mailto:masonf@chromium.org">
 <link rel=match href="select-appearance-button-after-span-ref.html">

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-button-after-text-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-button-after-text-expected.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <link rel=stylesheet href="resources/customizable-select-styles.css">
+<link rel=stylesheet href="update.css">
 
 <div class=customizable-select-button>
   Hello <span class=customizable-select-selectedcontent>option 1</span>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-button-after-text.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-button-after-text.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html class=reftest-wait>
+<style>select::picker(select), select::picker-icon { transition-duration: 0s !important; }</style>
 <meta name=fuzzy content="maxDifference=0-100;totalPixels=0-50">
 <link rel=author href="mailto:masonf@chromium.org">
 <link rel=match href="select-appearance-button-after-text-ref.html">

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-custom-button-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-custom-button-expected.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <link rel=stylesheet href="resources/customizable-select-styles.css">
+<link rel=stylesheet href="update.css">
 
 <button class=customizable-select-button popovertarget=popover id=button>
   <span class=customizable-select-selectedcontent>one</span>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-custom-button.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-custom-button.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html class=reftest-wait>
+<style>select::picker(select), select::picker-icon { transition-duration: 0s !important; }</style>
 <meta name=fuzzy content="maxDifference=0-3;totalPixels=0-1">
 <link rel=author href="mailto:jarhar@chromium.org">
 <link rel=help href="https://github.com/whatwg/html/issues/9799">

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-dark-mode-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-dark-mode-expected.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <link rel=stylesheet href="resources/customizable-select-styles.css">
+<link rel=stylesheet href="update.css">
 
 <style>
 :root {

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-dark-mode.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-dark-mode.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html class=reftest-wait>
+<style>select::picker(select), select::picker-icon { transition-duration: 0s !important; }</style>
 <meta name=fuzzy content="maxDifference=0-2;totalPixels=0-15">
 <link rel=author href="mailto:jarhar@chromium.org">
 <link rel=help href="https://github.com/whatwg/html/issues/9799">

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-default-button-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-default-button-expected.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <link rel=stylesheet href="resources/customizable-select-styles.css">
+<link rel=stylesheet href="update.css">
 
 <button class=customizable-select-button popovertarget=popover id=button>
   <span class=customizable-select-selectedcontent>one</span>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-default-button.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-default-button.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html class=reftest-wait>
+<style>select::picker(select), select::picker-icon { transition-duration: 0s !important; }</style>
 <meta name=fuzzy content="maxDifference=0-3;totalPixels=0-1">
 <link rel=author href="mailto:jarhar@chromium.org">
 <link rel=help href="https://github.com/whatwg/html/issues/9799">

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-disabled-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-disabled-expected.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <link rel=stylesheet href="resources/customizable-select-styles.css">
+<link rel=stylesheet href="update.css">
 
 <div class="customizable-select-button disabled" popovertarget=popover id=button>
   <span class=customizable-select-selectedcontent>option</span>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-disabled-option-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-disabled-option-expected.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <link rel=stylesheet href="resources/customizable-select-styles.css">
+<link rel=stylesheet href="update.css">
 
 <button class=customizable-select-button popovertarget=popover id=button>
   <span class=customizable-select-selectedcontent>option</span>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-disabled-option.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-disabled-option.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html class=reftest-wait>
+<style>select::picker(select), select::picker-icon { transition-duration: 0s !important; }</style>
 <meta name=fuzzy content="maxDifference=0-41;totalPixels=0-1">
 <link rel=author href="mailto:jarhar@chromium.org">
 <link rel=help href="https://github.com/whatwg/html/issues/9799">

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-disabled.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-disabled.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
-<meta name=fuzzy content="maxDifference=0-41;totalPixels=0-1">
+<style>select::picker(select), select::picker-icon { transition-duration: 0s !important; }</style>
+<meta name=fuzzy content="maxDifference=0-41;totalPixels=0-6">
 <link rel=author href="mailto:jarhar@chromium.org">
 <link rel=help href="https://github.com/w3c/csswg-drafts/issues/10857">
 <link rel=match href="select-appearance-disabled-ref.html">

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-fallback-bottom-left-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-fallback-bottom-left-expected.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<link rel=stylesheet href="update.css">
 <html class=reftest-wait>
 <script src="resources/fallback-helper.js"></script>
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-fallback-bottom-left-scroller-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-fallback-bottom-left-scroller-expected.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<link rel=stylesheet href="update.css">
 <html class=reftest-wait>
 <script src="resources/fallback-helper.js"></script>
 <body>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-fallback-bottom-left-scroller.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-fallback-bottom-left-scroller.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html class=reftest-wait>
+<style>select::picker(select), select::picker-icon { transition-duration: 0s !important; }</style>
 <link rel=author href="mailto:masonf@chromium.org">
 <link rel=match href="select-appearance-fallback-bottom-left-scroller-ref.html">
 <script src="/resources/testdriver.js"></script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-fallback-bottom-left.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-fallback-bottom-left.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html class=reftest-wait>
+<style>select::picker(select), select::picker-icon { transition-duration: 0s !important; }</style>
 <link rel=author href="mailto:masonf@chromium.org">
 <link rel=match href="select-appearance-fallback-bottom-left-ref.html">
 <script src="/resources/testdriver.js"></script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-fallback-bottom-right-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-fallback-bottom-right-expected.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<link rel=stylesheet href="update.css">
 <html class=reftest-wait>
 <script src="resources/fallback-helper.js"></script>
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-fallback-bottom-right-scroller-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-fallback-bottom-right-scroller-expected.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<link rel=stylesheet href="update.css">
 <html class=reftest-wait>
 <script src="resources/fallback-helper.js"></script>
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-fallback-bottom-right-scroller.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-fallback-bottom-right-scroller.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html class=reftest-wait>
+<style>select::picker(select), select::picker-icon { transition-duration: 0s !important; }</style>
 <link rel=author href="mailto:masonf@chromium.org">
 <link rel=match href="select-appearance-fallback-bottom-right-scroller-ref.html">
 <script src="/resources/testdriver.js"></script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-fallback-bottom-right.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-fallback-bottom-right.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html class=reftest-wait>
+<style>select::picker(select), select::picker-icon { transition-duration: 0s !important; }</style>
 <link rel=author href="mailto:masonf@chromium.org">
 <link rel=match href="select-appearance-fallback-bottom-right-ref.html">
 <script src="/resources/testdriver.js"></script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-fallback-top-left-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-fallback-top-left-expected.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<link rel=stylesheet href="update.css">
 <html class=reftest-wait>
 <script src="resources/fallback-helper.js"></script>
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-fallback-top-left-scroller-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-fallback-top-left-scroller-expected.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<link rel=stylesheet href="update.css">
 <html class=reftest-wait>
 <script src="resources/fallback-helper.js"></script>
 <body>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-fallback-top-left-scroller.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-fallback-top-left-scroller.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html class=reftest-wait>
+<style>select::picker(select), select::picker-icon { transition-duration: 0s !important; }</style>
 <link rel=author href="mailto:masonf@chromium.org">
 <link rel=match href="select-appearance-fallback-top-left-scroller-ref.html">
 <script src="/resources/testdriver.js"></script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-fallback-top-left.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-fallback-top-left.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html class=reftest-wait>
+<style>select::picker(select), select::picker-icon { transition-duration: 0s !important; }</style>
 <link rel=author href="mailto:masonf@chromium.org">
 <link rel=match href="select-appearance-fallback-top-left-ref.html">
 <script src="/resources/testdriver.js"></script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-fallback-top-right-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-fallback-top-right-expected.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<link rel=stylesheet href="update.css">
 <html class=reftest-wait>
 <script src="resources/fallback-helper.js"></script>
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-fallback-top-right-scroller-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-fallback-top-right-scroller-expected.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<link rel=stylesheet href="update.css">
 <html class=reftest-wait>
 <script src="resources/fallback-helper.js"></script>
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-fallback-top-right-scroller.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-fallback-top-right-scroller.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html class=reftest-wait>
+<style>select::picker(select), select::picker-icon { transition-duration: 0s !important; }</style>
 <link rel=author href="mailto:masonf@chromium.org">
 <link rel=match href="select-appearance-fallback-top-right-scroller-ref.html">
 <script src="/resources/testdriver.js"></script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-fallback-top-right.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-fallback-top-right.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html class=reftest-wait>
+<style>select::picker(select), select::picker-icon { transition-duration: 0s !important; }</style>
 <link rel=author href="mailto:masonf@chromium.org">
 <link rel=match href="select-appearance-fallback-top-right-ref.html">
 <script src="/resources/testdriver.js"></script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-font-inheriting-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-font-inheriting-expected.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <link rel=stylesheet href="resources/customizable-select-styles.css">
+<link rel=stylesheet href="update.css">
 
 <button class="customizable-select-button open" popovertarget=popover id=button>
   <span class=customizable-select-selectedcontent>one</span>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-font-inheriting.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-font-inheriting.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html class=reftest-wait>
+<style>select::picker(select), select::picker-icon { transition-duration: 0s !important; }</style>
 <meta name=fuzzy content="maxDifference=0-55;totalPixels=0-75">
 <link rel=author href="mailto:jarhar@chromium.org">
 <link rel=help href="https://github.com/whatwg/html/issues/9799">

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-hover-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-hover-expected.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <link rel=stylesheet href="resources/customizable-select-styles.css">
+<link rel=stylesheet href="update.css">
 
 <div class="customizable-select-button hover" popovertarget=popover id=button>
   <span class=customizable-select-selectedoption>option</span>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-hover.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-hover.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html class=reftest-wait>
+<style>select::picker(select), select::picker-icon { transition-duration: 0s !important; }</style>
 <meta name=fuzzy content="maxDifference=0-37;totalPixels=0-1">
 <link rel=author href="mailto:jarhar@chromium.org">
 <link rel=help href="https://github.com/w3c/csswg-drafts/issues/10909">

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-mixing-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-mixing-expected.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<style>select::picker(select), select::picker-icon { transition-duration: 0s !important; }</style>
 <style>
 .custom, .custom::picker(select) {
   appearance: base-select;

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-mixing.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-mixing.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<style>select::picker(select), select::picker-icon { transition-duration: 0s !important; }</style>
 <link rel=author href="mailto:jarhar@chromium.org">
 <link rel=help href="https://issues.chromium.org/issues/393500003">
 <link rel=help href="https://chromium-review.googlesource.com/c/chromium/src/+/7032708/comment/aa4b509b_fec51624/">

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-optgroup-legend-and-label-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-optgroup-legend-and-label-expected.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <link rel=stylesheet href="resources/customizable-select-styles.css">
+<link rel=stylesheet href="update.css">
 
 <button class=customizable-select-button popovertarget=popover id=button>
   <span class=customizable-select-selectedcontent>one</span>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-optgroup-legend-and-label.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-optgroup-legend-and-label.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html class=reftest-wait>
+<style>select::picker(select), select::picker-icon { transition-duration: 0s !important; }</style>
 <link rel=author href="mailto:jarhar@chromium.org">
 <link rel=help href="https://issues.chromium.org/issues/378601807">
 <link rel=match href="select-appearance-optgroup-legend-ref.html">

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-optgroup-legend-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-optgroup-legend-expected.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <link rel=stylesheet href="resources/customizable-select-styles.css">
+<link rel=stylesheet href="update.css">
 
 <button class=customizable-select-button popovertarget=popover id=button>
   <span class=customizable-select-selectedcontent>one</span>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-optgroup-legend.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-optgroup-legend.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html class=reftest-wait>
+<style>select::picker(select), select::picker-icon { transition-duration: 0s !important; }</style>
 <meta name=fuzzy content="maxDifference=0-3;totalPixels=0-1">
 <link rel=author href="mailto:jarhar@chromium.org">
 <link rel=help href="https://github.com/whatwg/html/issues/9799">

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-optgroup-rendering-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-optgroup-rendering-expected.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <link rel=stylesheet href="resources/customizable-select-styles.css">
+<link rel=stylesheet href="update.css">
 
 <style>
 .border {

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-optgroup-rendering.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-optgroup-rendering.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html class=reftest-wait>
+<style>select::picker(select), select::picker-icon { transition-duration: 0s !important; }</style>
 <meta name=fuzzy content="maxDifference=0-3;totalPixels=0-1">
 <link rel=author href="mailto:jarhar@chromium.org">
 <link rel=help href="https://github.com/whatwg/html/issues/9799">

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-option-with-label-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-option-with-label-expected.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <link rel=stylesheet href="resources/customizable-select-styles.css">
+<link rel=stylesheet href="update.css">
 
 <button class=customizable-select-button popovertarget=popover id=button>
   <span class=customizable-select-selectedcontent>one</span>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-option-with-label.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-option-with-label.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html class=reftest-wait>
+<style>select::picker(select), select::picker-icon { transition-duration: 0s !important; }</style>
 <meta name=fuzzy content="maxDifference=0-3;totalPixels=0-1">
 <link rel=author href="mailto:jarhar@chromium.org">
 <link rel=help href="https://github.com/openui/open-ui/issues/1115">

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-picker-select-border-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-picker-select-border-expected.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <link rel=stylesheet href="resources/customizable-select-styles.css">
+<link rel=stylesheet href="update.css">
 
 <button class=customizable-select-button id=button>
   <span class=customizable-select-selectedcontent>option</span>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-picker-select-border.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-picker-select-border.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html class=reftest-wait>
+<style>select::picker(select), select::picker-icon { transition-duration: 0s !important; }</style>
 <meta name=fuzzy content="maxDifference=0-41;totalPixels=0-6">
 <link rel=author href="mailto:jarhar@chromium.org">
 <link rel=help href="https://github.com/whatwg/html/issues/9799">

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-sizing-in-flex-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-sizing-in-flex-expected.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<style>select::picker(select), select::picker-icon { transition-duration: 0s !important; }</style>
 <html>
 <title>Test of sizing customizable select inside of flex</title>
 <link rel=author href="mailto:dbaron@chromium.org">

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-sizing-in-flex.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-sizing-in-flex.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html>
+<style>select::picker(select), select::picker-icon { transition-duration: 0s !important; }</style>
 <title>Test of sizing customizable select inside of flex</title>
 <link rel=author href="mailto:dbaron@chromium.org">
 <link rel=help href="https://github.com/whatwg/html/issues/9799">

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-switching-invalidation-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-switching-invalidation-expected.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <link rel=stylesheet href="resources/customizable-select-styles.css">
+<link rel=stylesheet href="update.css">
 
 <style>
 .blue {

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-switching-invalidation.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-switching-invalidation.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html class=reftest-wait>
+<style>select::picker(select), select::picker-icon { transition-duration: 0s !important; }</style>
 <meta name=fuzzy content="maxDifference=0-41;totalPixels=0-2">
 <link rel=author href="mailto:jarhar@chromium.org">
 <link rel=help href="https://github.com/whatwg/html/issues/9799">

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-writing-mode-vertical-lr-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-writing-mode-vertical-lr-expected.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <link rel=stylesheet href="resources/customizable-select-styles.css">
+<link rel=stylesheet href="update.css">
 
 <style>
 html {

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-writing-mode-vertical-lr.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-writing-mode-vertical-lr.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html class=reftest-wait>
+<style>select::picker(select), select::picker-icon { transition-duration: 0s !important; }</style>
 <link rel=author href="mailto:jarhar@chromium.org">
 <link rel=help href="https://github.com/whatwg/html/issues/9799">
 <link rel=match href="select-appearance-writing-mode-vertical-lr-ref.html">

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-writing-mode-vertical-rl-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-writing-mode-vertical-rl-expected.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <link rel=stylesheet href="resources/customizable-select-styles.css">
+<link rel=stylesheet href="update.css">
 
 <style>
 html {

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-writing-mode-vertical-rl.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-writing-mode-vertical-rl.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html class=reftest-wait>
+<style>select::picker(select), select::picker-icon { transition-duration: 0s !important; }</style>
 <link rel=author href="mailto:jarhar@chromium.org">
 <link rel=help href="https://github.com/whatwg/html/issues/9799">
 <link rel=match href="select-appearance-writing-mode-vertical-rl-ref.html">

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-wrong-picker-argument-expected-mismatch.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-wrong-picker-argument-expected-mismatch.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <link rel=stylesheet href="resources/customizable-select-styles.css">
+<link rel=stylesheet href="update.css">
 
 <button class=customizable-select-button popovertarget=popover id=button>
   <span class=customizable-select-selectedcontent>one</span>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-wrong-picker-argument.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-wrong-picker-argument.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html class=reftest-wait>
+<style>select::picker(select), select::picker-icon { transition-duration: 0s !important; }</style>
 <link rel=author href="mailto:jarhar@chromium.org">
 <link rel=help href="https://github.com/w3c/csswg-drafts/issues/10440">
 <link rel=mismatch href="select-appearance-button-ref.html">

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-base-appearance-computed-style-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-base-appearance-computed-style-expected.txt
@@ -1,13 +1,13 @@
 button
 SIBLING
 
-FAIL UA styles of base appearance <select>. assert_equals: min-inline-size expected "calc-size(auto, max(size, 24px))" but got "0px"
-PASS UA styles of base appearance select::picker-icon.
-PASS UA styles of base appearance ::picker(select)
-PASS UA styles of base appearance <option>.
-PASS UA styles of base appearance option::checkmark.
+FAIL UA styles of base appearance <select>. assert_equals: border expected "1px solid rgb(255, 0, 0)" but got "1px solid oklab(0.627955 0.224863 0.125846 / 0.5)"
+FAIL UA styles of base appearance select::picker-icon. assert_equals: content expected "counter(fake-counter-name, disclosure-open)" but got "\"⌵\" / \"\""
+FAIL UA styles of base appearance ::picker(select) assert_equals: margin expected "0px" but got "4px 0px"
+FAIL UA styles of base appearance <option>. assert_equals: padding-block-start expected "0px" but got "12px"
+FAIL UA styles of base appearance option::checkmark. assert_equals: font-family expected "monospace" but got "system-ui"
 PASS UA styles of base appearance <optgroup>.
-PASS UA styles of base appearance <legend>.
+FAIL UA styles of base appearance <legend>. assert_equals: padding-inline expected "12px" but got "15.299999px"
 PASS UA styles of base appearance select <button>.
 PASS UA styles of base appearance <option> in <optgroup>.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-button-text-and-icon-clipping-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-button-text-and-icon-clipping-expected.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<link rel=stylesheet href="update.css">
 <link rel=stylesheet href="/fonts/ahem.css">
 
 <style>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-button-text-and-icon-clipping.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-button-text-and-icon-clipping.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<style>select::picker(select), select::picker-icon { transition-duration: 0s !important; }</style>
 <title>appearance:base-select must not clip its button text or icon</title>
 <link rel=help href="https://html.spec.whatwg.org/multipage/form-elements.html#the-select-element">
 <link rel=match href="select-button-text-and-icon-clipping-ref.html">

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-clipping-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-clipping-expected.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <link rel=stylesheet href="resources/customizable-select-styles.css">
+<link rel=stylesheet href="update.css">
 
 <button class=customizable-select-button>
   <span class=customizable-select-selectedcontent>100</span>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-clipping.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-clipping.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<style>select::picker(select), select::picker-icon { transition-duration: 0s !important; }</style>
 <link rel=author href="mailto:jarhar@chromium.org">
 <link rel=match href="select-clipping-ref.html">
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-display-block.tentative-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-display-block.tentative-expected.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <link rel=stylesheet href="resources/customizable-select-styles.css">
+<link rel=stylesheet href="update.css">
 
 <style>
 .customizable-select-button {

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-display-block.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-display-block.tentative.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html class=reftest-wait>
+<style>select::picker(select), select::picker-icon { transition-duration: 0s !important; }</style>
 <meta name=fuzzy content="maxDifference=0-3;totalPixels=0-1">
 <link rel=author href="mailto:jarhar@chromium.org">
 <link rel=help href="https://github.com/whatwg/html/issues/9799">

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-explicit-size-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-explicit-size-expected.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <link rel=stylesheet href="resources/customizable-select-styles.css">
+<link rel=stylesheet href="update.css">
 
 <div class=customizable-select-button>
   <span class=customizable-select-selectedcontent>option</span>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-explicit-size.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-explicit-size.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<style>select::picker(select), select::picker-icon { transition-duration: 0s !important; }</style>
 <!-- Tests that select respects explicit size -->
 <link rel=author href="mailto:pkotwicz@chromium.org">
 <link rel="match" href="select-explicit-size-ref.html">

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-font-size-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-font-size-expected.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <link rel=stylesheet href="resources/customizable-select-styles.css">
+<link rel=stylesheet href="update.css">
 <button class=customizable-select-button>
   <span class=customizable-select-selectedcontent>option</span>
 </button>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-font-size.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-font-size.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<style>select::picker(select), select::picker-icon { transition-duration: 0s !important; }</style>
 <!-- Tests that select respects explicit size -->
 <meta name=fuzzy content="maxDifference=0-55;totalPixels=0-32">
 <link rel=author href="mailto:pkotwicz@chromium.org">

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-grid-before-after-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-grid-before-after-expected.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<link rel=stylesheet href="update.css">
 
 <style>
   div {

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-grid-before-after.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-grid-before-after.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<style>select::picker(select), select::picker-icon { transition-duration: 0s !important; }</style>
 <link rel=author href="mailto:jarhar@chromium.org">
 <link rel=help href="https://issues.chromium.org/issues/452087739">
 <link rel=match href="select-grid-before-after-ref.html">

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-home-end-pagedown-pageup-detailed.optional-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-home-end-pagedown-pageup-detailed.optional-expected.txt
@@ -1003,5 +1003,5 @@ Option #1000
 PASS Behavior of Home and End for customizable-<select>
 PASS Behavior of Home and End for customizable-<select>, starting at the top
 PASS Behavior of Home and End for customizable-<select>, starting at the bottom
-FAIL Behavior of PageUp and PageDown for customizable-<select> assert_equals: First page down should not scroll expected 305.390625 but got -240.609375
+FAIL Behavior of PageUp and PageDown for customizable-<select> assert_true: First page down should not scroll expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-home-end-pagedown-pageup-detailed.optional.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-home-end-pagedown-pageup-detailed.optional.html
@@ -22,6 +22,12 @@
 select,::picker(select) {
   appearance: base-select;
 }
+/* Suppress the picker open transition (scale/opacity) so option positions are
+   stable when measured; otherwise getBoundingClientRect() can be sampled
+   mid-animation and vary from run to run. */
+::picker(select) {
+  transition-duration: 0s !important;
+}
 </style>
 
 <select></select>
@@ -31,8 +37,18 @@ const keyMap = {
   'Home': '\uE011',
   'End': '\uE010',
   'PageUp': '\uE00E',
-  'PageDown': '\uE00F'
+  'PageDown': '\uE00F',
+  'Escape': '\uE00C'
 };
+
+// Dismiss the open picker. Clicking the select can't be used reliably: for a
+// long option list the picker grows tall enough to cover its own anchor
+// button, so a click at the select's position lands on an option (selecting
+// it) instead of toggling the picker closed. Escape dismisses without
+// committing a selection.
+async function closePicker() {
+  await test_driver.send_keys(document.activeElement, keyMap.Escape);
+}
 const select = document.querySelector('select');
 
 const nOptions = 1000;
@@ -68,9 +84,9 @@ promise_test(async () => {
   assert_equals(select.value, middleOption.value, 'Selected option should not change');
   assert_equals(document.activeElement, getOption(nOptions), 'Focus should move down to the last option');
 
-  await test_driver.click(select);
+  await closePicker();
   assert_equals(select.value, middleOption.value, 'Selected option should not change');
-  assert_false(select.matches(':open'),'Clicking select should close picker');
+  assert_false(select.matches(':open'),'Escape should close picker');
 }, 'Behavior of Home and End for customizable-<select>');
 
 promise_test(async () => {
@@ -84,9 +100,9 @@ promise_test(async () => {
   assert_equals(select.value, firstOption.value, 'Selected option should not change');
   assert_equals(document.activeElement, getOption(nOptions), 'Focus should move down to the last option');
 
-  await test_driver.click(select);
+  await closePicker();
   assert_equals(select.value, firstOption.value, 'Selected option should not change');
-  assert_false(select.matches(':open'),'Clicking select should close picker');
+  assert_false(select.matches(':open'),'Escape should close picker');
 }, 'Behavior of Home and End for customizable-<select>, starting at the top');
 
 promise_test(async () => {
@@ -100,9 +116,9 @@ promise_test(async () => {
   assert_equals(select.value, lastOption.value, 'Selected option should not change');
   assert_equals(document.activeElement, getOption(1), 'Focus should move up to the first option');
 
-  await test_driver.click(select);
+  await closePicker();
   assert_equals(select.value, lastOption.value, 'Selected option should not change');
-  assert_false(select.matches(':open'),'Clicking select should close picker');
+  assert_false(select.matches(':open'),'Escape should close picker');
 }, 'Behavior of Home and End for customizable-<select>, starting at the bottom');
 
 promise_test(async () => {
@@ -110,30 +126,33 @@ promise_test(async () => {
   await testStart(middleOption);
   assert_equals(document.activeElement, middleOption, 'Focus should be on the middle option');
   const middleOptionPos = middleOption.getBoundingClientRect().top;
-  assert_not_equals(middleOptionPos,0,'Middle option should be scrolled into view, to start');
+  // Compare positions as booleans rather than with assert_equals/assert_not_equals
+  // on the raw coordinates, so pass/fail output carries no environment-dependent
+  // pixel values and the checked-in expectation stays stable across machines.
+  assert_true(middleOptionPos !== 0,'Middle option should be scrolled into view, to start');
 
   await test_driver.send_keys(document.activeElement, keyMap.PageDown);
-  assert_equals(middleOption.getBoundingClientRect().top,middleOptionPos,'First page down should not scroll');
+  assert_true(middleOption.getBoundingClientRect().top === middleOptionPos,'First page down should not scroll');
   const focusedOption2 = document.activeElement;
   assert_not_equals(focusedOption2, middleOption, 'Focused option should change');
 
   await test_driver.send_keys(document.activeElement, keyMap.PageDown);
-  assert_not_equals(middleOption.getBoundingClientRect().top,middleOptionPos,'Second page down should scroll down by one page');
+  assert_true(middleOption.getBoundingClientRect().top !== middleOptionPos,'Second page down should scroll down by one page');
   const focusedOption3 = document.activeElement;
   assert_not_equals(focusedOption3, focusedOption2, 'Focused option should change');
   const focusedOption3ScrollPos = focusedOption3.getBoundingClientRect().top;
 
   await test_driver.send_keys(document.activeElement, keyMap.PageUp);
-  assert_equals(focusedOption3.getBoundingClientRect().top,focusedOption3ScrollPos,'Page up from here should not scroll');
+  assert_true(focusedOption3.getBoundingClientRect().top === focusedOption3ScrollPos,'Page up from here should not scroll');
   const focusedOption4 = document.activeElement;
   assert_not_equals(focusedOption4, focusedOption3, 'Focused option should change');
 
   await test_driver.send_keys(document.activeElement, keyMap.PageUp);
-  assert_not_equals(focusedOption3.getBoundingClientRect().top,focusedOption3ScrollPos,'Page up should scroll up by one page');
+  assert_true(focusedOption3.getBoundingClientRect().top !== focusedOption3ScrollPos,'Page up should scroll up by one page');
   assert_not_equals(document.activeElement, focusedOption4, 'Focused option should change');
 
-  await test_driver.click(select);
+  await closePicker();
   assert_equals(select.value, middleOption.value, 'Selected option should not change');
-  assert_false(select.matches(':open'),'Clicking select should close picker');
+  assert_false(select.matches(':open'),'Escape should close picker');
 }, 'Behavior of PageUp and PageDown for customizable-<select>');
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-home-end-pagedown-pageup.optional.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-home-end-pagedown-pageup.optional.html
@@ -23,9 +23,19 @@ const keyMap = {
   'Home': '\uE011',
   'End': '\uE010',
   'PageUp': '\uE00E',
-  'PageDown': '\uE00F'
+  'PageDown': '\uE00F',
+  'Escape': '\uE00C'
 };
 const select = document.querySelector('select');
+
+// Dismiss the open picker. Clicking the select can't be used reliably: for a
+// long option list the picker grows tall enough to cover its own anchor
+// button, so a click at the select's position lands on an option (selecting
+// it) instead of toggling the picker closed. Escape dismisses without
+// committing a selection.
+async function closePicker() {
+  await test_driver.send_keys(document.activeElement, keyMap.Escape);
+}
 
 for(let i=1;i<=1000;++i) {
   const option = document.createElement('option');
@@ -52,8 +62,8 @@ const middleOption = document.getElementById(500);
     assert_not_equals(document.activeElement, middleOption, 'Focus should move');
 
     select.value = firstOption.value;
-    await test_driver.click(select);
-    assert_false(select.matches(':open'),'Clicking select should close picker');
+    await closePicker();
+    assert_false(select.matches(':open'),'Escape should close picker');
     assert_equals(select.value, firstOption.value, 'Value should stay');
   }, `Behavior of ${keyName} for customizable-<select>`);
 });

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-icon-color-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-icon-color-expected.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <link rel=stylesheet href="resources/customizable-select-styles.css">
+<link rel=stylesheet href="update.css">
 
 <style>
 .customizable-select-button::after {

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-icon-color.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-icon-color.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<style>select::picker(select), select::picker-icon { transition-duration: 0s !important; }</style>
 <meta name=fuzzy content="maxDifference=0-41;totalPixels=0-6">
 <link rel=author href="mailto:jarhar@chromium.org">
 <link rel=help href="https://github.com/openui/open-ui/issues/881">

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-only-button-opt-in-expected-mismatch.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-only-button-opt-in-expected-mismatch.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <link rel=stylesheet href="resources/customizable-select-styles.css">
+<link rel=stylesheet href="update.css">
 
 <button class=customizable-select-button popovertarget=popover id=button>
   <span class=customizable-select-selectedcontent>one</span>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-only-button-opt-in.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-only-button-opt-in.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html class=reftest-wait>
+<style>select::picker(select), select::picker-icon { transition-duration: 0s !important; }</style>
 <link rel=author href="mailto:jarhar@chromium.org">
 <link rel=help href="https://github.com/w3c/csswg-drafts/issues/10440">
 <link rel=mismatch href="select-appearance-button-ref.html">

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-only-picker-opt-in-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-only-picker-opt-in-expected.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<style>select::picker(select), select::picker-icon { transition-duration: 0s !important; }</style>
 <html class=reftest-wait>
 <script src="/resources/testdriver.js"></script>
 <script src="/resources/testdriver-vendor.js"></script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-only-picker-opt-in.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-only-picker-opt-in.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html class=reftest-wait>
+<style>select::picker(select), select::picker-icon { transition-duration: 0s !important; }</style>
 <link rel=author href="mailto:jarhar@chromium.org">
 <link rel=help href="https://github.com/w3c/csswg-drafts/issues/10440">
 <link rel=match href="select-only-picker-opt-in-ref.html">

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-open-invalidation-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-open-invalidation-expected.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <link rel=stylesheet href="resources/customizable-select-styles.css">
+<link rel=stylesheet href="update.css">
 
 <style>
 .customizable-select-selectedoption {

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-open-invalidation.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-open-invalidation.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html class=reftest-wait>
+<style>select::picker(select), select::picker-icon { transition-duration: 0s !important; }</style>
 <meta name=fuzzy content="maxDifference=0-41;totalPixels=0-2">
 <link rel=author href="mailto:jarhar@chromium.org">
 <link rel=help href="https://github.com/whatwg/html/issues/9799">

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-optgroup-legend-label-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-optgroup-legend-label-expected.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<style>select::picker(select), select::picker-icon { transition-duration: 0s !important; }</style>
 <select size="4">
   <optgroup label="Foobar">
     <option>Lion</option>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-optgroup-legend-label.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-optgroup-legend-label.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<style>select::picker(select), select::picker-icon { transition-duration: 0s !important; }</style>
 <link rel=help href="https://html.spec.whatwg.org/multipage/form-elements.html#concept-optgroup-label">
 <link rel=match href="select-optgroup-legend-label-ref.html">
 <meta name=assert content="An optgroup's label comes from its first child legend element when present">

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-option-hover-styles-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-option-hover-styles-expected.txt
@@ -3,5 +3,5 @@ one
 two
 disabled
 
-PASS Hover styles should be present for appearance:base-select options.
+FAIL Hover styles should be present for appearance:base-select options. assert_equals: Disabled option color while hovering. expected "oklab(0 0 0 / 0.5)" but got "oklab(0 0 0 / 0.55)"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-option-images-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-option-images-expected.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <link rel=stylesheet href="resources/customizable-select-styles.css">
+<link rel=stylesheet href="update.css">
 
 <button class=customizable-select-button popovertarget=popover id=button>
   <span class=customizable-select-selectedoption>button</span>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-option-images.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-option-images.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html class=reftest-wait>
+<style>select::picker(select), select::picker-icon { transition-duration: 0s !important; }</style>
 <meta name=fuzzy content="maxDifference=0-41;totalPixels=0-2">
 <link rel=author href="mailto:jarhar@chromium.org">
 <link rel=help href="https://github.com/whatwg/html/issues/9799">

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-pseudo-backdrop-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-pseudo-backdrop-expected.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
 <link rel=stylesheet href="resources/customizable-select-styles.css">
+<link rel=stylesheet href="update.css">
 
 <style>
 body {

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-pseudo-backdrop.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-pseudo-backdrop.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html class="reftest-wait">
+<style>select::picker(select), select::picker-icon { transition-duration: 0s !important; }</style>
 <meta charset="utf-8">
 <title>CSS ::backdrop pseudo-element on select::picker(select)</title>
 <link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-pseudo-before-after-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-pseudo-before-after-expected.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
 <link rel=stylesheet href="resources/customizable-select-styles.css">
+<link rel=stylesheet href="update.css">
 
 <style>
 .before-placeholder {

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-pseudo-before-after.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-pseudo-before-after.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html class="reftest-wait">
+<style>select::picker(select), select::picker-icon { transition-duration: 0s !important; }</style>
 <meta charset="utf-8">
 <title>CSS ::before and ::after pseudo-elements on select::picker(select)</title>
 <link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-pseudo-first-letter-first-line-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-pseudo-first-letter-first-line-expected.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
 <link rel=stylesheet href="resources/customizable-select-styles.css">
+<link rel=stylesheet href="update.css">
 
 <style>
 .picker-first-letter {

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-pseudo-first-letter-first-line.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-pseudo-first-letter-first-line.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html class="reftest-wait">
+<style>select::picker(select), select::picker-icon { transition-duration: 0s !important; }</style>
 <meta charset="utf-8">
 <title>CSS ::first-letter and ::first-line pseudo-elements on select::picker(select)</title>
 <link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-pseudo-highlight-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-pseudo-highlight-expected.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
 <link rel=stylesheet href="resources/customizable-select-styles.css">
+<link rel=stylesheet href="update.css">
 
 <style>
 .highlight {

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-pseudo-highlight.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-pseudo-highlight.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html class="reftest-wait">
+<style>select::picker(select), select::picker-icon { transition-duration: 0s !important; }</style>
 <meta charset="utf-8">
 <title>CSS ::highlight() pseudo-element on select::picker(select)</title>
 <link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-pseudo-selection-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-pseudo-selection-expected.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
 <link rel=stylesheet href="resources/customizable-select-styles.css">
+<link rel=stylesheet href="update.css">
 
 <style>
 ::selection {

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-pseudo-selection.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-pseudo-selection.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html class="reftest-wait">
+<style>select::picker(select), select::picker-icon { transition-duration: 0s !important; }</style>
 <meta charset="utf-8">
 <title>CSS ::selection pseudo-element on select::picker(select)</title>
 <link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-pseudo-target-text-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-pseudo-target-text-expected.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
 <link rel=stylesheet href="resources/customizable-select-styles.css">
+<link rel=stylesheet href="update.css">
 
 <style>
 .target-text {

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-pseudo-target-text.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-pseudo-target-text.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html class="reftest-wait">
+<style>select::picker(select), select::picker-icon { transition-duration: 0s !important; }</style>
 <meta charset="utf-8">
 <title>CSS ::target-text pseudo-element on select::picker(select)</title>
 <link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-popover-exit-animation-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-popover-exit-animation-expected.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <link rel=stylesheet href="resources/customizable-select-styles.css">
+<link rel=stylesheet href="update.css">
 
 <div>hover target</div>
 <button class=customizable-select-button popovertarget=popover id=button>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-popover-exit-animation.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-popover-exit-animation.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html class=reftest-wait>
+<style>select::picker(select), select::picker-icon { transition-duration: 0s !important; }</style>
 <meta name=fuzzy content="maxDifference=0-41;totalPixels=0-6">
 <link rel=author href="mailto:jarhar@chromium.org">
 <link rel=match href="select-popover-exit-animation-ref.html">

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-second-child-button-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-second-child-button-expected.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <link rel=stylesheet href="resources/customizable-select-styles.css">
+<link rel=stylesheet href="update.css">
 
 <button class=customizable-select-button popovertarget=popover id=button>
   <span class=customizable-select-selectedcontent>option</span>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-second-child-button.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-second-child-button.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html class=reftest-wait>
+<style>select::picker(select), select::picker-icon { transition-duration: 0s !important; }</style>
 <meta name=fuzzy content="maxDifference=0-41;totalPixels=0-1">
 <link rel=author href="mailto:jarhar@chromium.org">
 <link rel=help href="https://github.com/whatwg/html/pull/10629">

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-size-multiple-new-content-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-size-multiple-new-content-expected.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<style>select::picker(select), select::picker-icon { transition-duration: 0s !important; }</style>
 
 <select size=5>
   <option>one</option>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-size-multiple-new-content.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-size-multiple-new-content.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<style>select::picker(select), select::picker-icon { transition-duration: 0s !important; }</style>
 <link rel=author href="mailto:jarhar@chromium.org">
 <link rel=help href="https://issues.chromium.org/issues/357047901">
 <link rel=match href="select-size-multiple-new-content-ref.html">

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-text-only-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-text-only-expected.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <link rel=stylesheet href="resources/customizable-select-styles.css">
-<div class="customizable-select-button open" style="anchor-name:--button" popovertarget=popover id=button>
+<link rel=stylesheet href="update.css">
+<div class="customizable-select-button" style="anchor-name:--button" popovertarget=popover id=button>
   <span class=customizable-select-selectedcontent>option</span>
 </div>
 <div id=popover popover=auto style="position-anchor:--button" class=customizable-select-popover>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-text-only.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-text-only.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<style>select::picker(select), select::picker-icon { transition-duration: 0s !important; }</style>
 <meta name=fuzzy content="maxDifference=0-41;totalPixels=0-1">
 <link rel=author href="mailto:jarhar@chromium.org">
 <link rel=help href="https://github.com/openui/open-ui/issues/702">

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/selectedcontent-color-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/selectedcontent-color-expected.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <link rel=stylesheet href="resources/customizable-select-styles.css">
-<div class="customizable-select-button open">
+<link rel=stylesheet href="update.css">
+<div class="customizable-select-button">
   <span class=customizable-select-selectedcontent>option</span>
 </div>
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/selectedcontent-color.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/selectedcontent-color.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<style>select::picker(select), select::picker-icon { transition-duration: 0s !important; }</style>
 <meta name=fuzzy content="maxDifference=0-41;totalPixels=0-1">
 <link rel=author href="mailto:jarhar@chromium.org">
 <link rel=match href="selectedcontent-color-ref.html">

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/standalone-optgroup-no-shadow-tree-after-select-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/standalone-optgroup-no-shadow-tree-after-select-expected.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<link rel=stylesheet href="update.css">
 <link rel=help href="https://html.spec.whatwg.org/multipage/form-elements.html#the-optgroup-element">
 
 <div id="ref">child text</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/standalone-optgroup-no-shadow-tree-after-select.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/standalone-optgroup-no-shadow-tree-after-select.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<style>select::picker(select), select::picker-icon { transition-duration: 0s !important; }</style>
 <link rel=help href="https://html.spec.whatwg.org/multipage/form-elements.html#the-optgroup-element">
 <link rel=match href="standalone-optgroup-no-shadow-tree-ref.html">
 <meta name=assert content="An optgroup element moved out of a select element should not render a UA shadow tree and should render its child text content.">

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/standalone-optgroup-no-shadow-tree-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/standalone-optgroup-no-shadow-tree-expected.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<link rel=stylesheet href="update.css">
 <link rel=help href="https://html.spec.whatwg.org/multipage/form-elements.html#the-optgroup-element">
 
 <div id="ref">child text</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/standalone-optgroup-no-shadow-tree.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/standalone-optgroup-no-shadow-tree.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<style>select::picker(select), select::picker-icon { transition-duration: 0s !important; }</style>
 <link rel=help href="https://html.spec.whatwg.org/multipage/form-elements.html#the-optgroup-element">
 <link rel=match href="standalone-optgroup-no-shadow-tree-ref.html">
 <meta name=assert content="A standalone optgroup element with a label attribute should not get a UA shadow tree and should render its child text content.">

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/standalone-option-no-shadow-tree-after-select-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/standalone-option-no-shadow-tree-after-select-expected.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<link rel=stylesheet href="update.css">
 <link rel=help href="https://html.spec.whatwg.org/multipage/form-elements.html#the-option-element">
 
 <div>child text</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/standalone-option-no-shadow-tree-after-select.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/standalone-option-no-shadow-tree-after-select.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<style>select::picker(select), select::picker-icon { transition-duration: 0s !important; }</style>
 <link rel=help href="https://html.spec.whatwg.org/multipage/form-elements.html#the-option-element">
 <link rel=match href="standalone-option-no-shadow-tree-ref.html">
 <meta name=assert content="An option element moved out of a select element should not render a UA shadow tree and should render its child text content.">

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/standalone-option-no-shadow-tree-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/standalone-option-no-shadow-tree-expected.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<link rel=stylesheet href="update.css">
 <link rel=help href="https://html.spec.whatwg.org/multipage/form-elements.html#the-option-element">
 
 <div>child text</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/standalone-option-no-shadow-tree.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/standalone-option-no-shadow-tree.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<style>select::picker(select), select::picker-icon { transition-duration: 0s !important; }</style>
 <link rel=help href="https://html.spec.whatwg.org/multipage/form-elements.html#the-option-element">
 <link rel=match href="standalone-option-no-shadow-tree-ref.html">
 <meta name=assert content="A standalone option element with a label attribute should not get a UA shadow tree and should render its child text content.">

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/update.css
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/update.css
@@ -1,0 +1,271 @@
+/*
+ * WebKit UA overrides for a customizable <select> (appearance: base-select),
+ * extracted from Source/WebCore/css/html.css.
+ *
+ * Extraction rules:
+ *   - macOS variants only (the non-WTF_PLATFORM_IOS_FAMILY branches).
+ *   - The base-appearance value of -internal-auto-base(auto, base) i.e. the
+ *     second argument.
+ *   - UA-stylesheet-only selectors rewritten to standard CSS:
+ *       select:-internal-uses-menulist  ->  select
+ *       :-internal-select-popover        ->  select::picker(select)
+ *     and the native listbox fallback (::-internal-fallback-popup-menu-*) and
+ *     non-menulist (multiple/size) rules are omitted as they are not part of
+ *     base-select.
+ *
+ * Each rule additionally targets the .customizable-select-* classes used by the
+ * div-based reference reconstructions in this directory.
+ *
+ * Cascade: the div-based -expected files link this file immediately AFTER
+ * resources/customizable-select-styles.css. Because these rules mirror that
+ * file's selectors at equal specificity, they win over the shared reference
+ * styles by source order, while still losing to the unlayered inline styles
+ * that come later in each individual reference. (The real-<select> references
+ * link this file on its own, for the element-based rules below.)
+ *
+ * Lastly, we force transition-duration to zero at the end, so that reftests
+ * snapshot correctly.
+ */
+
+/* ---- Select button ---- */
+
+select,
+.customizable-select-button {
+  box-sizing: border-box;
+  border: 1px solid color-mix(currentColor 50%);
+  border-radius: 4px;
+  padding-block: 0.4em;
+  padding-inline: 1em 0.7em;
+  color: inherit;
+  font: inherit;
+  background-color: light-dark(transparent, color-mix(currentColor 4%));
+  align-items: unset;
+  white-space: nowrap;
+  cursor: default;
+  gap: 0.5em;
+  min-block-size: 24px;
+  min-inline-size: 4em;
+  overflow: clip;
+  text-overflow: ellipsis;
+  -webkit-rtl-ordering: inherit;
+  text-shadow: inherit;
+  letter-spacing: inherit;
+  word-spacing: inherit;
+}
+
+select:not([popover]),
+.customizable-select-button {
+  display: inline-flex;
+}
+
+select:enabled:hover:not(:user-invalid),
+.customizable-select-button.hover {
+  border-color: color-mix(currentColor 70%);
+}
+
+/* The shared reference sheet tints the button background on hover, but WebKit's
+   base-select hover only changes the border-color. Restore the base background
+   so the div-based .customizable-select-button.hover reference matches (this
+   rule follows customizable-select-styles.css, so it wins at equal specificity). */
+.customizable-select-button.hover {
+  background-color: light-dark(transparent, color-mix(currentColor 4%));
+}
+
+select:enabled:active,
+.customizable-select-button.active {
+  background-color: color-mix(currentColor 8%);
+}
+
+select:disabled,
+.customizable-select-button.disabled {
+  background-color: color-mix(currentColor 6%);
+  color: color-mix(currentColor 55%);
+  border-color: color-mix(currentColor 25%);
+  cursor: not-allowed;
+}
+
+select:user-invalid {
+  border-color: light-dark(#dc3545, oklch(from #db2a37 calc(l + 0.17) c h));
+}
+
+select:not([multiple]) > button:first-child {
+  all: unset;
+  display: contents;
+}
+
+/* ---- selectedcontent ---- */
+
+select selectedcontent,
+.customizable-select-selectedcontent {
+  overflow: clip;
+  text-overflow: ellipsis;
+  min-inline-size: 0;
+}
+
+/* ---- Picker icon ---- */
+
+select::picker-icon,
+.customizable-select-button::after {
+  content: "\2335" / "";
+  font-family: system-ui;
+  font-style: normal;
+  text-orientation: sideways;
+  padding-inline: 0.3em 0.15em;
+  margin-inline-start: auto;
+  margin-block-start: -0.25em;
+  align-self: center;
+}
+
+/* ---- Picker popover ---- */
+
+select::picker(select),
+.customizable-select-popover {
+  box-sizing: border-box;
+  border: 1px solid color-mix(currentColor 50%);
+  border-radius: 4px;
+  padding: 0;
+  color: inherit;
+  background-color: color-mix(contrast-color(currentColor), white 15%);
+  margin: 0;
+  margin-block: 4px;
+  inset: auto;
+  min-inline-size: anchor-size(self-inline);
+  min-block-size: 1lh;
+  max-block-size: calc(100svb - 8px);
+  overflow: auto;
+  overscroll-behavior: contain;
+  box-shadow:
+    0 4px 6px -1px light-dark(rgba(0, 0, 0, 0.1), rgba(0, 0, 0, 0.35)),
+    0 8px 16px -4px light-dark(rgba(0, 0, 0, 0.08), rgba(0, 0, 0, 0.25));
+  position-area: self-block-end span-self-inline-end;
+  position-try-order: most-block-size;
+  position-try-fallbacks: flip-block, flip-inline, flip-block flip-inline;
+}
+
+select::picker(select):popover-open {
+  display: block;
+}
+
+/* ---- Options ---- */
+
+option {
+  display: block;
+}
+
+select option,
+.customizable-select-option {
+  min-inline-size: 24px;
+  min-block-size: max(24px, 1lh);
+  padding-block: 0.5em;
+  padding-inline: 0.75em 1.1em;
+  display: flex;
+  align-items: center;
+  gap: 0.5em;
+  white-space: nowrap;
+  box-sizing: border-box;
+  outline-offset: inset;
+}
+
+select option:enabled:hover,
+select option:enabled:focus-visible {
+  background-color: color-mix(currentColor 10%);
+}
+
+select option:enabled:active {
+  background-color: color-mix(currentColor 15%);
+}
+
+select option:disabled,
+.customizable-select-option.disabled {
+  color: color-mix(currentColor 55%);
+  cursor: not-allowed;
+}
+
+select option::checkmark,
+.customizable-select-option::before {
+  content: "\2713" / "";
+  font-family: system-ui;
+  font-style: normal;
+}
+
+select option:not(:checked)::checkmark,
+.customizable-select-option:not(.selected)::before {
+  visibility: hidden;
+}
+
+/* ---- Optgroups ---- */
+
+optgroup,
+.customizable-select-optgroup {
+  display: block;
+  font-weight: bolder;
+  box-sizing: border-box;
+}
+
+select optgroup:not(:first-child),
+.customizable-select-optgroup:not(:first-child) {
+  border-block-start: 1px solid color-mix(currentColor 12%);
+}
+
+select optgroup option,
+.customizable-select-optgroup .customizable-select-option {
+  font-weight: normal;
+}
+
+select optgroup legend,
+.customizable-select-legend {
+  box-sizing: border-box;
+  padding-block: 0.6em 0.15em;
+  padding-inline: 0.75em;
+  min-block-size: 1lh;
+  font-size: 0.85em;
+  font-weight: 400;
+  color: color-mix(currentColor 70%);
+  cursor: default;
+}
+
+/* ---- Media adjustments ---- */
+
+@media (prefers-contrast) {
+  select,
+  .customizable-select-button {
+    background-color: Canvas;
+    color: CanvasText;
+    border-color: CanvasText;
+  }
+  select:enabled:hover:hover,
+  select:open:enabled:hover:hover,
+  .customizable-select-button.hover {
+    background-color: Canvas;
+  }
+  select:enabled:active:active,
+  .customizable-select-button.active {
+    background-color: SelectedItem;
+    color: SelectedItemText;
+  }
+  select:disabled:disabled,
+  .customizable-select-button.disabled {
+    color: GrayText;
+    border-color: GrayText;
+    background-color: Canvas;
+  }
+  select::picker(select),
+  .customizable-select-popover {
+    background-color: Canvas;
+    color: CanvasText;
+    border-color: CanvasText;
+    box-shadow: none;
+  }
+}
+
+/* Ensure stable reftest snapshotting */
+
+select::picker(select),
+select::picker(select):popover-open,
+select::picker-icon,
+select:open::picker-icon,
+.customizable-select-popover,
+.customizable-select-button::after,
+.customizable-select-button.open::after {
+  transition-duration: 0s !important;
+}

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/uses-label-dynamic-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/uses-label-dynamic-expected.html
@@ -1,4 +1,5 @@
 <!DOCTYPE HTML>
+<style>select::picker(select), select::picker-icon { transition-duration: 0s !important; }</style>
 <html class="reftest-wait">
 <script src="/resources/testdriver.js"></script>
 <script src="/resources/testdriver-vendor.js"></script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/uses-label-dynamic.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/uses-label-dynamic.html
@@ -1,5 +1,6 @@
 <!DOCTYPE HTML>
 <html class="reftest-wait">
+<style>select::picker(select), select::picker-icon { transition-duration: 0s !important; }</style>
 <link rel="match" href="uses-label-dynamic-ref.html">
 <script src="/resources/testdriver.js"></script>
 <script src="/resources/testdriver-vendor.js"></script>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -125,8 +125,6 @@ imported/w3c/web-platform-tests/css/css-will-change/will-change-fixedpos-cb-003.
 imported/w3c/web-platform-tests/css/css-writing-modes/overconstrained-rel-pos-rtl-left-right-vlr-009.xht [ Pass ]
 imported/w3c/web-platform-tests/css/css-writing-modes/sizing-orthog-vlr-in-htb-008.xht [ Pass ]
 imported/w3c/web-platform-tests/css/css-writing-modes/text-combine-upright-rtl-002.html [ Pass ]
-imported/w3c/web-platform-tests/html/rendering/replaced-elements/the-select-element/customizable-select/min-height-in-flex.html [ Pass ]
-imported/w3c/web-platform-tests/html/rendering/replaced-elements/the-select-element/customizable-select/min-width-in-flex.html [ Pass ]
 imported/w3c/web-platform-tests/html/rendering/replaced-elements/the-select-element/select-button-min-height-001.html [ Pass ]
 imported/w3c/web-platform-tests/html/rendering/widgets/input-checkbox-zero-size.html [ Pass ]
 imported/w3c/web-platform-tests/html/rendering/widgets/the-select-element/option-add-label-quirks.html [ Pass ]
@@ -484,7 +482,6 @@ imported/w3c/web-platform-tests/html/rendering/widgets/the-select-element/select
 
 imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/link-rel-attribute-ascii-case-insensitive.html [ Pass ]
 imported/w3c/web-platform-tests/html/semantics/forms/the-datalist-element/input-text-datalist-removal.html [ Pass ]
-imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-sizing-in-flex.html [ Pass ]
 imported/w3c/web-platform-tests/html/semantics/forms/the-textarea-element/placeholder-white-space.tentative.html [ Pass ]
 imported/w3c/web-platform-tests/html/semantics/text-level-semantics/the-b-element/b-usage.html [ Pass ]
 imported/w3c/web-platform-tests/html/semantics/text-level-semantics/the-ruby-element/ruby-usage.html [ Pass ]

--- a/LayoutTests/platform/ios/fast/forms/select/base/option-focus-visible-outline-offset-expected.txt
+++ b/LayoutTests/platform/ios/fast/forms/select/base/option-focus-visible-outline-offset-expected.txt
@@ -4,8 +4,8 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 
 
 FAIL outlineOffset == -3 || outlineOffset == -2 should be true. Was false.
-PASS internals.usedOutlineOffset(opt1) is 0
-PASS internals.usedOutlineOffset(opt1) is 0
+PASS internals.usedOutlineOffset(opt1) == 0 is true
+PASS internals.usedOutlineOffset(opt1) == 0 is true
 PASS successfullyParsed is true
 Some tests failed.
 

--- a/LayoutTests/platform/ios/fast/forms/select/base/option-inset-outline-offset-expected.txt
+++ b/LayoutTests/platform/ios/fast/forms/select/base/option-inset-outline-offset-expected.txt
@@ -4,10 +4,10 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 
 
 FAIL defaultOffset == -3 || defaultOffset == -2 should be true. Was false.
-FAIL usedOffset should be -2. Was 0.
-FAIL usedOffset should be -10. Was 0.
+PASS usedOffset is -2
+PASS usedOffset is -10
 FAIL zoomedOffset == -6 || zoomedOffset == -4 should be true. Was false.
-FAIL usedOffset should be -10. Was 0.
+PASS usedOffset is -10
 PASS successfullyParsed is true
 Some tests failed.
 

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/rendering/widgets/the-select-element/select-as-listbox-default-styles.tentative-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/rendering/widgets/the-select-element/select-as-listbox-default-styles.tentative-expected.txt
@@ -49,17 +49,17 @@ PASS <option>1 (in <select multiple="">) - margin-top
 PASS <option>1 (in <select multiple="">) - margin-right
 PASS <option>1 (in <select multiple="">) - margin-bottom
 PASS <option>1 (in <select multiple="">) - margin-left
-PASS <option>1 (in <select multiple="">) - padding-top
-FAIL <option>1 (in <select multiple="">) - padding-right assert_equals: expected "0px" but got "5.5px"
-PASS <option>1 (in <select multiple="">) - padding-bottom
-FAIL <option>1 (in <select multiple="">) - padding-left assert_equals: expected "0px" but got "5.5px"
+FAIL <option>1 (in <select multiple="">) - padding-top assert_equals: expected "0px" but got "5.5px"
+FAIL <option>1 (in <select multiple="">) - padding-right assert_equals: expected "0px" but got "12.1px"
+FAIL <option>1 (in <select multiple="">) - padding-bottom assert_equals: expected "0px" but got "5.5px"
+FAIL <option>1 (in <select multiple="">) - padding-left assert_equals: expected "0px" but got "8.25px"
 PASS <option>1 (in <select multiple="">) - letter-spacing
 PASS <option>1 (in <select multiple="">) - word-spacing
 PASS <option>1 (in <select multiple="">) - text-transform
 PASS <option>1 (in <select multiple="">) - text-indent
 PASS <option>1 (in <select multiple="">) - text-shadow
 PASS <option>1 (in <select multiple="">) - appearance
-PASS <option>1 (in <select multiple="">) - box-sizing
+FAIL <option>1 (in <select multiple="">) - box-sizing assert_equals: expected "content-box" but got "border-box"
 PASS <option>1 (in <select multiple="">) - border-top-width
 PASS <option>1 (in <select multiple="">) - border-right-width
 PASS <option>1 (in <select multiple="">) - border-bottom-width
@@ -105,16 +105,16 @@ PASS <optgroup label="2"><option>3 (in <select multiple="">) - text-transform
 PASS <optgroup label="2"><option>3 (in <select multiple="">) - text-indent
 PASS <optgroup label="2"><option>3 (in <select multiple="">) - text-shadow
 PASS <optgroup label="2"><option>3 (in <select multiple="">) - appearance
-PASS <optgroup label="2"><option>3 (in <select multiple="">) - box-sizing
-PASS <optgroup label="2"><option>3 (in <select multiple="">) - border-top-width
+FAIL <optgroup label="2"><option>3 (in <select multiple="">) - box-sizing assert_equals: expected "content-box" but got "border-box"
+FAIL <optgroup label="2"><option>3 (in <select multiple="">) - border-top-width assert_equals: expected "0px" but got "1px"
 PASS <optgroup label="2"><option>3 (in <select multiple="">) - border-right-width
 PASS <optgroup label="2"><option>3 (in <select multiple="">) - border-bottom-width
 PASS <optgroup label="2"><option>3 (in <select multiple="">) - border-left-width
-PASS <optgroup label="2"><option>3 (in <select multiple="">) - border-top-style
+FAIL <optgroup label="2"><option>3 (in <select multiple="">) - border-top-style assert_equals: expected "none" but got "solid"
 PASS <optgroup label="2"><option>3 (in <select multiple="">) - border-right-style
 PASS <optgroup label="2"><option>3 (in <select multiple="">) - border-bottom-style
 PASS <optgroup label="2"><option>3 (in <select multiple="">) - border-left-style
-PASS <optgroup label="2"><option>3 (in <select multiple="">) - border-top-color
+FAIL <optgroup label="2"><option>3 (in <select multiple="">) - border-top-color assert_equals: expected "rgb(0, 0, 0)" but got "oklab(0 0 0 / 0.12)"
 PASS <optgroup label="2"><option>3 (in <select multiple="">) - border-right-color
 PASS <optgroup label="2"><option>3 (in <select multiple="">) - border-bottom-color
 PASS <optgroup label="2"><option>3 (in <select multiple="">) - border-left-color
@@ -141,17 +141,17 @@ PASS <option>3 (in <select multiple=""><optgroup label="2">) - margin-top
 PASS <option>3 (in <select multiple=""><optgroup label="2">) - margin-right
 PASS <option>3 (in <select multiple=""><optgroup label="2">) - margin-bottom
 PASS <option>3 (in <select multiple=""><optgroup label="2">) - margin-left
-PASS <option>3 (in <select multiple=""><optgroup label="2">) - padding-top
-FAIL <option>3 (in <select multiple=""><optgroup label="2">) - padding-right assert_equals: expected "0px" but got "5.5px"
-PASS <option>3 (in <select multiple=""><optgroup label="2">) - padding-bottom
-FAIL <option>3 (in <select multiple=""><optgroup label="2">) - padding-left assert_equals: expected "0px" but got "5.5px"
+FAIL <option>3 (in <select multiple=""><optgroup label="2">) - padding-top assert_equals: expected "0px" but got "5.5px"
+FAIL <option>3 (in <select multiple=""><optgroup label="2">) - padding-right assert_equals: expected "0px" but got "12.1px"
+FAIL <option>3 (in <select multiple=""><optgroup label="2">) - padding-bottom assert_equals: expected "0px" but got "5.5px"
+FAIL <option>3 (in <select multiple=""><optgroup label="2">) - padding-left assert_equals: expected "0px" but got "8.25px"
 PASS <option>3 (in <select multiple=""><optgroup label="2">) - letter-spacing
 PASS <option>3 (in <select multiple=""><optgroup label="2">) - word-spacing
 PASS <option>3 (in <select multiple=""><optgroup label="2">) - text-transform
 PASS <option>3 (in <select multiple=""><optgroup label="2">) - text-indent
 PASS <option>3 (in <select multiple=""><optgroup label="2">) - text-shadow
 PASS <option>3 (in <select multiple=""><optgroup label="2">) - appearance
-PASS <option>3 (in <select multiple=""><optgroup label="2">) - box-sizing
+FAIL <option>3 (in <select multiple=""><optgroup label="2">) - box-sizing assert_equals: expected "content-box" but got "border-box"
 PASS <option>3 (in <select multiple=""><optgroup label="2">) - border-top-width
 PASS <option>3 (in <select multiple=""><optgroup label="2">) - border-right-width
 PASS <option>3 (in <select multiple=""><optgroup label="2">) - border-bottom-width

--- a/Source/WebCore/css/html.css
+++ b/Source/WebCore/css/html.css
@@ -1042,51 +1042,62 @@ select {
 
 select:-internal-uses-menulist {
 #if defined(WTF_PLATFORM_IOS_FAMILY) && WTF_PLATFORM_IOS_FAMILY
-    padding-inline: -internal-auto-base(0.4em, 0.5em);
+    padding-inline: -internal-auto-base(0.4em, 1em 0.7em);
     color: -internal-auto-base(-apple-system-blue, inherit);
     font: -internal-auto-base(11px system-ui, inherit);
-    border-color: -internal-auto-base(-webkit-control-background, initial);
-    border-radius: -internal-auto-base(initial, 0.5em);
+    border-color: -internal-auto-base(-webkit-control-background, color-mix(currentColor 50%));
+    border-radius: -internal-auto-base(initial, 4px);
 #if defined(WTF_PLATFORM_VISION) && WTF_PLATFORM_VISION
-    background-color: -internal-auto-base(rgba(0, 0, 0, 0.04), transparent);
+    background-color: -internal-auto-base(rgba(0, 0, 0, 0.04), light-dark(transparent, color-mix(currentColor 4%)));
 #else
-    background-color: -internal-auto-base(-apple-system-opaque-secondary-fill, transparent);
+    background-color: -internal-auto-base(-apple-system-opaque-secondary-fill, light-dark(transparent, color-mix(currentColor 4%)));
 #endif /* defined(WTF_PLATFORM_VISION) && WTF_PLATFORM_VISION */
 #else
-    padding-inline: -internal-auto-base(0, 0.5em);
+    padding-inline: -internal-auto-base(0, 1em 0.7em);
     color: -internal-auto-base(CanvasText, inherit);
-    background-color: -internal-auto-base(Canvas, transparent);
-    border-radius: -internal-auto-base(5px, 0.5em);
+    border-color: -internal-auto-base(revert-rule, color-mix(currentColor 50%));
+    border-radius: -internal-auto-base(5px, 4px);
+    background-color: -internal-auto-base(Canvas, light-dark(transparent, color-mix(currentColor 4%)));
     font: -internal-auto-base(-webkit-small-control, inherit);
 #endif /* defined(WTF_PLATFORM_IOS_FAMILY) && WTF_PLATFORM_IOS_FAMILY */
-    padding-block: -internal-auto-base(0, 0.25em);
+    padding-block: -internal-auto-base(0, 0.4em);
     align-items: -internal-auto-base(center, unset);
-    white-space: -internal-auto-base(pre, initial);
-    cursor: -internal-auto-base(default, inherit);
+    white-space: -internal-auto-base(pre, nowrap);
+    cursor: default;
     gap: -internal-auto-base(initial, 0.5em);
+    min-block-size: -internal-auto-base(revert-rule, 24px);
+    min-inline-size: -internal-auto-base(revert-rule, 4em);
+    overflow: -internal-auto-base(revert-rule, clip);
+    text-overflow: -internal-auto-base(revert-rule, ellipsis);
 
     -webkit-rtl-ordering: -internal-auto-base(logical, inherit);
     text-shadow: -internal-auto-base(none, inherit);
-    text-transform: -internal-auto-base(none, initial);
     letter-spacing: -internal-auto-base(normal, inherit);
     word-spacing: -internal-auto-base(normal, inherit);
 }
 
-select:-internal-uses-menulist:enabled:hover {
-    background-color: -internal-auto-base(revert-rule, color-mix(currentColor 10%, transparent));
+select:-internal-uses-menulist:enabled:hover:not(:user-invalid) {
+    border-color: -internal-auto-base(revert-rule, color-mix(currentColor 70%));
 }
 
 select:-internal-uses-menulist:enabled:active {
-    background-color: -internal-auto-base(revert-rule, color-mix(currentColor 20%, transparent));
+    background-color: -internal-auto-base(revert-rule, color-mix(currentColor 8%));
 }
 
 select:-internal-uses-menulist:disabled {
 #if defined(WTF_PLATFORM_IOS_FAMILY) && WTF_PLATFORM_IOS_FAMILY
-    background-color: -internal-auto-base(-apple-system-opaque-secondary-fill-disabled, transparent);
-    color: -internal-auto-base(-apple-system-tertiary-label, color-mix(currentColor 50%, transparent));
+    background-color: -internal-auto-base(-apple-system-opaque-secondary-fill-disabled, color-mix(currentColor 6%));
+    color: -internal-auto-base(-apple-system-tertiary-label, color-mix(currentColor 55%));
 #else
-    color: -internal-auto-base(GrayText, color-mix(currentColor 50%, transparent));
+    background-color: -internal-auto-base(revert-rule, color-mix(currentColor 6%));
+    color: -internal-auto-base(GrayText, color-mix(currentColor 55%));
 #endif
+    border-color: -internal-auto-base(revert-rule, color-mix(currentColor 25%));
+    cursor: -internal-auto-base(revert-rule, not-allowed);
+}
+
+select:-internal-uses-menulist:user-invalid {
+    border-color: -internal-auto-base(revert-rule, light-dark(#dc3545, oklch(from #db2a37 calc(l + 0.17) c h)));
 }
 
 select:-internal-uses-menulist:not([popover]) {
@@ -1108,30 +1119,45 @@ select:not([multiple]):-internal-uses-menulist > button:first-child {
     display: contents;
 }
 
+select selectedcontent {
+    overflow: clip;
+    text-overflow: ellipsis;
+    min-inline-size: 0;
+}
+
 select::picker-icon {
-    content: counter(fake-counter-name, disclosure-open);
-    display: block;
+    content: "\2335" / "";
+    font-family: system-ui;
+    font-style: normal;
+    text-orientation: sideways;
+    padding-inline: 0.3em 0.15em;
     margin-inline-start: auto;
+    margin-block-start: -0.25em;
+    align-self: center;
 }
 
 :-internal-select-popover {
     box-sizing: border-box;
-    border: -internal-auto-base(none, 1px solid);
+    border: -internal-auto-base(none, 1px solid color-mix(currentColor 50%));
+    border-radius: 4px;
     padding: 0;
-    color: -internal-auto-base(inherit, CanvasText);
-    background-color: -internal-auto-base(transparent, Canvas);
+    color: inherit;
+    background-color: -internal-auto-base(transparent, color-mix(contrast-color(currentColor), white 15%));
     margin: 0;
+    margin-block: 4px;
     inset: auto;
     min-inline-size: -internal-auto-base(unset, anchor-size(self-inline));
     min-block-size: 1lh;
-    max-block-size: stretch;
+    max-block-size: calc(100svb - 8px);
     overflow: auto;
+    overscroll-behavior: contain;
+    box-shadow:
+        0 4px 6px -1px light-dark(rgba(0, 0, 0, 0.1), rgba(0, 0, 0, 0.35)),
+        0 8px 16px -4px light-dark(rgba(0, 0, 0, 0.08), rgba(0, 0, 0, 0.25));
     position-area: -internal-auto-base(unset, self-block-end span-self-inline-end);
     position-try-order: -internal-auto-base(unset, most-block-size);
     position-try-fallbacks: -internal-auto-base(unset, {
-        self-block-start span-self-inline-end,
-        self-block-end span-self-inline-start,
-        self-block-start span-self-inline-start });
+        flip-block, flip-inline, flip-block flip-inline });
     display: -internal-auto-base(contents, none);
 }
 
@@ -1142,8 +1168,8 @@ select::picker-icon {
 select:-internal-uses-menulist option {
     min-inline-size: 24px;
     min-block-size: max(24px, 1lh);
-    padding-inline: 0.5em;
-    padding-block-end: 0;
+    padding-block: 0.5em;
+    padding-inline: 0.75em 1.1em;
     display: flex;
     align-items: center;
     gap: 0.5em;
@@ -1151,26 +1177,28 @@ select:-internal-uses-menulist option {
 
 select option {
     white-space: nowrap;
+    box-sizing: border-box;
+    outline-offset: inset;
 }
 
-select option:enabled:hover {
-    background-color: color-mix(currentColor 10%, transparent);
+select option:enabled:hover,
+select option:enabled:focus-visible {
+    background-color: color-mix(currentColor 10%);
 }
 
 select option:enabled:active {
-    background-color: color-mix(currentColor 20%, transparent);
+    background-color: color-mix(currentColor 15%);
 }
 
 select option:disabled {
-    color: color-mix(currentColor 50%, transparent);
-}
-
-select option:focus-visible {
-    outline-offset: inset;
+    color: color-mix(currentColor 55%);
+    cursor: not-allowed;
 }
 
 select option::checkmark {
     content: "\2713" / "";
+    font-family: system-ui;
+    font-style: normal;
 }
 
 select option:not(:checked)::checkmark {
@@ -1180,6 +1208,11 @@ select option:not(:checked)::checkmark {
 optgroup {
     display: block;
     font-weight: bolder;
+    box-sizing: border-box;
+}
+
+select:-internal-uses-menulist optgroup:not(:first-child) {
+    border-block-start: 1px solid color-mix(currentColor 12%);
 }
 
 option {
@@ -1191,8 +1224,31 @@ select optgroup option {
 }
 
 select optgroup legend {
-    padding-inline: 0.5em;
+    box-sizing: border-box;
+    padding-block: 0.6em 0.15em;
+    padding-inline: 0.75em;
     min-block-size: 1lh;
+    font-size: 0.85em;
+    font-weight: 400;
+    color: color-mix(currentColor 70%);
+    cursor: default;
+}
+
+@media (prefers-contrast) {
+    :-internal-select-popover {
+        background-color: Canvas;
+        color: CanvasText;
+        border-color: CanvasText;
+    }
+
+    select option:enabled:is(:hover, :focus-visible, :active) {
+        background-color: SelectedItem;
+        color: SelectedItemText;
+    }
+    select option:disabled,
+    select optgroup legend {
+        color: GrayText;
+    }
 }
 
 select::-internal-fallback-popup-menu {


### PR DESCRIPTION
#### 0d950bca70506c66a29ee9fbafd80d6033021f1c
<pre>
appearance: base-select select styling lacks adequate polish and professionalism
<a href="https://bugs.webkit.org/show_bug.cgi?id=320157">https://bugs.webkit.org/show_bug.cgi?id=320157</a>
<a href="https://rdar.apple.com/183092726">rdar://183092726</a>

Reviewed by Tim Nguyen.

Folds in a number of experimental updates to customizable select UA styles,
with the goal of removing the *need* for authors to apply their own styling
(as well as fixing some very noticeable problems with the existing styles):
- Refinements to spacing (padding, margins, etc.)
- Refinements to border and background color-mix()es
- Adjustments to border-radius to more closely match common design patterns
- Handling overflow rather than letting it spill out
- More appropriate cursor styles
- Removing unnecessary text-transform rule. (none == initial)
- Switching to &apos;system-ui&apos; for iconography
- Applying border-box sizing more extensively, to better match author resets
- Corrections to anchor positioning fallback behaviors
- Adding a box-shadow to the picker dialog
- Adding optgroup styling
- Adding prefers-contrast mode colors

Slightly more experimental updates include:
- Styling for :user-invalid
- Color-matched styling for the picker dialog

Landing on main to keep open a compat gap with Chrome and help maintain
some space for the standardization groups to maneuver while these points
are discussed and resolved.

Tests were updated:
- A few marked as known failures given the new rules.
- Most reftests now import a copy of our html.css rules into their -expected
    references so they still work. ASuppressed animations so they snapshot reliably.
    These are both applied as one-liners for easy diffing.
- Some keyboard navigation tests depended too much on geometry, they are now
    more robust. This set of changes should be exported to WPT.
- Adjusted focus outline test to work with moved declaration. (Moved
    outline-offset to reduce selector matching in UA stylesheet, and to
    apply it more consistently.)

* LayoutTests/TestExpectations:
* LayoutTests/fast/forms/select/base/option-focus-visible-outline-offset-expected.txt:
* LayoutTests/fast/forms/select/base/option-focus-visible-outline-offset.html:
* LayoutTests/fast/forms/select/base/select-pagedown-pageup.html:
* LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/form-controls/resets-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/the-select-element/select-as-listbox-default-styles.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/appearance-base-and-base-select.tentative-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/appearance-base-and-base-select.tentative.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/appearance-base-select-other-elements-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/appearance-base-select-other-elements.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/border-rendering-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/border-rendering.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/checkmark-animation-002-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/checkmark-animation-002.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/closed-listbox-rendering-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/closed-listbox-rendering.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/focus-ring-rendering-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/focus-ring-rendering.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/option-label-in-shadow-tree-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/option-label-in-shadow-tree.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/picker-and-slotted-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/picker-and-slotted-invalidation-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/picker-and-slotted-invalidation.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/picker-and-slotted.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/picker-icon-and-slotted-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/picker-icon-and-slotted.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/picker-icon-animation-002-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/picker-icon-animation-002.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-active-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-active.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-button-after-option-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-button-after-option.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-button-after-span-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-button-after-span.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-button-after-text-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-button-after-text.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-custom-button-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-custom-button.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-dark-mode-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-dark-mode.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-default-button-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-default-button.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-disabled-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-disabled-option-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-disabled-option.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-disabled.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-fallback-bottom-left-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-fallback-bottom-left-scroller-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-fallback-bottom-left-scroller.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-fallback-bottom-left.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-fallback-bottom-right-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-fallback-bottom-right-scroller-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-fallback-bottom-right-scroller.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-fallback-bottom-right.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-fallback-top-left-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-fallback-top-left-scroller-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-fallback-top-left-scroller.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-fallback-top-left.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-fallback-top-right-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-fallback-top-right-scroller-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-fallback-top-right-scroller.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-fallback-top-right.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-font-inheriting-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-font-inheriting.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-hover-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-hover.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-mixing-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-mixing.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-optgroup-legend-and-label-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-optgroup-legend-and-label.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-optgroup-legend-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-optgroup-legend.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-optgroup-rendering-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-optgroup-rendering.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-option-with-label-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-option-with-label.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-picker-select-border-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-picker-select-border.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-sizing-in-flex-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-sizing-in-flex.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-switching-invalidation-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-switching-invalidation.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-writing-mode-vertical-lr-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-writing-mode-vertical-lr.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-writing-mode-vertical-rl-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-writing-mode-vertical-rl.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-wrong-picker-argument-expected-mismatch.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-wrong-picker-argument.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-base-appearance-computed-style-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-button-text-and-icon-clipping-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-button-text-and-icon-clipping.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-clipping-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-clipping.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-display-block.tentative-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-display-block.tentative.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-explicit-size-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-explicit-size.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-font-size-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-font-size.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-grid-before-after-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-grid-before-after.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-home-end-pagedown-pageup-detailed.optional-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-home-end-pagedown-pageup-detailed.optional.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-home-end-pagedown-pageup.optional.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-icon-color-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-icon-color.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-only-button-opt-in-expected-mismatch.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-only-button-opt-in.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-only-picker-opt-in-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-only-picker-opt-in.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-open-invalidation-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-open-invalidation.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-optgroup-legend-label-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-optgroup-legend-label.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-option-hover-styles-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-option-images-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-option-images.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-pseudo-backdrop-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-pseudo-backdrop.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-pseudo-before-after-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-pseudo-before-after.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-pseudo-first-letter-first-line-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-pseudo-first-letter-first-line.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-pseudo-highlight-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-pseudo-highlight.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-pseudo-selection-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-pseudo-selection.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-pseudo-target-text-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-pseudo-target-text.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-popover-exit-animation-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-popover-exit-animation.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-second-child-button-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-second-child-button.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-size-multiple-new-content-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-size-multiple-new-content.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-text-only-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-text-only.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/selectedcontent-color-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/selectedcontent-color.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/standalone-optgroup-no-shadow-tree-after-select-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/standalone-optgroup-no-shadow-tree-after-select.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/standalone-optgroup-no-shadow-tree-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/standalone-optgroup-no-shadow-tree.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/standalone-option-no-shadow-tree-after-select-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/standalone-option-no-shadow-tree-after-select.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/standalone-option-no-shadow-tree-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/standalone-option-no-shadow-tree.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/update.css: Added.
(select,):
(select:not([popover]),):
(select:enabled:hover:not(:user-invalid),):
(.customizable-select-button.hover):
(select:enabled:active,):
(select:disabled,):
(select:user-invalid):
(select:not([multiple]) &gt; button:first-child):
(select selectedcontent,):
(select::picker-icon,):
(select::picker(select),):
(select::picker(select):popover-open):
(option):
(select option,):
(select option:enabled:hover,):
(select option:enabled:active):
(select option:disabled,):
(select option::checkmark,):
(select option:not(:checked)::checkmark,):
(optgroup,):
(select optgroup,):
(optgroup:first-child,):
(select optgroup option,):
(select optgroup legend,):
(@media (prefers-contrast) select,):
(@media (prefers-contrast) select:enabled:hover:hover,):
(@media (prefers-contrast) select:enabled:active:active,):
(@media (prefers-contrast) select:disabled:disabled,):
(@media (prefers-contrast) select::picker(select),):
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/uses-label-dynamic-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/uses-label-dynamic.html:
* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/ios/fast/forms/select/base/option-focus-visible-outline-offset-expected.txt:
* LayoutTests/platform/ios/fast/forms/select/base/option-inset-outline-offset-expected.txt:
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/rendering/widgets/the-select-element/select-as-listbox-default-styles.tentative-expected.txt:
* Source/WebCore/css/html.css:
(select:-internal-uses-menulist):
(select:-internal-uses-menulist:enabled:hover:not(:user-invalid)):
(select:-internal-uses-menulist:enabled:active):
(select:-internal-uses-menulist:disabled):
(select:-internal-uses-menulist:user-invalid):
(select selectedcontent):
(select::picker-icon):
(:-internal-select-popover):
();):
(select:-internal-uses-menulist option):
(select option):
(select option:enabled:hover,):
(select option:enabled:active):
(select option:disabled):
(select option::checkmark):
(optgroup):
(select:-internal-uses-menulist optgroup):
(optgroup:first-child):
(select optgroup legend):
(@media (prefers-contrast) :-internal-select-popover):
(@media (prefers-contrast) select option:enabled:is(:hover, :focus-visible, :active)):
(@media (prefers-contrast) select option:disabled,):
(select:-internal-uses-menulist:enabled:hover): Deleted.
(select option:enabled:hover): Deleted.
(select option:focus-visible): Deleted.

Canonical link: <a href="https://commits.webkit.org/317980@main">https://commits.webkit.org/317980@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1dc29e4235e35839f35254ca701c1e42e5f87328

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176935 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50872 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44667 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186538 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140171 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0c6735db-29dc-4de5-bcae-60f8d6f08514) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178798 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52165 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50558 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137856 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140171 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d63c1b6a-91eb-4f54-8b01-f340d9361a1b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179891 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41366 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158644 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118325 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/182ac76c-e717-4fb7-9376-d9b35faf38e2) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40022 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38387 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150432 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38144 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35006 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42623 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42605 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188961 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50539 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/158184 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146931 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39500 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51222 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/34768 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146727 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41489 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123435 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117706 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49727 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13124 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49126 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49363 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49187 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->