### PR TITLE
IdleCallbackController::invokeIdleCallbackTimeout() is O(n) per call, causing O(n²) for a burst of same-timeout idle callbacks

### DIFF
--- a/Source/WebCore/dom/IdleCallbackController.cpp
+++ b/Source/WebCore/dom/IdleCallbackController.cpp
@@ -50,7 +50,9 @@ int IdleCallbackController::queueIdleCallback(Ref<IdleRequestCallback>&& callbac
     auto handle = m_idleCallbackIdentifier;
 
     bool hasTimeout = timeout > 0_s;
-    m_idleRequestCallbacks.append({ handle, WTF::move(callback), hasTimeout ? std::optional { MonotonicTime::now() + timeout } : std::nullopt });
+    auto request = IdleRequest::create(handle, WTF::move(callback), hasTimeout ? std::optional { MonotonicTime::now() + timeout } : std::nullopt);
+    m_idleRequestCallbacks.append(request.copyRef());
+    m_pendingIdleRequestsByIdentifier.add(handle, WTF::move(request));
 
     if (hasTimeout) {
         Timer::schedule(timeout, [weakThis = WeakPtr { *this }, handle]() mutable {
@@ -79,20 +81,17 @@ void IdleCallbackController::removeIdleCallback(int signedIdentifier)
         return;
     unsigned identifier = signedIdentifier;
 
-    m_idleRequestCallbacks.removeAllMatching([identifier](auto& request) {
-        return request.identifier == identifier;
-    });
-
-    m_runnableIdleCallbacks.removeAllMatching([identifier](auto& request) {
-        return request.identifier == identifier;
-    });
+    if (auto request = m_pendingIdleRequestsByIdentifier.take(identifier))
+        request->isPending = false;
 }
 
 // https://w3c.github.io/requestidlecallback/#start-an-idle-period-algorithm
 void IdleCallbackController::startIdlePeriod()
 {
-    for (auto& request : m_idleRequestCallbacks)
-        m_runnableIdleCallbacks.append(WTF::move(request));
+    for (auto& request : m_idleRequestCallbacks) {
+        if (request->isPending)
+            m_runnableIdleCallbacks.append(WTF::move(request));
+    }
     m_idleRequestCallbacks.clear();
 
     if (m_runnableIdleCallbacks.isEmpty())
@@ -120,17 +119,27 @@ bool IdleCallbackController::invokeIdleCallbacks()
     if (!document || !document->frame())
         return false;
 
+    // Drop cancelled/already-timed-out entries left at the front by removeIdleCallback()
+    // or invokeIdleCallbackTimeout() before spending any idle-time budget on them; this
+    // keeps isEmpty() accurate even if the deadline check below causes an early return.
+    while (!m_runnableIdleCallbacks.isEmpty() && !m_runnableIdleCallbacks.first()->isPending)
+        m_runnableIdleCallbacks.removeFirst();
+
+    if (m_runnableIdleCallbacks.isEmpty())
+        return false;
+
     Ref windowEventLoop = document->windowEventLoop();
     // FIXME: Implement "if the user-agent believes it should end the idle period early due to newly scheduled high-priority work, return from the algorithm."
 
     auto now = MonotonicTime::now();
     auto deadline = windowEventLoop->computeIdleDeadline();
-    if (now >= deadline || m_runnableIdleCallbacks.isEmpty())
+    if (now >= deadline)
         return false;
 
     auto request = m_runnableIdleCallbacks.takeFirst();
-    auto idleDeadline = IdleDeadline::create(request.timeout && *request.timeout < now ? IdleDeadline::DidTimeout::Yes : IdleDeadline::DidTimeout::No);
-    protect(request.callback)->invoke(idleDeadline.get());
+    m_pendingIdleRequestsByIdentifier.remove(request->identifier);
+    auto idleDeadline = IdleDeadline::create(request->timeout && *request->timeout < now ? IdleDeadline::DidTimeout::Yes : IdleDeadline::DidTimeout::No);
+    protect(request->callback)->invoke(idleDeadline.get());
 
     return !m_runnableIdleCallbacks.isEmpty();
 }
@@ -141,17 +150,14 @@ void IdleCallbackController::invokeIdleCallbackTimeout(unsigned identifier)
     if (!m_document)
         return;
 
-    auto it = m_idleRequestCallbacks.findIf([identifier](auto& request) {
-        return request.identifier == identifier;
-    });
-
-    if (it == m_idleRequestCallbacks.end())
+    auto request = m_pendingIdleRequestsByIdentifier.take(identifier);
+    if (!request)
         return;
 
+    request->isPending = false;
+
     auto idleDeadline = IdleDeadline::create(IdleDeadline::DidTimeout::Yes);
-    auto callback = WTF::move(it->callback);
-    m_idleRequestCallbacks.remove(it);
-    callback->invoke(idleDeadline.get());
+    protect(request->callback)->invoke(idleDeadline.get());
 }
 
 } // namespace WebCore

--- a/Source/WebCore/dom/IdleCallbackController.h
+++ b/Source/WebCore/dom/IdleCallbackController.h
@@ -28,7 +28,10 @@
 #include "IdleRequestCallback.h"
 #include <wtf/CheckedRef.h>
 #include <wtf/Deque.h>
+#include <wtf/HashMap.h>
 #include <wtf/MonotonicTime.h>
+#include <wtf/Ref.h>
+#include <wtf/RefCounted.h>
 #include <wtf/Seconds.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
@@ -57,14 +60,32 @@ private:
 
     unsigned m_idleCallbackIdentifier { 0 };
 
-    struct IdleRequest {
+    struct IdleRequest : RefCounted<IdleRequest> {
+        static Ref<IdleRequest> create(unsigned identifier, Ref<IdleRequestCallback>&& callback, std::optional<MonotonicTime> timeout)
+        {
+            return adoptRef(*new IdleRequest(identifier, WTF::move(callback), timeout));
+        }
+
         unsigned identifier { 0 };
         Ref<IdleRequestCallback> callback;
         std::optional<MonotonicTime> timeout;
+        bool isPending { true };
+
+    private:
+        IdleRequest(unsigned identifier, Ref<IdleRequestCallback>&& callback, std::optional<MonotonicTime> timeout)
+            : identifier(identifier)
+            , callback(WTF::move(callback))
+            , timeout(timeout)
+        {
+        }
     };
 
-    Deque<IdleRequest> m_idleRequestCallbacks;
-    Deque<IdleRequest> m_runnableIdleCallbacks;
+    // Removal/timeout only flips isPending to false so lookups by identifier stay
+    // O(1); stale entries are skipped lazily wherever the deques are drained,
+    // avoiding an O(n) find-and-shift per removal during a burst of cancellations.
+    Deque<Ref<IdleRequest>> m_idleRequestCallbacks;
+    Deque<Ref<IdleRequest>> m_runnableIdleCallbacks;
+    HashMap<unsigned, Ref<IdleRequest>> m_pendingIdleRequestsByIdentifier;
     WeakPtr<Document, WeakPtrImplWithEventTargetData> m_document;
 };
 


### PR DESCRIPTION
#### 917b486d97abe4ea57f1a9919f596c467d59b0be
<pre>
IdleCallbackController::invokeIdleCallbackTimeout() is O(n) per call, causing O(n²) for a burst of same-timeout idle callbacks
<a href="https://bugs.webkit.org/show_bug.cgi?id=320146">https://bugs.webkit.org/show_bug.cgi?id=320146</a>
<a href="https://rdar.apple.com/183084260">rdar://183084260</a>

Reviewed by NOBODY (OOPS!).

invokeIdleCallbackTimeout() did an O(n) findIf() over m_idleRequestCallbacks
followed by an O(n) Deque::remove() (shift-remove) for every timed-out
callback. When several requestIdleCallback() registrations share the same
timeout, the event loop invokes this once per callback in quick succession,
so a burst of n timeouts degraded to O(n²). removeIdleCallback() had the
same shape via removeAllMatching() on both deques.

Give each queued request stable identity via a small RefCounted IdleRequest
object and index it by identifier in a new HashMap. Cancellation and timeout
now do an O(1) HashMap::take() and just flip an isPending flag instead of
scanning and shift-removing from the Deque. Deque entries left behind by a
cancelled/timed-out request become stale and are skipped lazily:
startIdlePeriod() drops them when moving requests to the runnable queue, and
invokeIdleCallbacks() drains any stale run at the front of the runnable
queue before consuming idle-time budget, which also keeps isEmpty() (and
thus hasPendingIdleCallback()) accurate.

* Source/WebCore/dom/IdleCallbackController.cpp:
(WebCore::IdleCallbackController::queueIdleCallback):
(WebCore::IdleCallbackController::removeIdleCallback):
(WebCore::IdleCallbackController::startIdlePeriod):
(WebCore::IdleCallbackController::invokeIdleCallbacks):
(WebCore::IdleCallbackController::invokeIdleCallbackTimeout):
* Source/WebCore/dom/IdleCallbackController.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/917b486d97abe4ea57f1a9919f596c467d59b0be

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176501 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50436 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44226 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186102 "Built successfully") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/138772 "Failed to checkout and rebase branch from PR 70079") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c87c2c13-d239-48d7-939a-cac70099613a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178364 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51728 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50120 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137485 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/138772 "Failed to checkout and rebase branch from PR 70079") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a239dbb0-b994-45fb-948f-476539716359) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179457 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40974 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158263 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117960 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a3f24a6a-ee76-4d83-9c35-f0a68cfbecf2) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39624 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37992 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150039 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37761 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34570 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42167 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42203 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188525 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50101 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146536 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50785 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34379 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146346 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41106 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122989 "Built successfully") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117050 "Failed to checkout and rebase branch from PR 70079") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49289 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12736 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48691 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48925 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48750 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->