### PR TITLE
[WPE Platform] New API to create a touch event with multiple touch points

### DIFF
--- a/LayoutTests/platform/wpe/TestExpectations
+++ b/LayoutTests/platform/wpe/TestExpectations
@@ -938,21 +938,11 @@ webkit.org/b/228311 imported/w3c/web-platform-tests/css/css-scoping/css-scoping-
 fast/events/mouse-cursor-pseudo-elements.html [ Failure Pass ]
 
 webkit.org/b/278719 fast/events/touch/touch-event-frames.html [ Failure ]
-
-webkit.org/b/278719 fast/events/touch/basic-multi-touch-events.html [ Failure ]
-webkit.org/b/278719 fast/events/touch/basic-multi-touch-events-limited.html [ Failure ]
 webkit.org/b/278719 fast/events/touch/frame-hover-update.html [ Failure ]
-
-webkit.org/b/278719 fast/events/touch/multi-touch-grouped-targets.html [ Failure ]
-webkit.org/b/278719 fast/events/touch/multi-touch-inside-nested-iframes.html [ Failure ]
 webkit.org/b/278719 fast/events/touch/multi-touch-some-without-handlers.html [ Failure ]
 webkit.org/b/278719 fast/events/touch/ontouchstart-active-selector.html [ Failure  ]
 webkit.org/b/278719 fast/events/touch/send-oncancel-event.html [ Pass ]
 webkit.org/b/278719 fast/events/touch/touch-event-pageXY.html [ Failure ]
-webkit.org/b/278719 fast/events/touch/touch-target.html [ Timeout ]
-webkit.org/b/278719 fast/events/touch/touch-target-limited.html [ Failure ]
-
-webkit.org/b/278719 fast/events/touch/input-touch-target.html [ Failure ]
 webkit.org/b/278719 fast/events/touch/zoomed-touch-event-pageXY.html [ Failure ]
 
 # The assertion failure occurs to WPE only.

--- a/Source/WebKit/UIProcess/API/wpe/WPEWebViewPlatform.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/WPEWebViewPlatform.cpp
@@ -324,6 +324,35 @@ void ViewPlatform::toplevelStateChanged(WPEToplevelState previousState, WPETople
 }
 
 #if ENABLE(TOUCH_EVENTS)
+static Vector<WebKit::WebPlatformTouchPoint> platformTouchPoints(std::span<const WPETouchPoint> touchPoints)
+{
+    Vector<WebPlatformTouchPoint> points;
+    points.reserveInitialCapacity(touchPoints.size());
+    for (const auto& touchPoint : touchPoints) {
+        WebCore::IntPoint position(touchPoint.x, touchPoint.y);
+        WebPlatformTouchPoint::State state = WebPlatformTouchPoint::State::Stationary;
+        switch (touchPoint.state) {
+        case WPE_TOUCH_POINT_STATE_STATIONARY:
+            state = WebPlatformTouchPoint::State::Stationary;
+            break;
+        case WPE_TOUCH_POINT_STATE_PRESSED:
+            state = WebPlatformTouchPoint::State::Pressed;
+            break;
+        case WPE_TOUCH_POINT_STATE_MOVED:
+            state = WebPlatformTouchPoint::State::Moved;
+            break;
+        case WPE_TOUCH_POINT_STATE_RELEASED:
+            state = WebPlatformTouchPoint::State::Released;
+            break;
+        case WPE_TOUCH_POINT_STATE_CANCELLED:
+            state = WebPlatformTouchPoint::State::Cancelled;
+            break;
+        }
+        points.append(WebPlatformTouchPoint(touchPoint.sequence_id, state, position, position));
+    }
+    return points;
+}
+
 Vector<WebKit::WebPlatformTouchPoint> ViewPlatform::touchPointsForEvent(WPEEvent* event)
 {
     auto stateForEvent = [](uint32_t id, WPEEvent* event) -> WebPlatformTouchPoint::State {
@@ -361,6 +390,24 @@ Vector<WebKit::WebPlatformTouchPoint> ViewPlatform::touchPointsForEvent(WPEEvent
 
 gboolean ViewPlatform::handleEvent(WPEEvent* event)
 {
+#if ENABLE(TOUCH_EVENTS)
+    switch (wpe_event_get_event_type(event)) {
+    case WPE_EVENT_TOUCH_CANCEL:
+    case WPE_EVENT_TOUCH_DOWN:
+    case WPE_EVENT_TOUCH_MOVE:
+    case WPE_EVENT_TOUCH_UP: {
+        const WPETouchPoint* touchPoints = nullptr;
+        guint32 nTouchPoints = 0;
+        if (wpe_event_touch_get_touch_points(event, &touchPoints, &nTouchPoints)) {
+            page().handleTouchEvent(nullptr, NativeWebTouchEvent(event, platformTouchPoints(unsafeMakeSpan(touchPoints, nTouchPoints))));
+            return TRUE;
+        }
+        break;
+    }
+    default:
+        break;
+    }
+#endif
     switch (wpe_event_get_event_type(event)) {
     case WPE_EVENT_NONE:
         RELEASE_ASSERT_NOT_REACHED();

--- a/Source/WebKit/WPEPlatform/wpe/WPEEvent.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEEvent.cpp
@@ -28,6 +28,7 @@
 
 #include <wtf/FastMalloc.h>
 #include <wtf/StdLibExtras.h>
+#include <wtf/Vector.h>
 #include <wtf/glib/GRefPtr.h>
 
 struct WPEEventPointerButton {
@@ -69,6 +70,11 @@ struct WPEEventTouch {
     double y { 0 };
 };
 
+struct WPEEventTouch2 {
+    WPEModifiers modifiers { static_cast<WPEModifiers>(0) };
+    Vector<WPETouchPoint> touchPoints;
+};
+
 /**
  * WPEEvent: (ref-func wpe_event_ref) (unref-func wpe_event_unref)
  *
@@ -92,7 +98,7 @@ struct _WPEEvent {
         GDestroyNotify destroyFunction { nullptr };
     } userData;
 
-    Variant<WPEEventPointerButton, WPEEventPointerMove, WPEEventScroll, WPEEventKeyboard, WPEEventTouch> variant;
+    Variant<WPEEventPointerButton, WPEEventPointerMove, WPEEventScroll, WPEEventKeyboard, WPEEventTouch, WPEEventTouch2> variant;
 
     int referenceCount { 1 };
 };
@@ -247,6 +253,7 @@ WPEModifiers wpe_event_get_modifiers(WPEEvent* event)
         [](const WPEEventScroll& scroll) { return scroll.modifiers; },
         [](const WPEEventKeyboard& keyboard) { return keyboard.modifiers; },
         [](const WPEEventTouch& touch) { return touch.modifiers; },
+        [](const WPEEventTouch2& touch) { return touch.modifiers; },
         [](const auto&) { return static_cast<WPEModifiers>(0); }
     );
 }
@@ -574,6 +581,57 @@ guint32 wpe_event_touch_get_sequence_id(WPEEvent* event)
 {
     g_return_val_if_fail(event, 0);
     g_return_val_if_fail(event->type == WPE_EVENT_TOUCH_DOWN || event->type == WPE_EVENT_TOUCH_UP || event->type == WPE_EVENT_TOUCH_MOVE || event->type == WPE_EVENT_TOUCH_CANCEL, 0);
+    g_return_val_if_fail(std::holds_alternative<WPEEventTouch>(event->variant), 0);
 
     return std::get<WPEEventTouch>(event->variant).sequenceID;
+}
+
+/**
+ * wpe_event_touch_new_with_touch_points:
+ * @type: a #WPEEventType (%WPE_EVENT_TOUCH_DOWN, %WPE_EVENT_TOUCH_UP, %WPE_EVENT_TOUCH_MOVE or %WPE_EVENT_TOUCH_CANCEL)
+ * @view: a #WPEView
+ * @source: a #WPEInputSource
+ * @time: the event timestamp
+ * @modifiers: a #WPEModifiers
+ * @touch_points: (array length=n_touch_points) (element-type WPETouchPoint): an array of #WPETouchPoint
+ * @n_touch_points: the number of elements in @touch_points
+ *
+ * Create a #WPEEvent for a touch with multiple touch points
+ *
+ * Returns: (transfer full): a new allocated #WPEEvent.
+ */
+WPEEvent* wpe_event_touch_new_with_touch_points(WPEEventType type, WPEView* view, WPEInputSource source, guint32 time, WPEModifiers modifiers, const WPETouchPoint* touchPoints, guint32 numTouchPoints)
+{
+    g_return_val_if_fail(type == WPE_EVENT_TOUCH_DOWN || type == WPE_EVENT_TOUCH_UP || type == WPE_EVENT_TOUCH_MOVE || type == WPE_EVENT_TOUCH_CANCEL, nullptr);
+    g_return_val_if_fail(WPE_IS_VIEW(view), nullptr);
+
+    Vector<WPETouchPoint> vector(unsafeMakeSpan(touchPoints, numTouchPoints));
+    return new _WPEEvent { view, type, source, time, { nullptr, nullptr }, WPEEventTouch2 { modifiers,  WTF::move(vector) }, 1 };
+}
+
+/**
+ * wpe_event_touch_get_touch_points:
+ * @event: a #WPEEvent
+ * @touch_points: (out) (array length=n_touch_points) (element-type WPETouchPoint) (transfer none): return location for touch points
+ * @n_touch_points: (out): return location for the number of touch points
+ *
+ * Get the touch points of @event.
+ * Note that @event must be a touch event (%WPE_EVENT_TOUCH_DOWN, %WPE_EVENT_TOUCH_UP, %WPE_EVENT_TOUCH_MOVE or %WPE_EVENT_TOUCH_CANCEL)
+ * created with wpe_event_touch_new_with_touch_points()
+ *
+ * Returns: %TRUE if touch points were retrieved, or %FALSE otherwise
+ */
+gboolean wpe_event_touch_get_touch_points(WPEEvent *event, const WPETouchPoint **touchPoints, guint32 *numTouchPoints)
+{
+    *touchPoints = nullptr;
+    *numTouchPoints = 0;
+
+    g_return_val_if_fail(event, FALSE);
+    g_return_val_if_fail(event->type == WPE_EVENT_TOUCH_DOWN || event->type == WPE_EVENT_TOUCH_UP || event->type == WPE_EVENT_TOUCH_MOVE || event->type == WPE_EVENT_TOUCH_CANCEL, FALSE);
+    g_return_val_if_fail(std::holds_alternative<WPEEventTouch2>(event->variant), FALSE);
+
+    auto touchPointsSpan = std::get<WPEEventTouch2>(event->variant).touchPoints.span();
+    *touchPoints = touchPointsSpan.data();
+    *numTouchPoints = touchPointsSpan.size();
+    return TRUE;
 }

--- a/Source/WebKit/WPEPlatform/wpe/WPEEvent.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPEEvent.h
@@ -130,6 +130,24 @@ typedef enum {
 } WPEModifiers;
 
 /**
+ * WPETouchPointState:
+ * @WPE_TOUCH_POINT_STATE_STATIONARY: The touch point has no change.
+ * @WPE_TOUCH_POINT_STATE_PRESSED: The touch point is newly added.
+ * @WPE_TOUCH_POINT_STATE_MOVED: The touch point is moved.
+ * @WPE_TOUCH_POINT_STATE_RELEASED: The touch point is released.
+ * @WPE_TOUCH_POINT_STATE_CANCELLED: The touch point is canceled.
+ *
+ * State of a #WPETouchPoint.
+ */
+typedef enum {
+    WPE_TOUCH_POINT_STATE_STATIONARY,
+    WPE_TOUCH_POINT_STATE_PRESSED,
+    WPE_TOUCH_POINT_STATE_MOVED,
+    WPE_TOUCH_POINT_STATE_RELEASED,
+    WPE_TOUCH_POINT_STATE_CANCELLED,
+} WPETouchPointState;
+
+/**
  * WPE_BUTTON_PRIMARY:
  *
  * The primary button. This is typically the left mouse button, or the
@@ -152,6 +170,22 @@ typedef enum {
  */
 #define WPE_BUTTON_SECONDARY (3)
 
+/**
+ * WPETouchPoint:
+ * @sequence_id: the touch point sequence identifier
+ * @state: a #WPETouchPointState
+ * @x: the x coordinate of the touch point
+ * @y: the y coordinate of the touch point
+ *
+ * Structure representing a touch point.
+ */
+struct _WPETouchPoint {
+    guint32             sequence_id;
+    WPETouchPointState  state;
+    double              x;
+    double              y;
+};
+typedef struct _WPETouchPoint WPETouchPoint;
 
 WPE_API GType          wpe_event_get_type                       (void);
 WPE_API WPEEvent      *wpe_event_ref                            (WPEEvent      *event);
@@ -229,6 +263,19 @@ WPE_API WPEEvent      *wpe_event_touch_new                      (WPEEventType   
                                                                  double         x,
                                                                  double         y);
 WPE_API guint32        wpe_event_touch_get_sequence_id          (WPEEvent      *event);
+
+WPE_API WPEEvent      *wpe_event_touch_new_with_touch_points    (WPEEventType          type,
+                                                                 WPEView              *view,
+                                                                 WPEInputSource        source,
+                                                                 guint32               time,
+                                                                 WPEModifiers          modifiers,
+                                                                 const WPETouchPoint  *touch_points,
+                                                                 guint32               n_touch_points);
+
+WPE_API gboolean       wpe_event_touch_get_touch_points         (WPEEvent             *event,
+                                                                 const WPETouchPoint **touch_points,
+                                                                 guint32              *n_touch_points);
+
 
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(WPEEvent, wpe_event_unref)
 

--- a/Tools/WebKitTestRunner/wpe/EventSenderProxyClientWPE.cpp
+++ b/Tools/WebKitTestRunner/wpe/EventSenderProxyClientWPE.cpp
@@ -396,59 +396,68 @@ void EventSenderProxyClientWPE::clearTouchPoints()
     m_touchPoints.clear();
 }
 
-struct EventSenderProxyClientWPE::TouchPointContext {
-    const TouchPoint::State targetState;
-    const std::optional<TouchPoint::State> newState;
-    const WPEEventType eventType;
-    const double time;
-    const WPEModifiers modifiers;
-    WPEView* view;
-};
-
-std::function<bool(EventSenderProxyClientWPE::TouchPoint&)> EventSenderProxyClientWPE::pointProcessor(const TouchPointContext& context)
+void EventSenderProxyClientWPE::sendTouchEvent(int type, double time)
 {
-    return [context](TouchPoint& point) -> bool {
-        if (point.state != context.targetState)
-            return false;
-
-        if (context.newState)
-            point.state = *context.newState;
-
-        auto* event = wpe_event_touch_new(context.eventType, context.view, WPE_INPUT_SOURCE_TOUCHSCREEN, secToMsTimestamp(context.time), context.modifiers, point.id, point.x, point.y);
-        wpe_view_event(context.view, event);
-        wpe_event_unref(event);
-        return true;
+    auto toWPETouchPointState = [](EventSenderProxyClientWPE::TouchPoint::State state) -> WPETouchPointState {
+        switch (state) {
+        case EventSenderProxyClientWPE::TouchPoint::State::Down:
+            return WPE_TOUCH_POINT_STATE_PRESSED;
+        case EventSenderProxyClientWPE::TouchPoint::State::Up:
+            return WPE_TOUCH_POINT_STATE_RELEASED;
+        case EventSenderProxyClientWPE::TouchPoint::State::Move:
+            return WPE_TOUCH_POINT_STATE_MOVED;
+        case EventSenderProxyClientWPE::TouchPoint::State::Cancel:
+            return WPE_TOUCH_POINT_STATE_CANCELLED;
+        case EventSenderProxyClientWPE::TouchPoint::State::Stationary:
+            return WPE_TOUCH_POINT_STATE_STATIONARY;
+        }
+        ASSERT_NOT_REACHED();
+        return WPE_TOUCH_POINT_STATE_STATIONARY;
     };
+
+    auto* view = WKViewGetView(m_testController.mainWebView()->platformView());
+    auto points = m_touchPoints.map([&](const auto& point) {
+        return WPETouchPoint(point.id, toWPETouchPointState(point.state), point.x, point.y);
+    });
+    auto pointsSpan = points.span();
+
+    auto* event = wpe_event_touch_new_with_touch_points(static_cast<WPEEventType>(type), view, WPE_INPUT_SOURCE_TOUCHSCREEN, secToMsTimestamp(time), static_cast<WPEModifiers>(m_touchModifiers), pointsSpan.data(), pointsSpan.size());
+    wpe_view_event(view, event);
+    wpe_event_unref(event);
 }
 
 void EventSenderProxyClientWPE::touchStart(double time)
 {
-    auto* view = WKViewGetView(m_testController.mainWebView()->platformView());
-    auto downPointProcessor = pointProcessor(TouchPointContext { TouchPoint::State::Down, TouchPoint::State::Stationary, WPE_EVENT_TOUCH_DOWN, time, static_cast<WPEModifiers>(m_touchModifiers), view });
+    sendTouchEvent(WPE_EVENT_TOUCH_DOWN, time);
     for (auto& point : m_touchPoints)
-        downPointProcessor(point);
+        point.state = TouchPoint::State::Stationary;
 }
 
 void EventSenderProxyClientWPE::touchMove(double time)
 {
-    auto* view = WKViewGetView(m_testController.mainWebView()->platformView());
-    auto movePointProcessor = pointProcessor(TouchPointContext { TouchPoint::State::Move, TouchPoint::State::Stationary, WPE_EVENT_TOUCH_MOVE, time, static_cast<WPEModifiers>(m_touchModifiers), view });
+    sendTouchEvent(WPE_EVENT_TOUCH_MOVE, time);
     for (auto& point : m_touchPoints)
-        movePointProcessor(point);
+        point.state = TouchPoint::State::Stationary;
 }
 
 void EventSenderProxyClientWPE::touchEnd(double time)
 {
-    auto* view = WKViewGetView(m_testController.mainWebView()->platformView());
-    auto upPointProcessor = pointProcessor(TouchPointContext { TouchPoint::State::Up, std::nullopt, WPE_EVENT_TOUCH_UP, time, static_cast<WPEModifiers>(0), view });
-    m_touchPoints.removeAllMatching(upPointProcessor);
+    sendTouchEvent(WPE_EVENT_TOUCH_UP, time);
+    m_touchPoints.removeAllMatching([](const auto& point) {
+        return point.state == TouchPoint::State::Up;
+    });
+    for (auto& point : m_touchPoints)
+        point.state = TouchPoint::State::Stationary;
 }
 
 void EventSenderProxyClientWPE::touchCancel(double time)
 {
-    auto* view = WKViewGetView(m_testController.mainWebView()->platformView());
-    auto cancelPointProcessor = pointProcessor(TouchPointContext { TouchPoint::State::Cancel, std::nullopt, WPE_EVENT_TOUCH_CANCEL, time, static_cast<WPEModifiers>(0), view });
-    m_touchPoints.removeAllMatching(cancelPointProcessor);
+    sendTouchEvent(WPE_EVENT_TOUCH_CANCEL, time);
+    m_touchPoints.removeAllMatching([](const auto& point) {
+        return point.state == TouchPoint::State::Cancel;
+    });
+    for (auto& point : m_touchPoints)
+        point.state = TouchPoint::State::Stationary;
 }
 
 void EventSenderProxyClientWPE::setTouchModifier(WKEventModifiers wkModifiers, bool enable)

--- a/Tools/WebKitTestRunner/wpe/EventSenderProxyClientWPE.h
+++ b/Tools/WebKitTestRunner/wpe/EventSenderProxyClientWPE.h
@@ -60,6 +60,7 @@ private:
     void touchEnd(double) override;
     void touchCancel(double) override;
     void setTouchModifier(WKEventModifiers, bool);
+    void sendTouchEvent(int type, double time);
 
     struct TouchPoint {
         enum class State { Down, Up, Move, Cancel, Stationary };
@@ -71,8 +72,6 @@ private:
     };
 
     struct TouchPointContext;
-
-    std::function<bool(TouchPoint&)> pointProcessor(const TouchPointContext&);
 
     Vector<TouchPoint> m_touchPoints;
     unsigned m_touchModifiers { 0 };


### PR DESCRIPTION
#### 9cda3febf60f6c3fe67c75405066cca12ac0de7f
<pre>
[WPE Platform] New API to create a touch event with multiple touch points
<a href="https://bugs.webkit.org/show_bug.cgi?id=319941">https://bugs.webkit.org/show_bug.cgi?id=319941</a>

Reviewed by NOBODY (OOPS!).

WPE Platform API wpe_event_touch_new takes only a single touch point. This is
not a problem for normal usecases. If two fingers touch the screen, the
application calls wpe_event_touch_new twice with a single touch point each
time. WPEWebViewPlatform memorizes all touch points in m_touchEvents member
variable.

However, this causes two problems for layout tests. Some layout tests expect a
touch event with multiple touch points at a time. For example,
fast/events/touch/touch-target.html has this code.

&gt;     eventSender.clearTouchPoints();
&gt;     eventSender.addTouchPoint(50, 150);
&gt;     eventSender.addTouchPoint(50, 250);
&gt;     eventSender.touchStart();

This should dispatch a touchstart event with two touch points at a time.
However, WPE WebKitTestRunner tried to dispatch two touchstart events because
wpe_event_touch_new accepts only a single touch point at a time.

The second problem is that some layout tests don&apos;t release all touch points.
For example, fast/events/touch/touch-target.html has this code at the end of
the test.

&gt;    eventSender.releaseTouchPoint(1);
&gt;    eventSender.touchEnd();

Only the 1st touch point is released. The 0th touch point isn&apos;t released. This
causes a problme for the next test because WPEWebViewPlatform memorizes touch
points in m_touchEvents.

Added new API wpe_event_touch_new_with_touch_points and
wpe_event_touch_get_touch_points.

* Source/WebKit/UIProcess/API/wpe/WPEWebViewPlatform.cpp:
(WKWPE::platformTouchPoints):
(WKWPE::ViewPlatform::handleEvent):
* Source/WebKit/WPEPlatform/wpe/WPEEvent.cpp:
(wpe_event_get_modifiers):
(wpe_event_touch_get_sequence_id):
(wpe_event_touch_new_with_touch_points):
(wpe_event_touch_get_touch_points):
* Source/WebKit/WPEPlatform/wpe/WPEEvent.h:
* Tools/WebKitTestRunner/wpe/EventSenderProxyClientWPE.cpp:
(WTR::EventSenderProxyClientWPE::sendTouchEvent):
(WTR::EventSenderProxyClientWPE::touchStart):
(WTR::EventSenderProxyClientWPE::touchMove):
(WTR::EventSenderProxyClientWPE::touchEnd):
(WTR::EventSenderProxyClientWPE::touchCancel):
(WTR::std::function&lt;bool): Deleted.
* Tools/WebKitTestRunner/wpe/EventSenderProxyClientWPE.h:
* LayoutTests/platform/wpe/TestExpectations:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9cda3febf60f6c3fe67c75405066cca12ac0de7f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176537 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50472 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44262 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186138 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/138814 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178400 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51764 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50156 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137516 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/138814 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179493 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41002 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158295 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117991 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39652 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/38020 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150067 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37793 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34606 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42204 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42231 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188561 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50137 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146568 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50821 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/34416 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146378 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41137 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123025 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117095 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49325 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12768 "") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48727 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48961 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48786 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->