### PR TITLE
Make smart pointers in Style::ColorResolutionState const

### DIFF
--- a/Source/WebCore/style/values/color/StyleColorResolutionState.h
+++ b/Source/WebCore/style/values/color/StyleColorResolutionState.h
@@ -39,8 +39,8 @@ enum class ForVisitedLink : bool;
 // Used to resolve a CSS::Color to a Style::Color during style building.
 
 struct ColorResolutionState {
-    Ref<const Document> document;
-    CheckedRef<const ComputedStyle> style;
+    const Ref<const Document> document;
+    const CheckedRef<const ComputedStyle> style;
     CSSToLengthConversionData conversionData;
     ForVisitedLink forVisitedLink;
 

--- a/Source/WebCore/style/values/color/StyleKeywordColor.cpp
+++ b/Source/WebCore/style/values/color/StyleKeywordColor.cpp
@@ -41,21 +41,19 @@ namespace Style {
 
 Color toStyleColor(const CSS::KeywordColor& unresolved, ColorResolutionState& state)
 {
-    Ref protectedDocument = state.document;
-
     switch (unresolved.valueID) {
     case CSSValueInternalDocumentTextColor:
-        return { protectedDocument->textColor() };
+        return { state.document->textColor() };
     case CSSValueWebkitLink:
-        return { state.forVisitedLink == ForVisitedLink::Yes ? protectedDocument->visitedLinkColor(state.style) : protectedDocument->linkColor(state.style) };
+        return { state.forVisitedLink == ForVisitedLink::Yes ? state.document->visitedLinkColor(state.style) : state.document->linkColor(state.style) };
     case CSSValueWebkitActivelink:
-        return { protectedDocument->activeLinkColor(state.style) };
+        return { state.document->activeLinkColor(state.style) };
     case CSSValueWebkitFocusRingColor:
-        return { RenderTheme::singleton().focusRingColor(protectedDocument->styleColorOptions(state.style.ptr())) };
+        return { RenderTheme::singleton().focusRingColor(state.document->styleColorOptions(state.style.ptr())) };
     case CSSValueCurrentcolor:
         return { CurrentColor() };
     default:
-        return { CSS::colorFromKeyword(unresolved.valueID, protectedDocument->styleColorOptions(state.style.ptr())) };
+        return { CSS::colorFromKeyword(unresolved.valueID, state.document->styleColorOptions(state.style.ptr())) };
     }
 }
 

--- a/Source/WebCore/style/values/color/StyleLightDarkColor.cpp
+++ b/Source/WebCore/style/values/color/StyleLightDarkColor.cpp
@@ -41,7 +41,7 @@ Color toStyleColor(const CSS::LightDarkColor& unresolved, ColorResolutionState& 
     ColorResolutionStateNester nester { state };
 
     Ref<const Document> document = state.document;
-    if (document->useDarkAppearance(CheckedRef { state.style }.ptr()))
+    if (document->useDarkAppearance(state.style.ptr()))
         return toStyleColor(unresolved.darkColor, state);
     return toStyleColor(unresolved.lightColor, state);
 }


### PR DESCRIPTION
#### a3ef039b60735f7852569d5d6d61a5bacf6027ac
<pre>
Make smart pointers in Style::ColorResolutionState const
<a href="https://rdar.apple.com/183061220">rdar://183061220</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=320119">https://bugs.webkit.org/show_bug.cgi?id=320119</a>

Reviewed by Tim Nguyen.

Style::ColorResolutionState contains two smart pointers that can be
made const, so we don&apos;t need to refcount them before using it.

* Source/WebCore/style/values/color/StyleColorResolutionState.h:
* Source/WebCore/style/values/color/StyleKeywordColor.cpp:
(WebCore::Style::toStyleColor):
* Source/WebCore/style/values/color/StyleLightDarkColor.cpp:
(WebCore::Style::toStyleColor):

Canonical link: <a href="https://commits.webkit.org/317847@main">https://commits.webkit.org/317847@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5789518f4af27c8a432fd965edaf772ffc652f25

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176427 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50362 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44152 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186026 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/138690 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f44bfcdf-0c70-4440-bd9c-2f2fa6b780ea) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178290 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51654 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50046 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137423 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/138690 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/03867058-d077-438b-a66a-949755c5948b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179383 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40909 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158206 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117898 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2e30b002-9ee5-40d3-a7f4-86c553c29671) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39559 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37926 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149974 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37704 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34494 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42091 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42137 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188449 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50027 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146467 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39417 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50711 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34322 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146278 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41052 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122915 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/116974 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49215 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12679 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48617 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48851 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48676 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->