### PR TITLE
Find in Page "Begins with" option takes too long

### DIFF
--- a/Source/WebCore/editing/ICUSearcher.cpp
+++ b/Source/WebCore/editing/ICUSearcher.cpp
@@ -29,6 +29,7 @@
 #include "FontCascade.h"
 #include "TextBoundaries.h"
 #include <limits>
+#include <wtf/ASCIICType.h>
 #include <wtf/Compiler.h>
 #include <wtf/text/MakeString.h>
 #include <wtf/text/ParsingUtilities.h>
@@ -293,6 +294,31 @@ static std::pair<std::span<const char16_t>, size_t> extractSubspanIncludingConte
     return { buffer.subspan(contextStart, contextEnd - contextStart), contextStart };
 }
 
+static std::pair<std::span<const char16_t>, size_t> boundedWordContextForNonComplexText(std::span<const char16_t> buffer, size_t start, size_t length)
+{
+    size_t windowStart = start;
+    while (windowStart && !isASCIIWhitespace(buffer[windowStart - 1]))
+        --windowStart;
+
+    size_t windowEnd = std::min(start + length, buffer.size());
+    while (windowEnd < buffer.size() && !isASCIIWhitespace(buffer[windowEnd]))
+        ++windowEnd;
+
+    if (windowStart)
+        --windowStart;
+    if (windowEnd < buffer.size())
+        ++windowEnd;
+
+    return { buffer.subspan(windowStart, windowEnd - windowStart), windowStart };
+}
+
+static std::pair<std::span<const char16_t>, size_t> wordBreakContext(std::span<const char16_t> buffer, size_t start, size_t length, char32_t firstCharacter)
+{
+    if (requiresContextForWordBoundary(firstCharacter))
+        return extractSubspanIncludingContextNeededForDictionaryBasedWordBreak(buffer, start);
+    return boundedWordContextForNonComplexText(buffer, start, length);
+}
+
 bool isWordStartMatch(std::span<const char16_t> buffer, size_t start, size_t length, FindOptions options)
 {
     ASSERT(options.contains(FindOption::AtWordStarts));
@@ -341,7 +367,7 @@ bool isWordStartMatch(std::span<const char16_t> buffer, size_t start, size_t len
     if (FontCascade::isCJKIdeographOrSymbol(firstCharacter))
         return true;
 
-    auto [contextBuffer, contextOffset] = extractSubspanIncludingContextNeededForDictionaryBasedWordBreak(buffer, start);
+    auto [contextBuffer, contextOffset] = wordBreakContext(buffer, start, length, firstCharacter);
     size_t adjustedStart = start - contextOffset;
 
     // Clamp because the trimmed context window may be shorter than adjustedStart + length.
@@ -357,7 +383,12 @@ bool isWordEndMatch(std::span<const char16_t> buffer, size_t start, size_t lengt
     ASSERT(options.contains(FindOption::AtWordEnds));
     UNUSED_PARAM(options);
 
-    auto [contextBuffer, contextOffset] = extractSubspanIncludingContextNeededForDictionaryBasedWordBreak(buffer, start);
+    int size = buffer.size();
+    int offset = static_cast<int>(start);
+    char32_t firstCharacter;
+    U16_GET(buffer, 0, offset, size, firstCharacter);
+
+    auto [contextBuffer, contextOffset] = wordBreakContext(buffer, start, length, firstCharacter);
     size_t adjustedStart = start - contextOffset;
 
     // Start searching at the end of matched search, so that multiple word matches succeed.


### PR DESCRIPTION
#### 97b25967e86e2cdf28b0f1dea134d78659881e86
<pre>
Find in Page &quot;Begins with&quot; option takes too long
<a href="https://bugs.webkit.org/show_bug.cgi?id=320120">https://bugs.webkit.org/show_bug.cgi?id=320120</a>
<a href="https://rdar.apple.com/183061866">rdar://183061866</a>

Reviewed by Sammy Gill.

Searching for a string on a large page with the &quot;Beings with&quot; Find in
Page option takes significantly longer than searching with the &quot;contains&quot;
option.

The slowdown is caused by passing the entire buffer to findNextWordFromIndex
from TextBoundaries.h on every match. Note that this only happens when the
match does not require context for word boundaries. On mac,
findNextWordFromIndex copies the buffer to a new string.

To speed this up, we limit the size of the buffer passed to findNextWordFromIndex.
Instead of the whole buffer, we send a window that includes the match. This way,
the copy can be much faster.

* Source/WebCore/editing/ICUSearcher.cpp:
(WebCore::boundedWordContextForNonComplexText):
(WebCore::wordBreakContext):
(WebCore::isWordStartMatch):
(WebCore::isWordEndMatch):

Canonical link: <a href="https://commits.webkit.org/317845@main">https://commits.webkit.org/317845@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/25b055f03841b6473e64f02df2669597ea08051b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176434 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50369 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44159 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186034 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/138703 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1d21c45a-925a-4e61-a8fa-2d45c053bb3f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178297 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51661 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50053 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137433 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/138703 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bdeedeaf-bb7e-4650-97b3-de9079b32fc0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179390 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40913 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158218 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117908 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0a5caa42-d908-4227-80da-1ac59f63af3f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39563 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37932 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149978 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37716 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34501 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42098 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42143 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188456 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50034 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146475 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39414 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50718 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34334 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146285 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41055 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122922 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/116981 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49222 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12691 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48624 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48858 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48683 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->