### PR TITLE
Add support for loading a single nested model inside of a Spatial Portal

### DIFF
--- a/LayoutTests/spatial-css/spatial-portal-layers-expected.txt
+++ b/LayoutTests/spatial-css/spatial-portal-layers-expected.txt
@@ -1,0 +1,22 @@
+
+(CALayer tree root
+  (layer bounds [x: 0 y: 0 width: 353 height: 214])
+  (layer position [x: 198.5 y: 123])
+  (sublayers
+    (
+      (layer bounds [x: 0 y: 0 width: 320 height: 184])
+      (layer position [x: 168 y: 112])
+      (sublayers
+        (
+          (layer bounds [x: 0 y: 0 width: 320 height: 184])
+          (layer position [x: 160 y: 92]))
+        (
+          (layer bounds [x: 0 y: 0 width: 320 height: 184])
+          (layer position [x: 160 y: 92])
+          (sublayers
+            (
+              (layer bounds [x: 0 y: 0 width: 320 height: 184])
+              (layer position [x: 160 y: 92]))))))
+    (
+      (layer bounds [x: 0 y: 0 width: 353 height: 214])
+      (layer position [x: 176.5 y: 107]))))

--- a/LayoutTests/spatial-css/spatial-portal-layers.html
+++ b/LayoutTests/spatial-css/spatial-portal-layers.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html><!-- webkit-test-runner [ SpatialPortalEnabled=true ModelElementEnabled=true ModelProcessEnabled=true allowTestOnlyIPC=true ] -->
+<html>
+<head>
+<script src="../resources/ui-helper.js"></script>
+<style>
+    #portal {
+        spatial: portal;
+        width: 300px;
+        height: 150px;
+        padding: 24px 8px 10px 12px;
+        margin: 28px 10px 12px 14px;
+        border: 8px black solid;
+        box-shadow: 10px -5px 5px red;
+    }
+</style>
+</head>
+<body>
+<div id="portal">
+    <model id="model" src="../model-element/resources/cube.usdz"></model>
+    <span id="content">Hello!</span>
+</div>
+<pre id="results"></pre>
+<script>
+window.onload = async function () {
+    window.internals?.disableModelLoadDelaysForTesting();
+    window.testRunner?.waitUntilDone();
+    window.testRunner?.dumpAsText();
+    await document.getElementById("model").ready;
+
+    await UIHelper.ensureStablePresentationUpdate();
+    results.textContent = await UIHelper.getCALayerTreeForCompositedElement(document.getElementById("portal"));
+
+    document.getElementById("portal").remove();
+
+    window.testRunner?.notifyDone();
+};
+</script>
+</body>
+</html>

--- a/LayoutTests/spatial-css/spatial-portal-model-insert-remove-expected.txt
+++ b/LayoutTests/spatial-css/spatial-portal-model-insert-remove-expected.txt
@@ -1,0 +1,4 @@
+
+PASS Dynamically inserting a <model> into a spatial portal loads it
+PASS Removing spatial: portal renders the child model in standalone mode
+

--- a/LayoutTests/spatial-css/spatial-portal-model-insert-remove.html
+++ b/LayoutTests/spatial-css/spatial-portal-model-insert-remove.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ SpatialPortalEnabled=true ModelElementEnabled=true ModelProcessEnabled=true allowTestOnlyIPC=true ] -->
+<html>
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<script src="../resources/ui-helper.js"></script>
+<style>
+    #portal { spatial: portal; width: 300px; height: 150px; }
+</style>
+<body>
+<div id="portal"></div>
+<script>
+'use strict';
+
+window.internals?.disableModelLoadDelaysForTesting();
+
+promise_test(async t => {
+    const portal = document.getElementById("portal");
+
+    const model = document.createElement("model");
+    t.add_cleanup(() => model.remove());
+
+    let loadFired = false;
+    model.addEventListener("load", () => loadFired = true, { once: true });
+    portal.appendChild(model);
+
+    const source = document.createElement("source");
+    source.src = "../model-element/resources/cube.usdz";
+    model.appendChild(source);
+
+    await model.ready;
+    assert_true(loadFired, "dynamically inserted <model> fires load and ready");
+    assert_equals(model.getBoundingClientRect().width, 0, "delegated <model> has no box of its own");
+}, "Dynamically inserting a <model> into a spatial portal loads it");
+
+promise_test(async t => {
+    const portal = document.getElementById("portal");
+
+    const model = document.createElement("model");
+    t.add_cleanup(() => model.remove());
+
+    portal.appendChild(model);
+    const source = document.createElement("source");
+    source.src = "../model-element/resources/cube.usdz";
+    model.appendChild(source);
+
+    await model.ready;
+    assert_equals(model.getBoundingClientRect().width, 0, "delegated <model> has no box while inside the portal");
+
+    portal.style.spatial = "none";
+    await UIHelper.ensureStablePresentationUpdate();
+    assert_greater_than(model.getBoundingClientRect().width, 0, "standalone <model> regains a box of its own");
+}, "Removing spatial: portal renders the child model in standalone mode");
+</script>
+</body>
+</html>

--- a/LayoutTests/spatial-css/spatial-portal-model-move-expected.txt
+++ b/LayoutTests/spatial-css/spatial-portal-model-move-expected.txt
@@ -1,0 +1,3 @@
+
+PASS A <model> moved into a spatial portal delegates to the destination portal
+

--- a/LayoutTests/spatial-css/spatial-portal-model-move.html
+++ b/LayoutTests/spatial-css/spatial-portal-model-move.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ SpatialPortalEnabled=true ModelElementEnabled=true ModelProcessEnabled=true allowTestOnlyIPC=true ] -->
+<html>
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<script src="../resources/ui-helper.js"></script>
+<style>
+    .portal { spatial: portal; width: 300px; height: 150px; }
+</style>
+<body>
+<div id="portalA" class="portal"></div>
+<div id="portalB" class="portal"></div>
+<script>
+'use strict';
+
+window.internals?.disableModelLoadDelaysForTesting();
+
+promise_test(async t => {
+    const portalA = document.getElementById("portalA");
+    const portalB = document.getElementById("portalB");
+
+    const model = document.createElement("model");
+    t.add_cleanup(() => model.remove());
+
+    portalA.appendChild(model);
+    const source = document.createElement("source");
+    source.src = "../model-element/resources/cube.usdz";
+    model.appendChild(source);
+
+    await model.ready;
+    assert_equals(internals.numberOfHostedModelsInSpatialPortal(portalA), 1, "portal A hosts the model after insertion");
+    assert_equals(internals.numberOfHostedModelsInSpatialPortal(portalB), 0, "portal B does not host the model before the move");
+
+    portalB.appendChild(model);
+    await UIHelper.ensureStablePresentationUpdate();
+    assert_equals(internals.numberOfHostedModelsInSpatialPortal(portalB), 1, "portal B hosts the model after the move");
+    assert_equals(internals.numberOfHostedModelsInSpatialPortal(portalA), 0, "portal A no longer hosts the model after the move");
+}, "A <model> moved into a spatial portal delegates to the destination portal");
+</script>
+</body>
+</html>

--- a/LayoutTests/spatial-css/spatial-portal-nested-portals-expected.txt
+++ b/LayoutTests/spatial-css/spatial-portal-nested-portals-expected.txt
@@ -1,0 +1,3 @@
+
+PASS A <model> in nested spatial portals delegates to the outer portal
+

--- a/LayoutTests/spatial-css/spatial-portal-nested-portals.html
+++ b/LayoutTests/spatial-css/spatial-portal-nested-portals.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ SpatialPortalEnabled=true ModelElementEnabled=true ModelProcessEnabled=true allowTestOnlyIPC=true ] -->
+<html>
+<head>
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<script src="../resources/ui-helper.js"></script>
+<style>
+    #outer { spatial: portal; width: 400px; height: 200px; }
+    #inner { spatial: portal; width: 300px; height: 150px; }
+</style>
+<body>
+<div id="outer">
+    <div id="inner">
+        <model id="model"><source src="../model-element/resources/cube.usdz"></model>
+    </div>
+</div>
+<script>
+'use strict';
+
+window.internals?.disableModelLoadDelaysForTesting();
+
+promise_test(async t => {
+    const model = document.getElementById("model");
+    await model.ready;
+    await UIHelper.ensureStablePresentationUpdate();
+
+    const outer = document.getElementById("outer");
+    const inner = document.getElementById("inner");
+
+    assert_true(internals.establishesSpatialPortal(outer), "the outer element establishes a portal");
+    assert_false(internals.establishesSpatialPortal(inner), "the nested spatial: portal is a noop");
+
+    assert_equals(internals.numberOfHostedModelsInSpatialPortal(outer), 1, "the single (outer) portal hosts the model");
+    assert_equals(internals.numberOfHostedModelsInSpatialPortal(inner), 0, "the nested portal hosts nothing");
+}, "A <model> in nested spatial portals delegates to the outer portal");
+</script>
+</body>
+</html>

--- a/LayoutTests/spatial-css/spatial-portal-nesting-dynamic-expected.txt
+++ b/LayoutTests/spatial-css/spatial-portal-nesting-dynamic-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Toggling spatial: portal on an ancestor suppresses and restores a descendant portal
+

--- a/LayoutTests/spatial-css/spatial-portal-nesting-dynamic.html
+++ b/LayoutTests/spatial-css/spatial-portal-nesting-dynamic.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ SpatialPortalEnabled=true ModelElementEnabled=true ModelProcessEnabled=true allowTestOnlyIPC=true ] -->
+<html>
+<head>
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<script src="../resources/ui-helper.js"></script>
+<style>
+    .portal { spatial: portal; width: 400px; height: 200px; }
+</style>
+<body>
+<div id="outer">
+    <div id="inner" class="portal">
+        <model id="model"><source src="../model-element/resources/cube.usdz"></model>
+    </div>
+</div>
+<script>
+'use strict';
+
+window.internals?.disableModelLoadDelaysForTesting();
+
+promise_test(async t => {
+    const outer = document.getElementById("outer");
+    const inner = document.getElementById("inner");
+    const model = document.getElementById("model");
+
+    await model.ready;
+    await UIHelper.ensureStablePresentationUpdate();
+
+    assert_true(internals.establishesSpatialPortal(inner), "the inner portal is live while it has no portal ancestor");
+    assert_equals(internals.numberOfHostedModelsInSpatialPortal(inner), 1, "the inner portal hosts the model");
+
+    // Turning the ancestor into a portal must suppress the descendant portal.
+    outer.classList.add("portal");
+    await UIHelper.ensureStablePresentationUpdate();
+
+    assert_true(internals.establishesSpatialPortal(outer), "the outer element establishes a portal once it gains spatial: portal");
+    assert_false(internals.establishesSpatialPortal(inner), "the inner portal is suppressed by the new ancestor portal");
+    assert_equals(internals.numberOfHostedModelsInSpatialPortal(inner), 0, "the suppressed inner portal hosts nothing");
+
+    // Removing it again must hand the model back to the inner portal.
+    outer.classList.remove("portal");
+    await UIHelper.ensureStablePresentationUpdate();
+
+    assert_false(internals.establishesSpatialPortal(outer), "the outer element stops establishing a portal");
+    assert_true(internals.establishesSpatialPortal(inner), "the inner portal is restored");
+}, "Toggling spatial: portal on an ancestor suppresses and restores a descendant portal");
+</script>
+</body>
+</html>

--- a/LayoutTests/spatial-css/spatial-portal-scroll-to-load-expected.txt
+++ b/LayoutTests/spatial-css/spatial-portal-scroll-to-load-expected.txt
@@ -1,0 +1,3 @@
+
+PASS A <model> in a spatial portal loads only once the portal is scrolled into view
+

--- a/LayoutTests/spatial-css/spatial-portal-scroll-to-load.html
+++ b/LayoutTests/spatial-css/spatial-portal-scroll-to-load.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ SpatialPortalEnabled=true ModelElementEnabled=true ModelProcessEnabled=true allowTestOnlyIPC=true ] -->
+<html>
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<script src="../resources/ui-helper.js"></script>
+<style>
+    .spacer { height: 500vh; }
+    #portal { spatial: portal; width: 300px; height: 150px; }
+</style>
+<body>
+<div class="spacer"></div>
+<div id="portal"></div>
+<script>
+'use strict';
+
+promise_test(async t => {
+    const portal = document.getElementById("portal");
+
+    const model = document.createElement("model");
+    t.add_cleanup(() => model.remove());
+    portal.appendChild(model);
+    const source = document.createElement("source");
+    source.src = "../model-element/resources/cube.usdz";
+    model.appendChild(source);
+
+    await UIHelper.ensureStablePresentationUpdate();
+    assert_equals(internals.numberOfHostedModelsInSpatialPortal(portal), 0, "portal does not host its model while off-screen");
+
+    portal.scrollIntoView();
+    await model.ready;
+    assert_equals(internals.numberOfHostedModelsInSpatialPortal(portal), 1, "portal hosts the model after scrolling into view");
+}, "A <model> in a spatial portal loads only once the portal is scrolled into view");
+</script>
+</body>
+</html>

--- a/LayoutTests/spatial-css/spatial-portal-single-model-expected.txt
+++ b/LayoutTests/spatial-css/spatial-portal-single-model-expected.txt
@@ -1,0 +1,4 @@
+Hello!
+
+PASS A <model> nested in a spatial portal fires load/ready and displays properly
+

--- a/LayoutTests/spatial-css/spatial-portal-single-model.html
+++ b/LayoutTests/spatial-css/spatial-portal-single-model.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ SpatialPortalEnabled=true ModelElementEnabled=true ModelProcessEnabled=true allowTestOnlyIPC=true ] -->
+<html>
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<style>
+    #portal { spatial: portal; width: 300px; height: 150px; }
+</style>
+<body>
+<div id="portal">
+    <model id="model"><source src="../model-element/resources/cube.usdz"></model>
+    <span id="content">Hello!</span>
+</div>
+<script>
+'use strict';
+
+promise_test(async t => {
+    const portal = document.getElementById("portal");
+    const model = document.getElementById("model");
+    let loadFired = false;
+    model.addEventListener("load", () => loadFired = true, { once: true });
+    await model.ready;
+    assert_true(loadFired, "load event fired on the child model");
+    assert_equals(model.getBoundingClientRect().width, 0, "delegated <model> has no box of its own");
+    assert_equals(internals.numberOfHostedModelsInSpatialPortal(portal), 1, "the portal hosts the nested model");
+}, "A <model> nested in a spatial portal fires load/ready and displays properly");
+
+</script>
+</body>
+</html>

--- a/LayoutTests/spatial-css/spatial-portal-without-box-expected.txt
+++ b/LayoutTests/spatial-css/spatial-portal-without-box-expected.txt
@@ -1,0 +1,5 @@
+
+
+PASS A <model> inside an inline spatial: portal renders standalone
+PASS A <model> inside a display: contents spatial: portal renders standalone
+

--- a/LayoutTests/spatial-css/spatial-portal-without-box.html
+++ b/LayoutTests/spatial-css/spatial-portal-without-box.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ SpatialPortalEnabled=true ModelElementEnabled=true ModelProcessEnabled=true allowTestOnlyIPC=true ] -->
+<html>
+<head>
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<script src="../resources/ui-helper.js"></script>
+<style>
+    /* `spatial: portal` needs a box to establish a portal. These do not have one. */
+    #inline-portal { spatial: portal; }
+    #contents-portal { spatial: portal; display: contents; }
+</style>
+<body>
+<span id="inline-portal">
+    <model id="inline-model"><source src="../model-element/resources/cube.usdz"></model>
+</span>
+<div id="contents-portal">
+    <model id="contents-model"><source src="../model-element/resources/cube.usdz"></model>
+</div>
+<script>
+'use strict';
+
+window.internals?.disableModelLoadDelaysForTesting();
+
+for (const [portalID, modelID, description] of [
+    ["inline-portal", "inline-model", "an inline"],
+    ["contents-portal", "contents-model", "a display: contents"],
+]) {
+    promise_test(async t => {
+        const portal = document.getElementById(portalID);
+        const model = document.getElementById(modelID);
+
+        await model.ready;
+        await UIHelper.ensureStablePresentationUpdate();
+
+        assert_false(internals.establishesSpatialPortal(portal), "the element establishes no portal");
+        assert_equals(internals.numberOfHostedModelsInSpatialPortal(portal), 0, "no model is delegated to it");
+        assert_greater_than(model.getBoundingClientRect().width, 0, "the <model> renders standalone");
+    }, `A <model> inside ${description} spatial: portal renders standalone`);
+}
+</script>
+</body>
+</html>

--- a/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
@@ -108,6 +108,11 @@
 #include <WebCore/TouchEvent.h>
 #endif
 
+#if ENABLE(SPATIAL_PORTAL)
+#include "ElementAncestorIteratorInlines.h"
+#include "SpatialPortalController.h"
+#endif
+
 namespace WebCore {
 
 using namespace HTMLNames;
@@ -360,12 +365,97 @@ void HTMLModelElement::didMoveToNewDocument(Document& oldDocument, Document& new
 
 RenderPtr<RenderElement> HTMLModelElement::createElementRenderer(Style::ComputedStyle&& style, const RenderTreePosition& position)
 {
+#if ENABLE(SPATIAL_PORTAL)
+    if (isInsidePortal())
+        return nullptr;
+#endif
+
     if (RefPtr page = document().page()) {
         if (RefPtr provider = page->modelPlayerProvider(); provider && !provider->isAvailable())
             return HTMLElement::createElementRenderer(WTF::move(style), position);
     }
     return createRenderer<RenderModel>(*this, WTF::move(style));
 }
+
+bool HTMLModelElement::rendererIsNeeded(const Style::ComputedStyle& style)
+{
+#if ENABLE(SPATIAL_PORTAL)
+    if (isInsidePortal())
+        return false;
+#endif
+    return HTMLElement::rendererIsNeeded(style);
+}
+
+#if ENABLE(SPATIAL_PORTAL)
+RefPtr<const Element> HTMLModelElement::findPortalAncestor() const
+{
+    if (!document().settings().spatialPortalEnabled())
+        return nullptr;
+
+    for (Ref ancestor : ancestorsOfType<Element>(*this)) {
+        if (ancestor->establishesSpatialPortal())
+            return ancestor.ptr();
+    }
+
+    return nullptr;
+}
+
+bool HTMLModelElement::isInsidePortal() const
+{
+    return !!findPortalAncestor();
+}
+
+SpatialPortalController* HTMLModelElement::findPortalController() const
+{
+    RefPtr ancestor = findPortalAncestor();
+    return ancestor ? ancestor->spatialPortalController() : nullptr;
+}
+
+void HTMLModelElement::updateSpatialPortalController()
+{
+    CheckedPtr controller = findPortalController();
+
+    if (CheckedPtr previous = m_lastRegisteredPortalController.get(); previous && previous.get() != controller.get())
+        previous->unregisterChildModel(*this);
+
+    if (controller) {
+        m_lastRegisteredPortalController = *controller;
+        controller->registerChildModel(*this);
+    } else
+        m_lastRegisteredPortalController = nullptr;
+}
+
+void HTMLModelElement::didFinishLoadingInsidePortal()
+{
+    reportExtraMemoryCost();
+    if (!m_readyPromise->isFulfilled())
+        m_readyPromise->resolve(*this);
+}
+
+void HTMLModelElement::didFailLoadingInsidePortal(const ResourceError&)
+{
+    if (!m_readyPromise->isFulfilled())
+        m_readyPromise->reject(Exception { ExceptionCode::AbortError });
+
+    m_dataMemoryCost.store(0, std::memory_order_relaxed);
+    reportExtraMemoryCost();
+}
+
+void HTMLModelElement::spatialPortalContextDidChange()
+{
+    updateSpatialPortalController();
+
+    queueTaskKeepingObjectAlive(*this, TaskSource::DOMManipulation, [](auto& element) {
+        element.deletePendingModelPlayer();
+        element.deleteModelPlayer();
+        element.m_shouldCreateModelPlayerUponRendererAttachment = true;
+        element.invalidateStyleAndRenderersForSubtree();
+
+        if (CheckedPtr controller = element.findPortalController())
+            controller->childModelDidChange(element);
+    });
+}
+#endif
 
 void HTMLModelElement::didAttachRenderers()
 {
@@ -604,6 +694,13 @@ RefPtr<GraphicsLayer> HTMLModelElement::graphicsLayer() const
 
 bool HTMLModelElement::isVisible() const
 {
+#if ENABLE(SPATIAL_PORTAL)
+    if (RefPtr portal = findPortalAncestor()) {
+        if (CheckedPtr controller = portal->spatialPortalController())
+            return controller->isPortalVisible();
+        return !protect(document())->hidden();
+    }
+#endif
     bool isVisibleInline = !protect(document())->hidden() && m_isIntersectingViewport;
 #if ENABLE(MODEL_ELEMENT_IMMERSIVE)
     return isVisibleInline || m_detachedForImmersive;
@@ -635,6 +732,14 @@ void HTMLModelElement::modelDidChange()
         triggerModelPlayerCreationCallbacksIfNeeded(Exception { ExceptionCode::AbortError, "Model not associated with a page"_s });
         return;
     }
+
+#if ENABLE(SPATIAL_PORTAL)
+    if (isInsidePortal()) {
+        if (CheckedPtr controller = findPortalController())
+            controller->childModelDidChange(*this);
+        return;
+    }
+#endif
 
 #if ENABLE(MODEL_ELEMENT_IMMERSIVE)
     bool hasRenderer = this->renderer() || m_detachedForImmersive;
@@ -931,6 +1036,7 @@ void HTMLModelElement::configureGraphicsLayer(GraphicsLayer& graphicsLayer, Colo
     modelPlayer->configureGraphicsLayer(graphicsLayer, {
         .model = model(),
         .contentSize = contentSize(),
+        .contentOrigin = { },
         .backgroundColor = backgroundColor,
         .isInteractive = isInteractive(),
 #if ENABLE(MODEL_ELEMENT_PORTAL)
@@ -1964,6 +2070,15 @@ Node::NeedsPostConnectionSteps HTMLModelElement::insertionSteps(InsertionType in
             m_modelPlayerProvider = page->modelPlayerProvider();
             LazyLoadModelObserver::observe(*this);
         }
+#if ENABLE(SPATIAL_PORTAL)
+        updateSpatialPortalController();
+        if (isInsidePortal()) {
+            queueTaskKeepingObjectAlive(*this, TaskSource::DOMManipulation, [](auto& element) {
+                if (CheckedPtr controller = element.findPortalController())
+                    controller->childModelDidChange(element);
+            });
+        }
+#endif
     }
 
     return insertResult;
@@ -1982,6 +2097,12 @@ void HTMLModelElement::removingSteps(RemovalType removalType, ContainerNode& old
 
         deletePendingModelPlayer();
         deleteModelPlayer();
+
+#if ENABLE(SPATIAL_PORTAL)
+        if (CheckedPtr controller = m_lastRegisteredPortalController.get())
+            controller->unregisterChildModel(*this);
+        m_lastRegisteredPortalController = nullptr;
+#endif
     }
 }
 

--- a/Source/WebCore/Modules/model-element/HTMLModelElement.h
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.h
@@ -72,6 +72,10 @@ class Model;
 class ModelPlayerProvider;
 class MouseRelatedEvent;
 
+#if ENABLE(SPATIAL_PORTAL)
+class SpatialPortalController;
+#endif
+
 template<typename IDLType> class DOMPromiseDeferred;
 template<typename IDLType> class DOMPromiseProxy;
 template<typename IDLType> class DOMPromiseProxyWithResolveCallback;
@@ -99,6 +103,12 @@ public:
     bool complete() const { return m_dataComplete; }
 
     void configureGraphicsLayer(GraphicsLayer&, Color backgroundColor);
+
+#if ENABLE(SPATIAL_PORTAL)
+    void didFinishLoadingInsidePortal();
+    void didFailLoadingInsidePortal(const ResourceError&);
+    void spatialPortalContextDidChange();
+#endif
 
     std::optional<PlatformLayerIdentifier> layerID() const;
 
@@ -243,6 +253,7 @@ private:
     // Rendering overrides.
     RenderPtr<RenderElement> createElementRenderer(Style::ComputedStyle&&, const RenderTreePosition&) final;
     bool isReplaced(const Style::ComputedStyle* = nullptr) const final { return true; }
+    bool rendererIsNeeded(const Style::ComputedStyle&) final;
     void didAttachRenderers() final;
     void willDetachRenderers() final;
 
@@ -290,6 +301,13 @@ private:
 
     LayoutSize contentSize() const;
     bool modelContainerSizeIsEmpty() const;
+
+#if ENABLE(SPATIAL_PORTAL)
+    RefPtr<const Element> findPortalAncestor() const;
+    SpatialPortalController* findPortalController() const;
+    void updateSpatialPortalController();
+    bool isInsidePortal() const;
+#endif
 
     void reportExtraMemoryCost();
 
@@ -354,6 +372,10 @@ private:
     RefPtr<ModelPlayer> m_modelPlayer;
     RefPtr<ModelPlayer> m_pendingModelPlayer;
     EventLoopTimerHandle m_loadModelTimer;
+
+#if ENABLE(SPATIAL_PORTAL)
+    WeakPtr<SpatialPortalController> m_lastRegisteredPortalController;
+#endif
 
 #if ENABLE(MODEL_ELEMENT_ENTITY_TRANSFORM)
     Ref<DOMMatrixReadOnly> m_entityTransform;

--- a/Source/WebCore/Modules/model-element/ModelPlayerGraphicsLayerConfiguration.h
+++ b/Source/WebCore/Modules/model-element/ModelPlayerGraphicsLayerConfiguration.h
@@ -28,6 +28,7 @@
 #if ENABLE(MODEL_ELEMENT)
 
 #include <WebCore/Color.h>
+#include <WebCore/LayoutPoint.h>
 #include <WebCore/LayoutSize.h>
 #include <WebCore/Model.h>
 #include <wtf/RefPtr.h>
@@ -37,6 +38,7 @@ namespace WebCore {
 struct ModelPlayerGraphicsLayerConfiguration {
     RefPtr<Model> model;
     LayoutSize contentSize;
+    LayoutPoint contentOrigin;
     Color backgroundColor;
     bool isInteractive;
 #if ENABLE(MODEL_ELEMENT_PORTAL)

--- a/Source/WebCore/Modules/model-element/SpatialPortalController.cpp
+++ b/Source/WebCore/Modules/model-element/SpatialPortalController.cpp
@@ -28,13 +28,399 @@
 
 #if ENABLE(SPATIAL_PORTAL)
 
+#include "ContainerNodeInlines.h"
+#include "Document.h"
+#include "DocumentPage.h"
+#include "Element.h"
+#include "ElementInlines.h"
+#include "GraphicsLayer.h"
+#include "HTMLModelElement.h"
+#include "IntersectionObserver.h"
+#include "IntersectionObserverCallback.h"
+#include "IntersectionObserverEntry.h"
+#include "Model.h"
+#include "ModelPlayer.h"
+#include "ModelPlayerClient.h"
+#include "ModelPlayerProvider.h"
+#include "Page.h"
+#include "RenderBox.h"
+#include "RenderBoxInlines.h"
+#include "RenderLayer.h"
+#include "RenderLayerBacking.h"
+#include "RenderLayerModelObject.h"
+#include "ResourceError.h"
+#include <JavaScriptCore/ConsoleTypes.h>
+#include <wtf/RefCounted.h>
+
 namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(SpatialPortalController);
 
-SpatialPortalController::SpatialPortalController() = default;
+class PortalModelPlayerClient final : public RefCounted<PortalModelPlayerClient>, public ModelPlayerClient {
+public:
+    static Ref<PortalModelPlayerClient> create(SpatialPortalController& controller)
+    {
+        return adoptRef(*new PortalModelPlayerClient(controller));
+    }
 
-SpatialPortalController::~SpatialPortalController() = default;
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
+private:
+    explicit PortalModelPlayerClient(SpatialPortalController& controller)
+        : m_controller(controller)
+    {
+    }
+
+    void didFinishLoading(ModelPlayer& player, NodeIdentifier nodeID) final
+    {
+        if (CheckedPtr controller = m_controller.get())
+            controller->modelDidFinishLoading(player, nodeID);
+    }
+
+    void didFailLoading(ModelPlayer& player, NodeIdentifier nodeID, const ResourceError& error) final
+    {
+        if (CheckedPtr controller = m_controller.get())
+            controller->modelDidFailLoading(player, nodeID, error);
+    }
+
+#if ENABLE(MODEL_PROCESS)
+    void didConvertModelData(ModelPlayer&, Ref<SharedBuffer>&&, const String&) final { }
+#endif
+
+#if ENABLE(MODEL_ELEMENT_ENVIRONMENT_MAP)
+    void didFinishEnvironmentMapLoading(ModelPlayer&, bool) final { }
+#endif
+
+    void didUnload(ModelPlayer& player) final
+    {
+        if (CheckedPtr controller = m_controller.get())
+            controller->modelDidUnload(player);
+    }
+
+    void didUpdate(ModelPlayer& player) final
+    {
+        if (CheckedPtr controller = m_controller.get())
+            controller->modelDidUpdate(player);
+    }
+
+#if ENABLE(MODEL_ELEMENT_ENTITY_TRANSFORM)
+    void didUpdateEntityTransform(ModelPlayer&, NodeIdentifier, const TransformationMatrix&) final { }
+#endif
+#if ENABLE(MODEL_ELEMENT_BOUNDING_BOX)
+    void didUpdateBoundingBox(ModelPlayer&, NodeIdentifier, const FloatPoint3D&, const FloatPoint3D&) final { }
+#endif
+
+    RefPtr<GraphicsLayer> graphicsLayer() const final
+    {
+        CheckedPtr controller = m_controller.get();
+        return controller ? controller->portalGraphicsLayer() : nullptr;
+    }
+
+    bool isVisible() const final
+    {
+        CheckedPtr controller = m_controller.get();
+        return controller && controller->isPortalVisible();
+    }
+
+    void logWarning(ModelPlayer& player, const String& warningMessage) final
+    {
+        if (CheckedPtr controller = m_controller.get())
+            controller->logWarning(player, warningMessage);
+    }
+
+    const WeakPtr<SpatialPortalController> m_controller;
+};
+
+class PortalIntersectionObserverCallback final : public IntersectionObserverCallback {
+public:
+    static Ref<PortalIntersectionObserverCallback> create(Document& document, SpatialPortalController& controller)
+    {
+        return adoptRef(*new PortalIntersectionObserverCallback(document, controller));
+    }
+
+private:
+    PortalIntersectionObserverCallback(Document& document, SpatialPortalController& controller)
+        : IntersectionObserverCallback(&document)
+        , m_controller(controller)
+    {
+    }
+
+    bool NODELETE hasCallback() const final { return true; }
+
+    CallbackResult<void> invoke(IntersectionObserver&, const Vector<Ref<IntersectionObserverEntry>>& entries, IntersectionObserver&) final
+    {
+        CheckedPtr controller = m_controller.get();
+        if (!controller)
+            return { };
+        for (auto& entry : entries)
+            controller->viewportIntersectionChanged(entry->isIntersecting());
+        return { };
+    }
+
+    CallbackResult<void> invokeRethrowingException(IntersectionObserver& thisObserver, const Vector<Ref<IntersectionObserverEntry>>& entries, IntersectionObserver& observer) final
+    {
+        return invoke(thisObserver, entries, observer);
+    }
+
+    const WeakPtr<SpatialPortalController> m_controller;
+};
+
+SpatialPortalController::SpatialPortalController(Element& element)
+    : m_portalElement(element)
+{
+}
+
+SpatialPortalController::~SpatialPortalController()
+{
+    if (RefPtr observer = m_intersectionObserver)
+        observer->disconnect();
+    unloadModel();
+}
+
+void SpatialPortalController::unregisterChildModel(HTMLModelElement& model)
+{
+    if (m_childModel.get() != &model)
+        return;
+    m_childModel = nullptr;
+    unloadModel();
+}
+
+void SpatialPortalController::registerChildModel(HTMLModelElement& model)
+{
+    if (m_childModel && m_childModel.get() != &model) {
+        // FIXME: rdar://182292429
+        model.didFailLoadingInsidePortal(ResourceError { errorDomainWebKitInternal, 0, { }, "Only one model is supported per spatial portal"_s });
+        return;
+    }
+    m_childModel = model;
+
+    observePortalVisibility();
+
+    model.visibilityStateChanged();
+    loadChildModelIfReady();
+}
+
+void SpatialPortalController::childModelDidChange(HTMLModelElement& model)
+{
+    if (m_childModel.get() != &model)
+        return;
+    loadChildModelIfReady();
+}
+
+void SpatialPortalController::loadChildModelIfReady()
+{
+    RefPtr child = m_childModel.get();
+    if (!child)
+        return;
+
+    if (!isPortalVisible())
+        return;
+
+    RefPtr modelData = child->model();
+    if (!modelData)
+        return;
+
+    if (m_modelPlayer && m_model == modelData)
+        return;
+
+    if (m_modelPlayer)
+        unloadModel();
+
+    RefPtr player = ensureModelPlayer();
+    if (!player)
+        return;
+
+    m_model = modelData;
+    player->load(child->nodeIdentifier(), *modelData, portalContentSize(), false);
+}
+
+void SpatialPortalController::observePortalVisibility()
+{
+    if (m_intersectionObserver)
+        return;
+
+    RefPtr element = m_portalElement.get();
+    if (!element)
+        return;
+
+    Ref document = element->document();
+    auto callback = PortalIntersectionObserverCallback::create(document, *this);
+    IntersectionObserver::Init options { .scrollMargin = "100%"_s };
+    auto observer = IntersectionObserver::create(document, WTF::move(callback), WTF::move(options));
+    if (observer.hasException())
+        return;
+
+    m_intersectionObserver = observer.returnValue().ptr();
+    m_intersectionObserver->observe(*element);
+}
+
+void SpatialPortalController::viewportIntersectionChanged(bool isIntersecting)
+{
+    if (isIntersecting == m_isIntersectingViewport)
+        return;
+
+    m_isIntersectingViewport = isIntersecting;
+
+    if (RefPtr player = m_modelPlayer)
+        player->visibilityStateDidChange();
+
+    if (RefPtr child = m_childModel.get())
+        child->visibilityStateChanged();
+
+    if (isIntersecting)
+        loadChildModelIfReady();
+}
+
+ModelPlayer* SpatialPortalController::ensureModelPlayer()
+{
+    if (m_modelPlayer)
+        return m_modelPlayer.get();
+
+    RefPtr element = m_portalElement.get();
+    if (!element)
+        return nullptr;
+
+    RefPtr page = element->document().page();
+    if (!page)
+        return nullptr;
+
+    m_modelPlayerProvider = page->modelPlayerProvider();
+    RefPtr provider = m_modelPlayerProvider.get();
+    if (!provider)
+        return nullptr;
+
+    if (!m_playerClient)
+        lazyInitialize(m_playerClient, PortalModelPlayerClient::create(*this));
+
+    m_modelPlayer = provider->createModelPlayer(*m_playerClient);
+    return m_modelPlayer.get();
+}
+
+void SpatialPortalController::unloadModel()
+{
+    if (m_modelPlayer) {
+        // FIXME: rdar://182292429 - Remove model without destroying the player.
+        if (RefPtr provider = m_modelPlayerProvider.get())
+            provider->deleteModelPlayer(*m_modelPlayer);
+        m_modelPlayer = nullptr;
+    }
+    m_model = nullptr;
+}
+
+LayoutSize SpatialPortalController::portalContentSize() const
+{
+    RefPtr element = m_portalElement.get();
+    if (!element)
+        return { };
+    if (CheckedPtr box = dynamicDowncast<RenderBox>(element->renderer()))
+        return box->paddingBoxRect().size();
+    return { };
+}
+
+void SpatialPortalController::configureGraphicsLayer(GraphicsLayer& graphicsLayer, const Color& backgroundColor)
+{
+    RefPtr player = ensureModelPlayer();
+    if (!player)
+        return;
+
+    RefPtr child = m_childModel.get();
+    player->configureGraphicsLayer(graphicsLayer, {
+        .model = m_model,
+        .contentSize = portalContentSize(),
+        .contentOrigin = LayoutPoint(graphicsLayer.contentsRect().location()),
+        .backgroundColor = backgroundColor,
+        .isInteractive = child && child->isInteractive(),
+#if ENABLE(MODEL_ELEMENT_PORTAL)
+        .hasPortal = true, // N/A
+#endif
+#if ENABLE(MODEL_ELEMENT_IMMERSIVE)
+        .detachedForImmersive = false, // N/A
+#endif
+    });
+}
+
+void SpatialPortalController::sizeMayHaveChanged()
+{
+    if (RefPtr player = m_modelPlayer)
+        player->sizeDidChange(portalContentSize());
+}
+
+void SpatialPortalController::modelDidFinishLoading(ModelPlayer&, NodeIdentifier nodeID)
+{
+    RefPtr child = m_childModel.get();
+    if (!child || child->nodeIdentifier() != nodeID)
+        return;
+
+    child->didFinishLoadingInsidePortal();
+
+    reconfigurePortalLayer();
+}
+
+void SpatialPortalController::modelDidFailLoading(ModelPlayer&, NodeIdentifier nodeID, const ResourceError& error)
+{
+    RefPtr child = m_childModel.get();
+    if (!child || child->nodeIdentifier() != nodeID)
+        return;
+
+    child->didFailLoadingInsidePortal(error);
+}
+
+void SpatialPortalController::modelDidUnload(ModelPlayer& player)
+{
+    //  Mirrors HTMLModelElement::didUnload().
+    if (m_modelPlayer != &player)
+        return;
+
+    unloadModel();
+    // FIXME: rdar://148027600 Prevent infinite reloading of model.
+    loadChildModelIfReady();
+}
+
+void SpatialPortalController::modelDidUpdate(ModelPlayer&)
+{
+    reconfigurePortalLayer();
+}
+
+// Mirrors HTMLModelElement::logWarning().
+void SpatialPortalController::logWarning(ModelPlayer& player, const String& warningMessage)
+{
+    ASSERT_UNUSED(player, &player == m_modelPlayer);
+
+    RefPtr element = m_portalElement.get();
+    if (!element)
+        return;
+
+    Ref document = element->document();
+    document->addConsoleMessage(MessageSource::Other, MessageLevel::Warning, warningMessage);
+}
+
+void SpatialPortalController::reconfigurePortalLayer()
+{
+    if (RefPtr element = m_portalElement.get()) {
+        if (CheckedPtr renderer = dynamicDowncast<RenderLayerModelObject>(element->renderer()))
+            renderer->contentChanged(ContentChangeType::Model);
+    }
+}
+
+RefPtr<GraphicsLayer> SpatialPortalController::portalGraphicsLayer() const
+{
+    RefPtr element = m_portalElement.get();
+    if (!element)
+        return nullptr;
+
+    CheckedPtr renderLayerModelObject = dynamicDowncast<RenderLayerModelObject>(element->renderer());
+    if (!renderLayerModelObject || !renderLayerModelObject->isComposited())
+        return nullptr;
+
+    return renderLayerModelObject->layer()->backing()->graphicsLayer();
+}
+
+bool SpatialPortalController::isPortalVisible() const
+{
+    RefPtr element = m_portalElement.get();
+    return element && !element->document().hidden() && m_isIntersectingViewport;
+}
 
 } // namespace WebCore
 

--- a/Source/WebCore/Modules/model-element/SpatialPortalController.h
+++ b/Source/WebCore/Modules/model-element/SpatialPortalController.h
@@ -27,16 +27,73 @@
 
 #if ENABLE(SPATIAL_PORTAL)
 
+#include "LayoutSize.h"
+#include <WebCore/NodeIdentifier.h>
+#include <wtf/CheckedPtr.h>
+#include <wtf/RefPtr.h>
 #include <wtf/TZoneMalloc.h>
+#include <wtf/WeakPtr.h>
+#include <wtf/text/WTFString.h>
 
 namespace WebCore {
 
+class Color;
+class Element;
+class GraphicsLayer;
+class HTMLModelElement;
+class IntersectionObserver;
+class Model;
+class ModelPlayer;
+class ModelPlayerProvider;
+class PortalModelPlayerClient;
+class ResourceError;
+class WeakPtrImplWithEventTargetData;
+
 // Manages the portal / ModelPlayer for an element with `spatial: portal`.
-class SpatialPortalController {
+class SpatialPortalController : public CanMakeWeakPtr<SpatialPortalController>, public CanMakeCheckedPtr<SpatialPortalController> {
     WTF_MAKE_TZONE_ALLOCATED(SpatialPortalController);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SpatialPortalController);
+    friend class PortalModelPlayerClient;
+    friend class PortalIntersectionObserverCallback;
 public:
-    SpatialPortalController();
+    explicit SpatialPortalController(Element&);
     ~SpatialPortalController();
+
+    void unregisterChildModel(HTMLModelElement&);
+    void registerChildModel(HTMLModelElement&);
+    void childModelDidChange(HTMLModelElement&);
+
+    ModelPlayer* modelPlayer() const { return m_modelPlayer.get(); }
+    unsigned numberOfHostedModels() const { return m_model ? 1 : 0; }
+    void configureGraphicsLayer(GraphicsLayer&, const Color& backgroundColor);
+    void sizeMayHaveChanged();
+
+    bool isPortalVisible() const;
+
+private:
+    void modelDidFinishLoading(ModelPlayer&, NodeIdentifier);
+    void modelDidFailLoading(ModelPlayer&, NodeIdentifier, const ResourceError&);
+    void modelDidUnload(ModelPlayer&);
+    void modelDidUpdate(ModelPlayer&);
+    void logWarning(ModelPlayer&, const String&);
+    RefPtr<GraphicsLayer> portalGraphicsLayer() const;
+    void viewportIntersectionChanged(bool isIntersecting);
+
+    ModelPlayer* ensureModelPlayer();
+    void loadChildModelIfReady();
+    void unloadModel();
+    void reconfigurePortalLayer();
+    void observePortalVisibility();
+    LayoutSize portalContentSize() const;
+
+    const WeakPtr<Element, WeakPtrImplWithEventTargetData> m_portalElement;
+    WeakPtr<HTMLModelElement, WeakPtrImplWithEventTargetData> m_childModel;
+    WeakPtr<ModelPlayerProvider> m_modelPlayerProvider;
+    RefPtr<ModelPlayer> m_modelPlayer;
+    const RefPtr<PortalModelPlayerClient> m_playerClient;
+    RefPtr<Model> m_model;
+    RefPtr<IntersectionObserver> m_intersectionObserver;
+    bool m_isIntersectingViewport { false };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -5786,7 +5786,7 @@ SpatialPortalController& Element::ensureSpatialPortalController()
 {
     auto& rareData = ensureElementRareData();
     if (!rareData.spatialPortalController())
-        rareData.setSpatialPortalController(makeUnique<SpatialPortalController>());
+        rareData.setSpatialPortalController(makeUnique<SpatialPortalController>(*this));
     return *rareData.spatialPortalController();
 }
 
@@ -5801,6 +5801,11 @@ void Element::clearSpatialPortalController()
 {
     if (hasRareData())
         elementRareData()->setSpatialPortalController(nullptr);
+}
+
+bool Element::establishesSpatialPortal() const
+{
+    return !!spatialPortalController();
 }
 #endif
 

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -927,8 +927,9 @@ public:
 
 #if ENABLE(SPATIAL_PORTAL)
     SpatialPortalController& ensureSpatialPortalController();
-    SpatialPortalController* spatialPortalController() const;
+    WEBCORE_EXPORT SpatialPortalController* spatialPortalController() const;
     void clearSpatialPortalController();
+    WEBCORE_EXPORT bool establishesSpatialPortal() const;
 #endif
 
 protected:

--- a/Source/WebCore/platform/graphics/ModelContext.cpp
+++ b/Source/WebCore/platform/graphics/ModelContext.cpp
@@ -28,15 +28,16 @@
 
 namespace WebCore {
 
-Ref<ModelContext> ModelContext::create(const PlatformLayerIdentifier& modelLayerIdentifier, const LayerHostingContextIdentifier& modelContentsLayerHostingContextIdentifier, const LayoutSize& size, ModelContextDisablePortal disablePortal, std::optional<Color> backgroundColor)
+Ref<ModelContext> ModelContext::create(const PlatformLayerIdentifier& modelLayerIdentifier, const LayerHostingContextIdentifier& modelContentsLayerHostingContextIdentifier, const LayoutSize& size, const LayoutPoint& origin, ModelContextDisablePortal disablePortal, std::optional<Color> backgroundColor)
 {
-    return adoptRef(*new ModelContext(modelLayerIdentifier, modelContentsLayerHostingContextIdentifier, size, disablePortal, backgroundColor));
+    return adoptRef(*new ModelContext(modelLayerIdentifier, modelContentsLayerHostingContextIdentifier, size, origin, disablePortal, backgroundColor));
 }
 
-ModelContext::ModelContext(const PlatformLayerIdentifier& modelLayerIdentifier, const LayerHostingContextIdentifier& modelContentsLayerHostingContextIdentifier, const LayoutSize& size, ModelContextDisablePortal disablePortal, std::optional<Color> backgroundColor)
+ModelContext::ModelContext(const PlatformLayerIdentifier& modelLayerIdentifier, const LayerHostingContextIdentifier& modelContentsLayerHostingContextIdentifier, const LayoutSize& size, const LayoutPoint& origin, ModelContextDisablePortal disablePortal, std::optional<Color> backgroundColor)
     : m_modelLayerIdentifier(modelLayerIdentifier)
     , m_modelContentsLayerHostingContextIdentifier(modelContentsLayerHostingContextIdentifier)
     , m_modelLayoutSize(size)
+    , m_modelLayoutOrigin(origin)
     , m_disablePortal(disablePortal)
     , m_backgroundColor(backgroundColor)
 {

--- a/Source/WebCore/platform/graphics/ModelContext.h
+++ b/Source/WebCore/platform/graphics/ModelContext.h
@@ -27,6 +27,7 @@
 
 #include <WebCore/Color.h>
 #include <WebCore/LayerHostingContextIdentifier.h>
+#include <WebCore/LayoutPoint.h>
 #include <WebCore/LayoutSize.h>
 #include <WebCore/PlatformLayerIdentifier.h>
 #include <wtf/RefCounted.h>
@@ -37,22 +38,24 @@ enum class ModelContextDisablePortal : bool { No, Yes };
 
 class ModelContext final : public RefCounted<ModelContext> {
 public:
-    WEBCORE_EXPORT static Ref<ModelContext> NODELETE create(const PlatformLayerIdentifier&, const LayerHostingContextIdentifier&, const LayoutSize&, ModelContextDisablePortal, std::optional<Color>);
+    WEBCORE_EXPORT static Ref<ModelContext> NODELETE create(const PlatformLayerIdentifier&, const LayerHostingContextIdentifier&, const LayoutSize&, const LayoutPoint&, ModelContextDisablePortal, std::optional<Color>);
     WEBCORE_EXPORT ~ModelContext();
 
     PlatformLayerIdentifier modelLayerIdentifier() const { return m_modelLayerIdentifier; }
     LayerHostingContextIdentifier modelContentsLayerHostingContextIdentifier() const { return m_modelContentsLayerHostingContextIdentifier; }
     LayoutSize modelLayoutSize() const { return m_modelLayoutSize; }
+    LayoutPoint modelLayoutOrigin() const { return m_modelLayoutOrigin; }
     ModelContextDisablePortal disablePortal() const { return m_disablePortal; }
     std::optional<Color> backgroundColor() const { return m_backgroundColor; }
     void setBackgroundColor(std::optional<Color> backgroundColor) { m_backgroundColor = backgroundColor; }
 
 private:
-    explicit ModelContext(const PlatformLayerIdentifier&, const LayerHostingContextIdentifier&, const LayoutSize&, ModelContextDisablePortal, std::optional<Color>);
+    explicit ModelContext(const PlatformLayerIdentifier&, const LayerHostingContextIdentifier&, const LayoutSize&, const LayoutPoint&, ModelContextDisablePortal, std::optional<Color>);
 
     PlatformLayerIdentifier m_modelLayerIdentifier;
     LayerHostingContextIdentifier m_modelContentsLayerHostingContextIdentifier;
     LayoutSize m_modelLayoutSize;
+    LayoutPoint m_modelLayoutOrigin;
     ModelContextDisablePortal m_disablePortal;
     std::optional<Color> m_backgroundColor;
 };

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -115,6 +115,12 @@
 #include <wtf/StackStats.h>
 #include <wtf/TZoneMallocInlines.h>
 
+#if ENABLE(SPATIAL_PORTAL)
+#include "ElementAncestorIteratorInlines.h"
+#include "HTMLModelElement.h"
+#include "TypedElementDescendantIteratorInlines.h"
+#endif
+
 namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(RenderBox);
@@ -344,12 +350,42 @@ void RenderBox::invalidateAncestorBackgroundObscurationStatus()
 }
 
 #if ENABLE(SPATIAL_PORTAL)
-static void spatialPortalStyleDidChange(Element& element, SpatialType oldSpatial, SpatialType newSpatial)
+static bool isNestedInsideSpatialPortal(const Element& element)
 {
-    if (oldSpatial == SpatialType::None && newSpatial == SpatialType::Portal)
+    for (Ref ancestor : ancestorsOfType<Element>(element)) {
+        if (ancestor->establishesSpatialPortal())
+            return true;
+    }
+    return false;
+}
+
+static void updateSpatialPortalController(Element& element)
+{
+    bool hadController = element.establishesSpatialPortal();
+
+    CheckedPtr box = dynamicDowncast<RenderBox>(element.renderer());
+    if (box && box->style().spatial() == SpatialType::Portal && !isNestedInsideSpatialPortal(element))
         element.ensureSpatialPortalController();
-    else if (oldSpatial == SpatialType::Portal && newSpatial == SpatialType::None)
+    else
         element.clearSpatialPortalController();
+
+    if (box && hadController != element.establishesSpatialPortal()) {
+        if (CheckedPtr layer = box->layer())
+            layer->setNeedsCompositingConfigurationUpdate();
+    }
+}
+
+static void spatialPortalStyleDidChange(Element& element)
+{
+    updateSpatialPortalController(element);
+
+    for (Ref descendant : descendantsOfType<Element>(element)) {
+        if (CheckedPtr box = dynamicDowncast<RenderBox>(descendant->renderer()); box && box->style().spatial() == SpatialType::Portal)
+            updateSpatialPortalController(descendant);
+    }
+
+    for (Ref model : descendantsOfType<HTMLModelElement>(element))
+        model->spatialPortalContextDidChange();
 }
 #endif
 
@@ -472,7 +508,7 @@ void RenderBox::styleDidChange(Style::Difference diff, const Style::ComputedStyl
     auto oldSpatial = oldStyle ? oldStyle->spatial() : SpatialType::None;
     if (oldSpatial != newStyle.spatial()) {
         if (RefPtr element = this->element())
-            spatialPortalStyleDidChange(*element, oldSpatial, newStyle.spatial());
+            spatialPortalStyleDidChange(*element);
     }
 #endif
 }

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -138,6 +138,10 @@
 #include "ARKitBadgeSystemImage.h"
 #endif
 
+#if ENABLE(SPATIAL_PORTAL)
+#include "SpatialPortalController.h"
+#endif
+
 namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(RenderLayerBacking);
@@ -1367,6 +1371,18 @@ bool RenderLayerBacking::updateConfiguration(const RenderLayer* compositingAnces
     }
 #endif // ENABLE(MODEL_ELEMENT)
 
+#if ENABLE(SPATIAL_PORTAL)
+    if (RefPtr element = renderer().element()) {
+        if (CheckedPtr controller = element->spatialPortalController()) {
+            updateContentsRects();
+            auto portalBackgroundColor = blendSourceOver(renderer().theme().systemColor(CSSValueCanvas, renderer().styleColorOptions()), rendererBackgroundColor());
+            controller->configureGraphicsLayer(*m_graphicsLayer, portalBackgroundColor);
+            controller->sizeMayHaveChanged();
+            layerConfigChanged = true;
+        }
+    }
+#endif // ENABLE(SPATIAL_PORTAL)
+
     // FIXME: Why do we do this twice?
     if (CheckedPtr widget = dynamicDowncast<RenderWidget>(renderer())) {
         if (compositor.attachWidgetContentLayersIfNecessary(*widget).layerHierarchyChanged) {
@@ -2081,8 +2097,18 @@ void RenderLayerBacking::updateContentsRects()
 {
     m_graphicsLayer->setContentsRect(snapRectToDevicePixelsIfNeeded(contentsBox(), renderer()));
 
+#if HAVE(CORE_ANIMATION_SEPARATED_LAYERS) || ENABLE(SPATIAL_PORTAL)
+    bool needsContentsClippingRectUpdate = false;
 #if HAVE(CORE_ANIMATION_SEPARATED_LAYERS)
-    if (RenderLayerCompositor::isSeparated(renderer())) {
+    if (RenderLayerCompositor::isSeparated(renderer()))
+        needsContentsClippingRectUpdate = true;
+#endif
+#if ENABLE(SPATIAL_PORTAL)
+    if (RenderLayerCompositor::isSpatialPortal(renderer()))
+        needsContentsClippingRectUpdate = true;
+#endif
+
+    if (needsContentsClippingRectUpdate) {
         if (CheckedPtr renderBox = dynamicDowncast<RenderBox>(renderer())) {
             auto borderShape = BorderShape::shapeForBorderRect(renderBox->style(), renderBox->borderBoxRect());
             auto contentsClippingRect = borderShape.deprecatedPixelSnappedInnerRoundedRect(deviceScaleFactor());
@@ -3896,6 +3922,13 @@ LayoutRect RenderLayerBacking::contentsBox() const
 #if ENABLE(VIDEO)
     if (auto* renderVideo = dynamicDowncast<RenderVideo>(*renderBox))
         contentsRect = renderVideo->videoBox();
+    else
+#endif
+
+#if ENABLE(SPATIAL_PORTAL)
+    // The portal StereoLayer should cover the whole padding box.
+    if (RenderLayerCompositor::isSpatialPortal(renderer()))
+        contentsRect = renderBox->paddingBoxRect();
     else
 #endif
 

--- a/Source/WebCore/rendering/RenderLayerCompositor.cpp
+++ b/Source/WebCore/rendering/RenderLayerCompositor.cpp
@@ -1796,7 +1796,7 @@ void RenderLayerCompositor::updateBackingAndHierarchy(RenderLayer& layer, Vector
         bool needsForegroundLayer = !!layer.negativeZOrderLayers().size();
 #if ENABLE(SPATIAL_PORTAL)
         // Same thing for `spatial: portal` elements.
-        needsForegroundLayer = needsForegroundLayer || layer.renderer().style().spatial() == SpatialType::Portal;
+        needsForegroundLayer = needsForegroundLayer || isSpatialPortal(layer.renderer());
 #endif
         if (needsForegroundLayer && layerBacking && layerBacking->foregroundLayer())
             childList.append(Ref { *layerBacking->foregroundLayer() });
@@ -3828,6 +3828,17 @@ bool RenderLayerCompositor::isSeparated(const RenderObject& renderer)
 }
 #endif
 
+#if ENABLE(SPATIAL_PORTAL)
+bool RenderLayerCompositor::isSpatialPortal(const RenderObject& renderer)
+{
+    CheckedPtr renderElement = dynamicDowncast<RenderElement>(renderer);
+    if (!renderElement)
+        return false;
+    RefPtr element = renderElement->element();
+    return element && element->establishesSpatialPortal();
+}
+#endif
+
 // Return true if the given layer is a stacking context and has compositing child
 // layers that it needs to clip. In this case we insert a clipping GraphicsLayer
 // into the hierarchy between this layer and its children in the z-order hierarchy.
@@ -4040,7 +4051,7 @@ bool RenderLayerCompositor::requiresCompositingForModel(RenderLayerModelObject& 
 bool RenderLayerCompositor::requiresCompositingForSpatialPortal(RenderLayerModelObject& renderer) const
 {
 #if ENABLE(SPATIAL_PORTAL)
-    return renderer.style().spatial() == SpatialType::Portal;
+    return isSpatialPortal(renderer);
 #else
     UNUSED_PARAM(renderer);
     return false;
@@ -4533,7 +4544,7 @@ bool RenderLayerCompositor::needsContentsCompositingLayer(const RenderLayer& lay
 
 #if ENABLE(SPATIAL_PORTAL)
     // DOM content goes in the foreground layer by default, the content layer will be a StereoLayer for models.
-    if (layer.renderer().style().spatial() == SpatialType::Portal)
+    if (isSpatialPortal(layer.renderer()))
         return true;
 #endif
 

--- a/Source/WebCore/rendering/RenderLayerCompositor.h
+++ b/Source/WebCore/rendering/RenderLayerCompositor.h
@@ -325,6 +325,10 @@ public:
     static bool isSeparated(const RenderObject&);
 #endif
 
+#if ENABLE(SPATIAL_PORTAL)
+    static bool isSpatialPortal(const RenderObject&);
+#endif
+
     static RenderLayerCompositor* frameContentsCompositor(RenderWidget&);
 
     struct WidgetLayerAttachment {

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -445,6 +445,10 @@
 #include "HTMLModelElement.h"
 #endif
 
+#if ENABLE(SPATIAL_PORTAL)
+#include "SpatialPortalController.h"
+#endif
+
 #if ENABLE(SERVICE_CONTROLS)
 #include "ImageControlsMac.h"
 #endif
@@ -8755,6 +8759,19 @@ String Internals::modelElementState(HTMLModelElement& element)
 bool Internals::isModelElementIntersectingViewport(HTMLModelElement& element)
 {
     return element.isIntersectingViewport();
+}
+#endif
+
+#if ENABLE(SPATIAL_PORTAL)
+unsigned Internals::numberOfHostedModelsInSpatialPortal(Element& element)
+{
+    CheckedPtr controller = element.spatialPortalController();
+    return controller ? controller->numberOfHostedModels() : 0;
+}
+
+bool Internals::establishesSpatialPortal(Element& element)
+{
+    return element.establishesSpatialPortal();
 }
 #endif
 

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -1693,6 +1693,11 @@ public:
     bool NODELETE isModelElementIntersectingViewport(HTMLModelElement&);
 #endif
 
+#if ENABLE(SPATIAL_PORTAL)
+    unsigned NODELETE numberOfHostedModelsInSpatialPortal(Element&);
+    bool NODELETE establishesSpatialPortal(Element&);
+#endif
+
     ExceptionOr<void> copyImageAtLocation(int x, int y);
 
     bool NODELETE hasMediaSessionManager() const;

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -1551,6 +1551,9 @@ enum ContentsFormat {
     [Conditional=MODEL_ELEMENT] DOMString modelElementState(HTMLModelElement element);
     [Conditional=MODEL_ELEMENT] boolean isModelElementIntersectingViewport(HTMLModelElement element);
 
+    [Conditional=SPATIAL_PORTAL] unsigned long numberOfHostedModelsInSpatialPortal(Element element);
+    [Conditional=SPATIAL_PORTAL] boolean establishesSpatialPortal(Element element);
+
     undefined copyImageAtLocation(long x, long y);
 
     unsigned long fileConnectionHandleCount(FileSystemHandle handle);

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -5278,6 +5278,7 @@ enum class WebCore::ModelContextDisablePortal : bool
     WebCore::PlatformLayerIdentifier modelLayerIdentifier()
     WebCore::LayerHostingContextIdentifier modelContentsLayerHostingContextIdentifier()
     WebCore::LayoutSize modelLayoutSize()
+    WebCore::LayoutPoint modelLayoutOrigin()
     WebCore::ModelContextDisablePortal disablePortal()
     std::optional<WebCore::Color> backgroundColor()
 };

--- a/Source/WebKit/UIProcess/Model/PortalPresentationManagerProxy.mm
+++ b/Source/WebKit/UIProcess/Model/PortalPresentationManagerProxy.mm
@@ -34,6 +34,8 @@
 #import "WKPageHostedPortalView.h"
 #import "WKWebViewIOS.h"
 #import "WebPageProxy.h"
+#import <WebCore/FloatPoint.h>
+#import <WebCore/FloatSize.h>
 #import <wtf/RefPtr.h>
 #import <wtf/TZoneMallocInlines.h>
 
@@ -57,8 +59,8 @@ RetainPtr<WKPageHostedPortalView> PortalPresentationManagerProxy::setUpModelView
     auto& modelPresentation = ensurePortalPresentation(modelContext, *webPageProxy);
     auto view = modelPresentation.pageHostedPortalView;
     CGRect frame = [view frame];
-    frame.size.width = modelContext->modelLayoutSize().width().toFloat();
-    frame.size.height = modelContext->modelLayoutSize().height().toFloat();
+    frame.origin = WebCore::FloatPoint { modelContext->modelLayoutOrigin() };
+    frame.size = WebCore::FloatSize { modelContext->modelLayoutSize() };
     [view setFrame:frame];
     [view setShouldDisablePortal:modelContext->disablePortal() == WebCore::ModelContextDisablePortal::Yes];
     [view applyBackgroundColor:modelContext->backgroundColor()];

--- a/Source/WebKit/UIProcess/ios/WKPageHostedPortalView.mm
+++ b/Source/WebKit/UIProcess/ios/WKPageHostedPortalView.mm
@@ -289,14 +289,16 @@
     [self.layer setValue:(__bridge id)cachedCGColor(backgroundColor->opaqueColor()).get() forKeyPath:@"separatedOptions.material.clearColor"];
 }
 
-#if HAVE(RE_STEREO_CONTENT_SUPPORT)
 - (void)layoutSubviews
 {
     [super layoutSubviews];
 
+    [_containerView setFrame:self.bounds];
+
+#if HAVE(RE_STEREO_CONTENT_SUPPORT)
     [_stereoContentLayer setFrame:self.bounds];
-}
 #endif
+}
 
 - (void)setPortalCrossing:(BOOL)enabled
 {

--- a/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.cpp
+++ b/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.cpp
@@ -250,6 +250,7 @@ void ModelProcessModelPlayer::configureGraphicsLayer(WebCore::GraphicsLayer& gra
             *modelLayerIdentifier,
             *layerHostingContextIdentifier,
             configuration.contentSize,
+            configuration.contentOrigin,
             configuration.hasPortal ? WebCore::ModelContextDisablePortal::No : WebCore::ModelContextDisablePortal::Yes,
             configuration.backgroundColor
         ),

--- a/Tools/TestWebKitAPI/Resources/spatial-portal-two-models-page.html
+++ b/Tools/TestWebKitAPI/Resources/spatial-portal-two-models-page.html
@@ -1,0 +1,15 @@
+<style>
+    #portal { spatial: portal; width: 300px; height: 150px; }
+</style>
+<script>
+    internals.disableModelLoadDelaysForTesting()
+</script>
+<div id="portal">
+    <model><source src='cube.usdz'></model>
+    <model><source src='cube.usdz'></model>
+</div>
+<script>
+    const models = [...document.querySelectorAll('model')];
+    // FIXME: rdar://182292429 (Multi model support, switch to Promise.all)
+    Promise.allSettled(models.map(model => model.ready)).then(() => window.webkit.messageHandlers.modelLoading.postMessage('READY'));
+</script>

--- a/Tools/TestWebKitAPI/SourcesCocoa.txt
+++ b/Tools/TestWebKitAPI/SourcesCocoa.txt
@@ -289,6 +289,7 @@ Tests/WebKit/WKWebView/ShouldOpenAppLinks.mm @nonARC
 Tests/WebKit/WKWebView/SiteIsolation.mm @nonARC
 Tests/WebKit/WKWebView/SnapshotStore.mm @nonARC
 Tests/WebKit/WKWebView/ImmersiveVideoMetadata.mm @nonARC
+Tests/WebKit/WKWebView/SpatialPortal.mm @nonARC
 Tests/WebKit/WKWebView/SpeechRecognition.mm @nonARC
 Tests/WebKit/WKWebView/StopSuspendResumeAllMedia.mm @nonARC
 Tests/WebKit/WKWebView/StorageQuota.mm @nonARC

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SpatialPortal.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SpatialPortal.mm
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+
+#if ENABLE(MODEL_PROCESS) && ENABLE(SPATIAL_PORTAL)
+
+#import "Helpers/PlatformUtilities.h"
+#import "Helpers/Utilities.h"
+#import "Helpers/cocoa/ModelLoadingMessageHandler.h"
+#import "Helpers/cocoa/TestNavigationDelegate.h"
+#import "Helpers/cocoa/TestWKWebView.h"
+#import "Helpers/cocoa/WKWebViewConfigurationExtras.h"
+#import <WebKit/WKPreferencesPrivate.h>
+#import <WebKit/WKPreferencesRefPrivate.h>
+#import <WebKit/WKString.h>
+#import <WebKit/WKWebViewConfigurationPrivate.h>
+#import <WebKit/WKWebViewPrivate.h>
+#import <wtf/RetainPtr.h>
+
+namespace TestWebKitAPI {
+
+static RetainPtr<TestWKWebView> loadTwoModelPortalWebView(bool spatialPortalEnabled)
+{
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    [configuration _setAllowTestOnlyIPC:YES];
+    WKPreferencesSetBoolValueForKeyForTesting((__bridge WKPreferencesRef)[configuration preferences], true, WKStringCreateWithUTF8CString("ModelElementEnabled"));
+    WKPreferencesSetBoolValueForKeyForTesting((__bridge WKPreferencesRef)[configuration preferences], true, WKStringCreateWithUTF8CString("ModelProcessEnabled"));
+    WKPreferencesSetBoolValueForKeyForTesting((__bridge WKPreferencesRef)[configuration preferences], spatialPortalEnabled, WKStringCreateWithUTF8CString("SpatialPortalEnabled"));
+
+    RetainPtr messageHandler = adoptNS([[ModelLoadingMessageHandler alloc] init]);
+    [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"modelLoading"];
+
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400) configuration:configuration.get()]);
+    [webView synchronouslyLoadTestPageNamed:@"spatial-portal-two-models-page"];
+
+    // The page posts READY only after every model has settled, so the player
+    // count is stable by the time we read it.
+    while (![messageHandler modelIsReady])
+        Util::spinRunLoop();
+
+    return webView;
+}
+
+// Two <model>s in a spatial portal share the portal's single ModelPlayer when
+// the feature is enabled, but render as two independent standalone players when
+// it is disabled. The differing counts prove the preference actually gates
+// delegation (a single model would yield 1 either way and wouldn't distinguish).
+TEST(SpatialPortal, EnabledSharesOnePlayerAcrossModels)
+{
+    RetainPtr webView = loadTwoModelPortalWebView(true);
+    EXPECT_EQ([webView modelProcessModelPlayerCount], 1u);
+}
+
+TEST(SpatialPortal, DisabledRendersModelsStandalone)
+{
+    RetainPtr webView = loadTwoModelPortalWebView(false);
+    EXPECT_EQ([webView modelProcessModelPlayerCount], 2u);
+}
+
+} // namespace TestWebKitAPI
+
+#endif // ENABLE(MODEL_PROCESS) && ENABLE(SPATIAL_PORTAL)

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebViewServerTrustKVC.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebViewServerTrustKVC.mm
@@ -27,6 +27,7 @@
 
 #import "Helpers/PlatformUtilities.h"
 #import "Helpers/Test.h"
+#import "Helpers/Utilities.h"
 #import "Helpers/cocoa/HTTPServer.h"
 #import "Helpers/cocoa/TestNavigationDelegate.h"
 #import <wtf/RetainPtr.h>


### PR DESCRIPTION
#### 214a0eb36a63bf39948da15d0138b608016139a7
<pre>
Add support for loading a single nested model inside of a Spatial Portal
<a href="https://bugs.webkit.org/show_bug.cgi?id=320112">https://bugs.webkit.org/show_bug.cgi?id=320112</a>
&lt;<a href="https://rdar.apple.com/182292360">rdar://182292360</a>&gt;

Reviewed by Mike Wyrzykowski.

When a model is nested inside of a `spatial: portal` element, delegate
its loading / rendering to the portal.
When a Spatial Portal is nested inside of a Spatial Portal it&apos;s a noop.

Tests: spatial-css/spatial-portal-layers.html
       spatial-css/spatial-portal-model-insert-remove.html
       spatial-css/spatial-portal-model-move.html
       spatial-css/spatial-portal-nested-portals.html
       spatial-css/spatial-portal-scroll-to-load.html
       spatial-css/spatial-portal-single-model.html
       spatial-css/spatial-portal-nesting-dynamic.html
       spatial-css/spatial-portal-without-box.html
       Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SpatialPortal.mm

* LayoutTests/spatial-css/spatial-portal-layers-expected.txt: Added.
* LayoutTests/spatial-css/spatial-portal-layers.html: Added.
* LayoutTests/spatial-css/spatial-portal-model-insert-remove-expected.txt: Added.
* LayoutTests/spatial-css/spatial-portal-model-insert-remove.html: Added.
* LayoutTests/spatial-css/spatial-portal-model-move-expected.txt: Added.
* LayoutTests/spatial-css/spatial-portal-model-move.html: Added.
* LayoutTests/spatial-css/spatial-portal-nested-portals-expected.txt: Added.
* LayoutTests/spatial-css/spatial-portal-nested-portals.html: Added.
* LayoutTests/spatial-css/spatial-portal-scroll-to-load-expected.txt: Added.
* LayoutTests/spatial-css/spatial-portal-scroll-to-load.html: Added.
* LayoutTests/spatial-css/spatial-portal-single-model-expected.txt: Added.
* LayoutTests/spatial-css/spatial-portal-single-model.html: Added.
* LayoutTests/spatial-css/spatial-portal-nesting-dynamic-expected.txt: Added.
* LayoutTests/spatial-css/spatial-portal-nesting-dynamic.html: Added.
* LayoutTests/spatial-css/spatial-portal-without-box-expected.txt: Added.
* LayoutTests/spatial-css/spatial-portal-without-box.html: Added.
Complete the test suite to cover:
- the basic single model scenario
- the resulting CALayer tree
- dynamic insertions, removal and move between portals
- lazy loading while inside of a portal
- nested portals and dynamic updates

* Source/WebCore/Modules/model-element/HTMLModelElement.cpp:
(WebCore::HTMLModelElement::createElementRenderer):
(WebCore::HTMLModelElement::rendererIsNeeded):
(WebCore::HTMLModelElement::findPortalAncestor const):
(WebCore::HTMLModelElement::isInsidePortal const):
(WebCore::HTMLModelElement::findPortalController const):
(WebCore::HTMLModelElement::updateSpatialPortalController):
(WebCore::HTMLModelElement::didFinishLoadingInsidePortal):
(WebCore::HTMLModelElement::didFailLoadingInsidePortal):
(WebCore::HTMLModelElement::spatialPortalContextDidChange):
(WebCore::HTMLModelElement::isVisible const):
(WebCore::HTMLModelElement::modelDidChange):
(WebCore::HTMLModelElement::insertionSteps):
(WebCore::HTMLModelElement::removingSteps):
(WebCore::HTMLModelElement::configureGraphicsLayer):
* Source/WebCore/Modules/model-element/HTMLModelElement.h:
Detect if a model element is nested inside of a Spatial Portal. In that
case it doesn&apos;t get a Renderer and delegates to the
SpatialPortalController.

* Source/WebCore/Modules/model-element/ModelPlayerGraphicsLayerConfiguration.h:
* Source/WebCore/Modules/model-element/SpatialPortalController.cpp:
(WebCore::SpatialPortalController::SpatialPortalController):
(WebCore::SpatialPortalController::~SpatialPortalController):
(WebCore::SpatialPortalController::unregisterChildModel):
(WebCore::SpatialPortalController::registerChildModel):
(WebCore::SpatialPortalController::childModelDidChange):
(WebCore::SpatialPortalController::loadChildModelIfReady):
(WebCore::SpatialPortalController::observePortalVisibility):
(WebCore::SpatialPortalController::viewportIntersectionChanged):
(WebCore::SpatialPortalController::ensureModelPlayer):
(WebCore::SpatialPortalController::unloadModel):
(WebCore::SpatialPortalController::portalContentSize const):
(WebCore::SpatialPortalController::configureGraphicsLayer):
(WebCore::SpatialPortalController::sizeMayHaveChanged):
(WebCore::SpatialPortalController::modelDidFinishLoading):
(WebCore::SpatialPortalController::modelDidFailLoading):
(WebCore::SpatialPortalController::modelDidUnload):
(WebCore::SpatialPortalController::modelDidUpdate):
(WebCore::SpatialPortalController::reconfigurePortalLayer):
(WebCore::SpatialPortalController::portalGraphicsLayer const):
(WebCore::SpatialPortalController::isPortalVisible const):
(WebCore::SpatialPortalController::logWarning):
* Source/WebCore/Modules/model-element/SpatialPortalController.h:
(WebCore::SpatialPortalController::modelPlayer const):
(WebCore::SpatialPortalController::numberOfHostedModels const):
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::ensureSpatialPortalController):
(WebCore::Element::establishesSpatialPortal const):
* Source/WebCore/dom/Element.h:
* Source/WebCore/platform/graphics/ModelContext.cpp:
(WebCore::ModelContext::create):
(WebCore::ModelContext::ModelContext):
* Source/WebCore/platform/graphics/ModelContext.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/Model/PortalPresentationManagerProxy.mm:
(WebKit::PortalPresentationManagerProxy::setUpModelView):
* Source/WebKit/UIProcess/ios/WKPageHostedPortalView.mm:
(-[WKPageHostedPortalView layoutSubviews]):
* Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.cpp:
(WebKit::ModelProcessModelPlayer::configureGraphicsLayer):
Create a ModelPlayer and establish the portal&apos;s view hierarchy
(WKPageHostedPortalView and RemoteView to the ModelProcess) as soon as
the Spatial Portal is created (even if it contains no model element).
Add support for a custom origin (in the standalone model use case a 0x0
origin is always correct but not for Spatial Portals).

* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::spatialPortalStyleDidChange):
(WebCore::isNestedInsideSpatialPortal):
(WebCore::updateSpatialPortalController):
(WebCore::RenderBox::styleDidChange):
Signal nested model elements when a parent Spatial Portal is
created / destroyed.

* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::RenderLayerCompositor::updateBackingAndHierarchy):
(WebCore::RenderLayerCompositor::isSpatialPortal):
(WebCore::RenderLayerCompositor::requiresCompositingForSpatialPortal const):
(WebCore::RenderLayerCompositor::needsContentsCompositingLayer const):
* Source/WebCore/rendering/RenderLayerCompositor.h:
Prevent Spatial Portals nesting.

* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::updateConfiguration):
(WebCore::RenderLayerBacking::updateContentsRects):
(WebCore::RenderLayerBacking::contentsBox const):
Configure the Spatial Portal layers.

* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::numberOfHostedModelsInSpatialPortal):
(WebCore::Internals::establishesSpatialPortal):
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:
Test-only: expose the number of models nested in a portal and if an
element establishes a portal.
(More to come in <a href="https://rdar.apple.com/182292429">rdar://182292429</a>.)

* Tools/TestWebKitAPI/Resources/spatial-portal-two-models-page.html: Added.
* Tools/TestWebKitAPI/SourcesCocoa.txt:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SpatialPortal.mm: Added.
(TestWebKitAPI::loadTwoModelPortalWebView):
(TestWebKitAPI::TEST(SpatialPortal, EnabledSharesOnePlayerAcrossModels)):
(TestWebKitAPI::TEST(SpatialPortal, DisabledRendersModelsStandalone)):
Add basic API tests modeled after `ModelProcess.mm`.

* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebViewServerTrustKVC.mm:
Unified-build fix.

Canonical link: <a href="https://commits.webkit.org/318242@main">https://commits.webkit.org/318242@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d090ce6bf3ffb3b5d2335c3fc727063d77aa885e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177595 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51533 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45327 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187199 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140842 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179458 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52825 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51242 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138437 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140842 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180551 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41932 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159169 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118901 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40701 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38961 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151000 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38665 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35666 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/43318 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43196 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189628 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51200 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/158700 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147523 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39660 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51882 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35293 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147314 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42028 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124097 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118510 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50390 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13642 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49786 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50026 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49848 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->