### PR TITLE
RemoteAudioDestination plays stale buffer contents instead of silence on ring buffer underrun

### DIFF
--- a/Source/WebKit/GPUProcess/media/RemoteAudioDestinationManager.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioDestinationManager.cpp
@@ -32,6 +32,7 @@
 #include "GPUProcess.h"
 #include "Logging.h"
 #include <WebCore/AudioUtilities.h>
+#include <wtf/FixedVector.h>
 #include <wtf/LoggerHelper.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/ThreadSafeRefCounted.h>
@@ -75,6 +76,7 @@ public:
         ALWAYS_LOG(LOGIDENTIFIER);
 #if PLATFORM(COCOA)
         m_audioOutputUnitAdaptor.configure(hardwareSampleRate, numberOfOutputChannels);
+        m_lastRenderedSamples = FixedVector<float>(FillWith { }, m_numOutputChannels, 0.f);
 #endif
     }
 
@@ -191,13 +193,58 @@ private:
 
         if (m_ringBuffer->fetchIfHasEnoughData(ioData, numberOfFrames, m_startFrame)) {
             m_startFrame += numberOfFrames;
+            rememberLastRenderedSamples(ioData, numberOfFrames);
             status = noErr;
+        } else {
+            // Ring buffer underrun (common at stream start or under load). Rather than
+            // leaving stale samples in the output buffer, fade out from the last rendered
+            // samples down to silence to avoid an audible click, then output silence.
+            fadeOutToSilence(ioData, numberOfFrames);
         }
 
         incrementTotalFrameCount(numberOfFrames);
         m_renderSemaphore.signal();
 
         return status;
+    }
+
+    // The audio buffers are deinterleaved Float32, so there is one buffer per channel.
+    void rememberLastRenderedSamples(AudioBufferList* ioData, UInt32 numberOfFrames)
+    {
+        if (!numberOfFrames)
+            return;
+
+        auto buffers = span(*ioData);
+        for (size_t channel = 0; channel < m_lastRenderedSamples.size(); ++channel) {
+            if (channel >= buffers.size())
+                break;
+            auto samples = mutableSpan<float>(buffers[channel]);
+            auto frameCount = std::min<size_t>(numberOfFrames, samples.size());
+            m_lastRenderedSamples[channel] = frameCount ? samples[frameCount - 1] : 0.f;
+        }
+    }
+
+    void fadeOutToSilence(AudioBufferList* ioData, UInt32 numberOfFrames)
+    {
+        auto buffers = span(*ioData);
+        for (size_t channel = 0; channel < buffers.size(); ++channel) {
+            auto samples = mutableSpan<float>(buffers[channel]);
+            auto frameCount = std::min<size_t>(numberOfFrames, samples.size());
+            float startSample = channel < m_lastRenderedSamples.size() ? m_lastRenderedSamples[channel] : 0.f;
+            if (startSample && frameCount) {
+                // Linear ramp from the last rendered sample down to zero to declick.
+                float step = startSample / frameCount;
+                float value = startSample;
+                for (size_t frame = 0; frame < frameCount; ++frame) {
+                    value -= step;
+                    samples[frame] = value;
+                }
+                zeroSpan(samples.subspan(frameCount));
+            } else
+                zeroSpan(samples);
+        }
+        // We are now silent, so any subsequent consecutive underrun outputs pure silence.
+        m_lastRenderedSamples.fill(0.f);
     }
 #endif
 
@@ -220,6 +267,8 @@ private:
     const uint32_t m_numOutputChannels;
     std::unique_ptr<ConsumerSharedCARingBuffer> m_ringBuffer;
     uint64_t m_startFrame { 0 };
+    // Last rendered sample per channel, used to fade out to silence on a ring buffer underrun.
+    FixedVector<float> m_lastRenderedSamples;
 #endif
 
 #if PLATFORM(IOS_FAMILY)


### PR DESCRIPTION
#### c315a716758008c2e11d996fe2e663db6097d114
<pre>
RemoteAudioDestination plays stale buffer contents instead of silence on ring buffer underrun
<a href="https://bugs.webkit.org/show_bug.cgi?id=320149">https://bugs.webkit.org/show_bug.cgi?id=320149</a>

Reviewed by Jean-Yves Avenard.

RemoteAudioDestination::render() only writes into the output buffer when
ConsumerSharedCARingBuffer::fetchIfHasEnoughData() succeeds. On underrun
(common at stream start or under load) it left ioData untouched, so the
audio unit played whatever stale samples happened to be in the buffer
instead of silence, producing an audible glitch and leaking prior audio
content. The sibling WebRTC path
(RemoteAudioMediaStreamTrackRendererInternalUnitManager) already zero-fills
its buffer on underrun; this path did not.

Fill the output buffer on the underrun path rather than leaving it stale.
Instead of an abrupt cutoff to zero (which clicks when the last rendered
sample was non-zero), remember the last rendered sample per channel on
each successful render and, on the first underrun, linearly ramp from that
value down to zero to declick before going fully silent. Subsequent
consecutive underruns output pure silence.

* Source/WebKit/GPUProcess/media/RemoteAudioDestinationManager.cpp:

Canonical link: <a href="https://commits.webkit.org/317968@main">https://commits.webkit.org/317968@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b2532891f42613ce3a518a95225791ecfb4af3b2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176513 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50448 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44238 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186114 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/138787 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/49032a50-9069-4d32-b9e9-178795fe8efb) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51740 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50132 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137495 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/138787 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2febd557-544e-472d-a237-11d32f31c7fd) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179469 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40987 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158271 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117970 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/56389c89-ac36-4690-b0f6-0303b9266f0f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39637 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37998 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150052 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37769 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34582 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42180 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42209 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188537 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50113 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146546 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39495 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50797 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34388 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/bfcache/abort.tentative.https.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146356 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41118 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123001 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117063 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49301 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12744 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48703 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48937 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48762 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->