### PR TITLE
[GTK][WPE] Content view broken on GitLab

### DIFF
--- a/LayoutTests/compositing/geometry/composited-bounds-with-single-axis-clip-expected.txt
+++ b/LayoutTests/compositing/geometry/composited-bounds-with-single-axis-clip-expected.txt
@@ -1,0 +1,24 @@
+Bug 295662: a backing-sharing layer whose clip comes from an ancestor that clips one axis while the other stays overflow:visible must not inflate its backing provider's bounds with that unbounded clip. Test passes if no composited layer is near-LayoutUnit::max tall.
+
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 600.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 600.00)
+      (contentsOpaque 1)
+      (children 2
+        (GraphicsLayer
+          (position 8.00 86.00)
+          (bounds 50.00 50.00)
+        )
+        (GraphicsLayer
+          (position 20.00 20.00)
+          (bounds 300.00 600.00)
+          (drawsContent 1)
+        )
+      )
+    )
+  )
+)
+

--- a/LayoutTests/compositing/geometry/composited-bounds-with-single-axis-clip.html
+++ b/LayoutTests/compositing/geometry/composited-bounds-with-single-axis-clip.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+  .composited {
+      width: 50px;
+      height: 50px;
+      will-change: transform;
+  }
+
+  .provider {
+      position: absolute;
+      top: 20px;
+      left: 20px;
+      width: 300px;
+      height: 300px;
+  }
+
+  .clipper {
+      overflow-x: clip;
+      overflow-y: visible;
+      width: 300px;
+      height: 300px;
+  }
+
+  .sharing {
+      position: relative;
+      top: 50px;
+      left: 50px;
+      width: 200px;
+      height: 200px;
+      background: green;
+  }
+</style>
+</head>
+<body>
+<script>
+  if (window.testRunner) {
+      testRunner.dumpAsText();
+      testRunner.waitUntilDone();
+  }
+
+  async function runTest() {
+      if (window.testRunner) {
+          document.getElementById('layers').innerText = window.internals.layerTreeAsText(document);
+          testRunner.notifyDone();
+      }
+  }
+  window.addEventListener("load", runTest);
+</script>
+
+<p>Bug 295662: a backing-sharing layer whose clip comes from an ancestor that clips one axis while the other stays overflow:visible must not inflate its backing provider's bounds with that unbounded clip. Test passes if no composited layer is near-LayoutUnit::max tall.</p>
+<div class="composited"></div>
+<div class="provider"><div class="clipper"><div class="sharing"></div></div></div>
+<pre id="layers"></pre>
+</body>
+</html>
+

--- a/Source/WebCore/platform/graphics/LayoutRect.h
+++ b/Source/WebCore/platform/graphics/LayoutRect.h
@@ -217,10 +217,16 @@ public:
     LayoutRect transposedRect() const { return LayoutRect(m_location.transposedPoint(), m_size.transposedSize()); }
     bool isInfinite() const;
 
-    static LayoutRect infiniteRect()
+    static constexpr LayoutRect infiniteRect()
     {
         // Return a rect that is slightly smaller than the true max rect to allow pixelSnapping to round up to the nearest IntRect without overflowing.
         return LayoutRect(LayoutUnit::nearlyMin() / 2, LayoutUnit::nearlyMin() / 2, LayoutUnit::nearlyMax(), LayoutUnit::nearlyMax());
+    }
+
+    static constexpr LayoutRect renderableInfiniteRect()
+    {
+        // Return a infinite-like rect whose values are such that, when converted to float pixel values, they can reasonably represent device pixels.
+        return LayoutRect(LayoutUnit::nearlyMin() / 32, LayoutUnit::nearlyMin() / 32, LayoutUnit::nearlyMax() / 16, LayoutUnit::nearlyMax() / 16);
     }
 
     operator FloatRect() const { return FloatRect(m_location, m_size); }

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -5627,8 +5627,20 @@ LayoutRect RenderLayer::calculateLayerBounds(const RenderLayer* ancestorLayer, c
         const RenderLayer* clippingRootLayer = flags & UseLocalClipRectExcludingCompositingIfPossible ? this : clippingRootForPainting();
         LayoutSize offsetFromRoot = offsetFromAncestor(clippingRootLayer);
         LayoutRect clipRect = clipRectRelativeToAncestor(clippingRootLayer, offsetFromRoot, infiniteRect);
-        if (clipRect == infiniteRect)
+        if (clipRect.isInfinite())
             return infiniteRect;
+
+        auto renderableInfiniteRect = LayoutRect::renderableInfiniteRect();
+        if (clipRect.width() > renderableInfiniteRect.width() || clipRect.height() > renderableInfiniteRect.height()) {
+            // When ancestor clips only one axis, leaving the other one unbounded, clip again passing
+            // document rectangle as constraining rectangle to clipRectRelativeToAncestor(),
+            // like selfClipRect() does, to ensure we return a finite rectangle. Checking either width or
+            // height matches LayoutRect::infiniteRect doesn't work either because clipRectRelativeToAncestor()
+            // returns a rectangle that has been moved and intersected, so it's close to infinite but not exactly
+            // infinite. So, comparing to LayoutRect::renderableInfiniteRect() we make sure that we don't return
+            // a rectangle that can't be handled as layer bounds.
+            clipRect = clipRectRelativeToAncestor(clippingRootLayer, offsetFromRoot, renderer().view().documentRect());
+        }
 
         if (renderer().hasClip()) {
             if (CheckedPtr box = dynamicDowncast<RenderBox>(renderer())) {

--- a/Source/WebCore/rendering/RenderLayerCompositor.cpp
+++ b/Source/WebCore/rendering/RenderLayerCompositor.cpp
@@ -3684,11 +3684,7 @@ Vector<CompositedClipData> RenderLayerCompositor::computeAncestorClippingStack(c
             return;
 
         auto infiniteRect = LayoutRect::infiniteRect();
-        auto renderableInfiniteRect = [] {
-            // Return a infinite-like rect whose values are such that, when converted to float pixel values, they can reasonably represent device pixels.
-            return LayoutRect(LayoutUnit::nearlyMin() / 32, LayoutUnit::nearlyMin() / 32, LayoutUnit::nearlyMax() / 16, LayoutUnit::nearlyMax() / 16);
-        }();
-
+        auto renderableInfiniteRect = LayoutRect::renderableInfiniteRect();
         if (clipRect.width() == infiniteRect.width()) {
             clipRect.setX(renderableInfiniteRect.x());
             clipRect.setWidth(renderableInfiniteRect.width());


### PR DESCRIPTION
#### a727aa27c537e8ba89d35f20cd35dc033a6e358e
<pre>
[GTK][WPE] Content view broken on GitLab
<a href="https://bugs.webkit.org/show_bug.cgi?id=295662">https://bugs.webkit.org/show_bug.cgi?id=295662</a>

Reviewed by Simon Fraser.

A layer clipped by an ancestor in one axis while the other axis stays
overflow:visible has a semi-infinite clip rect: finite in one axis and
unbounded (near LayoutUnit::max) in the other, produced by
expandToInfiniteX/Y(). RenderLayer::calculateLayerBounds() was returning
the semi-infinite rectangle that caused a wrong cover rect being
computed in CoordinatedBackingStoreProxy::createOrDestroyTiles() for
coordinated graphics based ports. With an empty cover rect we basically
stopped producing new tiles for the layer, which caused that contents
were not rendered in GitLab diff page after scrolling down a bit.

This patch clips again passing the document rectangle as constraining
rectangle to clipRectRelativeToAncestor(), like selfClipRect() does,
to ensure we return a finite rectangle.

Test: compositing/geometry/composited-bounds-with-single-axis-clip.html

* LayoutTests/compositing/geometry/composited-bounds-with-single-axis-clip-expected.txt: Added.
* LayoutTests/compositing/geometry/composited-bounds-with-single-axis-clip.html: Added.
* Source/WebCore/platform/graphics/LayoutRect.h:
(WebCore::LayoutRect::renderableInfiniteRect):
(WebCore::LayoutRect::infiniteRect):
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::calculateClipRects const):
* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::RenderLayerCompositor::computeAncestorClippingStack const):

Canonical link: <a href="https://commits.webkit.org/318557@main">https://commits.webkit.org/318557@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8f8038fbf1e337c80d53fd3d21591d9deecab01a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177469 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51407 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45201 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187073 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/140716 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179332 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52699 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51116 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138314 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96323 "1 flakes 4 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180425 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41815 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159059 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118779 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40476 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38853 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150883 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38556 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35540 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/43192 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43087 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189501 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51074 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/158593 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147408 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39863 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51756 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35184 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147200 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41918 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123971 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118331 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50264 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13534 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49660 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49900 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49722 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->