### PR TITLE
[YARR] Start matching end-anchored fixed-size regexps at the only possible position

### DIFF
--- a/JSTests/microbenchmarks/regexp-end-anchored-class-run.js
+++ b/JSTests/microbenchmarks/regexp-end-anchored-class-run.js
@@ -1,0 +1,20 @@
+(function() {
+    var lines = [];
+    for (var i = 0; i < 400; i++) {
+        var line = "2026-07-23T12:34:56.789Z [worker-" + (i % 8) + "] processed request /api/v2/items/" + i + " in " + (i % 250) + "ms status=200 trace=";
+        line += i % 3 == 0 ? "0123456789abcdef0123456789abcdef01234567" : "deadbeef" + i;
+        lines.push(line);
+    }
+
+    var re = /[0-9a-f]{40}$/;
+    var n = 400;
+    var result = 0;
+    for (var i = 0; i < n; i++) {
+        for (var j = 0; j < lines.length; j++) {
+            if (re.test(lines[j]))
+                result++;
+        }
+    }
+    if (result !== n * 134)
+        throw "Error: bad result: " + result;
+})();

--- a/JSTests/microbenchmarks/regexp-end-anchored-literal-suffix.js
+++ b/JSTests/microbenchmarks/regexp-end-anchored-literal-suffix.js
@@ -1,0 +1,17 @@
+(function() {
+    var urls = [];
+    for (var i = 0; i < 1000; i++)
+        urls.push("https://cdn.example.com/assets/build/" + i + "/static/media/components/very/deeply/nested/directory/structure/image-" + i + (i % 7 == 0 ? ".png" : ".webp?width=1024&quality=80"));
+
+    var re = /\.png$/;
+    var n = 400;
+    var result = 0;
+    for (var i = 0; i < n; i++) {
+        for (var j = 0; j < urls.length; j++) {
+            if (re.test(urls[j]))
+                result++;
+        }
+    }
+    if (result !== n * 143)
+        throw "Error: bad result: " + result;
+})();

--- a/JSTests/stress/regexp-end-anchored-fixed-size.js
+++ b/JSTests/stress/regexp-end-anchored-fixed-size.js
@@ -1,0 +1,59 @@
+function shouldBe(actual, expected, msg) {
+    if (JSON.stringify(actual) !== JSON.stringify(expected))
+        throw new Error(`FAIL: ${msg}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+}
+
+for (let i = 0; i < testLoopCount; i++) {
+    shouldBe(/\.js$/.exec("path/app.js"), [".js"], "literal suffix");
+    shouldBe(/\.js$/.exec("path/app.jsx"), null, "literal suffix mismatch");
+    shouldBe(/abcdef$/.exec("def"), null, "pattern longer than subject");
+    shouldBe(/(?:\.png|\.gif)$/.exec("x.gif"), [".gif"], "equal-size alternatives");
+    shouldBe(/(?:d|cd)$/.exec("abcd"), ["cd"], "different-size alternatives");
+    shouldBe(/(?:x|abcd)$/.exec("ax"), ["x"], "different-size alternatives, shorter one matches");
+    shouldBe(/(\w)(\d)$/.exec("ab3zx9"), ["x9", "x", "9"], "captures");
+    shouldBe("abc".search(/$/), 3, "bare end assertion");
+    shouldBe(/(?:)$/.exec("ab").index, 2, "empty group then end");
+    shouldBe([/^abc$/.exec("abc"), /^abc$/.exec("xabc"), /^abc$/.exec("abcabc")], [["abc"], null, null], "BOL and EOL");
+    shouldBe(["a\nbc\nd".search(/bc$/m), /bc$/m.exec("a\nbc\nd")], [2, ["bc"]], "multiline is untouched");
+    shouldBe(/(a)\1$/.exec("xaa"), ["aa", "a"], "backreference (variable size) is untouched");
+    shouldBe(/[0-9a-f]{4}$/.exec("zzz9f0a"), ["9f0a"], "counted class");
+    shouldBe(/[0-9a-f]{4}$/.exec("zzz9f0az"), null, "counted class mismatch");
+    shouldBe([/\u{1F600}$/u.exec("hi\u{1F600}"), /.$/u.exec("a\u{1F600}")], [["\u{1F600}"], ["\u{1F600}"]], "unicode fixed size counts code units");
+    shouldBe([/(?<=x)ab$/.exec("xab"), /(?<=x)ab$/.exec("yab")], [["ab"], null], "lookbehind before the end");
+    shouldBe([/a(?=b$)b$/.exec("zab"), /(?!x)y$/.exec("xy")], [["ab"], ["y"]], "lookahead");
+    shouldBe([/\bfoo$/.exec("a foo"), /\Bfoo$/.exec("afoo"), /\bfoo$/.exec("afoo")], [["foo"], ["foo"], null], "word boundary before literal");
+    shouldBe([/\.JS$/i.exec("a.js"), /ÅB$/iu.exec("xåb")], [[".js"], ["åb"]], "ignoreCase");
+    shouldBe("a.b.c".replace(/\.c$/, "!"), "a.b!", "replace");
+    shouldBe(("x".repeat(300) + ".ts").search(/\.ts$/), 300, "search");
+    shouldBe([..."foo.ts".matchAll(/ts$/g)].map(m => m.index), [4], "matchAll");
+    shouldBe(/(t)s$/d.exec("a.ts").indices, [[2, 4], [2, 3]], "hasIndices");
+    shouldBe([/$/.exec("")[0], /a$/.exec("")], ["", null], "empty subject");
+    shouldBe([/\uDE00$/u.exec("\u{1F600}"), /\uDE00$/.exec("\u{1F600}")], [null, ["\uDE00"]], "lone surrogate at the end");
+    shouldBe("x".repeat(1000).replace(/xxx$/, "!"), "x".repeat(997) + "!", "long subject replace");
+
+    let re = /js$/g;
+    let s = "a.js";
+    let all = [];
+    let m;
+    while ((m = re.exec(s))) {
+        all.push([m.index, re.lastIndex]);
+        if (all.length > 3)
+            break;
+    }
+    shouldBe(all, [[2, 4]], "global iteration");
+
+    re = /js$/g;
+    re.lastIndex = 100;
+    shouldBe([re.exec("a.js"), re.lastIndex], [null, 0], "lastIndex beyond the subject");
+
+    re = /js$/g;
+    re.lastIndex = 3;
+    shouldBe(re.exec("a.js"), null, "lastIndex past the only possible start");
+
+    re = /js$/y;
+    re.lastIndex = 0;
+    shouldBe(re.exec("index.js"), null, "sticky does not search");
+    re.lastIndex = 6;
+    m = re.exec("index.js");
+    shouldBe(m && m.index, 6, "sticky matches only at lastIndex");
+}

--- a/Source/JavaScriptCore/yarr/YarrInterpreter.cpp
+++ b/Source/JavaScriptCore/yarr/YarrInterpreter.cpp
@@ -2249,6 +2249,9 @@ public:
         if (!input.isAvailableInput(0))
             return offsetNoMatch;
 
+        if (pattern->hasEndAnchoredFixedSize() && input.end() >= pattern->m_endAnchoredFixedSize)
+            input.setPos(std::max(input.getPos(), input.end() - pattern->m_endAnchoredFixedSize));
+
         ConcurrentJSLocker locker(pattern->m_lock);
 
         for (unsigned i = 0; i < pattern->m_body->m_numSubpatterns + 1; ++i)

--- a/Source/JavaScriptCore/yarr/YarrInterpreter.h
+++ b/Source/JavaScriptCore/yarr/YarrInterpreter.h
@@ -506,11 +506,13 @@ public:
         m_userCharacterClasses.shrinkToFit();
 
         m_numDuplicateNamedCaptureGroups = pattern.m_numDuplicateNamedCaptureGroups;
+        m_endAnchoredFixedSize = pattern.m_endAnchoredFixedSize;
     }
 
     size_t estimatedSizeInBytes() const { return m_body->estimatedSizeInBytes(); }
 
     bool hasDuplicateNamedCaptureGroups() const { return !!m_numDuplicateNamedCaptureGroups; }
+    bool hasEndAnchoredFixedSize() const { return m_endAnchoredFixedSize != YarrPattern::endAnchoredFixedSizeNotSet; }
 
     unsigned offsetForDuplicateNamedGroupId(unsigned duplicateNamedGroupId)
     {
@@ -546,6 +548,7 @@ public:
     ConcurrentJSLock* m_lock;
 
     unsigned m_numDuplicateNamedCaptureGroups;
+    unsigned m_endAnchoredFixedSize { YarrPattern::endAnchoredFixedSizeNotSet };
     unsigned m_offsetVectorBaseForNamedCaptures;
     unsigned m_offsetsSize;
     Vector<unsigned> m_duplicateNamedGroupForSubpatternId;

--- a/Source/JavaScriptCore/yarr/YarrJIT.cpp
+++ b/Source/JavaScriptCore/yarr/YarrJIT.cpp
@@ -6728,6 +6728,20 @@ class YarrGenerator final : public YarrJITInfo {
         return registers;
     }
 
+    void skipToEndAnchoredStart()
+    {
+        if (!m_pattern.hasEndAnchoredFixedSize())
+            return;
+
+        unsigned endAnchoredFixedSize = m_pattern.m_endAnchoredFixedSize;
+        MacroAssembler::JumpList noStartAdjustment;
+        noStartAdjustment.append(m_jit.branch32(MacroAssembler::Below, m_regs.length, MacroAssembler::TrustedImm32(endAnchoredFixedSize)));
+        m_jit.sub32(m_regs.length, MacroAssembler::TrustedImm32(endAnchoredFixedSize), m_regs.regT0);
+        noStartAdjustment.append(m_jit.branch32(MacroAssembler::AboveOrEqual, m_regs.index, m_regs.regT0));
+        m_jit.move(m_regs.regT0, m_regs.index);
+        noStartAdjustment.link(&m_jit);
+    }
+
     void generateEnter()
     {
 #if CPU(X86_64) || CPU(ARM_THUMB2) || CPU(RISCV64)
@@ -6998,6 +7012,8 @@ public:
         generateFailReturn();
         hasInput.link(&m_jit);
 
+        skipToEndAnchoredStart();
+
         if (m_callFrameSizeInBytes) {
             // Check stack size
             m_jit.addPtr(MacroAssembler::TrustedImm32(-m_callFrameSizeInBytes), MacroAssembler::stackPointerRegister, m_regs.regT0);
@@ -7054,11 +7070,15 @@ public:
         // Initialize subpatterns' starts. And initialize matchStart if `!m_pattern.m_body->m_hasFixedSize`.
         // If shouldRecordSubpatterns(), then matchStart is subpatterns[0]'s start.
         emitClearAllCaptures();
-        if (!m_pattern.m_body->m_hasFixedSize)
+        if (!m_pattern.m_body->m_hasFixedSize) {
+            ASSERT(!m_pattern.hasEndAnchoredFixedSize());
             setMatchStart(m_regs.index);
+        }
 
-        if (m_pattern.m_saveInitialStartValue)
+        if (m_pattern.m_saveInitialStartValue) {
+            ASSERT(!m_pattern.hasEndAnchoredFixedSize());
             storeToFrame(m_regs.index, m_pattern.m_initialStartValueFrameLocation);
+        }
 
         generate();
         if (m_disassembler)
@@ -7184,6 +7204,8 @@ public:
         generateFailReturn();
         hasInput.link(&m_jit);
 
+        skipToEndAnchoredStart();
+
         if (m_callFrameSizeInBytes) {
             // Create space on stack for matching context data.
             // Note that this stack check cannot clobber m_regs.regT1 as it is needed for the slow path we call if we fail the stack check.
@@ -7205,11 +7227,15 @@ public:
 #endif
 
         emitClearAllCaptures();
-        if (!m_pattern.m_body->m_hasFixedSize)
+        if (!m_pattern.m_body->m_hasFixedSize) {
+            ASSERT(!m_pattern.hasEndAnchoredFixedSize());
             setMatchStart(m_regs.index);
+        }
 
-        if (m_pattern.m_saveInitialStartValue)
+        if (m_pattern.m_saveInitialStartValue) {
+            ASSERT(!m_pattern.hasEndAnchoredFixedSize());
             storeToFrame(m_regs.index, m_pattern.m_initialStartValueFrameLocation);
+        }
 
         generate();
         if (m_disassembler)

--- a/Source/JavaScriptCore/yarr/YarrPattern.cpp
+++ b/Source/JavaScriptCore/yarr/YarrPattern.cpp
@@ -2587,6 +2587,20 @@ public:
         }
     }
 
+    void computeEndAnchoredFixedSize()
+    {
+        if (m_pattern.multiline() || m_pattern.sticky() || m_pattern.m_containsModifiers || m_pattern.m_containsBOL || m_pattern.m_containsUnsignedLengthPattern || !m_pattern.m_body->m_hasFixedSize || m_pattern.m_saveInitialStartValue)
+            return;
+
+        unsigned maximumSize = 0;
+        for (auto& alternative : m_pattern.m_body->m_alternatives) {
+            if (!alternative->m_hasFixedSize || alternative->m_terms.isEmpty() || alternative->m_terms.last().type != PatternTerm::Type::AssertionEOL)
+                return;
+            maximumSize = std::max(maximumSize, alternative->m_minimumSize);
+        }
+        m_pattern.m_endAnchoredFixedSize = maximumSize;
+    }
+
     void extractSpecificPattern()
     {
         if (m_pattern.m_containsBackreferences)
@@ -3063,6 +3077,7 @@ ErrorCode YarrPattern::compile(StringView patternString)
             return error;
     }
 
+    constructor.computeEndAnchoredFixedSize();
     constructor.setupNamedCaptures();
 
     constructor.extractSpecificPattern();
@@ -3446,6 +3461,8 @@ void YarrPattern::dumpPattern(PrintStream& out, StringView patternString)
     out.print(":\n");
     if (m_specificPattern != SpecificPattern::None)
         out.print("    specific pattern: ", m_specificPattern, "\n");
+    if (hasEndAnchoredFixedSize())
+        out.print("    end anchored fixed size: ", m_endAnchoredFixedSize, "\n");
     if (m_body->m_callFrameSize)
         out.print("    callframe size: ", m_body->m_callFrameSize, "\n");
     m_body->dump(out, this);

--- a/Source/JavaScriptCore/yarr/YarrPattern.h
+++ b/Source/JavaScriptCore/yarr/YarrPattern.h
@@ -31,6 +31,7 @@
 #include <JavaScriptCore/YarrFlags.h>
 #include <JavaScriptCore/YarrUnicodeProperties.h>
 #include <array>
+#include <limits>
 #include <wtf/BitSet.h>
 #include <wtf/CheckedArithmetic.h>
 #include <wtf/HashMap.h>
@@ -770,6 +771,8 @@ struct YarrPattern {
     bool dotAll() const { return m_flags.contains(Flags::DotAll); }
 
     bool hasDuplicateNamedCaptureGroups() const { return !!m_numDuplicateNamedCaptureGroups; }
+    static constexpr unsigned endAnchoredFixedSizeNotSet = std::numeric_limits<unsigned>::max();
+    bool hasEndAnchoredFixedSize() const { return m_endAnchoredFixedSize != endAnchoredFixedSizeNotSet; }
 
     CompileMode compileMode() const
     {
@@ -793,6 +796,7 @@ struct YarrPattern {
     ExecutionMode m_executionMode { ExecutionMode::IncludeSubpatterns };
     OptionSet<Flags> m_flags;
     SpecificPattern m_specificPattern { SpecificPattern::None };
+    unsigned m_endAnchoredFixedSize { endAnchoredFixedSizeNotSet };
     unsigned m_numSubpatterns { 0 };
     unsigned m_initialStartValueFrameLocation { 0 };
     unsigned m_numDuplicateNamedCaptureGroups { 0 };


### PR DESCRIPTION
#### 581f1d9583295898e8569aa01753b143356913f2
<pre>
[YARR] Start matching end-anchored fixed-size regexps at the only possible position
<a href="https://bugs.webkit.org/show_bug.cgi?id=320154">https://bugs.webkit.org/show_bug.cgi?id=320154</a>

Reviewed by Yusuke Suzuki.

When every top-level alternative of a pattern ends with a non-multiline $
and consumes a fixed number of code units, a match can only start at
(input length - size). YARR nevertheless searched from the given start
offset, bumping along the whole subject (or scanning it with the
Boyer-Moore prefilter), so /\.js$/.test(url) and /[0-9a-f]{40}$/.test(line)
did work proportional to the input length.

Compute the maximum alternative size for such patterns in YarrPattern and
advance the start position to (length - size) at the entry of the JIT code
and the interpreter. The match body is untouched, so captures, lastIndex and
global iteration behave as before. Sticky, multiline and BOL-containing
patterns are left alone since they either do not search or are already
handled by optimizeBOL().

The new field fits into existing padding of both YarrPattern and
BytecodePattern, so neither structure grows (232 and 120 bytes, unchanged).

                                          Baseline                  Patched

regexp-end-anchored-literal-suffix     8.9024+-0.1528     ^      3.8347+-0.3205        ^ definitely 2.3216x faster
regexp-end-anchored-class-run         16.7796+-0.4848     ^      2.4783+-0.1510        ^ definitely 6.7706x faster

Tests: JSTests/microbenchmarks/regexp-end-anchored-class-run.js
       JSTests/microbenchmarks/regexp-end-anchored-literal-suffix.js
       JSTests/microbenchmarks/regexp-unicode-bm-search-charclass.js
       JSTests/microbenchmarks/regexp-unicode-bm-search-emoji-charclass.js
       JSTests/microbenchmarks/regexp-unicode-bm-search-nomatch-charclass.js
       JSTests/stress/regexp-end-anchored-fixed-size.js

* JSTests/microbenchmarks/regexp-end-anchored-class-run.js: Added.
* JSTests/microbenchmarks/regexp-end-anchored-literal-suffix.js: Added.
* JSTests/microbenchmarks/regexp-unicode-bm-search-charclass.js: Added.
* JSTests/microbenchmarks/regexp-unicode-bm-search-emoji-charclass.js: Added.
* JSTests/microbenchmarks/regexp-unicode-bm-search-nomatch-charclass.js: Added.
* JSTests/stress/regexp-end-anchored-fixed-size.js: Added.
(shouldBe):
(i.m.re.exec):
* Source/JavaScriptCore/yarr/YarrInterpreter.cpp:
* Source/JavaScriptCore/yarr/YarrInterpreter.h:
(JSC::Yarr::BytecodePattern::BytecodePattern):
(JSC::Yarr::BytecodePattern::hasEndAnchoredFixedSize const):
* Source/JavaScriptCore/yarr/YarrJIT.cpp:
* Source/JavaScriptCore/yarr/YarrPattern.cpp:
(JSC::Yarr::YarrPatternConstructor::computeEndAnchoredFixedSize):
(JSC::Yarr::YarrPattern::compile):
* Source/JavaScriptCore/yarr/YarrPattern.h:
(JSC::Yarr::YarrPattern::hasEndAnchoredFixedSize const):

Canonical link: <a href="https://commits.webkit.org/318325@main">https://commits.webkit.org/318325@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/de453b4f24e665144ff83d0102f5a7bfc41370d3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177924 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51862 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45656 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187534 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/141171 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53155 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51571 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138691 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/141171 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180880 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42226 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159437 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119154 "Build is in progress. Recent messages:Running configuration; Checked out pull request; run-api-tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40889 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39245 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/1123 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/7930 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151294 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38930 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35995 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/39195 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44454 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43481 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189963 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51529 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147818 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39709 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52211 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35560 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147599 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42309 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124463 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118906 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50719 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13910 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50115 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50355 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50177 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->