### PR TITLE
[css-conditional-5] @container style queries not evaluating root-relative length correctly

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/style-query-registered-custom-rem-change-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/style-query-registered-custom-rem-change-expected.txt
@@ -1,5 +1,5 @@
 Should be green
 
 PASS Initially, 1rem * 10 evaluates to 160px
-FAIL Changing the :root font-size to 10px makes 1rem * 10 evaluate to 100px assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 0, 0)"
+PASS Changing the :root font-size to 10px makes 1rem * 10 evaluate to 100px
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/style-query-registered-custom-root-relative-units-change-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/style-query-registered-custom-root-relative-units-change-expected.txt
@@ -1,0 +1,10 @@
+Target 1: rem
+Target 2: rlh
+Target 3: vb
+Target 4: vi
+
+PASS assert_implements_style_container_queries()
+PASS rem in container style queries responds to root font size change
+PASS rlh in container style queries responds to root line height change
+PASS vi, vb in container style queries respond to root writing mode change
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/style-query-registered-custom-root-relative-units-change.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/style-query-registered-custom-root-relative-units-change.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+
+<title>CSS Container Queries Test: style() query with root-relative units for registered custom property</title>
+<link rel="help" href="https://drafts.csswg.org/css-conditional-5/#style-container">
+<link rel="author" title="Kiet Ho" href="mailto:kiet.ho@apple.com">
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="support/cq-testcommon.js"></script>
+
+<style>
+  @property --length {
+    syntax: "<length>";
+    initial-value: 0px;
+    inherits: false;
+  }
+
+  :root, body {
+    font-size: 16px;
+    line-height: 20px;
+  }
+
+  #container {
+    --length: 100px;
+  }
+
+  #t1, #t2, #t3, #t4 { color: red; }
+
+  @container style(--length: 10rem) {
+    #t1 { color: green; }
+  }
+
+  @container style(--length: 10rlh) {
+    #t2 { color: green; }
+  }
+
+  @container style(--length: 10vb) {
+    #t3 { color: green; }
+  }
+
+  @container style(--length: 10vi) {
+    #t4 { color: green; }
+  }
+</style>
+<div id="container">
+  <div id="t1">Target 1: rem</div>
+  <div id="t2">Target 2: rlh</div>
+  <div id="t3">Target 3: vb</div>
+  <div id="t4">Target 4: vi</div>
+</div>
+<script>
+  test(() => assert_implements_style_container_queries());
+
+  test(() => {
+    assert_equals(getComputedStyle(t1).color, "rgb(255, 0, 0)", "color before");
+    document.documentElement.style.fontSize = "10px";
+    assert_equals(getComputedStyle(t1).color, "rgb(0, 128, 0)", "color after");
+  }, "rem in container style queries responds to root font size change");
+
+  test(() => {
+    assert_equals(getComputedStyle(t2).color, "rgb(255, 0, 0)", "color before");
+    document.documentElement.style.lineHeight = "10px";
+    assert_equals(getComputedStyle(t2).color, "rgb(0, 128, 0)", "color after");
+  }, "rlh in container style queries responds to root line height change");
+
+  test(() => {
+    container.style.setProperty("--length", "10vw");
+    container.style.writingMode = "horizontal-tb";
+
+    assert_equals(getComputedStyle(t3).color, "rgb(255, 0, 0)", "In horizontal-tb mode, vb doesn't match vw");
+    assert_equals(getComputedStyle(t4).color, "rgb(0, 128, 0)", "In horizontal-tb mode, vi matches vw");
+
+    container.style.writingMode = "vertical-rl";
+
+    assert_equals(getComputedStyle(t3).color, "rgb(0, 128, 0)", "In vertical-rl mode, vb matches vw");
+    assert_equals(getComputedStyle(t4).color, "rgb(255, 0, 0)", "In vertical-rl mode, vi doesn't match vw");
+  }, "vi, vb in container style queries respond to root writing mode change");
+</script>

--- a/Source/WebCore/style/ContainerQueryEvaluator.cpp
+++ b/Source/WebCore/style/ContainerQueryEvaluator.cpp
@@ -99,7 +99,14 @@ auto ContainerQueryEvaluator::featureEvaluationContextForQuery(const CQ::Contain
     CheckedPtr containerParentStyle = containerParent ? CheckedPtr { styleForContainer(*containerParent, containerQuery.requirements, m_evaluationState) } : containerStyle;
 
     Ref document = element->document();
-    CheckedPtr rootStyle = document->documentElement()->renderStyle();
+
+    CheckedPtr rootStyle = [&] () -> const Style::ComputedStyle* {
+        RefPtr rootElement = document->documentElement();
+        if (!rootElement)
+            return nullptr;
+
+        return styleForContainer(*rootElement, containerQuery.requirements, m_evaluationState);
+    }();
 
     return MQ::FeatureEvaluationContext {
         document.get(),


### PR DESCRIPTION
#### a7b39ca3653c38e1984af164efaa13475f2b61e6
<pre>
[css-conditional-5] @container style queries not evaluating root-relative length correctly
<a href="https://rdar.apple.com/183094796">rdar://183094796</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=320160">https://bugs.webkit.org/show_bug.cgi?id=320160</a>

Reviewed by Tim Nguyen.

During style resolution, new element styles are not immediately committed to the
render tree. Instead, they&apos;re stored in a Style::Update, and the render tree updater
(which runs after style resolution) commits the new styles. This means accessing an
element&apos;s render style during style resolution will result in the style of the
previous resolution, not the current one.

This wouldn&apos;t work with container style queries, as it queries against the new
style, which hasn&apos;t been committed into the render tree. As ContainerQueryEvaluator
is run during style resolution, it has has a clever trick: it has access to the
Style::Update of the current resolution. This gives it access to the new styles.

ContainerQueryEvaluator::featureEvaluationContextForQuery uses styleForContainer
to grab the new style for the container and container&apos;s parent, but for the root
element style, it uses the current render style instead. This means if the style
queries specifies length using root-relative units (e.g rem, rlh, vb, vi), the
length are relative to the root&apos;s old style, not the new one. If the container
queries are re-evaluated because the root style changes (e.g font-size, line-height,
or writing-mode), then the queries will incorrectly evaluate the length against
the old root style.

Fix this by also using styleForContainer to get the newest possible root style.

Tests:  imported/w3c/web-platform-tests/css/css-conditional/container-queries/style-query-registered-custom-rem-change.html
        imported/w3c/web-platform-tests/css/css-conditional/container-queries/style-query-registered-custom-root-relative-units-change.html

* LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/style-query-registered-custom-rem-change-expected.txt:
    - Test progression

* LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/style-query-registered-custom-root-relative-units-change-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/style-query-registered-custom-root-relative-units-change.html: Added.
    - Add test that tests whether lengths using root-relative units in container style
      queries correctly re-evaluates when the root changes. This test is similar to
      style-query-registered-custom-rem-change.html, but it tests more root-relative
      units (rem, rlh, vb, vi)

* Source/WebCore/style/ContainerQueryEvaluator.cpp:
(WebCore::Style::ContainerQueryEvaluator::featureEvaluationContextForQuery const):

Canonical link: <a href="https://commits.webkit.org/318144@main">https://commits.webkit.org/318144@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fcb464556d2ea01458e9de99c9b256e9386113a9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177298 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51236 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45030 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186901 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140545 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e92f4322-e578-4dbd-ad02-0ab026f73043) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179161 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52528 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50925 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138157 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140545 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/af55d5f3-b550-4715-baf4-b4205d8f43c1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180254 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41669 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158927 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118622 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9dc37963-e48d-4d94-bff8-cf21d9dcebde) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40330 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38705 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150738 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38424 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35369 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/43021 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42919 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189330 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50902 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/158461 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147251 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39594 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51585 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35051 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147043 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41771 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123800 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118134 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50093 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13402 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49489 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49729 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49551 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->