### PR TITLE
[GFC] Store a grid item's resolved placement in UnplacedGridItem::GridPosition

### DIFF
--- a/Source/WebCore/layout/formattingContexts/grid/UnplacedGridItem.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/UnplacedGridItem.cpp
@@ -32,202 +32,148 @@
 namespace WebCore {
 namespace Layout {
 
+// Convert a 1-indexed explicit CSS grid line into a 0-indexed grid line. For example
+// grid-column-start: 1 maps to 0. https://www.w3.org/TR/css-grid-1/#line-placement
+static int explicitLineToIndex(const Style::GridPosition& position)
+{
+    ASSERT(position.isExplicit());
+    auto line = position.explicitPosition();
+    // A value of zero makes the declaration invalid.
+    ASSERT(line);
+    return line > 0 ? line - 1 : line;
+}
+
+UnplacedGridItem::GridPosition UnplacedGridItem::GridPosition::create(const Style::GridPosition& start, const Style::GridPosition& end)
+{
+    // An axis is only definite when one of its edges references an explicit line. Anything
+    // else (auto/auto, span/auto, auto/span) is auto-positioned; carry the span forward for
+    // the placement algorithm to resolve.
+    if (!start.isExplicit() && !end.isExplicit()) {
+        size_t span = 1;
+        if (start.isSpan())
+            span = start.spanPosition();
+        else if (end.isSpan())
+            span = end.spanPosition();
+        return AutoPosition { span };
+    }
+
+    int startLine = 0;
+    int endLine = 0;
+    if (start.isExplicit() && end.isExplicit()) {
+        startLine = explicitLineToIndex(start);
+        endLine = explicitLineToIndex(end);
+    } else if (start.isExplicit() && end.isSpan()) {
+        startLine = explicitLineToIndex(start);
+        endLine = startLine + end.spanPosition();
+    } else if (start.isSpan() && end.isExplicit()) {
+        endLine = explicitLineToIndex(end);
+        startLine = endLine - static_cast<int>(start.spanPosition());
+    } else if (start.isExplicit() && end.isAuto()) {
+        startLine = explicitLineToIndex(start);
+        endLine = startLine + 1;
+    } else {
+        ASSERT(start.isAuto() && end.isExplicit());
+        endLine = explicitLineToIndex(end);
+        startLine = endLine - 1;
+    }
+
+    // Negative line placement is not yet supported (grid coverage keeps such items on the
+    // legacy path), so the resolved lines are non-negative and safe to store as unsigned.
+    ASSERT(startLine >= 0 && endLine >= 0);
+    // The range is always forward. The span/auto branches derive endLine from startLine, and the
+    // explicit/explicit branch only reaches GFC for single-track placements: grid coverage requires
+    // the end line to be exactly one past the start (a distance of 1), so an inverted placement like
+    // grid-column: 3 / 1 stays on the legacy path and can never underflow span() here.
+    ASSERT(startLine <= endLine);
+    return DefinitePosition { static_cast<size_t>(startLine), static_cast<size_t>(endLine) };
+}
+
+size_t UnplacedGridItem::GridPosition::span() const
+{
+    if (auto* definitePosition = std::get_if<DefinitePosition>(&m_position))
+        return definitePosition->endLine - definitePosition->startLine;
+    return std::get<AutoPosition>(m_position).span;
+}
+
 UnplacedGridItem::UnplacedGridItem(const ElementBox& layoutBox, Style::GridPosition columnStart, Style::GridPosition columnEnd,
     Style::GridPosition rowStart, Style::GridPosition rowEnd)
     : m_layoutBox(layoutBox)
-    , m_columnPosition({ columnStart, columnEnd })
-    , m_rowPosition({ rowStart, rowEnd })
+    , m_columnPosition(GridPosition::create(columnStart, columnEnd))
+    , m_rowPosition(GridPosition::create(rowStart, rowEnd))
 {
 }
 
 UnplacedGridItem::UnplacedGridItem(WTF::HashTableEmptyValueType)
     : m_layoutBox(WTF::HashTableEmptyValue)
-    , m_columnPosition({ Style::ComputedStyle::initialGridItemColumnStart(), Style::ComputedStyle::initialGridItemColumnEnd() })
-    , m_rowPosition({ Style::ComputedStyle::initialGridItemRowStart(), Style::ComputedStyle::initialGridItemRowEnd() })
+    , m_columnPosition(GridPosition::create(Style::ComputedStyle::initialGridItemColumnStart(), Style::ComputedStyle::initialGridItemColumnEnd()))
+    , m_rowPosition(GridPosition::create(Style::ComputedStyle::initialGridItemRowStart(), Style::ComputedStyle::initialGridItemRowEnd()))
 {
-}
-
-int UnplacedGridItem::explicitColumnStart() const
-{
-    ASSERT(m_columnPosition.first.isExplicit());
-    auto explicitColumnStart = m_columnPosition.first.explicitPosition();
-    // https://www.w3.org/TR/css-grid-1/#line-placement
-    // An <integer> value of zero makes the declaration invalid.
-    ASSERT(explicitColumnStart);
-
-    // Convert from 1-indexed CSS grid lines to 0-indexed matrix positions.
-    return explicitColumnStart > 0 ? explicitColumnStart - 1 : explicitColumnStart;
 }
 
 size_t UnplacedGridItem::normalizedColumnStart() const
 {
-    return explicitColumnStart() + m_columnNormalizationOffset;
-}
-
-int UnplacedGridItem::explicitColumnEnd() const
-{
-    ASSERT(m_columnPosition.second.isExplicit());
-    auto explicitColumnEnd = m_columnPosition.second.explicitPosition();
-    // https://www.w3.org/TR/css-grid-1/#line-placement
-    // An <integer> value of zero makes the declaration invalid.
-    ASSERT(explicitColumnEnd);
-
-    // Convert from 1-indexed CSS grid lines to 0-indexed matrix positions.
-    return explicitColumnEnd > 0 ? explicitColumnEnd - 1 : explicitColumnEnd;
+    ASSERT(m_hasAppliedGridOffsets);
+    return m_columnPosition.definitePosition().startLine + m_columnNormalizationOffset;
 }
 
 size_t UnplacedGridItem::normalizedColumnEnd() const
 {
-    return explicitColumnEnd() + m_columnNormalizationOffset;
-}
-
-int UnplacedGridItem::explicitRowStart() const
-{
-    ASSERT(m_rowPosition.first.isExplicit());
-    auto explicitRowStart = m_rowPosition.first.explicitPosition();
-    // https://www.w3.org/TR/css-grid-1/#line-placement
-    // An <integer> value of zero makes the declaration invalid.
-    ASSERT(explicitRowStart);
-
-    // Convert from 1-indexed CSS grid lines to 0-indexed matrix positions.
-    return explicitRowStart > 0 ? explicitRowStart - 1 : explicitRowStart;
+    ASSERT(m_hasAppliedGridOffsets);
+    return m_columnPosition.definitePosition().endLine + m_columnNormalizationOffset;
 }
 
 size_t UnplacedGridItem::normalizedRowStart() const
 {
-    return explicitRowStart() + m_rowNormalizationOffset;
-}
-
-int UnplacedGridItem::explicitRowEnd() const
-{
-    ASSERT(m_rowPosition.second.isExplicit());
-    auto explicitRowEnd = m_rowPosition.second.explicitPosition();
-    // https://www.w3.org/TR/css-grid-1/#line-placement
-    // An <integer> value of zero makes the declaration invalid.
-    ASSERT(explicitRowEnd);
-
-    // Convert from 1-indexed CSS grid lines to 0-indexed matrix positions.
-    return explicitRowEnd > 0 ? explicitRowEnd - 1 : explicitRowEnd;
+    ASSERT(m_hasAppliedGridOffsets);
+    return m_rowPosition.definitePosition().startLine + m_rowNormalizationOffset;
 }
 
 size_t UnplacedGridItem::normalizedRowEnd() const
 {
-    return explicitRowEnd() + m_rowNormalizationOffset;
+    ASSERT(m_hasAppliedGridOffsets);
+    return m_rowPosition.definitePosition().endLine + m_rowNormalizationOffset;
 }
 
 bool UnplacedGridItem::hasDefiniteRowPosition() const
 {
-    return m_rowPosition.first.isExplicit() || m_rowPosition.second.isExplicit();
+    return m_rowPosition.isDefinite();
 }
 
 bool UnplacedGridItem::hasDefiniteColumnPosition() const
 {
-    return m_columnPosition.first.isExplicit() || m_columnPosition.second.isExplicit();
+    return m_columnPosition.isDefinite();
 }
 
 bool UnplacedGridItem::hasAutoColumnPosition() const
 {
-    return m_columnPosition.first.isAuto() && m_columnPosition.second.isAuto();
+    return m_columnPosition.isAuto();
 }
 
 bool UnplacedGridItem::hasAutoRowPosition() const
 {
-    return m_rowPosition.first.isAuto() && m_rowPosition.second.isAuto();
+    return m_rowPosition.isAuto();
 }
 
 size_t UnplacedGridItem::columnSpanSize() const
 {
-    auto firstPosition = m_columnPosition.first;
-    auto secondPosition = m_columnPosition.second;
-
-    // Case 1: Both positions are explicit - calculate span size
-    if (firstPosition.isExplicit() && secondPosition.isExplicit())
-        return explicitColumnEnd() - explicitColumnStart();
-
-    // Case 2: One position is a span - extract its span size.
-    ASSERT(!(firstPosition.isSpan() && secondPosition.isSpan()));
-    if (firstPosition.isSpan())
-        return firstPosition.spanPosition();
-    if (secondPosition.isSpan())
-        return secondPosition.spanPosition();
-
-    // Default to span 1
-    ASSERT(hasAutoColumnPosition());
-    return 1;
+    return m_columnPosition.span();
 }
 
 size_t UnplacedGridItem::rowSpanSize() const
 {
-    auto& firstPosition = m_rowPosition.first;
-    auto& secondPosition = m_rowPosition.second;
-
-    // Case 1: Both positions are explicit - calculate span size
-    if (firstPosition.isExplicit() && secondPosition.isExplicit())
-        return explicitRowEnd() - explicitRowStart();
-
-    // Case 2: One position is a span - extract its span size.
-    ASSERT(!(firstPosition.isSpan() && secondPosition.isSpan()));
-    if (firstPosition.isSpan())
-        return firstPosition.spanPosition();
-    if (secondPosition.isSpan())
-        return secondPosition.spanPosition();
-
-    // Default to span 1
-    ASSERT(hasAutoRowPosition());
-    return 1;
+    return m_rowPosition.span();
 }
 
 std::pair<int, int> UnplacedGridItem::definiteRowStartEnd() const
 {
-    auto startPosition = m_rowPosition.first;
-    auto endPosition = m_rowPosition.second;
-
-    if (startPosition.isExplicit() && endPosition.isExplicit())
-        return { explicitRowStart(), explicitRowEnd() };
-
-    if (startPosition.isExplicit() && endPosition.isSpan())
-        return { explicitRowStart(), explicitRowStart() + endPosition.spanPosition() };
-
-    if (startPosition.isSpan() && endPosition.isExplicit())
-        return { explicitRowEnd() - startPosition.spanPosition(), explicitRowEnd() };
-
-    if (startPosition.isExplicit() && endPosition.isAuto())
-        return { explicitRowStart(), explicitRowStart() + 1 };
-
-    if (startPosition.isAuto() && endPosition.isExplicit()) {
-        auto explicitEnd = explicitRowEnd();
-        ASSERT(explicitEnd >= 1);
-        return { explicitEnd - 1, explicitEnd };
-    }
-
-    ASSERT_NOT_REACHED();
-    return { 0, 0 };
+    auto& definitePosition = m_rowPosition.definitePosition();
+    return { static_cast<int>(definitePosition.startLine), static_cast<int>(definitePosition.endLine) };
 }
 
 std::pair<int, int> UnplacedGridItem::definiteColumnStartEnd() const
 {
-    auto startPosition = m_columnPosition.first;
-    auto endPosition = m_columnPosition.second;
-
-    if (startPosition.isExplicit() && endPosition.isExplicit())
-        return { explicitColumnStart(), explicitColumnEnd() };
-
-    if (startPosition.isExplicit() && endPosition.isSpan())
-        return { explicitColumnStart(), explicitColumnStart() + endPosition.spanPosition() };
-
-    if (startPosition.isSpan() && endPosition.isExplicit())
-        return { explicitColumnEnd() - startPosition.spanPosition(), explicitColumnEnd() };
-
-    if (startPosition.isExplicit() && endPosition.isAuto())
-        return { explicitColumnStart(), explicitColumnStart() + 1 };
-
-    if (startPosition.isAuto() && endPosition.isExplicit()) {
-        auto explicitEnd = explicitColumnEnd();
-        return { explicitEnd - 1, explicitEnd };
-    }
-
-    ASSERT_NOT_REACHED();
-    return { 0, 0 };
+    auto& definitePosition = m_columnPosition.definitePosition();
+    return { static_cast<int>(definitePosition.startLine), static_cast<int>(definitePosition.endLine) };
 }
 
 std::pair<size_t, size_t> UnplacedGridItem::normalizedRowStartEnd() const
@@ -280,7 +226,17 @@ void UnplacedGridItem::applyGridOffsets(size_t rowOffset, size_t columnOffset)
 
 void add(Hasher& hasher, const WebCore::Layout::UnplacedGridItem& unplacedGridItem)
 {
-    addArgs(hasher, unplacedGridItem.m_layoutBox.ptr(), unplacedGridItem.m_columnPosition, unplacedGridItem.m_rowPosition);
+    addArgs(hasher, unplacedGridItem.m_layoutBox.ptr());
+
+    auto addPosition = [&](const auto& position) {
+        if (position.isDefinite()) {
+            auto& definitePosition = position.definitePosition();
+            addArgs(hasher, static_cast<size_t>(0), definitePosition.startLine, definitePosition.endLine);
+        } else
+            addArgs(hasher, static_cast<size_t>(1), position.span());
+    };
+    addPosition(unplacedGridItem.m_columnPosition);
+    addPosition(unplacedGridItem.m_rowPosition);
 }
 
 } // namespace Layout

--- a/Source/WebCore/layout/formattingContexts/grid/UnplacedGridItem.h
+++ b/Source/WebCore/layout/formattingContexts/grid/UnplacedGridItem.h
@@ -34,48 +34,84 @@ class ElementBox;
 class GridLayout;
 
 class UnplacedGridItem {
+private:
+    // https://drafts.csswg.org/css-grid-1/#placement
+    // A definite value for any two of Start, End, and Span in a given dimension implies
+    // a definite value for the third.
+    //
+    // A "definite" axis (at least one edge references an explicit line) resolves to a concrete
+    // 0-based line range. Everything else (auto/auto, span/auto, auto/span) is auto-positioned
+    // and only carries the span size that the placement algorithm resolves into a position later.
+    struct DefinitePosition {
+        // 0-based grid line indices; endLine is exclusive.
+        size_t startLine { 0 };
+        size_t endLine { 0 };
+
+        bool operator==(const DefinitePosition&) const = default;
+    };
+
+    struct AutoPosition {
+        // Number of tracks the item spans; resolved to a position during auto-placement.
+        size_t span { 1 };
+
+        bool operator==(const AutoPosition&) const = default;
+    };
+
+    class GridPosition {
+    public:
+        static GridPosition create(const Style::GridPosition& start, const Style::GridPosition& end);
+
+        bool isDefinite() const { return std::holds_alternative<DefinitePosition>(m_position); }
+        bool isAuto() const { return std::holds_alternative<AutoPosition>(m_position); }
+
+        const DefinitePosition& definitePosition() const { return std::get<DefinitePosition>(m_position); }
+
+        size_t span() const;
+
+        bool operator==(const GridPosition&) const = default;
+
+    private:
+        using Value = Variant<DefinitePosition, AutoPosition>;
+
+        GridPosition(DefinitePosition position)
+            : m_position(position) { }
+        GridPosition(AutoPosition position)
+            : m_position(position) { }
+
+        Value m_position;
+    };
+
 public:
     UnplacedGridItem(const ElementBox&, Style::GridPosition columnStart, Style::GridPosition columnEnd, Style::GridPosition rowStart, Style::GridPosition rowEnd);
     UnplacedGridItem(WTF::HashTableEmptyValueType);
 
-    bool NODELETE operator==(const UnplacedGridItem& other) const;
+    bool operator==(const UnplacedGridItem& other) const;
 
     bool isHashTableDeletedValue() const { return m_layoutBox.isHashTableDeletedValue(); }
     bool isHashTableEmptyValue() const { return m_layoutBox.isHashTableEmptyValue(); }
     static constexpr bool safeToCompareToHashTableEmptyOrDeletedValue = true;
 
-    size_t NODELETE normalizedColumnStart() const;
-    size_t NODELETE normalizedColumnEnd() const;
-    size_t NODELETE normalizedRowStart() const;
-    size_t NODELETE normalizedRowEnd() const;
+    size_t normalizedColumnStart() const;
+    size_t normalizedColumnEnd() const;
+    size_t normalizedRowStart() const;
+    size_t normalizedRowEnd() const;
 
     bool NODELETE hasDefiniteRowPosition() const;
     bool NODELETE hasDefiniteColumnPosition() const;
     bool NODELETE hasAutoColumnPosition() const;
     bool NODELETE hasAutoRowPosition() const;
     size_t columnSpanSize() const;
-    size_t NODELETE rowSpanSize() const;
+    size_t rowSpanSize() const;
 
-    std::pair<size_t, size_t> NODELETE normalizedRowStartEnd() const;
-    std::pair<size_t, size_t> NODELETE normalizedColumnStartEnd() const;
+    std::pair<size_t, size_t> normalizedRowStartEnd() const;
+    std::pair<size_t, size_t> normalizedColumnStartEnd() const;
 
 private:
     CheckedRef<const ElementBox> m_layoutBox;
 
     // https://drafts.csswg.org/css-grid-1/#typedef-grid-row-start-grid-line
-    std::pair<Style::GridPosition, Style::GridPosition> m_columnPosition;
-    std::pair<Style::GridPosition, Style::GridPosition> m_rowPosition;
-
-    // The grammar for <grid-line>, which is used by the grid-{column, row}-{start-end}
-    // placement properties is 1-index in regards to line numbers. To allow for easy
-    // indexing from these line numbers into our structures we subtract 1 from them
-    // into these helper functions to make them 0-index. For example, grid-column-start: 1
-    // and grid-column-end: 2 would make to [0, 1] and place the grid item into
-    // Grid[rowIndex][0].
-    int NODELETE explicitColumnStart() const;
-    int NODELETE explicitColumnEnd() const;
-    int NODELETE explicitRowStart() const;
-    int NODELETE explicitRowEnd() const;
+    GridPosition m_columnPosition;
+    GridPosition m_rowPosition;
 
     std::pair<int, int> definiteRowStartEnd() const;
     std::pair<int, int> definiteColumnStartEnd() const;
@@ -94,7 +130,7 @@ private:
     friend class GridFormattingContext;
     friend class GridLayout;
     friend class PlacedGridItem;
-    friend void NODELETE add(Hasher&, const WebCore::Layout::UnplacedGridItem&);
+    friend void add(Hasher&, const WebCore::Layout::UnplacedGridItem&);
 };
 
 // https://drafts.csswg.org/css-grid-1/#auto-placement-algo


### PR DESCRIPTION
#### 743de0ac207deefbce5b1a927f0c07b0cfa43807
<pre>
[GFC] Store a grid item&apos;s resolved placement in UnplacedGridItem::GridPosition
<a href="https://bugs.webkit.org/show_bug.cgi?id=320130">https://bugs.webkit.org/show_bug.cgi?id=320130</a>
<a href="https://rdar.apple.com/problem/183069388">rdar://problem/183069388</a>

Reviewed by Alan Baradlay.

Currently, UnplacedGridItem holds the information needed to resolve a
grid item&apos;s position in two different fields. These two fields are each
a std::pair of Style::GridPosition which holds the computed style for
the item&apos;s start and end position. Then when we are trying to determine
the actual position of the item we query the computed values multiple
times to determine what type of position it is (e.g. a definite position
like grid-column-start: 1) or an automatic position.

Instead what we can do is we can store the position in a dedicated type
that represents the type of position that it is when we create the
UnplacedGridItem. This will then make the implementation for the code
that is actually used during layout a lot simpler since we figured out
all of this information before we run layout. So most of this patch is
just introducing this new type and moving the logic that was used to
determine the type of grid position so that it is instead used to
construct this new type.

* Source/WebCore/layout/formattingContexts/grid/UnplacedGridItem.h:
(WebCore::Layout::UnplacedGridItem::GridPosition::GridPosition):
GridPosition is the new type that will hold all of the information
needed to correctly place the grid item during layout. It replaces the
computed values that were on the item. This new type will hold a variant
which is one of the two possible types it could be: a DefinitePosition
(e.g. grid-column: 1 / 2) which represents a specific spot in the grid
it needs to be placed or an AutoPosition in which we will use an
algorithm to find the appropriate spot.

(WebCore::Layout::explicitLineToIndex):
The line numbers in the spec are 1-index based but we store the
information as 0-indexed so this is just a tiny wrapper to help us
convert.

(WebCore::Layout::UnplacedGridItem::GridPosition::create):
This is the core logic that takes in the two computed style values we
were holding onto earlier which were being queried during layout and
instead creates a DefinitePosition or AutoPosition based upon that same
set of logic we were using during layout.

Canonical link: <a href="https://commits.webkit.org/317903@main">https://commits.webkit.org/317903@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/905454d12990ba486f7c58d0eec5d1452b268b71

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176648 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50585 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44377 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186250 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/139416 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/938726a0-ef11-4b91-b561-ff338365014a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178511 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51878 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50271 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137602 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/139416 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/769dd232-a5a1-49ca-b628-8191821a3ff3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179604 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41104 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158389 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118076 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0c9d760f-749b-407f-946e-3b9a28a8a0d3) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39759 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38126 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150171 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37887 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-highlight-api/painting/custom-highlight-dynamic-font-metrics-001.html (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34718 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42325 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42342 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188674 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50252 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146665 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39449 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50935 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/34507 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146471 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41233 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123141 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117253 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49440 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12866 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48839 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49075 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48900 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->