### PR TITLE
Remove unused type aliases in StylePrimitiveNumericTypes.h

### DIFF
--- a/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes.h
+++ b/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes.h
@@ -127,51 +127,6 @@ template<CSS::Range nR = CSS::All, CSS::Range pR = nR, typename V = double> stru
     constexpr auto operator<=>(const NumberOrPercentageResolvedToNumber&) const = default;
 };
 
-// Standard Numbers
-using NumberAll = Number<CSS::All>;
-using NumberNonnegative = Number<CSS::Nonnegative>;
-
-// Standard Angles
-using AngleAllFloat = Angle<CSS::All, float>;
-
-// Standard Lengths
-using LengthAll = Length<CSS::All>;
-using LengthAllUnzoomed = Length<CSS::AllUnzoomed>;
-using LengthNonnegative = Length<CSS::Nonnegative>;
-using LengthNonnegativeUnzoomed = Length<CSS::NonnegativeUnzoomed>;
-
-// Standard LengthPercentages
-using LengthPercentageAll = LengthPercentage<CSS::All>;
-using LengthPercentageAllUnzoomed = LengthPercentage<CSS::AllUnzoomed>;
-using LengthPercentageNonnegative = LengthPercentage<CSS::Nonnegative>;
-using LengthPercentageNonnegativeUnzoomed = LengthPercentage<CSS::NonnegativeUnzoomed>;
-
-// Standard Percentages
-using PercentageAll = Percentage<CSS::All>;
-using PercentageAllUnzoomed = Percentage<CSS::AllUnzoomed>;
-using PercentageNonnegative = Percentage<CSS::Nonnegative>;
-using PercentageNonnegativeUnzoomed = Percentage<CSS::NonnegativeUnzoomed>;
-using PercentageAllFloat = Percentage<CSS::All, float>;
-using PercentageAllUnzoomedFloat = Percentage<CSS::AllUnzoomed, float>;
-using PercentageNonnegativeFloat = Percentage<CSS::Nonnegative, float>;
-using PercentageNonnegativeUnzoomedFloat = Percentage<CSS::NonnegativeUnzoomed, float>;
-
-// Standard Points
-using LengthPercentageSpaceSeparatedPointAll = SpaceSeparatedPoint<LengthPercentageAll>;
-using LengthPercentageSpaceSeparatedPointAllUnzoomed = SpaceSeparatedPoint<LengthPercentageAllUnzoomed>;
-using LengthPercentageSpaceSeparatedPointNonnegative = SpaceSeparatedPoint<LengthPercentageNonnegative>;
-using LengthPercentageSpaceSeparatedPointNonnegativeUnzoomed = SpaceSeparatedPoint<LengthPercentageNonnegativeUnzoomed>;
-
-// Standard Sizes
-using LengthPercentageSpaceSeparatedSizeAll = SpaceSeparatedSize<LengthPercentageAll>;
-using LengthPercentageSpaceSeparatedSizeAllUnzoomed = SpaceSeparatedSize<LengthPercentageAllUnzoomed>;
-using LengthPercentageSpaceSeparatedSizeNonnegative = SpaceSeparatedSize<LengthPercentageNonnegative>;
-using LengthPercentageSpaceSeparatedSizeNonnegativeUnzoomed = SpaceSeparatedSize<LengthPercentageNonnegativeUnzoomed>;
-using LengthPercentageMinimallySerializingSpaceSeparatedSizeAll = MinimallySerializingSpaceSeparatedSize<LengthPercentageAll>;
-using LengthPercentageMinimallySerializingSpaceSeparatedSizeAllUnzoomed = MinimallySerializingSpaceSeparatedSize<LengthPercentageAllUnzoomed>;
-using LengthPercentageMinimallySerializingSpaceSeparatedSizeNonnegative = MinimallySerializingSpaceSeparatedSize<LengthPercentageNonnegative>;
-using LengthPercentageMinimallySerializingSpaceSeparatedSizeNonnegativeUnzoomed = MinimallySerializingSpaceSeparatedSize<LengthPercentageNonnegativeUnzoomed>;
-
 // MARK: CSS -> Style
 
 template<auto nR, auto pR, typename V> struct ToStyleMapping<CSS::NumberOrPercentage<nR, pR, V>> {


### PR DESCRIPTION
#### 25fc77ac109b38671ff9c50c992f8ffbb97f0f50
<pre>
Remove unused type aliases in StylePrimitiveNumericTypes.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=319264">https://bugs.webkit.org/show_bug.cgi?id=319264</a>

Reviewed by Darin Adler.

We used to use these aliases to help with the IPC generator which had
some trouble with nested templates, but we no longer use style types
in IPC so these are now completely unused.

* Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes.h:

Canonical link: <a href="https://commits.webkit.org/317790@main">https://commits.webkit.org/317790@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9468210e03baa36784953939f5fcffa106f19bc8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176359 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50294 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44084 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185957 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/138615 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178222 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51586 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49978 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137370 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/138615 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179315 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; Passed webkitperl tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40852 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158151 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117845 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39501 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37866 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149917 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37649 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34425 "Built successfully") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/37627 "Build is in progress. Recent messages:") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42023 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/42077 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188380 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49959 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146407 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39371 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50643 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/34266 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146223 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40997 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/122847 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/116891 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49147 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12624 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48549 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48783 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48608 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->