### PR TITLE
AudioVideoRendererRemote::finishSeek should handle a superseded seek instead of asserting

### DIFF
--- a/Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.cpp
@@ -557,9 +557,14 @@ Ref<MediaTimePromise> AudioVideoRendererRemote::prepareToSeek(const MediaTime& t
 
 Ref<GenericPromise> AudioVideoRendererRemote::finishSeek(const MediaTime& time)
 {
-    if (!m_seeking)
-        ALWAYS_LOG(LOGIDENTIFIER, "state error");
-    ASSERT(m_seeking, "Invalid seeking state, bad API usage");
+    // m_seeking is set/read on MediaSourcePrivateAVFObjC::queueSingleton() but
+    // cleared on AudioVideoRendererRemote::queueSingleton(), so a superseding
+    // seek (or a GPU-not-running path) can clear it out from under this call.
+    // Treat that as a superseded seek and reject.
+    if (!m_seeking) {
+        ALWAYS_LOG(LOGIDENTIFIER, "seek superseded before finishSeek; skipping");
+        return GenericPromise::createAndReject();
+    }
     return invokeAsync(queueSingleton(), [protectedThis = Ref { *this }, this, time] -> Ref<GenericPromise> {
         cancelPendingSeek();
 


### PR DESCRIPTION
#### ae61725f4cb3e96e996777e60f91f1dab925aada
<pre>
AudioVideoRendererRemote::finishSeek should handle a superseded seek instead of asserting
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=320093">https://bugs.webkit.org/show_bug.cgi?id=320093</a>&gt;
&lt;<a href="https://rdar.apple.com/182961418">rdar://182961418</a>&gt;

Reviewed by Jean-Yves Avenard.

`AudioVideoRendererRemote::m_seeking` is an atomic flag, but its
accesses are split across two work queues.
`AudioVideoRendererRemote::prepareToSeek()` sets it and
`AudioVideoRendererRemote::finishSeek()` reads it while those methods
run on `MediaSourcePrivateAVFObjC::queueSingleton()`, whereas the
GPU-reply `whenSettled` callbacks inside them clear it on
`AudioVideoRendererRemote::queueSingleton()`.  With no ordering between
the two queues, a superseding seek whose `prepareToSeek()` reply is
definite (or a GPU-not-running path) can clear `m_seeking` while an
earlier seek is still being finished, so `finishSeek()` is entered with
`m_seeking` already false.  The debug `ASSERT(m_seeking)` at that entry
treats this internally-reachable state as caller misuse and traps,
which is the source of the crashes seen on Debug builds.
`AudioVideoRendererRemote::cancelPendingSeek()` does not close the
window: it can neither stop an in-flight GPU round trip from settling
and clearing the flag, nor a fresh `prepareToSeek()` from re-setting it.

Treat a no-longer-seeking state as a superseded seek and reject early,
matching `AudioVideoRendererAVFObjC::finishSeek()`, which already
handles the same interface state this way for the non-GPU-process
renderer.  Besides removing the Debug assertion, this also stops a
superseded seek from issuing a redundant `FinishSeek` to the GPU
process and completing the player to a stale seek time in release
builds.

These existing media-source seek tests exercise the path and hit the
assertion crash on the bots:

    media/media-source/media-source-muted-scroll-and-seek-crash.html
    media/media-source/media-source-no-preload-set-duration-crash.html
    media/media-source/media-source-real-scrub-then-play.html
    media/media-source/media-source-seek-and-play.html

* Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.cpp:
(WebKit::AudioVideoRendererRemote::finishSeek):

Canonical link: <a href="https://commits.webkit.org/317910@main">https://commits.webkit.org/317910@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/09d5bedd40e6beadbe716569b11bb38287b1168b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176601 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50538 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44330 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186203 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/139098 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51831 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50224 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137567 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/139098 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2d79d87a-7c16-41e0-ac8d-a405196d60dd) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179557 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41064 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158347 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118041 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a5b456af-d5ab-447c-940a-f0b76287f651) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39719 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38083 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150131 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37845 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34671 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42278 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42300 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188627 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50205 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146625 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50888 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34465 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/bfcache/abort.tentative.https.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146432 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26820 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41193 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123094 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117185 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49393 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12823 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48792 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49028 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48853 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->