### PR TITLE
AX: value and selection for an editable text field aren't updated together in isolated tree

### DIFF
--- a/LayoutTests/accessibility/mac/textarea-value-selection-consistency-on-valuechange-expected.txt
+++ b/LayoutTests/accessibility/mac/textarea-value-selection-consistency-on-valuechange-expected.txt
@@ -1,0 +1,11 @@
+
+This tests that when an AXValueChanged notification fires for a textarea after inserting text, the accessibility selection (caret position) reported at that moment is consistent with the newly-reported value. Regression test for an isolated-tree bug where value updates and selection updates are delivered to the isolated tree on separate channels, leaving it temporarily inconsistent (value updated, selection stale) at the time the value-changed notification is delivered.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS Value and selection were consistent at every AXValueChanged notification.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/mac/textarea-value-selection-consistency-on-valuechange.html
+++ b/LayoutTests/accessibility/mac/textarea-value-selection-consistency-on-valuechange.html
@@ -1,0 +1,134 @@
+<!DOCTYPE html><!-- webkit-test-runner [ runSingly=true ] -->
+<html>
+<head>
+<script src="../../resources/js-test.js"></script>
+<script src="../../resources/accessibility-helper.js"></script>
+</head>
+<body>
+
+<textarea id="textarea" rows="5" cols="40"></textarea>
+
+<p id="description"></p>
+<div id="console"></div>
+
+<script>
+description("This tests that when an AXValueChanged notification fires for a textarea after inserting text, the accessibility selection (caret position) reported at that moment is consistent with the newly-reported value. Regression test for an isolated-tree bug where value updates and selection updates are delivered to the isolated tree on separate channels, leaving it temporarily inconsistent (value updated, selection stale) at the time the value-changed notification is delivered.");
+
+var textareaElement = document.getElementById("textarea");
+var axTextarea = 0;
+var axWebArea = 0;
+
+// The number of characters we type. Each keystroke should produce an AXValueChanged.
+var charactersToType = 5;
+var valueChangedCount = 0;
+
+// Records any inconsistency seen at AXValueChanged-delivery time. We keep the
+// details in a string (rather than debug()-ing immediately) so the committed
+// expected result stays stable in the passing case; on failure the details are
+// surfaced through testFailed().
+var inconsistencies = [];
+
+// Returns the length of the accessibility value string (stripping "AXValue: ").
+function currentValueLength() {
+    var value = axTextarea.stringValue;
+    if (!value)
+        return -1;
+    return value.replace(/^AXValue: /, "").length;
+}
+
+// Caret offset from the node-level AXSelectedTextRange ("{location, length}").
+function caretOffsetFromSelectedTextRange() {
+    var range = axTextarea.selectedTextRange;
+    if (!range)
+        return -1;
+    var match = /\{(\d+), (\d+)\}/.exec(range);
+    return match ? parseInt(match[1], 10) : -1;
+}
+
+// Caret offset from the tree-level AXSelectedTextMarkerRange.
+function caretOffsetFromSelectedMarkerRange() {
+    var markerRange = axWebArea.selectedTextMarkerRange();
+    if (!markerRange)
+        return -1;
+    var startMarker = axWebArea.startTextMarkerForTextMarkerRange(markerRange);
+    if (!startMarker)
+        return -1;
+    return axWebArea.indexForTextMarker(startMarker);
+}
+
+function notificationCallback(notification) {
+    if (notification != "AXValueChanged")
+        return;
+
+    valueChangedCount++;
+
+    // At the moment the value-changed notification is delivered, the caret should
+    // sit at the end of the inserted text, i.e. the selection should report an
+    // offset equal to the current value length. AXSelectedTextRange is the node-level
+    // selection an assistive technology reads in response to AXValueChanged; if it
+    // lags behind the value, the isolated tree is in an inconsistent state.
+    var valueLength = currentValueLength();
+    var caretFromRange = caretOffsetFromSelectedTextRange();
+    // AXSelectedTextMarkerRange is a second, tree-level selection representation,
+    // reported here for diagnostics only.
+    var caretFromMarker = caretOffsetFromSelectedMarkerRange();
+
+    var detail = `AXValueChanged #${valueChangedCount}: valueLength=${valueLength}, ` +
+        `AXSelectedTextRange caret=${caretFromRange}, AXSelectedTextMarkerRange caret=${caretFromMarker}`;
+
+    if (caretFromRange != valueLength)
+        inconsistencies.push(detail + " (INCONSISTENT: selection is stale relative to value)");
+}
+
+// Returns a promise that wiggles the mouse over the textarea. Doing this concurrently with typing
+// interleaves extra main-thread and AX-thread work, which makes the value-vs-selection race far more
+// likely to reproduce in isolated tree mode.
+async function wigglePromise() {
+    if (!window.eventSender)
+        return;
+    var rect = textareaElement.getBoundingClientRect();
+    for (var i = 0; i < 6; i++) {
+        eventSender.mouseMoveTo(rect.left + (i * 3), rect.top + (i * 2));
+        await new Promise(requestAnimationFrame);
+    }
+}
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    textareaElement.focus();
+    axTextarea = accessibilityController.accessibleElementById("textarea");
+    axWebArea = accessibilityController.rootElement.childAtIndex(0);
+    axTextarea.addNotificationListener(notificationCallback);
+
+    setTimeout(async function() {
+        for (var i = 0; i < charactersToType; i++) {
+            var ch = String.fromCharCode("a".charCodeAt(0) + i);
+            // Kick off mouse wiggling concurrently with the keystroke to exercise the race.
+            var wiggle = wigglePromise();
+            if (window.eventSender)
+                eventSender.keyDown(ch);
+            else {
+                // Fallback for environments without eventSender: mutate the DOM directly.
+                textareaElement.value += ch;
+                textareaElement.setSelectionRange(textareaElement.value.length, textareaElement.value.length);
+            }
+            await wiggle;
+            // Wait until the AXValueChanged for this keystroke has been observed.
+            await waitFor(() => valueChangedCount > i);
+        }
+
+        if (!inconsistencies.length)
+            testPassed("Value and selection were consistent at every AXValueChanged notification.");
+        else {
+            for (var i = 0; i < inconsistencies.length; i++)
+                testFailed(inconsistencies[i]);
+        }
+
+        axTextarea.removeNotificationListener(notificationCallback);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/Source/WebCore/accessibility/AXCoreObject.cpp
+++ b/Source/WebCore/accessibility/AXCoreObject.cpp
@@ -241,7 +241,12 @@ bool AXCoreObject::isButton() const
 
 bool AXCoreObject::isTextControl() const
 {
-    switch (role()) {
+    return isTextControl(role());
+}
+
+bool AXCoreObject::isTextControl(AccessibilityRole role)
+{
+    switch (role) {
     case AccessibilityRole::ComboBox:
     case AccessibilityRole::SearchField:
     case AccessibilityRole::TextArea:

--- a/Source/WebCore/accessibility/AXCoreObject.h
+++ b/Source/WebCore/accessibility/AXCoreObject.h
@@ -650,6 +650,7 @@ public:
     bool isSwitch() const { return role() == AccessibilityRole::Switch; }
     bool isToggleButton() const { return role() == AccessibilityRole::ToggleButton; }
     bool NODELETE isTextControl() const;
+    static bool isTextControl(AccessibilityRole);
     virtual bool isEditableWebArea() const = 0;
     virtual bool isNonNativeTextControl() const = 0;
     bool isTabList() const { return role() == AccessibilityRole::TabList; }

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -6005,8 +6005,15 @@ void AXObjectCache::updateIsolatedTree(const Vector<std::pair<Ref<AccessibilityO
         case AXNotification::PressedStateChanged:
         case AXNotification::TextChanged:
         case AXNotification::TextSecurityChanged:
+            tree->queueNodeUpdate(notification.first->objectID(), NodeUpdateOptions::nodeUpdate());
+            break;
         case AXNotification::ValueChanged:
             tree->queueNodeUpdate(notification.first->objectID(), NodeUpdateOptions::nodeUpdate());
+            // A text control's value and selection must stay consistent for clients that read the
+            // selection in response to this notification, so push the current selection alongside the
+            // value rather than letting it arrive later on the selection-change channel.
+            if (notification.first->isTextControl())
+                onSelectedTextChanged(notification.first->selectedVisiblePositionRange(), notification.first.ptr());
             break;
         case AXNotification::LabelChanged: {
             tree->queueNodeUpdate(notification.first->objectID(), NodeUpdateOptions::nodeUpdate());

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
@@ -369,8 +369,32 @@ void AXIsolatedTree::queueChange(NodeChange&& nodeChange)
 
     AXID objectID = nodeChange.data.axID;
     Markable parentID = nodeChange.data.parentID;
+    bool isTextControl = AXCoreObject::isTextControl(nodeChange.data.role);
     auto pending = mutablePendingChanges();
     pending->appends.append(WTF::move(nodeChange));
+
+    // An append carries a full, fresh copy of the node's properties, so it supersedes a SelectedTextRange
+    // update already queued for this object in an earlier cycle. Drop that stale update; without this it
+    // would apply after the append on the reader thread (appends are applied before property changes) and
+    // clobber the fresh selection. Updates queued after this append are preserved (last-writer-wins).
+    // Only text controls carry a SelectedTextRange, so this is safely scoped to them, which also avoids
+    // scanning propertyChanges on the common non-text-control append.
+    //
+    // FIXME: An append supersedes *any* earlier-queued property change for the same object (as the
+    // same-cycle dedup in processQueuedNodeUpdates() already assumes), but we limit this to SelectedTextRange
+    // for now since other properties may intentionally be pushed as targeted updates. Consider generalizing.
+    if (isTextControl) {
+        for (auto& change : pending->propertyChanges) {
+            if (change.axID == objectID) {
+                change.properties.removeAllMatching([] (const auto& property) {
+                    return property.first == AXProperty::SelectedTextRange;
+                });
+            }
+        }
+        pending->propertyChanges.removeAllMatching([] (const auto& change) {
+            return change.properties.isEmpty();
+        });
+    }
 
     if (parentID) {
         auto siblingsIDs = m_nodeMap.get(*parentID).childrenIDs;


### PR DESCRIPTION
#### ec3a7ab1590bf34a2d0461690772437d3d1a2d7b
<pre>
AX: value and selection for an editable text field aren&apos;t updated together in isolated tree
<a href="https://bugs.webkit.org/show_bug.cgi?id=320074">https://bugs.webkit.org/show_bug.cgi?id=320074</a>
<a href="https://rdar.apple.com/182995716">rdar://182995716</a>

Reviewed by Tyler Wilcock.

When text is inserted into a text control, VoiceOver responds to the
value-changed notification and could observe the updated value but a stale caret
position. There were two root causes.

First, the tree-level selection (the selected text marker range) is
updated on the selection-change channel, which runs after the
value-changed notification is delivered. A client responding to the
value change therefore saw a selection from before the edit. The fix is to
push the current selection alongside the value change for text
controls, so both are delivered together. The live selection is
already up-to-date at this point, so no extra recomputation is needed.

Second, the node-level selection (AXProperty::SelectedTextRange) could
be reverted on the accessibility thread. A value change queues a full
node update, which is transported to the isolated tree as an &quot;append&quot;
carrying a complete, freshly recomputed copy of the node (including
its selection). Separately, selection changes queue a
SelectedTextRange property update, debounced by ~100ms to coalesce
rapid pure-selection changes such as drag-select. When a debounced
update from one keystroke and the full node append from the next
keystroke land in the same snapshot, the reader thread applies all
appends before all property changes, so the older debounced selection
was applied last and clobbered the fresh one. There is already
same-cycle dedup for this in processQueuedNodeUpdates() (a property
update is skipped when a full node update is pending for the same
object); the debounce simply moves the two into different cycles,
defeating it. queueChange() now drops an already-queued
SelectedTextRange update for an object when committing an append for
it, extending that dedup across cycles. Updates queued after the
append are preserved, keeping last-writer-wins by queue order intact.

The debounce is left in place for its original purpose. Value changes
are naturally throttled by typing speed, whereas pure selection
changes are not, so coalescing still matters for the latter.

Test: accessibility/mac/textarea-value-selection-consistency-on-valuechange.html

* LayoutTests/accessibility/mac/textarea-value-selection-consistency-on-valuechange-expected.txt: Added.
* LayoutTests/accessibility/mac/textarea-value-selection-consistency-on-valuechange.html: Added.
* Source/WebCore/accessibility/AXCoreObject.cpp:
(WebCore::AXCoreObject::isTextControl const):
(WebCore::AXCoreObject::isTextControl):
* Source/WebCore/accessibility/AXCoreObject.h:
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::updateIsolatedTree):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp:
(WebCore::AXIsolatedTree::queueChange):

Canonical link: <a href="https://commits.webkit.org/317898@main">https://commits.webkit.org/317898@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/777f334f15f8288fde4c6ba52388f2830c9fe079

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176510 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50445 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44235 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186111 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/138784 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4cba55a9-58e0-4303-a413-a40f2d3ea6d3) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178373 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51737 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50129 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137493 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/138784 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9f1660b9-3887-49b0-bb71-6fa33ddf848f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179466 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40979 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158269 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117968 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/220242e9-bfad-4adb-a2f0-4143193a29c5) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39629 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37999 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150044 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37767 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34579 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42177 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42210 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188534 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50110 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/157814 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146544 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39448 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50794 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34385 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146354 "Found 1 new API test failure: TestWTF:WTF_ParkingLot.UnparkOneFiftyThenFiftyAllFast (failure)") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41115 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122998 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117060 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49298 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12742 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48700 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48934 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48759 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->