### PR TITLE
REGRESSION(317709@main): http/tests/site-isolation/history/back-iframe-cross-site-no-bf-cache.html crashes invalidating LogStream's IPC connection off the log work queue

### DIFF
--- a/Source/WebKit/Shared/LogStream.mm
+++ b/Source/WebKit/Shared/LogStream.mm
@@ -31,6 +31,7 @@
 #import "StreamConnectionWorkQueue.h"
 #import "StreamServerConnection.h"
 #import "WebProcessProxy.h"
+#import <wtf/NeverDestroyed.h>
 #import <wtf/OSObjectPtr.h>
 #import <wtf/TZoneMallocInlines.h>
 
@@ -45,6 +46,17 @@ namespace WebKit {
 static std::atomic<unsigned> globalLogCountForTesting { 0 };
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(LogStream);
+
+#if ENABLE(STREAMING_IPC_IN_LOG_FORWARDING)
+// All LogStreams share a single work queue: the StreamServerConnection for each LogStream is opened on
+// (and thus bound to) this queue, so all of its connection work -- including invalidate() -- must run
+// on it. See rdar://182244946 and the comment in stopListeningForIPC().
+static IPC::StreamConnectionWorkQueue& logWorkQueue()
+{
+    static NeverDestroyed<Ref<IPC::StreamConnectionWorkQueue>> queue = IPC::StreamConnectionWorkQueue::create("Log work queue"_s);
+    return queue.get();
+}
+#endif
 
 LogStream::LogStream(WebProcessProxy& process, Ref<ConnectionType>&& connection, LogStreamIdentifier identifier)
     : m_connection(WTF::move(connection))
@@ -67,8 +79,22 @@ void LogStream::stopListeningForIPC()
     // and invalidate() invalidates the underlying IPC::Connection so its Mach port / kqueue workloop is
     // released. Neither alone is sufficient; without this the connection leaked after the WebContent
     // process was gone, until the UI process was killed for resource exhaustion. See rdar://182244946.
-    m_connection->stopReceivingMessages(Messages::LogStream::messageReceiverName(), m_identifier.toUInt64());
-    m_connection->invalidate();
+    //
+    // The connection was opened on the log work queue, so it is bound to that queue's dispatcher and its
+    // teardown must run there too: IPC::Connection::invalidate() asserts it is called on its own
+    // dispatcher (a release ASSERT_WITH_SECURITY_IMPLICATION). Dispatch the teardown onto the queue
+    // rather than running it synchronously on the main thread. The queue is shared by every LogStream,
+    // so we must not stop it (unlike single-owner StreamServerConnection users, which can block in
+    // StreamConnectionWorkQueue::stopAndWaitForCompletion()); we only invalidate our own connection.
+    //
+    // We are typically the last reference holder (ScopedActiveMessageReceiveQueue drops its RefPtr as
+    // soon as this returns), so capture Ref to both the LogStream and its connection: invalidate()
+    // clears the connection's CheckedPtr back to us (the client), so the LogStream must outlive the
+    // dispatched teardown.
+    logWorkQueue().dispatch([protectedThis = Ref { *this }, connection = Ref { m_connection }, identifier = m_identifier] {
+        connection->stopReceivingMessages(Messages::LogStream::messageReceiverName(), identifier.toUInt64());
+        connection->invalidate();
+    });
 #endif
 }
 
@@ -123,12 +149,12 @@ RefPtr<LogStream> LogStream::create(WebProcessProxy& process, IPC::StreamServerC
         completionHandler(invalidWakeUpSemaphore, invalidClientWaitSemaphore);
         return nullptr;
     }
-    static NeverDestroyed<Ref<IPC::StreamConnectionWorkQueue>> logQueue = IPC::StreamConnectionWorkQueue::create("Log work queue"_s);
+    Ref logQueue = logWorkQueue();
 
     Ref instance = adoptRef(*new LogStream(process, connection.releaseNonNull(), identifier));
     instance->m_connection->open(instance.get(), logQueue.get());
     instance->m_connection->startReceivingMessages(instance, Messages::LogStream::messageReceiverName(), identifier.toUInt64());
-    completionHandler(logQueue.get()->wakeUpSemaphore(), instance->m_connection->clientWaitSemaphore());
+    completionHandler(logQueue->wakeUpSemaphore(), instance->m_connection->clientWaitSemaphore());
     return instance;
 }
 


### PR DESCRIPTION
#### c2562ee994064554fd397a4b23345ef63d039ae7
<pre>
REGRESSION(317709@main): http/tests/site-isolation/history/back-iframe-cross-site-no-bf-cache.html crashes invalidating LogStream&apos;s IPC connection off the log work queue
<a href="https://bugs.webkit.org/show_bug.cgi?id=320138">https://bugs.webkit.org/show_bug.cgi?id=320138</a>
<a href="https://rdar.apple.com/183053307">rdar://183053307</a>

Reviewed by Per Arne Vollan.

317709@main fixed a LogStream connection leak by having
LogStream::stopListeningForIPC() invalidate its StreamServerConnection&apos;s
underlying IPC::Connection. However, stopListeningForIPC() runs on the main
thread, while the LogStream&apos;s StreamServerConnection is opened on (and thus
bound to) the shared &quot;Log work queue&quot;. IPC::Connection::invalidate() asserts
it is called on its own dispatcher (a release
ASSERT_WITH_SECURITY_IMPLICATION via assertIsCurrent(dispatcher())), so
invalidating from the main thread crashed on ASAN/debug builds during
WebProcessProxy::shutDown() -&gt; stopLogStream().

Fix stopListeningForIPC() to dispatch the connection teardown
(stopReceivingMessages() + invalidate()) onto the log work queue so it runs
on the connection&apos;s own dispatcher. Unlike single-owner
StreamServerConnection users (e.g. RemoteRenderingBackend), we cannot call
StreamConnectionWorkQueue::stopAndWaitForCompletion() because the queue is
shared by every LogStream; we only invalidate our own connection.

The dispatched lambda captures a Ref to both the LogStream and its
connection. The connection Ref keeps the connection alive; the LogStream Ref
is required because StreamServerConnection::invalidate() clears its
CheckedPtr back to the client (m_client = nullptr), and the LogStream is
otherwise destroyed synchronously when ScopedActiveMessageReceiveQueue drops
its reference as soon as stopListeningForIPC() returns. LogStream is
ThreadSafeRefCounted with DestructionThread::Any, so destroying it (and its
WeakPtr&lt;WebProcessProxy&gt; member) off the main thread is safe.

Also hoist the log work queue from a static local in LogStream::create() to a
file-static logWorkQueue() accessor so stopListeningForIPC() can reach the
same queue.

* Source/WebKit/Shared/LogStream.mm:
(WebKit::logWorkQueue):
(WebKit::LogStream::stopListeningForIPC):
(WebKit::LogStream::create):

Canonical link: <a href="https://commits.webkit.org/317826@main">https://commits.webkit.org/317826@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/31e85644431b95f103860557a35ecd8488d5dd83

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176473 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50408 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44198 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186074 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/138744 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b6ccd302-6cb7-436a-828e-96bc296969c0) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51700 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50092 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137457 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/138744 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/cec17aed-7f3d-4eb8-aa2f-f3aef0024f3f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179429 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40947 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158238 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117932 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39597 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/37964 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150012 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37736 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34542 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/42138 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/42175 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188497 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50073 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146509 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39398 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50757 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/34354 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146319 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41085 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122961 "Build is in progress. Recent messages:") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117020 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49261 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12711 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48663 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48897 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48722 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->