### PR TITLE
flex/grid `order` is ignored for paint order once an item forms a stacking context

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -5204,7 +5204,6 @@ webkit.org/b/221482 imported/w3c/web-platform-tests/css/css-flexbox/flexbox-coll
 webkit.org/b/221482 imported/w3c/web-platform-tests/css/css-flexbox/flexbox-collapsed-item-horiz-003.html [ ImageOnlyFailure ]
 
 # Painting order in flexbox
-webkit.org/b/221482 imported/w3c/web-platform-tests/css/css-flexbox/flexbox-paint-ordering-002.xhtml [ ImageOnlyFailure ]
 webkit.org/b/221482 imported/w3c/web-platform-tests/css/css-flexbox/order/order-abs-children-painting-order.html [ ImageOnlyFailure ]
 
 # Newly imported Canvas WPT tests that are failing.

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flex-order-paint-order-stacking-context-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flex-order-paint-order-stacking-context-expected.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Reference: seven green bars, no red visible</title>
+<style>
+  body { margin: 0; }
+  .bar { width: 60px; height: 40px; margin: 0 0 8px 0; background: green; }
+</style>
+<div class="bar"></div>
+<div class="bar"></div>
+<div class="bar"></div>
+<div class="bar"></div>
+<div class="bar"></div>
+<div class="bar"></div>
+<div class="bar"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flex-order-paint-order-stacking-context-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flex-order-paint-order-stacking-context-ref.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Reference: seven green bars, no red visible</title>
+<style>
+  body { margin: 0; }
+  .bar { width: 60px; height: 40px; margin: 0 0 8px 0; background: green; }
+</style>
+<div class="bar"></div>
+<div class="bar"></div>
+<div class="bar"></div>
+<div class="bar"></div>
+<div class="bar"></div>
+<div class="bar"></div>
+<div class="bar"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flex-order-paint-order-stacking-context.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flex-order-paint-order-stacking-context.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Flex 'order' determines paint order even when items form stacking contexts</title>
+<link rel="help" href="https://drafts.csswg.org/css-flexbox/#painting">
+<link rel="match" href="flex-order-paint-order-stacking-context-ref.html">
+<meta name="fuzzy" content="maxDifference=2-3; totalPixels=2400">
+<meta name="assert" content="Flex items are painted in order-modified document order even when they establish a stacking context; 'order' still controls paint order.">
+<style>
+  body { margin: 0; }
+  .row { display: flex; width: 60px; margin: 0 0 8px 0; }
+  .row > div { height: 40px; }
+  /* The green item is first in the DOM but has a higher 'order', so per
+     order-modified document order it must paint last (on top of red). */
+  .g { order: 2; width: 60px; margin-left: -30px; background: green; }
+  .r { order: 1; width: 30px; background: red; }
+  /* Each trigger establishes a stacking context on both items with no z-index
+     difference. Painting must still follow 'order', so green stays on top. */
+  .relz > div { position: relative; z-index: 0; }
+  .iso  > div { isolation: isolate; }
+  .op   > div { opacity: 0.99; }
+  .tf   > div { transform: translateZ(0); }
+  .wc   > div { will-change: transform; }
+  .flt  > div { filter: blur(0); }
+</style>
+<span class="row"><div class="g"></div><div class="r"></div></span>
+<span class="row relz"><div class="g"></div><div class="r"></div></span>
+<span class="row iso"><div class="g"></div><div class="r"></div></span>
+<span class="row op"><div class="g"></div><div class="r"></div></span>
+<span class="row tf"><div class="g"></div><div class="r"></div></span>
+<span class="row wc"><div class="g"></div><div class="r"></div></span>
+<span class="row flt"><div class="g"></div><div class="r"></div></span>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-order-paint-order-stacking-context-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-order-paint-order-stacking-context-expected.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Reference: seven green bars, no red visible</title>
+<style>
+  body { margin: 0; }
+  .bar { width: 60px; height: 40px; margin: 0 0 8px 0; background: green; }
+</style>
+<div class="bar"></div>
+<div class="bar"></div>
+<div class="bar"></div>
+<div class="bar"></div>
+<div class="bar"></div>
+<div class="bar"></div>
+<div class="bar"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-order-paint-order-stacking-context-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-order-paint-order-stacking-context-ref.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Reference: seven green bars, no red visible</title>
+<style>
+  body { margin: 0; }
+  .bar { width: 60px; height: 40px; margin: 0 0 8px 0; background: green; }
+</style>
+<div class="bar"></div>
+<div class="bar"></div>
+<div class="bar"></div>
+<div class="bar"></div>
+<div class="bar"></div>
+<div class="bar"></div>
+<div class="bar"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-order-paint-order-stacking-context.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-order-paint-order-stacking-context.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Grid 'order' determines paint order even when items form stacking contexts</title>
+<link rel="help" href="https://drafts.csswg.org/css-grid/#z-order">
+<link rel="match" href="grid-order-paint-order-stacking-context-ref.html">
+<meta name="fuzzy" content="maxDifference=2-3; totalPixels=2400">
+<meta name="assert" content="Grid items are painted in order-modified document order even when they establish a stacking context; 'order' still controls paint order.">
+<style>
+  body { margin: 0; }
+  .row { display: grid; width: 60px; margin: 0 0 8px 0; }
+  /* Both items occupy the same grid cell, so they overlap. The green item is
+     first in the DOM but has a higher 'order', so per order-modified document
+     order it must paint last (on top of red). */
+  .row > div { grid-area: 1 / 1; height: 40px; }
+  .g { order: 2; width: 60px; background: green; }
+  .r { order: 1; width: 30px; background: red; }
+  /* Each trigger establishes a stacking context on both items with no z-index
+     difference. Painting must still follow 'order', so green stays on top. */
+  .relz > div { position: relative; z-index: 0; }
+  .iso  > div { isolation: isolate; }
+  .op   > div { opacity: 0.99; }
+  .tf   > div { transform: translateZ(0); }
+  .wc   > div { will-change: transform; }
+  .flt  > div { filter: blur(0); }
+</style>
+<span class="row"><div class="g"></div><div class="r"></div></span>
+<span class="row relz"><div class="g"></div><div class="r"></div></span>
+<span class="row iso"><div class="g"></div><div class="r"></div></span>
+<span class="row op"><div class="g"></div><div class="r"></div></span>
+<span class="row tf"><div class="g"></div><div class="r"></div></span>
+<span class="row wc"><div class="g"></div><div class="r"></div></span>
+<span class="row flt"><div class="g"></div><div class="r"></div></span>

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -805,6 +805,31 @@ void RenderLayer::dirtyNormalFlowList()
         setNeedsCompositingPaintOrderChildrenUpdate();
 }
 
+static void reorderLayersForFlexOrGridOrder(Vector<RenderLayer*>& list)
+{
+    auto isFlexOrGridItem = [](const RenderLayer* layer) {
+        auto* parent = layer->renderer().parent();
+        return parent && !layer->renderer().isOutOfFlowPositioned()
+            && (parent->isFlexibleBoxIncludingDeprecated() || parent->isRenderGrid());
+    };
+    auto sameContainerItems = [&](const RenderLayer* a, const RenderLayer* b) {
+        return isFlexOrGridItem(a) && isFlexOrGridItem(b) && a->renderer().parent() == b->renderer().parent();
+    };
+
+    for (size_t runStart = 0; runStart < list.size(); ) {
+        size_t runEnd = runStart + 1;
+        while (runEnd < list.size() && list[runEnd]->zIndex() == list[runStart]->zIndex() && sameContainerItems(list[runStart], list[runEnd]))
+            ++runEnd;
+        if (runEnd - runStart > 1) {
+            auto run = list.mutableSpan().subspan(runStart, runEnd - runStart);
+            std::stable_sort(run.begin(), run.end(), [](const RenderLayer* a, const RenderLayer* b) {
+                return a->renderer().style().order() < b->renderer().style().order();
+            });
+        }
+        runStart = runEnd;
+    }
+}
+
 void RenderLayer::updateNormalFlowList()
 {
     if (!m_normalFlowListDirty)
@@ -822,8 +847,10 @@ void RenderLayer::updateNormalFlowList()
         }
     }
 
-    if (m_normalFlowList)
+    if (m_normalFlowList) {
+        reorderLayersForFlexOrGridOrder(*m_normalFlowList);
         m_normalFlowList->shrinkToFit();
+    }
 
     m_normalFlowListDirty = false;
 }
@@ -872,11 +899,13 @@ void RenderLayer::rebuildZOrderLists(std::unique_ptr<Vector<RenderLayer*>>& posZ
     // Sort the two lists.
     if (posZOrderList) {
         std::stable_sort(posZOrderList->begin(), posZOrderList->end(), compareZIndex);
+        reorderLayersForFlexOrGridOrder(*posZOrderList);
         posZOrderList->shrinkToFit();
     }
 
     if (negZOrderList) {
         std::stable_sort(negZOrderList->begin(), negZOrderList->end(), compareZIndex);
+        reorderLayersForFlexOrGridOrder(*negZOrderList);
         negZOrderList->shrinkToFit();
     }
 


### PR DESCRIPTION
#### 41ced9027ada024341b134e6b70c98be4c685d08
<pre>
flex/grid `order` is ignored for paint order once an item forms a stacking context
<a href="https://bugs.webkit.org/show_bug.cgi?id=221483">https://bugs.webkit.org/show_bug.cgi?id=221483</a>
<a href="https://rdar.apple.com/74279579">rdar://74279579</a>

Reviewed by NOBODY (OOPS!).

Per CSS Flexbox §5.4 and CSS Grid §6.4, flex and grid items paint in
order-modified document order, so the `order` property affects painting
order and not just layout order. WebKit honors this for items painted
through RenderFlexibleBox/RenderGrid via the OrderIterator, but once an
item establishes a stacking context (position:relative;z-index:0,
isolation:isolate, opacity, transform, will-change, filter, etc.) its
painting is driven by the RenderLayer z-order / normal-flow lists
instead. Those lists are collected in raw DOM order and sorted only by
z-index, so `order` is never consulted and items paint in source order,
unlike Chromium and Firefox.

Fix this by reordering, after the existing z-index sort, each maximal
run of same-z-index layers that are items of the same flex/grid
container, by their used `order` value. The comparison is scoped to
same-container in-flow items (out-of-flow positioned children of a
flex/grid container are not items, so `order` must not reorder them),
so it stays a stable, valid reordering that never moves unrelated
layers, adds no allocation, and only runs when the layer lists are
rebuilt (not per paint).

Tests: imported/w3c/web-platform-tests/css/css-flexbox/flex-order-paint-order-stacking-context-ref.html
       imported/w3c/web-platform-tests/css/css-flexbox/flex-order-paint-order-stacking-context.html
       imported/w3c/web-platform-tests/css/css-grid/grid-order-paint-order-stacking-context-ref.html
       imported/w3c/web-platform-tests/css/css-grid/grid-order-paint-order-stacking-context.html

* LayoutTests/TestExpectations: Progression
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flex-order-paint-order-stacking-context-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flex-order-paint-order-stacking-context-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flex-order-paint-order-stacking-context.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-order-paint-order-stacking-context-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-order-paint-order-stacking-context-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-order-paint-order-stacking-context.html: Added.
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::reorderLayersForFlexOrGridOrder):
(WebCore::RenderLayer::updateNormalFlowList):
(WebCore::RenderLayer::rebuildZOrderLists):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/41ced9027ada024341b134e6b70c98be4c685d08

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177736 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51674 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45468 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187345 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/140983 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/eca465ca-597d-49aa-b970-e959ab7c02b9) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179599 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52966 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51383 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138533 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96342 "2 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/cab23cc1-05f1-4098-a74e-cd7d4d0045ee) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180692 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42056 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159276 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118997 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/085808d0-1bf5-4274-951a-9010c00fc4e8) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40718 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39081 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151124 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38772 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35807 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/43459 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43316 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189773 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51341 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/158808 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147651 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52023 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35400 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147436 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42149 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124238 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118679 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50531 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13749 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49927 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50167 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49989 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->