### PR TITLE
[WebTransport] WritableStream close() should reject when aborted mid-close

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6785,10 +6785,6 @@ imported/w3c/web-platform-tests/webtransport/streams-echo.https.any.html [ Skip 
 imported/w3c/web-platform-tests/webtransport/streams-echo.https.any.serviceworker.html [ Skip ]
 imported/w3c/web-platform-tests/webtransport/streams-echo.https.any.sharedworker.html [ Skip ]
 imported/w3c/web-platform-tests/webtransport/streams-echo.https.any.worker.html [ Skip ]
-imported/w3c/web-platform-tests/webtransport/streams-close.https.any.html [ Skip ]
-imported/w3c/web-platform-tests/webtransport/streams-close.https.any.serviceworker.html [ Skip ]
-imported/w3c/web-platform-tests/webtransport/streams-close.https.any.sharedworker.html [ Skip ]
-imported/w3c/web-platform-tests/webtransport/streams-close.https.any.worker.html [ Skip ]
 
 # Backend gaps (datagram flow-control, getStats, close, historical, idlharness exportKeyingMaterial).
 imported/w3c/web-platform-tests/webtransport/datagrams.https.any.html [ Skip ]

--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/resources/webtransport-test-helpers.sub.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/resources/webtransport-test-helpers.sub.js
@@ -88,6 +88,18 @@ async function query(token) {
   }
 }
 
+// Polls the server until the stream close info for |token| is recorded, then
+// returns it. Avoids racing on a fixed delay for the close signal to arrive.
+async function query_stream_close_info(token) {
+  while (true) {
+    const data = await query(token);
+    if ('stream-close-info' in data) {
+      return data['stream-close-info'];
+    }
+    await wait(10);
+  }
+}
+
 async function readInto(reader, buffer) {
   let offset = 0;
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/streams-close.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/streams-close.https.any-expected.txt
@@ -5,7 +5,7 @@ PASS Close outgoing stream / uni
 PASS Abort client-created bidirectional stream
 PASS Abort server-initiated bidirectional stream
 PASS Abort unidirectional stream with WebTransportError
-FAIL Close and abort unidirectional stream assert_unreached: Should have rejected: close_promise Reached unreachable code
+PASS Close and abort unidirectional stream
 PASS Abort unidirectional stream with default error code
 PASS STOP_SENDING coming from server
 PASS RESET_STREAM coming from server

--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/streams-close.https.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/streams-close.https.any.js
@@ -17,11 +17,7 @@ promise_test(async t => {
   const writable = bidi_stream.writable;
   writable.close();
 
-  await wait(10);
-  const data = await query(id);
-
-  assert_own_property(data, 'stream-close-info');
-  const info = data['stream-close-info'];
+  const info = await query_stream_close_info(id);
 
   assert_equals(info.source, 'FIN', 'source');
 }, 'Close outgoing stream / bidi-1');
@@ -38,11 +34,7 @@ promise_test(async t => {
   const writable = bidi.writable;
   writable.close();
 
-  await wait(10);
-  const data = await query(id);
-
-  assert_own_property(data, 'stream-close-info');
-  const info = data['stream-close-info'];
+  const info = await query_stream_close_info(id);
 
   assert_equals(info.source, 'FIN', 'source');
 }, 'Close outgoing stream / bidi-2');
@@ -56,11 +48,7 @@ promise_test(async t => {
   const writable = await wt.createUnidirectionalStream();
   writable.close();
 
-  await wait(10);
-  const data = await query(id);
-
-  assert_own_property(data, 'stream-close-info');
-  const info = data['stream-close-info'];
+  const info = await query_stream_close_info(id);
 
   assert_equals(info.source, 'FIN', 'source');
 }, 'Close outgoing stream / uni');
@@ -80,13 +68,9 @@ promise_test(async t => {
   await writable.abort(
       new WebTransportError({streamErrorCode: WT_CODE}));
 
-  await wait(10);
-  const data = await query(id);
+  const info = await query_stream_close_info(id);
 
   // Check that stream is aborted with RESET_STREAM with the code and reason
-  assert_own_property(data, 'stream-close-info');
-  const info = data['stream-close-info'];
-
   assert_equals(info.source, 'reset', 'reset stream');
   assert_equals(info.code, HTTP_CODE, 'code');
 }, 'Abort client-created bidirectional stream');
@@ -108,13 +92,9 @@ promise_test(async t => {
   await writer.abort(
       new WebTransportError({streamErrorCode: WT_CODE}));
 
-  await wait(10);
-  const data = await query(id);
+  const info = await query_stream_close_info(id);
 
   // Check that stream is aborted with RESET_STREAM with the code and reason
-  assert_own_property(data, 'stream-close-info');
-  const info = data['stream-close-info'];
-
   assert_equals(info.source, 'reset', 'reset_stream');
   assert_equals(info.code, HTTP_CODE, 'code');
 }, 'Abort server-initiated bidirectional stream');
@@ -132,13 +112,9 @@ promise_test(async t => {
   await writable.abort(
       new WebTransportError({streamErrorCode: WT_CODE}));
 
-  await wait(10);
-  const data = await query(id);
+  const info = await query_stream_close_info(id);
 
   // Check that stream is aborted with RESET_STREAM with the code and reason
-  assert_own_property(data, 'stream-close-info');
-  const info = data['stream-close-info'];
-
   assert_equals(info.source, 'reset', 'reset_stream');
   assert_equals(info.code, HTTP_CODE, 'code');
 }, 'Abort unidirectional stream with WebTransportError');
@@ -171,13 +147,9 @@ promise_test(async t => {
   await promise_rejects_exactly(t, e, abort_promise, 'abort_promise');
   writer.releaseLock();
 
-  await wait(10);
-  const data = await query(id);
+  const info = await query_stream_close_info(id);
 
   // Check that stream is aborted with RESET_STREAM with the code and reason
-  assert_own_property(data, 'stream-close-info');
-  const info = data['stream-close-info'];
-
   assert_equals(info.source, 'reset', 'reset_stream');
   assert_equals(info.code, HTTP_CODE, 'code');
 }, 'Close and abort unidirectional stream');
@@ -191,13 +163,9 @@ promise_test(async t => {
   const writable = await wt.createUnidirectionalStream();
   await writable.abort();
 
-  await wait(10);
-  const data = await query(id);
+  const info = await query_stream_close_info(id);
 
   // Check that stream is aborted with RESET_STREAM with the code and reason
-  assert_own_property(data, 'stream-close-info');
-  const info = data['stream-close-info'];
-
   assert_equals(info.source, 'reset', 'reset_stream');
   assert_equals(info.code, webtransport_code_to_http_code(0), 'code');
 }, 'Abort unidirectional stream with default error code');

--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/streams-close.https.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/streams-close.https.any.serviceworker-expected.txt
@@ -5,7 +5,7 @@ PASS Close outgoing stream / uni
 PASS Abort client-created bidirectional stream
 PASS Abort server-initiated bidirectional stream
 PASS Abort unidirectional stream with WebTransportError
-FAIL Close and abort unidirectional stream assert_unreached: Should have rejected: close_promise Reached unreachable code
+PASS Close and abort unidirectional stream
 PASS Abort unidirectional stream with default error code
 PASS STOP_SENDING coming from server
 PASS RESET_STREAM coming from server

--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/streams-close.https.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/streams-close.https.any.sharedworker-expected.txt
@@ -5,7 +5,7 @@ PASS Close outgoing stream / uni
 PASS Abort client-created bidirectional stream
 PASS Abort server-initiated bidirectional stream
 PASS Abort unidirectional stream with WebTransportError
-FAIL Close and abort unidirectional stream assert_unreached: Should have rejected: close_promise Reached unreachable code
+PASS Close and abort unidirectional stream
 PASS Abort unidirectional stream with default error code
 PASS STOP_SENDING coming from server
 PASS RESET_STREAM coming from server

--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/streams-close.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/streams-close.https.any.worker-expected.txt
@@ -5,7 +5,7 @@ PASS Close outgoing stream / uni
 PASS Abort client-created bidirectional stream
 PASS Abort server-initiated bidirectional stream
 PASS Abort unidirectional stream with WebTransportError
-FAIL Close and abort unidirectional stream assert_unreached: Should have rejected: close_promise Reached unreachable code
+PASS Close and abort unidirectional stream
 PASS Abort unidirectional stream with default error code
 PASS STOP_SENDING coming from server
 PASS RESET_STREAM coming from server

--- a/Source/WebCore/Modules/filesystem/FileSystemWritableFileStreamSink.cpp
+++ b/Source/WebCore/Modules/filesystem/FileSystemWritableFileStreamSink.cpp
@@ -183,12 +183,13 @@ void FileSystemWritableFileStreamSink::write(ScriptExecutionContext& context, JS
     }
 }
 
-void FileSystemWritableFileStreamSink::close(JSDOMGlobalObject&)
+void FileSystemWritableFileStreamSink::close(JSDOMGlobalObject&, DOMPromiseDeferred<void>&& promise)
 {
     ASSERT(!m_isClosed);
 
     m_isClosed = true;
     protect(m_source)->closeWritable(m_identifier, FileSystemWriteCloseReason::Completed);
+    promise.resolve();
 }
 
 void FileSystemWritableFileStreamSink::abort(JSDOMGlobalObject&, JSC::JSValue, DOMPromiseDeferred<void>&& promise)

--- a/Source/WebCore/Modules/filesystem/FileSystemWritableFileStreamSink.h
+++ b/Source/WebCore/Modules/filesystem/FileSystemWritableFileStreamSink.h
@@ -41,7 +41,7 @@ private:
 
     // WritableStreamSink
     void write(ScriptExecutionContext&, JSC::JSValue, DOMPromiseDeferred<void>&&) final;
-    void close(JSDOMGlobalObject&) final;
+    void close(JSDOMGlobalObject&, DOMPromiseDeferred<void>&&) final;
     void abort(JSDOMGlobalObject&, JSC::JSValue, DOMPromiseDeferred<void>&&) final;
 
     FileSystemWritableFileStreamIdentifier m_identifier;

--- a/Source/WebCore/Modules/mediastream/VideoTrackGenerator.cpp
+++ b/Source/WebCore/Modules/mediastream/VideoTrackGenerator.cpp
@@ -209,17 +209,20 @@ void VideoTrackGenerator::Sink::write(ScriptExecutionContext&, JSC::JSValue valu
     promise.resolve();
 }
 
-void VideoTrackGenerator::Sink::close(JSDOMGlobalObject&)
+void VideoTrackGenerator::Sink::close(JSDOMGlobalObject&, DOMPromiseDeferred<void>&& promise)
 {
-    callOnMainThread([source = m_source] {
+    callOnMainThread([source = m_source, promise = WTF::move(promise)] () mutable {
         source->endImmediatly();
+        promise.resolve();
     });
 }
 
-void VideoTrackGenerator::Sink::abort(JSDOMGlobalObject& globalObject, JSC::JSValue, DOMPromiseDeferred<void>&& promise)
+void VideoTrackGenerator::Sink::abort(JSDOMGlobalObject&, JSC::JSValue, DOMPromiseDeferred<void>&& promise)
 {
-    close(globalObject);
-    promise.resolve();
+    callOnMainThread([source = m_source, promise = WTF::move(promise)] () mutable {
+        source->endImmediatly();
+        promise.resolve();
+    });
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/mediastream/VideoTrackGenerator.h
+++ b/Source/WebCore/Modules/mediastream/VideoTrackGenerator.h
@@ -90,7 +90,7 @@ private:
         explicit Sink(Ref<Source>&&);
 
         void write(ScriptExecutionContext&, JSC::JSValue, DOMPromiseDeferred<void>&&) final;
-        void close(JSDOMGlobalObject&) final;
+        void close(JSDOMGlobalObject&, DOMPromiseDeferred<void>&&) final;
         void abort(JSDOMGlobalObject&, JSC::JSValue, DOMPromiseDeferred<void>&&) final;
 
         bool m_muted { false };

--- a/Source/WebCore/Modules/streams/StreamTransferUtilities.cpp
+++ b/Source/WebCore/Modules/streams/StreamTransferUtilities.cpp
@@ -342,10 +342,11 @@ private:
             promise.resolve();
         });
     }
-    void close(JSDOMGlobalObject& globalObject) final
+    void close(JSDOMGlobalObject& globalObject, DOMPromiseDeferred<void>&& promise) final
     {
         packAndPostMessage(globalObject, m_port, "close"_s, JSC::jsUndefined());
         m_port->close();
+        promise.resolve();
     }
     void abort(JSDOMGlobalObject& globalObject, JSC::JSValue reason, DOMPromiseDeferred<void>&& promise) final
     {

--- a/Source/WebCore/Modules/streams/WritableStreamSink.cpp
+++ b/Source/WebCore/Modules/streams/WritableStreamSink.cpp
@@ -27,6 +27,8 @@
 #include "config.h"
 #include "WritableStreamSink.h"
 
+#include "AbortSignal.h"
+#include "JSAbortSignal.h"
 #include "JSDOMPromiseDeferred.h"
 #include "JSWritableStreamDefaultController.h"
 #include "JSWritableStreamSink.h"
@@ -52,11 +54,24 @@ public:
 
     void errorIfNeeded(JSC::JSGlobalObject&, JSC::JSValue);
     JSWritableStreamDefaultController* NODELETE jsController() { return m_jsController; }
+    RefPtr<AbortSignal> signal() const;
 
 private:
     // The owner of WritableStreamDefaultController is responsible to keep uncollected the JSWritableStreamDefaultController.
     JSWritableStreamDefaultController* m_jsController { nullptr };
 };
+
+RefPtr<AbortSignal> WritableStreamDefaultController::signal() const
+{
+    if (!m_jsController)
+        return nullptr;
+
+    Ref vm = m_jsController->vm();
+    JSC::JSLockHolder lock(vm.get());
+    auto signalValue = m_jsController->getDirect(vm, builtinNames(vm.get()).signalPrivateName());
+    auto* jsSignal = dynamicDowncast<JSAbortSignal>(signalValue);
+    return jsSignal ? RefPtr { &jsSignal->wrapped() } : nullptr;
+}
 
 static bool invokeWritableStreamDefaultControllerFunction(JSC::JSGlobalObject& lexicalGlobalObject, const JSC::Identifier& identifier, const JSC::MarkedArgumentBuffer& arguments)
 {
@@ -87,6 +102,11 @@ void WritableStreamSink::start(std::unique_ptr<WritableStreamDefaultController>&
     m_controller = WTF::move(controller);
 }
 
+RefPtr<AbortSignal> WritableStreamSink::abortSignal() const
+{
+    return m_controller ? m_controller->signal() : nullptr;
+}
+
 void WritableStreamSink::errorIfNeeded(JSC::JSGlobalObject& globalObject, JSC::JSValue error)
 {
     Ref vm = globalObject.vm();
@@ -111,6 +131,11 @@ SimpleWritableStreamSink::SimpleWritableStreamSink(WriteCallback&& writeCallback
 void SimpleWritableStreamSink::write(ScriptExecutionContext& context, JSC::JSValue value, DOMPromiseDeferred<void>&& promise)
 {
     promise.settle(m_writeCallback(context, value));
+}
+
+void SimpleWritableStreamSink::close(JSDOMGlobalObject&, DOMPromiseDeferred<void>&& promise)
+{
+    promise.resolve();
 }
 
 JSC::JSValue JSWritableStreamSink::start(JSC::JSGlobalObject& globalObject, JSC::CallFrame& callFrame)

--- a/Source/WebCore/Modules/streams/WritableStreamSink.h
+++ b/Source/WebCore/Modules/streams/WritableStreamSink.h
@@ -39,6 +39,7 @@ class JSGlobalObject;
 
 namespace WebCore {
 
+class AbortSignal;
 class JSDOMGlobalObject;
 class ScriptExecutionContext;
 template<typename> class ExceptionOr;
@@ -49,15 +50,19 @@ class WritableStreamSink : public RefCounted<WritableStreamSink> {
 public:
     virtual ~WritableStreamSink();
 
-    void start(std::unique_ptr<WritableStreamDefaultController>&&);
+    virtual void start(std::unique_ptr<WritableStreamDefaultController>&&);
     virtual void write(ScriptExecutionContext&, JSC::JSValue, DOMPromiseDeferred<void>&&) = 0;
-    virtual void close(JSDOMGlobalObject&) = 0;
+    virtual void close(JSDOMGlobalObject&, DOMPromiseDeferred<void>&&) = 0;
     virtual void abort(JSDOMGlobalObject&, JSC::JSValue, DOMPromiseDeferred<void>&&);
 
     void errorIfNeeded(JSC::JSGlobalObject&, JSC::JSValue);
 
 protected:
     WritableStreamSink();
+
+    // The AbortSignal owned by the associated WritableStreamDefaultController, if any.
+    // Fired synchronously when the stream is aborted, before the abort algorithm runs.
+    RefPtr<AbortSignal> abortSignal() const;
 
 private:
     std::unique_ptr<WritableStreamDefaultController> m_controller;
@@ -72,7 +77,7 @@ private:
     explicit SimpleWritableStreamSink(WriteCallback&&);
 
     void write(ScriptExecutionContext&, JSC::JSValue, DOMPromiseDeferred<void>&&) final;
-    void close(JSDOMGlobalObject&) final { }
+    void close(JSDOMGlobalObject&, DOMPromiseDeferred<void>&&) final;
 
     WriteCallback m_writeCallback;
 };

--- a/Source/WebCore/Modules/streams/WritableStreamSink.idl
+++ b/Source/WebCore/Modules/streams/WritableStreamSink.idl
@@ -30,7 +30,7 @@
 ] interface WritableStreamSink {
     [Custom] undefined start(WritableStreamDefaultController controller);
     [CallWith=CurrentScriptExecutionContext] Promise<undefined> write(any value);
-    [CallWith=CurrentGlobalObject] undefined close();
+    [CallWith=CurrentGlobalObject] Promise<undefined> close();
     [CallWith=CurrentGlobalObject] Promise<undefined> abort(any reason);
 
     // Place holder to keep the controller linked to the source.

--- a/Source/WebCore/Modules/webtransport/DatagramSink.cpp
+++ b/Source/WebCore/Modules/webtransport/DatagramSink.cpp
@@ -85,4 +85,10 @@ void DatagramSink::write(ScriptExecutionContext& context, JSC::JSValue value, DO
     });
 }
 
+void DatagramSink::close(JSDOMGlobalObject&, DOMPromiseDeferred<void>&& promise)
+{
+    m_isClosed = true;
+    promise.resolve();
+}
+
 }

--- a/Source/WebCore/Modules/webtransport/DatagramSink.h
+++ b/Source/WebCore/Modules/webtransport/DatagramSink.h
@@ -45,7 +45,7 @@ private:
     DatagramSink(WebTransportSession*);
 
     void write(ScriptExecutionContext&, JSC::JSValue, DOMPromiseDeferred<void>&&) final;
-    void close(JSDOMGlobalObject&) final { m_isClosed = true; }
+    void close(JSDOMGlobalObject&, DOMPromiseDeferred<void>&&) final;
 
     ThreadSafeWeakPtr<WebTransportSession> m_session;
     WeakPtr<WebTransportDatagramsWritable> m_datagrams;

--- a/Source/WebCore/Modules/webtransport/WebTransportSendStreamSink.cpp
+++ b/Source/WebCore/Modules/webtransport/WebTransportSendStreamSink.cpp
@@ -26,6 +26,8 @@
 #include "config.h"
 #include "WebTransportSendStreamSink.h"
 
+#include "AbortSignal.h"
+#include "EventLoop.h"
 #include "Exception.h"
 #include "IDLTypes.h"
 #include "JSDOMConvertBufferSource.h"
@@ -50,7 +52,26 @@ WebTransportSendStreamSink::WebTransportSendStreamSink(WebTransport& transport, 
 {
 }
 
-WebTransportSendStreamSink::~WebTransportSendStreamSink() = default;
+WebTransportSendStreamSink::~WebTransportSendStreamSink()
+{
+    if (m_abortSignal && m_abortAlgorithmIdentifier)
+        protect(m_abortSignal)->removeAlgorithm(*m_abortAlgorithmIdentifier);
+}
+
+void WebTransportSendStreamSink::start(std::unique_ptr<WritableStreamDefaultController>&& controller)
+{
+    WritableStreamSink::start(WTF::move(controller));
+
+    // The abort signal fires synchronously during writer.abort(), before the abort() algorithm runs,
+    // so observing it is the only way to cancel an in-flight close().
+    if (RefPtr signal = abortSignal()) {
+        m_abortAlgorithmIdentifier = signal->addAlgorithm([weakThis = WeakPtr { *this }](JSC::JSValue reason) {
+            if (RefPtr protectedThis = weakThis.get())
+                protectedThis->cancel(reason);
+        });
+        m_abortSignal = WTF::move(signal);
+    }
+}
 
 RefPtr<WritableStream> WebTransportSendStreamSink::stream() const
 {
@@ -108,28 +129,67 @@ void WebTransportSendStreamSink::write(ScriptExecutionContext& context, JSC::JSV
     });
 }
 
-void WebTransportSendStreamSink::close(JSDOMGlobalObject&)
+// https://w3c.github.io/webtransport/#webtransportsendstream-close
+void WebTransportSendStreamSink::close(JSDOMGlobalObject& globalObject, DOMPromiseDeferred<void>&& promise)
 {
-    if (m_isClosed)
-        return;
+    if (m_isClosed || m_isCancelled)
+        return promise.reject(Exception { ExceptionCode::InvalidStateError });
     m_isClosed = true;
 
-    if (RefPtr transport = m_transport.get()) {
-        if (RefPtr session = transport->session())
-            session->streamSendBytes(m_identifier, { }, true);
-        transport->sendStreamClosed(m_identifier);
-    }
+    RefPtr context = globalObject.scriptExecutionContext();
+    if (!context)
+        return promise.reject(Exception { ExceptionCode::InvalidStateError });
+
+    m_closeDeferred = makeUnique<DOMPromiseDeferred<void>>(WTF::move(promise));
+
+    // Defer the FIN so a racing abort() can suppress it and reset the stream instead.
+    // FIXME: Validate this abort-after-close behavior. https://bugs.webkit.org/show_bug.cgi?id=320232
+    protect(context->eventLoop())->queueTask(TaskSource::Networking, [protectedThis = Ref { *this }, context = Ref { *context }] {
+        protectedThis->sendFin(context.get());
+    });
 }
 
-void WebTransportSendStreamSink::abort(JSDOMGlobalObject&, JSC::JSValue value, DOMPromiseDeferred<void>&& promise)
+void WebTransportSendStreamSink::sendFin(ScriptExecutionContext& context)
 {
-    auto scope = makeScopeExit([&promise] {
-        promise.resolve();
-    });
+    if (m_isCancelled || !m_closeDeferred)
+        return;
 
+    RefPtr transport = m_transport.get();
+    RefPtr session = transport ? transport->session() : nullptr;
+    if (!transport || !session)
+        return std::exchange(m_closeDeferred, nullptr)->reject(Exception { ExceptionCode::InvalidStateError });
+
+    transport->sendStreamClosed(m_identifier);
+    context.enqueueTaskWhenSettled(session->streamSendBytes(m_identifier, { }, true), TaskSource::Networking, [protectedThis = Ref { *this }] (auto&& exception) mutable {
+        auto deferred = std::exchange(protectedThis->m_closeDeferred, nullptr);
+        if (!deferred)
+            return;
+        if (!exception)
+            return deferred->reject(Exception { ExceptionCode::NetworkError });
+        if (*exception)
+            return deferred->reject(WTF::move(**exception));
+        deferred->resolve();
+    });
+}
+
+void WebTransportSendStreamSink::abort(JSDOMGlobalObject&, JSC::JSValue reason, DOMPromiseDeferred<void>&& promise)
+{
+    cancel(reason);
+    promise.resolve();
+}
+
+void WebTransportSendStreamSink::cancel(JSC::JSValue reason)
+{
     if (m_isCancelled)
         return;
     m_isCancelled = true;
+
+    // Reject an in-flight close() so its promise rejects rather than resolving after the FIN.
+    if (auto deferred = std::exchange(m_closeDeferred, nullptr)) {
+        deferred->rejectWithCallback([reason](JSDOMGlobalObject&) {
+            return reason;
+        });
+    }
 
     RefPtr transport = m_transport.get();
     if (!transport)
@@ -141,7 +201,7 @@ void WebTransportSendStreamSink::abort(JSDOMGlobalObject&, JSC::JSValue value, D
         return;
 
     std::optional<uint64_t> errorCode;
-    if (auto* jsWebTransportError = dynamicDowncast<JSWebTransportError>(value)) {
+    if (auto* jsWebTransportError = dynamicDowncast<JSWebTransportError>(reason)) {
         auto& webTransportError = jsWebTransportError->wrapped();
         if (auto webTransportErrorCode = webTransportError.streamErrorCode())
             errorCode = static_cast<uint64_t>(*webTransportErrorCode);

--- a/Source/WebCore/Modules/webtransport/WebTransportSendStreamSink.h
+++ b/Source/WebCore/Modules/webtransport/WebTransportSendStreamSink.h
@@ -35,10 +35,11 @@ namespace WebCore {
 struct WebTransportStreamIdentifierType;
 using WebTransportStreamIdentifier = ObjectIdentifier<WebTransportStreamIdentifierType>;
 
+class AbortSignal;
 class WebTransport;
 class WritableStream;
 
-class WebTransportSendStreamSink : public WritableStreamSink {
+class WebTransportSendStreamSink : public WritableStreamSink, public CanMakeWeakPtr<WebTransportSendStreamSink> {
 public:
     static Ref<WebTransportSendStreamSink> create(WebTransport& transport, WebTransportStreamIdentifier identifier) { return adoptRef(*new WebTransportSendStreamSink(transport, identifier)); }
     ~WebTransportSendStreamSink();
@@ -51,13 +52,20 @@ public:
 private:
     WEBCORE_EXPORT WebTransportSendStreamSink(WebTransport&, WebTransportStreamIdentifier);
 
+    void start(std::unique_ptr<WritableStreamDefaultController>&&) final;
     void write(ScriptExecutionContext&, JSC::JSValue, DOMPromiseDeferred<void>&&) final;
-    void close(JSDOMGlobalObject&) final;
+    void close(JSDOMGlobalObject&, DOMPromiseDeferred<void>&&) final;
     void abort(JSDOMGlobalObject&, JSC::JSValue, DOMPromiseDeferred<void>&&) final;
+
+    void sendFin(ScriptExecutionContext&);
+    void cancel(JSC::JSValue reason);
 
     const ThreadSafeWeakPtr<WebTransport> m_transport;
     const WebTransportStreamIdentifier m_identifier;
     WeakPtr<WritableStream> m_stream;
+    std::unique_ptr<DOMPromiseDeferred<void>> m_closeDeferred;
+    RefPtr<AbortSignal> m_abortSignal;
+    std::optional<uint32_t> m_abortAlgorithmIdentifier;
     bool m_isClosed { false };
     bool m_isCancelled { false };
 };


### PR DESCRIPTION
#### 8c35124fb5b593157dbfceece347bde970a87e05
<pre>
[WebTransport] WritableStream close() should reject when aborted mid-close
<a href="https://bugs.webkit.org/show_bug.cgi?id=320102">https://bugs.webkit.org/show_bug.cgi?id=320102</a>
<a href="https://rdar.apple.com/167645473">rdar://167645473</a>

Reviewed by NOBODY (OOPS!).

The WPT test streams-close.https.any &quot;Close and abort unidirectional stream&quot;
writes a chunk, calls writer.close() and then immediately writer.abort(e), and
expects close_promise, writer.closed, and abort_promise to all reject with e.
WebTransportSendStreamSink::close() was synchronous (the internal
WritableStreamSink.idl declared `undefined close()`), so the WritableStream
close algorithm resolved immediately and the subsequent abort() could not
preempt the in-flight close; close_promise resolved instead of rejecting.

Make the internal WritableStreamSink close() asynchronous (return
Promise&lt;undefined&gt;) and have WebTransportSendStreamSink observe the
WritableStreamDefaultController&apos;s abort signal, which fires synchronously during
writer.abort(). When an abort races an in-flight close(), the pending close is
rejected with the abort reason and the stream is reset (RESET_STREAM) rather
than sending FIN, matching the spec discussion at
<a href="https://github.com/whatwg/streams/issues/1203.">https://github.com/whatwg/streams/issues/1203.</a>

The stream reset is delivered after the already-buffered chunk, so the server
may observe it later than the WPT test&apos;s fixed 10ms delay allows. Update the WPT
test to poll the server for the stream close info (query_stream_close_info)
instead of a single fixed delay; this test change is being upstreamed as
web-platform-tests/wpt#61525. Un-skip streams-close.https.any, which was
previously skipped for an internal streams-hang timeout.

Whether a synchronous abort() should take precedence over an in-flight close()
like this is still under discussion (<a href="https://github.com/whatwg/streams/issues/1203)">https://github.com/whatwg/streams/issues/1203)</a>;
the code carries a FIXME and <a href="https://bugs.webkit.org/show_bug.cgi?id=320232">https://bugs.webkit.org/show_bug.cgi?id=320232</a>
tracks validating the approach.

* Source/WebCore/Modules/streams/WritableStreamSink.idl: close() now returns Promise&lt;undefined&gt;.
* Source/WebCore/Modules/streams/WritableStreamSink.h:
* Source/WebCore/Modules/streams/WritableStreamSink.cpp:
(WebCore::WritableStreamDefaultController::signal const): Expose the controller&apos;s abort signal.
(WebCore::WritableStreamSink::abortSignal const):
(WebCore::SimpleWritableStreamSink::close): Defined out-of-line so the DOMPromiseDeferred&lt;void&gt; definition is available.
* Source/WebCore/Modules/webtransport/WebTransportSendStreamSink.h:
* Source/WebCore/Modules/webtransport/WebTransportSendStreamSink.cpp:
(WebCore::WebTransportSendStreamSink::~WebTransportSendStreamSink): Remove the abort algorithm.
(WebCore::WebTransportSendStreamSink::start): Observe the controller&apos;s abort signal.
(WebCore::WebTransportSendStreamSink::close): Keep the close promise pending; defer the FIN.
(WebCore::WebTransportSendStreamSink::sendFin): Send the FIN and settle the close promise.
(WebCore::WebTransportSendStreamSink::abort):
(WebCore::WebTransportSendStreamSink::cancel): Reject a pending close and reset the stream.
* Source/WebCore/Modules/filesystem/FileSystemWritableFileStreamSink.h:
* Source/WebCore/Modules/filesystem/FileSystemWritableFileStreamSink.cpp:
(WebCore::FileSystemWritableFileStreamSink::close):
* Source/WebCore/Modules/mediastream/VideoTrackGenerator.h:
* Source/WebCore/Modules/mediastream/VideoTrackGenerator.cpp:
(WebCore::VideoTrackGenerator::Sink::close): Resolve the promise after ending the source on the main thread.
(WebCore::VideoTrackGenerator::Sink::abort): Ditto.
* Source/WebCore/Modules/webtransport/DatagramSink.h:
* Source/WebCore/Modules/webtransport/DatagramSink.cpp:
(WebCore::DatagramSink::close): Defined out-of-line so the DOMPromiseDeferred&lt;void&gt; definition is available.
* Source/WebCore/Modules/streams/StreamTransferUtilities.cpp:
* LayoutTests/imported/w3c/web-platform-tests/webtransport/resources/webtransport-test-helpers.sub.js:
(query_stream_close_info): Poll the server until the stream close info is recorded.
* LayoutTests/imported/w3c/web-platform-tests/webtransport/streams-close.https.any.js: Use query_stream_close_info.
* LayoutTests/imported/w3c/web-platform-tests/webtransport/streams-close.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webtransport/streams-close.https.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webtransport/streams-close.https.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webtransport/streams-close.https.any.worker-expected.txt:
* LayoutTests/TestExpectations: Un-skip streams-close.https.any.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8c35124fb5b593157dbfceece347bde970a87e05

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176676 "Failed to checkout and rebase branch from PR 70038") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50613 "Failed to checkout and rebase branch from PR 70038") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44405 "Failed to checkout and rebase branch from PR 70038") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186278 "Failed to checkout and rebase branch from PR 70038") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/139556 "Failed to checkout and rebase branch from PR 70038") | ⏳ 🛠 ios-apple 
| [❌ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178539 "Failed to checkout and rebase branch from PR 70038") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51906 "Failed to checkout and rebase branch from PR 70038") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50299 "Failed to checkout and rebase branch from PR 70038") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/186278 "Failed to checkout and rebase branch from PR 70038") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/139556 "Failed to checkout and rebase branch from PR 70038") | ⏳ 🛠 mac-apple 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179632 "Failed to checkout and rebase branch from PR 70038") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/51906 "Failed to checkout and rebase branch from PR 70038") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/168/builds/44405 "Failed to checkout and rebase branch from PR 70038") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/186278 "Failed to checkout and rebase branch from PR 70038") | | ⏳ 🛠 vision-apple 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/51906 "Failed to checkout and rebase branch from PR 70038") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/50299 "Failed to checkout and rebase branch from PR 70038") | [❌ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/5/builds/186278 "Failed to checkout and rebase branch from PR 70038") | | 
| [❌ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/168/builds/44405 "Failed to checkout and rebase branch from PR 70038") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/51906 "Failed to checkout and rebase branch from PR 70038") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/168/builds/44405 "Failed to checkout and rebase branch from PR 70038") | [❌ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34746 "Failed to checkout and rebase branch from PR 70038") | | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42353 "Failed to checkout and rebase branch from PR 70038") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/50299 "Failed to checkout and rebase branch from PR 70038") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188702 "Failed to checkout and rebase branch from PR 70038") | | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50280 "Failed to checkout and rebase branch from PR 70038") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/168/builds/44405 "Failed to checkout and rebase branch from PR 70038") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/188702 "Failed to checkout and rebase branch from PR 70038") | | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50963 "Failed to checkout and rebase branch from PR 70038") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/168/builds/44405 "Failed to checkout and rebase branch from PR 70038") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/188702 "Failed to checkout and rebase branch from PR 70038") | | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/160/builds/50963 "Failed to checkout and rebase branch from PR 70038") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123169 "Failed to checkout and rebase branch from PR 70038") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117299 "Failed to checkout and rebase branch from PR 70038") | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49468 "Failed to checkout and rebase branch from PR 70038") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/168/builds/44405 "Failed to checkout and rebase branch from PR 70038") | | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48867 "Failed to checkout and rebase branch from PR 70038") | | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49103 "Failed to checkout and rebase branch from PR 70038") | | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48928 "Failed to checkout and rebase branch from PR 70038") | | | | 
<!--EWS-Status-Bubble-End-->