### PR TITLE
Repaint artifacts on techmeme.com after returning to the page with the back button

### DIFF
--- a/LayoutTests/fast/repaint/out-of-flow-inside-relative-inline-expected.txt
+++ b/LayoutTests/fast/repaint/out-of-flow-inside-relative-inline-expected.txt
@@ -1,7 +1,7 @@
 PASS if no red
 (repaint rects
   (rect 8 8 100 40)
-  (rect 108 26 80 80)
+  (rect 203 26 80 80)
   (rect 8 8 100 40)
   (rect 0 26 10 10)
 )

--- a/Source/WebCore/rendering/updating/RenderTreeUpdater.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeUpdater.cpp
@@ -792,6 +792,23 @@ static std::optional<DidRepaintAndMarkContainingBlock> repaintAndMarkContainingB
             // necessarily enclose this box.
             return destroyRootWithLayer->layer()->needsFullRepaint() || destroyRootWithLayer->isOutOfFlowPositioned();
         };
+
+        auto repaintUsingCachedRectIfNeeded = [&] {
+            if (!destroyRoot.hasLayer() || !destroyRoot.isOutOfFlowPositioned())
+                return false;
+            CheckedPtr container = destroyRoot.container();
+            if (!container || !container->isInFlowPositioned() || !is<RenderInline>(*container))
+                return false;
+            CheckedPtr layer = downcast<RenderLayerModelObject>(destroyRoot).layer();
+            auto cachedRepaintRect = layer->cachedClippedOverflowRect();
+            if (!cachedRepaintRect)
+                return false;
+            destroyRoot.repaintUsingContainer(layer->repaintContainer(), *cachedRepaintRect, false);
+            return true;
+        };
+        if (repaintUsingCachedRectIfNeeded())
+            return;
+
         destroyRoot.repaint(shouldForceRepaint() ? RenderObject::ForceRepaint::Yes : RenderObject::ForceRepaint::No);
     };
 


### PR DESCRIPTION
#### a60246ff6a2efda4643bff69a44dc873094415cf
<pre>
Repaint artifacts on techmeme.com after returning to the page with the back button
<a href="https://bugs.webkit.org/show_bug.cgi?id=320674">https://bugs.webkit.org/show_bug.cgi?id=320674</a>
<a href="https://rdar.apple.com/161198753">rdar://161198753</a>

Reviewed by Simon Fraser.

Showing one preview popover and hiding another land in the same render tree
update. Attaching the new out-of-flow box discards the paragraph&apos;s line layout,
so when the old box is torn down RenderInline::offsetForInFlowPositionedInline
can no longer find the anchor inline&apos;s first line box and falls back to a zero
offset. The repaint is issued at the right size but the wrong origin, leaving
the pixels the box painted on screen.

Repaint using the rect the layer cached while the geometry was still resolvable.
Limited to tearing down an out-of-flow box whose container is an in-flow
positioned inline.

Follow-ups: offsetForInFlowPositionedInline cannot signal failure, since
computeVisibleRectsInContainer already uses std::nullopt for &quot;nothing to
repaint&quot;; and invalidateLineLayout&apos;s InsertionOrRemoval path lacks the
InlineWalker repaint that ContentChange does before dropping line layout.

out-of-flow-inside-relative-inline.html covers this and had the displaced rect
baked into its baseline, so its &quot;PASS if no red&quot; was never actually met.
Rebaselined.

* LayoutTests/fast/repaint/out-of-flow-inside-relative-inline-expected.txt:
* Source/WebCore/rendering/updating/RenderTreeUpdater.cpp:
(WebCore::repaintAndMarkContainingBlockDirtyBeforeTearDown):

Canonical link: <a href="https://commits.webkit.org/318277@main">https://commits.webkit.org/318277@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e18a9a74fdcd4e3dd81f57fbca4d59dcdcfbf1db

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177849 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; check-webkit-style") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51787 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45581 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187459 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/141096 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179712 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53079 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51496 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/138621 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/141096 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180805 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42152 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/159369 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119084 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40815 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/39175 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151220 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38864 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35920 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/44378 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/43411 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189888 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51454 "Built successfully") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/147742 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39684 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52136 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/35493 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147528 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42241 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/124388 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118819 "Failed to checkout and rebase branch from PR 70075") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50644 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/13843 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50040 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/50280 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50102 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->