### PR TITLE
[EWS] Don't blame PR author for pre-existing flaky layout test failures

### DIFF
--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -4200,6 +4200,7 @@ class RunWebKitTests(shell.Test, AddToLogMixin, ShellMixin):
     ENABLE_GUARD_MALLOC = False
     ENABLE_ADDITIONAL_ARGUMENTS = True
     EXIT_AFTER_FAILURES = '60'
+    MAX_FAILURES_TO_CHECK_RESULTS_DB = 60
     STRESS_MODE = False
     command = ['python3', 'Tools/Scripts/run-webkit-tests',
                '--no-build',
@@ -4359,7 +4360,7 @@ class RunWebKitTests(shell.Test, AddToLogMixin, ShellMixin):
             if not has_commit:
                 yield self._addToLog(self.results_db_log_name, f"'{identifier}' could not be found on the results database, falling back to tip-of-tree\n")
 
-        for test in failing_tests:
+        for test in failing_tests[:self.MAX_FAILURES_TO_CHECK_RESULTS_DB]:
             data = yield ResultsDatabase.is_test_pre_existing_failure(
                 test, configuration=configuration,
                 commit=identifier if has_commit else None,
@@ -4368,10 +4369,6 @@ class RunWebKitTests(shell.Test, AddToLogMixin, ShellMixin):
             if data['is_existing_failure']:
                 self.preexisting_failures_in_results_db.append(test)
                 self.failing_tests_filtered.remove(test)
-            else:
-                # Optimization to skip consulting results-db for every failure if we encounter any new failure,
-                # since until there is atleast one failure which is not pre-existing, we will anayways have to continue with retry logic.
-                break
 
     def evaluateResult(self, cmd):
         result = SUCCESS
@@ -4868,8 +4865,12 @@ class RunWebKitTestsWithoutChange(RunWebKitTests):
         first_results_did_exceed_test_failure_limit = self.getProperty('first_results_exceed_failure_limit', False)
         second_results_did_exceed_test_failure_limit = self.getProperty('second_results_exceed_failure_limit', False)
         if not first_results_did_exceed_test_failure_limit and not second_results_did_exceed_test_failure_limit:
-            first_results_failing_tests = set(self.getProperty('first_run_failures', set()))
-            second_results_failing_tests = set(self.getProperty('second_run_failures', set()))
+            # Skip tests that results-db already flagged as pre-existing (use the filtered lists); the
+            # analysis step ignores them anyways, so re-running them on the clean tree is wasted work.
+            first_run_failures_filtered = self.getProperty('first_run_failures_filtered', None)
+            first_results_failing_tests = set(first_run_failures_filtered if first_run_failures_filtered is not None else self.getProperty('first_run_failures', []))
+            second_run_failures_filtered = self.getProperty('second_run_failures_filtered', None)
+            second_results_failing_tests = set(second_run_failures_filtered if second_run_failures_filtered is not None else self.getProperty('second_run_failures', []))
             list_failed_tests_with_change = sorted(first_results_failing_tests.union(second_results_failing_tests))
             if list_failed_tests_with_change:
                 positional_test_paths = self.positional_test_paths_from_additional_arguments()
@@ -5088,9 +5089,6 @@ class AnalyzeLayoutTestsResults(buildstep.BuildStep, BugzillaMixin, GitHubMixin)
         second_results_failing_tests = set(self.getProperty('second_run_failures', []))
         clean_tree_results_did_exceed_test_failure_limit = self.getProperty('clean_tree_results_exceed_failure_limit')
         clean_tree_results_failing_tests = set(self.getProperty('clean_tree_run_failures', []))
-        flaky_failures = first_results_failing_tests.union(second_results_failing_tests) - first_results_failing_tests.intersection(second_results_failing_tests)
-        num_flaky_failures = len(flaky_failures)
-        flaky_failures_string = ', '.join(sorted(flaky_failures)[:self.NUM_FAILURES_TO_DISPLAY])
 
         if (not first_results_failing_tests) and (not second_results_failing_tests):
             # If we've made it here, then layout-tests and re-run-layout-tests failed, which means
@@ -5107,6 +5105,19 @@ class AnalyzeLayoutTestsResults(buildstep.BuildStep, BugzillaMixin, GitHubMixin)
                 self.setProperty('build_summary', message)
                 return defer.returnValue(SUCCESS)
             return defer.returnValue(self.retry_build('Unexpected infrastructure issue, retrying build'))
+
+        # Ignore failures results-db already flagged as pre-existing (use the filtered lists) so a
+        # pre-existing flaky test is not blamed on the change. Done after the empty-check above, which
+        # must use the raw lists to detect the infrastructure 'no results' case.
+        first_run_failures_filtered = self.getProperty('first_run_failures_filtered', None)
+        if first_run_failures_filtered is not None:
+            first_results_failing_tests = set(first_run_failures_filtered)
+        second_run_failures_filtered = self.getProperty('second_run_failures_filtered', None)
+        if second_run_failures_filtered is not None:
+            second_results_failing_tests = set(second_run_failures_filtered)
+        flaky_failures = first_results_failing_tests.union(second_results_failing_tests) - first_results_failing_tests.intersection(second_results_failing_tests)
+        num_flaky_failures = len(flaky_failures)
+        flaky_failures_string = ', '.join(sorted(flaky_failures)[:self.NUM_FAILURES_TO_DISPLAY])
 
         if first_results_did_exceed_test_failure_limit and second_results_did_exceed_test_failure_limit:
             if (len(first_results_failing_tests) - len(clean_tree_results_failing_tests)) <= 5:

--- a/Tools/CISupport/ews-build/steps_unittest.py
+++ b/Tools/CISupport/ews-build/steps_unittest.py
@@ -2659,6 +2659,29 @@ class TestRunWebKitTestsWithoutChange(BuildStepMixinAdditions, unittest.TestCase
         with current_hostname(EWS_BUILD_HOSTNAMES[0]):
             return self.run_step()
 
+    def test_run_subtest_skips_results_db_pre_existing(self):
+        self.configureStep()
+        self.setProperty('fullPlatform', 'ios-simulator')
+        self.setProperty('configuration', 'release')
+        self.setProperty('first_run_failures', ['test1.html', 'test2.html', 'test3.html'])
+        self.setProperty('second_run_failures', ['test3.html', 'test4.html', 'test5.html'])
+        # results-db flagged test1/test5 as pre-existing; the clean tree should only run the filtered union.
+        self.setProperty('first_run_failures_filtered', ['test2.html', 'test3.html'])
+        self.setProperty('second_run_failures_filtered', ['test3.html', 'test4.html'])
+        self.expectRemoteCommands(
+            ExpectShell(workdir='wkdir',
+                        logfiles={'json': self.jsonFileName},
+                        log_environ=False,
+                        timeout=19800,
+                        command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', f'python3 Tools/Scripts/run-webkit-tests --no-build --no-show-results --no-new-test-results --clobber-old-results --release --results-directory layout-test-results --debug-rwt-logging --exit-after-n-failures 60 --skip-failing-tests --builder-name iOS-13-Simulator-WK2-Tests-EWS --build-number 123 --buildbot-worker ews126 --buildbot-master {EWS_BUILD_HOSTNAMES[0]} --report https://results.webkit.org/ --skipped=always test2.html test3.html test4.html 2>&1 | Tools/Scripts/filter-test-logs layout'],
+                        env={'RESULTS_SERVER_API_KEY': 'test-api-key'},
+                        )
+            .exit(0),
+        )
+        self.expect_outcome(result=SUCCESS, state_string='layout-tests')
+        with current_hostname(EWS_BUILD_HOSTNAMES[0]):
+            return self.run_step()
+
     def test_run_subtest_tests_strips_wpt_directory_from_additional_arguments(self):
         self.configureStep()
         self.setProperty('fullPlatform', 'ios-simulator')
@@ -3060,6 +3083,112 @@ class TestAnalyzeLayoutTestsResults(BuildStepMixinAdditions, unittest.TestCase):
         self.setProperty('clean_tree_run_status', SUCCESS)
         self.expect_outcome(result=FAILURE, state_string='Found 1 new test failure: test-was-skipped-change-removed-expectation-but-still-fails.html (failure)')
         return self.run_step()
+
+    def test_pre_existing_flaky_failure_not_blamed(self):
+        # A pre-existing flaky test fails with the change (both runs) but passes on the clean tree.
+        # results-db flagged it, so it is stripped from the *_filtered lists and must not be blamed.
+        self.configureStep()
+        self.setProperty('first_run_failures', ['pre-existing-flaky.html'])
+        self.setProperty('second_run_failures', ['pre-existing-flaky.html'])
+        self.setProperty('first_run_failures_filtered', [])
+        self.setProperty('second_run_failures_filtered', [])
+        self.setProperty('clean_tree_run_failures', [])
+        self.expect_outcome(result=SUCCESS, state_string='Passed layout tests')
+        return self.run_step()
+
+    def test_new_failure_still_reported_with_filtered_lists(self):
+        # A genuinely new failure stays in the *_filtered lists and must still be reported, while the
+        # pre-existing flaky one (stripped by results-db) is not blamed.
+        self.configureStep()
+        self.setProperty('first_run_failures', ['pre-existing-flaky.html', 'real-regression.html'])
+        self.setProperty('second_run_failures', ['pre-existing-flaky.html', 'real-regression.html'])
+        self.setProperty('first_run_failures_filtered', ['real-regression.html'])
+        self.setProperty('second_run_failures_filtered', ['real-regression.html'])
+        self.setProperty('clean_tree_run_failures', [])
+        self.expect_outcome(result=FAILURE, state_string='Found 1 new test failure: real-regression.html (failure)')
+        return self.run_step()
+
+    def test_flaky_limit_ignores_pre_existing(self):
+        # >10 tests flake between the two runs, but all are pre-existing (excluded by the filtered
+        # lists), so we must not report 'Too many flaky failures' and block the PR.
+        self.configureStep()
+        self.setProperty('first_run_failures', [f'test{i}' for i in range(0, 5)])
+        self.setProperty('second_run_failures', [f'test{i}' for i in range(5, 12)])
+        self.setProperty('first_run_failures_filtered', [])
+        self.setProperty('second_run_failures_filtered', [])
+        self.expect_outcome(result=SUCCESS, state_string='Passed layout tests')
+        return self.run_step()
+
+
+class TestFilterLayoutTestFailuresUsingResultsDB(BuildStepMixinAdditions, unittest.TestCase):
+    def setUp(self):
+        self.longMessage = True
+        return self.setup_test_build_step()
+
+    def tearDown(self):
+        return self.tear_down_test_build_step()
+
+    def _configure(self, pre_existing):
+        # pre_existing: set of test names results-db considers pre-existing failures.
+        self.setup_step(RunWebKitTests())
+        step = self.get_nth_step(0)
+        step._addToLog = lambda logName, message: defer.succeed(None)
+
+        def fake_is_pre_existing(cls, test, **kwargs):
+            return defer.succeed({
+                'is_existing_failure': test in pre_existing,
+                'pass_rate': 0 if test in pre_existing else 100,
+                'raw_data': {},
+                'logs': '',
+                'request_failed': False,
+            })
+
+        self.patch(ResultsDatabase, 'is_test_pre_existing_failure', classmethod(fake_is_pre_existing))
+        self.patch(ResultsDatabase, 'has_commit', classmethod(lambda cls, commit=None: defer.succeed(False)))
+        return step
+
+    @defer.inlineCallbacks
+    def _check_order(self, failing_tests, pre_existing):
+        step = self._configure(pre_existing)
+        yield step.filter_failures_using_results_db(failing_tests)
+        self.assertEqual(step.failing_tests_filtered, ['real.html'])
+        self.assertEqual(sorted(step.preexisting_failures_in_results_db), ['flaky1.html', 'flaky2.html'])
+
+    def test_pre_existing_after_real_failure_still_stripped(self):
+        # Regression guard: a pre-existing failure listed after a non-pre-existing one must still be
+        # filtered out (previously an early-break stopped at the first non-pre-existing test).
+        return self._check_order(
+            ['real.html', 'flaky1.html', 'flaky2.html'],
+            {'flaky1.html', 'flaky2.html'},
+        )
+
+    def test_pre_existing_interleaved_with_real_failure_stripped(self):
+        return self._check_order(
+            ['flaky1.html', 'real.html', 'flaky2.html'],
+            {'flaky1.html', 'flaky2.html'},
+        )
+
+    @defer.inlineCallbacks
+    def test_caps_number_of_results_db_queries(self):
+        # Only the first MAX_FAILURES_TO_CHECK_RESULTS_DB failures are checked against results-db.
+        queried = []
+
+        def fake_is_pre_existing(cls, test, **kwargs):
+            queried.append(test)
+            return defer.succeed({
+                'is_existing_failure': True, 'pass_rate': 0, 'raw_data': {}, 'logs': '', 'request_failed': False,
+            })
+
+        self.setup_step(RunWebKitTests())
+        step = self.get_nth_step(0)
+        step._addToLog = lambda logName, message: defer.succeed(None)
+        self.patch(ResultsDatabase, 'is_test_pre_existing_failure', classmethod(fake_is_pre_existing))
+        self.patch(ResultsDatabase, 'has_commit', classmethod(lambda cls, commit=None: defer.succeed(False)))
+
+        cap = RunWebKitTests.MAX_FAILURES_TO_CHECK_RESULTS_DB
+        failing_tests = [f'test{i}.html' for i in range(cap + 10)]
+        yield step.filter_failures_using_results_db(failing_tests)
+        self.assertEqual(len(queried), cap)
 
 
 class MockLayoutTestFailures(object):


### PR DESCRIPTION
#### f554adccfd9e2638290f0c899877cf155af3651d
<pre>
[EWS] Don&apos;t blame PR author for pre-existing flaky layout test failures
<a href="https://bugs.webkit.org/show_bug.cgi?id=319981">https://bugs.webkit.org/show_bug.cgi?id=319981</a>
<a href="https://rdar.apple.com/problem/182908056">rdar://problem/182908056</a>

Reviewed by Ryan Haddad.

A pre-existing flaky layout test can fail with the change and then pass on the clean-tree run
(because it is flaky), which made AnalyzeLayoutTestsResults report it as a new failure and blame
the PR author.

Use the results-db-filtered failure lists, which already have pre-existing failures removed,
so such a test is never counted as new (nor toward the &quot;too many flaky failures&quot; limit).
This relies on those lists being complete, so we no longer stop the results-db lookup at the first
non-pre-existing failure. run-layout-tests-without-change also skips those pre-existing tests, since
the analysis ignores them anyways.

* Tools/CISupport/ews-build/steps.py:
(RunWebKitTests): Add MAX_FAILURES_TO_CHECK_RESULTS_DB.
(RunWebKitTests.filter_failures_using_results_db):
(RunWebKitTestsWithoutChange.setLayoutTestCommand):
(AnalyzeLayoutTestsResults.run):
* Tools/CISupport/ews-build/steps_unittest.py:
(TestFilterLayoutTestFailuresUsingResultsDB):
(TestRunWebKitTestsWithoutChange.test_run_subtest_skips_results_db_pre_existing):

Canonical link: <a href="https://commits.webkit.org/317804@main">https://commits.webkit.org/317804@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/63b2239dbadc2670be4cdb2ba2cf185c9fd7d73e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176413 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/50348 "Build was cancelled. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/44138 "Build was cancelled. Recent messages:OS: Tahoe (26.5.1), Xcode: 26.5; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/186012 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/138676 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178276 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/51640 "Build was cancelled. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; Compiled WebKit (cancelled)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50032 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/186012 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/138676 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179369 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/51640 "Build was cancelled. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/44138 "Build was cancelled. Recent messages:OS: Tahoe (26.5.1), Xcode: 26.5; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/186012 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/51640 "Build was cancelled. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/37912 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/186012 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/44138 "Build was cancelled. Recent messages:OS: Tahoe (26.5.1), Xcode: 26.5; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/51640 "Build was cancelled. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/44138 "Build was cancelled. Recent messages:OS: Tahoe (26.5.1), Xcode: 26.5; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/34480 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/42123 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/188435 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/175816 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50013 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/44138 "Build was cancelled. Recent messages:OS: Tahoe (26.5.1), Xcode: 26.5; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/188435 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50697 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/44138 "Build was cancelled. Recent messages:OS: Tahoe (26.5.1), Xcode: 26.5; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/188435 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26781 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/41038 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/116954 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49201 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/44138 "Build was cancelled. Recent messages:OS: Tahoe (26.5.1), Xcode: 26.5; Checked out pull request; Compiled WebKit (cancelled)") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48603 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48837 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48662 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->