### PR TITLE
Make WebTransport's session a Ref instead of a RefPtr

### DIFF
--- a/Source/WebCore/Modules/webtransport/WebTransport.cpp
+++ b/Source/WebCore/Modules/webtransport/WebTransport.cpp
@@ -32,7 +32,8 @@
 #include "DatagramByteSource.h"
 #include "DatagramSink.h"
 #include "DatagramSource.h"
-#include "Document.h"
+#include "DocumentInlines.h"
+#include "EmptyClients.h"
 #include "ExceptionOr.h"
 #include "HTTPParsers.h"
 #include "JSDOMConvertDictionary.h"
@@ -51,6 +52,7 @@
 #include "WebTransportBidirectionalStreamSource.h"
 #include "WebTransportCloseInfo.h"
 #include "WebTransportCongestionControl.h"
+#include "WebTransportConnectionInfo.h"
 #include "WebTransportConnectionStats.h"
 #include "WebTransportDatagramDuplexStream.h"
 #include "WebTransportDatagramsWritable.h"
@@ -142,48 +144,23 @@ ExceptionOr<Ref<WebTransport>> WebTransport::create(ScriptExecutionContext& cont
         datagramSource = WTF::move(datagramDefaultSource);
     }
 
-    RefPtr socketProvider = context.socketProvider();
-    if (!socketProvider) {
-        ASSERT_NOT_REACHED();
-        return Exception { ExceptionCode::InvalidStateError };
-    }
-
     auto datagrams = WebTransportDatagramDuplexStream::create(incomingDatagrams.releaseNonNull());
 
-    auto transport = adoptRef(*new WebTransport(context, domGlobalObject, incomingBidirectionalStreams.releaseReturnValue(), incomingUnidirectionalStreams.releaseReturnValue(), options, WTF::move(datagrams), datagramSource.releaseNonNull(), WTF::move(receiveStreamSource), WTF::move(bidirectionalStreamSource)));
+    Ref transport = adoptRef(*new WebTransport(context, domGlobalObject, incomingBidirectionalStreams.releaseReturnValue(), incomingUnidirectionalStreams.releaseReturnValue(), options, WTF::move(datagrams), datagramSource.releaseNonNull(), WTF::move(receiveStreamSource), WTF::move(bidirectionalStreamSource), WTF::move(parsedURL)));
     transport->suspendIfNeeded();
-    transport->initializeOverHTTP(*socketProvider, context, WTF::move(parsedURL), WTF::move(options));
     return transport;
 }
 
-void WebTransport::initializeOverHTTP(SocketProvider& provider, ScriptExecutionContext& context, URL&& url, WebTransportOptions&& options)
+static ClientOrigin clientOrigin(ScriptExecutionContext& context)
 {
-    std::optional<TextPosition> sourcePosition;
-    if (RefPtr document = dynamicDowncast<Document>(context))
-        sourcePosition = document->currentParserSourcePosition();
-
-    if (CheckedPtr csp = context.contentSecurityPolicy(); !csp || !csp->allowConnectToSource(url, WTF::move(sourcePosition)))
-        return cleanupWithSessionError();
-
-    // FIXME: Rename SocketProvider to NetworkProvider or something to reflect that it provides a little more than just simple sockets. SocketAndTransportProvider?
-    auto [session, promise] = provider.initializeWebTransportSession(context, *this, url, options);
-    ASSERT(!m_session);
-    m_session = WTF::move(session);
-    m_datagrams->attachTo(*this);
-
-    context.enqueueTaskWhenSettled(WTF::move(promise), TaskSource::Networking, [this, protectedThis = Ref { *this }] (auto&& result) mutable {
-        if (!result) {
-            return cleanupWithSessionError();
-        }
-        auto& connectionInfo = result.value();
-        m_protocol = WTF::move(connectionInfo.protocol);
-        m_reliability = connectionInfo.reliabilityMode;
-        m_state = State::Connected;
-        protect(m_ready.second)->resolve();
-    });
+    if (RefPtr scope = dynamicDowncast<WorkerGlobalScope>(context))
+        return scope->clientOrigin();
+    return downcast<Document>(context).clientOrigin();
 }
 
-WebTransport::WebTransport(ScriptExecutionContext& context, JSDOMGlobalObject& globalObject, Ref<ReadableStream>&& incomingBidirectionalStreams, Ref<ReadableStream>&& incomingUnidirectionalStreams, const WebTransportOptions& options, Ref<WebTransportDatagramDuplexStream>&& datagrams, Ref<DatagramSource>&& datagramSource, Ref<WebTransportReceiveStreamSource>&& receiveStreamSource, Ref<WebTransportBidirectionalStreamSource>&& bidirectionalStreamSource)
+// FIXME: Rename SocketProvider to NetworkProvider or something to reflect that it provides a little more than just simple sockets. SocketAndTransportProvider?
+
+WebTransport::WebTransport(ScriptExecutionContext& context, JSDOMGlobalObject& globalObject, Ref<ReadableStream>&& incomingBidirectionalStreams, Ref<ReadableStream>&& incomingUnidirectionalStreams, const WebTransportOptions& options, Ref<WebTransportDatagramDuplexStream>&& datagrams, Ref<DatagramSource>&& datagramSource, Ref<WebTransportReceiveStreamSource>&& receiveStreamSource, Ref<WebTransportBidirectionalStreamSource>&& bidirectionalStreamSource, URL&& url)
     : ActiveDOMObject(&context)
     , m_incomingBidirectionalStreams(WTF::move(incomingBidirectionalStreams))
     , m_incomingUnidirectionalStreams(WTF::move(incomingUnidirectionalStreams))
@@ -194,20 +171,26 @@ WebTransport::WebTransport(ScriptExecutionContext& context, JSDOMGlobalObject& g
     , m_closed(createPromiseAndWrapper(globalObject))
     , m_draining(createPromiseAndWrapper(globalObject))
     , m_datagrams(WTF::move(datagrams))
+    , m_session(context.socketProvider() ? context.socketProvider()->createWebTransportSession(context, *this) : emptySocketProvider()->createWebTransportSession(context, *this))
     , m_datagramSource(WTF::move(datagramSource))
     , m_receiveStreamSource(WTF::move(receiveStreamSource))
     , m_bidirectionalStreamSource(WTF::move(bidirectionalStreamSource))
 {
-    // FIXME: Change initializeWebTransportSession to being called in the constructor,
-    // and change m_session to being a const Ref.
+    m_datagrams->attachTo(*this);
+    context.enqueueTaskWhenSettled(m_session->initialize(context, url, options, WebCore::clientOrigin(context)), WebCore::TaskSource::Networking, [weakThis = WeakPtr { *this }] (auto&& info) mutable {
+        RefPtr strongThis = weakThis.get();
+        if (!strongThis)
+            return;
+        if (!info)
+            return strongThis->cleanupWithSessionError();
+        strongThis->m_protocol = WTF::move(info->protocol);
+        strongThis->m_reliability = info->reliabilityMode;
+        strongThis->m_state = State::Connected;
+        protect(strongThis->m_ready.second)->resolve();
+    });
 }
 
 WebTransport::~WebTransport() = default;
-
-RefPtr<WebTransportSession> WebTransport::session()
-{
-    return m_session;
-}
 
 bool WebTransport::virtualHasPendingActivity() const
 {
@@ -234,15 +217,12 @@ void WebTransport::receiveIncomingUnidirectionalStream(WebTransportStreamIdentif
     auto* globalObject = context->globalObject();
     if (!globalObject)
         return;
-    RefPtr session = m_session;
-    if (!session)
-        return;
 
     auto& jsDOMGlobalObject = *downcast<JSDOMGlobalObject>(globalObject);
     Ref incomingStream = WebTransportReceiveStreamByteSource::create(*this, identifier);
     auto stream = [&] {
         Locker<JSC::JSLock> locker(jsDOMGlobalObject.vm().apiLock());
-        return WebTransportReceiveStream::create(identifier, *session, jsDOMGlobalObject, incomingStream.copyRef());
+        return WebTransportReceiveStream::create(identifier, m_session, jsDOMGlobalObject, incomingStream.copyRef());
     } ();
     if (stream.hasException())
         return;
@@ -254,7 +234,7 @@ void WebTransport::receiveIncomingUnidirectionalStream(WebTransportStreamIdentif
         ASSERT(!m_readStreamSources.contains(identifier));
         m_readStreamSources.add(identifier, WTF::move(incomingStream));
     } else
-        session->destroyStream(identifier, std::nullopt);
+        m_session->destroyStream(identifier, std::nullopt);
 }
 
 static ExceptionOr<Ref<WebTransportBidirectionalStream>> createBidirectionalStream(WebTransport& transport, WebTransportSession& session, JSDOMGlobalObject& globalObject, Ref<WebTransportSendStreamSink>&& sink, Ref<WebTransportReceiveStreamByteSource>&& source, const WebTransportSendStreamOptions& options)
@@ -283,14 +263,11 @@ void WebTransport::receiveBidirectionalStream(WebTransportStreamIdentifier ident
     auto* globalObject = context->globalObject();
     if (!globalObject)
         return;
-    RefPtr session = m_session;
-    if (!session)
-        return;
 
     Ref sink = WebTransportSendStreamSink::create(*this, identifier);
     auto& jsDOMGlobalObject = *downcast<JSDOMGlobalObject>(globalObject);
     Ref incomingStream = WebTransportReceiveStreamByteSource::create(*this, identifier);
-    auto stream = WebCore::createBidirectionalStream(*this, *session, jsDOMGlobalObject, sink.copyRef(), incomingStream.copyRef(), WebTransportSendStreamOptions { });
+    auto stream = WebCore::createBidirectionalStream(*this, m_session, jsDOMGlobalObject, sink.copyRef(), incomingStream.copyRef(), WebTransportSendStreamOptions { });
     if (stream.hasException())
         return;
     Ref bidiStream = stream.releaseReturnValue();
@@ -305,7 +282,7 @@ void WebTransport::receiveBidirectionalStream(WebTransportStreamIdentifier ident
         ASSERT(!m_sendStreamSinks.contains(identifier));
         m_sendStreamSinks.add(identifier, WTF::move(sink));
     } else
-        session->destroyStream(identifier, std::nullopt);
+        m_session->destroyStream(identifier, std::nullopt);
 }
 
 void WebTransport::streamReceiveBytes(WebTransportStreamIdentifier identifier, std::span<const uint8_t> span, bool withFin, std::optional<Exception>&& exception)
@@ -322,8 +299,6 @@ void WebTransport::streamReceiveError(WebTransportStreamIdentifier identifier, u
         return;
     auto* globalObject = context->globalObject();
     if (!globalObject)
-        return;
-    if (!m_session)
         return;
 
     if (RefPtr source = m_readStreamSources.get(identifier)) {
@@ -348,8 +323,6 @@ void WebTransport::streamSendError(WebTransportStreamIdentifier identifier, uint
     auto* globalObject = context->globalObject();
     if (!globalObject)
         return;
-    if (!m_session)
-        return;
 
     if (RefPtr sink = m_sendStreamSinks.get(identifier)) {
         auto& jsDOMGlobalObject = *downcast<JSDOMGlobalObject>(globalObject);
@@ -367,14 +340,10 @@ void WebTransport::streamSendError(WebTransportStreamIdentifier identifier, uint
 
 void WebTransport::getStats(ScriptExecutionContext& context, Ref<DeferredPromise>&& promise)
 {
-    RefPtr session = m_session;
-    if (!session)
-        return promise->reject(ExceptionCode::InvalidStateError);
-
     if (m_state == State::Failed)
         return promise->reject(ExceptionCode::InvalidStateError);
 
-    context.enqueueTaskWhenSettled(session->getStats(), WebCore::TaskSource::Networking, [promise = WTF::move(promise)] (auto&& stats) mutable {
+    context.enqueueTaskWhenSettled(m_session->getStats(), WebCore::TaskSource::Networking, [promise = WTF::move(promise)] (auto&& stats) mutable {
         if (!stats)
             return promise->reject(ExceptionCode::InvalidStateError);
         promise->resolve<IDLDictionary<WebTransportConnectionStats>>(*stats);
@@ -398,11 +367,7 @@ void WebTransport::exportKeyingMaterial(ScriptExecutionContext& scriptExecutionC
     if (m_state == State::Closed || m_state == State::Failed)
         return promise->reject(ExceptionCode::InvalidStateError);
 
-    RefPtr session = m_session;
-    if (!session)
-        return promise->reject(ExceptionCode::InvalidStateError);
-
-    scriptExecutionContext.enqueueTaskWhenSettled(session->exportKeyingMaterial(label.span(), context.span(), outputLength), WebCore::TaskSource::Networking, [promise = WTF::move(promise)] (auto&& keyingMaterial) mutable {
+    scriptExecutionContext.enqueueTaskWhenSettled(m_session->exportKeyingMaterial(label.span(), context.span(), outputLength), WebCore::TaskSource::Networking, [promise = WTF::move(promise)] (auto&& keyingMaterial) mutable {
         if (keyingMaterial)
             fulfillPromiseWithUint8ArrayFromSpan(WTF::move(promise), keyingMaterial->span());
         else
@@ -498,8 +463,7 @@ void WebTransport::cleanupContext()
     // (frame detached, null global object) and drop the rejection; this instead runs on resume.
     if (m_state == State::Connected) {
         m_state = State::Failed;
-        if (RefPtr session = m_session)
-            session->terminate(0, { });
+        m_session->terminate(0, { });
         queueTaskKeepingObjectAlive(*this, TaskSource::Networking, [](auto& transport) {
             transport.cleanupWithSessionError();
         });
@@ -515,8 +479,7 @@ void WebTransport::close(WebTransportCloseInfo&& closeInfo)
         return;
     if (m_state == State::Connecting)
         return cleanupWithSessionError();
-    if (RefPtr session = m_session)
-        session->terminate(closeInfo.closeCode, trimToValidUTF8Length1024(closeInfo.reason.utf8()));
+    m_session->terminate(closeInfo.closeCode, trimToValidUTF8Length1024(closeInfo.reason.utf8()));
     cleanup(DOMException::create(ExceptionCode::AbortError), WTF::move(closeInfo));
 }
 
@@ -586,15 +549,13 @@ WebTransportDatagramDuplexStream& WebTransport::datagrams()
 void WebTransport::createBidirectionalStream(ScriptExecutionContext& context, WebTransportSendStreamOptions&& options, Ref<DeferredPromise>&& promise)
 {
     // https://www.w3.org/TR/webtransport/#dom-webtransport-createbidirectionalstream
-    RefPtr session = m_session;
-    if (m_state == State::Closed || m_state == State::Failed || !session)
+    if (m_state == State::Closed || m_state == State::Failed)
         return promise->reject(ExceptionCode::InvalidStateError);
 
-    context.enqueueTaskWhenSettled(session->createBidirectionalStream(), WebCore::TaskSource::Networking, [
+    context.enqueueTaskWhenSettled(m_session->createBidirectionalStream(), WebCore::TaskSource::Networking, [
         promise = WTF::move(promise),
         context = WeakPtr { context },
         protectedThis = Ref { *this },
-        session,
         options = WTF::move(options)
     ] (auto&& identifier) mutable {
         if (!identifier)
@@ -608,7 +569,7 @@ void WebTransport::createBidirectionalStream(ScriptExecutionContext& context, We
         Ref sink = WebTransportSendStreamSink::create(protectedThis.get(), *identifier);
         auto& jsDOMGlobalObject = *downcast<JSDOMGlobalObject>(globalObject);
         Ref incomingStream = WebTransportReceiveStreamByteSource::create(protectedThis.get(), *identifier);
-        auto stream = WebCore::createBidirectionalStream(protectedThis, *session, jsDOMGlobalObject, sink.copyRef(), incomingStream.copyRef(), options);
+        auto stream = WebCore::createBidirectionalStream(protectedThis, protectedThis->m_session, jsDOMGlobalObject, sink.copyRef(), incomingStream.copyRef(), options);
         if (stream.hasException())
             return promise->reject(stream.releaseException());
         Ref bidiStream = stream.releaseReturnValue();
@@ -632,15 +593,13 @@ ReadableStream& WebTransport::incomingBidirectionalStreams()
 void WebTransport::createUnidirectionalStream(ScriptExecutionContext& context, WebTransportSendStreamOptions&& options, Ref<DeferredPromise>&& promise)
 {
     // https://www.w3.org/TR/webtransport/#dom-webtransport-createunidirectionalstream
-    RefPtr session = m_session;
-    if (m_state == State::Closed || m_state == State::Failed || !session)
+    if (m_state == State::Closed || m_state == State::Failed)
         return promise->reject(ExceptionCode::InvalidStateError);
 
-    context.enqueueTaskWhenSettled(session->createOutgoingUnidirectionalStream(), WebCore::TaskSource::Networking, [
+    context.enqueueTaskWhenSettled(m_session->createOutgoingUnidirectionalStream(), WebCore::TaskSource::Networking, [
         promise = WTF::move(promise),
         context = WeakPtr { context },
         protectedThis = Ref { *this },
-        session,
         options = WTF::move(options)
     ] (auto&& identifier) mutable {
         if (!identifier)

--- a/Source/WebCore/Modules/webtransport/WebTransport.h
+++ b/Source/WebCore/Modules/webtransport/WebTransport.h
@@ -66,6 +66,7 @@ class WorkerWebTransportSession;
 class WritableStream;
 
 struct WebTransportCloseInfo;
+struct WebTransportConnectionInfo;
 struct WebTransportOptions;
 struct WebTransportSendStreamOptions;
 struct WebTransportHash;
@@ -102,7 +103,7 @@ public:
     Ref<WebTransportSendGroup> createSendGroup();
     static bool NODELETE supportsReliableOnly();
 
-    RefPtr<WebTransportSession> NODELETE session();
+    const Ref<WebTransportSession>& session() const { return m_session; };
     void datagramsWritableCreated(WebTransportDatagramsWritable&);
     void cleanupContext();
 
@@ -110,9 +111,8 @@ public:
     void receiveStreamClosed(WebTransportStreamIdentifier);
 
 private:
-    WebTransport(ScriptExecutionContext&, JSDOMGlobalObject&, Ref<ReadableStream>&&, Ref<ReadableStream>&&, const WebTransportOptions&, Ref<WebTransportDatagramDuplexStream>&&, Ref<DatagramSource>&&, Ref<WebTransportReceiveStreamSource>&&, Ref<WebTransportBidirectionalStreamSource>&&);
+    WebTransport(ScriptExecutionContext&, JSDOMGlobalObject&, Ref<ReadableStream>&&, Ref<ReadableStream>&&, const WebTransportOptions&, Ref<WebTransportDatagramDuplexStream>&&, Ref<DatagramSource>&&, Ref<WebTransportReceiveStreamSource>&&, Ref<WebTransportBidirectionalStreamSource>&&, URL&&);
 
-    void initializeOverHTTP(SocketProvider&, ScriptExecutionContext&, URL&&, WebTransportOptions&&);
     void cleanup(Ref<DOMException>&&, std::optional<WebTransportCloseInfo>&&);
     void cleanupWithSessionError();
 
@@ -154,7 +154,7 @@ private:
     const PromiseAndWrapper m_closed;
     const PromiseAndWrapper m_draining;
     const Ref<WebTransportDatagramDuplexStream> m_datagrams;
-    RefPtr<WebTransportSession> m_session;
+    const Ref<WebTransportSession> m_session;
     const Ref<DatagramSource> m_datagramSource;
     const Ref<WebTransportReceiveStreamSource> m_receiveStreamSource;
     const Ref<WebTransportBidirectionalStreamSource> m_bidirectionalStreamSource;

--- a/Source/WebCore/Modules/webtransport/WebTransportDatagramDuplexStream.cpp
+++ b/Source/WebCore/Modules/webtransport/WebTransportDatagramDuplexStream.cpp
@@ -64,7 +64,7 @@ RefPtr<WebTransportSession> WebTransportDatagramDuplexStream::session()
     RefPtr transport = m_transport.get();
     if (!transport)
         return nullptr;
-    return transport->session();
+    return transport->session().ptr();
 }
 
 ExceptionOr<void> WebTransportDatagramDuplexStream::setIncomingMaxAge(std::optional<double> maxAge)

--- a/Source/WebCore/Modules/webtransport/WebTransportDatagramsWritable.cpp
+++ b/Source/WebCore/Modules/webtransport/WebTransportDatagramsWritable.cpp
@@ -49,7 +49,7 @@ ExceptionOr<Ref<WebTransportDatagramsWritable>> WebTransportDatagramsWritable::c
     }
     auto& domGlobalObject = *downcast<JSDOMGlobalObject>(globalObject);
 
-    Ref datagramSink = DatagramSink::create(transport ? transport->session().get() : nullptr);
+    Ref datagramSink = DatagramSink::create(transport ? transport->session().ptr() : nullptr);
     auto internal = createInternalWritableStream(domGlobalObject, datagramSink.copyRef());
     if (internal.hasException())
         return internal.releaseException();

--- a/Source/WebCore/Modules/webtransport/WebTransportReceiveStreamByteSource.cpp
+++ b/Source/WebCore/Modules/webtransport/WebTransportReceiveStreamByteSource.cpp
@@ -127,17 +127,13 @@ void WebTransportReceiveStreamByteSource::cancel(JSC::JSValue reason, Ref<Deferr
         return;
     transport->receiveStreamClosed(m_identifier);
 
-    RefPtr session = transport->session();
-    if (!session)
-        return;
-
     std::optional<uint64_t> errorCode;
     if (auto* jsWebTransportError = dynamicDowncast<JSWebTransportError>(reason)) {
         auto& webTransportError = jsWebTransportError->wrapped();
         if (auto webTransportErrorCode = webTransportError.streamErrorCode())
             errorCode = static_cast<uint64_t>(*webTransportErrorCode);
     }
-    session->cancelReceiveStream(m_identifier, errorCode);
+    transport->session()->cancelReceiveStream(m_identifier, errorCode);
 }
 
 }

--- a/Source/WebCore/Modules/webtransport/WebTransportSendGroup.cpp
+++ b/Source/WebCore/Modules/webtransport/WebTransportSendGroup.cpp
@@ -52,10 +52,7 @@ void WebTransportSendGroup::getStats(ScriptExecutionContext& context, Ref<Deferr
     RefPtr transport = m_transport.get();
     if (!transport)
         return promise->reject(ExceptionCode::InvalidStateError);
-    RefPtr session = transport->session();
-    if (!session)
-        return promise->reject(ExceptionCode::InvalidStateError);
-    context.enqueueTaskWhenSettled(session->getSendGroupStats(m_identifier), WebCore::TaskSource::Networking, [promise = WTF::move(promise)] (auto&& stats) mutable {
+    context.enqueueTaskWhenSettled(transport->session()->getSendGroupStats(m_identifier), WebCore::TaskSource::Networking, [promise = WTF::move(promise)] (auto&& stats) mutable {
         if (!stats)
             return promise->reject(ExceptionCode::InvalidStateError);
         promise->resolve<IDLDictionary<WebTransportSendStreamStats>>(*stats);

--- a/Source/WebCore/Modules/webtransport/WebTransportSendStream.cpp
+++ b/Source/WebCore/Modules/webtransport/WebTransportSendStream.cpp
@@ -76,10 +76,7 @@ void WebTransportSendStream::getStats(ScriptExecutionContext& context, Ref<Defer
     RefPtr transport = m_transport.get();
     if (!transport)
         return promise->reject(ExceptionCode::InvalidStateError);
-    RefPtr session = transport->session();
-    if (!session)
-        return promise->reject(ExceptionCode::InvalidStateError);
-    context.enqueueTaskWhenSettled(session->getSendStreamStats(m_identifier), WebCore::TaskSource::Networking, [promise = WTF::move(promise)] (auto&& stats) mutable {
+    context.enqueueTaskWhenSettled(transport->session()->getSendStreamStats(m_identifier), WebCore::TaskSource::Networking, [promise = WTF::move(promise)] (auto&& stats) mutable {
         if (!stats)
             return promise->reject(ExceptionCode::InvalidStateError);
         promise->resolve<IDLDictionary<WebTransportSendStreamStats>>(*stats);

--- a/Source/WebCore/Modules/webtransport/WebTransportSendStreamSink.cpp
+++ b/Source/WebCore/Modules/webtransport/WebTransportSendStreamSink.cpp
@@ -78,10 +78,6 @@ void WebTransportSendStreamSink::write(ScriptExecutionContext& context, JSC::JSV
     if (!transport)
         return promise.reject(Exception { ExceptionCode::InvalidStateError });
 
-    RefPtr session = transport->session();
-    if (!session)
-        return promise.reject(Exception { ExceptionCode::InvalidStateError });
-
     if (!context.globalObject())
         return promise.reject(Exception { ExceptionCode::InvalidStateError });
 
@@ -97,7 +93,7 @@ void WebTransportSendStreamSink::write(ScriptExecutionContext& context, JSC::JSV
 
     WTF::switchOn(bufferSource.releaseReturnValue(), [&] (auto&& arrayBufferOrView) {
         constexpr bool withFin { false };
-        context.enqueueTaskWhenSettled(session->streamSendBytes(m_identifier, arrayBufferOrView->span(), withFin), TaskSource::Networking, [promise = WTF::move(promise)] (auto&& exception) mutable {
+        context.enqueueTaskWhenSettled(transport->session()->streamSendBytes(m_identifier, arrayBufferOrView->span(), withFin), TaskSource::Networking, [promise = WTF::move(promise)] (auto&& exception) mutable {
             if (!exception)
                 promise.settle(Exception { ExceptionCode::NetworkError });
             else if (*exception)
@@ -115,8 +111,7 @@ void WebTransportSendStreamSink::close(JSDOMGlobalObject&)
     m_isClosed = true;
 
     if (RefPtr transport = m_transport.get()) {
-        if (RefPtr session = transport->session())
-            session->streamSendBytes(m_identifier, { }, true);
+        transport->session()->streamSendBytes(m_identifier, { }, true);
         transport->sendStreamClosed(m_identifier);
     }
 }
@@ -136,17 +131,13 @@ void WebTransportSendStreamSink::abort(JSDOMGlobalObject&, JSC::JSValue value, D
         return;
     transport->sendStreamClosed(m_identifier);
 
-    RefPtr session = transport->session();
-    if (!session)
-        return;
-
     std::optional<uint64_t> errorCode;
     if (auto* jsWebTransportError = dynamicDowncast<JSWebTransportError>(value)) {
         auto& webTransportError = jsWebTransportError->wrapped();
         if (auto webTransportErrorCode = webTransportError.streamErrorCode())
             errorCode = static_cast<uint64_t>(*webTransportErrorCode);
     }
-    session->cancelSendStream(m_identifier, errorCode);
+    transport->session()->cancelSendStream(m_identifier, errorCode);
 }
 
 }

--- a/Source/WebCore/Modules/webtransport/WebTransportSession.h
+++ b/Source/WebCore/Modules/webtransport/WebTransportSession.h
@@ -39,7 +39,10 @@ class WebTransportBidirectionalStream;
 class WebTransportSendStream;
 class WebTransportSessionClient;
 
+struct ClientOrigin;
+struct WebTransportConnectionInfo;
 struct WebTransportConnectionStats;
+struct WebTransportOptions;
 struct WebTransportReceiveStreamStats;
 struct WebTransportSendGroupIdentifierType;
 struct WebTransportSendStreamStats;
@@ -47,6 +50,7 @@ struct WebTransportStreamIdentifierType;
 
 using WebTransportSendGroupIdentifier = ObjectIdentifier<WebTransportSendGroupIdentifierType>;
 using WebTransportStreamIdentifier = ObjectIdentifier<WebTransportStreamIdentifierType>;
+using WebTransportSessionInitializationPromise = NativePromise<WebTransportConnectionInfo, void>;
 using WebTransportStreamPromise = NativePromise<WebTransportStreamIdentifier, void>;
 using WebTransportSendPromise = NativePromise<std::optional<Exception>, void>;
 using WebTransportConnectionStatsPromise = NativePromise<WebTransportConnectionStats, void>;
@@ -61,6 +65,7 @@ class WEBCORE_EXPORT WebTransportSession : public AbstractThreadSafeRefCountedAn
 public:
     virtual ~WebTransportSession();
 
+    virtual Ref<WebTransportSessionInitializationPromise> initialize(ScriptExecutionContext&, const URL&, const WebTransportOptions&, const ClientOrigin&) = 0;
     virtual Ref<WebTransportSendPromise> sendDatagram(std::optional<WebTransportSendGroupIdentifier>, std::span<const uint8_t>) = 0;
     virtual Ref<WebTransportStreamPromise> createOutgoingUnidirectionalStream() = 0;
     virtual Ref<WebTransportStreamPromise> createBidirectionalStream() = 0;

--- a/Source/WebCore/Modules/webtransport/WorkerWebTransportSession.cpp
+++ b/Source/WebCore/Modules/webtransport/WorkerWebTransportSession.cpp
@@ -29,6 +29,7 @@
 #include "Exception.h"
 #include "ScriptExecutionContext.h"
 #include "WebTransport.h"
+#include "WebTransportConnectionInfo.h"
 #include "WebTransportConnectionStats.h"
 #include "WebTransportReceiveStreamStats.h"
 #include "WebTransportSendStreamStats.h"
@@ -143,6 +144,14 @@ void WorkerWebTransportSession::streamSendError(WebTransportStreamIdentifier ide
             return;
         client->streamSendError(identifier, errorCode);
     });
+}
+
+Ref<WebTransportSessionInitializationPromise> WorkerWebTransportSession::initialize(ScriptExecutionContext& context, const URL& url, const WebTransportOptions& options, const ClientOrigin& origin)
+{
+    ASSERT(!RunLoop::isMain());
+    if (RefPtr session = m_session)
+        return session->initialize(context, url, options, origin);
+    return WebTransportSessionInitializationPromise::createAndReject();
 }
 
 Ref<WebTransportSendPromise> WorkerWebTransportSession::sendDatagram(std::optional<WebTransportSendGroupIdentifier> identifier, std::span<const uint8_t> datagram)

--- a/Source/WebCore/Modules/webtransport/WorkerWebTransportSession.h
+++ b/Source/WebCore/Modules/webtransport/WorkerWebTransportSession.h
@@ -54,6 +54,7 @@ private:
     void didFail(std::optional<uint32_t>&&, String&&) final;
     void didDrain() final;
 
+    Ref<WebTransportSessionInitializationPromise> initialize(ScriptExecutionContext&, const URL&, const WebTransportOptions&, const ClientOrigin&) final;
     Ref<WebTransportSendPromise> sendDatagram(std::optional<WebTransportSendGroupIdentifier>, std::span<const uint8_t>) final;
     Ref<WebTransportStreamPromise> createOutgoingUnidirectionalStream() final;
     Ref<WebTransportStreamPromise> createBidirectionalStream() final;

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -2117,7 +2117,7 @@ public:
     WEBCORE_EXPORT void ariaNotify(const String&);
     WEBCORE_EXPORT void ariaNotify(const String&, const AriaNotifyOptions&);
 
-    std::optional<TextPosition> currentParserSourcePosition() const;
+    WEBCORE_EXPORT std::optional<TextPosition> currentParserSourcePosition() const;
 
     bool shouldUseTouchEventRegions() const;
 

--- a/Source/WebCore/loader/EmptyClients.cpp
+++ b/Source/WebCore/loader/EmptyClients.cpp
@@ -87,6 +87,10 @@
 #include "UserContentProvider.h"
 #include "VisitedLinkStore.h"
 #include "WebRTCProvider.h"
+#include "WebTransportConnectionInfo.h"
+#include "WebTransportConnectionStats.h"
+#include "WebTransportReceiveStreamStats.h"
+#include "WebTransportSendStreamStats.h"
 #include "WebTransportSession.h"
 #include <JavaScriptCore/HeapInlines.h>
 #include <pal/SessionID.h>
@@ -1234,12 +1238,43 @@ private:
     void NODELETE postMessage(const PartitionedSecurityOrigin&, const String&, BroadcastChannelIdentifier, Ref<SerializedScriptValue>&&, CompletionHandler<void()>&&) final { }
 };
 
+class EmptyWebTransportSession final : public WebTransportSession, public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<EmptyWebTransportSession> {
+public:
+    WTF_ABSTRACT_THREAD_SAFE_REF_COUNTED_AND_CAN_MAKE_WEAK_PTR_IMPL;
+
+    Ref<WebTransportSessionInitializationPromise> initialize(ScriptExecutionContext&, const URL&, const WebTransportOptions&, const ClientOrigin&) final { return WebTransportSessionInitializationPromise::createAndReject(); }
+    Ref<WebTransportSendPromise> sendDatagram(std::optional<WebTransportSendGroupIdentifier>, std::span<const uint8_t>) final { return WebTransportSendPromise::createAndReject(); }
+    Ref<WebTransportStreamPromise> createOutgoingUnidirectionalStream() final { return WebTransportStreamPromise::createAndReject(); }
+    Ref<WebTransportStreamPromise> createBidirectionalStream() final { return WebTransportStreamPromise::createAndReject(); }
+    Ref<WebTransportSendPromise> streamSendBytes(WebTransportStreamIdentifier, std::span<const uint8_t>, bool) final { return WebTransportSendPromise::createAndReject(); }
+    Ref<WebTransportConnectionStatsPromise> getStats() final { return WebTransportConnectionStatsPromise::createAndReject(); }
+    Ref<WebTransportSendStreamStatsPromise> getSendStreamStats(WebTransportStreamIdentifier) final { return WebTransportSendStreamStatsPromise::createAndReject(); }
+    Ref<WebTransportReceiveStreamStatsPromise> getReceiveStreamStats(WebTransportStreamIdentifier) final { return WebTransportReceiveStreamStatsPromise::createAndReject(); }
+    Ref<WebTransportSendStreamStatsPromise> getSendGroupStats(WebTransportSendGroupIdentifier) final { return WebTransportSendStreamStatsPromise::createAndReject(); }
+    Ref<WebTransportExportKeyingMaterialPromise> exportKeyingMaterial(std::span<const uint8_t>, std::span<const uint8_t>, uint32_t) final { return WebTransportExportKeyingMaterialPromise::createAndReject(); }
+
+    void cancelReceiveStream(WebTransportStreamIdentifier, std::optional<WebTransportStreamErrorCode>) final { }
+    void cancelSendStream(WebTransportStreamIdentifier, std::optional<WebTransportStreamErrorCode>) final { }
+    void destroyStream(WebTransportStreamIdentifier, std::optional<WebTransportStreamErrorCode>) final { }
+    void terminate(WebTransportSessionErrorCode, CString&&) final { }
+    void datagramIncomingMaxAgeUpdated(std::optional<double>) final { }
+    void datagramOutgoingMaxAgeUpdated(std::optional<double>) final { }
+    void incomingMaxBufferedDatagramsUpdated(uint32_t) final { }
+    void outgoingMaxBufferedDatagramsUpdated(uint32_t) final { }
+};
+
 class EmptySocketProvider final : public SocketProvider {
 public:
     RefPtr<ThreadableWebSocketChannel> createWebSocketChannel(Document&, WebSocketChannelClient&, IsInitiatedByDedicatedWorker) final { return nullptr; }
 
-    std::pair<RefPtr<WebTransportSession>, Ref<WebTransportSessionPromise>> initializeWebTransportSession(ScriptExecutionContext&, WebTransportSessionClient&, const URL&, const WebTransportOptions&) { return { nullptr, WebTransportSessionPromise::createAndReject() }; }
+    Ref<WebTransportSession> createWebTransportSession(ScriptExecutionContext&, WebTransportSessionClient&) { return adoptRef(*new EmptyWebTransportSession()); }
 };
+
+Ref<SocketProvider> emptySocketProvider()
+{
+    static NeverDestroyed<Ref<SocketProvider>> provider { adoptRef(*new EmptySocketProvider()) };
+    return provider.get();
+}
 
 class EmptyHistoryItemClient final : public HistoryItemClient {
 public:
@@ -1256,7 +1291,7 @@ PageConfiguration pageConfigurationWithEmptyClients(std::optional<PageIdentifier
         std::nullopt,
         sessionID,
         makeUniqueRef<EmptyEditorClient>(),
-        adoptRef(*new EmptySocketProvider),
+        emptySocketProvider(),
         WebRTCProvider::create(),
         CacheStorageProvider::create(),
         adoptRef(*new EmptyUserContentProvider),

--- a/Source/WebCore/loader/EmptyClients.h
+++ b/Source/WebCore/loader/EmptyClients.h
@@ -53,6 +53,7 @@ class DiagnosticLoggingClient;
 class EditorClient;
 class HTMLImageElement;
 class PageConfiguration;
+class SocketProvider;
 enum class BroadcastFocusedElement : bool;
 enum class ContentChange : uint8_t;
 struct FocusOptions;
@@ -226,6 +227,7 @@ class EmptyChromeClient : public ChromeClient {
     RefPtr<Icon> createIconForFiles(const Vector<String>& /* filenames */) final;
 };
 
+WEBCORE_EXPORT Ref<SocketProvider> emptySocketProvider();
 DiagnosticLoggingClient& NODELETE emptyDiagnosticLoggingClient();
 WEBCORE_EXPORT PageConfiguration pageConfigurationWithEmptyClients(std::optional<PageIdentifier>, PAL::SessionID);
 

--- a/Source/WebCore/page/SocketProvider.h
+++ b/Source/WebCore/page/SocketProvider.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <WebCore/WebTransportConnectionInfo.h>
 #include <wtf/CompletionHandler.h>
 #include <wtf/NativePromise.h>
 #include <wtf/Ref.h>
@@ -42,14 +41,10 @@ class WebTransportSessionClient;
 
 enum class IsInitiatedByDedicatedWorker : bool;
 
-struct WebTransportOptions;
-
-using WebTransportSessionPromise = NativePromise<WebTransportConnectionInfo, void>;
-
 class WEBCORE_EXPORT SocketProvider : public ThreadSafeRefCounted<SocketProvider> {
 public:
     virtual RefPtr<ThreadableWebSocketChannel> createWebSocketChannel(Document&, WebSocketChannelClient&, IsInitiatedByDedicatedWorker) = 0;
-    virtual std::pair<RefPtr<WebTransportSession>, Ref<WebTransportSessionPromise>> initializeWebTransportSession(ScriptExecutionContext&, WebTransportSessionClient&, const URL&, const WebTransportOptions&) = 0;
+    virtual Ref<WebTransportSession> createWebTransportSession(ScriptExecutionContext&, WebTransportSessionClient&) = 0;
 
     virtual void countWebSocketChannelsForTesting(CompletionHandler<void(unsigned)>&& completionHandler) { completionHandler(0); }
 

--- a/Source/WebKit/WebProcess/Network/WebSocketProvider.cpp
+++ b/Source/WebKit/WebProcess/Network/WebSocketProvider.cpp
@@ -60,7 +60,7 @@ WebSocketProvider::WebSocketProvider(WebPageProxyIdentifier webPageProxyID)
     : m_webPageProxyID(webPageProxyID)
     , m_networkProcessConnection(WebProcess::singleton().ensureNetworkProcessConnection().connection()) { }
 
-std::pair<RefPtr<WebCore::WebTransportSession>, Ref<WebTransportSessionPromise>> WebSocketProvider::initializeWebTransportSession(ScriptExecutionContext& context, WebTransportSessionClient& client, const URL& url, const WebCore::WebTransportOptions& options)
+Ref<WebCore::WebTransportSession> WebSocketProvider::createWebTransportSession(ScriptExecutionContext& context, WebTransportSessionClient& client)
 {
     if (RefPtr scope = dynamicDowncast<WorkerGlobalScope>(context)) {
         ASSERT(!RunLoop::isMain());
@@ -80,15 +80,14 @@ std::pair<RefPtr<WebCore::WebTransportSession>, Ref<WebTransportSessionPromise>>
             connection = getConnection();
         }
 
-        auto [session, promise] = WebKit::WebTransportSession::initialize(WTF::move(connection), workerSession, url, options, m_webPageProxyID, scope->clientOrigin());
+        Ref session = WebKit::WebTransportSession::create(WTF::move(connection), workerSession, m_webPageProxyID);
         workerSession->attachSession(session);
-        return { WTF::move(workerSession), WTF::move(promise) };
+        return workerSession;
     }
 
     Ref document = downcast<Document>(context);
     ASSERT(RunLoop::isMain());
-    auto [session, promise] = WebKit::WebTransportSession::initialize(WebProcess::singleton().ensureNetworkProcessConnection().connection(), client, url, options, m_webPageProxyID, document->clientOrigin());
-    return { WTF::move(session), WTF::move(promise) };
+    return WebKit::WebTransportSession::create(WebProcess::singleton().ensureNetworkProcessConnection().connection(), client, m_webPageProxyID);
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/Network/WebSocketProvider.h
+++ b/Source/WebKit/WebProcess/Network/WebSocketProvider.h
@@ -41,7 +41,7 @@ public:
     ~WebSocketProvider();
 private:
     RefPtr<WebCore::ThreadableWebSocketChannel> createWebSocketChannel(WebCore::Document&, WebCore::WebSocketChannelClient&, WebCore::IsInitiatedByDedicatedWorker) final;
-    std::pair<RefPtr<WebCore::WebTransportSession>, Ref<WebCore::WebTransportSessionPromise>> initializeWebTransportSession(WebCore::ScriptExecutionContext&, WebCore::WebTransportSessionClient&, const URL&, const WebCore::WebTransportOptions&) final;
+    Ref<WebCore::WebTransportSession> createWebTransportSession(WebCore::ScriptExecutionContext&, WebCore::WebTransportSessionClient&) final;
     void countWebSocketChannelsForTesting(CompletionHandler<void(unsigned)>&&) final;
 
     explicit WebSocketProvider(WebPageProxyIdentifier);

--- a/Source/WebKit/WebProcess/Network/WebTransportSession.cpp
+++ b/Source/WebKit/WebProcess/Network/WebTransportSession.cpp
@@ -31,7 +31,10 @@
 #include "NetworkProcessConnection.h"
 #include "NetworkTransportSessionMessages.h"
 #include "WebProcess.h"
+#include <WebCore/ContentSecurityPolicy.h>
+#include <WebCore/Document.h>
 #include <WebCore/Exception.h>
+#include <WebCore/ScriptExecutionContext.h>
 #include <WebCore/WebTransportConnectionInfo.h>
 #include <WebCore/WebTransportConnectionStats.h>
 #include <WebCore/WebTransportOptions.h>
@@ -40,26 +43,20 @@
 #include <WebCore/WebTransportSessionClient.h>
 #include <wtf/Ref.h>
 #include <wtf/RunLoop.h>
+#include <wtf/text/TextPosition.h>
 
 namespace WebKit {
 
-std::pair<Ref<WebTransportSession>, Ref<WebCore::WebTransportSessionPromise>> WebTransportSession::initialize(Ref<IPC::Connection>&& connection, ThreadSafeWeakPtr<WebCore::WebTransportSessionClient>&& client, const URL& url, const WebCore::WebTransportOptions& options, const WebPageProxyIdentifier& pageID, const WebCore::ClientOrigin& clientOrigin)
+Ref<WebTransportSession> WebTransportSession::create(Ref<IPC::Connection>&& connection, ThreadSafeWeakPtr<WebCore::WebTransportSessionClient>&& client, const WebPageProxyIdentifier& pageID)
 {
-    auto identifier = WebTransportSessionIdentifier::generate();
-    return {
-        adoptRef(*new WebTransportSession(connection.copyRef(), WTF::move(client), identifier)),
-        connection->sendWithPromisedReply(Messages::NetworkConnectionToWebProcess::InitializeWebTransportSession(identifier, url, options, pageID, clientOrigin))->whenSettled(RunLoop::mainSingleton(), [] (auto&& result) {
-            if (result && *result)
-                return WebCore::WebTransportSessionPromise::createAndResolve(WTF::move(**result));
-            return WebCore::WebTransportSessionPromise::createAndReject();
-        })
-    };
+    return adoptRef(*new WebTransportSession(connection.copyRef(), WTF::move(client), WebTransportSessionIdentifier::generate(), pageID));
 }
 
-WebTransportSession::WebTransportSession(Ref<IPC::Connection>&& connection, ThreadSafeWeakPtr<WebCore::WebTransportSessionClient>&& client, WebTransportSessionIdentifier identifier)
+WebTransportSession::WebTransportSession(Ref<IPC::Connection>&& connection, ThreadSafeWeakPtr<WebCore::WebTransportSessionClient>&& client, WebTransportSessionIdentifier identifier, WebPageProxyIdentifier pageID)
     : m_connection(WTF::move(connection))
     , m_client(WTF::move(client))
     , m_identifier(identifier)
+    , m_pageID(pageID)
 {
     WebProcess::singleton().addWebTransportSession(m_identifier, *this);
 }
@@ -134,6 +131,20 @@ void WebTransportSession::didDrain()
     ASSERT(RunLoop::isMain());
     if (RefPtr strongClient = m_client.get())
         strongClient->didDrain();
+}
+
+Ref<WebCore::WebTransportSessionInitializationPromise> WebTransportSession::initialize(WebCore::ScriptExecutionContext& context, const URL& url, const WebCore::WebTransportOptions& options, const WebCore::ClientOrigin& origin)
+{
+    std::optional<TextPosition> sourcePosition;
+    if (RefPtr document = dynamicDowncast<WebCore::Document>(context))
+        sourcePosition = document->currentParserSourcePosition();
+    if (CheckedPtr csp = context.contentSecurityPolicy(); !csp || !csp->allowConnectToSource(url, WTF::move(sourcePosition)))
+        return WebCore::WebTransportSessionInitializationPromise::createAndReject();
+    return sendWithPromisedReply(Messages::NetworkConnectionToWebProcess::InitializeWebTransportSession(m_identifier, url, options, m_pageID, origin))->whenSettled(RunLoop::mainSingleton(), [] (auto&& result) {
+        if (result && *result)
+            return WebCore::WebTransportSessionInitializationPromise::createAndResolve(WTF::move(**result));
+        return WebCore::WebTransportSessionInitializationPromise::createAndReject();
+    });
 }
 
 Ref<WebCore::WebTransportSendPromise> WebTransportSession::sendDatagram(std::optional<WebCore::WebTransportSendGroupIdentifier> identifier, std::span<const uint8_t> datagram)

--- a/Source/WebKit/WebProcess/Network/WebTransportSession.h
+++ b/Source/WebKit/WebProcess/Network/WebTransportSession.h
@@ -47,7 +47,6 @@ struct WebTransportConnectionInfo;
 struct WebTransportOptions;
 struct WebTransportStreamIdentifierType;
 using WebTransportStreamIdentifier = ObjectIdentifier<WebTransportStreamIdentifierType>;
-using WebTransportSessionPromise = NativePromise<WebTransportConnectionInfo, void>;
 using WebTransportSendPromise = NativePromise<std::optional<Exception>, void>;
 using WebTransportSessionErrorCode = uint32_t;
 using WebTransportStreamErrorCode = uint64_t;
@@ -65,7 +64,7 @@ using WebTransportSessionIdentifier = AtomicObjectIdentifier<WebTransportSession
 
 class WebTransportSession : public WebCore::WebTransportSession, public IPC::MessageReceiver, public IPC::MessageSender, public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<WebTransportSession> {
 public:
-    static std::pair<Ref<WebTransportSession>, Ref<WebCore::WebTransportSessionPromise>> initialize(Ref<IPC::Connection>&&, ThreadSafeWeakPtr<WebCore::WebTransportSessionClient>&&, const URL&, const WebCore::WebTransportOptions&, const WebPageProxyIdentifier&, const WebCore::ClientOrigin&);
+    static Ref<WebTransportSession> create(Ref<IPC::Connection>&&, ThreadSafeWeakPtr<WebCore::WebTransportSessionClient>&&, const WebPageProxyIdentifier&);
     ~WebTransportSession();
 
     void receiveDatagram(std::span<const uint8_t>, bool, std::optional<WebCore::Exception>&&);
@@ -83,9 +82,10 @@ public:
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
 
 private:
-    WebTransportSession(Ref<IPC::Connection>&&, ThreadSafeWeakPtr<WebCore::WebTransportSessionClient>&&, WebTransportSessionIdentifier);
+    WebTransportSession(Ref<IPC::Connection>&&, ThreadSafeWeakPtr<WebCore::WebTransportSessionClient>&&, WebTransportSessionIdentifier, WebPageProxyIdentifier);
 
     // WebTransportSession
+    Ref<WebCore::WebTransportSessionInitializationPromise> initialize(WebCore::ScriptExecutionContext&, const URL&, const WebCore::WebTransportOptions&, const WebCore::ClientOrigin&) final;
     Ref<WebCore::WebTransportSendPromise> sendDatagram(std::optional<WebCore::WebTransportSendGroupIdentifier>, std::span<const uint8_t>) final;
     Ref<WebCore::WebTransportStreamPromise> createOutgoingUnidirectionalStream() final;
     Ref<WebCore::WebTransportStreamPromise> createBidirectionalStream() final;
@@ -112,6 +112,7 @@ private:
     const Ref<IPC::Connection> m_connection;
     const ThreadSafeWeakPtr<WebCore::WebTransportSessionClient> m_client;
     const WebTransportSessionIdentifier m_identifier;
+    const WebPageProxyIdentifier m_pageID;
 };
 
 }

--- a/Source/WebKitLegacy/WebCoreSupport/LegacySocketProvider.cpp
+++ b/Source/WebKitLegacy/WebCoreSupport/LegacySocketProvider.cpp
@@ -25,6 +25,8 @@
 
 #import "LegacySocketProvider.h"
 
+#import <WebCore/EmptyClients.h>
+
 #ifdef BUILDING_WITH_CMAKE
 // WebSocketChannel.cpp (in Sources.txt, not loaded by CMake) depends on SocketStreamHandle.
 // Stub out -- WK2 NetworkProcess handles WebSockets.
@@ -46,7 +48,7 @@ RefPtr<WebCore::ThreadableWebSocketChannel> LegacySocketProvider::createWebSocke
 }
 #endif
 
-std::pair<RefPtr<WebCore::WebTransportSession>, Ref<WebCore::WebTransportSessionPromise>> LegacySocketProvider::initializeWebTransportSession(WebCore::ScriptExecutionContext&, WebCore::WebTransportSessionClient&, const URL&, const WebCore::WebTransportOptions&)
+Ref<WebCore::WebTransportSession> LegacySocketProvider::createWebTransportSession(WebCore::ScriptExecutionContext& context, WebCore::WebTransportSessionClient& client)
 {
-    return { nullptr, WebCore::WebTransportSessionPromise::createAndReject() };
+    return WebCore::emptySocketProvider()->createWebTransportSession(context, client);
 }

--- a/Source/WebKitLegacy/WebCoreSupport/LegacySocketProvider.h
+++ b/Source/WebKitLegacy/WebCoreSupport/LegacySocketProvider.h
@@ -32,5 +32,5 @@ public:
     static Ref<LegacySocketProvider> create() { return adoptRef(*new LegacySocketProvider); }
 private:
     RefPtr<WebCore::ThreadableWebSocketChannel> createWebSocketChannel(WebCore::Document&, WebCore::WebSocketChannelClient&, WebCore::IsInitiatedByDedicatedWorker) final;
-    std::pair<RefPtr<WebCore::WebTransportSession>, Ref<WebCore::WebTransportSessionPromise>> initializeWebTransportSession(WebCore::ScriptExecutionContext&, WebCore::WebTransportSessionClient&, const URL&, const WebCore::WebTransportOptions&) final;
+    Ref<WebCore::WebTransportSession> createWebTransportSession(WebCore::ScriptExecutionContext&, WebCore::WebTransportSessionClient&) final;
 };


### PR DESCRIPTION
#### fd5b5997ff3424e7fdc0be8e451d8ed1bd59a379
<pre>
Make WebTransport&apos;s session a Ref instead of a RefPtr
<a href="https://bugs.webkit.org/show_bug.cgi?id=320161">https://bugs.webkit.org/show_bug.cgi?id=320161</a>
<a href="https://rdar.apple.com/183095821">rdar://183095821</a>

Reviewed by Basuke Suzuki.

This removes unneeded null checks and makes the code more consistent.
Everything the WebTransportSession does that returns something uses NativePromise
the same way now.  I initially made WebTransportSession able to be disconnected
when the connection terminates, but now that we need it around for getStats
after connection termination, we may as well make it a const Ref.

* Source/WebCore/Modules/webtransport/WebTransport.cpp:
(WebCore::WebTransport::create):
(WebCore::clientOrigin):
(WebCore::WebTransport::WebTransport):
(WebCore::WebTransport::receiveIncomingUnidirectionalStream):
(WebCore::WebTransport::receiveBidirectionalStream):
(WebCore::WebTransport::streamReceiveError):
(WebCore::WebTransport::streamSendError):
(WebCore::WebTransport::getStats):
(WebCore::WebTransport::exportKeyingMaterial):
(WebCore::WebTransport::cleanupContext):
(WebCore::WebTransport::close):
(WebCore::WebTransport::createBidirectionalStream):
(WebCore::WebTransport::createUnidirectionalStream):
(WebCore::WebTransport::initializeOverHTTP): Deleted.
(WebCore::WebTransport::session):
* Source/WebCore/Modules/webtransport/WebTransport.h:
(WebCore::WebTransport::session const):
* Source/WebCore/Modules/webtransport/WebTransportDatagramDuplexStream.cpp:
(WebCore::WebTransportDatagramDuplexStream::session):
* Source/WebCore/Modules/webtransport/WebTransportDatagramsWritable.cpp:
(WebCore::WebTransportDatagramsWritable::create):
* Source/WebCore/Modules/webtransport/WebTransportReceiveStreamByteSource.cpp:
(WebCore::WebTransportReceiveStreamByteSource::cancel):
* Source/WebCore/Modules/webtransport/WebTransportSendGroup.cpp:
(WebCore::WebTransportSendGroup::getStats):
* Source/WebCore/Modules/webtransport/WebTransportSendStream.cpp:
(WebCore::WebTransportSendStream::getStats):
* Source/WebCore/Modules/webtransport/WebTransportSendStreamSink.cpp:
(WebCore::WebTransportSendStreamSink::write):
(WebCore::WebTransportSendStreamSink::close):
(WebCore::WebTransportSendStreamSink::abort):
* Source/WebCore/Modules/webtransport/WebTransportSession.h:
* Source/WebCore/Modules/webtransport/WorkerWebTransportSession.cpp:
(WebCore::WorkerWebTransportSession::initialize):
* Source/WebCore/Modules/webtransport/WorkerWebTransportSession.h:
* Source/WebCore/dom/Document.h:
* Source/WebCore/loader/EmptyClients.cpp:
(WebCore::emptySocketProvider):
(WebCore::pageConfigurationWithEmptyClients):
* Source/WebCore/loader/EmptyClients.h:
* Source/WebCore/page/SocketProvider.h:
* Source/WebKit/WebProcess/Network/WebSocketProvider.cpp:
(WebKit::WebSocketProvider::createWebTransportSession):
(WebKit::WebSocketProvider::initializeWebTransportSession): Deleted.
* Source/WebKit/WebProcess/Network/WebSocketProvider.h:
* Source/WebKit/WebProcess/Network/WebTransportSession.cpp:
(WebKit::WebTransportSession::create):
(WebKit::WebTransportSession::WebTransportSession):
(WebKit::WebTransportSession::initialize):
* Source/WebKit/WebProcess/Network/WebTransportSession.h:
* Source/WebKitLegacy/WebCoreSupport/LegacySocketProvider.cpp:
(LegacySocketProvider::createWebTransportSession):
(LegacySocketProvider::initializeWebTransportSession): Deleted.
* Source/WebKitLegacy/WebCoreSupport/LegacySocketProvider.h:

Canonical link: <a href="https://commits.webkit.org/317885@main">https://commits.webkit.org/317885@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5118aa3b6257e37f9f563c74c480abb2db5f6f2a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176643 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50580 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44372 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186245 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/139404 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2b63ddb4-03ed-40df-9283-bc01a28cb86d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178506 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51873 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50266 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137599 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/139404 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/64d4dc50-aea1-48b5-a2e7-6ac5f53394f8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179599 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41102 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158387 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118073 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a8376b61-e1e8-44a5-bcf0-af1731c121d1) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39757 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38123 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150169 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37885 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34713 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42320 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/42339 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188669 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50247 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146660 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50930 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/34505 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146466 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26809 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41230 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/123136 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117247 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49435 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12864 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48834 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49070 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48895 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->