### PR TITLE
[interactive-widget] Implement logic to support resizes-content

### DIFF
--- a/LayoutTests/fast/visual-viewport/ios/interactive-widget-resizes-content-bottom-obscured-insets-expected.txt
+++ b/LayoutTests/fast/visual-viewport/ios/interactive-widget-resizes-content-bottom-obscured-insets-expected.txt
@@ -1,0 +1,14 @@
+PASS window.visualViewport.pageTop == 0 is true
+PASS window.visualViewport.scale == 1 is true
+PASS window.visualViewport.width == internals.layoutViewportRect().width is true
+PASS window.visualViewport.height == internals.layoutViewportRect().height is true
+PASS internals.layoutViewportRect().height == window.keyboardTopInView is true
+PASS window.visualViewport.pageTop == 0 is true
+PASS window.visualViewport.scale == 1 is true
+PASS window.visualViewport.width == internals.layoutViewportRect().width is true
+PASS window.visualViewport.height == internals.layoutViewportRect().height is true
+PASS internals.layoutViewportRect().height == window.initialLayoutViewportHeight - window.biggerInset is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/visual-viewport/ios/interactive-widget-resizes-content-bottom-obscured-insets.html
+++ b/LayoutTests/fast/visual-viewport/ios/interactive-widget-resizes-content-bottom-obscured-insets.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+<head>
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, interactive-widget=resizes-content"/>
+    <style>
+        input {
+            width: 400px;
+            height: 50px;
+        }
+        body {
+            background-color: pink;
+        }
+    </style>
+    <script src="../../../resources/js-test.js"></script>
+    <script src="../../../resources/ui-helper.js"></script>
+</head>
+<body>
+    <input id="input" type="text">
+    <script>
+        jsTestIsAsync = true;
+        addEventListener("load", async () => {
+            let textField = document.querySelector("input");
+            window.initialLayoutViewportHeight = internals.layoutViewportRect().height;
+            window.smallerInset = 50;
+            window.biggerInset = 600;
+
+            // Test the bottom inset being smaller than the keyboard.
+            await UIHelper.setObscuredInsets(0, 0, window.smallerInset, 0);
+            await UIHelper.renderingUpdate();
+            await UIHelper.activateElement(textField);
+            await UIHelper.waitForKeyboardToShow();
+
+            window.keyboardTopInView = (await UIHelper.inputViewBoundsInWebView()).top;
+
+            shouldBeTrue('window.visualViewport.pageTop == 0');
+            shouldBeTrue('window.visualViewport.scale == 1');
+            shouldBeTrue('window.visualViewport.width == internals.layoutViewportRect().width');
+            shouldBeTrue('window.visualViewport.height == internals.layoutViewportRect().height');
+
+            shouldBeTrue('internals.layoutViewportRect().height == window.keyboardTopInView');
+
+            // Test the bottom inset being bigger than the keyboard.
+            await UIHelper.setObscuredInsets(0, 0, window.biggerInset, 0);
+            await UIHelper.renderingUpdate();
+            await UIHelper.activateElement(textField);
+            await UIHelper.waitForKeyboardToShow();
+
+            shouldBeTrue('window.visualViewport.pageTop == 0');
+            shouldBeTrue('window.visualViewport.scale == 1');
+            shouldBeTrue('window.visualViewport.width == internals.layoutViewportRect().width');
+            shouldBeTrue('window.visualViewport.height == internals.layoutViewportRect().height');
+            shouldBeTrue('internals.layoutViewportRect().height == window.initialLayoutViewportHeight - window.biggerInset');
+
+            finishJSTest();
+        });
+    </script>
+</body>
+</html>

--- a/LayoutTests/fast/visual-viewport/ios/interactive-widget-resizes-content-inputmode-none-expected.txt
+++ b/LayoutTests/fast/visual-viewport/ios/interactive-widget-resizes-content-inputmode-none-expected.txt
@@ -1,0 +1,9 @@
+PASS window.visualViewport.pageTop == 0 is true
+PASS window.visualViewport.scale == 1 is true
+PASS window.visualViewport.width == internals.layoutViewportRect().width is true
+PASS window.visualViewport.height == internals.layoutViewportRect().height is true
+PASS internals.layoutViewportRect().height == window.initialLayoutViewportHeight is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/visual-viewport/ios/interactive-widget-resizes-content-inputmode-none.html
+++ b/LayoutTests/fast/visual-viewport/ios/interactive-widget-resizes-content-inputmode-none.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+<head>
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, interactive-widget=resizes-content"/>
+    <style>
+        input {
+            width: 400px;
+            height: 50px;
+        }
+    </style>
+    <script src="../../../resources/js-test.js"></script>
+    <script src="../../../resources/ui-helper.js"></script>
+</head>
+<body>
+    <input id="input" type="text" inputmode="none">
+
+    <script>
+        jsTestIsAsync = true;
+        addEventListener("load", async () => {
+            let textField = document.querySelector("input");
+            window.initialLayoutViewportHeight = internals.layoutViewportRect().height;
+
+            await UIHelper.activateElement(textField);
+            await UIHelper.ensurePresentationUpdate();
+
+            shouldBeTrue('window.visualViewport.pageTop == 0');
+            shouldBeTrue('window.visualViewport.scale == 1');
+            shouldBeTrue('window.visualViewport.width == internals.layoutViewportRect().width');
+            shouldBeTrue('window.visualViewport.height == internals.layoutViewportRect().height');
+
+            shouldBeTrue('internals.layoutViewportRect().height == window.initialLayoutViewportHeight');
+
+            finishJSTest();
+        });
+    </script>
+</body>
+
+</html>

--- a/LayoutTests/fast/visual-viewport/ios/interactive-widget-resizes-content-keyboard-scroll-expected.txt
+++ b/LayoutTests/fast/visual-viewport/ios/interactive-widget-resizes-content-keyboard-scroll-expected.txt
@@ -1,0 +1,20 @@
+Scrolled to 40, 1048
+PASS document.scrollingElement.scrollTop == 1048 is true
+PASS document.scrollingElement.scrollLeft == 40 is true
+PASS window.visualViewport.pageTop != 0 is true
+PASS window.visualViewport.scale == 1 is true
+PASS window.visualViewport.width == internals.layoutViewportRect().width is true
+PASS window.visualViewport.height == internals.layoutViewportRect().height is true
+PASS internals.layoutViewportRect().height == window.keyboardTopInView is true
+Scrolled to 0, 0
+PASS document.scrollingElement.scrollTop == 0 is true
+PASS document.scrollingElement.scrollLeft == 0 is true
+PASS window.visualViewport.pageTop == 0 is true
+PASS window.visualViewport.scale == 1 is true
+PASS window.visualViewport.width == internals.layoutViewportRect().width is true
+PASS window.visualViewport.height == internals.layoutViewportRect().height is true
+PASS internals.layoutViewportRect().height == window.keyboardTopInView is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/visual-viewport/ios/interactive-widget-resizes-content-keyboard-scroll.html
+++ b/LayoutTests/fast/visual-viewport/ios/interactive-widget-resizes-content-keyboard-scroll.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+<head>
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, interactive-widget=resizes-content"/>
+    <style>
+        body {
+            height: 2000px;
+            width: 2000px;
+        }
+        input {
+            width: 400px;
+            height: 50px;
+        }
+    </style>
+    <script src="../../../resources/js-test.js"></script>
+    <script src="../../../resources/ui-helper.js"></script>
+</head>
+<body>
+    <input id="input" type="text">
+    <script>
+        jsTestIsAsync = true;
+        addEventListener("load", async () => {
+            let textField = document.querySelector("input");
+
+            await UIHelper.activateElement(textField);
+            await UIHelper.waitForKeyboardToShow();
+
+            window.scrollTo(40, 1048);
+            debug('Scrolled to ' + window.scrollX + ', ' + window.scrollY);
+
+            await UIHelper.ensureVisibleContentRectUpdate();
+
+            window.keyboardTopInView = (await UIHelper.inputViewBoundsInWebView()).top;
+
+            shouldBeTrue('document.scrollingElement.scrollTop == 1048');
+            shouldBeTrue('document.scrollingElement.scrollLeft == 40');
+            shouldBeTrue('window.visualViewport.pageTop != 0');
+            shouldBeTrue('window.visualViewport.scale == 1');
+            shouldBeTrue('window.visualViewport.width == internals.layoutViewportRect().width');
+            shouldBeTrue('window.visualViewport.height == internals.layoutViewportRect().height');
+
+            shouldBeTrue('internals.layoutViewportRect().height == window.keyboardTopInView');
+
+            window.scrollTo(0, 0);
+            debug('Scrolled to ' + window.scrollX + ', ' + window.scrollY);
+
+            await UIHelper.ensureVisibleContentRectUpdate();
+
+            shouldBeTrue('document.scrollingElement.scrollTop == 0');
+            shouldBeTrue('document.scrollingElement.scrollLeft == 0');
+            shouldBeTrue('window.visualViewport.pageTop == 0');
+            shouldBeTrue('window.visualViewport.scale == 1');
+            shouldBeTrue('window.visualViewport.width == internals.layoutViewportRect().width');
+            shouldBeTrue('window.visualViewport.height == internals.layoutViewportRect().height');
+            shouldBeTrue('internals.layoutViewportRect().height == window.keyboardTopInView');
+
+            finishJSTest();
+        });
+    </script>
+</body>
+
+</html>

--- a/LayoutTests/fast/visual-viewport/ios/interactive-widget-resizes-content-top-obscured-insets-expected.txt
+++ b/LayoutTests/fast/visual-viewport/ios/interactive-widget-resizes-content-top-obscured-insets-expected.txt
@@ -1,0 +1,10 @@
+PASS window.visualViewport.width == internals.layoutViewportRect().width is true
+PASS window.visualViewport.height == internals.layoutViewportRect().height is true
+PASS window.layoutViewportHeightNoTopInset - window.layoutViewportHeightWithTopInset == window.topInset is true
+PASS window.visualViewport.scale == 1 is true
+PASS window.visualViewport.width == internals.layoutViewportRect().width is true
+PASS window.visualViewport.height == internals.layoutViewportRect().height is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/visual-viewport/ios/interactive-widget-resizes-content-top-obscured-insets.html
+++ b/LayoutTests/fast/visual-viewport/ios/interactive-widget-resizes-content-top-obscured-insets.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+<head>
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, interactive-widget=resizes-content"/>
+    <style>
+        input {
+            width: 400px;
+            height: 50px;
+        }
+    </style>
+    <script src="../../../resources/js-test.js"></script>
+    <script src="../../../resources/ui-helper.js"></script>
+</head>
+<body>
+    <input id="input" type="text">
+    <script>
+        jsTestIsAsync = true;
+        addEventListener("load", async () => {
+            let textField = document.querySelector("input");
+            window.topInset = 100;
+
+            // Keyboard up, no top inset.
+            await UIHelper.setObscuredInsets(0, 0, 0, 0);
+            await UIHelper.activateElement(textField);
+            await UIHelper.waitForKeyboardToShow();
+            await UIHelper.ensurePresentationUpdate();
+
+            window.layoutViewportHeightNoTopInset = internals.layoutViewportRect().height;
+            shouldBeTrue('window.visualViewport.width == internals.layoutViewportRect().width');
+            shouldBeTrue('window.visualViewport.height == internals.layoutViewportRect().height');
+
+            // Add the top inset.
+            await UIHelper.setObscuredInsets(window.topInset, 0, 0, 0);
+            await UIHelper.ensurePresentationUpdate();
+
+            window.layoutViewportHeightWithTopInset = internals.layoutViewportRect().height;
+
+            // The height should have dropped by exactly the top inset. 
+            shouldBeTrue('window.layoutViewportHeightNoTopInset - window.layoutViewportHeightWithTopInset == window.topInset')
+
+            // The two viewports still agree with each other.
+            shouldBeTrue('window.visualViewport.scale == 1');
+            shouldBeTrue('window.visualViewport.width == internals.layoutViewportRect().width');
+            shouldBeTrue('window.visualViewport.height == internals.layoutViewportRect().height');
+
+            finishJSTest();
+        });
+    </script>
+</body>
+</html>

--- a/LayoutTests/fast/visual-viewport/ios/interactive-widget-resizes-content-zoom-disabled-expected.txt
+++ b/LayoutTests/fast/visual-viewport/ios/interactive-widget-resizes-content-zoom-disabled-expected.txt
@@ -1,0 +1,11 @@
+PASS window.visualViewport.pageTop == 0 is true
+PASS window.visualViewport.scale == 1 is true
+PASS window.visualViewport.width == internals.layoutViewportRect().width is true
+PASS window.visualViewport.height == internals.layoutViewportRect().height is true
+PASS window.keyboardTopInView == internals.layoutViewportRect().height is true
+PASS window.visualViewport.height == window.initialLayoutViewportHeight is true
+PASS internals.layoutViewportRect().height == window.initialLayoutViewportHeight is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/visual-viewport/ios/interactive-widget-resizes-content-zoom-disabled.html
+++ b/LayoutTests/fast/visual-viewport/ios/interactive-widget-resizes-content-zoom-disabled.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+<head>
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, interactive-widget=resizes-content"/>
+    <style>
+        input {
+            width: 400px;
+            height: 50px;
+        }
+    </style>
+    <script src="../../../resources/js-test.js"></script>
+    <script src="../../../resources/ui-helper.js"></script>
+</head>
+<body>
+    <input id="input" type="text">
+
+    <script>
+        jsTestIsAsync = true;
+        addEventListener("load", async () => {
+            let textField = document.querySelector("input");
+            window.initialLayoutViewportHeight = internals.layoutViewportRect().height;
+
+            await UIHelper.activateElement(textField);
+            await UIHelper.waitForKeyboardToShow();
+
+            window.keyboardTopInView = (await UIHelper.inputViewBoundsInWebView()).top;
+
+            shouldBeTrue('window.visualViewport.pageTop == 0');
+            shouldBeTrue('window.visualViewport.scale == 1');
+            shouldBeTrue('window.visualViewport.width == internals.layoutViewportRect().width');
+            shouldBeTrue('window.visualViewport.height == internals.layoutViewportRect().height');
+            shouldBeTrue('window.keyboardTopInView == internals.layoutViewportRect().height');
+
+            // Dismiss the keyboard: the resized content should grow back to full height.
+            textField.blur();
+            await UIHelper.waitForKeyboardToHide();
+            await UIHelper.ensurePresentationUpdate();
+
+            shouldBeTrue('window.visualViewport.height == window.initialLayoutViewportHeight');
+            shouldBeTrue('internals.layoutViewportRect().height == window.initialLayoutViewportHeight');
+
+            finishJSTest();
+        });
+    </script>
+</body>
+
+</html>

--- a/LayoutTests/fast/visual-viewport/ios/interactive-widget-resizes-content-zoom-enabled-expected.txt
+++ b/LayoutTests/fast/visual-viewport/ios/interactive-widget-resizes-content-zoom-enabled-expected.txt
@@ -1,0 +1,7 @@
+PASS window.visualViewport.scale > 1 is true
+PASS Math.abs(internals.layoutViewportRect().height - window.keyboardTopInView) <= 1 is true
+PASS Math.abs(internals.visualViewportRect().height - window.keyboardTopInView / window.visualViewport.scale) <= 1 is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/visual-viewport/ios/interactive-widget-resizes-content-zoom-enabled.html
+++ b/LayoutTests/fast/visual-viewport/ios/interactive-widget-resizes-content-zoom-enabled.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+<head>
+    <meta name="viewport" content="width=device-width, initial-scale=1, interactive-widget=resizes-content"/>
+    <style>
+        input {
+            width: 400px;
+            height: 50px;
+        }
+    </style>
+    <script src="../../../resources/js-test.js"></script>
+    <script src="../../../resources/ui-helper.js"></script>
+</head>
+<body>
+    <input id="input" type="text">
+
+    <script>
+        jsTestIsAsync = true;
+        addEventListener("load", async () => {
+            let textField = document.querySelector("input");
+
+            await UIHelper.activateElement(textField);
+            await UIHelper.waitForKeyboardToShow();
+
+            await UIHelper.zoomToScale(2);
+            await UIHelper.ensureStablePresentationUpdate();
+
+            window.keyboardTopInView = (await UIHelper.inputViewBoundsInWebView()).top;
+
+            shouldBeTrue('window.visualViewport.scale > 1');
+            shouldBeTrue('Math.abs(internals.layoutViewportRect().height - window.keyboardTopInView) <= 1');
+            shouldBeTrue('Math.abs(internals.visualViewportRect().height - window.keyboardTopInView / window.visualViewport.scale) <= 1');
+
+            finishJSTest();
+        });
+    </script>
+</body>
+
+</html>

--- a/LayoutTests/resources/ui-helper.js
+++ b/LayoutTests/resources/ui-helper.js
@@ -1599,6 +1599,20 @@ window.UIHelper = class UIHelper {
         });
     }
 
+    static inputViewBoundsInWebView()
+    {
+        if (!this.isWebKit2() || !this.isIOSFamily())
+            return Promise.resolve();
+
+        return new Promise(resolve => {
+            testRunner.runUIScript(`(() => {
+                uiController.uiScriptComplete(JSON.stringify(uiController.inputViewBoundsInWebView));
+                })()`, jsonString => {
+                    resolve(JSON.parse(jsonString));
+            });
+        });
+    }
+
     static calendarType()
     {
         if (!this.isWebKit2())

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h
@@ -174,6 +174,7 @@ enum class TapHandlingResult : uint8_t;
 - (NSString *)_contentSizeCategory;
 - (void)_dispatchSetDeviceOrientation:(WebCore::IntDegrees)deviceOrientation;
 - (WebCore::FloatSize)activeViewLayoutSize:(const CGRect&)bounds;
+- (WebCore::InteractiveWidget)_viewportMetaTagInteractiveWidget;
 - (void)_updateScrollViewInsetAdjustmentBehavior;
 - (void)_resetScrollViewInsetAdjustmentBehavior;
 

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -2556,6 +2556,15 @@ static WebCore::FloatPoint constrainContentOffset(WebCore::FloatPoint contentOff
     if (!_page)
         return;
 
+    if (_perProcessState.viewportMetaTagInteractiveWidget == WebCore::InteractiveWidget::ResizesContent) {
+        CGRect keyboardInView = [self convertRect:[self _inputViewBoundsForViewportCalculations] fromView:nil];
+        if (!CGRectIsEmpty(keyboardInView)) {
+            CGFloat contentTop = [self _computedObscuredInset].top;
+            CGFloat maxHeight = CGRectGetMinY(keyboardInView) - contentTop;
+            viewLayoutSize.setHeight(std::max<float>(0, std::min<float>(viewLayoutSize.height(), maxHeight)));
+        }
+    }
+
     auto newMinimumEffectiveDeviceWidth = _page->minimumEffectiveDeviceWidth();
     if (_perProcessState.lastSentViewLayoutSize && CGSizeEqualToSize(_perProcessState.lastSentViewLayoutSize.value(), viewLayoutSize) && _perProcessState.lastSentMinimumEffectiveDeviceWidth && _perProcessState.lastSentMinimumEffectiveDeviceWidth == newMinimumEffectiveDeviceWidth)
         return;
@@ -2924,6 +2933,11 @@ static CGFloat liveResizeMinimumWidthDifference()
     if (_perProcessState.viewportMetaTagInteractiveWidget == WebCore::InteractiveWidget::OverlaysContent)
         return CGRectZero;
     return _inputViewBoundsInWindow;
+}
+
+- (WebCore::InteractiveWidget)_viewportMetaTagInteractiveWidget
+{
+    return _perProcessState.viewportMetaTagInteractiveWidget;
 }
 
 // Unobscured content rect where the user can interact. When the keyboard is up, this should be the area above or below the keyboard, wherever there is enough space.
@@ -3540,6 +3554,7 @@ static WebCore::IntDegrees activeOrientation(WKWebView *webView)
     })();
 
     BOOL keyboardShouldOverlayContent = _perProcessState.viewportMetaTagInteractiveWidget == WebCore::InteractiveWidget::OverlaysContent;
+    BOOL keyboardShouldResizeContent = _perProcessState.viewportMetaTagInteractiveWidget == WebCore::InteractiveWidget::ResizesContent;
 
     if (adjustScrollView && !keyboardShouldOverlayContent) {
         CGFloat bottomInsetBeforeAdjustment = [_scrollView contentInset].bottom;
@@ -3555,6 +3570,9 @@ static WebCore::IntDegrees activeOrientation(WKWebView *webView)
 
     if (selectionWasVisible && [_contentView _hasFocusedElement] && !CGRectIsEmpty(previousInputViewBounds) && !CGRectIsEmpty(_inputViewBoundsInWindow) && !CGRectEqualToRect(previousInputViewBounds, _inputViewBoundsInWindow))
         [self _scrollToAndRevealSelectionIfNeeded];
+
+    if (keyboardShouldResizeContent)
+        [self _dispatchSetViewLayoutSize:[self activeViewLayoutSize:self.bounds]];
 
     [self _scheduleVisibleContentRectUpdate];
 }

--- a/Source/WebKit/UIProcess/PageClient.h
+++ b/Source/WebKit/UIProcess/PageClient.h
@@ -54,6 +54,7 @@
 #include <WebCore/TextAnimationTypes.h>
 #include <WebCore/UserInterfaceLayoutDirection.h>
 #include <WebCore/ValidationBubble.h>
+#include <WebCore/ViewportArguments.h>
 #include <wtf/CompletionHandler.h>
 #include <wtf/Forward.h>
 #include <wtf/TZoneMallocInlines.h>
@@ -612,6 +613,7 @@ public:
     virtual void showDataDetectorsUIForPositionInformation(const InteractionInformationAtPosition&) = 0;
     virtual double minimumZoomScale() const = 0;
     virtual WebCore::FloatRect documentRect() const = 0;
+    virtual WebCore::InteractiveWidget viewportMetaTagInteractiveWidget() const = 0;
     virtual void scrollingNodeScrollViewWillStartPanGesture(WebCore::ScrollingNodeID) = 0;
     virtual void scrollingNodeScrollWillStartScroll(std::optional<WebCore::ScrollingNodeID>) = 0;
     virtual void scrollingNodeScrollDidEndScroll(std::optional<WebCore::ScrollingNodeID>) = 0;

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
@@ -234,6 +234,7 @@ private:
 
     double minimumZoomScale() const override;
     WebCore::FloatRect documentRect() const override;
+    WebCore::InteractiveWidget viewportMetaTagInteractiveWidget() const override;
 
     void showInspectorHighlight(const WebCore::InspectorOverlay::Highlight&) override;
     void hideInspectorHighlight() override;

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
@@ -418,6 +418,11 @@ WebCore::FloatRect PageClientImpl::documentRect() const
     return [contentView() bounds];
 }
 
+WebCore::InteractiveWidget PageClientImpl::viewportMetaTagInteractiveWidget() const
+{
+    return [webView() _viewportMetaTagInteractiveWidget];
+}
+
 void PageClientImpl::setCursor(const Cursor& cursor)
 {
     // The Web process may have asked to change the cursor when the view was in an active window, but

--- a/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
@@ -260,7 +260,9 @@ WebCore::FloatRect WebPageProxy::computeLayoutViewportRect(const FloatRect& unob
         constrainedUnobscuredRect.setHeight(adjustedUnexposedMaxEdge(documentRect.maxY(), constrainedUnobscuredRect.maxY(), factor) - constrainedUnobscuredRect.y());
     }
 
-    FloatSize constrainedSize = isBelowMinimumScale ? constrainedUnobscuredRect.size() : unobscuredContentRect.size();
+    bool resizesContent = pageClient->viewportMetaTagInteractiveWidget() == WebCore::InteractiveWidget::ResizesContent;
+    FloatRect sizeSourceRect = resizesContent ? unobscuredContentRectRespectingInputViewBounds : unobscuredContentRect;
+    FloatSize constrainedSize = isBelowMinimumScale ? constrainedUnobscuredRect.size() : sizeSourceRect.size();
     FloatRect unobscuredContentRectForViewport = isBelowMinimumScale ? constrainedUnobscuredRect : unobscuredContentRectRespectingInputViewBounds;
 
     double heightExpansionFactor = internals().allowsLayoutViewportHeightExpansion ? protect(m_preferences)->layoutViewportHeightExpansionFactor() : 0;

--- a/Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl
+++ b/Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl
@@ -384,6 +384,7 @@ interface UIScriptController {
     readonly attribute object calendarType;
     undefined setDefaultCalendarType(DOMString calendarIdentifier, DOMString localeIdentifier);
     readonly attribute object inputViewBounds;
+    readonly attribute object inputViewBoundsInWebView;
 
     undefined setKeyboardInputModeIdentifier(DOMString identifier);
     undefined setFocusStartsInputSessionPolicy(DOMString policy);

--- a/Tools/TestRunnerShared/UIScriptContext/UIScriptController.h
+++ b/Tools/TestRunnerShared/UIScriptContext/UIScriptController.h
@@ -336,6 +336,7 @@ public:
     virtual JSObjectRef calendarType() const { notImplemented(); return nullptr; }
     virtual void setDefaultCalendarType(JSStringRef, JSStringRef) { notImplemented(); }
     virtual JSObjectRef inputViewBounds() const { notImplemented(); return nullptr; }
+    virtual JSObjectRef inputViewBoundsInWebView() const { notImplemented(); return nullptr; }
     virtual void activateDataListSuggestion(unsigned, JSValueRef) { notImplemented(); }
     virtual void insertAutofillSuggestion(JSStringRef, JSStringRef, JSValueRef) { notImplemented(); }
     virtual void setSelectedColorForColorPicker(double, double, double) { notImplemented(); }

--- a/Tools/WebKitTestRunner/ios/UIScriptControllerIOS.h
+++ b/Tools/WebKitTestRunner/ios/UIScriptControllerIOS.h
@@ -128,6 +128,7 @@ private:
     JSObjectRef selectionCaretViewRect(id<UICoordinateSpace>) const;
     JSObjectRef selectionRangeViewRects() const override;
     JSObjectRef inputViewBounds() const override;
+    JSObjectRef inputViewBoundsInWebView() const override;
     JSRetainPtr<JSStringRef> scrollingTreeAsText() const override;
     JSRetainPtr<JSStringRef> uiViewTreeAsText() const override;
     JSRetainPtr<JSStringRef> uiViewTreeAsTextForViewWithLayerID(unsigned long long) const override;

--- a/Tools/WebKitTestRunner/ios/UIScriptControllerIOS.mm
+++ b/Tools/WebKitTestRunner/ios/UIScriptControllerIOS.mm
@@ -1162,6 +1162,12 @@ JSObjectRef UIScriptControllerIOS::inputViewBounds() const
     return JSValueToObject(m_context->jsContext(), [JSValue valueWithObject:toNSDictionary(webView()._inputViewBoundsInWindow) inContext:[JSContext contextWithJSGlobalContextRef:m_context->jsContext()]].JSValueRef, nullptr);
 }
 
+JSObjectRef UIScriptControllerIOS::inputViewBoundsInWebView() const
+{
+    CGRect boundsInWebView = [webView() convertRect:webView()._inputViewBoundsInWindow fromView:nil];
+    return JSValueToObject(m_context->jsContext(), [JSValue valueWithObject:toNSDictionary(boundsInWebView) inContext:[JSContext contextWithJSGlobalContextRef:m_context->jsContext()]].JSValueRef, nullptr);
+}
+
 JSRetainPtr<JSStringRef> UIScriptControllerIOS::scrollingTreeAsText() const
 {
     return adopt(JSStringCreateWithCFString((CFStringRef)[webView() _scrollingTreeAsText]));


### PR DESCRIPTION
#### 793fd9fdac661cae17ead6122323cc296ea552ea
<pre>
[interactive-widget] Implement logic to support resizes-content
<a href="https://bugs.webkit.org/show_bug.cgi?id=319903">https://bugs.webkit.org/show_bug.cgi?id=319903</a>
<a href="https://rdar.apple.com/182828312">rdar://182828312</a>

Reviewed by Aditya Keerthi and Abrar Rahman Protyasha.

Implement `interactive-widget=resizes-content`, in which the visual
viewport and the layout viewport should both resize as widgets
appear on the screen (e.g. the virtual keyboard here). By default,
the visual viewport clamps to the top of the keyboard, so no work is
needed here.

To ensure the layout viewport clamps accordingly, these changes
are necessary:
1. The changes in _dispatchSetViewLayoutSize alter baseLayoutViewportSize,
which will be utilized to report the layout viewport size.
2. The changes in computeLayoutViewportRect alter unobscuredContentSize,
which is used as the floor for the constrainedSize.
3. Wire the interactive-widget value through PageClient.

If only the floor was clamped, computeLayoutViewportRect would have
max(fullBaseHeight, clampedSize) which gives us the incorrect value. If only
the base size was clamped, the calculation would be max(clampedSize, fullHeight)
and the full height would take over. Thus, both changes are needed for the
layout viewport to actually take the height of the area between the keyboard
and any insets. If there is a bottom inset above the keyboard, the layout viewport
clamps accordingly to the bottom and top inset, if any.

Add layout tests that fail without the implementation changes. Ensure the tests are
device-agnostic by adding support for inputViewBoundsInWebView which converts the
keyboard rect from window coordinates to WKWebView&apos;s coordinate space.

The layout tests cover these cases with resizes-content:
- Zoom (disabled and enabled)
- Obscured insets (bottom and top)
- inputmode=none
- Keyboard showing, hiding and scrolling

* LayoutTests/fast/visual-viewport/ios/interactive-widget-resizes-content-bottom-obscured-insets-expected.txt: Added.
* LayoutTests/fast/visual-viewport/ios/interactive-widget-resizes-content-bottom-obscured-insets.html: Added.
* LayoutTests/fast/visual-viewport/ios/interactive-widget-resizes-content-inputmode-none-expected.txt: Added.
* LayoutTests/fast/visual-viewport/ios/interactive-widget-resizes-content-inputmode-none.html: Added.
* LayoutTests/fast/visual-viewport/ios/interactive-widget-resizes-content-keyboard-scroll-expected.txt: Added.
* LayoutTests/fast/visual-viewport/ios/interactive-widget-resizes-content-keyboard-scroll.html: Added.
* LayoutTests/fast/visual-viewport/ios/interactive-widget-resizes-content-top-obscured-insets-expected.txt: Added.
* LayoutTests/fast/visual-viewport/ios/interactive-widget-resizes-content-top-obscured-insets.html: Added.
* LayoutTests/fast/visual-viewport/ios/interactive-widget-resizes-content-zoom-disabled-expected.txt: Added.
* LayoutTests/fast/visual-viewport/ios/interactive-widget-resizes-content-zoom-disabled.html: Added.
* LayoutTests/fast/visual-viewport/ios/interactive-widget-resizes-content-zoom-enabled-expected.txt: Added.
* LayoutTests/fast/visual-viewport/ios/interactive-widget-resizes-content-zoom-enabled.html: Added.
* LayoutTests/resources/ui-helper.js:
(window.UIHelper.inputViewBoundsInWebView):
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h:
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _dispatchSetViewLayoutSize:]):
(-[WKWebView _viewportMetaTagInteractiveWidget]):
(-[WKWebView _keyboardChangedWithInfo:adjustScrollView:]):
* Source/WebKit/UIProcess/PageClient.h:
* Source/WebKit/UIProcess/ios/PageClientImplIOS.h:
* Source/WebKit/UIProcess/ios/PageClientImplIOS.mm:
(WebKit::PageClientImpl::viewportMetaTagInteractiveWidget const):
* Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm:
(WebKit::WebPageProxy::computeLayoutViewportRect const):
* Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl:
* Tools/TestRunnerShared/UIScriptContext/UIScriptController.h:
(WTR::UIScriptController::inputViewBoundsInWebView const):
* Tools/WebKitTestRunner/ios/UIScriptControllerIOS.h:
* Tools/WebKitTestRunner/ios/UIScriptControllerIOS.mm:
(WTR::UIScriptControllerIOS::inputViewBoundsInWebView const):

Canonical link: <a href="https://commits.webkit.org/318324@main">https://commits.webkit.org/318324@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/33dad63dd13e757a8dc8c3237611a321bc9e2691

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177871 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51809 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45603 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187481 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/141118 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179734 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53101 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51518 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138641 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/141118 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e4778a94-72e6-4d6e-bedc-58d063c2dea2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180827 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42178 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159388 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119104 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40841 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39195 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151246 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38883 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35942 "Built successfully") | | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44400 "Found 1 new failure in wasm/WasmConstExprGenerator.cpp") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43431 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189910 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51476 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/158919 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147763 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52158 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35512 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147548 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26988 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42258 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124410 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118841 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50666 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13862 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50062 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50302 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50124 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->