### PR TITLE
[JSC] stress/regexp-unicode-bmp-fast-path-code-points.js is timed out

### DIFF
--- a/JSTests/stress/regexp-unicode-bmp-fast-path-code-points.js
+++ b/JSTests/stress/regexp-unicode-bmp-fast-path-code-points.js
@@ -23,25 +23,23 @@ const singleCodePoint = /^.$/u;
 const twoCodePoints = /^(.)(.)$/u;
 const greedy = /^([^X]*)X$/u;
 
-for (let i = 0; i < testLoopCount; ++i) {
-    for (const first of codeUnits) {
-        for (const second of followers) {
-            const subject = String.fromCharCode(first, second);
-            const expected = codePointsOf(subject);
-            const tag = `[${first.toString(16)},${second.toString(16)}]`;
+for (const first of codeUnits) {
+    for (const second of followers) {
+        const subject = String.fromCharCode(first, second);
+        const expected = codePointsOf(subject);
+        const tag = `[${first.toString(16)},${second.toString(16)}]`;
 
-            shouldBe(singleCodePoint.test(subject), expected.length === 1, `single code point ${tag}`);
+        shouldBe(singleCodePoint.test(subject), expected.length === 1, `single code point ${tag}`);
 
-            const matched = twoCodePoints.exec(subject);
-            shouldBe(matched !== null, expected.length === 2, `two code points ${tag}`);
-            if (matched) {
-                shouldBe(matched[1].codePointAt(0), expected[0], `first code point ${tag}`);
-                shouldBe(matched[2].codePointAt(0), expected[1], `second code point ${tag}`);
-            }
-
-            const scanned = greedy.exec(subject + "X");
-            shouldBe(scanned !== null, true, `greedy scan ${tag}`);
-            shouldBe(scanned[1], subject, `greedy capture ${tag}`);
+        const matched = twoCodePoints.exec(subject);
+        shouldBe(matched !== null, expected.length === 2, `two code points ${tag}`);
+        if (matched) {
+            shouldBe(matched[1].codePointAt(0), expected[0], `first code point ${tag}`);
+            shouldBe(matched[2].codePointAt(0), expected[1], `second code point ${tag}`);
         }
+
+        const scanned = greedy.exec(subject + "X");
+        shouldBe(scanned !== null, true, `greedy scan ${tag}`);
+        shouldBe(scanned[1], subject, `greedy capture ${tag}`);
     }
 }


### PR DESCRIPTION
#### 3334d1ee02f63cff75754f95e265d5afb7e43fa9
<pre>
[JSC] stress/regexp-unicode-bmp-fast-path-code-points.js is timed out
<a href="https://bugs.webkit.org/show_bug.cgi?id=320156">https://bugs.webkit.org/show_bug.cgi?id=320156</a>
<a href="https://rdar.apple.com/183089589">rdar://183089589</a>

Reviewed by Tadeu Zagallo.

This test takes very long time. This patch removes testLoopCount from
this test as its intent is stressing RegExp, which is fine without
warmup count.

* JSTests/stress/regexp-unicode-bmp-fast-path-code-points.js:
(const.first.of.codeUnits.const.second.of.followers.first.toString):
(i.const.first.of.codeUnits.const.second.of.followers.first.toString): Deleted.

Canonical link: <a href="https://commits.webkit.org/317871@main">https://commits.webkit.org/317871@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/897395a53c00efc29f9ad3475d7a2859bbb6fad1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176522 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50457 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44247 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186123 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/138796 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/060a4b71-328f-4f70-a8aa-fcc89a94b9cf) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51749 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50141 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137497 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/138796 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/84d2f746-9055-4037-91d3-461252964e08) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179478 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40985 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158276 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117972 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f02bf96c-f13a-4afb-9e1a-ca3e596acbb3) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39635 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38005 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/6785 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150050 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37774 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34591 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/37790 "Built successfully and passed tests") | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42216 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188546 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50122 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146552 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50806 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34393 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146362 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26806 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41120 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117072 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49310 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12749 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48712 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48946 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48771 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->