### PR TITLE
Media query parser: keep <general-enclosed> name verbatim

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/scroll-state/at-container-scrollable-serialization-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/scroll-state/at-container-scrollable-serialization-expected.txt
@@ -1,6 +1,6 @@
 
 PASS Normalize spaces
-FAIL No value - invalid, serializes as <general-enclosed> assert_equals: expected "scroll-STate(scrollable:    )" but got "scroll-state(scrollable:    )"
+PASS No value - invalid, serializes as <general-enclosed>
 PASS Boolean context
 PASS Logical with 'or'
 PASS Not a scroll-state function with space before '('

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/scroll-state/at-container-scrolled-serialization-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/scroll-state/at-container-scrolled-serialization-expected.txt
@@ -1,6 +1,6 @@
 
 PASS Normalize spaces
-FAIL No value - invalid, serializes as <general-enclosed> assert_equals: expected "scroll-STate(scrolled:    )" but got "scroll-state(scrolled:    )"
+PASS No value - invalid, serializes as <general-enclosed>
 PASS Boolean context
 PASS Logical with 'or'
 PASS Not a scroll-state function with space before '('

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/scroll-state/at-container-snapped-serialization-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/scroll-state/at-container-snapped-serialization-expected.txt
@@ -1,6 +1,6 @@
 
 PASS Normalize spaces
-FAIL No value - invalid, serializes as <general-enclosed> assert_equals: expected "scroll-STate(snapped:    )" but got "scroll-state(snapped:    )"
+PASS No value - invalid, serializes as <general-enclosed>
 PASS Boolean context
 PASS Logical with 'or'
 PASS Not a scroll-state function with space before '('

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/scroll-state/at-container-stuck-serialization-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/scroll-state/at-container-stuck-serialization-expected.txt
@@ -1,6 +1,6 @@
 
 PASS Normalize spaces
-FAIL No value - invalid, serializes as <general-enclosed> assert_equals: expected "scroll-STate(stuck:    )" but got "scroll-state(stuck:    )"
+PASS No value - invalid, serializes as <general-enclosed>
 PASS Boolean context
 PASS Logical with 'or'
 PASS Not a scroll-state function with space before '('

--- a/Source/WebCore/css/query/GenericMediaQueryParser.h
+++ b/Source/WebCore/css/query/GenericMediaQueryParser.h
@@ -131,14 +131,16 @@ template<typename ConcreteParser>
 std::optional<QueryInParens> GenericMediaQueryParser<ConcreteParser>::consumeQueryInParens(CSSParserTokenRange& range, const MediaQueryParserContext& context, State& state)
 {
     std::optional<CSSValueID> functionId;
+    std::optional<StringView> functionName;
 
     if (range.peek().type() == FunctionToken) {
         if (state.inFunctionId)
             return { };
 
         functionId = range.peek().functionId();
+        functionName = range.peek().value();
+
         if (!ConcreteParser::isValidFunctionId(*functionId)) {
-            auto name = range.peek().value();
             auto functionRange = range.consumeBlock();
             range.consumeWhitespace();
 
@@ -146,7 +148,7 @@ std::optional<QueryInParens> GenericMediaQueryParser<ConcreteParser>::consumeQue
             if (!validationRange.consumeAnyValue())
                 return { };
 
-            return GeneralEnclosed { name.toString(), functionRange.serialize(CSSParserToken::SerializationMode::CustomProperty) };
+            return GeneralEnclosed { functionName->toString(), functionRange.serialize(CSSParserToken::SerializationMode::CustomProperty) };
         }
     }
 
@@ -181,7 +183,7 @@ std::optional<QueryInParens> GenericMediaQueryParser<ConcreteParser>::consumeQue
     if (!validationRange.consumeAnyValue())
         return { };
 
-    return GeneralEnclosed { functionId ? nameString(*functionId) : nullAtom(), originalBlockRange.serialize(CSSParserToken::SerializationMode::CustomProperty) };
+    return GeneralEnclosed { functionName ? functionName->toString() : nullString(), originalBlockRange.serialize(CSSParserToken::SerializationMode::CustomProperty) };
 }
 
 template<typename ConcreteParser>


### PR DESCRIPTION
#### 5e6f6100706823c48b060671a6af5de4ba4ee235
<pre>
Media query parser: keep &lt;general-enclosed&gt; name verbatim
<a href="https://rdar.apple.com/183065105">rdar://183065105</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=320124">https://bugs.webkit.org/show_bug.cgi?id=320124</a>

Reviewed by Tim Nguyen.

GenericMediaQueryParser&lt;ConcreteParser&gt;::consumeQueryInParens parses a
function name token into a CSSValueID, then when it parses it as a
&lt;general-enclosed&gt;, the function name CSSValueID is converted back to
string using nameString. But nameString doesn&apos;t preserve the original
casing of the function name. For example, &quot;ScrOLL-StAte(...)&quot; is parsed
into CSSValueScrollState, then converted back to &quot;scroll-state&quot;, which
doesn&apos;t match the original casing.

Fix this by saving both the function name CSSValueID and original string,
and use the original string when parsing as &lt;general-enclosed&gt;

* LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/scroll-state/at-container-scrollable-serialization-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/scroll-state/at-container-scrolled-serialization-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/scroll-state/at-container-snapped-serialization-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/scroll-state/at-container-stuck-serialization-expected.txt:
    - Test progression.

* Source/WebCore/css/query/GenericMediaQueryParser.h:
(WebCore::MQ::GenericMediaQueryParser&lt;ConcreteParser&gt;::consumeQueryInParens):

Canonical link: <a href="https://commits.webkit.org/318965@main">https://commits.webkit.org/318965@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e99b8edabbb8be9a520d83b1219cd4cebdc30a18

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179927 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53873 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47669 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190139 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144246 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6ff97b87-d886-43af-81d1-c28401771bb4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181789 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55170 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53589 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140309 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97143 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bf21b917-f255-4fff-a15c-c30e12ba365d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182883 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43960 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161091 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120760 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0fd31b31-ca20-4cf6-81c6-29d3b07f99a3) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42631 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40951 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153033 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40618 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1296 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46472 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45201 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192070 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53539 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149643 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40100 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54226 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37229 "Too many flaky failures: http/tests/misc/resource-timing-navigation-in-restored-iframe-2.html, http/tests/navigation/post-basic.html, http/tests/resourceLoadStatistics/enable-debug-mode.html, http/tests/security/canvas-cors-with-two-hosts.html, http/tests/security/contentSecurityPolicy/1.1/scriptnonce-allowed-by-enforced-policy-and-blocked-by-report-policy2.py, http/tests/security/contentSecurityPolicy/image-with-http-url-allowed-by-csp-img-src-star.html, http/tests/storageAccess/deny-storage-access-under-opener-if-auto-dismiss-ephemeral.html, http/tests/websocket/tests/hybi/contentextensions/block.html, http/tests/websocket/tests/hybi/fragmented-control-frame.html, http/tests/xmlhttprequest/abort-crash.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149372 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44021 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126489 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121546 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52743 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15604 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52125 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52363 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52189 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->