### PR TITLE
moveBefore() doesn't iterate through shadow roots

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/custom-element-move-reactions-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/custom-element-move-reactions-expected.txt
@@ -5,4 +5,5 @@ PASS When connectedMoveCallback is defined, it is called instead of disconnected
 PASS Reactions to atomic move are called in order of element, not in order of operation
 PASS When connectedCallback is not defined, no crash
 PASS When disconnectedCallback is not defined, no crash
+PASS connectedMove runs when custom element is nested within a shadow root
 

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/custom-element-move-reactions.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/custom-element-move-reactions.html
@@ -9,6 +9,9 @@
 
 <body>
   <section id="section"></section>
+  <x-custom id="customElement">
+    <template shadowrootmode="open"></template>
+  </x-custom>
   <script>
     let index = 0;
     function unique_element_name() {
@@ -134,5 +137,26 @@
         await Promise.resolve();
         assert_array_equals(reactions, ["connected"]);
     }, "When disconnectedCallback is not defined, no crash");
+
+    promise_test(async t => {
+        const ce = document.getElementById("ce");
+        let reactions = [];
+        const element_name = unique_element_name();
+        customElements.define(element_name,
+            class MockCustomElement extends HTMLElement {
+              connectedMoveCallback() { reactions.push("connectedMove"); }
+              connectedCallback() { reactions.push("connected"); }
+              disconnectedCallback() { reactions.push("disconnected"); }
+            }
+        );
+        const element = document.createElement(element_name);
+        t.add_cleanup(() => element.remove());
+        customElement.shadowRoot.appendChild(element)
+        await Promise.resolve();
+        reactions = [];
+        document.getElementById("section").moveBefore(customElement, null);
+        await Promise.resolve();
+        assert_array_equals(reactions, ["connectedMove"]);
+    }, "connectedMove runs when custom element is nested within a shadow root");
 </script>
 </body>

--- a/Source/WebCore/dom/ContainerNode.cpp
+++ b/Source/WebCore/dom/ContainerNode.cpp
@@ -1432,6 +1432,23 @@ void ContainerNode::replaceChildrenWithoutValidityCheck(NodeVector&& newChildren
     dispatchSubtreeModifiedEvent();
 }
 
+static void runMovingStepsForShadowIncludingInclusiveDescendants(Node& root, Node& movedNode, ContainerNode& oldParent, bool newParentIsConnected)
+{
+    for (RefPtr inclusiveDescendant = &root; inclusiveDescendant; inclusiveDescendant = NodeTraversal::next(*inclusiveDescendant, &root)) {
+        bool isSubtreeRoot = inclusiveDescendant.get() == &movedNode;
+
+        inclusiveDescendant->movingSteps(isSubtreeRoot, oldParent);
+
+        if (newParentIsConnected) {
+            if (RefPtr element = dynamicDowncast<Element>(*inclusiveDescendant); element && element->isDefinedCustomElement())
+                CustomElementReactionQueue::enqueueConnectedMoveCallbackIfNeeded(*element);
+        }
+
+        if (RefPtr shadowRoot = inclusiveDescendant->shadowRoot())
+            runMovingStepsForShadowIncludingInclusiveDescendants(*shadowRoot, movedNode, oldParent, newParentIsConnected);
+    }
+}
+
 // https://dom.spec.whatwg.org/#dom-parentnode-movebefore
 ExceptionOr<void> ContainerNode::moveBefore(Node& node, RefPtr<Node>&& refChild)
 {
@@ -1517,17 +1534,7 @@ ExceptionOr<void> ContainerNode::moveBefore(Node& node, RefPtr<Node>&& refChild)
 
     auto newParentIsConnected = isConnected();
 
-    // FIXME(281223): Need to recurse into shadow trees.
-    for (RefPtr inclusiveDescendant = &node; inclusiveDescendant; inclusiveDescendant = NodeTraversal::next(*inclusiveDescendant, &node)) {
-        bool isSubtreeRoot = inclusiveDescendant.get() == &node;
-
-        inclusiveDescendant->movingSteps(isSubtreeRoot, *oldParent);
-
-        if (newParentIsConnected) {
-            if (RefPtr element = dynamicDowncast<Element>(*inclusiveDescendant); element && element->isDefinedCustomElement())
-                CustomElementReactionQueue::enqueueConnectedMoveCallbackIfNeeded(*element);
-        }
-    }
+    runMovingStepsForShadowIncludingInclusiveDescendants(node, node, *oldParent, newParentIsConnected);
 
     // FIXME: Add a new type for ChildChange.
 


### PR DESCRIPTION
#### 1cc7b9f63d58412a3a05fcdc9620880677c55fb5
<pre>
moveBefore() doesn&apos;t iterate through shadow roots
<a href="https://bugs.webkit.org/show_bug.cgi?id=320096">https://bugs.webkit.org/show_bug.cgi?id=320096</a>

Reviewed by Ryosuke Niwa.

This updates the node traversal in moveBefore() to recurse into shadow roots, and
updates a test to cover the scenario of a shadowroot inside the moved container.

* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/custom-element-move-reactions-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/custom-element-move-reactions.html:
* Source/WebCore/dom/ContainerNode.cpp:
(WebCore::runMovingStepsForShadowIncludingInclusiveDescendants):
(WebCore::ContainerNode::moveBefore):

Canonical link: <a href="https://commits.webkit.org/318094@main">https://commits.webkit.org/318094@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6a11277ee3ceaacd499ba1d32506d63e71e86fd8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176356 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50291 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44081 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185954 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/138612 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178219 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51583 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49975 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137361 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/138612 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179312 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40851 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158143 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117836 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39500 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37860 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149916 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37641 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34421 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42020 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42071 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188377 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49956 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/157688 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146400 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39565 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50640 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34258 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146218 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40992 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122844 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/116888 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49144 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12616 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48546 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48780 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48605 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->