### PR TITLE
Evaluate element segment expressions exactly once per instance

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/bulk-memory/table_init.wast.js-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/bulk-memory/table_init.wast.js-expected.txt
@@ -940,7 +940,5 @@ PASS #938 Test that WebAssembly compilation succeeds (table_init.wast:2248)
 PASS #939 Test that WebAssembly instantiation succeeds (table_init.wast:2248)
 PASS #940 Test that WebAssembly compilation succeeds (table_init.wast:2272)
 PASS #941 Test that WebAssembly instantiation succeeds (table_init.wast:2272)
-FAIL #942 Test that a WebAssembly code returns a specific result (table_init.wast:2286) assert_equals: assert_return@async_index.js:324:29
-table_init_wast_js@table_init.wast.js:2500:14
-global code@table_init.wast.js:2502:3 expected 1 but got 0
+PASS #942 Test that a WebAssembly code returns a specific result (table_init.wast:2286)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/gc/array_init_elem.wast.js-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/gc/array_init_elem.wast.js-expected.txt
@@ -42,12 +42,8 @@ PASS #40 Test that a WebAssembly code returns a specific result (array_init_elem
 PASS #41 Test that a WebAssembly code returns a specific result (array_init_elem.wast:154)
 PASS #42 Test that a WebAssembly code returns a specific result (array_init_elem.wast:155)
 PASS #43 Test that a WebAssembly code returns a specific result (array_init_elem.wast:156)
-FAIL #44 Test that a WebAssembly code returns a specific result (array_init_elem.wast:157) assert_equals: assert_return@async_index.js:324:29
-array_init_elem_wast_js@array_init_elem.wast.js:109:14
-global code@array_init_elem.wast.js:120:3 expected 1 but got 0
+PASS #44 Test that a WebAssembly code returns a specific result (array_init_elem.wast:157)
 PASS #45 Test that WebAssembly compilation succeeds (array_init_elem.wast:160)
 PASS #46 Test that WebAssembly instantiation succeeds (array_init_elem.wast:160)
-FAIL #47 Test that a WebAssembly code returns a specific result (array_init_elem.wast:178) assert_equals: assert_return@async_index.js:324:29
-array_init_elem_wast_js@array_init_elem.wast.js:118:14
-global code@array_init_elem.wast.js:120:3 expected 1 but got 0
+PASS #47 Test that a WebAssembly code returns a specific result (array_init_elem.wast:178)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/gc/array_new_elem.wast.js-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/gc/array_new_elem.wast.js-expected.txt
@@ -34,7 +34,5 @@ PASS #32 Test that WebAssembly instantiation succeeds (array_new_elem.wast:77)
 PASS #33 Test that a WebAssembly code returns a specific result (array_new_elem.wast:103)
 PASS #34 Test that WebAssembly compilation succeeds (array_new_elem.wast:106)
 PASS #35 Test that WebAssembly instantiation succeeds (array_new_elem.wast:106)
-FAIL #36 Test that a WebAssembly code returns a specific result (array_new_elem.wast:121) assert_equals: assert_return@async_index.js:324:29
-array_new_elem_wast_js@array_new_elem.wast.js:88:14
-global code@array_new_elem.wast.js:90:3 expected 1 but got 0
+PASS #36 Test that a WebAssembly code returns a specific result (array_new_elem.wast:121)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table_init64.wast.js-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table_init64.wast.js-expected.txt
@@ -1042,7 +1042,5 @@ PASS #1040 Test that WebAssembly compilation succeeds (table_init64.wast:2433)
 PASS #1041 Test that WebAssembly instantiation succeeds (table_init64.wast:2433)
 PASS #1042 Test that WebAssembly compilation succeeds (table_init64.wast:2457)
 PASS #1043 Test that WebAssembly instantiation succeeds (table_init64.wast:2457)
-FAIL #1044 Test that a WebAssembly code returns a specific result (table_init64.wast:2471) assert_equals: assert_return@async_index.js:324:29
-table_init64_wast_js@table_init64.wast.js:2798:14
-global code@table_init64.wast.js:2800:3 expected 1 but got 0
+PASS #1044 Test that a WebAssembly code returns a specific result (table_init64.wast:2471)
 

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.cpp
@@ -220,6 +220,8 @@ void JSWebAssemblyInstance::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     Locker locker { cell->cellLock() };
     for (auto& wrapper : thisObject->functionWrappers())
         visitor.appendUnbarriered(wrapper.get());
+    for (auto& entry : thisObject->m_constantExpressionValues)
+        visitor.append(entry.value);
 }
 
 DEFINE_VISIT_CHILDREN(JSWebAssemblyInstance);
@@ -597,7 +599,7 @@ void JSWebAssemblyInstance::initElementSegment(uint32_t tableIndex, const Elemen
         else {
             ASSERT(initType == Element::InitializationType::FromExtendedExpression);
             uint64_t result;
-            bool success = evaluateConstantExpression(initialBitsOrIndex, segment.elementType, result);
+            bool success = ensureConstantExpressionValue(initialBitsOrIndex, segment.elementType, result);
             // FIXME: https://bugs.webkit.org/show_bug.cgi?id=264454
             // Currently this should never fail, as the parse phase already validated it.
             RELEASE_ASSERT(success);
@@ -687,7 +689,7 @@ void JSWebAssemblyInstance::copyElementSegment(JSWebAssemblyArray* array, const 
 
         ASSERT(initType == Element::InitializationType::FromExtendedExpression);
         uint64_t result;
-        bool success = evaluateConstantExpression(initialBitsOrIndex, segment.elementType, result);
+        bool success = ensureConstantExpressionValue(initialBitsOrIndex, segment.elementType, result);
         // FIXME: https://bugs.webkit.org/show_bug.cgi?id=264454
         // Currently this should never fail, as the parse phase already validated it.
         RELEASE_ASSERT(success);
@@ -703,6 +705,21 @@ bool JSWebAssemblyInstance::evaluateConstantExpression(uint64_t index, Type expe
         return false;
 
     result = evalResult.value();
+    return true;
+}
+
+bool JSWebAssemblyInstance::ensureConstantExpressionValue(uint64_t constantExpressionIndex, Type expectedType, uint64_t& result)
+{
+    if (auto found = m_constantExpressionValues.getOptional(constantExpressionIndex)) {
+        result = JSValue::encode(found.value().get());
+        return true;
+    }
+
+    if (!evaluateConstantExpression(constantExpressionIndex, expectedType, result)) [[unlikely]]
+        return false;
+
+    Locker locker { cellLock() };
+    m_constantExpressionValues.set(constantExpressionIndex, WriteBarrier<Unknown>(vm(), this, JSValue::decode(result)));
     return true;
 }
 

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.h
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.h
@@ -442,6 +442,7 @@ private:
 
     static size_t allocationSize(const Wasm::ModuleInformation&);
     bool evaluateConstantExpression(uint64_t, Wasm::Type, uint64_t&);
+    bool ensureConstantExpressionValue(uint64_t constantExpressionIndex, Wasm::Type, uint64_t&);
 
     VM* const m_vm;
     WriteBarrier<JSWebAssemblyModule> m_jsModule;
@@ -462,6 +463,9 @@ private:
     CallFrame* m_temporaryCallFrame { nullptr };
     Wasm::Global::Value* m_globals { nullptr };
     FunctionWrapperMap m_functionWrappers;
+
+    using ConstantExpressionValueMap = UncheckedKeyHashMap<uint64_t, WriteBarrier<Unknown>, IntHash<uint64_t>, WTF::UnsignedWithZeroKeyHashTraits<uint64_t>>;
+    ConstantExpressionValueMap m_constantExpressionValues;
     BitVector m_globalsToMark;
     BitVector m_globalsToBinding;
     unsigned m_numImportFunctions { 0 };


### PR DESCRIPTION
#### 8c7d5cdee6369ebb6b6f8e502ce16836737f73ca
<pre>
Evaluate element segment expressions exactly once per instance
<a href="https://bugs.webkit.org/show_bug.cgi?id=320129">https://bugs.webkit.org/show_bug.cgi?id=320129</a>
<a href="https://rdar.apple.com/183067192">rdar://183067192</a>

Reviewed by Marcus Plutowski.

Per the Wasm spec, an element segment&apos;s element expressions are evaluated
exactly once during module instantiation, and the resulting references are
stored in the element instance. Then, table.init and array.new_elem only copy
those already-evaluated references.

JSC instead re-evaluated the constant expression on every read of an element
segment (in initElementSegment and copyElementSegment). For reference-producing
GC expressions such as array.new_default, each evaluation allocates a fresh
object, so two table.init operations from the same passive segment produced
distinct arrays and ref.eq returned 0 instead of 1. This surfaced as a failure
in imported/w3c/web-platform-tests/wasm/core/memory64/table_init64.wast.js
(test #1044).

Evaluate each element-segment expression exactly once per instance by caching
the result in m_constantExpressionValues, and mark the cached references
during GC visitation.

* LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table_init64.wast.js-expected.txt:
* Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.cpp:
(JSC::JSWebAssemblyInstance::visitChildrenImpl):
(JSC::JSWebAssemblyInstance::initElementSegment):
(JSC::JSWebAssemblyInstance::copyElementSegment):
(JSC::JSWebAssemblyInstance::ensureConstantExpressionValue):
* Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.h:

Canonical link: <a href="https://commits.webkit.org/317904@main">https://commits.webkit.org/317904@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b8ae4017145e9f76ef64e9699e5901508a5a505c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176644 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50581 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44373 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186246 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/139406 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/485da3b1-2098-412c-91b3-b20d1ce0f6f2) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51874 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50267 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137596 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/139406 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f530e3e7-d934-4010-82d2-599eb4e87fda) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179600 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41100 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158384 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118070 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/94c8a5db-52bd-49e1-84fd-70c0dc2bbe38) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39755 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38122 "Passed tests") | [❌ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/35 "Found 4 new JSC stress test failures: wasm.yaml/wasm/stress/type-index-abstract-heap-types-concrete-vs-abstract.js.wasm-aggressive-inline, wasm.yaml/wasm/stress/type-index-abstract-heap-types-concrete-vs-abstract.js.wasm-eager, wasm.yaml/wasm/stress/type-index-abstract-heap-types-globals-and-tables.js.wasm-aggressive-inline, wasm.yaml/wasm/stress/type-index-abstract-heap-types-nulls-and-casts.js.wasm-aggressive-inline (failure)") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/6891 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150167 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37882 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-highlight-api/painting/custom-highlight-dynamic-font-metrics-001.html (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34714 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/37915 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42321 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42338 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188670 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50248 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146662 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39451 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50931 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/34502 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146468 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41229 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123137 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117249 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49436 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12861 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48835 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49071 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48896 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->