### PR TITLE
IdleDeadline::timeRemaining() recomputes the full idle deadline on every call

### DIFF
--- a/Source/WebCore/dom/WindowEventLoop.cpp
+++ b/Source/WebCore/dom/WindowEventLoop.cpp
@@ -213,6 +213,12 @@ std::optional<MonotonicTime> WindowEventLoop::nextScheduledWorkTime() const
 
 std::optional<MonotonicTime> WindowEventLoop::nextRenderingTime() const
 {
+    // Page::nextRenderingUpdateTimestamp() always returns the next update tick strictly
+    // after "now", so a previously computed tick remains correct for as long as "now"
+    // hasn't reached it yet, and self-invalidates the moment it does.
+    if (m_nextRenderingTimeCache && MonotonicTime::now() < *m_nextRenderingTimeCache)
+        return *m_nextRenderingTimeCache;
+
     std::optional<MonotonicTime> nextRenderingTime;
     const_cast<WindowEventLoop*>(this)->forEachAssociatedContext([&](ScriptExecutionContext& context) {
         RefPtr document = dynamicDowncast<Document>(context);
@@ -227,6 +233,7 @@ std::optional<MonotonicTime> WindowEventLoop::nextRenderingTime() const
         if (!nextRenderingTime || *renderingUpdateTimeForPage < *nextRenderingTime)
             nextRenderingTime = *renderingUpdateTimeForPage;
     });
+    m_nextRenderingTimeCache = nextRenderingTime;
     return nextRenderingTime;
 }
 

--- a/Source/WebCore/dom/WindowEventLoop.h
+++ b/Source/WebCore/dom/WindowEventLoop.h
@@ -104,6 +104,7 @@ private:
 
     MonotonicTime m_lastIdlePeriodStartTime;
     Seconds m_expectedIdleCallbackDuration { 4_ms };
+    mutable Markable<MonotonicTime> m_nextRenderingTimeCache;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 0e9ca8a16d40c7e86e8ac442d395eee0163da26e
<pre>
IdleDeadline::timeRemaining() recomputes the full idle deadline on every call
<a href="https://bugs.webkit.org/show_bug.cgi?id=320134">https://bugs.webkit.org/show_bug.cgi?id=320134</a>
<a href="https://rdar.apple.com/183070665">rdar://183070665</a>

Reviewed by NOBODY (OOPS!).

IdleDeadline::timeRemaining() calls WindowEventLoop::computeIdleDeadline(),
which walks every document/page in the same agent cluster via
nextRenderingTime() on every single call, unlike nextTimerFireTime(), which
is already cached. Callbacks that poll timeRemaining() in a tight work loop
repeat this walk on every call.

Cache the result in WindowEventLoop, mirroring the existing
m_nextTimerFireTimeCache. Page::nextRenderingUpdateTimestamp() always
returns the next update tick strictly after &quot;now&quot;, so a cached tick stays
correct until &quot;now&quot; reaches it, at which point the cache self-invalidates
and recomputes. A nullopt result (nothing scheduled) is never cached as a
sticky value, so a newly scheduled rendering update made from within the
idle callback itself (e.g. via requestAnimationFrame()) is still picked up
on the very next call.

Covered by existing tests; no new test added:
* LayoutTests/requestidlecallback/requestidlecallback-deadline-shortened-by-rendering-update.html
* LayoutTests/imported/w3c/web-platform-tests/requestidlecallback/deadline-max-rAF-dynamic.html

* Source/WebCore/dom/WindowEventLoop.cpp:
(WebCore::WindowEventLoop::nextRenderingTime const):
* Source/WebCore/dom/WindowEventLoop.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0e9ca8a16d40c7e86e8ac442d395eee0163da26e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176462 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50397 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44187 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186063 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/138732 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d8d5cd4f-26a2-437e-bc38-f08c79200eab) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178325 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51689 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50081 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137450 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96253 "2 flakes 5 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/90d85ab6-9689-4b35-9799-9ce40e70c377) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179418 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40935 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158229 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117925 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ee895e05-12bb-4984-aed3-231194b5d24c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39585 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37954 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150000 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37727 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34529 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42126 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42165 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188486 "Build is in progress. Recent messages:Printed configuration; Checked out pull request; Compiled WebKit (warnings)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50062 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146501 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50746 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34345 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146311 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41073 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122950 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117009 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49250 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12702 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48652 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48886 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48711 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->