### PR TITLE
makeStringByReplacingAll() uses a scalar scan instead of SIMD-accelerated find()

### DIFF
--- a/Source/WTF/wtf/text/StringView.cpp
+++ b/Source/WTF/wtf/text/StringView.cpp
@@ -442,34 +442,18 @@ SUPPRESS_NODELETE size_t StringView::reverseFind(StringView matchString, unsigne
 
 String makeStringByReplacingAll(StringView string, char16_t target, char16_t replacement)
 {
-    if (string.is8Bit()) {
-        if (!isLatin1(target)) {
-            // Looking for a 16-bit character in an 8-bit string, so we're done.
-            return string.toString();
-        }
-
-        auto characters = string.span8();
-        size_t i;
-        unsigned length = string.length();
-        for (i = 0; i != characters.size(); ++i) {
-            if (characters[i] == target)
-                break;
-        }
-        if (i == length)
+    auto replaceAll = [&](auto characters) -> String {
+        // find() is SIMD-accelerated, and its Latin1 overload returns notFound for a
+        // non-Latin1 target, so an 8-bit string with a 16-bit target is handled here too.
+        size_t i = find(characters, target);
+        if (i == notFound)
             return string.toString();
         return StringImpl::createByReplacingInCharacters(characters, target, replacement, i);
-    }
+    };
 
-    auto characters = string.span16();
-    size_t i;
-    unsigned length = string.length();
-    for (i = 0; i != characters.size(); ++i) {
-        if (characters[i] == target)
-            break;
-    }
-    if (i == length)
-        return string.toString();
-    return StringImpl::createByReplacingInCharacters(characters, target, replacement, i);
+    if (string.is8Bit())
+        return replaceAll(string.span8());
+    return replaceAll(string.span16());
 }
 
 SUPPRESS_NODELETE std::strong_ordering codePointCompare(StringView lhs, StringView rhs)


### PR DESCRIPTION
#### 6cb1077d85c825a9a89187ae89483449033a144c
<pre>
makeStringByReplacingAll() uses a scalar scan instead of SIMD-accelerated find()
<a href="https://bugs.webkit.org/show_bug.cgi?id=320155">https://bugs.webkit.org/show_bug.cgi?id=320155</a>
<a href="https://rdar.apple.com/183089603">rdar://183089603</a>

Reviewed by Chris Dumez.

makeStringByReplacingAll() hand-rolled a first-occurrence loop in both the
8-bit and 16-bit branches to locate the target character. WTF::find() is
SIMD-accelerated (find8()/find16()) and is used everywhere else for exactly
this, so replacing both loops is a real win on long strings.
Collapse the two branches into a single generic lambda templated on the span&apos;s
character type. This also drops the explicit !isLatin1(target) early return:
the find(span&lt;Latin1Character&gt;, char16_t) overload already returns notFound for
a non-Latin1 target, so an 8-bit string searched for a 16-bit target still
returns the original string unchanged. No behavior change.

* Source/WTF/wtf/text/StringView.cpp:
(WTF::makeStringByReplacingAll):

Canonical link: <a href="https://commits.webkit.org/318051@main">https://commits.webkit.org/318051@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bb895e851c42d7125b00923da1fdcbfba5986257

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176520 "Passed style check") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50455 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44245 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186121 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/138794 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/31c61b1d-7fb8-43f6-a259-8cc6809a5b1d) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51747 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50139 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137499 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/138794 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b10a40ad-f54c-40d9-b086-bc4220163277) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179476 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40990 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158277 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117974 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ab37e3a3-9d40-4578-9e68-bd9b3e2c1c2b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39640 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38006 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/6786 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150055 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37775 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34589 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/37788 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42187 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42217 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188544 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50120 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146551 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39541 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50804 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34394 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146361 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41119 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123008 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117070 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49308 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12750 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48710 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48944 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48769 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->