### PR TITLE
Prioritize interaction rendering before timer dispatch

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -91,6 +91,12 @@ fast/events/watchos [ Skip ]
 fast/events/pointer/ios [ Skip ]
 fast/events/touch/ios [ Skip ]
 http/tests/fast/events/touch/ios [ Skip ]
+# webkit.org/b/319911 These tests assert that a pending rendering update runs before an already-due timer while
+# an earlier commit is still in flight. Rendering under that backpressure requires RemoteLayerTree with
+# AllowMultipleCommitLayerTreePending, which is disabled on iOS; Coordinated Graphics ports prioritize only
+# while the compositor is idle. Enabled on macOS WK2 in platform/mac-wk2/TestExpectations.
+fast/events/interaction-rendering-priority.html [ Skip ]
+fast/events/interaction-rendering-priority-microtask.html [ Skip ]
 fast/history/ios [ Skip ]
 fast/scrolling/gtk [ Skip ]
 fast/scrolling/ios [ Skip ]

--- a/LayoutTests/fast/events/interaction-rendering-priority-expected.txt
+++ b/LayoutTests/fast/events/interaction-rendering-priority-expected.txt
@@ -1,0 +1,10 @@
+Tests that a pending interaction rendering update runs before a DOM timer.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS order.join(',') is "raf,first immediate timer,second immediate timer,delayed timer"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Choose

--- a/LayoutTests/fast/events/interaction-rendering-priority-microtask-expected.txt
+++ b/LayoutTests/fast/events/interaction-rendering-priority-microtask-expected.txt
@@ -1,0 +1,10 @@
+Tests that rendering requested by an interaction microtask runs before a DOM timer.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS order.join(',') is "raf,timer"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Click

--- a/LayoutTests/fast/events/interaction-rendering-priority-microtask.html
+++ b/LayoutTests/fast/events/interaction-rendering-priority-microtask.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useRemoteLayerTree=true ] -->
+<html>
+<head>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+<button id="target">Click</button>
+<script>
+
+'use strict';
+
+description('Tests that rendering requested by an interaction microtask runs before a DOM timer.');
+window.jsTestIsAsync = true;
+let order;
+
+function busyWait(milliseconds)
+{
+    const endTime = performance.now() + milliseconds;
+    while (performance.now() < endTime) { }
+}
+
+async function runTest()
+{
+    if (!window.eventSender || !window.internals) {
+        testFailed('This test requires eventSender and internals.');
+        finishJSTest();
+        return;
+    }
+
+    await testRunner.displayAndTrackRepaints();
+    internals.setPageVisibility(true);
+    internals.setPageIsFocusedAndActive(true);
+
+    order = [];
+    target.addEventListener('click', () => {
+        setTimeout(() => {
+            order.push('timer');
+            shouldBeEqualToString('order.join(\',\')', 'raf,timer');
+            finishJSTest();
+        }, 0);
+
+        queueMicrotask(() => {
+            target.style.backgroundColor = 'green';
+            requestAnimationFrame(() => order.push('raf'));
+
+            // Make the timer eligible before the pending rendering update runs.
+            busyWait((internals.timeToNextRenderingUpdate() || 16) + internals.preferredRenderingUpdateInterval() + 2);
+        });
+    }, { once: true });
+
+    await eventSender.asyncMouseMoveTo(target.offsetLeft + target.offsetWidth / 2, target.offsetTop + target.offsetHeight / 2);
+    await eventSender.asyncMouseDown();
+    await eventSender.asyncMouseUp();
+}
+
+runTest();
+
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/events/interaction-rendering-priority.html
+++ b/LayoutTests/fast/events/interaction-rendering-priority.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useRemoteLayerTree=true ] -->
+<html>
+<head>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+<label id="target"><input id="choice" type="radio" name="choice">Choose</label>
+<script>
+
+'use strict';
+
+description('Tests that a pending interaction rendering update runs before a DOM timer.');
+window.jsTestIsAsync = true;
+let order;
+
+function busyWait(milliseconds)
+{
+    const endTime = performance.now() + milliseconds;
+    while (performance.now() < endTime) { }
+}
+
+async function runTest()
+{
+    if (!window.eventSender || !window.internals) {
+        testFailed('This test requires eventSender and internals.');
+        finishJSTest();
+        return;
+    }
+
+    await testRunner.displayAndTrackRepaints();
+    internals.setPageVisibility(true);
+    internals.setPageIsFocusedAndActive(true);
+
+    order = [];
+    choice.addEventListener('click', () => {
+        target.style.backgroundColor = 'green';
+        // Create the delayed timer first to verify that prioritizing rendering does not
+        // disturb the timers' eligibility order.
+        setTimeout(() => {
+            order.push('delayed timer');
+            shouldBeEqualToString('order.join(\',\')', 'raf,first immediate timer,second immediate timer,delayed timer');
+            finishJSTest();
+        }, 10);
+        setTimeout(() => order.push('first immediate timer'), 0);
+        setTimeout(() => order.push('second immediate timer'), 0);
+        requestAnimationFrame(() => order.push('raf'));
+
+        // Match the manual repro by crossing at least two rendering opportunities.
+        busyWait((internals.timeToNextRenderingUpdate() || 16) + internals.preferredRenderingUpdateInterval() + 2);
+    });
+
+    await eventSender.asyncMouseMoveTo(choice.offsetLeft + choice.offsetWidth / 2, choice.offsetTop + choice.offsetHeight / 2);
+    await eventSender.asyncMouseDown();
+    await eventSender.asyncMouseUp();
+}
+
+runTest();
+
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -161,6 +161,12 @@ fast/repaint/placeholder-after-caps-lock-hidden.html [ Pass ]
 
 fast/events/inactive-window-no-mouse-event.html [ Pass ]
 
+# webkit.org/b/319911 macOS WK2 uses the RemoteLayerTree drawing area with AllowMultipleCommitLayerTreePending
+# enabled, so a prioritized interaction rendering update can run while an earlier commit is still in flight;
+# skipped elsewhere in LayoutTests/TestExpectations.
+fast/events/interaction-rendering-priority.html [ Pass ]
+fast/events/interaction-rendering-priority-microtask.html [ Pass ]
+
 fast/animation/request-animation-frame-in-two-pages.html [ Pass ]
 
 fast/forms/file/entries-api/image-transcode-open-panel.html [ Pass ]

--- a/Source/WebCore/dom/EventDispatcher.cpp
+++ b/Source/WebCore/dom/EventDispatcher.cpp
@@ -27,8 +27,10 @@
 #include "EventDispatcher.h"
 
 #include "CompositionEvent.h"
+#include "DocumentPage.h"
 #include "DocumentView.h"
 #include "EventContext.h"
+#include "EventLoop.h"
 #include "EventNames.h"
 #include "EventPath.h"
 #include "FrameDestructionObserverInlines.h"
@@ -41,6 +43,7 @@
 #include "Logging.h"
 #include "MouseEvent.h"
 #include "NodeDocument.h"
+#include "Page.h"
 #include "ScopedEventQueue.h"
 #include "ScriptDisallowedScope.h"
 #include "Settings.h"
@@ -177,6 +180,28 @@ static void resetAfterDispatchInShadowTree(Event& event)
     // FIXME: We should also clear the event's touch target list.
 }
 
+static bool isDiscreteUserInteractionEventType(EventType type)
+{
+    // Deliberately narrower than EventCategory::EventTimingEligible: hover-adjacent and continuous
+    // events (enter/leave/over/out, drag, composition) should not spend rendering priority.
+    switch (type) {
+    case EventType::auxclick:
+    case EventType::click:
+    case EventType::contextmenu:
+    case EventType::dblclick:
+    case EventType::keydown:
+    case EventType::keypress:
+    case EventType::keyup:
+    case EventType::mousedown:
+    case EventType::mouseup:
+    case EventType::pointerdown:
+    case EventType::pointerup:
+        return true;
+    default:
+        return false;
+    }
+}
+
 void EventDispatcher::dispatchEvent(Node& node, Event& event)
 {
     ASSERT_WITH_SECURITY_IMPLICATION(ScriptDisallowedScope::InMainThread::isEventDispatchAllowedInSubtree(node));
@@ -189,6 +214,18 @@ void EventDispatcher::dispatchEvent(Node& node, Event& event)
 
     auto typeInfo = eventNames().typeInfoForEvent(event.type());
     auto listenerCounts = eventListenerCounts(document, event);
+
+    bool shouldPrioritizeInteractionRendering = document->page() && event.isTrusted() && isDiscreteUserInteractionEventType(typeInfo.type());
+    auto prioritizeInteractionRendering = makeScopeExit([&] {
+        if (!shouldPrioritizeInteractionRendering)
+            return;
+        protect(document->eventLoop())->runAtEndOfMicrotaskCheckpoint([weakDocument = WeakPtr<Document, WeakPtrImplWithEventTargetData> { document }] {
+            if (RefPtr document = weakDocument.get()) {
+                if (RefPtr page = document->page())
+                    page->prioritizeRenderingUpdateAfterInteraction(*document);
+            }
+        });
+    });
 
     RefPtr window = document->window();
     std::optional<PerformanceEventTimingCandidate> pendingEventTiming;

--- a/Source/WebCore/page/ChromeClient.h
+++ b/Source/WebCore/page/ChromeClient.h
@@ -482,6 +482,8 @@ public:
     virtual bool shouldTriggerRenderingUpdate(unsigned) const { return true; }
     // Makes a rendering update happen soon, typically in the current runloop.
     virtual void triggerRenderingUpdate() = 0;
+    // Prioritize an already scheduled rendering update over other work in the current runloop cycle.
+    virtual void prioritizeRenderingUpdate() { }
     // Schedule a rendering update that coordinates with display refresh. Returns true if scheduled. (This is only used by SVGImageChromeClient.)
     virtual bool scheduleRenderingUpdate() { return false; }
     virtual void renderingUpdateFramesPerSecondChanged() { }

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -2181,6 +2181,22 @@ std::optional<Seconds> Page::timeToNextRenderingUpdateForTesting() const
     return *nextUpdate - MonotonicTime::now();
 }
 
+void Page::prioritizeRenderingUpdateAfterInteraction(Document& document)
+{
+    if (!document.isFullyActive() || document.page() != this)
+        return;
+    if (!isVisibleAndActive() || chrome().client().layerTreeStateIsFrozen())
+        return;
+    if (!m_renderingUpdateIsScheduled)
+        return;
+
+    auto nextTimerFireTime = protect(document.windowEventLoop())->nextTimerFireTime();
+    if (!nextTimerFireTime || *nextTimerFireTime > MonotonicTime::now())
+        return;
+
+    chrome().client().prioritizeRenderingUpdate();
+}
+
 void Page::didScheduleRenderingUpdate()
 {
 #if ENABLE(ASYNC_SCROLLING)

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -843,6 +843,7 @@ public:
 
     // Schedule a rendering update that coordinates with display refresh.
     WEBCORE_EXPORT void scheduleRenderingUpdate(OptionSet<RenderingUpdateStep> requestedSteps);
+    void prioritizeRenderingUpdateAfterInteraction(Document&);
     void didScheduleRenderingUpdate();
     // Trigger a rendering update in the current runloop. Only used for testing.
     void triggerRenderingUpdateForTesting();

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h
@@ -221,6 +221,7 @@ private:
     virtual void setPreferredFramesPerSecond(IPC::Connection&, WebCore::FramesPerSecond) { }
 
     void notifyPendingCommitLayerTree(IPC::Connection&, std::optional<TransactionID>);
+    void notifyPendingInteractionCommitLayerTree(IPC::Connection&, TransactionID);
     void notifyFlushingLayerTree(IPC::Connection&, TransactionID);
     void commitLayerTree(IPC::Connection&, const RemoteLayerTreeCommitBundle&, HashMap<ImageBufferSetIdentifier, std::unique_ptr<BufferSetBackendHandle>>&&);
     void commitLayerTreeTransaction(IPC::Connection&, const RemoteLayerTreeTransaction&, const RemoteScrollingCoordinatorTransaction&, const std::optional<MainFrameData>&, const PageData&, const TransactionID&);

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.messages.in
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.messages.in
@@ -28,6 +28,7 @@
 messages -> RemoteLayerTreeDrawingAreaProxy : DrawingAreaProxy {
     void SetPreferredFramesPerSecond(unsigned preferredFramesPerSecond)
     void NotifyPendingCommitLayerTree(std::optional<WebKit::TransactionID> transactionID) CanDispatchOutOfOrder
+    void NotifyPendingInteractionCommitLayerTree(WebKit::TransactionID transactionID) CanDispatchOutOfOrder
     void NotifyFlushingLayerTree(WebKit::TransactionID transactionID) CanDispatchOutOfOrder
     void CommitLayerTree(struct WebKit::RemoteLayerTreeCommitBundle bundle, HashMap<WebKit::ImageBufferSetIdentifier, std::unique_ptr<WebKit::BufferSetBackendHandle>> handlesMap) CanDispatchOutOfOrder
     void AsyncSetLayerContents(WebCore::PlatformLayerIdentifier layer, WebKit::RemoteLayerBackingStoreProperties properties)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
@@ -315,6 +315,28 @@ void RemoteLayerTreeDrawingAreaProxy::notifyPendingCommitLayerTree(IPC::Connecti
     }
 }
 
+void RemoteLayerTreeDrawingAreaProxy::notifyPendingInteractionCommitLayerTree(IPC::Connection& connection, TransactionID transactionID)
+{
+    ProcessState& state = processStateForConnection(connection);
+
+    MESSAGE_CHECK_BASE(allowMultipleCommitLayerTreePending(), connection);
+
+    // Consume a display refresh grant that is already in flight, or allocate the one extra slot supported by the multiple-pending-commit path.
+    if (!state.pendingCommits.isEmpty() && state.pendingCommits[0].pendingMessage == PendingCommitMessage::NotifyPendingCommitLayerTree) {
+        MESSAGE_CHECK_BASE(state.pendingCommits[0].transactionID == transactionID, connection);
+        state.pendingCommits[0].pendingMessage = PendingCommitMessage::NotifyFlushingLayerTree;
+        return;
+    }
+
+    MESSAGE_CHECK_BASE(state.pendingCommits.size() <= 1, connection);
+    if (!state.pendingCommits.isEmpty())
+        MESSAGE_CHECK_BASE(state.pendingCommits[0].pendingMessage == PendingCommitMessage::CommitLayerTree, connection);
+    MESSAGE_CHECK_BASE(state.nextLayerTreeTransactionID == transactionID, connection);
+
+    state.pendingCommits.insert(0, { transactionID, PendingCommitMessage::NotifyFlushingLayerTree, CommitDelayState::Pending });
+    state.nextLayerTreeTransactionID.increment();
+}
+
 void RemoteLayerTreeDrawingAreaProxy::notifyFlushingLayerTree(IPC::Connection& connection, TransactionID transactionID)
 {
     ProcessState& state = processStateForConnection(connection);
@@ -817,7 +839,8 @@ IPC::Error RemoteLayerTreeDrawingAreaProxy::didRefreshDisplay(ProcessState& stat
         return IPC::Error::NoError;
     }
 
-    state.pendingCommits.insert(0, { state.nextLayerTreeTransactionID, PendingCommitMessage::NotifyPendingCommitLayerTree, CommitDelayState::Pending });
+    auto transactionID = state.nextLayerTreeTransactionID;
+    state.pendingCommits.insert(0, { transactionID, PendingCommitMessage::NotifyPendingCommitLayerTree, CommitDelayState::Pending });
     state.nextLayerTreeTransactionID.increment();
 
     LOG_WITH_STREAM(RemoteLayerTree, stream << "RemoteLayerTreeDrawingAreaProxy::didRefreshDisplay new state " << state.pendingCommits);
@@ -830,7 +853,7 @@ IPC::Error RemoteLayerTreeDrawingAreaProxy::didRefreshDisplay(ProcessState& stat
     // Waiting for CA to commit is insufficient, because the render server can still be
     // using our backing store. We can improve this by waiting for the render server to commit
     // if we find API to do so, but for now we will make extra buffers if need be.
-    return connection.send(Messages::DrawingArea::DisplayDidRefresh(MonotonicTime::now()), identifier());
+    return connection.send(Messages::DrawingArea::DisplayDidRefreshForTransaction(MonotonicTime::now(), transactionID), identifier());
 }
 
 void RemoteLayerTreeDrawingAreaProxy::didRefreshDisplay(IPC::Connection* connection)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -1330,6 +1330,16 @@ void WebChromeClient::triggerRenderingUpdate()
         drawingArea->triggerRenderingUpdate();
 }
 
+void WebChromeClient::prioritizeRenderingUpdate()
+{
+    RefPtr page = m_page.get();
+    if (!page)
+        return;
+
+    if (RefPtr drawingArea = page->drawingArea())
+        drawingArea->prioritizeRenderingUpdate();
+}
+
 bool WebChromeClient::scheduleRenderingUpdate()
 {
     RefPtr page = m_page.get();

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
@@ -246,6 +246,7 @@ private:
     void setNeedsOneShotDrawingSynchronization() final;
     bool shouldTriggerRenderingUpdate(unsigned rescheduledRenderingUpdateCount) const final;
     void triggerRenderingUpdate() final;
+    void prioritizeRenderingUpdate() final;
     bool scheduleRenderingUpdate() final;
     void renderingUpdateFramesPerSecondChanged() final;
     unsigned remoteImagesCountForTesting() const final;

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphicsGLib.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphicsGLib.cpp
@@ -242,6 +242,14 @@ void DrawingAreaCoordinatedGraphics::triggerRenderingUpdate()
     m_renderer->scheduleRenderingUpdate();
 }
 
+void DrawingAreaCoordinatedGraphics::prioritizeRenderingUpdate()
+{
+    if (!m_renderer)
+        return;
+
+    m_renderer->prioritizeRenderingUpdate();
+}
+
 RefPtr<DisplayRefreshMonitor> DrawingAreaCoordinatedGraphics::createDisplayRefreshMonitor(PlatformDisplayID displayID)
 {
     return WebDisplayRefreshMonitor::create(displayID);

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphicsGLib.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphicsGLib.h
@@ -84,6 +84,7 @@ private:
     WebCore::GraphicsLayerFactory* graphicsLayerFactory() override;
     void setRootCompositingLayer(WebCore::Frame&, WebCore::GraphicsLayer*) override;
     void triggerRenderingUpdate() override;
+    void prioritizeRenderingUpdate() override;
 
     RefPtr<WebCore::DisplayRefreshMonitor> createDisplayRefreshMonitor(WebCore::PlatformDisplayID) override;
 

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/FrameRenderer.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/FrameRenderer.cpp
@@ -35,6 +35,7 @@ namespace WebKit {
 using namespace WebCore;
 
 FrameRenderer::FrameRenderer()
+    : m_prioritizedRenderingUpdateTimer([this] { prioritizedRenderingUpdateTimerFired(); })
 {
     m_renderingUpdateRunLoopObserver = makeUnique<RunLoopObserver>(RunLoopObserver::WellKnownOrder::RenderingUpdate, [this] {
         renderingUpdateRunLoopObserverFired();
@@ -81,6 +82,43 @@ void FrameRenderer::renderingUpdateRunLoopObserverFired()
 
     if (canUpdateRendering())
         updateRendering();
+}
+
+void FrameRenderer::prioritizeRenderingUpdate()
+{
+    if (m_layerTreeStateIsFrozen || m_isSuspended || m_isUpdatingRendering)
+        return;
+
+    // Interaction priority only reorders a rendering update that is already pending; it must never create one.
+    if (!m_renderingUpdateRunLoopObserver->isScheduled())
+        return;
+
+    // A new frame cannot be produced while the compositor is still rendering the previous one, so a pending
+    // update cannot run ahead of the already-due timers; keep the existing scheduling.
+    if (!canUpdateRendering())
+        return;
+
+    // All main thread timers, including the event loop's DOM timers, share the ThreadTimers heap and fire
+    // in fire-time order. Arming a timer with a far-past fire time runs the pending update ahead of any
+    // already-due timer without stopping, holding, or reordering the timers themselves. The run loop
+    // observer stays scheduled as the ordinary fallback in case the update cannot run when the timer fires.
+    // FIXME: Add a Timer interface for running ahead of all already-due timers instead of encoding
+    // priority as a far-past fire time.
+    m_prioritizedRenderingUpdateTimer.startOneShot(-1_h);
+    WindowEventLoop::breakToAllowRenderingUpdate();
+}
+
+void FrameRenderer::prioritizedRenderingUpdateTimerFired()
+{
+    // The update already ran or was invalidated through the ordinary paths since prioritization.
+    if (!m_renderingUpdateRunLoopObserver->isScheduled())
+        return;
+
+    // Leave the pending update to the still-scheduled run loop observer if it cannot run right now.
+    if (m_layerTreeStateIsFrozen || m_isSuspended || m_isUpdatingRendering || !canUpdateRendering())
+        return;
+
+    updateRendering();
 }
 
 void FrameRenderer::setLayerTreeStateIsFrozen(bool isFrozen)

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/FrameRenderer.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/FrameRenderer.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #if USE(COORDINATED_GRAPHICS)
+#include <WebCore/Timer.h>
 #include <wtf/CompletionHandler.h>
 
 namespace WebCore {
@@ -82,6 +83,7 @@ public:
 
     void setLayerTreeStateIsFrozen(bool);
     void updateRenderingWithForcedRepaintAsync(CompletionHandler<void()>&&);
+    void prioritizeRenderingUpdate();
 
 protected:
     FrameRenderer();
@@ -92,8 +94,10 @@ protected:
     virtual void scheduleRenderingUpdateRunLoopObserver();
     void invalidateRenderingUpdateRunLoopObserver();
     void renderingUpdateRunLoopObserverFired();
+    void prioritizedRenderingUpdateTimerFired();
 
     std::unique_ptr<WebCore::RunLoopObserver> m_renderingUpdateRunLoopObserver;
+    WebCore::Timer m_prioritizedRenderingUpdateTimer;
     bool m_layerTreeStateIsFrozen { false };
     bool m_isSuspended { false };
     bool m_isUpdatingRendering { false };

--- a/Source/WebKit/WebProcess/WebPage/DrawingArea.h
+++ b/Source/WebKit/WebProcess/WebPage/DrawingArea.h
@@ -29,6 +29,7 @@
 #include "DrawingAreaInfo.h"
 #include "LayerTreeContext.h"
 #include "MessageReceiver.h"
+#include "TransactionID.h"
 #include "WebPage.h"
 #include <WebCore/ActivityState.h>
 #include <WebCore/DisplayRefreshMonitorFactory.h>
@@ -138,6 +139,7 @@ public:
 
     // Cause a rendering update to happen as soon as possible.
     virtual void triggerRenderingUpdate() = 0;
+    virtual void prioritizeRenderingUpdate() { }
     virtual bool scheduleRenderingUpdate() { return false; }
     virtual void renderingUpdateFramesPerSecondChanged() { }
 
@@ -235,6 +237,7 @@ private:
 
     virtual void setDeviceScaleFactor(float, CompletionHandler<void()>&& completionHandler) { completionHandler(); }
     virtual void displayDidRefresh(MonotonicTime) { }
+    virtual void displayDidRefreshForTransaction(MonotonicTime start, TransactionID) { displayDidRefresh(start); }
 
     // DisplayRefreshMonitorFactory.
     RefPtr<WebCore::DisplayRefreshMonitor> createDisplayRefreshMonitor(WebCore::PlatformDisplayID) override;

--- a/Source/WebKit/WebProcess/WebPage/DrawingArea.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/DrawingArea.messages.in
@@ -36,6 +36,7 @@ messages -> DrawingArea {
 
     SetDeviceScaleFactor(float deviceScaleFactor) -> ()
     DisplayDidRefresh(MonotonicTime start)
+    DisplayDidRefreshForTransaction(MonotonicTime start, WebKit::TransactionID transactionID)
 
 #if PLATFORM(COCOA)
     UpdateGeometry(WebCore::IntSize viewSize, bool flushSynchronously, MachSendRight fencePort) -> ()

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.h
@@ -87,6 +87,7 @@ private:
     void addRootFrame(WebCore::FrameIdentifier) final;
     void removeRootFrame(WebCore::FrameIdentifier) final;
     void triggerRenderingUpdate() final;
+    void prioritizeRenderingUpdate() final;
     bool scheduleRenderingUpdate() final;
     void renderingUpdateFramesPerSecondChanged() final;
     void attachViewOverlayGraphicsLayer(WebCore::FrameIdentifier, WebCore::GraphicsLayer*) final;
@@ -121,6 +122,7 @@ private:
     void setExposedContentRect(const WebCore::FloatRect&) final;
 
     void displayDidRefresh(MonotonicTime) final;
+    void displayDidRefreshForTransaction(MonotonicTime, TransactionID) final;
 
     void setDeviceScaleFactor(float, CompletionHandler<void()>&&) final;
 
@@ -186,6 +188,9 @@ private:
 
     bool m_waitingForBackingStoreSwap { false };
     bool m_deferredRenderingUpdateWhileWaitingForBackingStoreSwap { false };
+    bool m_shouldInitiateInteractionPriorityCommit { false };
+    std::optional<TransactionID> m_interactionPriorityCommitTransactionID;
+    unsigned m_outstandingCommitCount { 0 };
 
     const Ref<WorkQueue> m_commitQueue;
     RefPtr<BackingStoreFlusher> m_backingStoreFlusher;

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm
@@ -54,6 +54,7 @@
 #import <WebCore/ScrollView.h>
 #import <WebCore/Settings.h>
 #import <WebCore/TiledBacking.h>
+#import <WebCore/WindowEventLoop.h>
 #import <pal/spi/cocoa/QuartzCoreSPI.h>
 #import <wtf/BlockPtr.h>
 #import <wtf/SetForScope.h>
@@ -316,14 +317,51 @@ void RemoteLayerTreeDrawingArea::triggerRenderingUpdate()
     startRenderingUpdateTimer();
 }
 
+void RemoteLayerTreeDrawingArea::prioritizeRenderingUpdate()
+{
+    if (m_isRenderingSuspended)
+        return;
+
+    // Interaction priority only reorders a rendering update that is already pending; it must never
+    // create one. A pending update takes one of four forms: waiting for the display link handoff
+    // (m_isScheduled), waiting for the pacing timer (m_scheduleRenderingTimer), armed to run
+    // (m_updateRenderingTimer), or deferred while a previous commit awaits its backing store swap.
+    if (!m_isScheduled && !m_scheduleRenderingTimer.isActive() && !m_updateRenderingTimer.isActive() && !m_deferredRenderingUpdateWhileWaitingForBackingStoreSwap)
+        return;
+
+    if (m_waitingForBackingStoreSwap) {
+        // The existing multiple-pending-commit path makes one additional backing store available while the
+        // previous commit flushes. Only use it while at most one commit awaits its backing store flush, so
+        // the UI process has consumed every earlier CommitLayerTree by the time the new transaction arrives.
+        RefPtr page = m_webPage->corePage();
+        if (m_interactionPriorityCommitTransactionID || m_outstandingCommitCount > 1 || !page || !page->settings().allowMultipleCommitLayerTreePending())
+            return;
+        m_shouldInitiateInteractionPriorityCommit = true;
+        m_deferredRenderingUpdateWhileWaitingForBackingStoreSwap = false;
+    }
+
+    m_isScheduled = false;
+    m_scheduleRenderingTimer.stop();
+
+    // All main thread timers, including the event loop's DOM timers, share the ThreadTimers heap and fire
+    // in fire-time order. Re-arming the pending update with a far-past fire time runs it ahead of any
+    // already-due timer without stopping, holding, or reordering the timers themselves.
+    // FIXME: Add a Timer interface for running ahead of all already-due timers instead of encoding
+    // priority as a far-past fire time.
+    m_updateRenderingTimer.startOneShot(-1_h);
+    WindowEventLoop::breakToAllowRenderingUpdate();
+}
+
 void RemoteLayerTreeDrawingArea::updateRendering()
 {
+    auto shouldInitiateInteractionPriorityCommit = std::exchange(m_shouldInitiateInteractionPriorityCommit, false) && m_waitingForBackingStoreSwap;
+
     if (m_isRenderingSuspended) {
         m_hasDeferredRenderingUpdate = true;
         return;
     }
 
-    if (m_waitingForBackingStoreSwap) {
+    if (m_waitingForBackingStoreSwap && !shouldInitiateInteractionPriorityCommit) {
         m_deferredRenderingUpdateWhileWaitingForBackingStoreSwap = true;
         return;
     }
@@ -338,6 +376,10 @@ void RemoteLayerTreeDrawingArea::updateRendering()
     Ref webPage = m_webPage.get();
     if (!webPage->hasRootFrames())
         return;
+
+    auto transactionID = takeNextTransactionID();
+    if (shouldInitiateInteractionPriorityCommit)
+        m_interactionPriorityCommitTransactionID = transactionID;
 
     scaleViewToFitDocumentIfNeeded();
 
@@ -366,8 +408,10 @@ void RemoteLayerTreeDrawingArea::updateRendering()
     backingStoreCollection->willFlushLayers();
 
     // FIXME: Minimize these transactions if nothing changed.
-    auto transactionID = takeNextTransactionID();
-    send(Messages::RemoteLayerTreeDrawingAreaProxy::NotifyPendingCommitLayerTree(transactionID));
+    if (shouldInitiateInteractionPriorityCommit)
+        send(Messages::RemoteLayerTreeDrawingAreaProxy::NotifyPendingInteractionCommitLayerTree(transactionID));
+    else
+        send(Messages::RemoteLayerTreeDrawingAreaProxy::NotifyPendingCommitLayerTree(transactionID));
 
     auto transactions = WTF::map(m_rootLayers, [&](RootLayerInfo& rootLayer) -> RemoteLayerTreeCommitBundle::RootFrameData {
         backingStoreCollection->willBuildTransaction();
@@ -424,6 +468,7 @@ void RemoteLayerTreeDrawingArea::updateRendering()
     webPage->didUpdateRendering(didUpdateRenderingFlags);
 
     m_backingStoreFlusher->markHasPendingFlush();
+    m_outstandingCommitCount++;
 
     send(Messages::RemoteLayerTreeDrawingAreaProxy::NotifyFlushingLayerTree(transactionID));
 
@@ -444,8 +489,20 @@ void RemoteLayerTreeDrawingArea::updateRendering()
 
 void RemoteLayerTreeDrawingArea::didCompleteRenderingUpdateDisplayFlush(bool flushSucceeded)
 {
+    ASSERT(m_outstandingCommitCount);
+    if (m_outstandingCommitCount)
+        m_outstandingCommitCount--;
+
     protect(m_webPage)->didFlushLayerTreeAtTime(MonotonicTime::now(), flushSucceeded);
     didCompleteRenderingUpdateDisplay();
+}
+
+void RemoteLayerTreeDrawingArea::displayDidRefreshForTransaction(MonotonicTime start, TransactionID transactionID)
+{
+    // The interaction update may have consumed a display refresh grant that was already in flight.
+    if (m_interactionPriorityCommitTransactionID == transactionID)
+        return;
+    displayDidRefresh(start);
 }
 
 void RemoteLayerTreeDrawingArea::displayDidRefresh(MonotonicTime start)
@@ -454,6 +511,7 @@ void RemoteLayerTreeDrawingArea::displayDidRefresh(MonotonicTime start)
     // the callers of that function are not strictly paired.
 
     auto wasWaitingForBackingStoreSwap = std::exchange(m_waitingForBackingStoreSwap, false);
+    m_interactionPriorityCommitTransactionID = std::nullopt;
 
     if (!WebProcess::singleton().shouldUseRemoteRenderingFor(WebCore::RenderingPurpose::DOM)) {
         // This empty transaction serves to trigger CA's garbage collection of IOSurfaces. See <rdar://problem/16110687>
@@ -573,10 +631,10 @@ bool RemoteLayerTreeDrawingArea::scheduleRenderingUpdate()
             return true;
 
         callOnMainRunLoop([self = WeakPtr { this }] () {
-            if (self) {
-                self->m_isScheduled = false;
-                self->triggerRenderingUpdate();
-            }
+            if (!self || !self->m_isScheduled)
+                return;
+            self->m_isScheduled = false;
+            self->triggerRenderingUpdate();
         });
     } else
         m_scheduleRenderingTimer.startOneShot(m_preferredRenderingUpdateInterval);


### PR DESCRIPTION
#### 742c90add51367f8087d68dd7ea2d45712526b8d
<pre>
Prioritize interaction rendering before timer dispatch
<a href="https://bugs.webkit.org/show_bug.cgi?id=319911">https://bugs.webkit.org/show_bug.cgi?id=319911</a>

Reviewed by NOBODY (OOPS!).

A trusted interaction may schedule a rendering update while a DOM timer is already
due. Running the timer first can delay the interaction&apos;s animation frame and visual
response by one display refresh.

At the end of a trusted discrete interaction event&apos;s microtask checkpoint, check
whether the page has both a pending rendering update and a due event-loop timer. If
so, ask the drawing area to prioritize the pending update, which it does by arming a
timer for the update with a far-past fire time; because DOM timers and drawing area
timers share the ThreadTimers heap and fire in fire-time order, the pending update
runs before any already-due timer without stopping, holding, or reordering the timers
themselves.

When RemoteLayerTree is waiting for a backing-store swap, allow the interaction update
to initiate at most one concurrent commit on configurations that support multiple
pending commits, and only while at most one earlier commit still awaits its backing
store flush so the UI process pending-commit checks always admit the new transaction.
Associate display-refresh grants with transaction IDs so each grant authorizes only
its intended transaction.

Eligibility is limited to discrete pointer, mouse, click, and key events rather than
the full set of Event Timing eligible events, and priority is only spent when an
event-loop timer is already due, so ordinary rendering scheduling is unchanged.

The priority path is implemented for RemoteLayerTree and for the Coordinated Graphics
frame renderers. Drawing areas that do not override prioritizeRenderingUpdate() keep
their existing scheduling. iOS, where AllowMultipleCommitLayerTreePending is disabled,
and Coordinated Graphics, whose compositor renders one frame at a time, spend priority
only when no earlier commit is still in flight. The tests therefore run on macOS WK2
only.

Tests: fast/events/interaction-rendering-priority-microtask.html
       fast/events/interaction-rendering-priority.html

* LayoutTests/TestExpectations: Skipped the interaction rendering priority tests on ports that cannot
run the prioritized update while an earlier commit is still in flight.
* LayoutTests/fast/events/interaction-rendering-priority-expected.txt: Added expected ordering.
* LayoutTests/fast/events/interaction-rendering-priority-microtask-expected.txt: Added expected ordering.
* LayoutTests/fast/events/interaction-rendering-priority-microtask.html: Added microtask and timer FIFO coverage.
* LayoutTests/fast/events/interaction-rendering-priority.html: Added trusted interaction ordering coverage.
* LayoutTests/platform/mac-wk2/TestExpectations: Enabled the interaction rendering priority tests.
* Source/WebCore/dom/EventDispatcher.cpp:
(WebCore::isDiscreteUserInteractionEventType): Limit eligibility to discrete interaction events.
(WebCore::EventDispatcher::dispatchEvent): Request rendering priority after the interaction&apos;s microtask checkpoint.
* Source/WebCore/page/ChromeClient.h:
(WebCore::ChromeClient::prioritizeRenderingUpdate): Added a default no-op hook for prioritizing an
already scheduled rendering update within the current run loop cycle.
* Source/WebCore/page/Page.cpp:
(WebCore::Page::prioritizeRenderingUpdateAfterInteraction): Admit only visible, active pages with a
pending rendering update and a due event-loop timer.
* Source/WebCore/page/Page.h: Declared prioritizeRenderingUpdateAfterInteraction().
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h: Declared the handler for
the interaction pending-commit message.
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.messages.in: Added
NotifyPendingInteractionCommitLayerTree.
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm:
(WebKit::RemoteLayerTreeDrawingAreaProxy::notifyPendingInteractionCommitLayerTree): Consume an in-flight
display refresh grant or allocate the one extra pending commit slot for the interaction transaction.
(WebKit::RemoteLayerTreeDrawingAreaProxy::didRefreshDisplay): Tag each display refresh grant with the
transaction ID it authorizes.
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::prioritizeRenderingUpdate): Forward the priority request to the drawing area.
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h: Declared the ChromeClient override.
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphicsGLib.cpp:
(WebKit::DrawingAreaCoordinatedGraphics::prioritizeRenderingUpdate): Forward to the frame renderer.
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphicsGLib.h:
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/FrameRenderer.cpp:
(WebKit::FrameRenderer::prioritizeRenderingUpdate): Promote a pending update ahead of already-due timers
in the ThreadTimers heap when the compositor is not rendering the previous frame.
(WebKit::FrameRenderer::prioritizedRenderingUpdateTimerFired): Run the pending update, leaving the still
scheduled run loop observer as the ordinary fallback when it cannot run.
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/FrameRenderer.h:
* Source/WebKit/WebProcess/WebPage/DrawingArea.h:
(WebKit::DrawingArea::prioritizeRenderingUpdate): Added a default no-op for drawing areas without a
priority path.
(WebKit::DrawingArea::displayDidRefreshForTransaction): Fall back to the untagged displayDidRefresh()
for drawing areas that do not track per-transaction grants.
* Source/WebKit/WebProcess/WebPage/DrawingArea.messages.in: Added DisplayDidRefreshForTransaction
carrying the transaction ID the grant authorizes.
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.h: Declared the
interaction-priority commit state and the outstanding-commit count.
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm:
(WebKit::RemoteLayerTreeDrawingArea::prioritizeRenderingUpdate): Promote the pending update ahead of
already-due timers in the ThreadTimers heap; under backpressure, initiate at most one tagged interaction
commit while at most one earlier commit awaits its flush.
(WebKit::RemoteLayerTreeDrawingArea::updateRendering): Reserve the interaction transaction ID before the
WebCore update and send the dedicated pending-commit notification; count outstanding commits.
(WebKit::RemoteLayerTreeDrawingArea::didCompleteRenderingUpdateDisplayFlush): Decrement the outstanding
commit count once the commit message has been sent.
(WebKit::RemoteLayerTreeDrawingArea::displayDidRefreshForTransaction): Ignore a grant that the
interaction transaction already consumed.
(WebKit::RemoteLayerTreeDrawingArea::scheduleRenderingUpdate): Respect a promotion that cleared the
queued main-run-loop handoff.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/742c90add51367f8087d68dd7ea2d45712526b8d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178866 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52805 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46600 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188483 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/143175 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/180729 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54098 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52515 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139478 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96714 "3 flakes 2 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181823 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43050 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160213 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119928 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41721 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40065 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152120 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39716 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45411 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44311 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190912 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52475 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/159730 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148669 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53155 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36340 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148427 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43124 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125425 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/120110 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51673 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14694 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51058 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51299 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51119 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->