### PR TITLE
[JSC][Wasm] Add regression test for i32 extended const wrap-around

### DIFF
--- a/JSTests/wasm/stress/const-expr-i32-wrap.js
+++ b/JSTests/wasm/stress/const-expr-i32-wrap.js
@@ -1,0 +1,57 @@
+//@ requireOptions("--useExecutableAllocationFuzz=false")
+import { instantiate } from "../wabt-wrapper.js";
+import * as assert from "../assert.js";
+
+// Bug 319894 / 314444: i32 extended const results used as data/elem offsets (and globals)
+// must behave as mod 2^32. Typed i32 consumers must not treat the full uint64 value as the offset.
+
+const extended = { extended_const: true };
+
+{
+    // 4 * 0x40000000 = 2^32 -> offset 0; active data should write at the start of memory.
+    let instance = await instantiate(`
+    (module
+      (memory (export "memory") 1)
+      (data (offset (i32.mul (i32.const 4) (i32.const 0x40000000))) "A"))
+    `, {}, extended);
+    assert.eq(new Uint8Array(instance.exports.memory.buffer)[0], 0x41);
+}
+
+{
+    // 65536 * 65536 = 2^32 -> 0.
+    let instance = await instantiate(`
+    (module
+      (memory (export "memory") 1)
+      (data (offset (i32.mul (i32.const 65536) (i32.const 65536))) "B"))
+    `, {}, extended);
+    assert.eq(new Uint8Array(instance.exports.memory.buffer)[0], 0x42);
+}
+
+{
+    let instance = await instantiate(`
+    (module
+      (global (export "mul") i32 (i32.mul (i32.const 4) (i32.const 0x40000000)))
+      (global (export "add") i32 (i32.add (i32.const 0x7fffffff) (i32.const 1)))
+      (global (export "sub") i32 (i32.sub (i32.const 0) (i32.const 1)))
+      (global (export "chain") i32
+        (i32.add
+          (i32.mul (i32.const 0x40000000) (i32.const 4))
+          (i32.const 7))))
+    `, {}, extended);
+    assert.eq(instance.exports.mul.value, 0);
+    assert.eq(instance.exports.add.value, -2147483648);
+    assert.eq(instance.exports.sub.value, -1);
+    assert.eq(instance.exports.chain.value, 7);
+}
+
+{
+    let instance = await instantiate(`
+    (module
+      (table (export "table") 1 funcref)
+      (elem (offset (i32.mul (i32.const 4) (i32.const 0x40000000))) $f)
+      (func $f (export "f") (result i32) (i32.const 42)))
+    `, {}, extended);
+    assert.eq(instance.exports.table.get(0)(), 42);
+}
+
+print("const-expr-i32-wrap: ok");


### PR DESCRIPTION
#### 238312eeaa6a8afc001b849bb3bbcb422085a81e
<pre>
[JSC][Wasm] Add regression test for i32 extended const wrap-around
<a href="https://bugs.webkit.org/show_bug.cgi?id=319894">https://bugs.webkit.org/show_bug.cgi?id=319894</a>

Reviewed by Yusuke Suzuki.

Regression coverage for i32 extended constant expressions used as data/elem
offsets and global inits (mod 2^32). Production readers already truncate typed
i32 results (see 314444 / 317633@main for memory32 data offsets).

* JSTests/wasm/stress/const-expr-i32-wrap.js: Added.

Canonical link: <a href="https://commits.webkit.org/318395@main">https://commits.webkit.org/318395@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ae7b087fa7b07c0a0b7041d5422de3a40c0a9e51

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176362 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50297 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44087 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185961 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/138618 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51589 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49981 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137369 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96245 "2 flakes 4 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179318 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40854 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158146 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117844 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39503 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37868 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/6655 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149919 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37644 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34429 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/37630 "Built successfully and passed tests") | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42079 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188384 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49962 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146409 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50646 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34261 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146225 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27023 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40995 "Passed tests") | | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/116894 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49150 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12619 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48552 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48786 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48611 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->