### PR TITLE
(317709@main) ASSERTION FAILED: queue.isCurrent()

### DIFF
--- a/Source/WebKit/Shared/LogStream.mm
+++ b/Source/WebKit/Shared/LogStream.mm
@@ -46,6 +46,14 @@ static std::atomic<unsigned> globalLogCountForTesting { 0 };
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(LogStream);
 
+#if ENABLE(STREAMING_IPC_IN_LOG_FORWARDING)
+static IPC::StreamConnectionWorkQueue& logWorkQueueSingleton()
+{
+    static NeverDestroyed<Ref<IPC::StreamConnectionWorkQueue>> queue = IPC::StreamConnectionWorkQueue::create("Log work queue"_s);
+    return queue.get().get();
+}
+#endif
+
 LogStream::LogStream(WebProcessProxy& process, Ref<ConnectionType>&& connection, LogStreamIdentifier identifier)
     : m_connection(WTF::move(connection))
 #if ENABLE(STREAMING_IPC_IN_LOG_FORWARDING)
@@ -68,7 +76,10 @@ void LogStream::stopListeningForIPC()
     // released. Neither alone is sufficient; without this the connection leaked after the WebContent
     // process was gone, until the UI process was killed for resource exhaustion. See rdar://182244946.
     m_connection->stopReceivingMessages(Messages::LogStream::messageReceiverName(), m_identifier.toUInt64());
-    m_connection->invalidate();
+    // invalidate() asserts it is called on the connection's own dispatcher.
+    logWorkQueueSingleton().dispatch([connection = m_connection] {
+        connection->invalidate();
+    });
 #endif
 }
 
@@ -123,12 +134,10 @@ RefPtr<LogStream> LogStream::create(WebProcessProxy& process, IPC::StreamServerC
         completionHandler(invalidWakeUpSemaphore, invalidClientWaitSemaphore);
         return nullptr;
     }
-    static NeverDestroyed<Ref<IPC::StreamConnectionWorkQueue>> logQueue = IPC::StreamConnectionWorkQueue::create("Log work queue"_s);
-
     Ref instance = adoptRef(*new LogStream(process, connection.releaseNonNull(), identifier));
-    instance->m_connection->open(instance.get(), logQueue.get());
+    instance->m_connection->open(instance.get(), logWorkQueueSingleton());
     instance->m_connection->startReceivingMessages(instance, Messages::LogStream::messageReceiverName(), identifier.toUInt64());
-    completionHandler(logQueue.get()->wakeUpSemaphore(), instance->m_connection->clientWaitSemaphore());
+    completionHandler(logWorkQueueSingleton().wakeUpSemaphore(), instance->m_connection->clientWaitSemaphore());
     return instance;
 }
 


### PR DESCRIPTION
#### 12569689f868b096c6adab7abdd17fa08b2fc346
<pre>
(<a href="https://commits.webkit.org/317709@main">317709@main</a>) ASSERTION FAILED: queue.isCurrent()
<a href="https://bugs.webkit.org/show_bug.cgi?id=320143">https://bugs.webkit.org/show_bug.cgi?id=320143</a>
<a href="https://rdar.apple.com/183082248">rdar://183082248</a>

Reviewed by NOBODY (OOPS!).

invalidate() asserts it is called on the connection&apos;s own dispatcher,
so dispatch it there first.

* Source/WebKit/Shared/LogStream.mm:
(WebKit::logWorkQueueSingleton):
(WebKit::LogStream::stopListeningForIPC):
(WebKit::LogStream::create):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/12569689f868b096c6adab7abdd17fa08b2fc346

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176497 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50432 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44222 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186098 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/138768 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/70c20fcc-59ff-4120-b55c-48ca2ac2ddef) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51724 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50116 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137479 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/138768 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3db78b0a-4e18-4ebc-9ef7-637d70b9e5e3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179453 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40971 "Found 60 new test failures: accessibility/aria-actions.html accessibility/aria-owns-text-stitching.html accessibility/attachment-element.html accessibility/attributed-string-text-stitching.html accessibility/changing-aria-hidden-with-display-none-parent.html accessibility/dirty-relations-and-modal-tree-update-crash.html accessibility/display-contents/dynamically-added-children.html accessibility/dynamic-text-stitching.html accessibility/ios-simulator/aria-notify.html accessibility/ios-simulator/attributed-string-for-range.html ... (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158254 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117954 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f47aa3be-a9aa-4c8d-a054-9adbbefd3bf5) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39621 "Found 60 new test failures: imported/w3c/web-platform-tests/FileAPI/reading-data-section/filereader_readAsText.any.worker.html imported/w3c/web-platform-tests/FileAPI/url/cross-global-revoke.sub.html imported/w3c/web-platform-tests/FileAPI/url/url-format.any.html imported/w3c/web-platform-tests/FileAPI/url/url-in-tags.window.html imported/w3c/web-platform-tests/IndexedDB/back-forward-cache-open-transaction.window.html imported/w3c/web-platform-tests/IndexedDB/delete-range.any.html imported/w3c/web-platform-tests/IndexedDB/idb-partitioned-persistence.sub.html imported/w3c/web-platform-tests/IndexedDB/serialize-sharedarraybuffer-throws.https.html imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any.html?1-1000 imported/w3c/web-platform-tests/beacon/headers/header-referrer-same-origin.html ... (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37987 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150036 "Found 163 new API test failures: TestWebKitAPI.SiteIsolation.LoadStringAfterOpen, TestWebKitAPI.ProcessSwap.KillProvisionalWebContentProcessThenStartNewLoad, TestWebKitAPI.WebKit.DoAfterNextStablePresentationUpdateAfterCrash, TestWebKitAPI.SiteIsolation.WindowOpenRedirect, TestWebKitAPI.WKNavigation.PreferredHTTPSPolicyAutomaticHTTPFallbackAfterSessionRestore, TestWebKitAPI.WKWebExtensionAPIRuntime.StartupEvent, TestWebKitAPI.TimeBasedEviction.ThrottledToConfiguredInterval, TestWebKitAPI.WebKit.WebsiteDataStoreRenameOrigin, TestWebKitAPI.WebKit.DownloadNavigationResponseFromMemoryCache, TestWebKitAPI.WKNavigation.PreferredHTTPSPolicyAutomaticHTTPFallbackHTTPDowngradeAndSameSiteNavigation ... (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37752 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34566 "Built successfully") | | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42162 "Failed to checkout and rebase branch from PR 70077") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/42198 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188521 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50097 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146532 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50781 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/34370 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146342 "Passed tests") | | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41101 "Found 41 new test failures: cookies/cookie-store-start-listening-for-change-with-null-url-crash.html fast/images/spatial-image-controls-rtl.html http/tests/pdf/linearized-pdf-in-display-none-iframe.html http/tests/pdf/page-in-window-update-with-linearized-pdf-in-display-none-iframe.html http/tests/security/model-element/exit-immersive-by-navigating-iframe.html imported/w3c/web-platform-tests/webxr/events_input_source_recreation.https.html interaction-region/aria-roles.html interaction-region/clip-path-with-label.html interaction-region/consolidated-nested-regions.html interaction-region/content-hint.html ... (failure)") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122985 "Failed to checkout and rebase branch from PR 70077") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117046 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49285 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12727 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48687 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48921 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48746 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->