### PR TITLE
Avoid recomputing anonymousWrappers on removal of out-of-flow elements.

### DIFF
--- a/LayoutTests/fast/block/remove-out-of-flow-child-does-not-affect-anonymous-wrappers-expected.txt
+++ b/LayoutTests/fast/block/remove-out-of-flow-child-does-not-affect-anonymous-wrappers-expected.txt
@@ -1,0 +1,20 @@
+Removing an out-of-flow child should not crash or disturb anonymous wrapper blocks created for its in-flow siblings, while removing an in-flow block child should still collapse them.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS internals.elementRenderTreeAsText(absoluteContainer).includes(absoluteTreeBefore.split('\n')[1]) is true
+PASS internals.elementRenderTreeAsText(absoluteContainer).includes('RenderBlock (anonymous)') is true
+PASS internals.elementRenderTreeAsText(floatContainer).includes(floatTreeBefore.split('\n')[1]) is true
+PASS internals.elementRenderTreeAsText(floatContainer).includes('RenderBlock (anonymous)') is true
+PASS internals.elementRenderTreeAsText(collapseContainer).includes('RenderBlock (anonymous)') is false
+PASS successfullyParsed is true
+
+TEST COMPLETE
+webkit.org/b/320142: Removing an out-of-flow (floating or absolutely positioned) child must not crash and must not disturb anonymous wrapper blocks created for its in-flow siblings. Removing an in-flow block child must still collapse anonymous wrappers that are no longer needed.
+
+inline
+block
+inline
+block
+inlinefloat

--- a/LayoutTests/fast/block/remove-out-of-flow-child-does-not-affect-anonymous-wrappers.html
+++ b/LayoutTests/fast/block/remove-out-of-flow-child-does-not-affect-anonymous-wrappers.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.container {
+    position: relative;
+    width: 320px;
+}
+</style>
+</head>
+<body>
+<script src="../../resources/js-test.js"></script>
+<p>webkit.org/b/320142: Removing an out-of-flow (floating or absolutely positioned) child must not
+crash and must not disturb anonymous wrapper blocks created for its in-flow siblings. Removing an
+in-flow block child must still collapse anonymous wrappers that are no longer needed.</p>
+
+<div id="absoluteContainer" class="container">
+    <span>inline</span><div id="absoluteChild" style="position: absolute;"></div><div>block</div>
+</div>
+
+<div id="floatContainer" class="container">
+    <span>inline</span><div id="floatChild" style="float: left;"></div><div>block</div>
+</div>
+
+<div id="collapseContainer" class="container">
+    <span>inline</span><div id="collapseChild"></div><div style="float: left;">float</div>
+</div>
+
+<script>
+description("Removing an out-of-flow child should not crash or disturb anonymous wrapper blocks created for its in-flow siblings, while removing an in-flow block child should still collapse them.");
+
+document.body.offsetTop;
+
+var absoluteContainer = document.getElementById("absoluteContainer");
+var absoluteTreeBefore = internals.elementRenderTreeAsText(absoluteContainer);
+document.getElementById("absoluteChild").remove();
+// The anonymous wrapper still holds the inline content; only the removed
+// out-of-flow child's own line is gone from the dump.
+shouldBeTrue("internals.elementRenderTreeAsText(absoluteContainer).includes(absoluteTreeBefore.split('\\n')[1])");
+shouldBeTrue("internals.elementRenderTreeAsText(absoluteContainer).includes('RenderBlock (anonymous)')");
+
+var floatContainer = document.getElementById("floatContainer");
+var floatTreeBefore = internals.elementRenderTreeAsText(floatContainer);
+document.getElementById("floatChild").remove();
+shouldBeTrue("internals.elementRenderTreeAsText(floatContainer).includes(floatTreeBefore.split('\\n')[1])");
+shouldBeTrue("internals.elementRenderTreeAsText(floatContainer).includes('RenderBlock (anonymous)')");
+
+// Control case: after removing the in-flow block child, the only remaining
+// children are inline text and a float, so the anonymous wrapper is no longer
+// needed and must still be collapsed.
+var collapseContainer = document.getElementById("collapseContainer");
+document.getElementById("collapseChild").remove();
+shouldBeFalse("internals.elementRenderTreeAsText(collapseContainer).includes('RenderBlock (anonymous)')");
+
+var successfullyParsed = true;
+</script>
+</body>
+</html>

--- a/Source/WebCore/rendering/updating/RenderTreeBuilder.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilder.cpp
@@ -954,10 +954,15 @@ void RenderTreeBuilder::destroyAndCleanUpAnonymousWrappers(RenderObject& rendere
         destroy(rendererToDestroy);
     }
 
+    bool destroyRootWasInFlow = destroyRoot->isInFlow();
+
     if (destroyRoot) {
         auto anonymousDestroyRoot = SetForScope { m_anonymousDestroyRoot, destroyRoot.get() != &rendererToDestroy ? destroyRoot : nullptr };
         destroy(*destroyRoot);
     }
+
+    if (!destroyRootWasInFlow)
+        return;
 
     if (!destroyRootParent)
         return;


### PR DESCRIPTION
#### 947e0ed57ed11d54e8a568748e8cfdc547251ac9
<pre>
Avoid recomputing anonymousWrappers on removal of out-of-flow elements.
<a href="https://bugs.webkit.org/show_bug.cgi?id=320142">https://bugs.webkit.org/show_bug.cgi?id=320142</a>
<a href="https://rdar.apple.com/183081340">rdar://183081340</a>

Reviewed by Alan Baradlay.

Since out-of-flow/floating boxes don&apos;t participate in the inline/block
determination that creates anonymous wrappers, removing an out-of-flow
positioned or floating child cannot change whether the parent&apos;s in-flow children
need their anonymous wrappers.

When removing many absolutely-positioned children from a large container,
removeAnonymousWrappersForInlineChildrenIfNeeded() scans all of the parent&apos;s
children, so skipping it for out-of-flow removals avoids O(n) work per removed
child.

* Source/WebCore/rendering/updating/RenderTreeBuilder.cpp:
(WebCore::RenderTreeBuilder::destroyAndCleanUpAnonymousWrappers):
* LayoutTests/fast/block/remove-out-of-flow-child-does-not-affect-anonymous-wrappers-expected.txt: Added.
* LayoutTests/fast/block/remove-out-of-flow-child-does-not-affect-anonymous-wrappers.html: Added.

Canonical link: <a href="https://commits.webkit.org/318113@main">https://commits.webkit.org/318113@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/648500991059f8a9aa2476db847d6b4e548a4ca8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177142 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51079 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44874 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186745 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140378 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/641109bf-6d83-4832-8f86-40355be4e13e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179005 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52372 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50870 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138023 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140378 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/649e5510-61a3-4141-b6c3-edf22c733373) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180098 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41527 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158785 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118490 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/dac2ba42-00cd-4377-ad74-978387431058) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40183 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38657 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150593 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38284 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35213 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42857 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42871 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189171 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50746 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/158324 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147108 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39574 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51429 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34908 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146902 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41632 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123643 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117935 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49934 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13264 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49333 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49570 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49394 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->