### PR TITLE
Support external and data: URL filter references on HTML elements

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -5976,6 +5976,8 @@ imported/w3c/web-platform-tests/css/filter-effects/svg-mutation-object-transform
 imported/w3c/web-platform-tests/css/filter-effects/svg-mutation-single-to-multiple-001.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/filter-effects/svg-mutation-single-to-multiple-002.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/filter-effects/svg-mutation-url-to-function.html [ ImageOnlyFailure ]
+webkit.org/b/320225 imported/w3c/web-platform-tests/css/filter-effects/svg-relative-urls-001.html [ ImageOnlyFailure ]
+webkit.org/b/320225 imported/w3c/web-platform-tests/css/filter-effects/svg-relative-urls-002.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/filter-effects/svg-shorthand-drop-shadow-001.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/filter-effects/svg-shorthand-hue-rotate-001.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/filter-effects/backdrop-filter-reference-filter.html [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/img-src/css-filter-blocked.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/img-src/css-filter-blocked.tentative-expected.txt
@@ -1,5 +1,3 @@
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT Blocked CSS filter: SVG Test timed out
+PASS Blocked CSS filter: SVG
 

--- a/Source/WebCore/rendering/ReferencedSVGResources.cpp
+++ b/Source/WebCore/rendering/ReferencedSVGResources.cpp
@@ -355,6 +355,15 @@ RefPtr<SVGFilterElement> ReferencedSVGResources::referencedFilterElement(TreeSco
     if (filterReference.cachedFragment.isEmpty())
         return nullptr;
 
+    Ref document = treeScope.documentScope();
+    CheckedRef extensions = document->svgExtensions();
+    if (auto externalDocument = extensions->externalResourceDocument(filterReference.url.resolved)) {
+        RefPtr resolvedDocument = *externalDocument;
+        if (!resolvedDocument)
+            return nullptr;
+        return downcast<SVGFilterElement>(elementForResourceID(*resolvedDocument, filterReference.cachedFragment, SVGNames::filterTag));
+    }
+
     return downcast<SVGFilterElement>(elementForResourceID(treeScope, filterReference.cachedFragment, SVGNames::filterTag));
 }
 

--- a/Source/WebCore/style/StylePendingResources.cpp
+++ b/Source/WebCore/style/StylePendingResources.cpp
@@ -82,7 +82,7 @@ static void loadPendingImage(Document& document, const Image* image, const Eleme
     const_cast<Image&>(*image).load(protect(document.cachedResourceLoader()), options);
 }
 
-static void loadExternalSVGResource(Document& document, const WTF::URL& url)
+static void loadExternalSVGResource(Document& document, const Element* element, const WTF::URL& url)
 {
     if (url.isNull())
         return;
@@ -97,9 +97,14 @@ static void loadExternalSVGResource(Document& document, const WTF::URL& url)
     if (extensions->hasExternalSVGResource(documentURL))
         return;
 
+    // The resource is fetched as an image, so it is subject to img-src CSP unless it lives in a user-agent
+    // shadow tree (matching loadPendingImage).
+    bool isInUserAgentShadowTree = element && element->isInUserAgentShadowTree();
     auto options = CachedResourceLoader::defaultCachedResourceOptions();
     options.mode = FetchOptions::Mode::SameOrigin;
     options.sameOriginDataURLFlag = SameOriginDataURLFlag::Set;
+    options.contentSecurityPolicyImposition = isInUserAgentShadowTree ? ContentSecurityPolicyImposition::SkipPolicyCheck : ContentSecurityPolicyImposition::DoPolicyCheck;
+    options.shouldEnableContentExtensionsCheck = isInUserAgentShadowTree ? ShouldEnableContentExtensionsCheck::No : ShouldEnableContentExtensionsCheck::Yes;
 
     CachedResourceRequest request(ResourceRequest(WTF::URL { documentURL }), options);
     request.setInitiatorType(cachedResourceRequestInitiatorTypes().css);
@@ -109,22 +114,34 @@ static void loadExternalSVGResource(Document& document, const WTF::URL& url)
     extensions->addExternalSVGResource(documentURL, *cachedImage, document);
 }
 
-static void loadPendingExternalSVGPaint(Document& document, const Style::SVGPaint& paint)
+static void loadPendingExternalSVGPaint(Document& document, const Element* element, const Style::SVGPaint& paint)
 {
     if (auto url = paint.tryAnyURL())
-        loadExternalSVGResource(document, url->resolved);
+        loadExternalSVGResource(document, element, url->resolved);
 }
 
-static void loadPendingExternalSVGMarker(Document& document, const Style::SVGMarkerResource& marker)
+static void loadPendingExternalSVGMarker(Document& document, const Element* element, const Style::SVGMarkerResource& marker)
 {
     if (auto url = marker.tryURL())
-        loadExternalSVGResource(document, url->resolved);
+        loadExternalSVGResource(document, element, url->resolved);
 }
 
-static void loadPendingExternalSVGClipPath(Document& document, const Style::ClipPath& clipPath)
+static void loadPendingExternalSVGClipPath(Document& document, const Element* element, const Style::ClipPath& clipPath)
 {
     if (auto referencePath = clipPath.tryReference())
-        loadExternalSVGResource(document, referencePath->url().resolved);
+        loadExternalSVGResource(document, element, referencePath->url().resolved);
+}
+
+static void loadPendingExternalSVGFilter(Document& document, const Element* element, const Style::Filter& filter)
+{
+    if (filter.size() != 1)
+        return;
+    WTF::switchOn(filter.first(),
+        [&](const Style::FilterReference& filterReference) {
+            loadExternalSVGResource(document, element, filterReference.url.resolved);
+        },
+        [](const auto&) { }
+    );
 }
 
 void loadPendingResources(Style::ComputedStyle& style, Document& document, const Element* element)
@@ -165,27 +182,18 @@ void loadPendingResources(Style::ComputedStyle& style, Document& document, const
         loadPendingImage(document, shapeValueImage.get(), element, LoadPolicy::Anonymous);
 
     if (document.settings().svgExternalResourcesEnabled()) {
-        // Paint servers, markers, and filter= resolve through SVGResources, which only applies to SVG
-        // elements.
+        // Paint servers and markers resolve through SVGResources, which only applies to SVG elements.
         if (element && is<SVGElement>(*element)) {
-            loadPendingExternalSVGPaint(document, style.fill());
-            loadPendingExternalSVGPaint(document, style.stroke());
+            loadPendingExternalSVGPaint(document, element, style.fill());
+            loadPendingExternalSVGPaint(document, element, style.stroke());
 
-            loadPendingExternalSVGMarker(document, style.markerStart());
-            loadPendingExternalSVGMarker(document, style.markerMid());
-            loadPendingExternalSVGMarker(document, style.markerEnd());
-
-            if (style.filter().size() == 1) {
-                WTF::switchOn(style.filter().first(),
-                    [&](const Style::FilterReference& filterReference) {
-                        loadExternalSVGResource(document, filterReference.url.resolved);
-                    },
-                    [](const auto&) { }
-                );
-            }
+            loadPendingExternalSVGMarker(document, element, style.markerStart());
+            loadPendingExternalSVGMarker(document, element, style.markerMid());
+            loadPendingExternalSVGMarker(document, element, style.markerEnd());
         }
 
-        loadPendingExternalSVGClipPath(document, style.clipPath());
+        loadPendingExternalSVGClipPath(document, element, style.clipPath());
+        loadPendingExternalSVGFilter(document, element, style.filter());
     }
 
     // Are there other pseudo-elements that need resource loading?


### PR DESCRIPTION
#### 690ab3f55222060f2c53a44c81373dd003440dfb
<pre>
Support external and data: URL filter references on HTML elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=320118">https://bugs.webkit.org/show_bug.cgi?id=320118</a>
<a href="https://rdar.apple.com/183059589">rdar://183059589</a>

Reviewed by Simon Fraser.

The CSS filter: property on an HTML element now resolves a &lt;filter&gt;
referenced by an external file or a data: URL.

* LayoutTests/TestExpectations:

svg-relative-urls-001 and -002 are marked ImageOnlyFailure: they exercise
relative filter URLs that are not re-resolved when an element moves
documents, a pre-existing issue surfaced here and tracked in bug 320225.

* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/img-src/css-filter-blocked.tentative-expected.txt: now passes
* Source/WebCore/rendering/ReferencedSVGResources.cpp:
(WebCore::ReferencedSVGResources::referencedFilterElement):
* Source/WebCore/style/StylePendingResources.cpp:
(WebCore::Style::loadPendingExternalSVGFilter):
(WebCore::Style::loadPendingResources):
(WebCore::Style::loadExternalSVGResource):
(WebCore::Style::loadPendingExternalSVGPaint):
(WebCore::Style::loadPendingExternalSVGMarker):
(WebCore::Style::loadPendingExternalSVGClipPath):

Canonical link: <a href="https://commits.webkit.org/317991@main">https://commits.webkit.org/317991@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d3fa7c8cdc8ffbe37541aefb38bccc1cee19e73b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176957 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50894 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44689 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186560 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140193 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/62edcdf2-960d-459c-bb72-ca5fcd880b00) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178820 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52187 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50580 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137877 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140193 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f27eb62f-0d1e-496f-a5fc-24b8cca88d96) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179913 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41387 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158664 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118346 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/98b77ef5-1d3a-49f8-9410-a754d4bcdec8) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40043 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38406 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150453 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38164 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35028 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42646 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42624 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188983 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50561 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/158204 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146952 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39505 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51244 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/34788 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146749 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41509 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123457 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117744 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49749 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13144 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49148 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49385 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49209 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->