### PR TITLE
[JSC] Remove `AbstractModuleRecord::m_dependencies`

### DIFF
--- a/Source/JavaScriptCore/runtime/AbstractModuleRecord.cpp
+++ b/Source/JavaScriptCore/runtime/AbstractModuleRecord.cpp
@@ -97,8 +97,6 @@ void AbstractModuleRecord::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     visitor.append(thisObject->m_asyncCapability);
     Locker locker { thisObject->cellLock() };
     visitor.append(thisObject->m_asyncParentModules.begin(), thisObject->m_asyncParentModules.end());
-    auto values = thisObject->m_dependencies.values();
-    visitor.append(values.begin(), values.end());
     for (const auto& [key, loadedModule] : thisObject->m_loadedModules)
         visitor.append(loadedModule.m_module);
 }
@@ -203,11 +201,13 @@ auto AbstractModuleRecord::Resolution::ambiguous() -> Resolution
     return Resolution { Type::Ambiguous, nullptr, Identifier() };
 }
 
-AbstractModuleRecord* AbstractModuleRecord::hostResolveImportedModule(JSGlobalObject* globalObject, const Identifier& moduleName)
+AbstractModuleRecord* AbstractModuleRecord::hostResolveImportedModule(JSGlobalObject*, const Identifier& moduleName)
 {
-    if (auto iter = m_dependencies.find(moduleName.string()); iter != m_dependencies.end())
-        return iter->value.get();
-    return globalObject->moduleLoader()->maybeGetImportedModule(this, moduleName);
+    for (auto type : { ScriptFetchParameters::Type::JavaScript, ScriptFetchParameters::Type::JSON, ScriptFetchParameters::Type::WebAssembly, ScriptFetchParameters::Type::None }) {
+        if (auto iter = m_loadedModules.find(ModuleMapKey { moduleName.impl(), type }); iter != m_loadedModules.end())
+            return iter->value.m_module.get();
+    }
+    return nullptr;
 }
 
 auto AbstractModuleRecord::resolveImport(JSGlobalObject* globalObject, const Identifier& localName) -> Resolution
@@ -1347,10 +1347,6 @@ unsigned AbstractModuleRecord::innerModuleLinking(JSGlobalObject* globalObject, 
     for (const ModuleRequest& request : module->requestedModules()) {
         // 9.a. Let requiredModule be GetImportedModule(module, request).
         AbstractModuleRecord* requiredModule = JSModuleLoader::getImportedModule(module, request);
-        {
-            Locker locker { cellLock() };
-            m_dependencies.set(request.m_specifier.string(), WriteBarrier<AbstractModuleRecord>(vm, this, requiredModule));
-        }
         checkSafeToRecurse(globalObject, scope);
         RETURN_IF_EXCEPTION(scope, invalid);
         // 9.b. Set index to ? InnerModuleLinking(requiredModule, stack, index).

--- a/Source/JavaScriptCore/runtime/AbstractModuleRecord.h
+++ b/Source/JavaScriptCore/runtime/AbstractModuleRecord.h
@@ -284,8 +284,6 @@ protected:
 
     AsyncEvaluationOrder m_asyncEvaluationOrder { };
 
-    UncheckedKeyHashMap<String, WriteBarrier<AbstractModuleRecord>> m_dependencies;
-
     WriteBarrier<JSPromise> m_topLevelCapability;
 
     std::optional<int> m_pendingAsyncDependencies;

--- a/Source/JavaScriptCore/runtime/JSModuleLoader.cpp
+++ b/Source/JavaScriptCore/runtime/JSModuleLoader.cpp
@@ -571,15 +571,6 @@ AbstractModuleRecord* JSModuleLoader::getImportedModule(AbstractModuleRecord* re
     return iter->value.m_module.get();
 }
 
-AbstractModuleRecord* JSModuleLoader::maybeGetImportedModule(AbstractModuleRecord* referrer, const Identifier& moduleKey)
-{
-    for (const auto& [key, loadedModuleRequest] : referrer->loadedModules()) {
-        if (loadedModuleRequest.m_specifier == moduleKey)
-            return loadedModuleRequest.m_module.get();
-    }
-    return nullptr;
-}
-
 JSPromise* JSModuleLoader::hostLoadImportedModule(JSGlobalObject* globalObject, const ModuleReferrer& referrer, const ModuleRequest& moduleRequest, JSCell* payload, RefPtr<ScriptFetcher> scriptFetcher, bool useImportMap)
 {
     // HostLoadImportedModule(referrer, moduleRequest, loadState, payload)

--- a/Source/JavaScriptCore/runtime/JSModuleLoader.h
+++ b/Source/JavaScriptCore/runtime/JSModuleLoader.h
@@ -114,7 +114,6 @@ public:
     DECLARE_VISIT_CHILDREN;
 
     static AbstractModuleRecord* getImportedModule(AbstractModuleRecord* referrer, const AbstractModuleRecord::ModuleRequest&);
-    static AbstractModuleRecord* maybeGetImportedModule(AbstractModuleRecord* referrer, const Identifier& moduleKey);
 
     // Options correspond to Script Records, Cyclic Module Records and Realm Records, in that order.
     struct ModuleReferrer : Variant<ProgramExecutable*, CyclicModuleRecord*, JSGlobalObject*> {


### PR DESCRIPTION
#### d651aafbb69606ecc27bde540533e014d5908ce5
<pre>
[JSC] Remove `AbstractModuleRecord::m_dependencies`
<a href="https://bugs.webkit.org/show_bug.cgi?id=320144">https://bugs.webkit.org/show_bug.cgi?id=320144</a>

Reviewed by Yusuke Suzuki.

AbstractModuleRecord::m_dependencies duplicated the specifier-to-module mapping
that m_loadedModules ([[LoadedModules]]) already holds, and was populated a second
time during InnerModuleLinking. hostResolveImportedModule now looks up m_loadedModules
directly by probing each ScriptFetchParameters::Type (JavaScript first, which is what
requests default to), which also lets us drop the linear-scan fallback
JSModuleLoader::maybeGetImportedModule and one Vector copy in visitChildren.

This shrinks AbstractModuleRecord from 264 to 256 bytes and removes one hash table
allocation (and its String keys) per module record.

* Source/JavaScriptCore/runtime/AbstractModuleRecord.cpp:
(JSC::AbstractModuleRecord::visitChildrenImpl):
(JSC::AbstractModuleRecord::hostResolveImportedModule):
(JSC::AbstractModuleRecord::innerModuleLinking):
* Source/JavaScriptCore/runtime/AbstractModuleRecord.h:
* Source/JavaScriptCore/runtime/JSModuleLoader.cpp:
(JSC::JSModuleLoader::maybeGetImportedModule): Deleted.
* Source/JavaScriptCore/runtime/JSModuleLoader.h:

Canonical link: <a href="https://commits.webkit.org/317844@main">https://commits.webkit.org/317844@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/22ba8bec9ba612eb719553e17fa89f15196cb6a6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176500 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50435 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44225 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186101 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/138771 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51727 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50119 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137483 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/138771 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179456 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40976 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158261 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117958 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39626 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37990 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/6770 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150041 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37759 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34569 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/37768 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42170 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42201 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188524 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50100 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146535 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39413 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50784 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/34377 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146345 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41104 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122988 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117049 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49288 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12734 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48690 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48924 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48749 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->