### PR TITLE
[GTK][WPE] SkiaCompositingLayer: incorrect z-ordering at Snow Stack

### DIFF
--- a/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp
@@ -38,7 +38,6 @@
 #include "PlatformDisplay.h"
 #include "Region.h"
 #include "SkiaBackingStore.h"
-#include "SkiaCompositingLayer3DRenderingContext.h"
 #include "SkiaCompositingLayerFilters.h"
 #include "SkiaCompositingLayerOverlapRegions.h"
 #include "SkiaDamageRegion.h"
@@ -1449,29 +1448,53 @@ void SkiaCompositingLayer::paintWithBlendMode(SkCanvas& canvas, PaintContext& co
     }
 }
 
-void SkiaCompositingLayer::collect3DRenderingContextLayers(Vector<Ref<SkiaCompositingLayer>>& layers)
+FloatRect SkiaCompositingLayer::transformedFlattenedBounds() const
+{
+    auto bounds = m_transforms.combined.mapRect(FloatRect({ }, m_size));
+
+    if (!m_masksToBounds && !m_mask) {
+        for (const auto& child : m_children)
+            bounds.unite(child->transformedFlattenedBounds());
+    }
+
+    return bounds;
+}
+
+FloatPolygon3D SkiaCompositingLayer::geometryFor3DRenderingContext() const
+{
+    FloatRect bounds;
+    if (isLeafOf3DRenderingContext() && !m_children.isEmpty() && !m_masksToBounds && !m_mask && m_transforms.combined.isInvertible()) {
+        auto inverse = m_transforms.combined.inverse().value_or(TransformationMatrix());
+        bounds = inverse.mapRect(transformedFlattenedBounds());
+    } else
+        bounds = FloatRect({ }, m_size);
+
+    return FloatPolygon3D(bounds, m_transforms.combined);
+}
+
+void SkiaCompositingLayer::collect3DRenderingContextLayers(Vector<SkiaCompositingLayer3DRenderingContext::Layer>& layers)
 {
     if (m_preserves3D || isLeafOf3DRenderingContext()) {
         // Add layers to 3d rendering context only if they get actually painted.
         bool hasVisualContentOrFilters = hasVisualContent() || filter() || m_backdrop.filter;
         if (isVisible() && (hasVisualContentOrFilters || (isLeafOf3DRenderingContext() && !m_children.isEmpty())))
-            layers.append(Ref { *this });
+            layers.append(SkiaCompositingLayer3DRenderingContext::Layer(Ref { *this }, geometryFor3DRenderingContext()));
 
         // Stop recursion on 3d rendering context leaf
         if (isLeafOf3DRenderingContext())
             return;
     }
 
-    for (auto& child : m_children)
+    for (const auto& child : m_children)
         child->collect3DRenderingContextLayers(layers);
 }
 
 void SkiaCompositingLayer::paintWith3DRenderingContext(SkCanvas& canvas, PaintContext& context)
 {
-    Vector<Ref<SkiaCompositingLayer>> layers;
+    Vector<SkiaCompositingLayer3DRenderingContext::Layer> layers;
     collect3DRenderingContextLayers(layers);
 
-    SkiaCompositingLayer3DRenderingContext::paint(layers, [&](SkiaCompositingLayer& layer, std::optional<SkPath> clipPath) {
+    SkiaCompositingLayer3DRenderingContext::paint(WTF::move(layers), [&](SkiaCompositingLayer& layer, std::optional<SkPath> clipPath) {
         ScopedFlush autoFlush(canvas, context.imageSetBatch, clipPath ? ScopedFlush::Mode::FlushBeforeAndAfter : ScopedFlush::Mode::DoNothing);
         if (clipPath)
             canvas.clipPath(*clipPath);

--- a/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.h
@@ -35,6 +35,7 @@
 #include "FloatRect.h"
 #include "FloatRoundedRect.h"
 #include "IntSize.h"
+#include "SkiaCompositingLayer3DRenderingContext.h"
 #include "SkiaCompositingLayerImageSetBatch.h"
 #include "SkiaCompositingLayerOverlapRegions.h"
 #include "SkiaDamageRegion.h"
@@ -237,7 +238,9 @@ private:
     TransformationMatrix combinedTransform(const PaintContext&) const;
     IntRect clipBounds(const SkCanvas&, const PaintContext&) const;
     sk_sp<SkImage> maskImage();
-    void collect3DRenderingContextLayers(Vector<Ref<SkiaCompositingLayer>>&);
+    FloatPolygon3D geometryFor3DRenderingContext() const;
+    FloatRect transformedFlattenedBounds() const;
+    void collect3DRenderingContextLayers(Vector<SkiaCompositingLayer3DRenderingContext::Layer>&);
     void recursiveCleanUpAfterPaint();
 
     void clipRect(SkCanvas&, const FloatRoundedRect&, const TransformationMatrix& = { });

--- a/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer3DRenderingContext.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer3DRenderingContext.cpp
@@ -110,17 +110,10 @@ static inline bool quadsIntersect(const FloatQuad& quadA, const FloatQuad& quadB
 
 WTF_MAKE_STRUCT_TZONE_ALLOCATED_IMPL(SkiaCompositingLayer3DRenderingContext::LayerNode);
 
-void SkiaCompositingLayer3DRenderingContext::paint(const Vector<Ref<SkiaCompositingLayer>>& compositingLayers, const std::function<void(SkiaCompositingLayer&, std::optional<SkPath>)>& paintLayerFunction)
+void SkiaCompositingLayer3DRenderingContext::paint(Vector<Layer>&& layers, const std::function<void(SkiaCompositingLayer&, std::optional<SkPath>)>& paintLayerFunction)
 {
-    if (compositingLayers.isEmpty())
+    if (layers.isEmpty())
         return;
-
-    Vector<Layer> layers;
-    for (auto& compositingLayer : compositingLayers) {
-        FloatPolygon3D geometry(compositingLayer->effectiveLayerRect(), compositingLayer->toSurfaceTransform());
-        BoundingBox boundingBox = computeBoundingBox(geometry);
-        layers.append({ geometry, boundingBox, compositingLayer });
-    }
 
     // Perform a broad-phase sweep-and-prune to identify potential intersections.
     // By determining which layers might intersect, we can limit BSP cutting planes to those areas only,
@@ -149,7 +142,7 @@ void SkiaCompositingLayer3DRenderingContext::paint(const Vector<Ref<SkiaComposit
             return layerA.boundingBox.min.z() < layerB.boundingBox.min.z();
         });
 
-        for (auto& layer : layers)
+        for (const auto& layer : layers)
             paintLayerFunction(layer.compositingLayer.get(), std::nullopt);
         return;
     }
@@ -157,12 +150,14 @@ void SkiaCompositingLayer3DRenderingContext::paint(const Vector<Ref<SkiaComposit
     Deque<Layer> layerDeque;
     for (auto& layer : layers)
         layerDeque.append(WTF::move(layer));
-    layers.clear();
 
     auto root = makeUnique<LayerNode>(layerDeque.takeFirst());
     buildTree(*root, layerDeque);
 
     auto buildClipPath = [](const Layer& layer) -> std::optional<SkPath> {
+        if (layer.isSplit == Layer::IsSplit::No)
+            return std::nullopt;
+
         auto toLayerTransform = layer.compositingLayer->toSurfaceTransform().inverse();
         unsigned numVertices = layer.geometry.numberOfVertices();
         if (!toLayerTransform || numVertices < 3)
@@ -182,14 +177,8 @@ void SkiaCompositingLayer3DRenderingContext::paint(const Vector<Ref<SkiaComposit
 
     // Paint in BSP order, building SkPath clip paths for split layers.
     traverseTree(*root, [&paintLayerFunction, &buildClipPath](LayerNode& node) {
-        for (auto& layer : node.layers) {
-            if (!layer.isSplit) {
-                paintLayerFunction(layer.compositingLayer.get(), std::nullopt);
-                continue;
-            }
-
+        for (const auto& layer : node.layers)
             paintLayerFunction(layer.compositingLayer.get(), buildClipPath(layer));
-        }
     });
 }
 
@@ -278,9 +267,9 @@ void SkiaCompositingLayer3DRenderingContext::buildTree(LayerNode& root, Deque<La
         case LayerPosition::Intersecting:
             auto [backGeometry, frontGeometry] = layer.geometry.split(rootPlane);
             if (backGeometry.numberOfVertices() > 2)
-                backList.append({ backGeometry, { }, layer.compositingLayer, true });
+                backList.append(Layer(layer.compositingLayer.copyRef(), WTF::move(backGeometry), Layer::IsSplit::Yes));
             if (frontGeometry.numberOfVertices() > 2)
-                frontList.append({ frontGeometry, { }, layer.compositingLayer, true });
+                frontList.append(Layer(layer.compositingLayer.copyRef(), WTF::move(frontGeometry), Layer::IsSplit::Yes));
             break;
         }
     }

--- a/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer3DRenderingContext.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer3DRenderingContext.h
@@ -43,8 +43,34 @@ class SkiaCompositingLayer;
 
 class SkiaCompositingLayer3DRenderingContext {
 public:
-    static void paint(const Vector<Ref<SkiaCompositingLayer>>&,
-        const std::function<void(SkiaCompositingLayer&, std::optional<SkPath>)>&);
+    struct BoundingBox {
+        FloatPoint3D min;
+        FloatPoint3D max;
+    };
+
+    struct Layer {
+        enum class IsSplit : bool { No, Yes };
+
+        Layer(Ref<SkiaCompositingLayer>&& layer, FloatPolygon3D&& layerGeometry, IsSplit layerIsSplit = IsSplit::No)
+            : compositingLayer(WTF::move(layer))
+            , geometry(WTF::move(layerGeometry))
+            , isSplit(layerIsSplit)
+        {
+            if (isSplit == IsSplit::No)
+                boundingBox = computeBoundingBox(geometry);
+        }
+
+        Layer(const Layer&) = delete;
+        Layer& operator=(const Layer&) = delete;
+        Layer(Layer&&) = default;
+        Layer& operator=(Layer&&) = default;
+
+        Ref<SkiaCompositingLayer> compositingLayer;
+        FloatPolygon3D geometry;
+        IsSplit isSplit { IsSplit::No };
+        BoundingBox boundingBox;
+    };
+    static void paint(Vector<Layer>&&, const std::function<void(SkiaCompositingLayer&, std::optional<SkPath>)>&);
 
 private:
     enum class LayerPosition {
@@ -52,18 +78,6 @@ private:
         Behind,
         Coplanar,
         Intersecting
-    };
-
-    struct BoundingBox {
-        FloatPoint3D min;
-        FloatPoint3D max;
-    };
-
-    struct Layer {
-        FloatPolygon3D geometry;
-        BoundingBox boundingBox;
-        Ref<SkiaCompositingLayer> compositingLayer;
-        bool isSplit { false };
     };
 
     struct LayerNode {


### PR DESCRIPTION
#### 7a767a006f81bc3462b6c2ea74e65316a4ae5e21
<pre>
[GTK][WPE] SkiaCompositingLayer: incorrect z-ordering at Snow Stack
<a href="https://bugs.webkit.org/show_bug.cgi?id=314883">https://bugs.webkit.org/show_bug.cgi?id=314883</a>

Reviewed by Nikolas Zimmermann.

Make SkiaCompositingLayer3DRenderingContext::Layer public and make
SkiaCompositingLayer3DRenderingContext::paint() receive a list of
SkiaCompositingLayer3DRenderingContext::Layer instead. This way while
collecting the 3D context layers we can build the
SkiaCompositingLayer3DRenderingContext::Layer without having to iterate
the layers again in paint(). The geometry for 3D context is now computed
taking into account the flattened bounding box when needed instead of
always using the layer rectangle, which is what actually fixes the
incorrect z-ordering.

* Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp:
(WebCore::SkiaCompositingLayer::transformedFlattenedBounds const):
(WebCore::SkiaCompositingLayer::geometryFor3DRenderingContext const):
(WebCore::SkiaCompositingLayer::collect3DRenderingContextLayers):
(WebCore::SkiaCompositingLayer::paintWith3DRenderingContext):
* Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.h:
* Source/WebCore/platform/graphics/skia/SkiaCompositingLayer3DRenderingContext.cpp:
(WebCore::SkiaCompositingLayer3DRenderingContext::paint):
(WebCore::SkiaCompositingLayer3DRenderingContext::buildTree):
* Source/WebCore/platform/graphics/skia/SkiaCompositingLayer3DRenderingContext.h:
(WebCore::SkiaCompositingLayer3DRenderingContext::Layer::Layer):

Canonical link: <a href="https://commits.webkit.org/318066@main">https://commits.webkit.org/318066@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/df3750bd0527acc9dcfbafa98fd398f8f5b58239

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177183 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51120 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44915 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186786 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140419 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179046 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52413 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50806 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138058 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140419 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180139 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41565 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158820 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118525 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40221 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38604 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150632 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38319 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35254 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42902 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/42826 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189212 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50787 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147146 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51470 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34948 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146939 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26872 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41670 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123684 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117990 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49975 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13299 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49374 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49611 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49435 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->