### PR TITLE
webkitpy: cpp and basexcconfig style checkers leak open file handles

### DIFF
--- a/Tools/Scripts/webkitpy/style/checkers/basexcconfig.py
+++ b/Tools/Scripts/webkitpy/style/checkers/basexcconfig.py
@@ -50,21 +50,22 @@ class BaseXcconfigChecker(object):
 
         common_base_xcconfig_path = os.path.join(
             os.path.dirname(__file__), '../../../../..', 'Configurations/CommonBase.xcconfig')
-        for line in open(common_base_xcconfig_path):
-            # Find lines containing assignments.
-            lhs, operator, rhs = map(str.strip, line.partition('='))
+        with open(common_base_xcconfig_path) as common_base_xcconfig_file:
+            for line in common_base_xcconfig_file:
+                # Find lines containing assignments.
+                lhs, operator, rhs = map(str.strip, line.partition('='))
 
-            # Skip non-assignment lines, comments, and WK_ variables which are allowed to be overridden.
-            if operator != '=' or lhs.startswith('//') or lhs.startswith('WK_'):
-                continue
+                # Skip non-assignment lines, comments, and WK_ variables which are allowed to be overridden.
+                if operator != '=' or lhs.startswith('//') or lhs.startswith('WK_'):
+                    continue
 
-            # Discard any setting condition.
-            name = lhs.partition('[')[0]
+                # Discard any setting condition.
+                name = lhs.partition('[')[0]
 
-            if '$(inherited)' in rhs:
-                inherited_vars[name] = 1
-            elif not self.default_vars.get(name):
-                override_vars[name] = 1
+                if '$(inherited)' in rhs:
+                    inherited_vars[name] = 1
+                elif not self.default_vars.get(name):
+                    override_vars[name] = 1
 
         return inherited_vars, override_vars
 

--- a/Tools/Scripts/webkitpy/style/checkers/cpp.py
+++ b/Tools/Scripts/webkitpy/style/checkers/cpp.py
@@ -4997,21 +4997,21 @@ def update_include_state(filename, include_state, io=codecs):
       True if a header was succesfully added. False otherwise.
     """
     io = _unit_test_config.get(INCLUDE_IO_INJECTION_KEY, codecs)
-    header_file = None
     try:
         header_file = io.open(filename, 'r', 'utf8', 'replace')
     except IOError:
         return False
-    line_number = 0
-    for line in header_file:
-        line_number += 1
-        clean_line = cleanse_comments(line)
-        matched = _RE_PATTERN_INCLUDE.search(clean_line)
-        if matched:
-            include = matched.group(2)
-            # The value formatting is cute, but not really used right now.
-            # What matters here is that the key is in include_state.
-            include_state.setdefault(include, '%s:%d' % (filename, line_number))
+    with header_file:
+        line_number = 0
+        for line in header_file:
+            line_number += 1
+            clean_line = cleanse_comments(line)
+            matched = _RE_PATTERN_INCLUDE.search(clean_line)
+            if matched:
+                include = matched.group(2)
+                # The value formatting is cute, but not really used right now.
+                # What matters here is that the key is in include_state.
+                include_state.setdefault(include, '%s:%d' % (filename, line_number))
     return True
 
 

--- a/Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py
+++ b/Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py
@@ -112,13 +112,27 @@ class ErrorCollector:
 
 # This class is a lame mock of codecs. We do not verify filename, mode, or
 # encoding, but for the current use case it is not needed.
+class MockFile:
+    def __init__(self, lines):
+        self.lines = lines
+
+    def __iter__(self):
+        return iter(self.lines)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        pass
+
+
 class MockIo:
     def __init__(self, mock_file):
         self.mock_file = mock_file
 
     def open(self, unused_filename, unused_mode, unused_encoding, _):  # NOLINT
         # (lint doesn't like open as a method name)
-        return self.mock_file
+        return MockFile(self.mock_file)
 
 
 class CppFunctionsTest(unittest.TestCase):


### PR DESCRIPTION
#### deb3a9a4d7af063caa77989e6ac8b8669cf77462
<pre>
webkitpy: cpp and basexcconfig style checkers leak open file handles
<a href="https://bugs.webkit.org/show_bug.cgi?id=320080">https://bugs.webkit.org/show_bug.cgi?id=320080</a>
<a href="https://rdar.apple.com/183001070">rdar://183001070</a>

Reviewed by NOBODY (OOPS!).

update_include_state() in cpp.py opens each #include&apos;s header file via
io.open() but never closes it, leaking a file descriptor once per
in basexcconfig.py has the same issue, opening CommonBase.xcconfig
without closing it.

Wrap both reads in `with` blocks so the file handles are closed
deterministically.

* Tools/Scripts/webkitpy/style/checkers/basexcconfig.py:
(BaseXcconfigChecker.read_common_base_xcconfig_variables): Use `with`
to ensure the xcconfig file is closed.
* Tools/Scripts/webkitpy/style/checkers/cpp.py:
(update_include_state): Use `with` to ensure header_file is closed.
* Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py:
(MockFile): Added; wraps mock file contents so they support the
context manager protocol, matching real file objects.
(MockFile.__init__):
(MockFile.__iter__):
(MockFile.__enter__):
(MockFile.__exit__):
(MockIo.open): Return a MockFile instead of a raw list.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/deb3a9a4d7af063caa77989e6ac8b8669cf77462

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176304 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50239 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44029 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185900 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/138697 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178167 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51531 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49923 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137323 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96249 "1 flakes 4 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179260 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40802 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158100 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117798 "Passed tests") | | ⏳ 🛠 vision-apple 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/175627 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39451 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37818 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149867 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37598 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34369 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42029 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188324 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49904 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146359 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50588 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34215 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/bfcache/abort.tentative.https.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146176 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40946 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/116792 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49092 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12572 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48494 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48728 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48553 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->