### PR TITLE
Add the Local Network Access check algorithm and a NetworkProcess-resident permission stub

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -422,6 +422,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     Modules/fetch/FetchRequestMode.h
     Modules/fetch/FetchResponse.h
     Modules/fetch/IPAddressSpace.h
+    Modules/fetch/LocalNetworkAccess.h
     Modules/fetch/RequestPriority.h
 
     Modules/filesystem/FileSystemDirectoryHandle.h

--- a/Source/WebCore/Modules/fetch/IPAddressSpace.cpp
+++ b/Source/WebCore/Modules/fetch/IPAddressSpace.cpp
@@ -26,13 +26,17 @@
 #include "config.h"
 #include "IPAddressSpace.h"
 
+#include "DNS.h"
 #include <array>
-#include <cstdio>
 #include <wtf/URL.h>
 #include <wtf/Vector.h>
 #include <wtf/text/MakeString.h>
 #include <wtf/text/StringToIntegerConversion.h>
 #include <wtf/text/StringView.h>
+
+#if OS(UNIX)
+#include <arpa/inet.h>
+#endif
 
 namespace WebCore {
 
@@ -141,5 +145,28 @@ IPAddressSpace determineIPAddressSpace(const URL& url)
 
     return classifyHost(host.toString());
 }
+
+#if OS(UNIX)
+IPAddressSpace classifyIPAddressSpace(const IPAddress& address)
+{
+    char buffer[INET6_ADDRSTRLEN];
+    if (address.isIPv4()) {
+        if (!inet_ntop(AF_INET, &address.ipv4Address(), buffer, sizeof(buffer)))
+            return IPAddressSpace::Unknown;
+    } else if (address.isIPv6()) {
+        if (!inet_ntop(AF_INET6, &address.ipv6Address(), buffer, sizeof(buffer)))
+            return IPAddressSpace::Unknown;
+    } else
+        return IPAddressSpace::Unknown;
+
+    return classifyHost(String::fromLatin1(buffer));
+}
+#else
+IPAddressSpace classifyIPAddressSpace(const IPAddress&)
+{
+    // IPAddress::fromString() is OS(UNIX)-only (see DNS.cpp), so there's no address to classify here.
+    return IPAddressSpace::Unknown;
+}
+#endif
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/fetch/IPAddressSpace.h
+++ b/Source/WebCore/Modules/fetch/IPAddressSpace.h
@@ -27,10 +27,13 @@
 
 namespace WebCore {
 
+class IPAddress;
+
 enum class IPAddressSpace : uint8_t {
     Public,
     Local,
-    Loopback
+    Loopback,
+    Unknown
 };
 
 constexpr uint8_t publicnessRank(IPAddressSpace space)
@@ -42,6 +45,8 @@ constexpr uint8_t publicnessRank(IPAddressSpace space)
         return 1;
     case IPAddressSpace::Public:
         return 2;
+    case IPAddressSpace::Unknown:
+        return 0;
     }
     return 2;
 }
@@ -52,5 +57,7 @@ inline bool isLessPublicThan(IPAddressSpace a, IPAddressSpace b)
 }
 
 WEBCORE_EXPORT IPAddressSpace determineIPAddressSpace(const WTF::URL&);
+
+WEBCORE_EXPORT IPAddressSpace classifyIPAddressSpace(const IPAddress&);
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/fetch/LocalNetworkAccess.cpp
+++ b/Source/WebCore/Modules/fetch/LocalNetworkAccess.cpp
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "LocalNetworkAccess.h"
+
+#include "IPAddressSpace.h"
+#include "ResourceRequest.h"
+#include "SecurityOrigin.h"
+#include "SecurityOriginData.h"
+
+namespace WebCore {
+
+std::optional<ResourceError> performLocalNetworkAccessCheck(const ResourceRequest& request, IPAddressSpace connectionAddressSpace, IPAddressSpace clientPolicyContainerAddressSpace, bool clientIsSecureContext, const SecurityOriginData& clientOrigin, NOESCAPE const LocalNetworkAccessPermissionCheckFunction& permissionCheck)
+{
+    auto requestOrigin = SecurityOriginData::fromURL(request.url());
+    if (requestOrigin == clientOrigin) {
+        if (clientOrigin.securityOrigin()->isPotentiallyTrustworthy())
+            return std::nullopt;
+    }
+
+    if (connectionAddressSpace != IPAddressSpace::Unknown) {
+        if (request.targetAddressSpace() != IPAddressSpace::Public && request.targetAddressSpace() != connectionAddressSpace) {
+            return ResourceError { "WebKitErrorDomain"_s, 0, request.url(),
+                "Local Network Access: connection's resolved address space does not match the request's declared targetAddressSpace"_s,
+                ResourceError::Type::AccessControl };
+        }
+
+        if (!isLessPublicThan(connectionAddressSpace, clientPolicyContainerAddressSpace))
+            return std::nullopt;
+    }
+
+    auto error = ResourceError { "WebKitErrorDomain"_s, 0, request.url(),
+        "Local Network Access: connection to a less public address space than the requesting document was blocked"_s,
+        ResourceError::Type::AccessControl };
+
+    if (!clientIsSecureContext)
+        return error;
+
+    switch (permissionCheck(clientOrigin, connectionAddressSpace)) {
+    case LocalNetworkAccessPermissionDecision::Granted:
+        return std::nullopt;
+    case LocalNetworkAccessPermissionDecision::Denied:
+    case LocalNetworkAccessPermissionDecision::Prompt:
+        return error;
+    }
+    return error;
+}
+
+} // namespace WebCore

--- a/Source/WebCore/Modules/fetch/LocalNetworkAccess.h
+++ b/Source/WebCore/Modules/fetch/LocalNetworkAccess.h
@@ -25,50 +25,25 @@
 
 #pragma once
 
-#include <wtf/HashFunctions.h>
-#include <wtf/HashTraits.h>
+#include "ResourceError.h"
+#include <optional>
+#include <wtf/Forward.h>
+#include <wtf/Function.h>
 
 namespace WebCore {
 
-class IPAddress;
+enum class IPAddressSpace : uint8_t;
+class ResourceRequest;
+class SecurityOriginData;
 
-enum class IPAddressSpace : uint8_t {
-    Public,
-    Local,
-    Loopback,
-    Unknown
+enum class LocalNetworkAccessPermissionDecision : uint8_t {
+    Granted,
+    Denied,
+    Prompt
 };
 
-constexpr uint8_t publicnessRank(IPAddressSpace space)
-{
-    switch (space) {
-    case IPAddressSpace::Loopback:
-        return 0;
-    case IPAddressSpace::Local:
-        return 1;
-    case IPAddressSpace::Public:
-        return 2;
-    case IPAddressSpace::Unknown:
-        return 0;
-    }
-    return 2;
-}
+using LocalNetworkAccessPermissionCheckFunction = Function<LocalNetworkAccessPermissionDecision(const SecurityOriginData& clientOrigin, IPAddressSpace connectionAddressSpace)>;
 
-inline bool isLessPublicThan(IPAddressSpace a, IPAddressSpace b)
-{
-    return publicnessRank(a) < publicnessRank(b);
-}
-
-WEBCORE_EXPORT IPAddressSpace determineIPAddressSpace(const WTF::URL&);
-
-WEBCORE_EXPORT IPAddressSpace classifyIPAddressSpace(const IPAddress&);
+WEBCORE_EXPORT std::optional<ResourceError> performLocalNetworkAccessCheck(const ResourceRequest&, IPAddressSpace connectionAddressSpace, IPAddressSpace clientPolicyContainerAddressSpace, bool clientIsSecureContext, const SecurityOriginData& clientOrigin, NOESCAPE const LocalNetworkAccessPermissionCheckFunction&);
 
 } // namespace WebCore
-
-namespace WTF {
-
-template<> struct DefaultHash<WebCore::IPAddressSpace> : IntHash<WebCore::IPAddressSpace> { };
-template<> struct HashTraits<WebCore::IPAddressSpace> : StrongEnumHashTraits<WebCore::IPAddressSpace> { };
-
-} // namespace WTF
-

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -136,6 +136,7 @@ Modules/fetch/FetchRequest.cpp @cost:3
 Modules/fetch/FetchResponse.cpp @cost:4
 Modules/fetch/FormDataConsumer.cpp
 Modules/fetch/IPAddressSpace.cpp
+Modules/fetch/LocalNetworkAccess.cpp
 Modules/fetch/WindowOrWorkerGlobalScopeFetch.cpp @cost:3
 Modules/filesystem/FileSystemDirectoryHandle.cpp
 Modules/filesystem/FileSystemFileHandle.cpp

--- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
+++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
@@ -1379,6 +1379,7 @@
 		3BB6B81122A7D313003A2A69 /* TabSize.h in Headers */ = {isa = PBXBuildFile; fileRef = 3BB6B80F22A7D311003A2A69 /* TabSize.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		3C244FEAA375AC633F88BE6F /* RenderLayerModelObject.h in Headers */ = {isa = PBXBuildFile; fileRef = 3C244FE4A375AC633F88BE6F /* RenderLayerModelObject.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		3C8D24EE2E25CF1A00D2A929 /* IPAddressSpace.h in Headers */ = {isa = PBXBuildFile; fileRef = 3C8D24ED2E25CF1A00D2A929 /* IPAddressSpace.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		58E9CA87641E10563C3CE61C /* LocalNetworkAccess.h in Headers */ = {isa = PBXBuildFile; fileRef = DAE4358201103A6E524EB9AE /* LocalNetworkAccess.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		3D42BC4514B0E28F44D62E77 /* UnifiedSource51-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6D90699809046B96AE290168 /* UnifiedSource51-header-RenderStyleGetters.cpp */; };
 		3D4E6A98F12B0C85A2C173D6 /* RenderLayerSVGAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 2C7B5F48E0A31D9467FB8C52 /* RenderLayerSVGAdditions.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		3F42B31D1881191B00278AAC /* WebVideoFullscreenControllerAVKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 3F42B31B1881191B00278AAC /* WebVideoFullscreenControllerAVKit.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -10892,6 +10893,8 @@
 		3C6A595F2E4E5D5300A908CC /* IPAddressSpace.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = IPAddressSpace.cpp; sourceTree = "<group>"; };
 		3C8D24ED2E25CF1A00D2A929 /* IPAddressSpace.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = IPAddressSpace.h; sourceTree = "<group>"; };
 		3CE7C6702E270278005CDFD8 /* IPAddressSpace.idl */ = {isa = PBXFileReference; lastKnownFileType = text; path = IPAddressSpace.idl; sourceTree = "<group>"; };
+		DAE4358201103A6E524EB9AE /* LocalNetworkAccess.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = LocalNetworkAccess.h; sourceTree = "<group>"; };
+		DAD333D76403A91488F601D7 /* LocalNetworkAccess.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = LocalNetworkAccess.cpp; sourceTree = "<group>"; };
 		3DCCA4B4BF1CEDC0C5E7B3BB /* Airplay.svg */ = {isa = PBXFileReference; lastKnownFileType = text; path = Airplay.svg; sourceTree = "<group>"; };
 		3EB98985C78E4C2A4C58889D /* UnifiedSource61-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource61-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
 		3F3BB5821E709EE400C701F2 /* CoreAudioCaptureSource.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CoreAudioCaptureSource.cpp; sourceTree = "<group>"; };
@@ -27903,6 +27906,8 @@
 				3C6A595F2E4E5D5300A908CC /* IPAddressSpace.cpp */,
 				3C8D24ED2E25CF1A00D2A929 /* IPAddressSpace.h */,
 				3CE7C6702E270278005CDFD8 /* IPAddressSpace.idl */,
+				DAD333D76403A91488F601D7 /* LocalNetworkAccess.cpp */,
+				DAE4358201103A6E524EB9AE /* LocalNetworkAccess.h */,
 				44CF5098299B906F0038D284 /* RequestPriority.h */,
 				44CF5097299B90600038D284 /* RequestPriority.idl */,
 				7C2E0BD125106AC4005F3C87 /* WindowOrWorkerGlobalScope+Fetch.idl */,
@@ -47239,6 +47244,7 @@
 				E35B907F23F60A50000011FF /* LocalizedDeviceModel.h in Headers */,
 				935207BE09BD410A00F2038D /* LocalizedStrings.h in Headers */,
 				550A0BCC085F6039007353D7 /* LocalNameWithNamespace.h in Headers */,
+				58E9CA87641E10563C3CE61C /* LocalNetworkAccess.h in Headers */,
 				41FCD6BB23CE027700C62567 /* LocalSampleBufferDisplayLayer.h in Headers */,
 				BCE1C41B0D982980003B02F2 /* Location.h in Headers */,
 				E3C788EE2D035C9500D6C13D /* LogClient.h in Headers */,

--- a/Source/WebCore/page/ChromeClient.h
+++ b/Source/WebCore/page/ChromeClient.h
@@ -182,8 +182,10 @@ enum class AXTextChange : uint8_t;
 enum class BroadcastFocusedElement : bool;
 enum class ContentChange : uint8_t;
 enum class DidFilterLinkDecoration : bool { No, Yes };
+enum class IPAddressSpace : uint8_t;
 enum class IsLoggedIn : uint8_t;
 enum class LinkDecorationFilteringTrigger : uint8_t;
+enum class LocalNetworkAccessPermissionDecision : uint8_t;
 enum class ModalContainerControlType : uint8_t;
 enum class ModalContainerDecision : uint8_t;
 enum class PlatformEventModifier : uint8_t;
@@ -471,6 +473,8 @@ public:
     virtual RefPtr<ShapeDetection::TextDetector> createTextDetector() const;
 
     virtual void registerBlobPathForTesting(const String&, CompletionHandler<void()>&&) { }
+
+    virtual void setLocalNetworkAccessPermissionForTesting(SecurityOriginData&&, IPAddressSpace, LocalNetworkAccessPermissionDecision, CompletionHandler<void()>&& completionHandler) { completionHandler(); }
 
     // Pass nullptr as the GraphicsLayer to detatch the root layer.
     virtual void attachRootGraphicsLayer(LocalFrame&, GraphicsLayer*) = 0;

--- a/Source/WebCore/platform/network/ResourceResponseBase.cpp
+++ b/Source/WebCore/platform/network/ResourceResponseBase.cpp
@@ -90,7 +90,7 @@ ResourceResponseBase::ResourceResponseBase(std::optional<ResourceResponseData>&&
     , m_tainting(data ? data->tainting : Tainting::Basic)
     , m_source(data ? data->source : Source::Unknown)
     , m_type(data ? data->type : Type::Default)
-    , m_ipAddressSpace(data ? data->ipAddressSpace : IPAddressSpace::Public)
+    , m_ipAddressSpace(data ? data->ipAddressSpace : IPAddressSpace::Unknown)
 {
 }
 
@@ -1058,7 +1058,7 @@ std::optional<WebCore::ResourceResponseData> Coder<WebCore::ResourceResponseData
         WTF::move(*proxyName),
         *isRangeRequested,
         WTF::move(*certificateInfo),
-        WebCore::IPAddressSpace::Public
+        WebCore::IPAddressSpace::Unknown
     };
 }
 

--- a/Source/WebCore/platform/network/ResourceResponseBase.h
+++ b/Source/WebCore/platform/network/ResourceResponseBase.h
@@ -64,7 +64,7 @@ static constexpr unsigned bitWidthOfWasPrivateRelayed = 1;
 static_assert(static_cast<unsigned>(WasPrivateRelayed::Yes) <= ((1U << bitWidthOfWasPrivateRelayed) - 1));
 
 static constexpr unsigned bitWidthOfIPAddressSpace = 2;
-static_assert(((1U << bitWidthOfIPAddressSpace) - 1) >= static_cast<unsigned>(IPAddressSpace::Loopback));
+static_assert(((1U << bitWidthOfIPAddressSpace) - 1) >= static_cast<unsigned>(IPAddressSpace::Unknown));
 
 enum class ResourceResponseBaseType : uint8_t { Basic, Cors, Default, Error, Opaque, Opaqueredirect };
 enum class ResourceResponseBaseTainting : uint8_t { Basic, Cors, Opaque, Opaqueredirect };
@@ -153,7 +153,7 @@ public:
     void setProxyName(String&& proxyName) { m_proxyName = WTF::move(proxyName); }
     const String& proxyName() const LIFETIME_BOUND { return m_proxyName; }
 
-    IPAddressSpace ipAddressSpace() { return m_ipAddressSpace; }
+    IPAddressSpace ipAddressSpace() const { return m_ipAddressSpace; }
     void setIPAddressSpace(IPAddressSpace ipAddressSpace) { m_ipAddressSpace = ipAddressSpace; }
 
     // These functions return parsed values of the corresponding response headers.
@@ -297,7 +297,7 @@ private:
     Tainting m_tainting : bitWidthOfTainting { Tainting::Basic };
     Source m_source : bitWidthOfSource { Source::Unknown };
     Type m_type : bitWidthOfType { Type::Default };
-    IPAddressSpace m_ipAddressSpace : bitWidthOfIPAddressSpace { IPAddressSpace::Public };
+    IPAddressSpace m_ipAddressSpace : bitWidthOfIPAddressSpace { IPAddressSpace::Unknown };
 
 };
 

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -131,6 +131,7 @@
 #include "HitTestResult.h"
 #include "IDBRequest.h"
 #include "IDBTransaction.h"
+#include "IPAddressSpace.h"
 #include "ImageData.h"
 #include "ImageOverlay.h"
 #include "ImageOverlayController.h"
@@ -153,6 +154,7 @@
 #include "LocalDOMWindow.h"
 #include "LocalFrame.h"
 #include "LocalFrameView.h"
+#include "LocalNetworkAccess.h"
 #include "LocalizedStrings.h"
 #include "Location.h"
 #include "MallocStatistics.h"
@@ -230,6 +232,7 @@
 #include "ScrollingCoordinator.h"
 #include "ScrollingMomentumCalculator.h"
 #include "SecurityOrigin.h"
+#include "SecurityOriginData.h"
 #include "SelectorFilter.h"
 #include "SerializedScriptValue.h"
 #include "ServiceWorker.h"
@@ -6149,6 +6152,41 @@ String Internals::createTemporaryFile(const String& name, const String& contents
 
     file.write(byteCast<uint8_t>(contents.utf8().span()));
     return path;
+}
+
+static WebCore::LocalNetworkAccessPermissionDecision toLocalNetworkAccessPermissionDecision(Internals::LocalNetworkAccessPermissionDecision decision)
+{
+    switch (decision) {
+    case Internals::LocalNetworkAccessPermissionDecision::Granted:
+        return WebCore::LocalNetworkAccessPermissionDecision::Granted;
+    case Internals::LocalNetworkAccessPermissionDecision::Denied:
+        return WebCore::LocalNetworkAccessPermissionDecision::Denied;
+    case Internals::LocalNetworkAccessPermissionDecision::Prompt:
+        return WebCore::LocalNetworkAccessPermissionDecision::Prompt;
+    }
+    return WebCore::LocalNetworkAccessPermissionDecision::Denied;
+}
+
+void Internals::setLocalNetworkAccessPermissionForTesting(const String& originURL, IPAddressSpace addressSpace, LocalNetworkAccessPermissionDecision decision, DOMPromiseDeferred<void>&& promise)
+{
+    Document* document = contextDocument();
+    if (!document) {
+        promise.reject(ExceptionCode::InvalidStateError);
+        return;
+    }
+
+    URL url = document->encodingParseURL(originURL);
+    auto origin = SecurityOriginData::fromURL(url);
+
+    RefPtr page = document->page();
+    if (!page) {
+        promise.reject(ExceptionCode::InvalidStateError);
+        return;
+    }
+
+    page->chrome().client().setLocalNetworkAccessPermissionForTesting(WTF::move(origin), addressSpace, toLocalNetworkAccessPermissionDecision(decision), [promise = WTF::move(promise)]() mutable {
+        promise.resolve();
+    });
 }
 
 void Internals::queueMicroTask(int testNumber)

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -156,6 +156,7 @@ class XMLHttpRequest;
 struct VideoConfiguration;
 
 enum class DocumentMarkerType : uint32_t;
+enum class IPAddressSpace : uint8_t;
 
 #if ENABLE(ENCRYPTED_MEDIA)
 class MediaKeys;
@@ -985,6 +986,9 @@ public:
     RefPtr<File> createFile(const String&);
     void asyncCreateFile(const String&, DOMPromiseDeferred<IDLInterface<File>>&&);
     String createTemporaryFile(const String& name, const String& contents);
+
+    enum class LocalNetworkAccessPermissionDecision { Granted, Denied, Prompt };
+    void setLocalNetworkAccessPermissionForTesting(const String& originURL, IPAddressSpace, LocalNetworkAccessPermissionDecision, DOMPromiseDeferred<void>&&);
 
     void queueMicroTask(int);
     bool testPreloaderSettingViewport();

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -60,6 +60,13 @@ enum UserInterfaceLayoutDirection {
     "RTL"
 };
 
+// FIXME: Remove this enum, and the stub it configures, once a real permission prompt exists.
+enum LocalNetworkAccessPermissionDecision {
+    "granted",
+    "denied",
+    "prompt"
+};
+
 enum BaseWritingDirection {
     "Natural",
     "Ltr",
@@ -1161,6 +1168,8 @@ enum ContentsFormat {
     File? createFile(DOMString url);
     Promise<File> asyncCreateFile(DOMString url);
     DOMString createTemporaryFile(DOMString name, DOMString contents);
+
+    Promise<undefined> setLocalNetworkAccessPermissionForTesting(DOMString originURL, IPAddressSpace addressSpace, LocalNetworkAccessPermissionDecision decision);
 
     undefined queueMicroTask(long testNumber);
     boolean testPreloaderSettingViewport();

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
@@ -82,6 +82,8 @@
 #include <WebCore/DeprecatedGlobalSettings.h>
 #include <WebCore/DocumentStorageAccess.h>
 #include <WebCore/HTTPCookieAcceptPolicy.h>
+#include <WebCore/IPAddressSpace.h>
+#include <WebCore/LocalNetworkAccess.h>
 #include <WebCore/LogInitialization.h>
 #include <WebCore/LoginStatus.h>
 #include <WebCore/NetworkStorageSession.h>
@@ -1340,6 +1342,13 @@ void NetworkConnectionToWebProcess::generalStoragePathForTesting(CompletionHandl
     if (!session)
         return completion({ });
     completion(String { session->storageManager().path() });
+}
+
+void NetworkConnectionToWebProcess::setLocalNetworkAccessPermissionForTesting(WebCore::SecurityOriginData&& origin, WebCore::IPAddressSpace addressSpace, WebCore::LocalNetworkAccessPermissionDecision decision, CompletionHandler<void()>&& completion)
+{
+    if (CheckedPtr session = networkSession())
+        session->setLocalNetworkAccessPermissionForTesting(WTF::move(origin), addressSpace, decision);
+    completion();
 }
 
 void NetworkConnectionToWebProcess::allowAccessToFile(const String& path)

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
@@ -88,10 +88,13 @@ class LoginStatus;
 class MockContentFilterSettings;
 class ResourceError;
 class ResourceRequest;
+class SecurityOriginData;
 class Site;
 enum class AdvancedPrivacyProtections : uint16_t;
 enum class StorageAccessScope : bool;
 enum class IsLoggedIn : uint8_t;
+enum class IPAddressSpace : uint8_t;
+enum class LocalNetworkAccessPermissionDecision : uint8_t;
 enum class ShouldPartitionCookie : bool;
 struct ClientOrigin;
 struct Cookie;
@@ -346,6 +349,7 @@ private:
     void writeBlobsToTemporaryFilesForIndexedDB(const Vector<String>& blobURLs, CompletionHandler<void(Vector<String>&&)>&&);
     void registerBlobPathForTesting(const String& path, CompletionHandler<void()>&&);
     void generalStoragePathForTesting(CompletionHandler<void(String&&)>&&);
+    void setLocalNetworkAccessPermissionForTesting(WebCore::SecurityOriginData&&, WebCore::IPAddressSpace, WebCore::LocalNetworkAccessPermissionDecision, CompletionHandler<void()>&&);
     bool isFilePathAllowed(String path);
 
     void registerBlobURLHandle(const URL&, const std::optional<WebCore::SecurityOriginData>& topOrigin);

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in
@@ -77,6 +77,7 @@ messages -> NetworkConnectionToWebProcess WantsDispatchMessage {
     UnregisterBlobURLHandle(URL url, std::optional<WebCore::SecurityOriginData> topOrigin);
     RegisterBlobPathForTesting(String path) -> ();
     [EnabledBy=AllowTestOnlyIPC] GeneralStoragePathForTesting() -> (String path);
+    [EnabledBy=AllowTestOnlyIPC] SetLocalNetworkAccessPermissionForTesting(WebCore::SecurityOriginData origin, enum:uint8_t WebCore::IPAddressSpace addressSpace, enum:uint8_t WebCore::LocalNetworkAccessPermissionDecision decision) -> ();
 
     SetCaptureExtraNetworkLoadMetricsEnabled(bool enabled)
 

--- a/Source/WebKit/NetworkProcess/NetworkSession.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkSession.cpp
@@ -54,8 +54,11 @@
 #include "WebSharedWorkerServer.h"
 #include "WebSocketTask.h"
 #include <WebCore/CookieJar.h>
+#include <WebCore/IPAddressSpace.h>
+#include <WebCore/LocalNetworkAccess.h>
 #include <WebCore/ResourceRequest.h>
 #include <WebCore/SWServer.h>
+#include <WebCore/SecurityOriginData.h>
 #include <numeric>
 #include <wtf/RuntimeApplicationChecks.h>
 #include <wtf/StdLibExtras.h>
@@ -439,6 +442,19 @@ std::optional<WebCore::IPAddress> NetworkSession::firstPartyHostIPAddress(const 
         return std::nullopt;
 
     return { iterator->value };
+}
+
+WebCore::LocalNetworkAccessPermissionDecision NetworkSession::localNetworkAccessPermission(const WebCore::SecurityOriginData& origin, WebCore::IPAddressSpace addressSpace) const
+{
+    auto iterator = m_localNetworkAccessPermissions.find({ origin, addressSpace });
+    if (iterator == m_localNetworkAccessPermissions.end())
+        return WebCore::LocalNetworkAccessPermissionDecision::Denied;
+    return iterator->value;
+}
+
+void NetworkSession::setLocalNetworkAccessPermissionForTesting(WebCore::SecurityOriginData&& origin, WebCore::IPAddressSpace addressSpace, WebCore::LocalNetworkAccessPermissionDecision decision)
+{
+    m_localNetworkAccessPermissions.set({ WTF::move(origin), addressSpace }, decision);
 }
 
 void NetworkSession::storePrivateClickMeasurement(WebCore::PrivateClickMeasurement&& unattributedPrivateClickMeasurement)

--- a/Source/WebKit/NetworkProcess/NetworkSession.h
+++ b/Source/WebKit/NetworkProcess/NetworkSession.h
@@ -60,6 +60,8 @@
 
 namespace WebCore {
 class CertificateInfo;
+enum class IPAddressSpace : uint8_t;
+enum class LocalNetworkAccessPermissionDecision : uint8_t;
 class NetworkStorageSession;
 class ResourceMonitorThrottlerHolder;
 class ResourceRequest;
@@ -166,6 +168,10 @@ public:
     std::optional<WebCore::RegistrableDomain> thirdPartyCNAMEDomainForTesting() const { return m_thirdPartyCNAMEDomainForTesting; }
     void resetFirstPartyDNSData();
     void destroyResourceLoadStatistics(CompletionHandler<void()>&&);
+
+    // FIXME: Stub permission decision; replace with a real prompt-mediated check once one exists.
+    WebCore::LocalNetworkAccessPermissionDecision localNetworkAccessPermission(const WebCore::SecurityOriginData&, WebCore::IPAddressSpace) const;
+    void setLocalNetworkAccessPermissionForTesting(WebCore::SecurityOriginData&&, WebCore::IPAddressSpace, WebCore::LocalNetworkAccessPermissionDecision);
     
 #if ENABLE(APP_BOUND_DOMAINS)
     virtual bool hasAppBoundSession() const { return false; }
@@ -350,6 +356,7 @@ protected:
     HashMap<String, WebCore::RegistrableDomain> m_firstPartyHostCNAMEDomains;
     HashMap<String, WebCore::IPAddress> m_firstPartyHostIPAddresses;
     std::optional<WebCore::RegistrableDomain> m_thirdPartyCNAMEDomainForTesting;
+    HashMap<std::pair<WebCore::SecurityOriginData, WebCore::IPAddressSpace>, WebCore::LocalNetworkAccessPermissionDecision> m_localNetworkAccessPermissions;
     bool m_isStaleWhileRevalidateEnabled { false };
     const Ref<PCM::ManagerInterface> m_privateClickMeasurement;
     bool m_privateClickMeasurementDebugModeEnabled { false };

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm
@@ -39,6 +39,7 @@
 #import <WebCore/AdvancedPrivacyProtections.h>
 #import <WebCore/AuthenticationChallenge.h>
 #import <WebCore/HTTPStatusCodes.h>
+#import <WebCore/IPAddressSpace.h>
 #import <WebCore/NetworkStorageSession.h>
 #import <WebCore/NotImplemented.h>
 #import <WebCore/OriginAccessPatterns.h>
@@ -429,12 +430,18 @@ void NetworkDataTaskCocoa::didReceiveResponse(WebCore::ResourceResponse&& respon
             session->reportNetworkIssue(*m_webPageProxyID, firstRequest().url());
     }
 #endif
-    NetworkDataTask::didReceiveResponse(WTF::move(response), negotiatedLegacyTLS, privateRelayed, WebCore::IPAddress::fromString(lastRemoteIPAddress(m_task.get())), WTF::move(completionHandler));
+    auto resolvedIPAddress = WebCore::IPAddress::fromString(lastRemoteIPAddress(m_task.get()));
+    if (resolvedIPAddress)
+        response.setIPAddressSpace(WebCore::classifyIPAddressSpace(*resolvedIPAddress));
+    NetworkDataTask::didReceiveResponse(WTF::move(response), negotiatedLegacyTLS, privateRelayed, resolvedIPAddress, WTF::move(completionHandler));
 }
 
 void NetworkDataTaskCocoa::willPerformHTTPRedirection(WebCore::ResourceResponse&& redirectResponse, WebCore::ResourceRequest&& request, RedirectCompletionHandler&& completionHandler)
 {
     WTFEmitSignpost(m_task.get(), DataTask, "redirect");
+
+    if (auto resolvedIPAddress = WebCore::IPAddress::fromString(lastRemoteIPAddress(m_task.get())))
+        redirectResponse.setIPAddressSpace(WebCore::classifyIPAddressSpace(*resolvedIPAddress));
 
     networkLoadMetrics().hasCrossOriginRedirect = networkLoadMetrics().hasCrossOriginRedirect || !WebCore::SecurityOrigin::create(request.url())->canRequest(redirectResponse.url(), WebCore::EmptyOriginAccessPatterns::singleton());
 

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -1313,6 +1313,7 @@ def headers_for_type(type, for_implementation_file=False):
         'WebCore::LegacyCDMSessionClient::MediaKeyErrorCode': ['<WebCore/LegacyCDMSession.h>'],
         'WebCore::LineCap': ['<WebCore/GraphicsTypes.h>'],
         'WebCore::LineJoin': ['<WebCore/GraphicsTypes.h>'],
+        'WebCore::LocalNetworkAccessPermissionDecision': ['<WebCore/LocalNetworkAccess.h>'],
         'WebCore::PackedColor::RGBA': ['<WebCore/ColorTypes.h>'],
         'WebCore::PaginationMode': ['<WebCore/Pagination.h>'],
         'WebCore::PlatformLayerIdentifierID': ['"GeneratedSerializers.h"'],

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -37,7 +37,8 @@ header: <WebCore/IPAddressSpace.h>
 enum class WebCore::IPAddressSpace : uint8_t {
     Public,
     Local,
-    Loopback
+    Loopback,
+    Unknown
 };
 
 enum class WebCore::NotificationEventType : bool;

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -41,6 +41,14 @@ enum class WebCore::IPAddressSpace : uint8_t {
     Unknown
 };
 
+header: <WebCore/LocalNetworkAccess.h>
+
+enum class WebCore::LocalNetworkAccessPermissionDecision : uint8_t {
+    Granted,
+    Denied,
+    Prompt
+};
+
 enum class WebCore::NotificationEventType : bool;
 
 enum class WebCore::PermissionName : uint8_t {

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -110,10 +110,12 @@
 #include <WebCore/HTMLParserIdioms.h>
 #include <WebCore/HTMLPlugInElement.h>
 #include <WebCore/HTMLVideoElement.h>
+#include <WebCore/IPAddressSpace.h>
 #include <WebCore/Icon.h>
 #include <WebCore/ImageBuffer.h>
 #include <WebCore/LocalFrameInlines.h>
 #include <WebCore/LocalFrameView.h>
+#include <WebCore/LocalNetworkAccess.h>
 #include <WebCore/NotImplemented.h>
 #include <WebCore/PointerLockController.h>
 #include <WebCore/PopupMenuClient.h>
@@ -1360,6 +1362,10 @@ void WebChromeClient::registerBlobPathForTesting(const String& path, CompletionH
     WebProcess::singleton().ensureNetworkProcessConnection().connection().sendWithAsyncReply(Messages::NetworkConnectionToWebProcess::RegisterBlobPathForTesting(path), WTF::move(completionHandler));
 }
 
+void WebChromeClient::setLocalNetworkAccessPermissionForTesting(WebCore::SecurityOriginData&& origin, WebCore::IPAddressSpace addressSpace, WebCore::LocalNetworkAccessPermissionDecision decision, CompletionHandler<void()>&& completionHandler)
+{
+    WebProcess::singleton().ensureNetworkProcessConnection().connection().sendWithAsyncReply(Messages::NetworkConnectionToWebProcess::SetLocalNetworkAccessPermissionForTesting(WTF::move(origin), addressSpace, decision), WTF::move(completionHandler));
+}
 
 void WebChromeClient::contentRuleListNotification(const URL& url, const ContentRuleListResults& results)
 {

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
@@ -250,6 +250,7 @@ private:
     void renderingUpdateFramesPerSecondChanged() final;
     unsigned remoteImagesCountForTesting() const final;
     void registerBlobPathForTesting(const String& path, CompletionHandler<void()>&&) final;
+    void setLocalNetworkAccessPermissionForTesting(WebCore::SecurityOriginData&&, WebCore::IPAddressSpace, WebCore::LocalNetworkAccessPermissionDecision, CompletionHandler<void()>&&) final;
 
     void contentRuleListNotification(const URL&, const WebCore::ContentRuleListResults&) final;
     void contentRuleListMatchedRule(const WebCore::ContentRuleListMatchedRule&) final;

--- a/Tools/TestWebKitAPI/CMakeLists.txt
+++ b/Tools/TestWebKitAPI/CMakeLists.txt
@@ -243,6 +243,7 @@ if (ENABLE_WEBCORE)
         Tests/WebCore/KeyedCoding.cpp
         Tests/WebCore/LayoutRoundedRectTests.cpp
         Tests/WebCore/LayoutUnitTests.cpp
+        Tests/WebCore/LocalNetworkAccess.cpp
         Tests/WebCore/MIMESniffer.cpp
         Tests/WebCore/MIMETypeRegistry.cpp
         Tests/WebCore/MediaReorderQueue.cpp

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -768,6 +768,7 @@
 				WebCore/KeyedCoding.cpp,
 				WebCore/LayoutRoundedRectTests.cpp,
 				WebCore/LayoutUnitTests.cpp,
+				WebCore/LocalNetworkAccess.cpp,
 				WebCore/Logging.cpp,
 				WebCore/LoginStatus.cpp,
 				WebCore/MarkedText.cpp,

--- a/Tools/TestWebKitAPI/Tests/WebCore/IPAddressSpaceTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/IPAddressSpaceTests.cpp
@@ -25,7 +25,9 @@
 
 #include "config.h"
 
+#include <WebCore/DNS.h>
 #include <WebCore/IPAddressSpace.h>
+#include <WebCore/ResourceResponse.h>
 #include <wtf/URL.h>
 
 namespace TestWebKitAPI {
@@ -283,6 +285,37 @@ TEST(IPAddressSpace, IPv4BoundaryConditions)
     EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://198.19.255.255/"_s)), WebCore::IPAddressSpace::Local);
     EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://198.17.255.255/"_s)), WebCore::IPAddressSpace::Public);
     EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://198.20.0.0/"_s)), WebCore::IPAddressSpace::Public);
+}
+
+// classifyIPAddressSpace() goes through IPAddress::fromString() -> inet_ntop() rather than URL
+// parsing, so it's worth confirming it agrees with determineIPAddressSpace() above.
+TEST(IPAddressSpace, ClassifyIPAddressSpaceFromResolvedAddress)
+{
+    EXPECT_EQ(WebCore::classifyIPAddressSpace(*WebCore::IPAddress::fromString("127.0.0.1"_s)), WebCore::IPAddressSpace::Loopback);
+    EXPECT_EQ(WebCore::classifyIPAddressSpace(*WebCore::IPAddress::fromString("::1"_s)), WebCore::IPAddressSpace::Loopback);
+    EXPECT_EQ(WebCore::classifyIPAddressSpace(*WebCore::IPAddress::fromString("192.168.1.1"_s)), WebCore::IPAddressSpace::Local);
+    EXPECT_EQ(WebCore::classifyIPAddressSpace(*WebCore::IPAddress::fromString("fc00::1"_s)), WebCore::IPAddressSpace::Local);
+    EXPECT_EQ(WebCore::classifyIPAddressSpace(*WebCore::IPAddress::fromString("8.8.8.8"_s)), WebCore::IPAddressSpace::Public);
+    EXPECT_EQ(WebCore::classifyIPAddressSpace(*WebCore::IPAddress::fromString("2001:4860:4860::8888"_s)), WebCore::IPAddressSpace::Public);
+
+    // IPv4-mapped IPv6 addresses must classify by their embedded IPv4 address, not as opaque IPv6.
+    EXPECT_EQ(WebCore::classifyIPAddressSpace(*WebCore::IPAddress::fromString("::ffff:192.168.1.1"_s)), WebCore::IPAddressSpace::Local);
+    EXPECT_EQ(WebCore::classifyIPAddressSpace(*WebCore::IPAddress::fromString("::ffff:127.0.0.1"_s)), WebCore::IPAddressSpace::Loopback);
+}
+
+TEST(IPAddressSpace, ClassifyUnclassifiableAddressIsUnknown)
+{
+    WebCore::IPAddress unclassifiable { WTF::HashTableEmptyValue };
+    EXPECT_EQ(WebCore::classifyIPAddressSpace(unclassifiable), WebCore::IPAddressSpace::Unknown);
+}
+
+TEST(IPAddressSpace, ResourceResponseAddressSpaceDefaultsToUnknown)
+{
+    WebCore::ResourceResponse response;
+    EXPECT_EQ(response.ipAddressSpace(), WebCore::IPAddressSpace::Unknown);
+
+    response.setIPAddressSpace(WebCore::IPAddressSpace::Local);
+    EXPECT_EQ(response.ipAddressSpace(), WebCore::IPAddressSpace::Local);
 }
 
 }

--- a/Tools/TestWebKitAPI/Tests/WebCore/LocalNetworkAccess.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/LocalNetworkAccess.cpp
@@ -1,0 +1,200 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#include <WebCore/IPAddressSpace.h>
+#include <WebCore/LocalNetworkAccess.h>
+#include <WebCore/ResourceRequest.h>
+#include <WebCore/SecurityOriginData.h>
+
+namespace TestWebKitAPI {
+
+using namespace WebCore;
+
+static LocalNetworkAccessPermissionCheckFunction permissionCheckReturning(LocalNetworkAccessPermissionDecision decision)
+{
+    return [decision](const SecurityOriginData&, IPAddressSpace) {
+        return decision;
+    };
+}
+
+TEST(LocalNetworkAccess, SameOriginTrustworthyExemption)
+{
+    ResourceRequest request { URL { "https://example.com/"_s } };
+    auto clientOrigin = SecurityOriginData::fromURL(URL { "https://example.com/"_s });
+
+    auto error = performLocalNetworkAccessCheck(request, IPAddressSpace::Loopback, IPAddressSpace::Public, true, clientOrigin, permissionCheckReturning(LocalNetworkAccessPermissionDecision::Denied));
+    EXPECT_FALSE(error.has_value());
+}
+
+TEST(LocalNetworkAccess, SameOriginButNotTrustworthyIsNotExempt)
+{
+    ResourceRequest request { URL { "http://example.com/"_s } };
+    auto clientOrigin = SecurityOriginData::fromURL(URL { "http://example.com/"_s });
+
+    auto error = performLocalNetworkAccessCheck(request, IPAddressSpace::Loopback, IPAddressSpace::Public, true, clientOrigin, permissionCheckReturning(LocalNetworkAccessPermissionDecision::Denied));
+    ASSERT_TRUE(error.has_value());
+    EXPECT_TRUE(error->isAccessControl());
+}
+
+TEST(LocalNetworkAccess, CrossOriginIsNotExempt)
+{
+    ResourceRequest request { URL { "https://example.com/"_s } };
+    auto clientOrigin = SecurityOriginData::fromURL(URL { "https://other.com/"_s });
+
+    auto error = performLocalNetworkAccessCheck(request, IPAddressSpace::Loopback, IPAddressSpace::Public, true, clientOrigin, permissionCheckReturning(LocalNetworkAccessPermissionDecision::Denied));
+    ASSERT_TRUE(error.has_value());
+    EXPECT_TRUE(error->isAccessControl());
+}
+
+TEST(LocalNetworkAccess, MatchingTargetAddressSpaceStillRequiresPermission)
+{
+    ResourceRequest request { URL { "https://example.com/"_s } };
+    request.setTargetAddressSpace(IPAddressSpace::Loopback);
+    auto clientOrigin = SecurityOriginData::fromURL(URL { "https://other.com/"_s });
+
+    auto error = performLocalNetworkAccessCheck(request, IPAddressSpace::Loopback, IPAddressSpace::Public, true, clientOrigin, permissionCheckReturning(LocalNetworkAccessPermissionDecision::Denied));
+    ASSERT_TRUE(error.has_value());
+    EXPECT_TRUE(error->isAccessControl());
+}
+
+TEST(LocalNetworkAccess, MatchingTargetAddressSpaceAllowedWithGrant)
+{
+    ResourceRequest request { URL { "https://example.com/"_s } };
+    request.setTargetAddressSpace(IPAddressSpace::Loopback);
+    auto clientOrigin = SecurityOriginData::fromURL(URL { "https://other.com/"_s });
+
+    auto error = performLocalNetworkAccessCheck(request, IPAddressSpace::Loopback, IPAddressSpace::Public, true, clientOrigin, permissionCheckReturning(LocalNetworkAccessPermissionDecision::Granted));
+    EXPECT_FALSE(error.has_value());
+}
+
+TEST(LocalNetworkAccess, MismatchedTargetAddressSpaceIsBlocked)
+{
+    ResourceRequest request { URL { "https://example.com/"_s } };
+    request.setTargetAddressSpace(IPAddressSpace::Local);
+    auto clientOrigin = SecurityOriginData::fromURL(URL { "https://other.com/"_s });
+
+    auto error = performLocalNetworkAccessCheck(request, IPAddressSpace::Loopback, IPAddressSpace::Public, false, clientOrigin, permissionCheckReturning(LocalNetworkAccessPermissionDecision::Granted));
+    ASSERT_TRUE(error.has_value());
+    EXPECT_TRUE(error->isAccessControl());
+}
+
+TEST(LocalNetworkAccess, MorePublicConnectionIsAllowed)
+{
+    ResourceRequest request { URL { "https://example.com/"_s } };
+    auto clientOrigin = SecurityOriginData::fromURL(URL { "https://other.com/"_s });
+
+    auto error = performLocalNetworkAccessCheck(request, IPAddressSpace::Public, IPAddressSpace::Public, true, clientOrigin, permissionCheckReturning(LocalNetworkAccessPermissionDecision::Denied));
+    EXPECT_FALSE(error.has_value());
+}
+
+TEST(LocalNetworkAccess, LoopbackToLoopbackIsAllowedWithoutExplicitTargetAddressSpace)
+{
+    ResourceRequest request { URL { "https://example.com/"_s } };
+    auto clientOrigin = SecurityOriginData::fromURL(URL { "https://other.com/"_s });
+
+    auto error = performLocalNetworkAccessCheck(request, IPAddressSpace::Loopback, IPAddressSpace::Loopback, true, clientOrigin, permissionCheckReturning(LocalNetworkAccessPermissionDecision::Denied));
+    EXPECT_FALSE(error.has_value());
+}
+
+TEST(LocalNetworkAccess, NonSecureContextIsBlockedWithoutConsultingPermissionStub)
+{
+    ResourceRequest request { URL { "https://example.com/"_s } };
+    auto clientOrigin = SecurityOriginData::fromURL(URL { "https://other.com/"_s });
+
+    auto error = performLocalNetworkAccessCheck(request, IPAddressSpace::Loopback, IPAddressSpace::Public, false, clientOrigin, permissionCheckReturning(LocalNetworkAccessPermissionDecision::Granted));
+    ASSERT_TRUE(error.has_value());
+    EXPECT_TRUE(error->isAccessControl());
+}
+
+TEST(LocalNetworkAccess, SecureContextGrantedByPermissionStub)
+{
+    ResourceRequest request { URL { "https://example.com/"_s } };
+    auto clientOrigin = SecurityOriginData::fromURL(URL { "https://other.com/"_s });
+
+    auto error = performLocalNetworkAccessCheck(request, IPAddressSpace::Loopback, IPAddressSpace::Public, true, clientOrigin, permissionCheckReturning(LocalNetworkAccessPermissionDecision::Granted));
+    EXPECT_FALSE(error.has_value());
+}
+
+TEST(LocalNetworkAccess, SecureContextDeniedByPermissionStub)
+{
+    ResourceRequest request { URL { "https://example.com/"_s } };
+    auto clientOrigin = SecurityOriginData::fromURL(URL { "https://other.com/"_s });
+
+    auto error = performLocalNetworkAccessCheck(request, IPAddressSpace::Loopback, IPAddressSpace::Public, true, clientOrigin, permissionCheckReturning(LocalNetworkAccessPermissionDecision::Denied));
+    ASSERT_TRUE(error.has_value());
+    EXPECT_TRUE(error->isAccessControl());
+}
+
+TEST(LocalNetworkAccess, SecureContextPromptIsTreatedAsDenied)
+{
+    ResourceRequest request { URL { "https://example.com/"_s } };
+    auto clientOrigin = SecurityOriginData::fromURL(URL { "https://other.com/"_s });
+
+    auto error = performLocalNetworkAccessCheck(request, IPAddressSpace::Loopback, IPAddressSpace::Public, true, clientOrigin, permissionCheckReturning(LocalNetworkAccessPermissionDecision::Prompt));
+    ASSERT_TRUE(error.has_value());
+    EXPECT_TRUE(error->isAccessControl());
+}
+
+TEST(LocalNetworkAccess, UndeterminedConnectionSpaceInNonSecureContextIsBlocked)
+{
+    ResourceRequest request { URL { "https://example.com/"_s } };
+    auto clientOrigin = SecurityOriginData::fromURL(URL { "https://other.com/"_s });
+
+    auto error = performLocalNetworkAccessCheck(request, IPAddressSpace::Unknown, IPAddressSpace::Public, false, clientOrigin, permissionCheckReturning(LocalNetworkAccessPermissionDecision::Granted));
+    ASSERT_TRUE(error.has_value());
+    EXPECT_TRUE(error->isAccessControl());
+}
+
+TEST(LocalNetworkAccess, UndeterminedConnectionSpaceIsBlockedByDefaultPermission)
+{
+    ResourceRequest request { URL { "https://example.com/"_s } };
+    auto clientOrigin = SecurityOriginData::fromURL(URL { "https://other.com/"_s });
+
+    auto error = performLocalNetworkAccessCheck(request, IPAddressSpace::Unknown, IPAddressSpace::Public, true, clientOrigin, permissionCheckReturning(LocalNetworkAccessPermissionDecision::Denied));
+    ASSERT_TRUE(error.has_value());
+    EXPECT_TRUE(error->isAccessControl());
+}
+
+TEST(LocalNetworkAccess, UndeterminedConnectionSpaceCanStillBeGranted)
+{
+    ResourceRequest request { URL { "https://example.com/"_s } };
+    auto clientOrigin = SecurityOriginData::fromURL(URL { "https://other.com/"_s });
+
+    auto error = performLocalNetworkAccessCheck(request, IPAddressSpace::Unknown, IPAddressSpace::Public, true, clientOrigin, permissionCheckReturning(LocalNetworkAccessPermissionDecision::Granted));
+    EXPECT_FALSE(error.has_value());
+}
+
+TEST(LocalNetworkAccess, UndeterminedConnectionSpaceStillHonorsSameOriginTrustworthyExemption)
+{
+    ResourceRequest request { URL { "https://example.com/"_s } };
+    auto clientOrigin = SecurityOriginData::fromURL(URL { "https://example.com/"_s });
+
+    auto error = performLocalNetworkAccessCheck(request, IPAddressSpace::Unknown, IPAddressSpace::Public, true, clientOrigin, permissionCheckReturning(LocalNetworkAccessPermissionDecision::Denied));
+    EXPECT_FALSE(error.has_value());
+}
+
+} // namespace TestWebKitAPI


### PR DESCRIPTION
#### 0c9ffd53cb5aef3dec1709c040cba2fdb46a6ef5
<pre>
Add the Local Network Access check algorithm and a NetworkProcess-resident permission stub
<a href="https://bugs.webkit.org/show_bug.cgi?id=319907">https://bugs.webkit.org/show_bug.cgi?id=319907</a>
<a href="https://rdar.apple.com/182830329">rdar://182830329</a>

Reviewed by NOBODY (OOPS!).

Adds WebCore::performLocalNetworkAccessCheck(): a same-origin/trustworthy exemption, a
targetAddressSpace mismatch check, a publicness comparison via isLessPublicThan(), and a fail-closed
result for non-secure contexts. The permission decision is looked up via a NOESCAPE callback, since
WebCore can&apos;t link against the NetworkProcess-resident permission store directly.

Since no native prompt exists yet, adds a test-only stub: NetworkSession keeps a per-session
(origin, address space) -&gt; decision map, settable via a new AllowTestOnlyIPC-gated message reachable
from Internals. Prompt is treated as Denied for now.

* Source/WebCore/Headers.cmake:
* Source/WebCore/Modules/fetch/IPAddressSpace.h:
* Source/WebCore/Modules/fetch/LocalNetworkAccess.cpp: Added.
(WebCore::performLocalNetworkAccessCheck):
* Source/WebCore/Modules/fetch/LocalNetworkAccess.h: Added.
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/page/ChromeClient.h:
* Source/WebCore/testing/Internals.cpp:
(WebCore::toLocalNetworkAccessPermissionDecision):
(WebCore::Internals::setLocalNetworkAccessPermissionForTesting):
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp:
(WebKit::NetworkConnectionToWebProcess::setLocalNetworkAccessPermissionForTesting):
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h:
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in:
* Source/WebKit/NetworkProcess/NetworkSession.cpp:
(WebKit::NetworkSession::setLocalNetworkAccessPermissionForTesting):
(WebKit::NetworkSession::localNetworkAccessPermission):
* Source/WebKit/NetworkProcess/NetworkSession.h:
* Source/WebKit/Scripts/webkit/messages.py:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::setLocalNetworkAccessPermissionForTesting):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h:
* Tools/TestWebKitAPI/CMakeLists.txt:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebCore/LocalNetworkAccess.cpp: Added.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/493ed3a09269b4ba4e5afc559a4e75e271cd521b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176460 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50395 "Hash 493ed3a0 for PR 70064 does not build (failure)") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/44185 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/186061 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/138730 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178323 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51687 "Hash 493ed3a0 for PR 70064 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50079 "Hash 493ed3a0 for PR 70064 does not build (failure)") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/186061 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/138730 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179416 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/51687 "Hash 493ed3a0 for PR 70064 does not build (failure)") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/44185 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/186061 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/175783 "Passed tests") | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/51687 "Hash 493ed3a0 for PR 70064 does not build (failure)") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/50079 "Hash 493ed3a0 for PR 70064 does not build (failure)") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/186061 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/44185 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/51687 "Hash 493ed3a0 for PR 70064 does not build (failure)") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/44185 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34527 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/42124 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/50079 "Hash 493ed3a0 for PR 70064 does not build (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188484 "Built successfully") | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50060 "Hash 493ed3a0 for PR 70064 does not build (failure)") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/44185 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/146502 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/50744 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/44185 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/146312 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/50744 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/122948 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/117007 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49248 "Hash 493ed3a0 for PR 70064 does not build (failure)") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/44185 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/48650 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/48884 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/48709 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->