### PR TITLE
corner-shape: bevel/notch/square corners are mis-positioned on outlines and box-shadow spread

### DIFF
--- a/Source/WebCore/rendering/BackgroundPainter.cpp
+++ b/Source/WebCore/rendering/BackgroundPainter.cpp
@@ -1004,7 +1004,7 @@ void BackgroundPainter::paintBoxShadow(const LayoutRect& paintRect, const Style:
                 influenceRadii.expand(2 * shadowPaintingExtent + shadowSpread);
                 influenceShape.setRadii(influenceRadii);
 
-                if (influenceShape.outerShapeContains(m_paintInfo.rect))
+                if (!shadowShape.hasNonRoundCornerShape() && influenceShape.outerShapeContains(m_paintInfo.rect))
                     context.fillRect(shadowShape.snappedOuterRect(deviceScaleFactor), Color::black);
                 else
                     shadowShape.fillOuterShape(context, Color::black, deviceScaleFactor);
@@ -1026,7 +1026,7 @@ void BackgroundPainter::paintBoxShadow(const LayoutRect& paintRect, const Style:
             if (!closedEdges.bottom())
                 outerRectExpandedToObscureOpenEdges.setHeight(outerRectExpandedToObscureOpenEdges.height() - std::min<LayoutUnit>(shadowOffset.height(), 0) + shadowInfluence);
 
-            auto shapeForInnerHole = BorderShape(outerRectExpandedToObscureOpenEdges, borderWidthsWithSpread, borderShape.radii());
+            auto shapeForInnerHole = BorderShape(outerRectExpandedToObscureOpenEdges, borderWidthsWithSpread, borderShape.radii(), borderShape.cornerCurvatures());
             if (shapeForInnerHole.snappedInnerRect(deviceScaleFactor).isEmpty()) {
                 shapeForInnerHole.fillOuterShape(context, shadowColor, deviceScaleFactor);
                 continue;

--- a/Source/WebCore/rendering/BorderPainter.cpp
+++ b/Source/WebCore/rendering/BorderPainter.cpp
@@ -676,7 +676,7 @@ void BorderPainter::paintBorderSides(const BorderShape& borderShape, const Sides
             return !firstRadius.isEmpty() || !secondRadius.isEmpty();
         };
 
-        bool usePath = !sides.outerEdgeIsRectangular && (borderStyleHasInnerDetail(edge.style()) || borderWillArcInnerEdge(firstRadius, secondRadius));
+        bool usePath = !sides.outerEdgeIsRectangular && (borderStyleHasInnerDetail(edge.style()) || borderWillArcInnerEdge(firstRadius, secondRadius) || borderShape.hasNonRoundCornerShape());
         paintOneBorderSide(borderShape, sides, sideRect, side, adjacentSide1, adjacentSide2, usePath ? &roundedPath : nullptr, antialias, overrideColor);
     };
 

--- a/Source/WebCore/rendering/BorderShape.cpp
+++ b/Source/WebCore/rendering/BorderShape.cpp
@@ -40,6 +40,7 @@
 #include "LayoutRoundedRect.h"
 #include "Path.h"
 #include "StyleComputedStyle+GettersInlines.h"
+#include <cmath>
 
 namespace WebCore {
 
@@ -118,6 +119,8 @@ BorderShape BorderShape::shapeForOffsetRect(const Style::ComputedStyle& style, c
 
     if (style.border().hasBorderRadius()) {
         auto radii = Style::evaluate<LayoutRoundedRectRadii>(style.borderRadii(), borderRect.size(), style.usedZoomForLength());
+        // Copy the unmodified border-box radii for the offset reference, before we expand them for the offset rect.
+        auto referenceRadii = radii;
 
         auto leftDelta = borderRect.x() - offsetRect.x();
         auto topDelta = borderRect.y() - offsetRect.y();
@@ -130,7 +133,17 @@ BorderShape BorderShape::shapeForOffsetRect(const Style::ComputedStyle& style, c
         if (!radii.areRenderableInRect(offsetRect))
             radii.makeRenderableInRect(offsetRect);
 
-        return BorderShape { offsetRect, usedEdgeWidths, radii, cornerCurvaturesFromStyle(style) };
+        auto shape = BorderShape { offsetRect, usedEdgeWidths, radii, cornerCurvaturesFromStyle(style) };
+
+        // Always record the border-box shape for offset shapes: corners with no radius to expand or inset (bevel,
+        // notch, square) are rebuilt by offsetting this reference curve to the moved rect
+        referenceRadii.scale(calcBorderRadiiConstraintScaleFor(borderRect, referenceRadii));
+        zeroRadiiForOpenEdges(referenceRadii, closedEdges);
+        if (!referenceRadii.areRenderableInRect(borderRect))
+            referenceRadii.makeRenderableInRect(borderRect);
+        shape.m_offsetReferenceRect = LayoutRoundedRect { borderRect, referenceRadii };
+
+        return shape;
     }
 
     return BorderShape { offsetRect, usedEdgeWidths };
@@ -164,7 +177,9 @@ BorderShape::BorderShape(const LayoutRect& borderRect, const RectEdges<LayoutUni
 
 BorderShape BorderShape::shapeWithBorderWidths(const RectEdges<LayoutUnit>& borderWidths) const
 {
-    return BorderShape(m_borderRect.rect(), borderWidths, m_borderRect.radii(), m_cornerCurvatures);
+    auto shape = BorderShape(m_borderRect.rect(), borderWidths, m_borderRect.radii(), m_cornerCurvatures);
+    shape.m_offsetReferenceRect = m_offsetReferenceRect;
+    return shape;
 }
 
 LayoutRoundedRect BorderShape::deprecatedRoundedRect() const
@@ -255,6 +270,8 @@ void BorderShape::move(LayoutSize offset)
 {
     m_borderRect.move(offset);
     m_innerEdgeRect.move(offset);
+    if (m_offsetReferenceRect)
+        m_offsetReferenceRect->move(offset);
 }
 
 void BorderShape::inflate(LayoutUnit amount)
@@ -320,6 +337,46 @@ static void buildScaledCornerInputs(const FloatRoundedRect& outerSnapped, const 
     }
 }
 
+enum class UseScaledInputs : bool { No, Yes };
+
+// Bevel, notch, and square have no radius to expand or inset (the way round/superellipse corners are offset), so they're rebuilt by offsetting the border-box corner to the moved rect.
+static void rebuildOffsetCornersFromReference(RectCorners<CornerInput>& contourCorners, const std::optional<FloatRoundedRect>& borderBoxReference, const RectCorners<float>& cornerCurvatures, const FloatRect& contourRect, UseScaledInputs useScaledInputs)
+{
+    if (!borderBoxReference)
+        return;
+
+    auto needsRebuild = [](float curvature) {
+        return curvature == 0.0f || std::isinf(curvature);
+    };
+    bool hasCornerNeedingRebuild = needsRebuild(cornerCurvatures.topLeft()) || needsRebuild(cornerCurvatures.topRight())
+        || needsRebuild(cornerCurvatures.bottomLeft()) || needsRebuild(cornerCurvatures.bottomRight());
+    if (!hasCornerNeedingRebuild)
+        return;
+
+    auto snappedReference = *borderBoxReference;
+    auto snappedReferenceRect = snappedReference.rect();
+
+    double leftOffset = snappedReferenceRect.x() - contourRect.x();
+    double topOffset = snappedReferenceRect.y() - contourRect.y();
+    double rightOffset = contourRect.maxX() - snappedReferenceRect.maxX();
+    double bottomOffset = contourRect.maxY() - snappedReferenceRect.maxY();
+
+    RectCorners<CornerInput> rebuiltCorners;
+    if (useScaledInputs == UseScaledInputs::Yes)
+        buildScaledCornerInputs(snappedReference, cornerCurvatures, -leftOffset, -topOffset, -rightOffset, -bottomOffset, rebuiltCorners);
+    else
+        buildCornerInputs(snappedReference, cornerCurvatures, -leftOffset, -topOffset, -rightOffset, -bottomOffset, rebuiltCorners);
+
+    if (needsRebuild(cornerCurvatures.topLeft()))
+        contourCorners.topLeft() = rebuiltCorners.topLeft();
+    if (needsRebuild(cornerCurvatures.topRight()))
+        contourCorners.topRight() = rebuiltCorners.topRight();
+    if (needsRebuild(cornerCurvatures.bottomLeft()))
+        contourCorners.bottomLeft() = rebuiltCorners.bottomLeft();
+    if (needsRebuild(cornerCurvatures.bottomRight()))
+        contourCorners.bottomRight() = rebuiltCorners.bottomRight();
+}
+
 bool BorderShape::hasNonRoundCornerShape() const
 {
     const auto& radii = m_borderRect.radii();
@@ -344,23 +401,31 @@ Path BorderShape::pathForInnerRoundedRect(const FloatRoundedRect& innerSnapped) 
     return path;
 }
 
-static void addOuterCornerShapeToPath(Path& path, const FloatRoundedRect& outerSnapped, const RectCorners<float>& cornerCurvatures)
+std::optional<FloatRoundedRect> BorderShape::snappedOffsetReferenceRect(float deviceScaleFactor) const
+{
+    if (!m_offsetReferenceRect)
+        return std::nullopt;
+    return m_offsetReferenceRect->pixelSnappedRoundedRectForPainting(deviceScaleFactor);
+}
+
+static void addOuterCornerShapeToPath(Path& path, const FloatRoundedRect& outerSnapped, const RectCorners<float>& cornerCurvatures, const std::optional<FloatRoundedRect>& offsetReferenceRect)
 {
     RectCorners<CornerInput> cornerRects;
     buildCornerInputs(outerSnapped, cornerCurvatures, 0, 0, 0, 0, cornerRects);
+    rebuildOffsetCornersFromReference(cornerRects, offsetReferenceRect, cornerCurvatures, outerSnapped.rect(), UseScaledInputs::No);
     borderContourPath(path, cornerRects);
 }
 
-Path BorderShape::pathForOuterCornerShape(const FloatRoundedRect& outerSnapped) const
+Path BorderShape::pathForOuterCornerShape(const FloatRoundedRect& outerSnapped, const std::optional<FloatRoundedRect>& snappedOffsetReference) const
 {
     Path path;
-    addOuterCornerShapeToPath(path, outerSnapped, m_cornerCurvatures);
+    addOuterCornerShapeToPath(path, outerSnapped, m_cornerCurvatures, snappedOffsetReference);
     if (!path.isEmpty())
         return path;
     return pathForOuterRoundedRect(outerSnapped);
 }
 
-static void addInnerCornerShapeToPath(Path& path, const FloatRoundedRect& outerSnapped, const FloatRoundedRect& innerSnapped, const RectCorners<float>& cornerCurvatures)
+static void addInnerCornerShapeToPath(Path& path, const FloatRoundedRect& outerSnapped, const FloatRoundedRect& innerSnapped, const RectCorners<float>& cornerCurvatures, const std::optional<FloatRoundedRect>& offsetReferenceRect)
 {
     auto outerRect = outerSnapped.rect();
     auto innerRect = innerSnapped.rect();
@@ -372,13 +437,14 @@ static void addInnerCornerShapeToPath(Path& path, const FloatRoundedRect& outerS
 
     RectCorners<CornerInput> cornerRects;
     buildScaledCornerInputs(outerSnapped, cornerCurvatures, leftWidth, topWidth, rightWidth, bottomWidth, cornerRects);
+    rebuildOffsetCornersFromReference(cornerRects, offsetReferenceRect, cornerCurvatures, innerRect, UseScaledInputs::Yes);
     borderContourPath(path, cornerRects, &innerRect);
 }
 
-Path BorderShape::pathForInnerCornerShape(const FloatRoundedRect& outerSnapped, const FloatRoundedRect& innerSnapped) const
+Path BorderShape::pathForInnerCornerShape(const FloatRoundedRect& outerSnapped, const FloatRoundedRect& innerSnapped, const std::optional<FloatRoundedRect>& snappedOffsetReference) const
 {
     Path path;
-    addInnerCornerShapeToPath(path, outerSnapped, innerSnapped, m_cornerCurvatures);
+    addInnerCornerShapeToPath(path, outerSnapped, innerSnapped, m_cornerCurvatures, snappedOffsetReference);
     if (path.isEmpty())
         return pathForInnerRoundedRect(innerSnapped);
     return path;
@@ -388,7 +454,7 @@ Path BorderShape::pathForOuterShape(float deviceScaleFactor) const
 {
     auto outerSnapped = m_borderRect.pixelSnappedRoundedRectForPainting(deviceScaleFactor);
     if (hasNonRoundCornerShape())
-        return pathForOuterCornerShape(outerSnapped);
+        return pathForOuterCornerShape(outerSnapped, snappedOffsetReferenceRect(deviceScaleFactor));
     return pathForOuterRoundedRect(outerSnapped);
 }
 
@@ -397,7 +463,7 @@ Path BorderShape::pathForInnerShape(float deviceScaleFactor) const
     auto outerSnapped = m_borderRect.pixelSnappedRoundedRectForPainting(deviceScaleFactor);
     auto innerSnapped = m_innerEdgeRect.pixelSnappedRoundedRectForPainting(deviceScaleFactor);
     if (hasNonRoundCornerShape())
-        return pathForInnerCornerShape(outerSnapped, innerSnapped);
+        return pathForInnerCornerShape(outerSnapped, innerSnapped, snappedOffsetReferenceRect(deviceScaleFactor));
     return pathForInnerRoundedRect(innerSnapped);
 }
 
@@ -405,12 +471,8 @@ void BorderShape::addOuterShapeToPath(Path& path, float deviceScaleFactor) const
 {
     auto outerSnapped = m_borderRect.pixelSnappedRoundedRectForPainting(deviceScaleFactor);
     if (hasNonRoundCornerShape()) {
-        Path cornerPath;
-        addOuterCornerShapeToPath(cornerPath, outerSnapped, m_cornerCurvatures);
-        if (!cornerPath.isEmpty()) {
-            path.addPath(cornerPath, AffineTransform());
-            return;
-        }
+        path.addPath(pathForOuterCornerShape(outerSnapped, snappedOffsetReferenceRect(deviceScaleFactor)), AffineTransform());
+        return;
     }
     addRoundedRectToPath(outerSnapped, path);
 }
@@ -420,12 +482,8 @@ void BorderShape::addInnerShapeToPath(Path& path, float deviceScaleFactor) const
     auto outerSnapped = m_borderRect.pixelSnappedRoundedRectForPainting(deviceScaleFactor);
     auto innerSnapped = m_innerEdgeRect.pixelSnappedRoundedRectForPainting(deviceScaleFactor);
     if (hasNonRoundCornerShape()) {
-        Path cornerPath;
-        addInnerCornerShapeToPath(cornerPath, outerSnapped, innerSnapped, m_cornerCurvatures);
-        if (!cornerPath.isEmpty()) {
-            path.addPath(cornerPath, AffineTransform());
-            return;
-        }
+        path.addPath(pathForInnerCornerShape(outerSnapped, innerSnapped, snappedOffsetReferenceRect(deviceScaleFactor)), AffineTransform());
+        return;
     }
     ASSERT(innerSnapped.isRenderable());
     addRoundedRectToPath(innerSnapped, path);
@@ -455,7 +513,7 @@ void BorderShape::clipToOuterShape(GraphicsContext& context, float deviceScaleFa
 {
     auto outerSnapped = m_borderRect.pixelSnappedRoundedRectForPainting(deviceScaleFactor);
     if (hasNonRoundCornerShape()) {
-        context.clipPath(pathForOuterCornerShape(outerSnapped));
+        context.clipPath(pathForOuterCornerShape(outerSnapped, snappedOffsetReferenceRect(deviceScaleFactor)));
         return;
     }
 
@@ -470,7 +528,7 @@ void BorderShape::clipToInnerShape(GraphicsContext& context, float deviceScaleFa
     auto outerSnapped = m_borderRect.pixelSnappedRoundedRectForPainting(deviceScaleFactor);
     auto innerSnapped = m_innerEdgeRect.pixelSnappedRoundedRectForPainting(deviceScaleFactor);
     if (hasNonRoundCornerShape()) {
-        context.clipPath(pathForInnerCornerShape(outerSnapped, innerSnapped));
+        context.clipPath(pathForInnerCornerShape(outerSnapped, innerSnapped, snappedOffsetReferenceRect(deviceScaleFactor)));
         return;
     }
 
@@ -488,7 +546,7 @@ void BorderShape::clipOutOuterShape(GraphicsContext& context, float deviceScaleF
         return;
 
     if (hasNonRoundCornerShape()) {
-        context.clipOut(pathForOuterCornerShape(outerSnapped));
+        context.clipOut(pathForOuterCornerShape(outerSnapped, snappedOffsetReferenceRect(deviceScaleFactor)));
         return;
     }
 
@@ -506,7 +564,7 @@ void BorderShape::clipOutInnerShape(GraphicsContext& context, float deviceScaleF
         return;
 
     if (hasNonRoundCornerShape()) {
-        context.clipOut(pathForInnerCornerShape(outerSnapped, innerSnapped));
+        context.clipOut(pathForInnerCornerShape(outerSnapped, innerSnapped, snappedOffsetReferenceRect(deviceScaleFactor)));
         return;
     }
 
@@ -521,7 +579,7 @@ void BorderShape::fillOuterShape(GraphicsContext& context, const Color& color, f
     auto outerSnapped = m_borderRect.pixelSnappedRoundedRectForPainting(deviceScaleFactor);
     if (hasNonRoundCornerShape()) {
         context.setFillColor(color);
-        context.fillPath(pathForOuterCornerShape(outerSnapped));
+        context.fillPath(pathForOuterCornerShape(outerSnapped, snappedOffsetReferenceRect(deviceScaleFactor)));
         return;
     }
 
@@ -537,7 +595,7 @@ void BorderShape::fillInnerShape(GraphicsContext& context, const Color& color, f
     auto innerSnapped = m_innerEdgeRect.pixelSnappedRoundedRectForPainting(deviceScaleFactor);
     if (hasNonRoundCornerShape()) {
         context.setFillColor(color);
-        context.fillPath(pathForInnerCornerShape(outerSnapped, innerSnapped));
+        context.fillPath(pathForInnerCornerShape(outerSnapped, innerSnapped, snappedOffsetReferenceRect(deviceScaleFactor)));
         return;
     }
 

--- a/Source/WebCore/rendering/BorderShape.h
+++ b/Source/WebCore/rendering/BorderShape.h
@@ -29,17 +29,18 @@
 
 #pragma once
 
+#include "FloatRoundedRect.h"
 #include "LayoutRoundedRect.h"
 #include "RectCorners.h"
 #include "RectEdges.h"
 #include "RenderStyleConstants.h"
+#include <optional>
 
 namespace WebCore {
 
 class Color;
 class GraphicsContext;
 class FloatRect;
-class FloatRoundedRect;
 class Path;
 
 namespace Style {
@@ -90,6 +91,8 @@ public:
     const LayoutRoundedRectRadii& radii() const LIFETIME_BOUND { return m_borderRect.radii(); }
     void setRadii(const LayoutRoundedRectRadii& radii) { m_borderRect.setRadii(radii); }
 
+    const RectCorners<float>& cornerCurvatures() const LIFETIME_BOUND { return m_cornerCurvatures; }
+
     // Note that the inner edge isn't necessarily a rounded rect, but the radii still represent where the straight edge sections terminate.
     const LayoutRoundedRectRadii& innerEdgeRadii() const LIFETIME_BOUND { return m_innerEdgeRect.radii(); }
 
@@ -100,6 +103,8 @@ public:
 
     bool NODELETE outerShapeIsRectangular() const;
     bool NODELETE innerShapeIsRectangular() const;
+
+    bool hasNonRoundCornerShape() const;
 
     bool isEmpty() const { return m_borderRect.rect().isEmpty(); }
 
@@ -133,19 +138,20 @@ private:
     // Insets the snapped outer rect by device-rounded widths so opposite sides stay equal thickness.
     FloatRoundedRect snappedInnerEdgeRectForPainting(float deviceScaleFactor) const;
 
-    // True if any corner uses a non-`round` shape (curvature != 1), so the shape
-    bool hasNonRoundCornerShape() const;
+    std::optional<FloatRoundedRect> snappedOffsetReferenceRect(float deviceScaleFactor) const;
 
     Path pathForOuterRoundedRect(const FloatRoundedRect& outerSnapped) const;
     Path pathForInnerRoundedRect(const FloatRoundedRect& innerSnapped) const;
 
-    Path pathForOuterCornerShape(const FloatRoundedRect& outerSnapped) const;
-    Path pathForInnerCornerShape(const FloatRoundedRect& outerSnapped, const FloatRoundedRect& innerSnapped) const;
+    Path pathForOuterCornerShape(const FloatRoundedRect& outerSnapped, const std::optional<FloatRoundedRect>& snappedOffsetReference) const;
+    Path pathForInnerCornerShape(const FloatRoundedRect& outerSnapped, const FloatRoundedRect& innerSnapped, const std::optional<FloatRoundedRect>& snappedOffsetReference) const;
 
     LayoutRoundedRect m_borderRect;
     LayoutRoundedRect m_innerEdgeRect;
     RectEdges<LayoutUnit> m_borderWidths;
     RectCorners<float> m_cornerCurvatures { 1.0f, 1.0f, 1.0f, 1.0f };
+
+    std::optional<LayoutRoundedRect> m_offsetReferenceRect;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 615d0d245f473fb9fcf6db8ec087bfe7f7626a04
<pre>
corner-shape: bevel/notch/square corners are mis-positioned on outlines and box-shadow spread
<a href="https://bugs.webkit.org/show_bug.cgi?id=320106">https://bugs.webkit.org/show_bug.cgi?id=320106</a>
<a href="https://rdar.apple.com/183043471">rdar://183043471</a>

Reviewed by Simon Fraser.

Record the border-box rounded rect on the offset BorderShape (new
alignCornersToCurve flag on shapeForOffsetRect). When building an
outline or box-shadow contour, regenerate just the exact-shape corners
(bevel/notch/square) directly from that reference, offset out/in to
the contour rect, rather than scaling their corner box(rebuildOffsetCornersFromReference).

New tests will be written in a seperate commit for WPT

* Source/WebCore/rendering/BackgroundPainter.cpp:
(WebCore::BackgroundPainter::paintBoxShadow const):
* Source/WebCore/rendering/BorderPainter.cpp:
(WebCore::BorderPainter::paintBorderSides const):
* Source/WebCore/rendering/BorderShape.cpp:
(WebCore::BorderShape::shapeForOffsetRect):
(WebCore::BorderShape::shapeWithBorderWidths const):
(WebCore::BorderShape::move):
(WebCore::rebuildOffsetCornersFromReference):
(WebCore::addOuterCornerShapeToPath):
(WebCore::BorderShape::pathForOuterCornerShape const):
(WebCore::addInnerCornerShapeToPath):
(WebCore::BorderShape::pathForInnerCornerShape const):
(WebCore::BorderShape::pathForOuterShape const):
(WebCore::BorderShape::pathForInnerShape const):
(WebCore::BorderShape::addOuterShapeToPath const):
(WebCore::BorderShape::addInnerShapeToPath const):
(WebCore::BorderShape::clipToOuterShape const):
(WebCore::BorderShape::clipToInnerShape const):
(WebCore::BorderShape::clipOutOuterShape const):
(WebCore::BorderShape::clipOutInnerShape const):
(WebCore::BorderShape::fillOuterShape const):
(WebCore::BorderShape::fillInnerShape const):
(WebCore::snapOffsetReference):
(WebCore::BorderShape::snappedOffsetReferenceRect const):
* Source/WebCore/rendering/BorderShape.h:
(WebCore::BorderShape::shapeForOffsetRect):

Canonical link: <a href="https://commits.webkit.org/318193@main">https://commits.webkit.org/318193@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f443bfddab29df3ed1476cd13f36793b9fc4f2d4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177306 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51244 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45038 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186909 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140553 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179169 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52536 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50933 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138167 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140553 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180262 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41680 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158930 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118632 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40341 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38709 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150749 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38427 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35377 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/43029 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42923 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189338 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50910 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147260 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51593 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35054 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147051 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26934 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41775 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123808 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118142 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50101 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13405 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49497 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49737 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49559 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->