### PR TITLE
providerDidCloseNotifications() stops closing notifications after the first persistent one

### DIFF
--- a/Source/WebKit/UIProcess/Notifications/WebNotificationManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/Notifications/WebNotificationManagerProxy.cpp
@@ -266,7 +266,7 @@ void WebNotificationManagerProxy::providerDidCloseNotifications(API::Array* glob
                 protect(dataStore->networkProcess())->processNotificationEvent(notification->data(), NotificationEventType::Close, [](bool) { });
             else
                 RELEASE_LOG_ERROR(Notifications, "WebsiteDataStore not found from sessionID %" PRIu64 ", dropping notification close", notification->sessionID().toUInt64());
-            return;
+            continue;
         }
 
         m_globalNotificationMap.remove(notification->identifier());

--- a/Tools/TestWebKitAPI/Helpers/TestNotificationProvider.cpp
+++ b/Tools/TestWebKitAPI/Helpers/TestNotificationProvider.cpp
@@ -74,6 +74,9 @@ TestNotificationProvider::TestNotificationProvider(Vector<WKNotificationManagerR
 
 TestNotificationProvider::~TestNotificationProvider()
 {
+    for (auto& [manager, identifier] : m_pendingNotifications)
+        WKRelease(manager);
+
     for (auto& manager : m_managers)
         WKNotificationManagerSetProvider(manager, nullptr);
 }
@@ -132,7 +135,7 @@ void TestNotificationProvider::showWebNotification(WKPageRef page, WKNotificatio
     WKNotificationManagerProviderDidShowNotification(notificationManager, identifier);
 
     WKRetain(notificationManager);
-    m_pendingNotification = std::make_pair(notificationManager, identifier);
+    m_pendingNotifications.append(std::make_pair(notificationManager, identifier));
 
     m_lastNotificationDataStoreIdentifier = adoptWK(WKNotificationCopyDataStoreIdentifier(notification));
 }
@@ -151,10 +154,10 @@ void TestNotificationProvider::resetHasReceivedNotification()
 
 bool TestNotificationProvider::simulateNotificationClick()
 {
-    if (!m_pendingNotification.first)
+    if (m_pendingNotifications.isEmpty())
         return false;
 
-    callOnMainThread([pair = std::exchange(m_pendingNotification, { })] {
+    callOnMainThread([pair = m_pendingNotifications.takeLast()] {
         WKNotificationManagerProviderDidClickNotification(pair.first, pair.second);
         WKRelease(pair.first);
     });
@@ -164,16 +167,43 @@ bool TestNotificationProvider::simulateNotificationClick()
 
 bool TestNotificationProvider::simulateNotificationClose()
 {
-    if (!m_pendingNotification.first)
+    if (m_pendingNotifications.isEmpty())
         return false;
 
-    callOnMainThread([pair = std::exchange(m_pendingNotification, { })] {
+    callOnMainThread([pair = m_pendingNotifications.takeLast()] {
         auto id = adoptWK(WKUInt64Create(pair.second));
         auto idRef = static_cast<WKTypeRef>(id.get());
         auto wkArray = adoptWK(WKArrayCreate(&idRef, 1));
 
         WKNotificationManagerProviderDidCloseNotifications(pair.first, wkArray.get());
         WKRelease(pair.first);
+    });
+
+    return true;
+}
+
+bool TestNotificationProvider::simulateMultipleNotificationsClose()
+{
+    if (m_pendingNotifications.isEmpty())
+        return false;
+
+    callOnMainThread([pending = std::exchange(m_pendingNotifications, { })] {
+        // A single provider callback may carry notifications belonging to more than one manager,
+        // so group the identifiers by manager and close each manager's notifications in one array.
+        HashMap<WKNotificationManagerRef, Vector<WKRetainPtr<WKUInt64Ref>>> notificationsByManager;
+        for (auto& [manager, identifier] : pending)
+            notificationsByManager.add(manager, Vector<WKRetainPtr<WKUInt64Ref>> { }).iterator->value.append(adoptWK(WKUInt64Create(identifier)));
+
+        for (auto& [manager, identifiers] : notificationsByManager) {
+            Vector<WKTypeRef> notificationIDs;
+            notificationIDs.reserveInitialCapacity(identifiers.size());
+            for (auto& identifier : identifiers)
+                notificationIDs.append(identifier.get());
+
+            auto wkArray = adoptWK(WKArrayCreate(notificationIDs.mutableSpan().data(), notificationIDs.size()));
+            WKNotificationManagerProviderDidCloseNotifications(manager, wkArray.get());
+            WKRelease(manager);
+        }
     });
 
     return true;

--- a/Tools/TestWebKitAPI/Helpers/TestNotificationProvider.h
+++ b/Tools/TestWebKitAPI/Helpers/TestNotificationProvider.h
@@ -51,6 +51,10 @@ public:
     void closeWebNotification(WKNotificationRef);
     bool simulateNotificationClick();
     bool simulateNotificationClose();
+    // Closes every notification shown so far in a single provider callback, i.e. passing all
+    // their identifiers to WKNotificationManagerProviderDidCloseNotifications as one array.
+    bool simulateMultipleNotificationsClose();
+    size_t pendingNotificationCount() const { return m_pendingNotifications.size(); }
     WKStringRef lastNotificationDataStoreIdentifier() const { return m_lastNotificationDataStoreIdentifier.get(); };
 
     bool hasReceivedShowNotification() const { return m_hasReceivedShowNotification; }
@@ -64,7 +68,7 @@ private:
 
     bool m_hasReceivedShowNotification { false };
     bool m_hasReceivedCloseNotification { false };
-    std::pair<WKNotificationManagerRef, uint64_t> m_pendingNotification;
+    Vector<std::pair<WKNotificationManagerRef, uint64_t>> m_pendingNotifications;
     WKRetainPtr<WKStringRef> m_lastNotificationDataStoreIdentifier;
 };
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/PushAPI.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/PushAPI.mm
@@ -1099,6 +1099,105 @@ TEST(PushAPI, fireNotificationCloseEvent)
     clearWebsiteDataStore([configuration websiteDataStore]);
 }
 
+static unsigned notificationCloseEventCount = 0;
+
+@interface CountNotificationCloseMessageHandler : NSObject <WKScriptMessageHandler>
+@end
+
+@implementation CountNotificationCloseMessageHandler
+- (void)userContentController:(WKUserContentController *)userContentController didReceiveScriptMessage:(WKScriptMessage *)message
+{
+    if ([message.body hasPrefix:@"Received notificationclose"])
+        ++notificationCloseEventCount;
+    done = true;
+}
+@end
+
+static constexpr auto fireMultipleNotificationCloseEventsScriptBytes = R"SWRESOURCE(
+let port;
+self.addEventListener("message", (event) => {
+    port = event.data.port;
+    port.postMessage("Ready");
+});
+self.addEventListener("push", (event) => {
+    self.registration.showNotification("notification1", { tag: "tag1" });
+    self.registration.showNotification("notification2", { tag: "tag2" });
+    port.postMessage("Received: " + (event.data ? event.data.text() : "null data"));
+});
+self.addEventListener("notificationclose", async (event) => {
+    for (let client of await self.clients.matchAll({includeUncontrolled:true}))
+        client.postMessage("Received notificationclose: " + event.notification.title);
+});
+)SWRESOURCE"_s;
+
+TEST(PushAPI, fireMultipleNotificationCloseEvents)
+{
+    TestWebKitAPI::HTTPServer server({
+        { "/"_s, { fireNotificationClickEventMainBytes } },
+        { "/sw.js"_s, { {{ "Content-Type"_s, "application/javascript"_s }}, fireMultipleNotificationCloseEventsScriptBytes } }
+    }, TestWebKitAPI::HTTPServer::Protocol::Http);
+
+    [WKWebsiteDataStore _allowWebsiteDataRecordsForAllOrigins];
+
+    auto configuration = createConfigurationWithNotificationsEnabled();
+
+    auto provider = TestWebKitAPI::TestNotificationProvider({ [[configuration processPool] _notificationManagerForTesting], WKNotificationManagerGetSharedServiceWorkerNotificationManager() });
+    provider.setPermission(server.origin(), true);
+
+    RetainPtr messageHandler = adoptNS([[CountNotificationCloseMessageHandler alloc] init]);
+    [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"sw"];
+
+    clearWebsiteDataStore([configuration websiteDataStore]);
+
+    notificationCloseEventCount = 0;
+
+    done = false;
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    [webView loadRequest:server.request()];
+
+    TestWebKitAPI::Util::run(&done);
+
+    provider.resetHasReceivedNotification();
+    auto& providerRef = provider;
+
+    done = false;
+    pushMessageProcessed = false;
+    pushMessageSuccessful = false;
+    NSString *message = @"Sweet Potatoes";
+
+    [[configuration websiteDataStore] _processPushMessage:messageDictionary([message dataUsingEncoding:NSUTF8StringEncoding], [server.request() URL]) completionHandler:^(bool result) {
+        EXPECT_TRUE(providerRef.hasReceivedShowNotification());
+        pushMessageSuccessful = result;
+        pushMessageProcessed = true;
+    }];
+    TestWebKitAPI::Util::run(&done);
+
+    TestWebKitAPI::Util::run(&pushMessageProcessed);
+    EXPECT_TRUE(pushMessageSuccessful);
+
+    // Both notifications must have reached the provider before we close them together.
+    EXPECT_TRUE(pushAPIWaitUntilEvaluatesToTrue([&] {
+        return providerRef.pendingNotificationCount() >= 2;
+    }));
+    EXPECT_EQ(providerRef.pendingNotificationCount(), 2u);
+
+    // Wait long enough such that persistent notifications will be allowed to close.
+    TestWebKitAPI::Util::runFor(WebCore::silentPushTimeoutForTesting);
+
+    // Close both persistent notifications in a single provider callback. The buggy implementation
+    // returns after handling the first persistent notification, so the second never fires its
+    // notificationclose event and only one message arrives.
+    EXPECT_TRUE(providerRef.simulateMultipleNotificationsClose());
+
+    // Allow ample time for both notificationclose events to be delivered.
+    pushAPIWaitUntilEvaluatesToTrue([&] {
+        return notificationCloseEventCount >= 2;
+    });
+    EXPECT_EQ(notificationCloseEventCount, 2u);
+
+    clearWebsiteDataStore([configuration websiteDataStore]);
+}
+
 static constexpr auto closeNotificationMainBytes = R"SWRESOURCE(
 <script>
 function log(msg)


### PR DESCRIPTION
#### e64287e8977f5c4445ef74621f35416737f28aa6
<pre>
providerDidCloseNotifications() stops closing notifications after the first persistent one
<a href="https://bugs.webkit.org/show_bug.cgi?id=320162">https://bugs.webkit.org/show_bug.cgi?id=320162</a>

Reviewed by Brady Eidson.

WebNotificationManagerProxy::providerDidCloseNotifications() iterates over the
array of notification identifiers passed by the notification provider and closes
each one. For a persistent (service worker) notification, it dispatched the close
event to the service worker and then did `return;` instead of `continue;`, which
had two consequences:

- Any notification identifiers appearing after the first persistent notification
  in the batch were never processed: they were not closed and no
  DidCloseNotifications message was sent for them.
- The persistent notification had already been removed from m_notifications via
  take(), but the early return skipped removing its entry from
  m_globalNotificationMap, leaving a stale identifier mapping behind.

Every other skip case in the same loop already uses `continue;`; this one should
too. Replace the `return;` with `continue;`.

The existing TestNotificationProvider could only close a single notification per
provider callback (it tracked one pending notification and built a one-element
array), so the batch path was never exercised. Extend it to remember every shown
notification and add simulateMultipleNotificationsClose(), which closes them all
in a single WKNotificationManagerProviderDidCloseNotifications() call. The
now-redundant single m_pendingNotification member is removed and the existing
simulateNotificationClick()/simulateNotificationClose() helpers are reimplemented
on top of m_pendingNotifications.

Add a regression test that shows two persistent notifications, closes them in one
provider callback, and verifies both fire a notificationclose event.

Test: PushAPI.fireMultipleNotificationCloseEvents

* Source/WebKit/UIProcess/Notifications/WebNotificationManagerProxy.cpp:
(WebKit::WebNotificationManagerProxy::providerDidCloseNotifications):
* Tools/TestWebKitAPI/Helpers/TestNotificationProvider.cpp:
(TestWebKitAPI::TestNotificationProvider::~TestNotificationProvider):
(TestWebKitAPI::TestNotificationProvider::showWebNotification):
(TestWebKitAPI::TestNotificationProvider::simulateNotificationClick):
(TestWebKitAPI::TestNotificationProvider::simulateNotificationClose):
(TestWebKitAPI::TestNotificationProvider::simulateMultipleNotificationsClose):
* Tools/TestWebKitAPI/Helpers/TestNotificationProvider.h:
(TestWebKitAPI::TestNotificationProvider::pendingNotificationCount const):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/PushAPI.mm:
(-[CountNotificationCloseMessageHandler userContentController:didReceiveScriptMessage:]):
((PushAPI, fireMultipleNotificationCloseEvents)):

Canonical link: <a href="https://commits.webkit.org/318007@main">https://commits.webkit.org/318007@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8591ba69bb8140cd8c475f7de49a42839188a359

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176540 "6 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50475 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44265 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186141 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/138817 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b3c18c17-6ab4-4ef4-808e-8e8874dfdfde) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178403 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51767 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50159 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137513 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/138817 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b2e5e862-2abe-4a08-a043-2edfd4d4c36f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179496 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41007 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158290 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117988 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b73b5786-b256-4eac-b4f6-aa7b61f1dd8c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39657 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38023 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150072 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37788 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34609 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42207 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42234 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188564 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50140 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146570 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39513 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50824 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34411 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146380 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41140 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123028 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117101 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49328 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12763 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48730 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48964 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48789 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->