### PR TITLE
[JSC] DFG / FTL should have fast-fail filter for RegExp with BOL assertions

### DIFF
--- a/JSTests/stress/regexp-exec-anchored-first-char-filter.js
+++ b/JSTests/stress/regexp-exec-anchored-first-char-filter.js
@@ -1,0 +1,52 @@
+//@ skip if not $jitTests
+//@ $skipModes << :lockdown
+// Verify the anchored (^, non-multiline) non-sticky RegExp.exec first-character fast-fail filter:
+// a filtered no-match must equal the operation's result, and NON-anchored patterns must never be
+// filtered (a match can appear anywhere).
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error("bad value: " + actual + " expected: " + expected);
+}
+
+function execStr(re, s) {
+    var m = re.exec(s);
+    return m === null ? "null" : "[" + m.map(function (x) { return x === undefined ? "u" : JSON.stringify(x); }).join(",") + "]@" + m.index;
+}
+
+function step() {
+    // Anchored ^ non-sticky exec: match must start at 0, so input[0] gates it.
+    shouldBe(execStr(/^foo/, "foobar"), '["foo"]@0');
+    shouldBe(execStr(/^foo/, "xfoobar"), "null");        // filtered (x != f)
+    shouldBe(execStr(/^foo/, ""), "null");               // empty
+    shouldBe(execStr(/^(?:await|case|return)$/, "case"), '["case"]@0');
+    shouldBe(execStr(/^(?:await|case|return)$/, ";"), "null");     // filtered
+    shouldBe(execStr(/^(?:await|case|return)$/, "config"), "null"); // c passes filter, op fails
+    shouldBe(execStr(/^(#?)[0-9]+/, "123"), '["123",""]@0');       // capture group preserved
+    shouldBe(execStr(/^(#?)[0-9]+/, "#12"), '["#12","#"]@0');
+    shouldBe(execStr(/^(#?)[0-9]+/, "abc"), "null");     // filtered
+
+    // NON-anchored non-sticky exec: MUST NOT be filtered (match can be anywhere).
+    shouldBe(execStr(/foo/, "xxfoo"), '["foo"]@2');
+    shouldBe(execStr(/[0-9]+/, "abc99"), '["99"]@3');
+
+    // Multiline ^ is not anchored-at-0.
+    shouldBe(execStr(/^bar/m, "x\nbar"), '["bar"]@2');
+
+    // A character whose Unicode case-fold partner is ASCII (U+212A KELVIN -> k/K) becomes a folded
+    // character class under /iu, so its ASCII partner must be in the bitmap and NOT fast-failed.
+    shouldBe(execStr(/^K/iu, "k"), '["k"]@0');
+    shouldBe(execStr(/^K/iu, "K"), '["K"]@0');
+    shouldBe(execStr(/^K/iu, "x"), "null");
+    shouldBe(execStr(/^K/i, "k"), "null");    // non-unicode: KELVIN does not fold to ASCII
+
+    // Global RegExp state after a filtered no-match reflects the last successful match, not the
+    // failed one (a no-match exec never records).
+    shouldBe(execStr(/^z/, "zzz"), '["z"]@0');
+    var savedLastMatch = RegExp.lastMatch;
+    shouldBe(execStr(/^q/, "abc"), "null");              // filtered no-match
+    shouldBe(RegExp.lastMatch, savedLastMatch);
+}
+
+for (var i = 0; i < testLoopCount; ++i)
+    step();

--- a/JSTests/stress/regexp-exec-sticky-first-char-filter.js
+++ b/JSTests/stress/regexp-exec-sticky-first-char-filter.js
@@ -1,0 +1,112 @@
+// Verify the sticky RegExp.exec first-character fast-fail filter: a filtered no-match must behave
+// exactly like the operation - reset lastIndex to 0, return null, and leave RegExp's global match
+// state (RegExp.$1, lastMatch, input, contexts) untouched.
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error("bad value: " + actual + " expected: " + expected);
+}
+
+function shouldThrow(fn, name) {
+    let threw = false;
+    try { fn(); } catch (e) { threw = true; shouldBe(e.constructor.name, name); }
+    if (!threw)
+        throw new Error("expected " + name);
+}
+
+// A capturing sticky regexp that cannot match empty: first char must be a digit.
+const re = /(\d)(\d)?/y;
+const input = "a12b3";
+
+// Exercise a no-match at a position whose byte is filtered (not a digit), asserting the whole
+// observable contract, including that global RegExp state from a PRIOR success is preserved.
+function step() {
+    // Prior success at index 1 ("12"), which records global state.
+    re.lastIndex = 1;
+    let m = re.exec(input);
+    shouldBe(m[0], "12");
+    shouldBe(m[1], "1");
+    shouldBe(m[2], "2");
+    shouldBe(m.index, 1);
+    shouldBe(re.lastIndex, 3);
+    // Capture the global match state established by that success.
+    const savedLastMatch = RegExp.lastMatch;   // "12"
+    const savedParen1 = RegExp.$1;              // "1"
+    const savedParen2 = RegExp.$2;              // "2"
+    const savedLeft = RegExp.leftContext;       // "a"
+    const savedRight = RegExp.rightContext;     // "b3"
+    const savedInput = RegExp.input;            // input
+    shouldBe(savedLastMatch, "12");
+    shouldBe(savedParen1, "1");
+    shouldBe(savedParen2, "2");
+
+    // No-match at index 0 ('a' is not a digit): this is the filtered fast-fail path.
+    re.lastIndex = 0;
+    shouldBe(re.exec(input), null);
+    shouldBe(re.lastIndex, 0);                  // sticky no-match resets lastIndex to 0.
+    // Global state must be UNCHANGED by the failed exec.
+    shouldBe(RegExp.lastMatch, savedLastMatch);
+    shouldBe(RegExp.$1, savedParen1);
+    shouldBe(RegExp.$2, savedParen2);
+    shouldBe(RegExp.leftContext, savedLeft);
+    shouldBe(RegExp.rightContext, savedRight);
+    shouldBe(RegExp.input, savedInput);
+
+    // No-match at a filtered position past the last digit ('b' at index 3).
+    re.lastIndex = 3;
+    shouldBe(re.exec(input), null);
+    shouldBe(re.lastIndex, 0);
+
+    // lastIndex beyond the end: null + reset, matching operationRegExpExecStickyKnownRegExp.
+    re.lastIndex = 100;
+    shouldBe(re.exec(input), null);
+    shouldBe(re.lastIndex, 0);
+
+    // A match with the optional second group absent (single trailing digit "3" at index 4).
+    re.lastIndex = 4;
+    m = re.exec(input);
+    shouldBe(m[0], "3");
+    shouldBe(m[1], "3");
+    shouldBe(m[2], undefined);
+    shouldBe(re.lastIndex, 5);
+}
+
+for (let i = 0; i < testLoopCount; ++i)
+    step();
+
+// Negative lastIndex is not isUInt32; the filter must delegate to the operation, which clamps and
+// searches from 0. Here index 0 is 'a' (no match) so the result is null with lastIndex reset.
+(function () {
+    const re2 = /(\d)(\d)?/y;
+    for (let i = 0; i < testLoopCount; ++i) {
+        re2.lastIndex = -5;
+        shouldBe(re2.exec("a12"), null);
+        shouldBe(re2.lastIndex, 0);
+    }
+})();
+
+// A non-writable lastIndex must make a failing sticky exec throw a TypeError (Set(...,,true)); the
+// filter guards on the writable flag and delegates to the operation, which throws.
+(function () {
+    for (let i = 0; i < testLoopCount; ++i) {
+        const re3 = /\d+/y;
+        re3.lastIndex = 0;
+        Object.defineProperty(re3, "lastIndex", { writable: false });
+        shouldThrow(() => re3.exec("abc"), "TypeError");
+    }
+})();
+
+// 16-bit (non-Latin-1) subject strings must still behave correctly (filter is 8-bit only, so this
+// exercises the delegated path). The digit "5" is Latin-1 but the string is 16-bit.
+(function () {
+    const re4 = /\d/y;
+    const wide = "あい" + "5";   // forces a 16-bit string
+    for (let i = 0; i < testLoopCount; ++i) {
+        re4.lastIndex = 0;
+        shouldBe(re4.exec(wide), null);   // first char is a wide non-digit
+        shouldBe(re4.lastIndex, 0);
+        re4.lastIndex = 2;
+        shouldBe(re4.exec(wide)[0], "5");
+        shouldBe(re4.lastIndex, 3);
+    }
+})();

--- a/JSTests/stress/regexp-test-anchored-first-char-filter.js
+++ b/JSTests/stress/regexp-test-anchored-first-char-filter.js
@@ -1,0 +1,64 @@
+//@ skip if not $jitTests
+//@ $skipModes << :lockdown
+// Verify the anchored (^, non-multiline) RegExp.test first-character fast-fail filter: a filtered
+// no-match must equal the operation's result, non-anchored patterns must never be wrongly filtered,
+// case-insensitive folds must be reflected in the bitmap, and a .compile() that changes the pattern
+// must be handled (the runtime identity guard falls back).
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error("bad value: " + actual + " expected: " + expected);
+}
+
+function step() {
+    // Anchored ^ .test() on constant regexes (filtered when input[0] can't begin a match).
+    shouldBe(/^(?:await|case|return)$/.test("case"), true);
+    shouldBe(/^(?:await|case|return)$/.test(";"), false);       // filtered
+    shouldBe(/^(?:await|case|return)$/.test("config"), false);  // 'c' passes filter, op fails
+    shouldBe(/^[0-9]+$/.test("42"), true);
+    shouldBe(/^[0-9]+$/.test("x4"), false);                     // filtered
+    shouldBe(/^#\w+/.test("#tag"), true);
+    shouldBe(/^#\w+/.test("tag"), false);                       // filtered
+
+    // Case-insensitive patterns ARE filtered (the bitmap folds ASCII case; Latin-1 letters with a
+    // case pair are folded character classes); results must be correct across the folded set.
+    shouldBe(/^hsl/i.test("HSL(1,2%,3%)"), true);
+    shouldBe(/^hsl/i.test("hsl(1)"), true);
+    shouldBe(/^hsl/i.test("rgb"), false);
+    shouldBe(/^[a-f]+$/i.test("ABC"), true);
+    shouldBe(/^ä/i.test("Ä!"), true);   // Latin-1 letter with case pair (folded class)
+    shouldBe(/^ä/i.test("x"), false);
+    shouldBe(/^k/i.test("K"), true);
+
+    // Characters whose Unicode case-fold partner is ASCII (U+212A KELVIN -> k/K, U+017F LONG S ->
+    // s/S) become folded character classes under /iu; the ASCII partner must be in the bitmap so the
+    // filter does not wrongly fast-fail an ASCII input. Under non-unicode /i they do NOT fold to
+    // ASCII (they only match themselves).
+    shouldBe(/^K/iu.test("k"), true);
+    shouldBe(/^K/iu.test("K"), true);
+    shouldBe(/^K/iu.test("x"), false);
+    shouldBe(/^ſ/iu.test("s"), true);
+    shouldBe(/^ſ/iu.test("q"), false);
+    shouldBe(/^K/i.test("k"), false);        // non-unicode: KELVIN does not fold to ASCII
+    shouldBe(/^K/i.test("K"), true);    // but matches itself
+
+    // Non-anchored .test(): match can be anywhere, never filtered.
+    shouldBe(/foo/.test("xxfoo"), true);
+    shouldBe(/[0-9]/.test("abc9"), true);
+
+    // Multiline ^ is not anchored-at-0.
+    shouldBe(/^bar/m.test("x\nbar"), true);
+}
+
+for (var i = 0; i < testLoopCount; ++i)
+    step();
+
+// A .compile() that changes the pattern must be handled by the identity guard: the filter for the
+// old pattern must not produce wrong answers for the new one.
+(function () {
+    var re = /^a+/;
+    function check(a, b) { shouldBe(re.test(a), b); }
+    for (var i = 0; i < testLoopCount; ++i) { check("abc", true); check("zzz", false); }
+    re.compile("^z+");
+    for (var i = 0; i < testLoopCount; ++i) { check("zzz", true); check("abc", false); }
+})();

--- a/Source/JavaScriptCore/dfg/DFGCommonData.h
+++ b/Source/JavaScriptCore/dfg/DFGCommonData.h
@@ -45,6 +45,7 @@
 #include "RecordedStatuses.h"
 #include "YarrJIT.h"
 #include <wtf/Bag.h>
+#include <wtf/BitSet.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/text/StringSearch.h>
 
@@ -138,7 +139,8 @@ public:
     Bag<OptimizingCallLinkInfo> m_callLinkInfos;
     Bag<DirectCallLinkInfo> m_directCallLinkInfos;
     Yarr::YarrBoyerMooreData m_boyerMooreData;
-    
+    Bag<WTF::BitSet<256>> m_regExpFirstCharacterBitmaps;
+
     ScratchBuffer* catchOSREntryBuffer;
     RefPtr<Profiler::Compilation> compilation;
     

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -14154,6 +14154,60 @@ void SpeculativeJIT::compileRegExpTest(Node* node)
             speculateRegExpObject(node->child2(), baseGPR);
             speculateString(node->child3(), argumentGPR);
 
+#if CPU(ARM64) || CPU(X86_64)
+            // Anchored RegExp.test(string) fast-fail on a constant RegExpObject; tests input[0].
+            {
+                RegExp* regExp = nullptr;
+                if (RegExpObject* regExpObject = node->child2()->dynamicCastConstant<RegExpObject*>())
+                    regExp = regExpObject->regExp();
+                else if (node->child2()->op() == NewRegExp)
+                    regExp = node->child2()->castOperand<RegExp*>();
+                std::optional<WTF::BitSet<256>> localBitmap;
+                if (regExp && !regExp->globalOrSticky())
+                    localBitmap = Yarr::computeAnchoredFirstCharacterBitmap(regExp->pattern(), regExp->flags());
+                if (localBitmap) {
+                    const uint8_t* bitmap = jitCode()->common.m_regExpFirstCharacterBitmaps.add(*localBitmap)->storageBytes().data();
+
+                    GPRTemporary result(this);
+                    GPRTemporary scratch1(this);
+                    GPRTemporary scratch2(this);
+
+                    GPRReg resultGPR = result.gpr();
+                    GPRReg scratch1GPR = scratch1.gpr();
+                    GPRReg scratch2GPR = scratch2.gpr();
+
+                    flushRegisters();
+
+                    JumpList slowCases;
+                    JumpList doneCases;
+
+                    // The object must still wrap the expected RegExp (guards against .compile()).
+                    loadPtr(Address(baseGPR, RegExpObject::offsetOfRegExpAndFlags()), scratch1GPR);
+                    and64(TrustedImm64(RegExpObject::regExpMask), scratch1GPR);
+                    slowCases.append(branchLinkableConstant(NotEqual, scratch1GPR, LinkableConstant(*this, regExp)));
+
+                    loadPtr(Address(argumentGPR, JSString::offsetOfValue()), scratch1GPR);
+                    slowCases.append(branchIfRopeStringImpl(scratch1GPR));
+                    slowCases.append(branchTest32(Zero, Address(scratch1GPR, StringImpl::flagsOffset()), TrustedImm32(StringImpl::flagIs8Bit())));
+                    slowCases.append(branchTest32(Zero, Address(scratch1GPR, StringImpl::lengthMemoryOffset())));
+
+                    loadPtr(Address(scratch1GPR, StringImpl::dataOffset()), scratch1GPR);
+                    load8(Address(scratch1GPR), scratch2GPR);
+                    emitFirstCharacterBitmapMatch(bitmap, scratch2GPR, scratch1GPR, resultGPR, slowCases);
+
+                    move(TrustedImm32(0), resultGPR);
+                    doneCases.append(jump());
+
+                    slowCases.link(this);
+                    callOperation(operationRegExpTestString, resultGPR, globalObjectGPR, baseGPR, argumentGPR);
+
+                    doneCases.link(this);
+                    unblessedBooleanResult(resultGPR, node);
+                    return;
+                }
+            }
+#endif
+
             flushRegisters();
             GPRFlushedCallResult result(this);
             callOperation(operationRegExpTestString, result.gpr(), globalObjectGPR, baseGPR, argumentGPR);
@@ -14367,6 +14421,51 @@ void SpeculativeJIT::compileRegExpExecNonGlobalOrSticky(Node* node)
 
     speculateString(node->child2(), argumentGPR);
 
+#if CPU(ARM64) || CPU(X86_64)
+    // Anchored non-sticky exec fast-fail; tests input[0].
+    {
+        RegExp* regExp = node->castOperand<RegExp*>();
+        if (auto localBitmap = Yarr::computeAnchoredFirstCharacterBitmap(regExp->pattern(), regExp->flags())) {
+            const uint8_t* bitmap = jitCode()->common.m_regExpFirstCharacterBitmaps.add(*localBitmap)->storageBytes().data();
+
+            GPRTemporary result(this);
+            GPRTemporary scratch1(this);
+            GPRTemporary scratch2(this);
+            GPRTemporary scratch3(this);
+
+            GPRReg resultGPR = result.gpr();
+            GPRReg scratch1GPR = scratch1.gpr();
+            GPRReg scratch2GPR = scratch2.gpr();
+            GPRReg scratch3GPR = scratch3.gpr();
+
+            flushRegisters();
+
+            JumpList slowCases;
+            JumpList doneCases;
+
+            loadPtr(Address(argumentGPR, JSString::offsetOfValue()), scratch1GPR);
+            slowCases.append(branchIfRopeStringImpl(scratch1GPR));
+            slowCases.append(branchTest32(Zero, Address(scratch1GPR, StringImpl::flagsOffset()), TrustedImm32(StringImpl::flagIs8Bit())));
+            // An anchored pattern cannot match empty, so delegate an empty string to the operation.
+            slowCases.append(branchTest32(Zero, Address(scratch1GPR, StringImpl::lengthMemoryOffset())));
+
+            loadPtr(Address(scratch1GPR, StringImpl::dataOffset()), scratch1GPR);
+            load8(Address(scratch1GPR), scratch2GPR);
+            emitFirstCharacterBitmapMatch(bitmap, scratch2GPR, scratch1GPR, scratch3GPR, slowCases);
+
+            move(TrustedImm64(JSValue::encode(jsNull())), resultGPR);
+            doneCases.append(jump());
+
+            slowCases.link(this);
+            callOperation(operationRegExpExecNonGlobalOrSticky, resultGPR, globalObjectGPR, LinkableConstant(*this, node->cellOperand()->cell()), argumentGPR);
+
+            doneCases.link(this);
+            jsValueResult(resultGPR, node);
+            return;
+        }
+    }
+#endif
+
     flushRegisters();
     JSValueRegsFlushedCallResult result(this);
     JSValueRegs resultRegs = result.regs();
@@ -14388,6 +14487,68 @@ void SpeculativeJIT::compileRegExpExecSticky(Node* node)
 
     speculateRegExpObject(node->child2(), baseGPR);
     speculateString(node->child3(), argumentGPR);
+
+#if CPU(ARM64) || CPU(X86_64)
+    // Sticky exec fast-fail; when input[lastIndex] cannot begin a match, reset lastIndex to 0 and
+    // return null inline.
+    {
+        RegExp* regExp = node->castOperand<RegExp*>();
+        auto localBitmap = Yarr::computeStickyFirstCharacterBitmap(regExp->pattern(), regExp->flags());
+        if (localBitmap) {
+            const uint8_t* bitmap = jitCode()->common.m_regExpFirstCharacterBitmaps.add(*localBitmap)->storageBytes().data();
+
+            GPRTemporary result(this);
+            GPRTemporary scratch1(this);
+            GPRTemporary scratch2(this);
+            GPRTemporary scratch3(this);
+            GPRReg resultGPR = result.gpr();
+            GPRReg scratch1GPR = scratch1.gpr();
+            GPRReg scratch2GPR = scratch2.gpr();
+            GPRReg scratch3GPR = scratch3.gpr();
+
+            // baseGPR/argumentGPR/globalObjectGPR are preserved across flushRegisters for the
+            // slow-path operation call; the scratch registers are free to clobber.
+            flushRegisters();
+
+            JumpList slowCases;
+            JumpList doneCases;
+
+            // The string must be a resolved 8-bit string.
+            loadPtr(Address(argumentGPR, JSString::offsetOfValue()), scratch1GPR);
+            slowCases.append(branchIfRopeStringImpl(scratch1GPR));
+            slowCases.append(branchTest32(Zero, Address(scratch1GPR, StringImpl::flagsOffset()), TrustedImm32(StringImpl::flagIs8Bit())));
+
+            // lastIndex must be writable so the inline no-match path can reset it to 0.
+            slowCases.append(branchTest32(NonZero, Address(baseGPR, RegExpObject::offsetOfRegExpAndFlags()), TrustedImm32(RegExpObject::lastIndexIsNotWritableFlag)));
+
+            // lastIndex must be an Int32.
+            load64(Address(baseGPR, RegExpObject::offsetOfLastIndex()), scratch2GPR);
+            slowCases.append(branchIfNotInt32(scratch2GPR));
+            zeroExtend32ToWord(scratch2GPR, scratch2GPR);
+
+            // Need 0 <= lastIndex < length. An unsigned compare rejects negatives too.
+            load32(Address(scratch1GPR, StringImpl::lengthMemoryOffset()), scratch3GPR);
+            slowCases.append(branch32(AboveOrEqual, scratch2GPR, scratch3GPR));
+
+            // character = input[lastIndex] (scratch1GPR becomes the data pointer).
+            loadPtr(Address(scratch1GPR, StringImpl::dataOffset()), scratch1GPR);
+            load8(BaseIndex(scratch1GPR, scratch2GPR, TimesOne), scratch3GPR);
+            emitFirstCharacterBitmapMatch(bitmap, scratch3GPR, scratch1GPR, scratch2GPR, slowCases);
+
+            // The byte cannot begin a match: reset lastIndex to 0 and return null.
+            store64(TrustedImm64(JSValue::encode(jsNumber(0))), Address(baseGPR, RegExpObject::offsetOfLastIndex()));
+            move(TrustedImm64(JSValue::encode(jsNull())), resultGPR);
+            doneCases.append(jump());
+
+            slowCases.link(this);
+            callOperation(operationRegExpExecStickyKnownRegExp, resultGPR, globalObjectGPR, LinkableConstant(*this, node->cellOperand()->cell()), baseGPR, argumentGPR);
+
+            doneCases.link(this);
+            jsValueResult(resultGPR, node);
+            return;
+        }
+    }
+#endif
 
     flushRegisters();
     JSValueRegsFlushedCallResult result(this);

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
@@ -1730,6 +1730,7 @@ public:
     void compileRegExpExec(Node*);
     void compileRegExpExecNonGlobalOrSticky(Node*);
     void compileRegExpExecSticky(Node*);
+    void emitFirstCharacterBitmapMatch(const uint8_t* bitmap, GPRReg characterGPR, GPRReg scratch1GPR, GPRReg scratch2GPR, JumpList& matchMaybeCases);
     void compileRegExpMatchFast(Node*);
     void compileRegExpMatchFastGlobal(Node*);
     void compileRegExpSplitFast(Node*);

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
@@ -9980,6 +9980,21 @@ void SpeculativeJIT::compileMultiPutByVal(Node* node)
     noResult(node);
 }
 
+void SpeculativeJIT::emitFirstCharacterBitmapMatch(const uint8_t* bitmap, GPRReg characterGPR, GPRReg scratch1GPR, GPRReg scratch2GPR, JumpList& matchMaybeCases)
+{
+    move(TrustedImmPtr(bitmap), scratch1GPR);
+#if CPU(ARM64)
+    extractUnsignedBitfield32(characterGPR, TrustedImm32(6), TrustedImm32(2), scratch2GPR);
+    load64(BaseIndex(scratch1GPR, scratch2GPR, TimesEight), scratch2GPR);
+    urshift64(characterGPR, scratch2GPR);
+    matchMaybeCases.append(branchTest64(NonZero, scratch2GPR, TrustedImm32(1)));
+#else
+    urshift32(characterGPR, TrustedImm32(6), scratch2GPR);
+    load64(BaseIndex(scratch1GPR, scratch2GPR, TimesEight), scratch2GPR);
+    matchMaybeCases.append(branchTestBit64(NonZero, scratch2GPR, characterGPR));
+#endif
+}
+
 #endif
 
 } } // namespace JSC::DFG

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -19341,8 +19341,68 @@ IGNORE_CLANG_WARNINGS_END
     {
         LValue globalObject = lowCell(m_node->child1());
         LValue argument = lowString(m_node->child2());
+
+        if (compileRegExpExecNonGlobalOrStickyAnchoredFilter(globalObject, argument))
+            return;
+
         LValue result = vmCall(Int64, operationRegExpExecNonGlobalOrSticky, globalObject, frozenPointer(m_node->cellOperand()), argument);
         setJSValue(result);
+    }
+
+    // Nonzero iff `character` (0..255) might begin a match per the first-character `bitmap`.
+    LValue firstCharacterBitmapContains(LValue character, const uint8_t* bitmap)
+    {
+        LValue bitmapByte = m_out.load8ZeroExt32(m_out.baseIndex(m_heaps.characters8, m_out.constIntPtr(bitmap), m_out.zeroExtPtr(m_out.lShr(character, m_out.constInt32(3)))));
+        LValue bit = m_out.shl(m_out.constInt32(1), m_out.bitAnd(character, m_out.constInt32(7)));
+        return m_out.testNonZero32(bitmapByte, bit);
+    }
+
+    // Anchored non-sticky exec fast-fail; tests input[0].
+    bool compileRegExpExecNonGlobalOrStickyAnchoredFilter(LValue globalObject, LValue argument)
+    {
+        RegExp* regExp = uncheckedDowncast<RegExp>(m_node->cellOperand()->value());
+        auto localBitmap = Yarr::computeAnchoredFirstCharacterBitmap(regExp->pattern(), regExp->flags());
+        if (!localBitmap)
+            return false;
+        const uint8_t* bitmap = m_ftlState.jitCode->dfgCommon()->m_regExpFirstCharacterBitmaps.add(*localBitmap)->storageBytes().data();
+
+        LBasicBlock check8Bit = m_out.newBlock();
+        LBasicBlock checkLength = m_out.newBlock();
+        LBasicBlock filterCase = m_out.newBlock();
+        LBasicBlock noMatchCase = m_out.newBlock();
+        LBasicBlock operationCase = m_out.newBlock();
+        LBasicBlock continuation = m_out.newBlock();
+
+        m_out.branch(isRopeString(argument, m_node->child2()), rarely(operationCase), usually(check8Bit));
+
+        LBasicBlock lastNext = m_out.appendTo(check8Bit, checkLength);
+        LValue stringImpl = m_out.loadPtr(argument, m_heaps.JSString_value);
+        m_out.branch(
+            m_out.testIsZero32(
+                m_out.load32(stringImpl, m_heaps.StringImpl_hashAndFlags),
+                m_out.constInt32(StringImpl::flagIs8Bit())),
+            rarely(operationCase), usually(checkLength));
+
+        // An anchored pattern cannot match empty, so delegate an empty string to the operation.
+        m_out.appendTo(checkLength, filterCase);
+        m_out.branch(m_out.equal(m_out.load32(stringImpl, m_heaps.StringImpl_length), m_out.int32Zero), rarely(operationCase), usually(filterCase));
+
+        m_out.appendTo(filterCase, noMatchCase);
+        LValue stringData = m_out.loadPtr(stringImpl, m_heaps.StringImpl_data);
+        LValue character = m_out.load8ZeroExt32(m_out.baseIndex(m_heaps.characters8, stringData, m_out.constIntPtr(0)));
+        m_out.branch(firstCharacterBitmapContains(character, bitmap), unsure(operationCase), unsure(noMatchCase));
+
+        m_out.appendTo(noMatchCase, operationCase);
+        ValueFromBlock nullResult = m_out.anchor(m_out.constInt64(JSValue::encode(jsNull())));
+        m_out.jump(continuation);
+
+        m_out.appendTo(operationCase, continuation);
+        ValueFromBlock operationResult = m_out.anchor(vmCall(Int64, operationRegExpExecNonGlobalOrSticky, globalObject, frozenPointer(m_node->cellOperand()), argument));
+        m_out.jump(continuation);
+
+        m_out.appendTo(continuation, lastNext);
+        setJSValue(m_out.phi(Int64, nullResult, operationResult));
+        return true;
     }
 
     void compileRegExpExecSticky()
@@ -19350,8 +19410,80 @@ IGNORE_CLANG_WARNINGS_END
         LValue globalObject = lowCell(m_node->child1());
         LValue base = lowRegExpObject(m_node->child2());
         LValue argument = lowString(m_node->child3());
+
+        if (compileRegExpExecStickyFirstCharFilter(globalObject, base, argument))
+            return;
+
         LValue result = vmCall(Int64, operationRegExpExecStickyKnownRegExp, globalObject, frozenPointer(m_node->cellOperand()), base, argument);
         setJSValue(result);
+    }
+
+    // Sticky exec fast-fail; when input[lastIndex] cannot begin a match, reset lastIndex to 0 and
+    // return null inline.
+    bool compileRegExpExecStickyFirstCharFilter(LValue globalObject, LValue base, LValue argument)
+    {
+        RegExp* regExp = uncheckedDowncast<RegExp>(m_node->cellOperand()->value());
+        ASSERT(regExp->sticky() && !regExp->global());
+
+        auto localBitmap = Yarr::computeStickyFirstCharacterBitmap(regExp->pattern(), regExp->flags());
+        if (!localBitmap)
+            return false;
+        const uint8_t* bitmap = m_ftlState.jitCode->dfgCommon()->m_regExpFirstCharacterBitmaps.add(*localBitmap)->storageBytes().data();
+
+        LBasicBlock check8Bit = m_out.newBlock();
+        LBasicBlock checkWritable = m_out.newBlock();
+        LBasicBlock checkInt32 = m_out.newBlock();
+        LBasicBlock checkInBounds = m_out.newBlock();
+        LBasicBlock filterCase = m_out.newBlock();
+        LBasicBlock noMatchCase = m_out.newBlock();
+        LBasicBlock operationCase = m_out.newBlock();
+        LBasicBlock continuation = m_out.newBlock();
+
+        m_out.branch(isRopeString(argument, m_node->child3()), rarely(operationCase), usually(check8Bit));
+
+        LBasicBlock lastNext = m_out.appendTo(check8Bit, checkWritable);
+        LValue stringImpl = m_out.loadPtr(argument, m_heaps.JSString_value);
+        m_out.branch(
+            m_out.testIsZero32(
+                m_out.load32(stringImpl, m_heaps.StringImpl_hashAndFlags),
+                m_out.constInt32(StringImpl::flagIs8Bit())),
+            rarely(operationCase), usually(checkWritable));
+
+        // lastIndex must be writable so the no-match path can reset it to 0.
+        m_out.appendTo(checkWritable, checkInt32);
+        m_out.branch(
+            m_out.testNonZeroPtr(
+                m_out.loadPtr(base, m_heaps.RegExpObject_regExpAndFlags),
+                m_out.constIntPtr(RegExpObject::lastIndexIsNotWritableFlag)),
+            rarely(operationCase), usually(checkInt32));
+
+        m_out.appendTo(checkInt32, checkInBounds);
+        LValue lastIndexJSValue = m_out.load64(base, m_heaps.RegExpObject_lastIndex);
+        m_out.branch(isNotInt32(lastIndexJSValue), rarely(operationCase), usually(checkInBounds));
+
+        // Unsigned compare also rejects negative lastIndex; lastIndex == length is left to the operation.
+        m_out.appendTo(checkInBounds, filterCase);
+        LValue lastIndex = unboxInt32(lastIndexJSValue);
+        LValue stringLength = m_out.load32(stringImpl, m_heaps.StringImpl_length);
+        m_out.branch(m_out.aboveOrEqual(lastIndex, stringLength), rarely(operationCase), usually(filterCase));
+
+        m_out.appendTo(filterCase, noMatchCase);
+        LValue stringData = m_out.loadPtr(stringImpl, m_heaps.StringImpl_data);
+        LValue character = m_out.load8ZeroExt32(m_out.baseIndex(m_heaps.characters8, stringData, m_out.zeroExtPtr(lastIndex)));
+        m_out.branch(firstCharacterBitmapContains(character, bitmap), unsure(operationCase), unsure(noMatchCase));
+
+        m_out.appendTo(noMatchCase, operationCase);
+        m_out.store64(m_out.constInt64(JSValue::encode(jsNumber(0))), base, m_heaps.RegExpObject_lastIndex);
+        ValueFromBlock nullResult = m_out.anchor(m_out.constInt64(JSValue::encode(jsNull())));
+        m_out.jump(continuation);
+
+        m_out.appendTo(operationCase, continuation);
+        ValueFromBlock operationResult = m_out.anchor(vmCall(Int64, operationRegExpExecStickyKnownRegExp, globalObject, frozenPointer(m_node->cellOperand()), base, argument));
+        m_out.jump(continuation);
+
+        m_out.appendTo(continuation, lastNext);
+        setJSValue(m_out.phi(Int64, nullResult, operationResult));
+        return true;
     }
 
     void compileRegExpMatchFastGlobal()
@@ -19390,6 +19522,8 @@ IGNORE_CLANG_WARNINGS_END
 
             if (m_node->child3().useKind() == StringUse) {
                 LValue argument = lowString(m_node->child3());
+                if (compileRegExpTestAnchoredFilter(globalObject, base, argument))
+                    return;
                 LValue result = vmCall(Int32, operationRegExpTestString, globalObject, base, argument);
                 setBoolean(result);
                 return;
@@ -19405,6 +19539,64 @@ IGNORE_CLANG_WARNINGS_END
         LValue argument = lowJSValue(m_node->child3());
         LValue result = vmCall(Int32, operationRegExpTestGeneric, globalObject, base, argument);
         setBoolean(result);
+    }
+
+    // Anchored RegExp.test(string) fast-fail on a constant RegExpObject; tests input[0]. A runtime
+    // guard (below) keeps it correct across .compile() without a recompile watchpoint.
+    bool compileRegExpTestAnchoredFilter(LValue globalObject, LValue base, LValue argument)
+    {
+        RegExp* regExp = nullptr;
+        if (RegExpObject* regExpObject = m_node->child2()->dynamicCastConstant<RegExpObject*>())
+            regExp = regExpObject->regExp();
+        else if (m_node->child2()->op() == NewRegExp)
+            regExp = m_node->child2()->castOperand<RegExp*>();
+        if (!regExp || regExp->globalOrSticky())
+            return false;
+        auto localBitmap = Yarr::computeAnchoredFirstCharacterBitmap(regExp->pattern(), regExp->flags());
+        if (!localBitmap)
+            return false;
+        const uint8_t* bitmap = m_ftlState.jitCode->dfgCommon()->m_regExpFirstCharacterBitmaps.add(*localBitmap)->storageBytes().data();
+
+        LBasicBlock checkRope = m_out.newBlock();
+        LBasicBlock check8Bit = m_out.newBlock();
+        LBasicBlock checkLength = m_out.newBlock();
+        LBasicBlock filterCase = m_out.newBlock();
+        LBasicBlock falseCase = m_out.newBlock();
+        LBasicBlock operationCase = m_out.newBlock();
+        LBasicBlock continuation = m_out.newBlock();
+
+        // The object must still wrap the RegExp whose bitmap we baked (guards against .compile()).
+        LValue currentRegExp = m_out.bitAnd(m_out.loadPtr(base, m_heaps.RegExpObject_regExpAndFlags), m_out.constIntPtr(RegExpObject::regExpMask));
+        m_out.branch(m_out.equal(currentRegExp, frozenPointer(m_graph.freeze(regExp))), usually(checkRope), rarely(operationCase));
+
+        LBasicBlock lastNext = m_out.appendTo(checkRope, check8Bit);
+        m_out.branch(isRopeString(argument, m_node->child3()), rarely(operationCase), usually(check8Bit));
+
+        m_out.appendTo(check8Bit, checkLength);
+        LValue stringImpl = m_out.loadPtr(argument, m_heaps.JSString_value);
+        m_out.branch(
+            m_out.testIsZero32(m_out.load32(stringImpl, m_heaps.StringImpl_hashAndFlags), m_out.constInt32(StringImpl::flagIs8Bit())),
+            rarely(operationCase), usually(checkLength));
+
+        m_out.appendTo(checkLength, filterCase);
+        m_out.branch(m_out.equal(m_out.load32(stringImpl, m_heaps.StringImpl_length), m_out.int32Zero), rarely(operationCase), usually(filterCase));
+
+        m_out.appendTo(filterCase, falseCase);
+        LValue stringData = m_out.loadPtr(stringImpl, m_heaps.StringImpl_data);
+        LValue character = m_out.load8ZeroExt32(m_out.baseIndex(m_heaps.characters8, stringData, m_out.constIntPtr(0)));
+        m_out.branch(firstCharacterBitmapContains(character, bitmap), unsure(operationCase), unsure(falseCase));
+
+        m_out.appendTo(falseCase, operationCase);
+        ValueFromBlock falseResult = m_out.anchor(m_out.int32Zero);
+        m_out.jump(continuation);
+
+        m_out.appendTo(operationCase, continuation);
+        ValueFromBlock operationResult = m_out.anchor(vmCall(Int32, operationRegExpTestString, globalObject, base, argument));
+        m_out.jump(continuation);
+
+        m_out.appendTo(continuation, lastNext);
+        setBoolean(m_out.phi(Int32, falseResult, operationResult));
+        return true;
     }
 
 #if ENABLE(YARR_JIT_REGEXP_TEST_INLINE)

--- a/Source/JavaScriptCore/yarr/YarrPattern.cpp
+++ b/Source/JavaScriptCore/yarr/YarrPattern.cpp
@@ -3376,6 +3376,153 @@ std::optional<char16_t> CharacterClass::hasSharedLeadSurrogate() const
     return commonLeadSurrogate;
 }
 
+class FirstCharacterBitmapBuilder {
+public:
+    explicit FirstCharacterBitmapBuilder(WTF::BitSet<256>& bitmap)
+        : m_bitmap(bitmap)
+    {
+    }
+
+    bool build(PatternDisjunction* body)
+    {
+        addDisjunction(body, 0);
+        return !m_gaveUp;
+    }
+
+private:
+    void setBit(char32_t c)
+    {
+        if (c <= 0xff)
+            m_bitmap.set(c);
+    }
+
+    void addCharacterClass(const CharacterClass* cc)
+    {
+        if (cc->m_anyCharacter || !cc->m_strings.isEmpty()) {
+            m_gaveUp = true;
+            return;
+        }
+        for (char32_t c : cc->m_matches8)
+            setBit(c);
+        for (auto& range : cc->m_ranges8) {
+            char32_t end = std::min<char32_t>(range.end, 0xff);
+            for (char32_t c = range.begin; c <= end; ++c)
+                setBit(c);
+        }
+    }
+
+    // Sets `consumes` when the term definitely consumes >= 1 character, so it fully determines the
+    // first character and scanning can stop.
+    void addTerm(const PatternTerm& term, bool& consumes, unsigned depth)
+    {
+        using Type = PatternTerm::Type;
+        consumes = false;
+        if (m_gaveUp)
+            return;
+        if (term.m_matchDirection == Backward) {
+            m_gaveUp = true;
+            return;
+        }
+
+        switch (term.type) {
+        case Type::AssertionBOL:
+        case Type::AssertionEOL:
+        case Type::AssertionWordBoundary:
+        case Type::ParentheticalAssertion:
+            return;
+        case Type::PatternCharacter:
+            // A case-insensitive literal is always ASCII-alpha here (non-ASCII case-folding characters become character classes).
+            if (term.ignoreCase() && isASCIIAlpha(term.patternCharacter)) {
+                setBit(toASCIIUpper(term.patternCharacter));
+                setBit(toASCIILower(term.patternCharacter));
+            } else
+                setBit(term.patternCharacter);
+            consumes = term.quantityMinCount > 0;
+            return;
+        case Type::CharacterClass:
+            // Classes are already case-folded at construction. An inverted class is not a useful filter.
+            if (term.invert()) {
+                m_gaveUp = true;
+                return;
+            }
+            addCharacterClass(term.characterClass);
+            consumes = term.quantityMinCount > 0;
+            return;
+        case Type::ParenthesesSubpattern: {
+            if (depth > 8) {
+                m_gaveUp = true;
+                return;
+            }
+            addDisjunction(term.parentheses.disjunction, depth + 1);
+            consumes = term.quantityMinCount > 0 && term.parentheses.disjunction->m_minimumSize >= 1;
+            return;
+        }
+        default:
+            m_gaveUp = true;
+            return;
+        }
+    }
+
+    void addAlternative(PatternAlternative* alternative, unsigned depth)
+    {
+        for (auto& term : alternative->m_terms) {
+            bool consumes = false;
+            addTerm(term, consumes, depth);
+            if (m_gaveUp)
+                return;
+            if (consumes)
+                return;
+        }
+    }
+
+    void addDisjunction(PatternDisjunction* disjunction, unsigned depth)
+    {
+        for (auto& alternative : disjunction->m_alternatives) {
+            addAlternative(alternative.get(), depth);
+            if (m_gaveUp)
+                return;
+        }
+    }
+
+    WTF::BitSet<256>& m_bitmap;
+    bool m_gaveUp { false };
+};
+
+std::optional<WTF::BitSet<256>> computeStickyFirstCharacterBitmap(StringView patternString, OptionSet<Flags> flags)
+{
+    ErrorCode errorCode = ErrorCode::NoError;
+    YarrPattern pattern(patternString, flags, errorCode);
+    if (hasError(errorCode) || !pattern.m_body || pattern.m_body->m_minimumSize < 1)
+        return std::nullopt;
+    WTF::BitSet<256> bitmap;
+    FirstCharacterBitmapBuilder builder(bitmap);
+    if (!builder.build(pattern.m_body))
+        return std::nullopt;
+    return bitmap;
+}
+
+std::optional<WTF::BitSet<256>> computeAnchoredFirstCharacterBitmap(StringView patternString, OptionSet<Flags> flags)
+{
+    ErrorCode errorCode = ErrorCode::NoError;
+    YarrPattern pattern(patternString, flags, errorCode);
+    if (hasError(errorCode) || !pattern.m_body || pattern.m_body->m_minimumSize < 1)
+        return std::nullopt;
+    // The bitmap describes position 0, so it is only sound when every match must begin there:
+    // ^-anchored at the start of every alternative, and neither multiline nor a modifier group can
+    // make that ^ match after a newline.
+    if (pattern.multiline() || pattern.m_containsModifiers)
+        return std::nullopt;
+    for (auto& alternative : pattern.m_body->m_alternatives) {
+        if (!alternative->m_startsWithBOL)
+            return std::nullopt;
+    }
+    WTF::BitSet<256> bitmap;
+    FirstCharacterBitmapBuilder builder(bitmap);
+    if (!builder.build(pattern.m_body))
+        return std::nullopt;
+    return bitmap;
+}
+
 } } // namespace JSC::Yarr
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/JavaScriptCore/yarr/YarrPattern.h
+++ b/Source/JavaScriptCore/yarr/YarrPattern.h
@@ -31,6 +31,7 @@
 #include <JavaScriptCore/YarrFlags.h>
 #include <JavaScriptCore/YarrUnicodeProperties.h>
 #include <array>
+#include <wtf/BitSet.h>
 #include <wtf/CheckedArithmetic.h>
 #include <wtf/HashMap.h>
 #include <wtf/OptionSet.h>
@@ -43,6 +44,12 @@ namespace JSC { namespace Yarr {
 
 struct YarrPattern;
 struct PatternDisjunction;
+
+// Superset of the Latin-1 bytes that can begin a match (a clear bit guarantees no match begins
+// there), or nullopt when not useful. computeAnchored additionally requires the pattern be
+// ^-anchored at position 0 (not multiline). Safe to call on a compiler thread.
+std::optional<WTF::BitSet<256>> computeStickyFirstCharacterBitmap(StringView, OptionSet<Flags>);
+std::optional<WTF::BitSet<256>> computeAnchoredFirstCharacterBitmap(StringView, OptionSet<Flags>);
 
 enum class CompileMode : uint8_t {
     Legacy,


### PR DESCRIPTION
#### d328c270769037f111e31474429e19999c446382
<pre>
[JSC] DFG / FTL should have fast-fail filter for RegExp with BOL assertions
<a href="https://bugs.webkit.org/show_bug.cgi?id=320128">https://bugs.webkit.org/show_bug.cgi?id=320128</a>
<a href="https://rdar.apple.com/183067008">rdar://183067008</a>

Reviewed by Yijia Huang.

/^regexp/ or sticky bit (y) is used for testing frequently, and the
purpose of this is typically accepting or rejecting a subject. In
particular, sticky bit is introduced mainly for tokenizing pattern, and
it should extremely quickly reject a subject when it does not match and
this pattern is expected use case.

From this perspective, this patch introduces fast-fail filter. This is
similar to YarrJIT boyermoore lookahead, but the purpose is more
specific: it is quickly rejecting a subject which never matches. On the
other hand, boyermoore lookahead&apos;s purpose is finding the false-positive
matching index. We run FirstCharacterBitmapBuilder to collect BitSet for
latin-1 range which quickly answers rejection to avoid actual costly
matching operations. Currently we are only accepting latin-1 (8-bit),
but we should extend it for 16-bit cases as well.

When sticky bit is used, RegExp will work as if it is having BOL
assertion with the current lastIndex offset of a subject. So we do not
need to check BOL, and instead, we need to extract a character from
lastIndex place. Otherwise, we can just extract a character from index 0
and do this filtering only when the pattern is having
one-character-size-prefix and the subject is 8-bit. We do not do this
filtering for global bit case as it is extracting a character from lastIndex.

Tests: JSTests/stress/regexp-exec-anchored-first-char-filter.js
       JSTests/stress/regexp-exec-sticky-first-char-filter.js
       JSTests/stress/regexp-test-anchored-first-char-filter.js

* JSTests/stress/regexp-exec-anchored-first-char-filter.js: Added.
(shouldBe):
(execStr):
(step):
* JSTests/stress/regexp-exec-sticky-first-char-filter.js: Added.
(shouldBe):
(shouldThrow):
(step):
* JSTests/stress/regexp-test-anchored-first-char-filter.js: Added.
(shouldBe):
(step):
(check):
* Source/JavaScriptCore/dfg/DFGCommonData.h:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp:
(JSC::DFG::SpeculativeJIT::emitFirstCharacterBitmapMatch):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileCompareStrictEq):
* Source/JavaScriptCore/yarr/YarrPattern.cpp:
(JSC::Yarr::FirstCharacterBitmapBuilder::FirstCharacterBitmapBuilder):
(JSC::Yarr::FirstCharacterBitmapBuilder::build):
(JSC::Yarr::FirstCharacterBitmapBuilder::setBit):
(JSC::Yarr::FirstCharacterBitmapBuilder::addCharacterClass):
(JSC::Yarr::FirstCharacterBitmapBuilder::addTerm):
(JSC::Yarr::FirstCharacterBitmapBuilder::addAlternative):
(JSC::Yarr::FirstCharacterBitmapBuilder::addDisjunction):
(JSC::Yarr::computeStickyFirstCharacterBitmap):
(JSC::Yarr::computeAnchoredFirstCharacterBitmap):
* Source/JavaScriptCore/yarr/YarrPattern.h:

Canonical link: <a href="https://commits.webkit.org/317836@main">https://commits.webkit.org/317836@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3800acdd5d22f67c89638a517796f3047b87aa94

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176514 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/50449 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/44239 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/186115 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/138788 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/51741 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50133 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/186115 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/138788 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179470 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/51741 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/44239 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/186115 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/51741 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38001 "Build is in progress. Recent messages:") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/186115 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/44239 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/51741 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/44239 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34583 "Built successfully") | | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/37782 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/42181 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42212 "Build is in progress. Recent messages:") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188538 "Built successfully") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/50114 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/44239 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/146548 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/50798 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/44239 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/146358 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26790 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/50798 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/123002 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117064 "Built successfully") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/49302 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/44239 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/48704 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/48938 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/48763 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->