### PR TITLE
Web Inspector: Worker: bind delayed heap events to the current run loop

### DIFF
--- a/LayoutTests/inspector/worker/heap-gc-expected.txt
+++ b/LayoutTests/inspector/worker/heap-gc-expected.txt
@@ -1,0 +1,12 @@
+Test for HeapAgent in a Worker.
+
+
+== Running test suite: Worker.Heap
+-- Running test case: Worker.Heap.GarbageCollected
+PASS: Event should come from the Worker target.
+PASS: Event should have GarbageCollection data.
+PASS: GarbageCollection type should be Full.
+
+-- Running test case: Worker.Heap.Terminate
+PASS: Terminating the Worker should remove its target.
+

--- a/LayoutTests/inspector/worker/heap-gc.html
+++ b/LayoutTests/inspector/worker/heap-gc.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../http/tests/inspector/resources/inspector-test.js"></script>
+<script>
+let worker = new Worker("resources/worker-1.js");
+
+function terminateWorker()
+{
+    worker.terminate();
+}
+
+function test()
+{
+    let workerTarget = Array.from(WI.targets).find((target) => target.type === WI.TargetType.Worker);
+    if (!workerTarget) {
+        InspectorTest.fail("Missing Worker Target");
+        InspectorTest.completeTest();
+        return;
+    }
+
+    let suite = InspectorTest.createAsyncSuite("Worker.Heap");
+
+    suite.addTestCase({
+        name: "Worker.Heap.GarbageCollected",
+        description: "Calling Heap.gc on a Worker should trigger a Heap.garbageCollected event.",
+        async test() {
+            let garbageCollectedPromise = new Promise((resolve) => {
+                let listener = WI.heapManager.addEventListener(WI.HeapManager.Event.GarbageCollected, (event) => {
+                    if (event.data.target !== workerTarget || event.data.collection.type !== WI.GarbageCollection.Type.Full)
+                        return;
+
+                    WI.heapManager.removeEventListener(WI.HeapManager.Event.GarbageCollected, listener);
+                    resolve(event);
+                });
+            });
+
+            await workerTarget.HeapAgent.gc();
+            let event = await garbageCollectedPromise;
+
+            InspectorTest.expectEqual(event.data.target, workerTarget, "Event should come from the Worker target.");
+            InspectorTest.expectThat(event.data.collection instanceof WI.GarbageCollection, "Event should have GarbageCollection data.");
+            InspectorTest.expectEqual(event.data.collection.type, WI.GarbageCollection.Type.Full, "GarbageCollection type should be Full.");
+        },
+    });
+
+    suite.addTestCase({
+        name: "Worker.Heap.Terminate",
+        description: "Terminating a Worker after Heap.gc should stop its delayed event timer on the Worker thread.",
+        async test() {
+            let targetRemovedPromise = WI.targetManager.awaitEvent(WI.TargetManager.Event.TargetRemoved);
+            await InspectorTest.evaluateInPage("terminateWorker()");
+            let event = await targetRemovedPromise;
+
+            InspectorTest.expectEqual(event.data.target, workerTarget, "Terminating the Worker should remove its target.");
+        },
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+</head>
+<body onload="runTest()">
+<p>Test for HeapAgent in a Worker.</p>
+</body>
+</html>

--- a/Source/WebCore/inspector/agents/WebHeapAgent.cpp
+++ b/Source/WebCore/inspector/agents/WebHeapAgent.cpp
@@ -65,7 +65,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(SendGarbageCollectionEventsTask);
 
 SendGarbageCollectionEventsTask::SendGarbageCollectionEventsTask(WebHeapAgent& agent)
     : m_agent(agent)
-    , m_timer(RunLoop::mainSingleton(), "SendGarbageCollectionEventsTask::Timer"_s, this, &SendGarbageCollectionEventsTask::timerFired)
+    , m_timer(RunLoop::currentSingleton(), "SendGarbageCollectionEventsTask::Timer"_s, this, &SendGarbageCollectionEventsTask::timerFired)
 {
 }
 


### PR DESCRIPTION
#### c608bab05f6e8ec912c90e2254a45fab47ea4ffc
<pre>
Web Inspector: Worker: bind delayed heap events to the current run loop
<a href="https://bugs.webkit.org/show_bug.cgi?id=320159">https://bugs.webkit.org/show_bug.cgi?id=320159</a>

Reviewed by Yusuke Suzuki.

* Source/WebCore/inspector/agents/WebHeapAgent.cpp:
(WebCore::SendGarbageCollectionEventsTask::SendGarbageCollectionEventsTask):
Use the current `RunLoop` so that `Worker` teardown stops the `Timer` on the thread that owns it.

* LayoutTests/inspector/worker/heap-gc.html: Added.
* LayoutTests/inspector/worker/heap-gc-expected.txt: Added.

Canonical link: <a href="https://commits.webkit.org/317842@main">https://commits.webkit.org/317842@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8d79527bf46aea770ec52544b6729c815abb5645

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176533 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50468 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44258 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186134 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/138810 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178396 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51760 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50152 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137510 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/138810 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179489 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40999 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/158286 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117985 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/39649 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/38017 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/150064 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/37784 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34602 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/42200 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/42228 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188557 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50133 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/157831 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146562 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39408 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50817 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/34403 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146372 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41135 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/123021 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117090 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49321 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12759 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Checked out pull request; Uploaded test results") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48723 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48957 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48782 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->