### PR TITLE
[Site Isolation] Loopback/local-network sites should not enter shared process

### DIFF
--- a/Source/WebCore/Modules/fetch/IPAddressSpace.cpp
+++ b/Source/WebCore/Modules/fetch/IPAddressSpace.cpp
@@ -27,6 +27,7 @@
 #include "IPAddressSpace.h"
 
 #include "DNS.h"
+#include "Site.h"
 #include <array>
 #include <wtf/URL.h>
 #include <wtf/Vector.h>
@@ -136,14 +137,23 @@ static IPAddressSpace classifyHost(String host)
     return IPAddressSpace::Public;
 }
 
-IPAddressSpace determineIPAddressSpace(const URL& url)
+static IPAddressSpace determineIPAddressSpaceFromHost(StringView host)
 {
     // Defined in https://wicg.github.io/local-network-access/#ip-address-space-section
-    StringView host = url.host();
     if (host.startsWith('[') && host.endsWith(']'))
         host = host.substring(1, host.length() - 2);
 
     return classifyHost(host.toString());
+}
+
+IPAddressSpace determineIPAddressSpace(const URL& url)
+{
+    return determineIPAddressSpaceFromHost(url.host());
+}
+
+IPAddressSpace determineIPAddressSpace(const Site& site)
+{
+    return determineIPAddressSpaceFromHost(site.domain().string());
 }
 
 #if OS(UNIX)

--- a/Source/WebCore/Modules/fetch/IPAddressSpace.h
+++ b/Source/WebCore/Modules/fetch/IPAddressSpace.h
@@ -29,6 +29,8 @@ namespace WebCore {
 
 class IPAddress;
 
+class Site;
+
 enum class IPAddressSpace : uint8_t {
     Public,
     Local,
@@ -57,6 +59,7 @@ inline bool isLessPublicThan(IPAddressSpace a, IPAddressSpace b)
 }
 
 WEBCORE_EXPORT IPAddressSpace determineIPAddressSpace(const WTF::URL&);
+WEBCORE_EXPORT IPAddressSpace determineIPAddressSpace(const Site&);
 
 WEBCORE_EXPORT IPAddressSpace classifyIPAddressSpace(const IPAddress&);
 

--- a/Source/WebKit/UIProcess/BrowsingContextGroup.cpp
+++ b/Source/WebKit/UIProcess/BrowsingContextGroup.cpp
@@ -37,6 +37,8 @@
 #include "WebPageProxy.h"
 #include "WebProcessPool.h"
 #include "WebProcessProxy.h"
+#include <WebCore/IPAddressSpace.h>
+#include <WebCore/SecurityOrigin.h>
 
 namespace WebKit {
 
@@ -46,13 +48,25 @@ BrowsingContextGroup::BrowsingContextGroup() = default;
 
 BrowsingContextGroup::~BrowsingContextGroup() = default;
 
+static bool isLoopbackOrLocalNetworkSite(const Site& site)
+{
+    if (determineIPAddressSpace(site) != IPAddressSpace::Public)
+        return true;
+    return SecurityOrigin::isLocalHostOrLoopbackIPAddress(site.domain().string());
+}
+
 void BrowsingContextGroup::sharedProcessForSite(WebsiteDataStore& websiteDataStore, API::WebsitePolicies* websitePolicies, const WebPreferences& preferences, const WebCore::Site& site, const WebCore::Site& mainFrameSite,
     WebProcessProxy::LockdownMode lockdownMode, EnhancedSecurity enhancedSecurity, API::PageConfiguration& pageConfiguration, IsMainFrame isMainFrame, CompletionHandler<void(FrameProcess*)>&& completionHandler)
 {
     if (!preferences.siteIsolationEnabled() || !preferences.siteIsolationSharedProcessEnabled())
         return completionHandler(nullptr);
+
     if (site.isEmpty() || m_processMap.contains(site))
         return completionHandler(nullptr);
+
+    if (isLoopbackOrLocalNetworkSite(site))
+        return completionHandler(nullptr);
+
     if (!m_sharedProcessSites.contains(site)) {
         if (isMainFrame == IsMainFrame::Yes)
             return completionHandler(nullptr);

--- a/Tools/TestWebKitAPI/Tests/WebCore/IPAddressSpaceTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/IPAddressSpaceTests.cpp
@@ -28,6 +28,7 @@
 #include <WebCore/DNS.h>
 #include <WebCore/IPAddressSpace.h>
 #include <WebCore/ResourceResponse.h>
+#include <WebCore/Site.h>
 #include <wtf/URL.h>
 
 namespace TestWebKitAPI {
@@ -316,6 +317,22 @@ TEST(IPAddressSpace, ResourceResponseAddressSpaceDefaultsToUnknown)
 
     response.setIPAddressSpace(WebCore::IPAddressSpace::Local);
     EXPECT_EQ(response.ipAddressSpace(), WebCore::IPAddressSpace::Local);
+}
+
+TEST(IPAddressSpace, SiteMatchesURLForIPLiterals)
+{
+    EXPECT_EQ(WebCore::determineIPAddressSpace(WebCore::Site(URL("http://127.0.0.1/"_s))), WebCore::IPAddressSpace::Loopback);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(WebCore::Site(URL("http://[::1]/"_s))), WebCore::IPAddressSpace::Loopback);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(WebCore::Site(URL("http://192.168.1.1/"_s))), WebCore::IPAddressSpace::Local);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(WebCore::Site(URL("http://[fc00::1]/"_s))), WebCore::IPAddressSpace::Local);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(WebCore::Site(URL("http://8.8.8.8/"_s))), WebCore::IPAddressSpace::Public);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(WebCore::Site(URL("https://example.com/"_s))), WebCore::IPAddressSpace::Public);
+}
+
+TEST(IPAddressSpace, SiteDoesNotSpecialCaseLocalhostName)
+{
+    // determineIPAddressSpace currently only classifies IP literals.
+    EXPECT_EQ(WebCore::determineIPAddressSpace(WebCore::Site(URL("http://localhost/"_s))), WebCore::IPAddressSpace::Public);
 }
 
 }

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
@@ -6966,6 +6966,48 @@ TEST(SiteIsolation, SharedProcessSameOrigin)
     });
 }
 
+TEST(SiteIsolation, SharedProcessExcludesLoopback)
+{
+    HTTPServer localServer({
+        { "/local"_s, { "hi"_s } },
+    }, HTTPServer::Protocol::Https);
+
+    HTTPServer server({
+        { "/example"_s, { makeString("<!DOCTYPE html><iframe src='https://webkit.org/webkit'></iframe><iframe src='https://apple.com/apple'></iframe><iframe src='https://127.0.0.1:"_s, localServer.port(), "/local'></iframe>"_s) } },
+        { "/webkit"_s, { "hi"_s } },
+        { "/apple"_s, { "hi"_s } },
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    [navigationDelegate allowAnyTLSCertificate];
+    RetainPtr storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
+    [storeConfiguration setHTTPSProxy:[NSURL URLWithString:[NSString stringWithFormat:@"https://127.0.0.1:%d/", server.port()]]];
+    RetainPtr viewConfiguration = adoptNS([WKWebViewConfiguration new]);
+    [viewConfiguration setWebsiteDataStore:adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]).get()];
+    enableSiteIsolation(viewConfiguration.get());
+    enableFeature(viewConfiguration.get(), @"SiteIsolationSharedProcessEnabled");
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:viewConfiguration.get()]);
+    webView.get().navigationDelegate = navigationDelegate.get();
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/example"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    checkFrameTreesInProcesses(webView.get(), {
+        {
+            "https://example.com"_s,
+            { { RemoteFrame }, { RemoteFrame }, { RemoteFrame } }
+        },
+        {
+            RemoteFrame,
+            { { "https://webkit.org"_s }, { "https://apple.com"_s }, { RemoteFrame } }
+        },
+        {
+            RemoteFrame,
+            { { RemoteFrame }, { RemoteFrame }, { makeString("https://127.0.0.1:"_s, localServer.port()) } }
+        },
+    });
+}
+
 TEST(SiteIsolation, SharedProcessLoadIsolatedSiteInSubframeOfNewWindow)
 {
     HTTPServer server({


### PR DESCRIPTION
#### 43701fcf3eede83baf3a124ad8359677ba3619e7
<pre>
[Site Isolation] Loopback/local-network sites should not enter shared process
<a href="https://bugs.webkit.org/show_bug.cgi?id=320135">https://bugs.webkit.org/show_bug.cgi?id=320135</a>
<a href="https://rdar.apple.com/183071225">rdar://183071225</a>

Reviewed by Ryosuke Niwa.

Site Isolation&apos;s shared process mode puts multiple cross-site frames into one WebProcess for performance, trading away
some of the process-boundary protection between the co-located sites. Loopback/local-network endpoints (routers,
printers, NAS boxes, local dev servers) often expose sensitive data or privileged functionality behind weak or no
authentication, so colocating them with an arbitrary other site&apos;s renderer increases the blast radius of a renderer
compromise. Therefore, exclude them from the shared process pool.

BrowsingContextGroup::sharedProcessForSite now bails out for any site whose host is a loopback/local-network IP literal
or a literal localhost/*.localhost.

Also, Added a WebCore::Site overload of determineIPAddressSpace() so the check can classify a Site the same way the
existing URL overload classifies a URL.

Test: TestWebKitAPI.IPAddressSpace
      TestWebKitAPI.SiteIsolation.SharedProcessExcludesLoopback

* Source/WebCore/Modules/fetch/IPAddressSpace.cpp:
(WebCore::determineIPAddressSpaceFromHost):
(WebCore::determineIPAddressSpace):
* Source/WebCore/Modules/fetch/IPAddressSpace.h:
* Source/WebKit/UIProcess/BrowsingContextGroup.cpp:
(WebKit::isLoopbackOrLocalNetworkSite):
(WebKit::BrowsingContextGroup::sharedProcessForSite):
* Tools/TestWebKitAPI/Tests/WebCore/IPAddressSpaceTests.cpp:
(TestWebKitAPI::TEST(IPAddressSpace, SiteMatchesURLForIPLiterals)):
(TestWebKitAPI::TEST(IPAddressSpace, SiteDoesNotSpecialCaseLocalhostName)):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm:
(TestWebKitAPI::(SiteIsolation, SharedProcessExcludesLoopback)):

Canonical link: <a href="https://commits.webkit.org/317865@main">https://commits.webkit.org/317865@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6b35e0ba60df649a249b5792dc65b307375a823c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176529 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50464 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44254 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186130 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/138803 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1d88fc0e-cd12-40b7-ba9e-caf9c70c48fb) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178392 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51756 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50148 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137512 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/138803 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/cbfbb34d-b6dc-4406-9de7-7120c3b90c09) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179485 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40997 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158283 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117987 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bcf21b40-5c0f-4277-b92d-75ec6fd939d2) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39647 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38013 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150062 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37781 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34598 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42196 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42224 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188553 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50129 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146563 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39425 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50813 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34406 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146373 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41131 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123017 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117082 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49317 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12756 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48719 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48953 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48778 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->