### PR TITLE
Stream uploads should fail in case of 401 responses

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/api/basic/request-upload.h2.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/api/basic/request-upload.h2.any-expected.txt
@@ -1,4 +1,3 @@
-web-platform.test:9000 - didReceiveAuthenticationChallenge - ProtectionSpaceAuthenticationSchemeHTTPBasic - Simulating cancelled authentication sheet
 
 PASS Fetch with POST with empty ReadableStream
 PASS Fetch with POST with ReadableStream
@@ -10,6 +9,6 @@ PASS Synchronous feature detect fails if feature unsupported
 PASS Streaming upload with body containing a String
 PASS Streaming upload with body containing null
 PASS Streaming upload with body containing a number
-FAIL Streaming upload should fail on a 401 response assert_unreached: Should have rejected: undefined Reached unreachable code
+PASS Streaming upload should fail on a 401 response
 PASS ReadbleStream should be closed on signal.abort
 

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/api/basic/request-upload.h2.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/api/basic/request-upload.h2.any.serviceworker-expected.txt
@@ -1,4 +1,3 @@
-web-platform.test:9000 - didReceiveAuthenticationChallenge - ProtectionSpaceAuthenticationSchemeHTTPBasic - Simulating cancelled authentication sheet
 
 PASS Fetch with POST with empty ReadableStream
 PASS Fetch with POST with ReadableStream
@@ -10,6 +9,6 @@ PASS Synchronous feature detect fails if feature unsupported
 PASS Streaming upload with body containing a String
 PASS Streaming upload with body containing null
 PASS Streaming upload with body containing a number
-FAIL Streaming upload should fail on a 401 response assert_unreached: Should have rejected: undefined Reached unreachable code
+PASS Streaming upload should fail on a 401 response
 PASS ReadbleStream should be closed on signal.abort
 

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/api/basic/request-upload.h2.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/api/basic/request-upload.h2.any.sharedworker-expected.txt
@@ -1,4 +1,3 @@
-web-platform.test:9000 - didReceiveAuthenticationChallenge - ProtectionSpaceAuthenticationSchemeHTTPBasic - Simulating cancelled authentication sheet
 
 PASS Fetch with POST with empty ReadableStream
 PASS Fetch with POST with ReadableStream
@@ -10,6 +9,6 @@ PASS Synchronous feature detect fails if feature unsupported
 PASS Streaming upload with body containing a String
 PASS Streaming upload with body containing null
 PASS Streaming upload with body containing a number
-FAIL Streaming upload should fail on a 401 response assert_unreached: Should have rejected: undefined Reached unreachable code
+PASS Streaming upload should fail on a 401 response
 PASS ReadbleStream should be closed on signal.abort
 

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/api/basic/request-upload.h2.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/api/basic/request-upload.h2.any.worker-expected.txt
@@ -1,4 +1,3 @@
-web-platform.test:9000 - didReceiveAuthenticationChallenge - ProtectionSpaceAuthenticationSchemeHTTPBasic - Simulating cancelled authentication sheet
 
 PASS Fetch with POST with empty ReadableStream
 PASS Fetch with POST with ReadableStream
@@ -10,6 +9,6 @@ PASS Synchronous feature detect fails if feature unsupported
 PASS Streaming upload with body containing a String
 PASS Streaming upload with body containing null
 PASS Streaming upload with body containing a number
-FAIL Streaming upload should fail on a 401 response assert_unreached: Should have rejected: undefined Reached unreachable code
+PASS Streaming upload should fail on a 401 response
 PASS ReadbleStream should be closed on signal.abort
 

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm
@@ -408,6 +408,15 @@ void NetworkDataTaskCocoa::didReceiveChallenge(WebCore::AuthenticationChallenge&
 {
     WTFEmitSignpost(m_task.get(), DataTask, "received challenge");
 
+    if (hasPendingStreamBody() && challenge.failureResponse().httpStatusCode() == httpStatus401Unauthorized) {
+        if (RefPtr client = m_client) {
+            WebCore::ResourceError error { WebCore::errorDomainWebKitInternal, 0, firstRequest().url(), "Fetch upload streams cannot handle 401"_s, WebCore::ResourceError::Type::Cancellation };
+            client->didCompleteWithError(error, { });
+        }
+        completionHandler(AuthenticationChallengeDisposition::Cancel, { });
+        return;
+    }
+
     if (tryPasswordBasedAuthentication(challenge, completionHandler))
         return;
 


### PR DESCRIPTION
#### 1b7ece377648aa95e437460a650e5240e155679f
<pre>
Stream uploads should fail in case of 401 responses
<a href="https://rdar.apple.com/183002185">rdar://183002185</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=320082">https://bugs.webkit.org/show_bug.cgi?id=320082</a>

Reviewed by Chris Dumez.

As per fetch spec, we fail a stream upload in case of 401 response.
We do this in NetworkDataTaskCocoa::didReceiveChallenge.

Covered by rebased WPT tests.

* LayoutTests/imported/w3c/web-platform-tests/fetch/api/basic/request-upload.h2.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fetch/api/basic/request-upload.h2.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fetch/api/basic/request-upload.h2.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fetch/api/basic/request-upload.h2.any.worker-expected.txt:
* Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm:
(WebKit::NetworkDataTaskCocoa::didReceiveChallenge):

Canonical link: <a href="https://commits.webkit.org/317858@main">https://commits.webkit.org/317858@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6b6464f567aa8791d9a7c0864885b1ee0ce440f9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176594 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50531 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44323 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186196 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/139084 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8563b064-8bcd-4909-bb52-6eb925685e1b) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51824 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50217 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/137562 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/139084 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4bcb71d7-7edf-4015-97f8-342950aaedb7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179550 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41055 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158338 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118036 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d3482acd-c4b4-40b5-9d3e-5b1cafc5b5e3) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39710 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/38075 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150122 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37836 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34664 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/42271 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/42292 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188620 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50198 "Built successfully") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/146620 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39420 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50881 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/34456 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146427 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41185 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/123087 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117173 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49383 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12809 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48784 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49021 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48846 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->