### PR TITLE
Add support for sending stream upload data from WebProcess to Network process

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -1394,12 +1394,6 @@ webkit.org/b/247283 imported/w3c/web-platform-tests/fetch/metadata/generated/css
 imported/w3c/web-platform-tests/fetch/corb [ Skip ]
 imported/w3c/web-platform-tests/fetch/fetch-later [ Skip ]
 
-# ReadableStream upload is not supported.
-imported/w3c/web-platform-tests/fetch/api/basic/request-upload.h2.any.html [ Skip ]
-imported/w3c/web-platform-tests/fetch/api/basic/request-upload.h2.any.worker.html [ Skip ]
-imported/w3c/web-platform-tests/fetch/api/basic/request-upload.h2.any.serviceworker.html [ Skip ]
-imported/w3c/web-platform-tests/fetch/api/basic/request-upload.h2.any.sharedworker.html [ Skip ]
-
 # This fetch test crashes.
 [ Debug ] imported/w3c/web-platform-tests/fetch/api/crashtests/huge-fetch.any.serviceworker.html [ Skip ]
 

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/api/basic/request-upload.h2.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/api/basic/request-upload.h2.any-expected.txt
@@ -1,0 +1,17 @@
+web-platform.test:9000 - didReceiveAuthenticationChallenge - ProtectionSpaceAuthenticationSchemeHTTPBasic - Simulating cancelled authentication sheet
+
+Harness Error (FAIL), message = Unhandled rejection: promise_rejects_exactly: function "function() { throw e; }" threw object "AbortError: Fetch is aborted" but we expected it to throw "foo abort"
+
+PASS Fetch with POST with empty ReadableStream
+PASS Fetch with POST with ReadableStream
+PASS Fetch with POST with ReadableStream on 421 response should return the response and not retry.
+PASS Feature detect for POST with ReadableStream
+PASS Feature detect for POST with ReadableStream, using request object
+PASS Synchronous feature detect
+PASS Synchronous feature detect fails if feature unsupported
+PASS Streaming upload with body containing a String
+PASS Streaming upload with body containing null
+PASS Streaming upload with body containing a number
+FAIL Streaming upload should fail on a 401 response assert_unreached: Should have rejected: undefined Reached unreachable code
+FAIL ReadbleStream should be closed on signal.abort promise_test: Unhandled rejection with value: "streamCancelPromise timed out"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/api/basic/request-upload.h2.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/api/basic/request-upload.h2.any.js
@@ -186,10 +186,11 @@ promise_test(async (t) => {
 
 promise_test(async (t) => {
   const abortMessage = 'foo abort';
-  let streamCancelPromise = new Promise(async res => {
+  let streamCancelPromise = new Promise(async (resolve, reject) => {
+    t.step_timeout(() => reject("streamCancelPromise timed out"), 1000);
     var stream = new ReadableStream({
       cancel: function(reason) {
-        res(reason);
+        resolve(reason);
       }
     });
     let abortController = new AbortController();

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/api/basic/request-upload.h2.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/api/basic/request-upload.h2.any.serviceworker-expected.txt
@@ -1,0 +1,17 @@
+web-platform.test:9000 - didReceiveAuthenticationChallenge - ProtectionSpaceAuthenticationSchemeHTTPBasic - Simulating cancelled authentication sheet
+
+Harness Error (FAIL), message = Unhandled rejection: promise_rejects_exactly: function "function() { throw e; }" threw object "AbortError: Fetch is aborted" but we expected it to throw "foo abort"
+
+PASS Fetch with POST with empty ReadableStream
+PASS Fetch with POST with ReadableStream
+PASS Fetch with POST with ReadableStream on 421 response should return the response and not retry.
+PASS Feature detect for POST with ReadableStream
+PASS Feature detect for POST with ReadableStream, using request object
+PASS Synchronous feature detect
+PASS Synchronous feature detect fails if feature unsupported
+PASS Streaming upload with body containing a String
+PASS Streaming upload with body containing null
+PASS Streaming upload with body containing a number
+FAIL Streaming upload should fail on a 401 response assert_unreached: Should have rejected: undefined Reached unreachable code
+FAIL ReadbleStream should be closed on signal.abort promise_test: Unhandled rejection with value: "streamCancelPromise timed out"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/api/basic/request-upload.h2.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/api/basic/request-upload.h2.any.sharedworker-expected.txt
@@ -1,0 +1,17 @@
+web-platform.test:9000 - didReceiveAuthenticationChallenge - ProtectionSpaceAuthenticationSchemeHTTPBasic - Simulating cancelled authentication sheet
+
+Harness Error (FAIL), message = Unhandled rejection: promise_rejects_exactly: function "function() { throw e; }" threw object "AbortError: Fetch is aborted" but we expected it to throw "foo abort"
+
+PASS Fetch with POST with empty ReadableStream
+PASS Fetch with POST with ReadableStream
+PASS Fetch with POST with ReadableStream on 421 response should return the response and not retry.
+PASS Feature detect for POST with ReadableStream
+PASS Feature detect for POST with ReadableStream, using request object
+PASS Synchronous feature detect
+PASS Synchronous feature detect fails if feature unsupported
+PASS Streaming upload with body containing a String
+PASS Streaming upload with body containing null
+PASS Streaming upload with body containing a number
+FAIL Streaming upload should fail on a 401 response assert_unreached: Should have rejected: undefined Reached unreachable code
+FAIL ReadbleStream should be closed on signal.abort promise_test: Unhandled rejection with value: "streamCancelPromise timed out"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/api/basic/request-upload.h2.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/api/basic/request-upload.h2.any.worker-expected.txt
@@ -1,0 +1,17 @@
+web-platform.test:9000 - didReceiveAuthenticationChallenge - ProtectionSpaceAuthenticationSchemeHTTPBasic - Simulating cancelled authentication sheet
+
+Harness Error (FAIL), message = Unhandled rejection: promise_rejects_exactly: function "function() { throw e; }" threw object "AbortError: Fetch is aborted" but we expected it to throw "foo abort"
+
+PASS Fetch with POST with empty ReadableStream
+PASS Fetch with POST with ReadableStream
+PASS Fetch with POST with ReadableStream on 421 response should return the response and not retry.
+PASS Feature detect for POST with ReadableStream
+PASS Feature detect for POST with ReadableStream, using request object
+PASS Synchronous feature detect
+PASS Synchronous feature detect fails if feature unsupported
+PASS Streaming upload with body containing a String
+PASS Streaming upload with body containing null
+PASS Streaming upload with body containing a number
+FAIL Streaming upload should fail on a 401 response assert_unreached: Should have rejected: undefined Reached unreachable code
+FAIL ReadbleStream should be closed on signal.abort promise_test: Unhandled rejection with value: "streamCancelPromise timed out"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/fetch-event.https.h2-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/fetch-event.https.h2-expected.txt
@@ -1,8 +1,8 @@
 
 PASS global setup
 FAIL The streaming request body is readable in the service worker. promise_test: Unhandled rejection with value: object "TypeError: FetchEvent.respondWith received an error: NotSupportedError: Stream upload reading is not yet supported"
-FAIL Network fallback for streaming upload. assert_equals: body expected "i am the request body" but got ""
+PASS Network fallback for streaming upload.
 FAIL When the streaming request body is used, network fallback fails. assert_unreached: Should have rejected: undefined Reached unreachable code
-FAIL Running clone() in the service worker does not prevent network fallback. assert_equals: body expected "i am the request body" but got ""
+PASS Running clone() in the service worker does not prevent network fallback.
 PASS restore global state
 

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -277,6 +277,12 @@ imported/w3c/web-platform-tests/css/css-break/change-inline-color.html [ Pass ]
 http/wpt/background-fetch [ Skip ]
 imported/w3c/web-platform-tests/background-fetch [ Pass Failure ]
 
+# ReadableStream upload is not supported.
+imported/w3c/web-platform-tests/fetch/api/basic/request-upload.h2.any.html [ Skip ]
+imported/w3c/web-platform-tests/fetch/api/basic/request-upload.h2.any.worker.html [ Skip ]
+imported/w3c/web-platform-tests/fetch/api/basic/request-upload.h2.any.serviceworker.html [ Skip ]
+imported/w3c/web-platform-tests/fetch/api/basic/request-upload.h2.any.sharedworker.html [ Skip ]
+
 imported/mozilla/svg/blend-hard-light.svg [ Pass ]
 imported/mozilla/svg/dynamic-textPath-01.svg [ Pass ]
 imported/mozilla/svg/dynamic-textPath-02.svg [ Pass ]

--- a/Source/WebCore/Modules/fetch/FetchBody.cpp
+++ b/Source/WebCore/Modules/fetch/FetchBody.cpp
@@ -41,7 +41,10 @@
 #include "JSDOMConvertStrings.h"
 #include "JSDOMFormData.h"
 #include "JSDOMPromiseDeferred.h"
+#include "PendingStreamState.h"
 #include "ReadableStreamSource.h"
+#include "ReadableStreamToSharedBufferSink.h"
+#include "SharedBuffer.h"
 #include "StreamPipeOptions.h"
 #include "TransformStream.h"
 #include "WritableStream.h"
@@ -281,11 +284,35 @@ RefPtr<FormData> FetchBody::bodyAsFormData() const
         return &const_cast<FormData&>(formDataBody());
     if (RefPtr data = protect(const_cast<FetchBody*>(this)->consumer())->data())
         return FormData::create(data->makeContiguous()->span());
-    if (isReadableStream())
-        return FormData::create(PendingStreamIdentifier::generate());
+    if (isReadableStream()) {
+        ASSERT(m_pendingStreamState);
+        Ref formData = FormData::create(PendingStreamIdentifier::generate(), protect(m_pendingStreamState));
+        return formData;
+    }
 
     ASSERT_NOT_REACHED();
     return nullptr;
+}
+
+Ref<ReadableStreamToSharedBufferSink> FetchBody::startPendingStreamUpload()
+{
+    ASSERT(isReadableStream());
+    ASSERT(!m_pendingStreamState);
+
+    Ref state = PendingStreamState::create();
+    m_pendingStreamState = state.copyRef();
+
+    Ref sink = ReadableStreamToSharedBufferSink::create([state = WTF::move(state)](auto&& result) mutable {
+        WTF::switchOn(result,
+            [&](std::nullptr_t) { state->endStream(); },
+            [&](std::span<const uint8_t> chunk) { state->appendData(SharedBuffer::create(chunk)); },
+            [&](JSC::JSValue) { state->errorStream(-1); },
+            [&](Exception&) { state->errorStream(-1); }
+        );
+    });
+
+    sink->pipeFrom(protect(readableStreamBody()));
+    return sink;
 }
 
 void FetchBody::convertReadableStreamToArrayBuffer(FetchBodyOwner& owner, CompletionHandler<void(std::optional<Exception>&&)>&& completionHandler)

--- a/Source/WebCore/Modules/fetch/FetchBody.h
+++ b/Source/WebCore/Modules/fetch/FetchBody.h
@@ -32,6 +32,7 @@
 #include "DOMFormData.h"
 #include "FetchBodyConsumer.h"
 #include "FormData.h"
+#include "PendingStreamState.h"
 #include "ReadableStream.h"
 #include "URLSearchParams.h"
 
@@ -40,6 +41,7 @@ namespace WebCore {
 class DeferredPromise;
 class FetchBodyOwner;
 class FetchBodySource;
+class ReadableStreamToSharedBufferSink;
 class ScriptExecutionContext;
 
 template<typename> class ExceptionOr;
@@ -105,6 +107,9 @@ public:
 
     void convertReadableStreamToArrayBuffer(FetchBodyOwner&, CompletionHandler<void(std::optional<Exception>&&)>&&);
 
+    Ref<ReadableStreamToSharedBufferSink> startPendingStreamUpload();
+    PendingStreamState* pendingStreamState() const { return m_pendingStreamState.get(); }
+
     bool isBlob() const { return std::holds_alternative<Ref<Blob>>(m_data); }
     bool isFormData() const { return std::holds_alternative<Ref<FormData>>(m_data); }
     bool isReadableStream() const { return std::holds_alternative<Ref<ReadableStream>>(m_data); }
@@ -138,12 +143,14 @@ private:
     String& textBody() LIFETIME_BOUND { return std::get<String>(m_data); }
     const String& textBody() const LIFETIME_BOUND { return std::get<String>(m_data); }
     URLSearchParams& urlSearchParamsBody() const { return std::get<Ref<URLSearchParams>>(m_data).get(); }
+    ReadableStream& readableStreamBody() LIFETIME_BOUND { return std::get<Ref<ReadableStream>>(m_data); }
 
     using Data = Variant<std::nullptr_t, Ref<Blob>, Ref<FormData>, Ref<ArrayBuffer>, Ref<ArrayBufferView>, Ref<URLSearchParams>, String, Ref<ReadableStream>>;
     Data m_data { nullptr };
 
     std::unique_ptr<FetchBodyConsumer> m_consumer;
     RefPtr<ReadableStream> m_readableStream;
+    RefPtr<PendingStreamState> m_pendingStreamState;
 };
 
 struct FetchBodyWithType {

--- a/Source/WebCore/Modules/fetch/FetchResponse.cpp
+++ b/Source/WebCore/Modules/fetch/FetchResponse.cpp
@@ -274,11 +274,13 @@ Ref<FetchResponse> FetchResponse::createFetchResponse(ScriptExecutionContext& co
 
 void FetchResponse::fetch(ScriptExecutionContext& context, FetchRequest& request, NotificationCallback&& responseCallback, const String& initiator)
 {
+    RefPtr<ReadableStreamToSharedBufferSink> uploadSink;
     if (request.isReadableStreamBody()) {
         if (!context.settingsValues().fetchUploadStreamsEnabled) {
             responseCallback(Exception { ExceptionCode::NotSupportedError, "ReadableStream uploading is not supported"_s });
             return;
         }
+        uploadSink = request.body().startPendingStreamUpload();
     } else if (request.hasReadableStreamBody()) {
         request.body().convertReadableStreamToArrayBuffer(request, [context = Ref { context }, weakRequest = WeakPtr { request }, responseCallback = WTF::move(responseCallback), initiator](auto&& exception) mutable {
             if (!!exception) {
@@ -294,6 +296,8 @@ void FetchResponse::fetch(ScriptExecutionContext& context, FetchRequest& request
     }
 
     Ref response = createFetchResponse(context, request, WTF::move(responseCallback));
+    if (uploadSink)
+        protect(response->m_loader)->setUploadSink(uploadSink.releaseNonNull());
     response->startLoader(context, request, initiator);
 }
 

--- a/Source/WebCore/Modules/fetch/FetchResponse.h
+++ b/Source/WebCore/Modules/fetch/FetchResponse.h
@@ -48,6 +48,7 @@ class AbortSignal;
 class FetchRequest;
 class FetchResponseBodyLoader;
 class ReadableStreamSource;
+class ReadableStreamToSharedBufferSink;
 
 class FetchResponse final : public FetchBodyOwner {
 public:
@@ -170,6 +171,8 @@ private:
         NotificationCallback takeNotificationCallback() { return WTF::move(m_responseCallback); }
         ConsumeDataByChunkCallback takeConsumeDataCallback() { return WTF::move(m_consumeDataCallback); }
 
+        void setUploadSink(Ref<ReadableStreamToSharedBufferSink>&& sink) { m_uploadSink = WTF::move(sink); }
+
     private:
         Loader(FetchResponse&, NotificationCallback&&);
 
@@ -183,6 +186,7 @@ private:
         NotificationCallback m_responseCallback;
         ConsumeDataByChunkCallback m_consumeDataCallback;
         RefPtr<FetchLoader> m_loader;
+        RefPtr<ReadableStreamToSharedBufferSink> m_uploadSink;
         const Ref<PendingActivity<FetchResponse>> m_pendingActivity;
         FetchOptions::Credentials m_credentials;
         bool m_shouldStartStreaming { false };

--- a/Source/WebCore/platform/network/FormData.cpp
+++ b/Source/WebCore/platform/network/FormData.cpp
@@ -97,10 +97,11 @@ Ref<FormData> FormData::create(Vector<WebCore::FormDataElement>&& elements, uint
     return result;
 }
 
-Ref<FormData> FormData::create(PendingStreamIdentifier identifier)
+Ref<FormData> FormData::create(PendingStreamIdentifier identifier, RefPtr<WebCore::PendingStreamState>&& state)
 {
     auto result = create();
     result->m_elements.append(FormDataElement { FormDataElement::PendingStreamData { identifier } });
+    result->m_pendingStreamState = WTF::move(state);
     return result;
 }
 
@@ -130,6 +131,8 @@ Ref<FormData> FormData::isolatedCopy() const
     auto formData = create();
     formData->m_alwaysStream = m_alwaysStream;
     formData->m_elements = crossThreadCopy(m_elements);
+    // We copy m_pendingStreamState as it is thread-safe, but only one consumer of data per PendingStreamState is possible.
+    formData->m_pendingStreamState = m_pendingStreamState;
     return formData;
 }
 

--- a/Source/WebCore/platform/network/FormData.h
+++ b/Source/WebCore/platform/network/FormData.h
@@ -135,7 +135,7 @@ public:
     static Ref<FormData> create(const Vector<uint8_t>&);
     static Ref<FormData> create(const DOMFormData&, EncodingType = EncodingType::FormURLEncoded);
     static Ref<FormData> createMultiPart(const DOMFormData&);
-    WEBCORE_EXPORT static Ref<FormData> create(PendingStreamIdentifier);
+    WEBCORE_EXPORT static Ref<FormData> create(PendingStreamIdentifier, RefPtr<WebCore::PendingStreamState>&&);
     WEBCORE_EXPORT ~FormData();
 
     // FIXME: Both these functions perform a deep copy of m_elements, but differ in handling of other data members.

--- a/Source/WebCore/platform/network/PendingStreamState.cpp
+++ b/Source/WebCore/platform/network/PendingStreamState.cpp
@@ -168,6 +168,33 @@ size_t PendingStreamState::read(std::span<uint8_t> outBuffer, bool& atEOF, int& 
     return written;
 }
 
+RefPtr<SharedBuffer> PendingStreamState::takeNextChunk(bool& atEOF, int& errorCode)
+{
+    Locker locker { m_lock };
+    errorCode = m_errorCode;
+    atEOF = false;
+
+    if (errorCode)
+        return nullptr;
+
+    if (m_chunks.isEmpty()) {
+        if (m_ended)
+            atEOF = true;
+        return nullptr;
+    }
+
+    RefPtr<SharedBuffer> chunk = m_chunks.takeFirst();
+    if (m_frontChunkOffset) {
+        chunk = SharedBuffer::create(chunk->span().subspan(m_frontChunkOffset));
+        m_frontChunkOffset = 0;
+    }
+
+    if (m_chunks.isEmpty() && m_ended)
+        atEOF = true;
+
+    return chunk;
+}
+
 bool PendingStreamState::hasReadyData()
 {
     Locker locker { m_lock };

--- a/Source/WebCore/platform/network/PendingStreamState.h
+++ b/Source/WebCore/platform/network/PendingStreamState.h
@@ -56,12 +56,13 @@ public:
 
     WEBCORE_EXPORT void setHTTPVersionProbe(HTTPVersionProbe&&);
 
-    void setDataAvailableHandler(Function<void()>&&);
-    void clearDataAvailableHandler();
+    WEBCORE_EXPORT void setDataAvailableHandler(Function<void()>&&);
+    WEBCORE_EXPORT void clearDataAvailableHandler();
 
     HTTPVersion currentHTTPVersion();
 
     size_t read(std::span<uint8_t> outBuffer, bool& atEOF, int& errorCode);
+    WEBCORE_EXPORT RefPtr<SharedBuffer> takeNextChunk(bool& atEOF, int& errorCode);
     bool hasReadyData();
 
 private:

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
@@ -185,8 +185,6 @@ NetworkResourceLoader::NetworkResourceLoader(NetworkResourceLoadParameters&& par
     if (RefPtr body = m_parameters.request.httpBody()) {
         if (body->isPendingStream()) {
             m_pendingStreamState = PendingStreamState::create();
-            // FIXME: Until we add support for getting data from web process, we pretend the body is empty.
-            protect(m_pendingStreamState)->endStream();
             body->setPendingStreamState(*m_pendingStreamState);
         }
     }
@@ -1674,6 +1672,31 @@ void NetworkResourceLoader::continueDidReceiveResponse()
 
     if (!m_responseCompletionHandlers.isEmpty())
         m_responseCompletionHandlers.takeFirst()(PolicyAction::Use);
+}
+
+void NetworkResourceLoader::pendingStreamAppendData(IPC::SharedBufferReference&& chunk)
+{
+    ASSERT(m_pendingStreamState);
+    if (!m_pendingStreamState)
+        return;
+    RefPtr buffer = chunk.unsafeBuffer();
+    if (!buffer)
+        return;
+    protect(m_pendingStreamState)->appendData(buffer.releaseNonNull());
+}
+
+void NetworkResourceLoader::pendingStreamEnd()
+{
+    ASSERT(m_pendingStreamState);
+    if (RefPtr state = m_pendingStreamState)
+        state->endStream();
+}
+
+void NetworkResourceLoader::pendingStreamError()
+{
+    ASSERT(m_pendingStreamState);
+    if (RefPtr state = m_pendingStreamState)
+        state->errorStream(-1);
 }
 
 void NetworkResourceLoader::didSendData(uint64_t bytesSent, uint64_t totalBytesToBeSent)

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.h
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.h
@@ -49,6 +49,10 @@
 #include <wtf/MonotonicTime.h>
 #include <wtf/WeakPtr.h>
 
+namespace IPC {
+class SharedBufferReference;
+}
+
 namespace WebCore {
 class BlobDataFileReference;
 class ContentFilter;
@@ -115,6 +119,10 @@ public:
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&);
 
     void continueWillSendRequest(WebCore::ResourceRequest&&, bool isAllowedToAskUserForCredentials, CompletionHandler<void(WebCore::ResourceRequest&&)>&&);
+
+    void pendingStreamAppendData(IPC::SharedBufferReference&&);
+    void pendingStreamEnd();
+    void pendingStreamError();
 
     void setResponse(WebCore::ResourceResponse&& response) { m_response = WTF::move(response); }
     const WebCore::ResourceResponse& response() const LIFETIME_BOUND { return m_response; }

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.messages.in
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.messages.in
@@ -27,4 +27,8 @@
 ]
 messages -> NetworkResourceLoader {
     ContinueDidReceiveResponse()
+
+    PendingStreamAppendData(IPC::SharedBufferReference chunk)
+    PendingStreamEnd()
+    PendingStreamError()
 }

--- a/Source/WebKit/Scripts/webkit/opaque_ipc_types.tracking.in
+++ b/Source/WebKit/Scripts/webkit/opaque_ipc_types.tracking.in
@@ -416,6 +416,7 @@
     [Legacy] MessageParam WebPageProxy.RegisterAttachmentIdentifierFromData data
     [Legacy] MessageParam ServiceWorkerDownloadTask.DidReceiveData data
     [Legacy] MessageParam ServiceWorkerFetchTask.DidReceiveData data
+    [Legacy] MessageParam NetworkResourceLoader.PendingStreamAppendData chunk
 
     [NotSentFromWebContent] MessageParam WebResourceLoader.DidReceiveData data
     [NotSentFromWebContent] MessageParam WebSWClientConnection.NotifyRecordResponseBodyChunk data

--- a/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
+++ b/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
@@ -66,6 +66,7 @@
 #include <WebCore/NetscapePlugInStreamLoader.h>
 #include <WebCore/NetworkLoadInformation.h>
 #include <WebCore/NodeDocument.h>
+#include <WebCore/PendingStreamState.h>
 #include <WebCore/PlatformStrategies.h>
 #include <WebCore/ReferrerPolicy.h>
 #include <WebCore/ResourceLoader.h>
@@ -663,7 +664,10 @@ void WebLoaderStrategy::scheduleLoadFromNetworkProcess(ResourceLoader& resourceL
         return;
     }
 
-    auto loader = WebResourceLoader::create(resourceLoader, trackingParameters);
+    RefPtr<PendingStreamState> state;
+    if (RefPtr body = resourceLoader.request().httpBody())
+        state = body->pendingStreamState();
+    auto loader = WebResourceLoader::create(resourceLoader, trackingParameters, WTF::move(state));
     m_webResourceLoaders.set(identifier, WTF::move(loader));
 }
 

--- a/Source/WebKit/WebProcess/Network/WebResourceLoader.cpp
+++ b/Source/WebKit/WebProcess/Network/WebResourceLoader.cpp
@@ -53,6 +53,7 @@
 #include <WebCore/LocalFrameLoaderClient.h>
 #include <WebCore/NetworkLoadMetrics.h>
 #include <WebCore/Page.h>
+#include <WebCore/PendingStreamState.h>
 #include <WebCore/ResourceError.h>
 #include <WebCore/ResourceLoader.h>
 #include <WebCore/SubresourceLoader.h>
@@ -72,17 +73,47 @@
 namespace WebKit {
 using namespace WebCore;
 
-Ref<WebResourceLoader> WebResourceLoader::create(Ref<ResourceLoader>&& coreLoader, const std::optional<TrackingParameters>& trackingParameters)
+Ref<WebResourceLoader> WebResourceLoader::create(Ref<ResourceLoader>&& coreLoader, const std::optional<TrackingParameters>& trackingParameters, RefPtr<PendingStreamState>&& state)
 {
-    return adoptRef(*new WebResourceLoader(WTF::move(coreLoader), trackingParameters));
+    return adoptRef(*new WebResourceLoader(WTF::move(coreLoader), trackingParameters, WTF::move(state)));
 }
 
-WebResourceLoader::WebResourceLoader(Ref<WebCore::ResourceLoader>&& coreLoader, const std::optional<TrackingParameters>& trackingParameters)
+WebResourceLoader::WebResourceLoader(Ref<WebCore::ResourceLoader>&& coreLoader, const std::optional<TrackingParameters>& trackingParameters, RefPtr<PendingStreamState>&& state)
     : m_coreLoader(WTF::move(coreLoader))
     , m_trackingParameters(trackingParameters)
+    , m_pendingStreamState(state.get())
     , m_loadStart(MonotonicTime::now())
 {
     WEBRESOURCELOADER_RELEASE_LOG(WebResourceLoaderConstructor);
+    if (state) {
+        state->setDataAvailableHandler([weakThis = WeakPtr { *this }] {
+            ensureOnMainThread([weakThis] {
+                RefPtr protectedThis = weakThis.get();
+                if (!protectedThis || !protectedThis->m_pendingStreamState)
+                    return;
+                Ref state = *protectedThis->m_pendingStreamState;
+                while (true) {
+                    bool atEOF = false;
+                    int errorCode = 0;
+                    RefPtr chunk = state->takeNextChunk(atEOF, errorCode);
+                    if (errorCode) {
+                        protectedThis->send(Messages::NetworkResourceLoader::PendingStreamError { });
+                        protectedThis->m_pendingStreamState = nullptr;
+                        return;
+                    }
+                    if (chunk)
+                        protectedThis->send(Messages::NetworkResourceLoader::PendingStreamAppendData { IPC::SharedBufferReference(*chunk) });
+                    if (atEOF) {
+                        protectedThis->send(Messages::NetworkResourceLoader::PendingStreamEnd { });
+                        protectedThis->m_pendingStreamState = nullptr;
+                        return;
+                    }
+                    if (!chunk)
+                        return;
+                }
+            });
+        });
+    }
 }
 
 WebResourceLoader::~WebResourceLoader() = default;

--- a/Source/WebKit/WebProcess/Network/WebResourceLoader.h
+++ b/Source/WebKit/WebProcess/Network/WebResourceLoader.h
@@ -37,6 +37,7 @@
 #include <wtf/MonotonicTime.h>
 #include <wtf/RefCounted.h>
 #include <wtf/RefPtr.h>
+#include <wtf/WeakPtr.h>
 
 namespace IPC {
 class FormDataReference;
@@ -46,6 +47,7 @@ class SharedBufferReference;
 namespace WebCore {
 class ContentFilterUnblockHandler;
 class NetworkLoadMetrics;
+class PendingStreamState;
 class ResourceError;
 class ResourceLoader;
 class ResourceRequest;
@@ -58,7 +60,7 @@ namespace WebKit {
 
 enum class PrivateRelayed : bool;
 
-class WebResourceLoader : public RefCounted<WebResourceLoader>, public IPC::MessageSender {
+class WebResourceLoader : public RefCounted<WebResourceLoader>, public IPC::MessageSender, public CanMakeWeakPtr<WebResourceLoader> {
 public:
     struct TrackingParameters {
         WebPageProxyIdentifier webPageProxyID;
@@ -67,7 +69,7 @@ public:
         WebCore::ResourceLoaderIdentifier resourceID;
     };
 
-    static Ref<WebResourceLoader> create(Ref<WebCore::ResourceLoader>&&, const std::optional<TrackingParameters>&);
+    static Ref<WebResourceLoader> create(Ref<WebCore::ResourceLoader>&&, const std::optional<TrackingParameters>&, RefPtr<WebCore::PendingStreamState>&& = { });
 
     ~WebResourceLoader();
 
@@ -78,7 +80,7 @@ public:
     void detachFromCoreLoader();
 
 private:
-    WebResourceLoader(Ref<WebCore::ResourceLoader>&&, const std::optional<TrackingParameters>&);
+    WebResourceLoader(Ref<WebCore::ResourceLoader>&&, const std::optional<TrackingParameters>&, RefPtr<WebCore::PendingStreamState>&&);
 
     // IPC::MessageSender
     IPC::Connection* messageSenderConnection() const override;
@@ -115,6 +117,7 @@ private:
     RefPtr<WebCore::ResourceLoader> m_coreLoader;
     const std::optional<TrackingParameters> m_trackingParameters;
     WebResourceInterceptController m_interceptController;
+    RefPtr<WebCore::PendingStreamState> m_pendingStreamState;
     size_t m_numBytesReceived { 0 };
     size_t m_bytesTransferredOverNetwork { 0 };
 


### PR DESCRIPTION
#### 70dd30c16360692ec8542536eb191927435640bd
<pre>
Add support for sending stream upload data from WebProcess to Network process
<a href="https://bugs.webkit.org/show_bug.cgi?id=320083#">https://bugs.webkit.org/show_bug.cgi?id=320083#</a>
<a href="https://rdar.apple.com/problem/183002484">rdar://problem/183002484</a>

Reviewed by Alex Christensen.

At stream upload start, we assign the FormData a PendingStreamState object.
This PendingStreamState object will be given data from the request&apos;s ReadableStream via a ReadableStreamToSharedBufferSink.
This PendingStreamState object is converyed through the FormData up to WebResourceLoader.
WebResourceLoader will read the data from the PendingStreamState and send it through IPC to NetworkResourceLoader.

NetworkResourceLoader will then give that data to the PendingStreamState object which will give it to CFNetwork.

Covered by enabled tests.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/fetch/api/basic/request-upload.h2.any-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/fetch/api/basic/request-upload.h2.any.js:
* LayoutTests/imported/w3c/web-platform-tests/fetch/api/basic/request-upload.h2.any.serviceworker-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/fetch/api/basic/request-upload.h2.any.sharedworker-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/fetch/api/basic/request-upload.h2.any.worker-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/fetch-event.https.h2-expected.txt:
* LayoutTests/platform/glib/TestExpectations:
* Source/WebCore/Modules/fetch/FetchBody.cpp:
(WebCore::FetchBody::bodyAsFormData const):
(WebCore::FetchBody::startPendingStreamUpload):
* Source/WebCore/Modules/fetch/FetchBody.h:
(WebCore::FetchBody::pendingStreamState const):
* Source/WebCore/Modules/fetch/FetchResponse.cpp:
(WebCore::FetchResponse::fetch):
* Source/WebCore/Modules/fetch/FetchResponse.h:
* Source/WebCore/platform/network/FormData.cpp:
(WebCore::FormData::create):
(WebCore::FormData::isolatedCopy const):
* Source/WebCore/platform/network/FormData.h:
* Source/WebCore/platform/network/PendingStreamState.cpp:
(WebCore::PendingStreamState::takeNextChunk):
* Source/WebCore/platform/network/PendingStreamState.h:
* Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp:
(WebKit::NetworkResourceLoader::pendingStreamAppendData):
(WebKit::NetworkResourceLoader::pendingStreamEnd):
(WebKit::NetworkResourceLoader::pendingStreamError):
* Source/WebKit/NetworkProcess/NetworkResourceLoader.h:
* Source/WebKit/NetworkProcess/NetworkResourceLoader.messages.in:
* Source/WebKit/Scripts/webkit/opaque_ipc_types.tracking.in:
* Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp:
(WebKit::WebLoaderStrategy::scheduleLoadFromNetworkProcess):
* Source/WebKit/WebProcess/Network/WebResourceLoader.cpp:
(WebKit::WebResourceLoader::create):
(WebKit::WebResourceLoader::WebResourceLoader):
* Source/WebKit/WebProcess/Network/WebResourceLoader.h:
(WebKit::WebResourceLoader::create):

Canonical link: <a href="https://commits.webkit.org/317846@main">https://commits.webkit.org/317846@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a45209e5db4497193551dbd801d04313322261d9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176559 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50494 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/44284 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186160 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/138855 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b6ce5a65-aca1-4d7f-8750-2cffcd443544) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178422 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51786 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50178 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/137536 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/138855 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f3c9292c-c93b-4a4d-b827-a838723def1e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179515 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/41027 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/158314 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118011 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/69b98c02-65be-4706-bd06-3cebb9bfc255) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/175882 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/39677 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/38040 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/150092 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/37812 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34628 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/42228 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/42253 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188583 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50159 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/157859 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/146586 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39416 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50843 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/34435 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146395 "Passed tests") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/41161 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/123047 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117121 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49347 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/12787 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48749 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48983 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48808 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->