### PR TITLE
[JSC] instanceof prototype-chain IC condition mismatch (release assertion)

### DIFF
--- a/JSTests/stress/instanceof-prototype-change-during-compilation.js
+++ b/JSTests/stress/instanceof-prototype-change-during-compilation.js
@@ -1,0 +1,61 @@
+"use strict";
+
+let globalSink = 0;
+
+function attempt(round) {
+  function rootACtor() { this.round = round; }
+    const rootA = new rootACtor();
+    const rootB = {};
+    const rootC = {};
+    const mid = {};
+    const leaf = {};
+
+    Object.setPrototypeOf(mid, rootA);
+    Object.setPrototypeOf(leaf, mid);
+
+    let tick = 0;
+    let sink = 0;
+
+    const proxyProto = new Proxy(rootB, {
+        getPrototypeOf(target) {
+            tick++;
+            if ((tick & 3) === 0)
+                Object.setPrototypeOf(mid, rootA);
+            return Reflect.getPrototypeOf(target);
+        }
+    });
+
+    const quietGate = { get trip() { return 1; } };
+    const noisyGate = {
+        get trip() {
+            tick++;
+            Object.setPrototypeOf(mid, (tick & 1) ? proxyProto : rootC);
+            return 1;
+        }
+    };
+
+    function hot(value, proto, gate) {
+        const guard = gate.trip;
+        const result = value instanceof proto;
+        sink ^= result ? guard : (guard << 1);
+        return result;
+    }
+
+    function drive(i) {
+        const gate = i < 42000 ? quietGate : noisyGate;
+        if (i === 42000)
+            Object.setPrototypeOf(mid, proxyProto);
+        return hot(leaf, rootACtor, gate);
+    }
+
+    for (let i = 0; i < 70000; i++)
+        drive(i);
+
+    globalSink ^= sink;
+}
+
+for (let round = 0; round < 8; round++)
+    attempt(round);
+
+if (globalSink === 0x12345678)
+    throw new Error("unreachable");

--- a/Source/JavaScriptCore/bytecode/ObjectPropertyConditionSet.cpp
+++ b/Source/JavaScriptCore/bytecode/ObjectPropertyConditionSet.cpp
@@ -479,7 +479,16 @@ ObjectPropertyConditionSet generateConditionsForInstanceOf(
             if (ObjectPropertyConditionSetInternal::verbose)
                 dataLog("Encountered object: ", RawPointer(object), "\n");
             if (object == prototype) {
-                RELEASE_ASSERT(shouldHit);
+                // The prototype chain can be mutated by user code (e.g. a Proxy
+                // getPrototypeOf trap or a getter) that runs while defaultHasInstance
+                // computes the instanceof result. When that happens, the chain we walk
+                // here may no longer match the result we observed, so we can reach the
+                // prototype even though the operation reported a miss (shouldHit is
+                // false). In that case there is no consistent IC to build, so bail out
+                // and let the caller fall back to the megamorphic case instead of
+                // caching a stale condition set.
+                if (!shouldHit) [[unlikely]]
+                    return false;
                 didHit = true;
                 return true;
             }
@@ -494,7 +503,8 @@ ObjectPropertyConditionSet generateConditionsForInstanceOf(
     if (result.isValid()) {
         if (ObjectPropertyConditionSetInternal::verbose)
             dataLog("didHit = ", didHit, ", shouldHit = ", shouldHit, "\n");
-        RELEASE_ASSERT(didHit == shouldHit);
+        if (didHit != shouldHit) [[unlikely]]
+            return ObjectPropertyConditionSet::invalid();
     }
     return result;
 }


### PR DESCRIPTION
#### 9fc2f58ca9fcd8d0977d0805f96e6cc9785e7490
<pre>
[JSC] instanceof prototype-chain IC condition mismatch (release assertion)
<a href="https://bugs.webkit.org/show_bug.cgi?id=318144">https://bugs.webkit.org/show_bug.cgi?id=318144</a>
<a href="https://rdar.apple.com/180959164">rdar://180959164</a>

Reviewed by Yusuke Suzuki.

While optimizing instanceof, we first compute the result then trigger the IC generation.
However, the prototype chain can be mutated by user code (e.g. a Proxy getPrototypeOf
trap or a getter) that runs while defaultHasInstance computes the instanceof result.
When that happens, the chain walked during inline cache generation may no longer match
the result we observed, so we can reach the prototype even though the operation reported
a miss (shouldHit is false). In that case there is no consistent IC to build, so bail out
and let the caller fall back to the megamorphic case instead of caching a stale condition set.

Test: JSTests/stress/instanceof-prototype-change-during-compilation.js
* JSTests/stress/instanceof-prototype-change-during-compilation.js: Added.
(attempt.rootACtor):
(attempt.const.quietGate.get trip):
(attempt.const.noisyGate.get trip):
(attempt.hot):
(attempt.drive):
(attempt):
* Source/JavaScriptCore/bytecode/ObjectPropertyConditionSet.cpp:
(JSC::generateConditionsForInstanceOf):

Canonical link: <a href="https://commits.webkit.org/317875@main">https://commits.webkit.org/317875@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4d2ea72c079a86c502f37e3c3f1aa4d13ec15014

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176574 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50509 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44299 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186175 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/139036 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ca8c4d94-4bb7-415c-8d43-83276e639a5f) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51801 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50193 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137543 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/139036 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c6bd5e97-39f4-4f40-a29e-9839220efd11) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179530 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41036 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158330 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118018 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7aa677b7-283d-4872-b470-48700944d6e8) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39686 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38063 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/6844 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150101 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37828 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34643 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/37842 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42244 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42279 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188598 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50174 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146601 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39428 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50858 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/34451 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146410 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41171 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123062 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117141 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49362 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12803 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48764 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48998 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48823 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->