### PR TITLE
LibWebRTCAudioModule has a data race on m_isPlaying and m_audioTransport

### DIFF
--- a/Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCAudioModule.cpp
+++ b/Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCAudioModule.cpp
@@ -56,7 +56,7 @@ int32_t LibWebRTCAudioModule::RegisterAudioCallback(webrtc::AudioTransport* audi
 
 int32_t LibWebRTCAudioModule::StartPlayout()
 {
-    RELEASE_LOG(WebRTC, "LibWebRTCAudioModule::StartPlayout %d", m_isPlaying);
+    RELEASE_LOG(WebRTC, "LibWebRTCAudioModule::StartPlayout %d", m_isPlaying.load());
 
     if (m_isPlaying)
         return 0;
@@ -78,7 +78,7 @@ int32_t LibWebRTCAudioModule::StartPlayout()
 
 int32_t LibWebRTCAudioModule::StopPlayout()
 {
-    RELEASE_LOG(WebRTC, "LibWebRTCAudioModule::StopPlayout %d", m_isPlaying);
+    RELEASE_LOG(WebRTC, "LibWebRTCAudioModule::StopPlayout %d", m_isPlaying.load());
 
     m_isPlaying = false;
     callOnMainThread([this, protectedThis = Ref { *this }] {
@@ -130,14 +130,15 @@ void LibWebRTCAudioModule::pollAudioData()
 
 void LibWebRTCAudioModule::pollFromSource()
 {
-    if (!m_audioTransport)
+    auto* audioTransport = m_audioTransport.load();
+    if (!audioTransport)
         return;
 
     for (unsigned i = 0; i < PollSamplesCount; i++) {
         int64_t elapsedTime = -1;
         int64_t ntpTime = -1;
         char data[LibWebRTCAudioFormat::sampleByteSize * channels * LibWebRTCAudioFormat::chunkSampleCount];
-        m_audioTransport->PullRenderData(LibWebRTCAudioFormat::sampleByteSize * 8, LibWebRTCAudioFormat::sampleRate, channels, LibWebRTCAudioFormat::chunkSampleCount, data, &elapsedTime, &ntpTime);
+        audioTransport->PullRenderData(LibWebRTCAudioFormat::sampleByteSize * 8, LibWebRTCAudioFormat::sampleRate, channels, LibWebRTCAudioFormat::chunkSampleCount, data, &elapsedTime, &ntpTime);
 #if PLATFORM(COCOA)
         if (m_isRenderingIncomingAudioCounter)
             m_incomingAudioMediaStreamTrackRendererUnit->newAudioChunkPushed(m_currentAudioSampleCount);

--- a/Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCAudioModule.h
+++ b/Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCAudioModule.h
@@ -154,8 +154,8 @@ private:
     static constexpr Seconds logTimerInterval = 2_s;
 
     const Ref<WorkQueue> m_queue;
-    bool m_isPlaying { false };
-    webrtc::AudioTransport* m_audioTransport { nullptr };
+    std::atomic<bool> m_isPlaying { false };
+    std::atomic<webrtc::AudioTransport*> m_audioTransport { nullptr };
     MonotonicTime m_pollingTime;
     Timer m_logTimer;
     int m_timeSpent { 0 };


### PR DESCRIPTION
#### 17afba52f935e236c57013631ed39f83e5c4668d
<pre>
LibWebRTCAudioModule has a data race on m_isPlaying and m_audioTransport
<a href="https://bugs.webkit.org/show_bug.cgi?id=320113">https://bugs.webkit.org/show_bug.cgi?id=320113</a>
<a href="https://rdar.apple.com/183054655">rdar://183054655</a>

Reviewed by Youenn Fablet.

m_isPlaying and m_audioTransport are written from StartPlayout(),
StopPlayout(), and RegisterAudioCallback() — called from libwebrtc&apos;s
callback threads — and read from pollAudioData()/pollFromSource() on
the internal WorkQueue thread, as well as from Playing(), with no
lock or atomic. Make both members std::atomic to close the race.

* Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCAudioModule.cpp:
(WebCore::LibWebRTCAudioModule::StartPlayout):
(WebCore::LibWebRTCAudioModule::StopPlayout):
(WebCore::LibWebRTCAudioModule::pollFromSource):
* Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCAudioModule.h:

Canonical link: <a href="https://commits.webkit.org/318047@main">https://commits.webkit.org/318047@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9917390b48d570fe6cdd524db673cb0db72de3d9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176416 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50351 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44141 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186015 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/138679 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4bc85efa-09ca-496a-b309-e7d9452aa008) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178279 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51643 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50035 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137414 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/138679 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bc3037ae-0313-4c5d-b6a9-c19910f3b2d3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179372 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40900 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158194 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117889 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c0a5bf41-7b3d-4c1f-91c1-e4a06aed0a84) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39550 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37916 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149965 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37692 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34483 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42080 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42127 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188438 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50016 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146458 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39538 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50700 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34310 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146269 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41041 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122904 "Build is in progress. Recent messages:OS: Tahoe (26.3.1), Xcode: 26.2; Checked out pull request; Found 27545 issues") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/116958 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49204 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12667 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48606 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48840 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48665 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->