### PR TITLE
Debounce Find in Page requests

### DIFF
--- a/Source/WebKit/WebProcess/WebPage/FindController.cpp
+++ b/Source/WebKit/WebProcess/WebPage/FindController.cpp
@@ -70,6 +70,8 @@ using namespace WebCore;
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(FindController);
 
+static constexpr Seconds findDebounceInterval = 200_ms;
+
 #if ENABLE(VIDEO)
 static Vector<FindMatch> mergeByDocumentOrder(Page& page, Vector<SimpleRange>&& domRanges, Vector<CueMatch>&& cueMatches)
 {
@@ -191,10 +193,14 @@ FindController::FindController(WebPage* webPage)
 #else
     , m_findIndicator(WTF::makeUnique<FindIndicator>(webPage))
 #endif
+    , m_findDebounceTimer(*this, &FindController::findDebounceTimerFired, findDebounceInterval)
 {
 }
 
-FindController::~FindController() = default;
+FindController::~FindController()
+{
+    cancelPendingFindRequests();
+}
 
 #if ENABLE(PDF_PLUGIN)
 
@@ -495,7 +501,47 @@ void FindController::findStringIncludingImages(const String& string, OptionSet<F
 
 void FindController::findString(const String& string, OptionSet<FindOptions> options, unsigned maxMatchCount, CompletionHandler<void(std::optional<FrameIdentifier>, Vector<IntRect>&&, uint32_t, int32_t, bool)>&& completionHandler)
 {
-    findString(string, options, maxMatchCount, ShouldReuseLastFoundRange::No, WTF::move(completionHandler));
+    if (string.isEmpty()) {
+        cancelPendingFindRequests();
+        findString(string, options, maxMatchCount, ShouldReuseLastFoundRange::No, WTF::move(completionHandler));
+        return;
+    }
+
+    bool termChanged = string != m_lastSearchedString || options != m_lastSearchedOptions;
+    if (!termChanged && !m_findDebounceTimer.isActive()) {
+        findString(string, options, maxMatchCount, ShouldReuseLastFoundRange::No, WTF::move(completionHandler));
+        return;
+    }
+
+    m_pendingFindRequest.string = string;
+    m_pendingFindRequest.options = options;
+    m_pendingFindRequest.maxMatchCount = maxMatchCount;
+    m_pendingFindRequest.completionHandlers.append(WTF::move(completionHandler));
+    m_findDebounceTimer.restart();
+}
+
+void FindController::findDebounceTimerFired()
+{
+    auto completionHandlers = std::exchange(m_pendingFindRequest.completionHandlers, { });
+    m_lastSearchedString = m_pendingFindRequest.string;
+    m_lastSearchedOptions = m_pendingFindRequest.options;
+
+    findString(m_pendingFindRequest.string, m_pendingFindRequest.options, m_pendingFindRequest.maxMatchCount, ShouldReuseLastFoundRange::No, [completionHandlers = WTF::move(completionHandlers)](std::optional<FrameIdentifier> frameID, Vector<IntRect>&& matchRects, uint32_t matchCount, int32_t matchIndex, bool didWrap) mutable {
+        for (auto& completionHandler : completionHandlers)
+            completionHandler(frameID, Vector<IntRect> { matchRects }, matchCount, matchIndex, didWrap);
+    });
+
+    m_pendingFindRequest.string = { };
+}
+
+void FindController::cancelPendingFindRequests()
+{
+    m_findDebounceTimer.stop();
+    m_lastSearchedString = { };
+    m_pendingFindRequest.string = { };
+    auto completionHandlers = std::exchange(m_pendingFindRequest.completionHandlers, { });
+    for (auto& completionHandler : completionHandlers)
+        completionHandler(std::nullopt, { }, 0, 0, false);
 }
 
 void FindController::selectLastFoundRange(const String& string, OptionSet<FindOptions> options, unsigned maxMatchCount, CompletionHandler<void(std::optional<FrameIdentifier>, Vector<IntRect>&&, int32_t, bool)>&& completionHandler)
@@ -727,6 +773,7 @@ void FindController::indicateFindMatch(uint32_t matchIndex)
 
 void FindController::hideFindUI()
 {
+    cancelPendingFindRequests();
     m_findMatches.clear();
     m_lastFoundRange = std::nullopt;
     if (RefPtr findPageOverlay = m_findPageOverlay.get())

--- a/Source/WebKit/WebProcess/WebPage/FindController.h
+++ b/Source/WebKit/WebProcess/WebPage/FindController.h
@@ -34,6 +34,7 @@
 #include <WebCore/PageOverlay.h>
 #include <WebCore/ShareableBitmap.h>
 #include <WebCore/SimpleRange.h>
+#include <WebCore/Timer.h>
 #include <WebCore/VisibleSelection.h>
 #include <wtf/CompletionHandler.h>
 #include <wtf/Forward.h>
@@ -109,6 +110,10 @@ private:
     enum class ShouldReuseLastFoundRange : bool { No, Yes };
     void findString(const String&, OptionSet<FindOptions>, unsigned maxMatchCount, ShouldReuseLastFoundRange, CompletionHandler<void(std::optional<WebCore::FrameIdentifier>, Vector<WebCore::IntRect>&&, uint32_t, int32_t, bool)>&&);
 
+    using FindStringCompletionHandler = CompletionHandler<void(std::optional<WebCore::FrameIdentifier>, Vector<WebCore::IntRect>&&, uint32_t, int32_t, bool)>;
+    void findDebounceTimerFired();
+    void cancelPendingFindRequests();
+
     void updateFindPageOverlay(bool shouldShowOverlay);
     void updateFindIndicatorIfNeeded(bool found, OptionSet<FindOptions>, bool shouldShowOverlay);
     unsigned markMatches(const String&, OptionSet<FindOptions>, unsigned maxMatchCount, unsigned cueMatchCount);
@@ -131,6 +136,18 @@ private:
     std::optional<FindMatch> m_lastFoundRange;
     bool m_lastFoundRangeDidWrap { false };
     std::unique_ptr<FindIndicator> m_findIndicator;
+
+    struct PendingFindRequest {
+        String string;
+        OptionSet<FindOptions> options;
+        unsigned maxMatchCount { 0 };
+        Vector<FindStringCompletionHandler> completionHandlers;
+    };
+
+    WebCore::DeferrableOneShotTimer m_findDebounceTimer;
+    String m_lastSearchedString;
+    OptionSet<FindOptions> m_lastSearchedOptions;
+    PendingFindRequest m_pendingFindRequest;
 };
 
 } // namespace WebKit


### PR DESCRIPTION
#### df35c8a367d79c632f6cf46fe825b3362f5be1aa
<pre>
Debounce Find in Page requests
<a href="https://bugs.webkit.org/show_bug.cgi?id=320115">https://bugs.webkit.org/show_bug.cgi?id=320115</a>
<a href="https://rdar.apple.com/183057865">rdar://183057865</a>

Reviewed by NOBODY (OOPS!).

When users type in their search term, an entire search is
conducted for each letter they type. On large pages, this can
be a visible slow down, especially for an uncached page (the
first search). To fix this, I debounce the search. Only after
inactivity for 200ms is the search performed. I special cased
the empty string so results will disappear quickly when the
user removes the search string.

* Source/WebKit/WebProcess/WebPage/FindController.cpp:
(WebKit::FindController::FindController):
(WebKit::FindController::~FindController):
(WebKit::FindController::findString):
(WebKit::FindController::findDebounceTimerFired):
(WebKit::FindController::cancelPendingFindRequests):
(WebKit::FindController::hideFindUI):
* Source/WebKit/WebProcess/WebPage/FindController.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/df35c8a367d79c632f6cf46fe825b3362f5be1aa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176420 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50355 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44145 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186019 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/138683 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1c11dc86-2666-4c77-8cca-448fde627505) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51647 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50039 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137419 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/138683 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2bd6e066-f6af-439a-a92d-6eb69714ab26) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179376 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40903 "Found 2 new test failures: platform/ios/fast/scrolling/find-text-in-overflow-node-indicator-position-limit.html platform/ios/fast/scrolling/find-text-in-overflow-node-indicator-position.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158202 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117894 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/50b63189-ce50-4c45-8440-720304f951cf) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39553 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37919 "Found 1 new API test failure: TestWebKitAPI._WKDownload.DownloadMonitorCancel (failure)") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149968 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37700 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34487 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42084 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42130 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188442 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50020 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146463 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50704 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34318 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146274 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41044 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122908 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/116962 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49208 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12675 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48610 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48844 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48669 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->