### PR TITLE
Stuck hover popover after Back navigation restores a page from the back/forward cache

### DIFF
--- a/LayoutTests/fast/history/back-forward-cache-dismisses-hover-on-freeze-expected.txt
+++ b/LayoutTests/fast/history/back-forward-cache-dismisses-hover-on-freeze-expected.txt
@@ -1,0 +1,11 @@
+A hover-triggered popover (shown via onmouseover, hidden via onmouseout) must be dismissed after navigating away while hovering it and coming back via the back/forward cache, even if the mouse never moves again after the restore. Entering the back/forward cache tears down hover state internally but must also dispatch a real mouseout/mouseleave so page script can react, matching mouse-left-the-page behavior.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS document.getElementById('popover').style.display is "block"
+PASS document.getElementById('popover').style.display is "none"
+PASS document.getElementById('cluster').matches(':hover') is false
+PASS successfullyParsed is true
+
+TEST COMPLETE

--- a/LayoutTests/fast/history/back-forward-cache-dismisses-hover-on-freeze.html
+++ b/LayoutTests/fast/history/back-forward-cache-dismisses-hover-on-freeze.html
@@ -1,0 +1,59 @@
+<!-- webkit-test-runner [ UsesBackForwardCache=true ] -->
+<!DOCTYPE html>
+<html>
+<body>
+<div id="cluster" style="position:absolute; top:20px; left:20px; width:200px; height:100px; background:#ddd;"
+     onmouseover="document.getElementById('popover').style.display = 'block'"
+     onmouseout="document.getElementById('popover').style.display = 'none'">
+  Hover me
+  <a id="link" href="resources/page-cache-helper.html">go to page B</a>
+  <div id="popover" style="display:none; background:red; width:100px; height:40px;">POPOVER</div>
+</div>
+<script src="../../resources/js-test.js"></script>
+<script>
+description("A hover-triggered popover (shown via onmouseover, hidden via onmouseout) must be " +
+    "dismissed after navigating away while hovering it and coming back via the back/forward " +
+    "cache, even if the mouse never moves again after the restore. Entering the back/forward " +
+    "cache tears down hover state internally but must also dispatch a real mouseout/mouseleave " +
+    "so page script can react, matching mouse-left-the-page behavior.");
+window.jsTestIsAsync = true;
+
+if (window.testRunner)
+    testRunner.clearAllDatabases();
+
+window.addEventListener("pageshow", function(event) {
+    if (!event.persisted)
+        return;
+
+    // Deliberately do NOT move the mouse here -- the fix must dismiss the popover as a result of
+    // freeze-time mouseout/mouseleave dispatch alone, without relying on any further mouse
+    // movement after the page is restored.
+    shouldBeEqualToString("document.getElementById('popover').style.display", "none");
+    shouldBeFalse("document.getElementById('cluster').matches(':hover')");
+    finishJSTest();
+});
+
+function runTest()
+{
+    if (!window.eventSender) {
+        testFailed("This test requires eventSender.");
+        finishJSTest();
+        return;
+    }
+
+    var clusterRect = document.getElementById("cluster").getBoundingClientRect();
+    eventSender.mouseMoveTo(clusterRect.left + 10, clusterRect.top + 10);
+    shouldBeEqualToString("document.getElementById('popover').style.display", "block");
+
+    // Click the link inside the still-hovered cluster to navigate away, mirroring the reported
+    // steps to reproduce (hover a cluster, then click a link inside it).
+    var linkRect = document.getElementById("link").getBoundingClientRect();
+    eventSender.mouseMoveTo(linkRect.left + linkRect.width / 2, linkRect.top + linkRect.height / 2);
+    eventSender.mouseDown();
+    eventSender.mouseUp();
+}
+
+window.addEventListener("load", runTest);
+</script>
+</body>
+</html>

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -7681,6 +7681,15 @@ void Document::setBackForwardCacheState(BackForwardCacheState state)
             idbConnectionProxy->setContextSuspended(*scriptExecutionContext(), false);
         break;
     case AboutToEnterBackForwardCache:
+        // Render tree teardown (Page::willEnterBackForwardCache() -> destroyRenderTrees()) clears hover
+        // state as a side effect, but never dispatches mouseout/mouseleave, so a JS onmouseout handler
+        // (e.g. one that hides a hover-triggered popover) would otherwise never run for whatever was
+        // hovered at freeze time. Fire it now, synchronously, while script is still allowed to run and the
+        // DOM is fully live, so any resulting change (like hiding the popover) is baked into the state that
+        // gets cached and later restored, even if the mouse never moves again after a restore
+        // (rdar://161198753).
+        if (RefPtr frame = this->frame())
+            frame->eventHandler().clearHoveredElementAndDispatchMouseOutIfNeeded();
         break;
     }
 }

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -3262,6 +3262,24 @@ void EventHandler::updateMouseEventTargetAfterLayoutIfNeeded()
     }
 }
 
+void EventHandler::clearHoveredElementAndDispatchMouseOutIfNeeded()
+{
+    if (!m_elementUnderMouse)
+        return;
+
+    RefPtr document = m_frame->document();
+
+    auto modifiers = PlatformKeyboardEvent::currentStateOfModifierKeys();
+    PlatformMouseEvent syntheticEvent(valueOrDefault(m_lastKnownMousePosition), m_lastKnownMouseGlobalPosition,
+        MouseButton::None, PlatformEvent::Type::NoType, 0, modifiers, MonotonicTime::now(), 0, SyntheticClickType::NoTap, MouseEventInputSource::UserDriven);
+
+    // A null target makes updateMouseEventTargetNode() diff the current hover chain against nothing,
+    // i.e. fire mouseout/mouseleave for everything currently hovered, as if the mouse left the page.
+    updateMouseEventTargetNode(eventNames().mousemoveEvent, nullptr, syntheticEvent, FireMouseOverOut::Yes);
+    if (document)
+        document->updateHoverActiveState(hoverTimerHitType, nullptr);
+}
+
 void EventHandler::notifyScrollableAreasOfMouseEvents(const AtomString& eventType, Element* lastElementUnderMouse, Element* elementUnderMouse)
 {
     Ref frame = m_frame.get();

--- a/Source/WebCore/page/EventHandler.h
+++ b/Source/WebCore/page/EventHandler.h
@@ -185,6 +185,13 @@ public:
     WEBCORE_EXPORT void dispatchFakeMouseMoveEventSoon();
     void dispatchFakeMouseMoveEventSoonInQuad(const FloatQuad&);
 
+    // Synchronously dispatches mouseout/mouseleave for the currently hovered element chain, as if the
+    // mouse left the page. Used when a page is about to enter the back/forward cache: render tree teardown
+    // will otherwise silently clear hover state with no event dispatch, leaving hover-driven UI (e.g. a
+    // popover shown by a mouseover handler) stuck visible even if the mouse never moves again after a
+    // later restore (rdar://161198753).
+    void clearHoveredElementAndDispatchMouseOutIfNeeded();
+
     WEBCORE_EXPORT HitTestResult hitTestResultAtPoint(const LayoutPoint& pointInContentsCoordinateSpace, OptionSet<HitTestRequest::Type>) const;
 
     bool mousePressed() const { return m_mousePressed; }


### PR DESCRIPTION
rdar://161198753

A page that shows/hides UI (e.g. a popover) via mouseover/mouseout handlers can get stuck showing that UI after the user clicks a link inside it, navigates away, and comes back via the back/forward cache — if the mouse never moves again after the restore.

**Root cause:** entering the back/forward cache tears down the render tree (`Page::willEnterBackForwardCache()` -> `destroyRenderTrees()`), which clears hover state as a side effect but never dispatches `mouseout`/`mouseleave`. Any JS handler that would normally undo the hover effect never runs, and since `EventHandler::clear()` also resets the last-known mouse position on restore, nothing re-evaluates hover state unless the mouse genuinely moves again.

**Fix:** dispatch the real `mouseout`/`mouseleave` events synchronously at freeze time, while the DOM/script are still live — `EventHandler::clearHoveredElementAndDispatchMouseOutIfNeeded()`, called from `Document::setBackForwardCacheState()`'s `AboutToEnterBackForwardCache` case, before render-tree teardown. Any resulting JS-driven UI change is baked into the state that gets cached and restored, independent of later mouse movement.

Verified via MCP browser automation against the confirmed repro (fixed: popover no longer stuck after Back + mouse-away) and regression checks (normal hover/unhover, repeated freeze/thaw, mouse-still-hovering-at-freeze edge case).

Added `LayoutTests/fast/history/back-forward-cache-dismisses-hover-on-freeze.html` as a regression test. Note: this test could not be run locally (sandboxed environment lacks a valid WebKitTestRunner code-signing identity) - please double check the expected output on EWS.
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/623b413d9e47a2e638494104353ccf376ca25c19

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176483 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50418 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/44208 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/186084 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/138754 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178346 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51710 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50102 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/186084 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/138754 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179439 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/40956 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/44208 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/186084 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/39606 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/37973 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/186084 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/44208 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/150021 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/44208 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34552 "Failed to checkout and rebase branch from PR 70074") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/42148 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/42184 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188507 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50083 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/44208 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/146519 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50767 "Failed to checkout and rebase branch from PR 70074") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/44208 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/146329 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/160/builds/50767 "Failed to checkout and rebase branch from PR 70074") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/122971 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/117030 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49271 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/44208 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48673 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/48907 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/48732 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->