### PR TITLE
WIP: lazily set structure watchpoints in DFG

### DIFF
--- a/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
@@ -3831,8 +3831,10 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
                     bool canFold = false;
                     JSGlobalObject* globalObject = m_graph.globalObjectFor(node->origin.semantic);
                     if (Structure* originalSetStructure = globalObject->setStructureConcurrently()) {
-                        if (forNode(node->child1()).m_structure.isSubsetOf(RegisteredStructureSet(m_graph.registerStructure(originalSetStructure))))
+                        if (forNode(node->child1()).m_structure.isSubsetOf(RegisteredStructureSet(m_graph.registerStructure(originalSetStructure)))) {
+                            m_graph.trustStructures(forNode(node->child1()).m_structure);
                             canFold = true;
+                        }
                     }
                     if (canFold)
                         didFoldClobberWorld();
@@ -5938,6 +5940,7 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
                     if (m_graph.isWatchingPromiseSpeciesWatchpoint(node)) {
                         if (auto structure = argument.m_structure.onlyStructure()) {
                             if (structure.get() == globalObject->promiseStructure()) {
+                                m_graph.trustStructures(argument.m_structure);
                                 didFoldClobberWorld();
                                 forNode(node) = argument;
                                 break;

--- a/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
@@ -4878,7 +4878,13 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
     }
 
     case Arrayify: {
-        if (node->arrayMode().alreadyChecked(m_graph, node, forNode(node->child1()))) {
+        AbstractValue& arrayifyValue = forNode(node->child1());
+        if (node->arrayMode().alreadyChecked(m_graph, node, arrayifyValue)) {
+            // We model Arrayify as a no-op (no structure clobber) because the array is already
+            // in the required mode. If that proof relies on a finite structure set, watch it so
+            // the mode can't change under us (else the runtime Arrayify would convert & clobber).
+            if (arrayifyValue.m_structure.isFinite())
+                m_graph.trustStructures(arrayifyValue.m_structure);
             didFoldClobberStructures();
             break;
         }

--- a/Source/JavaScriptCore/dfg/DFGAbstractValue.cpp
+++ b/Source/JavaScriptCore/dfg/DFGAbstractValue.cpp
@@ -30,6 +30,7 @@
 
 #include "DFGGraph.h"
 #include "JSCJSValueInlines.h"
+#include "Options.h"
 #include "TrackedReferences.h"
 #include <wtf/AlignedStorage.h>
 #include <wtf/StdLibExtras.h>
@@ -54,8 +55,16 @@ void AbstractValue::set(Graph& graph, const FrozenValue& value, StructureClobber
 {
     if (!!value && value.value().isCell()) {
         Structure* structure = value.structure();
-        if (graph.tryWatch(structure)) {
+        // The finite-vs-TOP decision is identical either way (it is dfgMayWatch()); only the
+        // timing of the watchpoint install differs. With useDFGLazyStructureWatchpoints we keep
+        // the constant's structure finite without watching it now and mark needsWatch, so the
+        // watchpoint is installed only if a consumer relies on the structure being stable.
+        // Otherwise we install eagerly here via tryWatch.
+        bool keepFinite = Options::useDFGLazyStructureWatchpoints() ? structure->dfgMayWatch() : graph.tryWatch(structure);
+        if (keepFinite) {
             m_structure = graph.registerStructure(structure);
+            if (Options::useDFGLazyStructureWatchpoints())
+                m_structure.setNeedsWatch(true);
             if (clobberState == StructuresAreClobbered) {
                 m_arrayModes = ALL_ARRAY_MODES;
                 m_structure.clobber(graph);

--- a/Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp
@@ -277,6 +277,7 @@ private:
                 }
 
                 if (value.m_structure.isSubsetOf(set)) {
+                    m_graph.trustStructures(value.m_structure);
                     m_interpreter.execute(indexInBlock); // Catch the fact that we may filter on cell.
                     node->remove(m_graph);
                     eliminated = true;
@@ -435,17 +436,24 @@ private:
 
             case CheckArray:
             case Arrayify: {
-                if (!node->arrayMode().alreadyChecked(m_graph, node, m_state.forNode(node->child1())))
+                AbstractValue& value = m_state.forNode(node->child1());
+                if (!node->arrayMode().alreadyChecked(m_graph, node, value))
                     break;
+                // If the array-mode proof relies on a finite structure set, watch those
+                // structures before eliding. When it is structure-independent (proved via
+                // arrayModes/type, so the structure may be infinite) no watchpoint is needed.
+                if (value.m_structure.isFinite())
+                    m_graph.trustStructures(value.m_structure);
                 node->remove(m_graph);
                 eliminated = true;
                 break;
             }
-                
+
             case PutStructure: {
-                if (m_state.forNode(node->child1()).m_structure.onlyStructure() != node->transition()->next)
+                AbstractValue& value = m_state.forNode(node->child1());
+                if (value.m_structure.onlyStructure() != node->transition()->next)
                     break;
-                
+                m_graph.trustStructures(value.m_structure);
                 node->remove(m_graph);
                 eliminated = true;
                 break;
@@ -533,13 +541,12 @@ private:
                             }
                         });
 
-                        if (canFold) {
-                            if (m_graph.isWatchingArrayBufferDetachWatchpoint(node)) {
-                                node->setOp(GetUndetachedTypeArrayLength);
-                                node->setArrayMode(arrayMode.withArrayClass(Array::NonArray));
-                                changed = true;
-                                break;
-                            }
+                        if (canFold && m_graph.isWatchingArrayBufferDetachWatchpoint(node)) {
+                            m_graph.trustStructures(abstractValue.m_structure);
+                            node->setOp(GetUndetachedTypeArrayLength);
+                            node->setArrayMode(arrayMode.withArrayClass(Array::NonArray));
+                            changed = true;
+                            break;
                         }
                     }
                 }
@@ -558,13 +565,12 @@ private:
                         }
                     });
 
-                    if (canFold) {
-                        if (m_graph.isWatchingArrayBufferDetachWatchpoint(node)) {
-                            m_interpreter.execute(indexInBlock); // Catch the fact that we may filter on cell.
-                            node->remove(m_graph);
-                            eliminated = true;
-                            break;
-                        }
+                    if (canFold && m_graph.isWatchingArrayBufferDetachWatchpoint(node)) {
+                        m_graph.trustStructures(abstractValue.m_structure);
+                        m_interpreter.execute(indexInBlock); // Catch the fact that we may filter on cell.
+                        node->remove(m_graph);
+                        eliminated = true;
+                        break;
                     }
                 }
                 break;
@@ -1343,6 +1349,11 @@ private:
                     m_graph.watchpoints().addLazily(globalObject->objectPrototypeChainIsSaneWatchpointSet());
                 }
 
+                // The folded field reads use KnownCellUse on the descriptor (no runtime
+                // CheckStructure), so they rely on the descriptor actually having
+                // descriptorStructure. Watch it before committing to the fold.
+                m_graph.trustStructures(descriptor.m_structure);
+
                 m_interpreter.execute(indexInBlock);
                 alreadyHandled = true;
                 if (!m_state.isValid())
@@ -1665,6 +1676,7 @@ private:
                         ok &= (structure->typeInfo().inlineTypeFlags() & bits) == bits;
                     });
                     if (ok) {
+                        m_graph.trustStructures(abstractValue.m_structure);
                         eliminated = true;
                         node->remove(m_graph);
                         break;
@@ -1692,9 +1704,11 @@ private:
                     });
 
                     if (canFoldToTrue) {
+                        m_graph.trustStructures(child.m_structure);
                         m_graph.convertToConstant(node, jsBoolean(true));
                         changed = true;
                     } else if (canFoldToFalse) {
+                        m_graph.trustStructures(child.m_structure);
                         m_graph.convertToConstant(node, jsBoolean(false));
                         changed = true;
                     }
@@ -2058,6 +2072,7 @@ private:
                             if (m_graph.isWatchingPromiseSpeciesWatchpoint(node)) {
                                 if (auto structure = argument.m_structure.onlyStructure()) {
                                     if (structure.get() == globalObject->promiseStructure()) {
+                                        m_graph.trustStructures(argument.m_structure);
                                         m_interpreter.execute(indexInBlock); // Push CFA over this node after we get the state before.
                                         alreadyHandled = true; // Don't allow the default constant folder to do things to this.
                                         node->convertToIdentityOn(node->child2().node());
@@ -2467,7 +2482,11 @@ private:
                 OpInfo(m_graph.addStructureSet(set.toStructureSet())), node->child1());
             return;
         }
-        
+
+        // We're eliding the CheckStructure because the base's proven structures are a subset of
+        // `set`, so watch those structures to back the elision.
+        m_graph.trustStructures(baseValue.m_structure);
+
         if (baseValue.m_type & ~SpecCell)
             m_insertionSet.insertCheck(indexInBlock, node->origin, node->child1());
     }
@@ -2561,6 +2580,11 @@ private:
         });
         if (!ok)
             return false;
+
+        // The fold's validity (property absent, extensible, non-overriding put, ...) was proven
+        // from baseValue's structures, and the resulting PutByIdDirect uses CellUse rather than a
+        // CheckStructure, so we must watch those structures to trust the fold.
+        m_graph.trustStructures(baseValue.m_structure);
 
         // Execute the original DefineDataProperty (clobbers world) before we mutate the node,
         // so the abstract state we propagate matches post-fold semantics — PutByIdDirect also

--- a/Source/JavaScriptCore/dfg/DFGGraph.cpp
+++ b/Source/JavaScriptCore/dfg/DFGGraph.cpp
@@ -1735,6 +1735,30 @@ bool Graph::isWatched(Structure* structure)
     return m_plan.watchpoints().isWatched(structure->transitionWatchpointSet());
 }
 
+void Graph::trustStructures(const StructureAbstractValue& structures)
+{
+    // With the feature off, set()/clobber() already installed the watchpoints eagerly.
+    if (!Options::useDFGLazyStructureWatchpoints())
+        return;
+
+    // Callers only rely on a finite structure set.
+    RELEASE_ASSERT(structures.isFinite());
+
+    // If this finiteness is already guaranteed on the current path (by a dominating runtime
+    // structure check or a fresh allocation) rather than by surviving a clobber / being a
+    // constant, no transition watchpoint is needed.
+    if (!structures.needsWatch())
+        return;
+
+    // Install the transition watchpoints now, at the point of reliance. If a structure was
+    // invalidated by the mutator while we were compiling, we watch it anyway; installing an
+    // already-invalidated watchpoint at finalization invalidates (jettisons) this compilation,
+    // which is correct. That race should be rare (FIXME: measure whether it happens in practice).
+    structures.forEach([&](RegisteredStructure structure) {
+        watch(structure.get());
+    });
+}
+
 void Graph::assertIsRegistered(Structure* structure)
 {
     // It's convenient to be able to call this with a maybe-null structure.
@@ -2054,6 +2078,10 @@ bool Graph::canDoFastSpread(Node* node, const AbstractValue& value)
             && !structure->mayInterceptIndexedAccesses();
     });
 
+    // The fast spread relies on these structures keeping the properties checked above, so we
+    // must watch them (unless the finiteness is already runtime-check-guaranteed).
+    if (allGood)
+        trustStructures(value.m_structure);
     return allGood;
 }
 

--- a/Source/JavaScriptCore/dfg/DFGGraph.h
+++ b/Source/JavaScriptCore/dfg/DFGGraph.h
@@ -295,6 +295,15 @@ public:
     void watch(Structure*);
     bool isWatched(Structure*);
 
+    // Commit to relying on the given (finite) structure abstract value being stable, installing
+    // its transition watchpoints unless that stability is already guaranteed by a dominating
+    // runtime check or fresh allocation (see StructureAbstractValue::needsWatch()). The value
+    // must be finite (asserted). If a structure was invalidated by the mutator mid-compilation we
+    // still watch it; installing an already-fired watchpoint at finalization invalidates this
+    // compilation, which is the correct (and rare) outcome. With useDFGLazyStructureWatchpoints
+    // disabled this is a no-op, since the watchpoints were already installed eagerly.
+    void trustStructures(const StructureAbstractValue&);
+
     void assertIsRegistered(Structure* structure);
     
     // CodeBlock is optional, but may allow additional information to be dumped (e.g. Identifier names).

--- a/Source/JavaScriptCore/dfg/DFGLICMPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGLICMPhase.cpp
@@ -446,6 +446,24 @@ private:
         
         dataLogLnIf(verbose, "    Hoisting ", node, " from ", *fromBlock, " to ", *data.preHeader);
 
+        // We're committing to move this node to the pre-header. safeToExecute() above may have
+        // proven the move safe by relying on a child's finite structure set (its structure cases
+        // read m_structure); since the hoisted node runs without re-checking, those structures must
+        // be backed by a transition watchpoint. With lazy structure watchpoints, trust the finite
+        // structures of the node's children now, at the point of the hoist. This over-approximates
+        // which child safeToExecute actually relied on, but it is deliberately robust: it can't miss
+        // a structure-reliant case, and it stays within the eager baseline's watched set (a hoisted
+        // node's finite children are a subset of the clobber-survived structures the eager path
+        // watched unconditionally). trustStructures() no-ops on !needsWatch sets, so it only installs
+        // for finiteness that actually needs watching.
+        if (Options::useDFGLazyStructureWatchpoints()) {
+            m_graph.doToChildren(node, [&] (Edge& edge) {
+                auto& structures = m_state.forNode(edge).m_structure;
+                if (structures.isFinite())
+                    m_graph.trustStructures(structures);
+            });
+        }
+
         insertHoistedNode(node);
         updateAbstractState();
 

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -9625,7 +9625,8 @@ void SpeculativeJIT::compileSpread(Node* node)
             if (!m_state.forNode(node->child1()).m_structure.isSubsetOf(RegisteredStructureSet { registeredSetStructure })) {
                 load32(Address(argument, JSCell::structureIDOffset()), scratch2GPR);
                 slowPath.append(branch32(NotEqual, scratch2GPR, TrustedImm32(registeredSetStructure->id().bits())));
-            }
+            } else
+                m_graph.trustStructures(m_state.forNode(node->child1()).m_structure);
         }
 
         // Load Set storage pointer.
@@ -10488,8 +10489,10 @@ void SpeculativeJIT::compileArrayIndexOfOrArrayIncludes(Node* node)
                 return false;
             if (auto structure = base.m_structure.onlyStructure()) {
                 JSGlobalObject* globalObject = m_graph.globalObjectFor(node->origin.semantic);
-                if (structure.get() == globalObject->originalArrayStructureForIndexingType(CopyOnWriteArrayWithContiguous))
+                if (structure.get() == globalObject->originalArrayStructureForIndexingType(CopyOnWriteArrayWithContiguous)) {
+                    m_graph.trustStructures(base.m_structure);
                     return true;
+                }
             }
             return false;
         };
@@ -15504,11 +15507,19 @@ void SpeculativeJIT::compileGetPropertyEnumerator(Node* node)
                 if (structure->indexingType() > ArrayWithUndecided)
                     hasIndexing = true;
             });
-            if (!hasIndexing)
-                skipIndexingMaskCheck = true;
-            onlyStructure = baseValue.m_structure.onlyStructure();
-            if (onlyStructure)
-                rareData = onlyStructure->tryRareData();
+            RegisteredStructure only = baseValue.m_structure.onlyStructure();
+            // We only rely on (and thus must watch) the proven structures if we'd skip the
+            // indexing-mask check (relies on their indexing types) or embed the structure /
+            // read its rareData directly (relies on the single structure). rareData derives from
+            // onlyStructure, so gating on `only` covers the rareData path too. If neither
+            // applies we emit the runtime check and load the structure, relying on nothing.
+            if (!hasIndexing || only) {
+                m_graph.trustStructures(baseValue.m_structure);
+                skipIndexingMaskCheck = !hasIndexing;
+                onlyStructure = only;
+                if (onlyStructure)
+                    rareData = onlyStructure->tryRareData();
+            }
         }
 
         if (!skipIndexingMaskCheck) {
@@ -17011,13 +17022,17 @@ void SpeculativeJIT::compileGetPrototypeOf(Node* node)
                     hasMonoProto = true;
             });
 
+            // We only rely on (and watch) the structures when they agree on proto layout, i.e.
+            // when we actually take a fast path. A mixed set falls through to the general path.
             if (hasMonoProto && !hasPolyProto) {
+                m_graph.trustStructures(value.m_structure);
                 loadValue(Address(tempGPR, Structure::prototypeOffset()), resultRegs);
                 jsValueResult(resultRegs, node);
                 return;
             }
 
             if (hasPolyProto && !hasMonoProto) {
+                m_graph.trustStructures(value.m_structure);
                 loadValue(Address(objectGPR, offsetRelativeToBase(knownPolyProtoOffset)), resultRegs);
                 jsValueResult(resultRegs, node);
                 return;

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -1158,7 +1158,12 @@ void SpeculativeJIT::checkArray(Node* node)
     SpeculateCellOperand base(this, node->child1());
     GPRReg baseReg = base.gpr();
     
-    if (arrayMode.alreadyChecked(m_graph, node, m_state.forNode(node->child1()))) {
+    AbstractValue& child1Value = m_state.forNode(node->child1());
+    if (arrayMode.alreadyChecked(m_graph, node, child1Value)) {
+        // We're eliding the array/structure check. If alreadyChecked relied on a finite
+        // structure set (rather than arrayModes/type), watch those structures.
+        if (child1Value.m_structure.isFinite())
+            m_graph.trustStructures(child1Value.m_structure);
         // We can purge Empty check completely in this case of CheckArrayOrEmpty since CellUse only accepts SpecCell | SpecEmpty.
 #if USE(JSVALUE64)
         ASSERT(typeFilterFor(node->child1().useKind()) & SpecEmpty);

--- a/Source/JavaScriptCore/dfg/DFGStructureAbstractValue.cpp
+++ b/Source/JavaScriptCore/dfg/DFGStructureAbstractValue.cpp
@@ -30,6 +30,7 @@
 
 #include "DFGGraph.h"
 #include "JSCJSValueInlines.h"
+#include "Options.h"
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
@@ -48,18 +49,30 @@ void StructureAbstractValue::assertIsRegistered(Graph& graph) const
 
 void StructureAbstractValue::clobber(Graph& graph)
 {
-    // The premise of this approach to clobbering is that anytime we introduce
-    // a watchable structure into an abstract value, we watchpoint it.
+    // Clobbering keeps only watchable structures finite across the side-effect. With
+    // useDFGLazyStructureWatchpoints, instead of eagerly installing their transition
+    // watchpoints here, we record that the surviving finite set needs watching if some
+    // consumer later decides to rely on it (see needsWatch() / Graph::trustStructures).
+    // With the feature off, we install the watchpoints eagerly, matching prior behavior:
+    // the premise being that anytime we introduce a watchable structure into an abstract
+    // value, we watchpoint it.
 
     if (isTop())
         return;
 
+    bool lazy = Options::useDFGLazyStructureWatchpoints();
+
     setClobbered(true);
-        
+    
     if (m_set.isThin()) {
         if (!m_set.singleEntry())
             return;
-        if (!graph.tryWatch(m_set.singleEntry().get()))
+        if (lazy) {
+            if (!m_set.singleEntry()->dfgMayWatch())
+                makeTopWhenThin();
+            else
+                m_needsWatch = true;
+        } else if (!graph.tryWatch(m_set.singleEntry().get()))
             makeTopWhenThin();
         return;
     }
@@ -71,8 +84,12 @@ void StructureAbstractValue::clobber(Graph& graph)
         }
     }
 
-    for (auto& item : m_set.list()->lengthSpan())
-        graph.watch(item.get());
+    if (lazy)
+        m_needsWatch = true;
+    else {
+        for (auto& item : m_set.list()->lengthSpan())
+            graph.watch(item.get());
+    }
 }
 
 void StructureAbstractValue::observeTransition(RegisteredStructure from, RegisteredStructure to)
@@ -171,6 +188,13 @@ bool StructureAbstractValue::mergeSlow(const StructureAbstractValue& other)
     
     if (!isClobbered() && other.isClobbered()) {
         setClobbered(true);
+        changed = true;
+    }
+    
+    // A merged value's finiteness needs watching if either input did. This is monotonic
+    // (false -> true only), so it does not impede abstract-interpreter convergence.
+    if (!m_needsWatch && other.m_needsWatch) {
+        m_needsWatch = true;
         changed = true;
     }
     
@@ -373,7 +397,8 @@ bool StructureAbstractValue::equalsSlow(const StructureAbstractValue& other) con
     ASSERT(!other.isTop());
     
     return m_set == other.m_set
-        && isClobbered() == other.isClobbered();
+        && isClobbered() == other.isClobbered()
+        && m_needsWatch == other.m_needsWatch;
 }
 
 void StructureAbstractValue::dumpInContext(PrintStream& out, DumpContext* context) const
@@ -381,6 +406,9 @@ void StructureAbstractValue::dumpInContext(PrintStream& out, DumpContext* contex
     if (isClobbered())
         out.print("Clobbered:");
     
+    if (needsWatch())
+        out.print("NeedsWatch:");
+
     if (isTop())
         out.print("TOP");
     else

--- a/Source/JavaScriptCore/dfg/DFGStructureAbstractValue.h
+++ b/Source/JavaScriptCore/dfg/DFGStructureAbstractValue.h
@@ -57,24 +57,31 @@ public:
         : m_set(other.m_set)
     {
         setClobbered(other.isClobbered());
+        m_needsWatch = other.m_needsWatch;
     }
     
+    // Assigning a known/checked structure set (a CheckStructure's set, a freshly allocated
+    // object's structure, a transition target, ...) (re)establishes it fresh: its stability is
+    // guaranteed here without a watchpoint, so needsWatch resets to false. See needsWatch().
     ALWAYS_INLINE StructureAbstractValue& operator=(RegisteredStructure structure)
     {
         m_set = RegisteredStructureSet(structure);
         setClobbered(false);
+        m_needsWatch = false;
         return *this;
     }
     ALWAYS_INLINE StructureAbstractValue& operator=(const RegisteredStructureSet& other)
     {
         m_set = other;
         setClobbered(false);
+        m_needsWatch = false;
         return *this;
     }
     ALWAYS_INLINE StructureAbstractValue& operator=(const StructureAbstractValue& other)
     {
         m_set = other.m_set;
         setClobbered(other.isClobbered());
+        m_needsWatch = other.m_needsWatch;
         return *this;
     }
     
@@ -82,12 +89,14 @@ public:
     {
         m_set.clear();
         setClobbered(false);
+        m_needsWatch = false;
     }
     
     void makeTop()
     {
         m_set.deleteListIfNecessary();
         m_set.m_pointer = topValue;
+        m_needsWatch = false;
     }
     
 #if ASSERT_ENABLED
@@ -131,6 +140,18 @@ public:
 
     // An infinite structure abstract value may currently have any structure.
     bool isInfinite() const { return !isFinite(); }
+
+    // When useDFGLazyStructureWatchpoints is enabled, we keep watchable structures finite in
+    // the abstract value without eagerly installing their transition watchpoints. This flag
+    // records that the current (finite) set's stability is NOT already guaranteed by a runtime
+    // structure check on this path - i.e. trusting it to elide a check requires watching the
+    // structures first. It is set exactly where the pre-existing code would have watched to
+    // keep a value finite (a watchable constant in AbstractValue::set, or surviving a clobber),
+    // OR'd on merge, and preserved across invalidation points. It is cleared (false) whenever
+    // the value is freshly (re)established from a known/checked structure set. See
+    // Graph::trustStructures.
+    bool needsWatch() const { return m_needsWatch; }
+    void setNeedsWatch(bool needsWatch) { m_needsWatch = needsWatch; }
     
     bool add(RegisteredStructure);
     
@@ -174,7 +195,7 @@ public:
     ALWAYS_INLINE bool operator==(const StructureAbstractValue& other) const
     {
         if ((m_set.isThin() && other.m_set.isThin()) || isTop() || other.isTop())
-            return m_set.m_pointer == other.m_set.m_pointer;
+            return m_set.m_pointer == other.m_set.m_pointer && m_needsWatch == other.m_needsWatch;
         
         return equalsSlow(other);
     }
@@ -267,6 +288,7 @@ private:
     {
         ASSERT(m_set.isThin());
         m_set.m_pointer = topValue;
+        m_needsWatch = false;
     }
     
     bool mergeNotTop(const RegisteredStructureSet& other);
@@ -278,6 +300,10 @@ private:
     }
     
     RegisteredStructureSet m_set;
+
+    // See needsWatch(). Only meaningful when useDFGLazyStructureWatchpoints is enabled;
+    // otherwise it stays false and is ignored (watchpoints are installed eagerly).
+    bool m_needsWatch { false };
 };
 
 } } // namespace JSC::DFG

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -5879,8 +5879,13 @@ private:
         Edge edge = m_node->child1();
         LValue cell = lowCell(edge);
 
-        if (m_node->arrayMode().alreadyChecked(m_graph, m_node, abstractValue(edge)))
+        if (m_node->arrayMode().alreadyChecked(m_graph, m_node, abstractValue(edge))) {
+            // Eliding the array/structure check: watch the proven structures if the proof
+            // relied on a finite structure set (arrayModes/type proofs need no watchpoint).
+            if (abstractValue(edge).m_structure.isFinite())
+                m_graph.trustStructures(abstractValue(edge).m_structure);
             return;
+        }
 
         speculate(
             BadIndexingType, jsValueValue(cell), nullptr,
@@ -5895,6 +5900,8 @@ private:
         if (m_node->arrayMode().alreadyChecked(m_graph, m_node, abstractValue(edge))) {
             // We can purge Empty check of CheckArrayOrEmpty completely in this case since CellUse only accepts SpecCell | SpecEmpty.
             ASSERT(typeFilterFor(m_node->child1().useKind()) & SpecEmpty);
+            if (abstractValue(edge).m_structure.isFinite())
+                m_graph.trustStructures(abstractValue(edge).m_structure);
             return;
         }
 

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -6041,12 +6041,16 @@ IGNORE_CLANG_WARNINGS_END
                         hasMonoProto = true;
                 });
 
+                // Only rely on (and watch) the structures when they agree on proto layout, i.e.
+                // when we take a fast path. A mixed set falls through to the general path.
                 if (hasMonoProto && !hasPolyProto) {
+                    m_graph.trustStructures(value.m_structure);
                     setJSValue(m_out.load64(structure, m_heaps.Structure_prototype));
                     return;
                 }
 
                 if (hasPolyProto && !hasMonoProto) {
+                    m_graph.trustStructures(value.m_structure);
                     setJSValue(m_out.load64(m_out.baseIndex(m_heaps.properties.atAnyNumber(), object, m_out.constInt64(knownPolyProtoOffset), ScaleEight, JSObject::offsetOfInlineStorage())));
                     return;
                 }
@@ -8741,8 +8745,10 @@ IGNORE_CLANG_WARNINGS_END
                     return false;
                 if (auto structure = base.m_structure.onlyStructure()) {
                     JSGlobalObject* globalObject = m_graph.globalObjectFor(m_node->origin.semantic);
-                    if (structure.get() == globalObject->originalArrayStructureForIndexingType(CopyOnWriteArrayWithContiguous))
+                    if (structure.get() == globalObject->originalArrayStructureForIndexingType(CopyOnWriteArrayWithContiguous)) {
+                        m_graph.trustStructures(base.m_structure);
                         return true;
+                    }
                 }
                 return false;
             };
@@ -10848,9 +10854,10 @@ IGNORE_CLANG_WARNINGS_END
                 m_out.jump(slowPath);
             else {
                 RegisteredStructure registeredSetStructure = m_graph.registerStructure(originalSetStructure);
-                if (m_state.forNode(m_node->child1()).m_structure.isSubsetOf(RegisteredStructureSet { registeredSetStructure }))
+                if (m_state.forNode(m_node->child1()).m_structure.isSubsetOf(RegisteredStructureSet { registeredSetStructure })) {
+                    m_graph.trustStructures(m_state.forNode(m_node->child1()).m_structure);
                     m_out.jump(storageCheck);
-                else {
+                } else {
                     LValue structureID = m_out.load32(argument, m_heaps.JSCell_structureID);
                     m_out.branch(m_out.notEqual(structureID,
                         weakStructureID(registeredSetStructure)),
@@ -12715,6 +12722,8 @@ IGNORE_CLANG_WARNINGS_END
             }
         }
         bool structuresChecked = m_interpreter.forNode(m_node->child1()).m_structure.isSubsetOf(baseSet);
+        if (structuresChecked)
+            m_graph.trustStructures(m_interpreter.forNode(m_node->child1()).m_structure);
         emitSwitchForMultiByOffset(base, structuresChecked, cases, exit);
 
         LBasicBlock lastNext = m_out.m_nextBlock;
@@ -12823,6 +12832,8 @@ IGNORE_CLANG_WARNINGS_END
             }
         }
         bool structuresChecked = m_interpreter.forNode(m_node->child1()).m_structure.isSubsetOf(baseSet);
+        if (structuresChecked)
+            m_graph.trustStructures(m_interpreter.forNode(m_node->child1()).m_structure);
         emitSwitchForMultiByOffset(base, structuresChecked, cases, exit);
 
         LBasicBlock lastNext = m_out.m_nextBlock;
@@ -12917,6 +12928,8 @@ IGNORE_CLANG_WARNINGS_END
                 cases.append(SwitchCase(weakStructureID(structure), blocks[variant.result() ? trueBlock : falseBlock], Weight(1)));
         }
         bool structuresChecked = m_interpreter.forNode(m_node->child1()).m_structure.isSubsetOf(baseSet);
+        if (structuresChecked)
+            m_graph.trustStructures(m_interpreter.forNode(m_node->child1()).m_structure);
         emitSwitchForMultiByOffset(base, structuresChecked, cases, exit);
 
         LBasicBlock lastNext = m_out.m_nextBlock;
@@ -12999,6 +13012,8 @@ IGNORE_CLANG_WARNINGS_END
                 variant.result ? trueBlock : falseBlock, Weight(1)));
         }
         bool structuresChecked = m_interpreter.forNode(m_node->child1()).m_structure.isSubsetOf(baseSet);
+        if (structuresChecked)
+            m_graph.trustStructures(m_interpreter.forNode(m_node->child1()).m_structure);
         emitSwitchForMultiByOffset(base, structuresChecked, cases, exitBlock);
 
         m_out.appendTo(trueBlock, falseBlock);
@@ -18129,11 +18144,17 @@ IGNORE_CLANG_WARNINGS_END
                     if (structure->indexingType() > ArrayWithUndecided)
                         hasIndexing = true;
                 });
-                if (!hasIndexing)
-                    skipIndexingMaskCheck = true;
-                onlyStructure = baseValue.m_structure.onlyStructure();
-                if (onlyStructure)
-                    rareData = onlyStructure->tryRareData();
+                RegisteredStructure only = baseValue.m_structure.onlyStructure();
+                // Only rely on (and watch) the proven structures if we'd skip the indexing-mask
+                // check or embed the structure / read its rareData directly. rareData derives
+                // from onlyStructure, so gating on `only` covers it. Otherwise we rely on nothing.
+                if (!hasIndexing || only) {
+                    m_graph.trustStructures(baseValue.m_structure);
+                    skipIndexingMaskCheck = !hasIndexing;
+                    onlyStructure = only;
+                    if (onlyStructure)
+                        rareData = onlyStructure->tryRareData();
+                }
             }
 
             LValue notHavingIndexing = nullptr;
@@ -18457,10 +18478,12 @@ IGNORE_CLANG_WARNINGS_END
 
         m_out.appendTo(checkStructureBlock);
         LValue structureID;
-        auto structure = m_state.forNode(baseEdge.node()).m_structure.onlyStructure();
-        if (structure)
+        auto& baseAbstractValue = m_state.forNode(baseEdge.node());
+        auto structure = baseAbstractValue.m_structure.onlyStructure();
+        if (structure) {
+            m_graph.trustStructures(baseAbstractValue.m_structure);
             structureID = m_out.constInt32(structure->id().bits());
-        else
+        } else
             structureID = m_out.load32(base, m_heaps.JSCell_structureID);
 
         LValue hasEnumeratorStructure = m_out.equal(structureID, m_out.load32(enumerator, m_heaps.JSPropertyNameEnumerator_cachedStructureID));
@@ -18617,10 +18640,12 @@ IGNORE_CLANG_WARNINGS_END
 
         m_out.appendTo(checkStructureBlock);
         LValue structureID;
-        auto structure = m_state.forNode(baseEdge.node()).m_structure.onlyStructure();
-        if (structure)
+        auto& baseAbstractValue = m_state.forNode(baseEdge.node());
+        auto structure = baseAbstractValue.m_structure.onlyStructure();
+        if (structure) {
+            m_graph.trustStructures(baseAbstractValue.m_structure);
             structureID = m_out.constInt32(structure->id().bits());
-        else
+        } else
             structureID = m_out.load32(base, m_heaps.JSCell_structureID);
 
         LValue hasEnumeratorStructure = m_out.equal(structureID, m_out.load32(enumerator, m_heaps.JSPropertyNameEnumerator_cachedStructureID));

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -279,6 +279,7 @@ bool hasCapacityToUseLargeGigacage();
     v(Bool, usePutStackSinking, true, Normal, nullptr) \
     v(Bool, useObjectAllocationSinking, true, Normal, nullptr) \
     v(Bool, verboseObjectAllocationSinking, false, Normal, nullptr) \
+    v(Bool, useDFGLazyStructureWatchpoints, true, Normal, "if true, the DFG defers installing structure transition watchpoints until code that relies on structure stability is actually emitted, rather than eagerly watching in AbstractValue::set/StructureAbstractValue::clobber"_s) \
     v(Bool, useValueRepElimination, true, Normal, nullptr) \
     v(Bool, useArityFixupInlining, true, Normal, nullptr) \
     v(Bool, logExecutableAllocation, false, Normal, nullptr) \


### PR DESCRIPTION
#### 9ef56f0d66c749bddb10313e5f68dd0f20446df0
<pre>
WIP: lazily set structure watchpoints in DFG
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/48943dcc27cc5613b28afcc298c2a5cf7ea727a0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176505 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50440 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44230 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186106 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/138776 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/34af53cd-1bb8-4b0d-ba6e-2dba53b992f8) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51732 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50124 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137490 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96255 "1 flakes 4 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2940fc48-df41-429f-8cf1-2d24babf377b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179461 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40978 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158267 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117965 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d8b6f3df-245b-4072-9e9a-cd1502414ed1) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39628 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37995 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| [❌ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/6776 "Found 30 new JSC stress test failures: stress/get-own-property-names-dfg.js.bytecode-cache, stress/get-own-property-names-dfg.js.default, stress/get-own-property-names-dfg.js.dfg-eager, stress/get-own-property-names-dfg.js.dfg-eager-no-cjit-validate, stress/get-own-property-names-dfg.js.eager-jettison-no-cjit, stress/get-own-property-names-dfg.js.ftl-eager, stress/get-own-property-names-dfg.js.ftl-eager-no-cjit, stress/get-own-property-names-dfg.js.ftl-no-cjit-no-inline-validate, stress/get-own-property-names-dfg.js.ftl-no-cjit-no-put-stack-validate, stress/get-own-property-names-dfg.js.ftl-no-cjit-small-pool ... (failure)") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150043 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37765 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34574 "Built successfully") | | 
| [❌ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/37773 "Found 25 new JSC stress test failures: stress/get-own-property-names-dfg.js.bytecode-cache, stress/get-own-property-names-dfg.js.default, stress/get-own-property-names-dfg.js.dfg-eager, stress/get-own-property-names-dfg.js.dfg-eager-no-cjit-validate, stress/get-own-property-names-dfg.js.eager-jettison-no-cjit, stress/get-own-property-names-dfg.js.ftl-eager, stress/get-own-property-names-dfg.js.ftl-no-cjit-no-inline-validate, stress/get-own-property-names-dfg.js.ftl-no-cjit-no-put-stack-validate, stress/get-own-property-names-dfg.js.ftl-no-cjit-small-pool, stress/get-own-property-names-dfg.js.ftl-no-cjit-validate-sampling-profiler ... (failure)") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42172 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42206 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188529 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50105 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146541 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50789 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34383 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146351 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41112 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122993 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117054 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49293 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12740 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48695 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48929 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48754 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->