### PR TITLE
[YARR] `tryReadUnicodeChar` should read the first code unit before testing whether a second one is needed

### DIFF
--- a/Source/JavaScriptCore/yarr/YarrJIT.cpp
+++ b/Source/JavaScriptCore/yarr/YarrJIT.cpp
@@ -457,16 +457,13 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(MaskedAlternativeInfo);
 
 static constexpr MacroAssembler::TrustedImm32 surrogateTagMask = MacroAssembler::TrustedImm32(0xfc00fc00);
 static constexpr MacroAssembler::TrustedImm32 surrogatePairTags = MacroAssembler::TrustedImm32(0xdc00d800);
-static constexpr MacroAssembler::TrustedImm32 firstCharacterNonBMPBit = MacroAssembler::TrustedImm32(0x8000);
-static constexpr MacroAssembler::TrustedImm32 firstCharacterSurrogateTagMask = MacroAssembler::TrustedImm32(0xf800);
-static constexpr MacroAssembler::TrustedImm32 firstCharacterSurrogateTag = MacroAssembler::TrustedImm32(0xd800);
+static constexpr MacroAssembler::TrustedImm32 surrogateTagShiftedRight11 = MacroAssembler::TrustedImm32(0xd800 >> 11);
 
 #if ENABLE(YARR_JIT_UNICODE_EXPRESSIONS)
 template<TryReadUnicodeCharGenFirstNonBMPOptimization useNonBMPOptimization>
 void tryReadUnicodeCharImpl(VM& vm, CCallHelpers& jit, MacroAssembler::RegisterID resultReg)
 {
     MacroAssembler::JumpList slowCases;
-    MacroAssembler::JumpList isBMP;
     MacroAssembler::JumpList done;
 
     YarrJITDefaultRegisters regs;
@@ -474,16 +471,19 @@ void tryReadUnicodeCharImpl(VM& vm, CCallHelpers& jit, MacroAssembler::RegisterI
     if (resultReg != regs.regT0)
         jit.swap(regs.regT0, resultReg);
 
-    // Check if we can read two UTF-16 characters at once.
+    // A code unit that is not a surrogate is a BMP code point on its own.
+    jit.load16Unaligned(MacroAssembler::Address(regs.regUnicodeInputAndTrail), resultReg);
+    jit.urshift32(resultReg, MacroAssembler::TrustedImm32(11), regs.unicodeAndSubpatternIdTemp);
+    done.append(jit.branch32(MacroAssembler::NotEqual, regs.unicodeAndSubpatternIdTemp, surrogateTagShiftedRight11));
+
+    // The first character is a surrogate. Check if we can read the trailing code unit as well.
     jit.add64(MacroAssembler::TrustedImm32(4), regs.regUnicodeInputAndTrail, regs.unicodeAndSubpatternIdTemp);
     slowCases.append(jit.branchPtr(MacroAssembler::Above, regs.unicodeAndSubpatternIdTemp, regs.endOfStringAddress));
 
-    // Load and try to process two UTF-16 characters.
-    // If they are a proper surrogate pair, compute the non-BMP codepoint.
+    // Load the pair. If it is a proper surrogate pair, compute the non-BMP codepoint.
     jit.load32(MacroAssembler::Address(regs.regUnicodeInputAndTrail), resultReg);
-    isBMP.append(jit.branchTest32(MacroAssembler::Zero, resultReg, firstCharacterNonBMPBit));
     jit.and32(surrogateTagMask, resultReg, regs.unicodeAndSubpatternIdTemp);
-    MacroAssembler::Jump notSurrogatePair = jit.branch32(MacroAssembler::NotEqual, regs.unicodeAndSubpatternIdTemp, surrogatePairTags);
+    slowCases.append(jit.branch32(MacroAssembler::NotEqual, regs.unicodeAndSubpatternIdTemp, surrogatePairTags));
 
     // Create the UTF32 character from the surrogate pair.
 #if CPU(ARM64)
@@ -501,15 +501,6 @@ void tryReadUnicodeCharImpl(VM& vm, CCallHelpers& jit, MacroAssembler::RegisterI
     if (useNonBMPOptimization == TryReadUnicodeCharGenFirstNonBMPOptimization::UseOptimization)
         jit.move(MacroAssembler::TrustedImm32(1), regs.firstCharacterAdditionalReadSize);
 #endif
-    done.append(jit.jump());
-
-    notSurrogatePair.link(&jit);
-    jit.and32(firstCharacterSurrogateTagMask, regs.unicodeAndSubpatternIdTemp, regs.unicodeAndSubpatternIdTemp);
-    slowCases.append(jit.branch32(MacroAssembler::Equal, regs.unicodeAndSubpatternIdTemp, firstCharacterSurrogateTag));
-
-    isBMP.link(jit);
-    jit.and32(MacroAssembler::TrustedImm32(0xffff), resultReg);
-
     done.append(jit.jump());
 
     slowCases.link(&jit);


### PR DESCRIPTION
#### 0f79baf7bc085f19e03dcbce2800870afb57eeb7
<pre>
[YARR] `tryReadUnicodeChar` should read the first code unit before testing whether a second one is needed
<a href="https://bugs.webkit.org/show_bug.cgi?id=320088">https://bugs.webkit.org/show_bug.cgi?id=320088</a>

Reviewed by Yusuke Suzuki.

tryReadUnicodeCharImpl loads 32 bits up front so that it can detect a
surrogate pair, and therefore checks that both code units are in bounds before
loading anything.

Surrogate pairs are rare compared to BMP code points, though, and deciding
whether a code unit is a BMP code point on its own does not need 32 bits. Load
the first code unit alone and test its top five bits: U+D800-U+DFFF are exactly
the code units whose top five bits are 0b11011. If it is not a surrogate, it is
the code point, so jump to done right there. Only if it is a surrogate do we
check the bounds, load 32 bits, and either decode a proper surrogate pair or
fall into the slow cases.

Keeping the bit 15 test from 317749@main as the fast-path branch would take
fewer instructions, but that branch depends on the character being read and
mispredicts badly once the subject mixes code units below and above U+8000.
The surrogate test costs one more instruction but only changes direction when
a surrogate actually appears.

                                            Baseline           Patched

regexp-unicode-bmp-hangul-and-fullwidth 43.9718+-0.9491    34.3181+-2.8952   definitely 1.2813x faster
regexp-unicode-bmp-above-latin          45.6190+-0.7442    35.8214+-2.6717   definitely 1.2735x faster
regexp-u-global-es6                     31.8327+-0.2765    30.5326+-0.3346   definitely 1.0426x faster
regexp-unicode-latin-before-surrogate   55.0738+-1.6395    52.8071+-3.0785   might be 1.0429x faster
regexp-unicode-surrogate-pairs          45.9197+-1.5007    46.1131+-1.7645   neutral

* Source/JavaScriptCore/yarr/YarrJIT.cpp:
(JSC::Yarr::tryReadUnicodeCharImpl):

Canonical link: <a href="https://commits.webkit.org/317930@main">https://commits.webkit.org/317930@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3468e2c302b7b25392028e423f7b93f1185916aa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176320 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50255 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44045 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185916 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/138575 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51547 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49939 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137335 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/138575 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179276 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40817 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158114 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117810 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39466 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37830 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/6623 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149882 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37612 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34385 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/37588 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41981 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42041 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188340 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49920 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146372 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39464 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50604 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34229 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146190 "Build is in progress. Recent messages:Printed configuration; Checked out pull request; 2 api tests failed or timed out; 1 api test failed or timed out; Compiled WebKit (warnings); run-api-tests-without-change; Passed API tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40960 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122808 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/116819 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49108 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12587 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48510 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48744 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48569 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->