### PR TITLE
[Site Isolation] Test camera, microphone, and display-capture permissions policy in cross-origin frames

### DIFF
--- a/LayoutTests/http/tests/site-isolation/permissions-api-camera-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/permissions-api-camera-expected.txt
@@ -1,0 +1,13 @@
+Verifies the camera Permissions API reflects permissions policy on cross-site frames
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS state is "denied"
+PASS event.origin is 'http://localhost:8000'
+PASS state === 'denied' is false
+PASS event.origin is 'http://localhost:8000'
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/site-isolation/permissions-api-camera.html
+++ b/LayoutTests/http/tests/site-isolation/permissions-api-camera.html
@@ -1,0 +1,32 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<script src="/js-test-resources/js-test.js"></script>
+<script>
+
+description("Verifies the camera Permissions API reflects permissions policy on cross-site frames");
+jsTestIsAsync = true;
+
+if (window.testRunner)
+    testRunner.setUserMediaPermission(true);
+
+onmessage = (event) => {
+    let iframe = document.getElementById("iframe");
+    if (iframe.getAttribute("allow") === "camera 'none'") {
+        state = event.data;
+        shouldBeEqualToString("state", "denied");
+        shouldBe("event.origin", "'http://localhost:8000'");
+
+        iframe.setAttribute("allow", "camera *");
+        iframe.src = "http://localhost:8000/site-isolation/resources/permissions-query-frame.html?name=camera&allow";
+    } else {
+        state = event.data;
+        shouldBeFalse("state === 'denied'");
+        shouldBe("event.origin", "'http://localhost:8000'");
+
+        finishJSTest();
+    }
+}
+
+</script>
+<body>
+<iframe id="iframe" allow="camera 'none'" src="http://localhost:8000/site-isolation/resources/permissions-query-frame.html?name=camera&deny"></iframe>
+</body>

--- a/LayoutTests/http/tests/site-isolation/permissions-api-microphone-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/permissions-api-microphone-expected.txt
@@ -1,0 +1,13 @@
+Verifies the microphone Permissions API reflects permissions policy on cross-site frames
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS state is "denied"
+PASS event.origin is 'http://localhost:8000'
+PASS state === 'denied' is false
+PASS event.origin is 'http://localhost:8000'
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/site-isolation/permissions-api-microphone.html
+++ b/LayoutTests/http/tests/site-isolation/permissions-api-microphone.html
@@ -1,0 +1,32 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<script src="/js-test-resources/js-test.js"></script>
+<script>
+
+description("Verifies the microphone Permissions API reflects permissions policy on cross-site frames");
+jsTestIsAsync = true;
+
+if (window.testRunner)
+    testRunner.setUserMediaPermission(true);
+
+onmessage = (event) => {
+    let iframe = document.getElementById("iframe");
+    if (iframe.getAttribute("allow") === "microphone 'none'") {
+        state = event.data;
+        shouldBeEqualToString("state", "denied");
+        shouldBe("event.origin", "'http://localhost:8000'");
+
+        iframe.setAttribute("allow", "microphone *");
+        iframe.src = "http://localhost:8000/site-isolation/resources/permissions-query-frame.html?name=microphone&allow";
+    } else {
+        state = event.data;
+        shouldBeFalse("state === 'denied'");
+        shouldBe("event.origin", "'http://localhost:8000'");
+
+        finishJSTest();
+    }
+}
+
+</script>
+<body>
+<iframe id="iframe" allow="microphone 'none'" src="http://localhost:8000/site-isolation/resources/permissions-query-frame.html?name=microphone&deny"></iframe>
+</body>

--- a/LayoutTests/http/tests/site-isolation/permissions-policy-camera-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/permissions-policy-camera-expected.txt
@@ -1,0 +1,15 @@
+CONSOLE MESSAGE: Permission policy 'Camera' check failed for document with origin 'http://localhost:8000'.
+CONSOLE MESSAGE: Not allowed to call getUserMedia.
+Verifies camera permissions policy is set correctly on cross-site frames
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS event.data is 'denied'
+PASS event.origin is 'http://localhost:8000'
+PASS event.data is 'granted'
+PASS event.origin is 'http://localhost:8000'
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/site-isolation/permissions-policy-camera.html
+++ b/LayoutTests/http/tests/site-isolation/permissions-policy-camera.html
@@ -1,0 +1,30 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<script src="/js-test-resources/js-test.js"></script>
+<script>
+
+description("Verifies camera permissions policy is set correctly on cross-site frames");
+jsTestIsAsync = true;
+
+if (window.testRunner)
+    testRunner.setUserMediaPermission(true);
+
+onmessage = (event) => {
+    let iframe = document.getElementById("iframe");
+    if (iframe.getAttribute("allow") === "camera 'none'") {
+        shouldBe("event.data", "'denied'");
+        shouldBe("event.origin", "'http://localhost:8000'");
+
+        iframe.setAttribute("allow", "camera *");
+        iframe.src = "http://localhost:8000/site-isolation/resources/getUserMedia-permission-frame.html?media=camera&allow";
+    } else {
+        shouldBe("event.data", "'granted'");
+        shouldBe("event.origin", "'http://localhost:8000'");
+
+        finishJSTest();
+    }
+}
+
+</script>
+<body>
+<iframe id="iframe" allow="camera 'none'" src="http://localhost:8000/site-isolation/resources/getUserMedia-permission-frame.html?media=camera&deny"></iframe>
+</body>

--- a/LayoutTests/http/tests/site-isolation/permissions-policy-display-capture-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/permissions-policy-display-capture-expected.txt
@@ -1,0 +1,15 @@
+CONSOLE MESSAGE: Permission policy 'DisplayCapture' check failed for document with origin 'http://localhost:8000'.
+CONSOLE MESSAGE: Not allowed to call getDisplayMedia.
+Verifies display-capture permissions policy is set correctly on cross-site frames
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS event.data is 'denied'
+PASS event.origin is 'http://localhost:8000'
+PASS event.data is 'granted'
+PASS event.origin is 'http://localhost:8000'
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/site-isolation/permissions-policy-display-capture.html
+++ b/LayoutTests/http/tests/site-isolation/permissions-policy-display-capture.html
@@ -1,0 +1,30 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<script src="/js-test-resources/js-test.js"></script>
+<script>
+
+description("Verifies display-capture permissions policy is set correctly on cross-site frames");
+jsTestIsAsync = true;
+
+if (window.testRunner)
+    testRunner.setUserMediaPermission(true);
+
+onmessage = (event) => {
+    let iframe = document.getElementById("iframe");
+    if (iframe.getAttribute("allow") === "display-capture 'none'") {
+        shouldBe("event.data", "'denied'");
+        shouldBe("event.origin", "'http://localhost:8000'");
+
+        iframe.setAttribute("allow", "display-capture *");
+        iframe.src = "http://localhost:8000/site-isolation/resources/getDisplayMedia-permission-frame.html?allow";
+    } else {
+        shouldBe("event.data", "'granted'");
+        shouldBe("event.origin", "'http://localhost:8000'");
+
+        finishJSTest();
+    }
+}
+
+</script>
+<body>
+<iframe id="iframe" allow="display-capture 'none'" src="http://localhost:8000/site-isolation/resources/getDisplayMedia-permission-frame.html?deny"></iframe>
+</body>

--- a/LayoutTests/http/tests/site-isolation/permissions-policy-microphone-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/permissions-policy-microphone-expected.txt
@@ -1,0 +1,15 @@
+CONSOLE MESSAGE: Permission policy 'Microphone' check failed for document with origin 'http://localhost:8000'.
+CONSOLE MESSAGE: Not allowed to call getUserMedia.
+Verifies microphone permissions policy is set correctly on cross-site frames
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS event.data is 'denied'
+PASS event.origin is 'http://localhost:8000'
+PASS event.data is 'granted'
+PASS event.origin is 'http://localhost:8000'
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/site-isolation/permissions-policy-microphone.html
+++ b/LayoutTests/http/tests/site-isolation/permissions-policy-microphone.html
@@ -1,0 +1,30 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<script src="/js-test-resources/js-test.js"></script>
+<script>
+
+description("Verifies microphone permissions policy is set correctly on cross-site frames");
+jsTestIsAsync = true;
+
+if (window.testRunner)
+    testRunner.setUserMediaPermission(true);
+
+onmessage = (event) => {
+    let iframe = document.getElementById("iframe");
+    if (iframe.getAttribute("allow") === "microphone 'none'") {
+        shouldBe("event.data", "'denied'");
+        shouldBe("event.origin", "'http://localhost:8000'");
+
+        iframe.setAttribute("allow", "microphone *");
+        iframe.src = "http://localhost:8000/site-isolation/resources/getUserMedia-permission-frame.html?media=microphone&allow";
+    } else {
+        shouldBe("event.data", "'granted'");
+        shouldBe("event.origin", "'http://localhost:8000'");
+
+        finishJSTest();
+    }
+}
+
+</script>
+<body>
+<iframe id="iframe" allow="microphone 'none'" src="http://localhost:8000/site-isolation/resources/getUserMedia-permission-frame.html?media=microphone&deny"></iframe>
+</body>

--- a/LayoutTests/http/tests/site-isolation/permissions-policy-sync-xhr-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/permissions-policy-sync-xhr-expected.txt
@@ -1,5 +1,5 @@
 CONSOLE MESSAGE: Permission policy 'SyncXHR' check failed for document with origin 'http://localhost:8000'.
-Verifies permissions policy is set correctly on cross-site frames
+Verifies sync-xhr permissions policy is set correctly on cross-site frames
 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 

--- a/LayoutTests/http/tests/site-isolation/permissions-policy-sync-xhr.html
+++ b/LayoutTests/http/tests/site-isolation/permissions-policy-sync-xhr.html
@@ -2,7 +2,7 @@
 <script src="/js-test-resources/js-test.js"></script>
 <script>
 
-description("Verifies permissions policy is set correctly on cross-site frames");
+description("Verifies sync-xhr permissions policy is set correctly on cross-site frames");
 jsTestIsAsync = true;
 
 onmessage = (event) => {

--- a/LayoutTests/http/tests/site-isolation/resources/getDisplayMedia-permission-frame.html
+++ b/LayoutTests/http/tests/site-isolation/resources/getDisplayMedia-permission-frame.html
@@ -1,0 +1,14 @@
+<script>
+window.internals.settings.setScreenCaptureEnabled(true);
+var streamPromise = null;
+window.internals.withUserGesture(() => {
+    streamPromise = navigator.mediaDevices.getDisplayMedia({ video: true });
+});
+streamPromise
+    .then(stream => {
+        stream.getTracks().forEach(track => track.stop());
+        window.parent.postMessage("granted", "*");
+    }).catch(error => {
+        window.parent.postMessage(error.name === "NotAllowedError" ? "denied" : `fail (${error.name})`, "*");
+    });
+</script>

--- a/LayoutTests/http/tests/site-isolation/resources/getUserMedia-permission-frame.html
+++ b/LayoutTests/http/tests/site-isolation/resources/getUserMedia-permission-frame.html
@@ -1,0 +1,15 @@
+<script>
+const media = new URLSearchParams(location.search).get("media");
+const constraints = media === "microphone" ? { audio: true } : { video: true };
+var streamPromise = null;
+window.internals.withUserGesture(() => {
+    streamPromise = navigator.mediaDevices.getUserMedia(constraints);
+});
+streamPromise
+    .then(stream => {
+        stream.getTracks().forEach(track => track.stop());
+        window.parent.postMessage("granted", "*");
+    }).catch(error => {
+        window.parent.postMessage(error.name === "NotAllowedError" ? "denied" : `fail (${error.name})`, "*");
+    });
+</script>

--- a/LayoutTests/http/tests/site-isolation/resources/permissions-query-frame.html
+++ b/LayoutTests/http/tests/site-isolation/resources/permissions-query-frame.html
@@ -1,0 +1,9 @@
+<script>
+const name = new URLSearchParams(location.search).get("name");
+navigator.permissions.query({ name })
+    .then(status => {
+        window.parent.postMessage(status.state, "*");
+    }).catch(error => {
+        window.parent.postMessage(`fail (${error.name})`, "*");
+    });
+</script>


### PR DESCRIPTION
#### 4893de6f65eec801340e27b932b8d5ebdc66891c
<pre>
[Site Isolation] Test camera, microphone, and display-capture permissions policy in cross-origin frames
<a href="https://bugs.webkit.org/show_bug.cgi?id=320139">https://bugs.webkit.org/show_bug.cgi?id=320139</a>
<a href="https://rdar.apple.com/183074348">rdar://183074348</a>

Reviewed by Jer Noble.

Added site-isolation layout tests that verify camera, microphone, and display-capture permissions
policy in cross-origin frames.

* LayoutTests/http/tests/site-isolation/permissions-api-camera-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/permissions-api-camera.html: Added.
* LayoutTests/http/tests/site-isolation/permissions-api-microphone-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/permissions-api-microphone.html: Added.
* LayoutTests/http/tests/site-isolation/permissions-policy-camera-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/permissions-policy-camera.html: Added.
* LayoutTests/http/tests/site-isolation/permissions-policy-display-capture-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/permissions-policy-display-capture.html: Added.
* LayoutTests/http/tests/site-isolation/permissions-policy-microphone-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/permissions-policy-microphone.html: Added.
* LayoutTests/http/tests/site-isolation/permissions-policy-sync-xhr-expected.txt: Renamed from LayoutTests/http/tests/site-isolation/permissions-policy-expected.txt.
* LayoutTests/http/tests/site-isolation/permissions-policy-sync-xhr.html: Renamed from LayoutTests/http/tests/site-isolation/permissions-policy.html.
* LayoutTests/http/tests/site-isolation/resources/getDisplayMedia-permission-frame.html: Added.
* LayoutTests/http/tests/site-isolation/resources/getUserMedia-permission-frame.html: Added.
* LayoutTests/http/tests/site-isolation/resources/permissions-query-frame.html: Added.

Canonical link: <a href="https://commits.webkit.org/317873@main">https://commits.webkit.org/317873@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6d542ead7e6efe2b0c2faa24a8c89e20aa84da15

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176485 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50420 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44210 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186086 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/138756 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a4e99d8e-6179-4e87-a939-2e05c3eab116) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51712 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50104 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137465 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/138756 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ba877024-e013-42ed-bf7b-3129afc9bcf5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179441 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40958 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158249 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117940 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f0c862bb-f2d8-459e-9557-2d477bc866ba) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39608 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37975 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150023 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37747 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34554 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42186 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188509 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50085 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/157794 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146521 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39430 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50769 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34365 "Found 1 new test failure: imported/w3c/web-platform-tests/largest-contentful-paint/observe-svg-data-uri-image.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146331 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41093 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117032 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49273 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12722 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48675 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48909 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48734 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->