### PR TITLE
Add Style::URL::fragment() to unify same-document fragment extraction

### DIFF
--- a/Source/WebCore/style/values/filter-effects/StyleFilterReference.cpp
+++ b/Source/WebCore/style/values/filter-effects/StyleFilterReference.cpp
@@ -54,11 +54,7 @@ auto ToCSS<FilterReference>::operator()(const FilterReference& value, const Styl
 auto ToStyle<CSS::FilterReference>::operator()(const CSS::FilterReference& value, const BuilderState& state) -> FilterReference
 {
     auto url = toStyle(value.url, state);
-
-    // FIXME: Unify all the fragment accessing/construction.
-    auto fragment = url.resolved.string().startsWith('#')
-        ? StringView(url.resolved.string()).substring(1).toAtomString()
-        : url.resolved.fragmentIdentifier().toAtomString();
+    auto fragment = url.fragment();
 
     return {
         .url = WTF::move(url),

--- a/Source/WebCore/style/values/primitives/StyleURL.cpp
+++ b/Source/WebCore/style/values/primitives/StyleURL.cpp
@@ -53,6 +53,17 @@ namespace Style {
 //      CSS:    [.specified = "foo/bar.png", .resolved = null-url]
 //      Style:  [.resolved = "foo/bar.png"]
 
+AtomString URL::fragment() const
+{
+    if (resolved.hasFragmentIdentifier())
+        return resolved.fragmentIdentifier().toAtomString();
+
+    // A bare "#id" same-document reference is stored unresolved (an invalid URL), so WTF::URL can't
+    // report its fragment; read it directly from the string.
+    auto string = resolved.string();
+    return string.startsWith('#') ? StringView(string).substring(1).toAtomString() : nullAtom();
+}
+
 auto toStyleWithScriptExecutionContext(const CSS::URL& url, const ScriptExecutionContext& context) -> URL
 {
     if (url.resolved.isNull()) {

--- a/Source/WebCore/style/values/primitives/StyleURL.h
+++ b/Source/WebCore/style/values/primitives/StyleURL.h
@@ -26,6 +26,7 @@
 
 #include <WebCore/CSSURL.h>
 #include <WebCore/StyleValueTypes.h>
+#include <wtf/text/AtomString.h>
 
 namespace WebCore {
 
@@ -37,6 +38,10 @@ namespace Style {
 struct URL {
     WTF::URL resolved;
     CSS::URLModifiers modifiers;
+
+    // The fragment identifier of `resolved`. `resolved` may be a bare "#id" same-document reference,
+    // which is not a valid standalone URL, so this handles that case as well as absolute URLs.
+    AtomString fragment() const;
 
     bool operator==(const URL&) const = default;
 };

--- a/Source/WebCore/style/values/shapes/StylePathOperationWrappers.cpp
+++ b/Source/WebCore/style/values/shapes/StylePathOperationWrappers.cpp
@@ -61,10 +61,7 @@ RefPtr<PathOperation> CSSValueConversion<RefPtr<PathOperation>>::operator()(Buil
     if (RefPtr url = dynamicDowncast<CSSURLValue>(value)) {
         auto styleURL = toStyle(url->url(), state);
 
-        // FIXME: Unify all the fragment accessing/construction.
-        auto fragment = styleURL.resolved.string().startsWith('#')
-            ? StringView(styleURL.resolved.string()).substring(1).toAtomString()
-            : styleURL.resolved.fragmentIdentifier().toAtomString();
+        auto fragment = styleURL.fragment();
 
         Ref treeScope = [&] -> Ref<const TreeScope> {
             if (auto* element = state.element())


### PR DESCRIPTION
#### a9ebc5b071777463f6b6a352d6e7b6e57c9b087f
<pre>
Add Style::URL::fragment() to unify same-document fragment extraction
<a href="https://bugs.webkit.org/show_bug.cgi?id=320098">https://bugs.webkit.org/show_bug.cgi?id=320098</a>
<a href="https://rdar.apple.com/183030303">rdar://183030303</a>

Reviewed by Sam Weinig.

Style::FilterReference and clip-path&apos;s ReferencePathOperation both had
the same fragment extraction logic.

Move that logic to a single Style::URL::fragment() accessor, on the type that
actually owns the quirk, and use it from both call sites. No behavior change.

* Source/WebCore/style/values/filter-effects/StyleFilterReference.cpp:
(WebCore::Style::ToStyle&lt;CSS::FilterReference&gt;::operator):
* Source/WebCore/style/values/primitives/StyleURL.cpp:
(WebCore::Style::URL::fragment const):
* Source/WebCore/style/values/primitives/StyleURL.h:
* Source/WebCore/style/values/shapes/StylePathOperationWrappers.cpp:
(WebCore::Style::CSSValueConversion&lt;RefPtr&lt;PathOperation&gt;&gt;::operator):

Canonical link: <a href="https://commits.webkit.org/317792@main">https://commits.webkit.org/317792@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/af216f8addf7c1537d957a3cc35c2c31d0b07cb8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176355 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50290 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44080 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185953 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/138611 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ed5b0dc0-c73f-4baf-8fa6-b64fb5ad6541) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178218 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51582 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49974 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137366 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/138611 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a4366bc6-2167-49bd-9780-d23f735c739e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179311 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40849 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158144 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117841 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a6bb2df0-0487-4397-85f8-b7f30bc637bd) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39498 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37861 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149914 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37642 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34420 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42019 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/42072 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188376 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49955 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146402 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39376 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50639 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/34259 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146220 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40993 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122843 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/116887 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49143 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12617 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48545 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48779 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48604 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->