### PR TITLE
Make ModelPlayer node-addressable for Multi-Model

### DIFF
--- a/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
@@ -418,8 +418,13 @@ void HTMLModelElement::notifyFinished(CachedResource& resource, const NetworkLoa
 
 // MARK: - ModelPlayerClient overrides.
 
-void HTMLModelElement::didFinishLoading(ModelPlayer& modelPlayer)
+void HTMLModelElement::didFinishLoading(ModelPlayer& modelPlayer, NodeIdentifier nodeID)
 {
+    if (nodeID != nodeIdentifier()) {
+        ASSERT_NOT_REACHED();
+        return;
+    }
+
 #if ENABLE(GPU_PROCESS_MODEL)
     if (&modelPlayer == m_pendingModelPlayer) {
         // The pending player has finished loading. Promote it to live and
@@ -455,8 +460,13 @@ void HTMLModelElement::didFinishLoading(ModelPlayer& modelPlayer)
         m_readyPromise->resolve(*this);
 }
 
-void HTMLModelElement::didFailLoading(ModelPlayer& modelPlayer, const ResourceError&)
+void HTMLModelElement::didFailLoading(ModelPlayer& modelPlayer, NodeIdentifier nodeID, const ResourceError&)
 {
+    if (nodeID != nodeIdentifier()) {
+        ASSERT_NOT_REACHED();
+        return;
+    }
+
 #if ENABLE(GPU_PROCESS_MODEL)
     if (&modelPlayer == m_pendingModelPlayer) {
         // The pending reload failed. Tear down only the pending player and
@@ -549,8 +559,13 @@ void HTMLModelElement::didUpdate(ModelPlayer& modelPlayer)
 
 #if ENABLE(MODEL_ELEMENT_ENTITY_TRANSFORM)
 
-void HTMLModelElement::didUpdateEntityTransform(ModelPlayer&, const TransformationMatrix& transform)
+void HTMLModelElement::didUpdateEntityTransform(ModelPlayer&, NodeIdentifier nodeID, const TransformationMatrix& transform)
 {
+    if (nodeID != nodeIdentifier()) {
+        ASSERT_NOT_REACHED();
+        return;
+    }
+
     m_entityTransform = DOMMatrixReadOnly::create(transform, DOMMatrixReadOnly::Is2D::No);
 }
 
@@ -558,8 +573,13 @@ void HTMLModelElement::didUpdateEntityTransform(ModelPlayer&, const Transformati
 
 #if ENABLE(MODEL_ELEMENT_BOUNDING_BOX)
 
-void HTMLModelElement::didUpdateBoundingBox(ModelPlayer&, const FloatPoint3D& center, const FloatPoint3D& extents)
+void HTMLModelElement::didUpdateBoundingBox(ModelPlayer&, NodeIdentifier nodeID, const FloatPoint3D& center, const FloatPoint3D& extents)
 {
+    if (nodeID != nodeIdentifier()) {
+        ASSERT_NOT_REACHED();
+        return;
+    }
+
     m_boundingBoxCenter = DOMPointReadOnly::fromFloatPoint(center);
     m_boundingBoxExtents = DOMPointReadOnly::fromFloatPoint(extents);
 }
@@ -688,10 +708,12 @@ void HTMLModelElement::createModelPlayer()
         return;
     }
 
+    auto nodeID = nodeIdentifier();
+
 #if ENABLE(MODEL_ELEMENT_ANIMATIONS_CONTROL)
-    modelPlayer->setAutoplay(autoplay());
-    modelPlayer->setLoop(loop());
-    modelPlayer->setPlaybackRate(m_playbackRate, [](double) { });
+    modelPlayer->setAutoplay(nodeID, autoplay());
+    modelPlayer->setLoop(nodeID, loop());
+    modelPlayer->setPlaybackRate(nodeID, m_playbackRate, [](double) { });
 #endif
 
 #if ENABLE(MODEL_ELEMENT_PORTAL)
@@ -712,7 +734,7 @@ void HTMLModelElement::createModelPlayer()
 #if ENABLE(MODEL_ELEMENT_IMMERSIVE)
     isForImmersive = m_detachedForImmersive;
 #endif
-    modelPlayer->load(*model, contentSize(), isForImmersive);
+    modelPlayer->load(nodeID, *model, contentSize(), isForImmersive);
 
 #if ENABLE(MODEL_ELEMENT_ENVIRONMENT_MAP)
     if (m_environmentMapData)
@@ -766,8 +788,9 @@ void HTMLModelElement::unloadModelPlayer(bool onSuspend)
     if (!modelPlayer || modelPlayer->isPlaceholder())
         return;
 
-    auto animationState = modelPlayer->currentAnimationState();
-    auto transformState = modelPlayer->currentTransformState();
+    auto nodeID = nodeIdentifier();
+    auto animationState = modelPlayer->currentAnimationState(nodeID);
+    auto transformState = modelPlayer->currentTransformState(nodeID);
     if (!animationState || !transformState) {
         RELEASE_LOG(ModelElement, "%p - HTMLModelElement: Model player cannot handle temporary unload", this);
         deleteModelPlayer();
@@ -807,8 +830,9 @@ void HTMLModelElement::reloadModelPlayer()
 
     ASSERT(document().page());
 
-    auto animationState = modelPlayer->currentAnimationState();
-    auto transformState = modelPlayer->currentTransformState();
+    auto nodeID = nodeIdentifier();
+    auto animationState = modelPlayer->currentAnimationState(nodeID);
+    auto transformState = modelPlayer->currentTransformState(nodeID);
     ASSERT(animationState && transformState);
 
 #if ENABLE(MODEL_PROCESS) || ENABLE(GPU_PROCESS_MODEL)
@@ -837,7 +861,7 @@ void HTMLModelElement::reloadModelPlayer()
     modelPlayer->setDynamicRangeLimit(m_dynamicRangeLimit, m_currentEDRHeadroom, m_suppressEDR);
 #endif
 
-    modelPlayer->reload(*model, contentSize(), *animationState, WTF::move(*transformState));
+    modelPlayer->reload(nodeID, *model, contentSize(), *animationState, WTF::move(*transformState));
 
 #if ENABLE(MODEL_ELEMENT_ENVIRONMENT_MAP)
     if (m_environmentMapData)
@@ -944,7 +968,7 @@ ExceptionOr<void> HTMLModelElement::setEntityTransform(const DOMMatrixReadOnly& 
         return Exception { ExceptionCode::NotSupportedError };
 
     m_entityTransform = DOMMatrixReadOnly::create(matrix, DOMMatrixReadOnly::Is2D::No);
-    player->setEntityTransform(matrix);
+    player->setEntityTransform(nodeIdentifier(), matrix);
 
     return { };
 }
@@ -1317,17 +1341,17 @@ void HTMLModelElement::setPlaybackRate(double playbackRate)
     m_playbackRate = playbackRate;
 
     if (m_modelPlayer)
-        m_modelPlayer->setPlaybackRate(playbackRate, [](double) { });
+        m_modelPlayer->setPlaybackRate(nodeIdentifier(), playbackRate, [](double) { });
 }
 
 double HTMLModelElement::duration() const
 {
-    return m_modelPlayer ? m_modelPlayer->duration() : 0;
+    return m_modelPlayer ? m_modelPlayer->duration(nodeIdentifier()) : 0;
 }
 
 bool HTMLModelElement::paused() const
 {
-    return m_modelPlayer ? m_modelPlayer->paused() : true;
+    return m_modelPlayer ? m_modelPlayer->paused(nodeIdentifier()) : true;
 }
 
 void HTMLModelElement::play(DOMPromiseDeferred<void>&& promise)
@@ -1347,7 +1371,7 @@ void HTMLModelElement::setPaused(bool paused, DOMPromiseDeferred<void>&& promise
         return;
     }
 
-    m_modelPlayer->setPaused(paused, [promise = WTF::move(promise)] (bool succeeded) mutable {
+    m_modelPlayer->setPaused(nodeIdentifier(), paused, [promise = WTF::move(promise)] (bool succeeded) mutable {
         if (succeeded)
             promise.resolve();
         else
@@ -1363,7 +1387,7 @@ bool HTMLModelElement::autoplay() const
 void HTMLModelElement::updateAutoplay()
 {
     if (m_modelPlayer)
-        m_modelPlayer->setAutoplay(autoplay());
+        m_modelPlayer->setAutoplay(nodeIdentifier(), autoplay());
 }
 
 bool HTMLModelElement::loop() const
@@ -1374,18 +1398,18 @@ bool HTMLModelElement::loop() const
 void HTMLModelElement::updateLoop()
 {
     if (m_modelPlayer)
-        m_modelPlayer->setLoop(loop());
+        m_modelPlayer->setLoop(nodeIdentifier(), loop());
 }
 
 double HTMLModelElement::currentTime() const
 {
-    return m_modelPlayer ? m_modelPlayer->currentTime().seconds() : 0;
+    return m_modelPlayer ? m_modelPlayer->currentTime(nodeIdentifier()).seconds() : 0;
 }
 
 void HTMLModelElement::setCurrentTime(double currentTime)
 {
     if (m_modelPlayer)
-        m_modelPlayer->setCurrentTime(Seconds(currentTime), [] { });
+        m_modelPlayer->setCurrentTime(nodeIdentifier(), Seconds(currentTime), [] { });
 }
 
 #endif
@@ -1606,7 +1630,7 @@ void HTMLModelElement::isPlayingAnimation(IsPlayingAnimationPromise&& promise)
         return;
     }
 
-    modelPlayer->isPlayingAnimation([promise = WTF::move(promise)](std::optional<bool> isPlaying) mutable {
+    modelPlayer->isPlayingAnimation(nodeIdentifier(), [promise = WTF::move(promise)](std::optional<bool> isPlaying) mutable {
         if (!isPlaying)
             promise.reject();
         else
@@ -1622,7 +1646,7 @@ void HTMLModelElement::setAnimationIsPlaying(bool isPlaying, DOMPromiseDeferred<
         return;
     }
 
-    modelPlayer->setAnimationIsPlaying(isPlaying, [promise = WTF::move(promise)](bool success) mutable {
+    modelPlayer->setAnimationIsPlaying(nodeIdentifier(), isPlaying, [promise = WTF::move(promise)](bool success) mutable {
         if (success)
             promise.resolve();
         else
@@ -1648,7 +1672,7 @@ void HTMLModelElement::isLoopingAnimation(IsLoopingAnimationPromise&& promise)
         return;
     }
 
-    modelPlayer->isLoopingAnimation([promise = WTF::move(promise)](std::optional<bool> isLooping) mutable {
+    modelPlayer->isLoopingAnimation(nodeIdentifier(), [promise = WTF::move(promise)](std::optional<bool> isLooping) mutable {
         if (!isLooping)
             promise.reject();
         else
@@ -1664,7 +1688,7 @@ void HTMLModelElement::setIsLoopingAnimation(bool isLooping, DOMPromiseDeferred<
         return;
     }
 
-    modelPlayer->setIsLoopingAnimation(isLooping, [promise = WTF::move(promise)](bool success) mutable {
+    modelPlayer->setIsLoopingAnimation(nodeIdentifier(), isLooping, [promise = WTF::move(promise)](bool success) mutable {
         if (success)
             promise.resolve();
         else
@@ -1680,7 +1704,7 @@ void HTMLModelElement::animationDuration(DurationPromise&& promise)
         return;
     }
 
-    modelPlayer->animationDuration([promise = WTF::move(promise)] (std::optional<Seconds> duration) mutable {
+    modelPlayer->animationDuration(nodeIdentifier(), [promise = WTF::move(promise)] (std::optional<Seconds> duration) mutable {
         if (!duration)
             promise.reject();
         else
@@ -1696,7 +1720,7 @@ void HTMLModelElement::animationCurrentTime(CurrentTimePromise&& promise)
         return;
     }
 
-    modelPlayer->animationCurrentTime([promise = WTF::move(promise)] (std::optional<Seconds> currentTime) mutable {
+    modelPlayer->animationCurrentTime(nodeIdentifier(), [promise = WTF::move(promise)] (std::optional<Seconds> currentTime) mutable {
         if (!currentTime)
             promise.reject();
         else
@@ -1712,7 +1736,7 @@ void HTMLModelElement::setAnimationCurrentTime(double currentTime, DOMPromiseDef
         return;
     }
 
-    modelPlayer->setAnimationCurrentTime(Seconds(currentTime), [promise = WTF::move(promise)](bool success) mutable {
+    modelPlayer->setAnimationCurrentTime(nodeIdentifier(), Seconds(currentTime), [promise = WTF::move(promise)](bool success) mutable {
         if (success)
             promise.resolve();
         else

--- a/Source/WebCore/Modules/model-element/HTMLModelElement.h
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.h
@@ -251,18 +251,18 @@ private:
     void notifyFinished(CachedResource&, const NetworkLoadMetrics&, LoadWillContinueInAnotherProcess) final;
 
     // ModelPlayerClient overrides.
-    void didFinishLoading(ModelPlayer&) final;
-    void didFailLoading(ModelPlayer&, const ResourceError&) final;
+    void didFinishLoading(ModelPlayer&, NodeIdentifier) final;
+    void didFailLoading(ModelPlayer&, NodeIdentifier, const ResourceError&) final;
 #if ENABLE(MODEL_PROCESS)
     void didConvertModelData(ModelPlayer&, Ref<SharedBuffer>&& convertedData, const String& convertedMIMEType) final;
 #endif
     void didUnload(ModelPlayer&) final;
     void didUpdate(ModelPlayer&) final;
 #if ENABLE(MODEL_ELEMENT_ENTITY_TRANSFORM)
-    void didUpdateEntityTransform(ModelPlayer&, const TransformationMatrix&) final;
+    void didUpdateEntityTransform(ModelPlayer&, NodeIdentifier, const TransformationMatrix&) final;
 #endif
 #if ENABLE(MODEL_ELEMENT_BOUNDING_BOX)
-    void didUpdateBoundingBox(ModelPlayer&, const FloatPoint3D&, const FloatPoint3D&) final;
+    void didUpdateBoundingBox(ModelPlayer&, NodeIdentifier, const FloatPoint3D&, const FloatPoint3D&) final;
 #endif
 #if ENABLE(MODEL_ELEMENT_ENVIRONMENT_MAP)
     void didFinishEnvironmentMapLoading(ModelPlayer&, bool succeeded) final;

--- a/Source/WebCore/Modules/model-element/ModelPlayer.cpp
+++ b/Source/WebCore/Modules/model-element/ModelPlayer.cpp
@@ -54,17 +54,21 @@ bool ModelPlayer::isWebModelPlayerInstance() const
     return false;
 }
 
-std::optional<ModelPlayerAnimationState> ModelPlayer::currentAnimationState() const
+std::optional<ModelPlayerAnimationState> ModelPlayer::currentAnimationState(NodeIdentifier) const
 {
     return std::nullopt;
 }
 
-std::optional<std::unique_ptr<ModelPlayerTransformState>> ModelPlayer::currentTransformState() const
+std::optional<std::unique_ptr<ModelPlayerTransformState>> ModelPlayer::currentTransformState(NodeIdentifier) const
 {
     return std::nullopt;
 }
 
-void ModelPlayer::reload(Model&, LayoutSize, ModelPlayerAnimationState&, std::unique_ptr<ModelPlayerTransformState>&&)
+void ModelPlayer::reload(NodeIdentifier, Model&, LayoutSize, ModelPlayerAnimationState&, std::unique_ptr<ModelPlayerTransformState>&&)
+{
+}
+
+void ModelPlayer::unload(NodeIdentifier)
 {
 }
 
@@ -83,12 +87,12 @@ RefPtr<ImageBuffer> ModelPlayer::snapshotCurrentFrame(const FloatSize&, const De
 
 #if ENABLE(MODEL_ELEMENT_BOUNDING_BOX)
 
-std::optional<FloatPoint3D> ModelPlayer::boundingBoxCenter() const
+std::optional<FloatPoint3D> ModelPlayer::boundingBoxCenter(NodeIdentifier) const
 {
     return std::nullopt;
 }
 
-std::optional<FloatPoint3D> ModelPlayer::boundingBoxExtents() const
+std::optional<FloatPoint3D> ModelPlayer::boundingBoxExtents(NodeIdentifier) const
 {
     return std::nullopt;
 }
@@ -97,12 +101,12 @@ std::optional<FloatPoint3D> ModelPlayer::boundingBoxExtents() const
 
 #if ENABLE(MODEL_ELEMENT_ENTITY_TRANSFORM)
 
-std::optional<TransformationMatrix> ModelPlayer::entityTransform() const
+std::optional<TransformationMatrix> ModelPlayer::entityTransform(NodeIdentifier) const
 {
     return std::nullopt;
 }
 
-void ModelPlayer::setEntityTransform(TransformationMatrix)
+void ModelPlayer::setEntityTransform(NodeIdentifier, TransformationMatrix)
 {
 }
 
@@ -129,40 +133,40 @@ void ModelPlayer::setInteractionEnabled(bool)
 
 #if ENABLE(MODEL_ELEMENT_ANIMATIONS_CONTROL)
 
-void ModelPlayer::setAutoplay(bool)
+void ModelPlayer::setAutoplay(NodeIdentifier, bool)
 {
 }
 
-void ModelPlayer::setLoop(bool)
+void ModelPlayer::setLoop(NodeIdentifier, bool)
 {
 }
 
-void ModelPlayer::setPlaybackRate(double, CompletionHandler<void(double effectivePlaybackRate)>&& completionHandler)
+void ModelPlayer::setPlaybackRate(NodeIdentifier, double, CompletionHandler<void(double effectivePlaybackRate)>&& completionHandler)
 {
     completionHandler(1.0);
 }
 
-double ModelPlayer::duration() const
+double ModelPlayer::duration(NodeIdentifier) const
 {
     return 0;
 }
 
-bool ModelPlayer::paused() const
+bool ModelPlayer::paused(NodeIdentifier) const
 {
     return true;
 }
 
-void ModelPlayer::setPaused(bool, CompletionHandler<void(bool succeeded)>&& completionHandler)
+void ModelPlayer::setPaused(NodeIdentifier, bool, CompletionHandler<void(bool succeeded)>&& completionHandler)
 {
     completionHandler(false);
 }
 
-Seconds ModelPlayer::currentTime() const
+Seconds ModelPlayer::currentTime(NodeIdentifier) const
 {
     return 0_s;
 }
 
-void ModelPlayer::setCurrentTime(Seconds, CompletionHandler<void()>&& completionHandler)
+void ModelPlayer::setCurrentTime(NodeIdentifier, Seconds, CompletionHandler<void()>&& completionHandler)
 {
     completionHandler();
 }

--- a/Source/WebCore/Modules/model-element/ModelPlayer.h
+++ b/Source/WebCore/Modules/model-element/ModelPlayer.h
@@ -32,6 +32,7 @@
 #include <WebCore/LayoutSize.h>
 #include <WebCore/ModelPlayerAccessibilityChildren.h>
 #include <WebCore/ModelPlayerIdentifier.h>
+#include <WebCore/NodeIdentifier.h>
 #include <optional>
 #include <wtf/Forward.h>
 #include <wtf/MonotonicTime.h>
@@ -74,8 +75,9 @@ public:
     virtual bool NODELETE isWebModelPlayerInstance() const;
 
     // Loading.
-    virtual void load(Model&, LayoutSize, bool) = 0;
-    virtual void NODELETE reload(Model&, LayoutSize, ModelPlayerAnimationState&, std::unique_ptr<ModelPlayerTransformState>&&);
+    virtual void load(NodeIdentifier, Model&, LayoutSize, bool) = 0;
+    virtual void unload(NodeIdentifier);
+    virtual void NODELETE reload(NodeIdentifier, Model&, LayoutSize, ModelPlayerAnimationState&, std::unique_ptr<ModelPlayerTransformState>&&);
 
     // Graphics.
     virtual void configureGraphicsLayer(GraphicsLayer&, ModelPlayerGraphicsLayerConfiguration&&) = 0;
@@ -88,17 +90,17 @@ public:
     virtual void sizeDidChange(LayoutSize) = 0;
 
     // State accessors.
-    virtual std::optional<ModelPlayerAnimationState> currentAnimationState() const;
-    virtual std::optional<std::unique_ptr<ModelPlayerTransformState>> currentTransformState() const;
+    virtual std::optional<ModelPlayerAnimationState> currentAnimationState(NodeIdentifier) const;
+    virtual std::optional<std::unique_ptr<ModelPlayerTransformState>> currentTransformState(NodeIdentifier) const;
 
 #if ENABLE(MODEL_ELEMENT_BOUNDING_BOX)
-    virtual std::optional<FloatPoint3D> boundingBoxCenter() const;
-    virtual std::optional<FloatPoint3D> boundingBoxExtents() const;
+    virtual std::optional<FloatPoint3D> boundingBoxCenter(NodeIdentifier) const;
+    virtual std::optional<FloatPoint3D> boundingBoxExtents(NodeIdentifier) const;
 #endif
 
 #if ENABLE(MODEL_ELEMENT_ENTITY_TRANSFORM)
-    virtual std::optional<TransformationMatrix> entityTransform() const;
-    virtual void setEntityTransform(TransformationMatrix);
+    virtual std::optional<TransformationMatrix> entityTransform(NodeIdentifier) const;
+    virtual void setEntityTransform(NodeIdentifier, TransformationMatrix);
     virtual bool supportsTransform(TransformationMatrix);
 #endif
 
@@ -122,27 +124,27 @@ public:
 
     virtual void getCamera(CompletionHandler<void(std::optional<HTMLModelElementCamera>&&)>&&) = 0;
     virtual void setCamera(HTMLModelElementCamera, CompletionHandler<void(bool success)>&&) = 0;
-    virtual void isPlayingAnimation(CompletionHandler<void(std::optional<bool>&&)>&&) = 0;
-    virtual void setAnimationIsPlaying(bool, CompletionHandler<void(bool success)>&&) = 0;
-    virtual void isLoopingAnimation(CompletionHandler<void(std::optional<bool>&&)>&&) = 0;
-    virtual void setIsLoopingAnimation(bool, CompletionHandler<void(bool success)>&&) = 0;
-    virtual void animationDuration(CompletionHandler<void(std::optional<Seconds>&&)>&&) = 0;
-    virtual void animationCurrentTime(CompletionHandler<void(std::optional<Seconds>&&)>&&) = 0;
-    virtual void setAnimationCurrentTime(Seconds, CompletionHandler<void(bool success)>&&) = 0;
+    virtual void isPlayingAnimation(NodeIdentifier, CompletionHandler<void(std::optional<bool>&&)>&&) = 0;
+    virtual void setAnimationIsPlaying(NodeIdentifier, bool, CompletionHandler<void(bool success)>&&) = 0;
+    virtual void isLoopingAnimation(NodeIdentifier, CompletionHandler<void(std::optional<bool>&&)>&&) = 0;
+    virtual void setIsLoopingAnimation(NodeIdentifier, bool, CompletionHandler<void(bool success)>&&) = 0;
+    virtual void animationDuration(NodeIdentifier, CompletionHandler<void(std::optional<Seconds>&&)>&&) = 0;
+    virtual void animationCurrentTime(NodeIdentifier, CompletionHandler<void(std::optional<Seconds>&&)>&&) = 0;
+    virtual void setAnimationCurrentTime(NodeIdentifier, Seconds, CompletionHandler<void(bool success)>&&) = 0;
 
 #if ENABLE(MODEL_ELEMENT_ACCESSIBILITY)
     virtual ModelPlayerAccessibilityChildren accessibilityChildren() = 0;
 #endif
 
 #if ENABLE(MODEL_ELEMENT_ANIMATIONS_CONTROL)
-    virtual void setAutoplay(bool);
-    virtual void setLoop(bool);
-    virtual void setPlaybackRate(double, CompletionHandler<void(double effectivePlaybackRate)>&&);
-    virtual double duration() const;
-    virtual bool paused() const;
-    virtual void setPaused(bool, CompletionHandler<void(bool succeeded)>&&);
-    virtual Seconds currentTime() const;
-    virtual void setCurrentTime(Seconds, CompletionHandler<void()>&&);
+    virtual void setAutoplay(NodeIdentifier, bool);
+    virtual void setLoop(NodeIdentifier, bool);
+    virtual void setPlaybackRate(NodeIdentifier, double, CompletionHandler<void(double effectivePlaybackRate)>&&);
+    virtual double duration(NodeIdentifier) const;
+    virtual bool paused(NodeIdentifier) const;
+    virtual void setPaused(NodeIdentifier, bool, CompletionHandler<void(bool succeeded)>&&);
+    virtual Seconds currentTime(NodeIdentifier) const;
+    virtual void setCurrentTime(NodeIdentifier, Seconds, CompletionHandler<void()>&&);
 #endif
 
 #if ENABLE(MODEL_ELEMENT_ENVIRONMENT_MAP)

--- a/Source/WebCore/Modules/model-element/ModelPlayerClient.h
+++ b/Source/WebCore/Modules/model-element/ModelPlayerClient.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <WebCore/LayerHostingContextIdentifier.h>
+#include <WebCore/NodeIdentifier.h>
 #include <WebCore/PlatformLayerIdentifier.h>
 #include <WebCore/SharedBuffer.h>
 #include <WebCore/TransformationMatrix.h>
@@ -45,8 +46,8 @@ class WEBCORE_EXPORT ModelPlayerClient : public AbstractRefCountedAndCanMakeWeak
 public:
     virtual ~ModelPlayerClient();
 
-    virtual void didFinishLoading(ModelPlayer&) = 0;
-    virtual void didFailLoading(ModelPlayer&, const ResourceError&) = 0;
+    virtual void didFinishLoading(ModelPlayer&, NodeIdentifier) = 0;
+    virtual void didFailLoading(ModelPlayer&, NodeIdentifier, const ResourceError&) = 0;
 #if ENABLE(MODEL_PROCESS)
     virtual void didConvertModelData(ModelPlayer&, Ref<SharedBuffer>&& convertedData, const String& convertedMIMEType) = 0;
 #endif
@@ -58,10 +59,10 @@ public:
     virtual void didUpdate(ModelPlayer&) = 0;
 
 #if ENABLE(MODEL_ELEMENT_ENTITY_TRANSFORM)
-    virtual void didUpdateEntityTransform(ModelPlayer&, const TransformationMatrix&) = 0;
+    virtual void didUpdateEntityTransform(ModelPlayer&, NodeIdentifier, const TransformationMatrix&) = 0;
 #endif
 #if ENABLE(MODEL_ELEMENT_BOUNDING_BOX)
-    virtual void didUpdateBoundingBox(ModelPlayer&, const FloatPoint3D&, const FloatPoint3D&) = 0;
+    virtual void didUpdateBoundingBox(ModelPlayer&, NodeIdentifier, const FloatPoint3D&, const FloatPoint3D&) = 0;
 #endif
 
     virtual RefPtr<GraphicsLayer> graphicsLayer() const = 0;

--- a/Source/WebCore/Modules/model-element/PlaceholderModelPlayer.cpp
+++ b/Source/WebCore/Modules/model-element/PlaceholderModelPlayer.cpp
@@ -63,7 +63,7 @@ PlaceholderModelPlayer::PlaceholderModelPlayer(bool suspended, const ModelPlayer
 
 PlaceholderModelPlayer::~PlaceholderModelPlayer() = default;
 
-std::optional<ModelPlayerAnimationState> PlaceholderModelPlayer::currentAnimationState() const
+std::optional<ModelPlayerAnimationState> PlaceholderModelPlayer::currentAnimationState(NodeIdentifier) const
 {
     if (!m_lastPausedStateIfSuspended || *m_lastPausedStateIfSuspended)
         return m_animationState;
@@ -74,29 +74,29 @@ std::optional<ModelPlayerAnimationState> PlaceholderModelPlayer::currentAnimatio
     return unsuspendedAnimationState;
 }
 
-std::optional<std::unique_ptr<ModelPlayerTransformState>> PlaceholderModelPlayer::currentTransformState() const
+std::optional<std::unique_ptr<ModelPlayerTransformState>> PlaceholderModelPlayer::currentTransformState(NodeIdentifier) const
 {
     return m_transformState->clone();
 }
 
-void PlaceholderModelPlayer::load(Model&, LayoutSize, bool)
+void PlaceholderModelPlayer::load(NodeIdentifier, Model&, LayoutSize, bool)
 {
     RELEASE_ASSERT_NOT_REACHED();
 }
 
-void PlaceholderModelPlayer::reload(Model&, LayoutSize, ModelPlayerAnimationState&, std::unique_ptr<ModelPlayerTransformState>&&)
+void PlaceholderModelPlayer::reload(NodeIdentifier, Model&, LayoutSize, ModelPlayerAnimationState&, std::unique_ptr<ModelPlayerTransformState>&&)
 {
     RELEASE_ASSERT_NOT_REACHED();
 }
 
 #if ENABLE(MODEL_ELEMENT_BOUNDING_BOX)
 
-std::optional<WebCore::FloatPoint3D> PlaceholderModelPlayer::boundingBoxCenter() const
+std::optional<WebCore::FloatPoint3D> PlaceholderModelPlayer::boundingBoxCenter(NodeIdentifier) const
 {
     return m_transformState->boundingBoxCenter();
 }
 
-std::optional<WebCore::FloatPoint3D> PlaceholderModelPlayer::boundingBoxExtents() const
+std::optional<WebCore::FloatPoint3D> PlaceholderModelPlayer::boundingBoxExtents(NodeIdentifier) const
 {
     return m_transformState->boundingBoxExtents();
 }
@@ -105,13 +105,13 @@ std::optional<WebCore::FloatPoint3D> PlaceholderModelPlayer::boundingBoxExtents(
 
 #if ENABLE(MODEL_ELEMENT_ENTITY_TRANSFORM)
 
-std::optional<WebCore::TransformationMatrix> PlaceholderModelPlayer::entityTransform() const
+std::optional<WebCore::TransformationMatrix> PlaceholderModelPlayer::entityTransform(NodeIdentifier) const
 {
     return m_transformState->entityTransform();
 }
 
 /// This comes from JS side, so we need to tell Model Process about it. Not to be confused with didUpdateEntityTransform().
-void PlaceholderModelPlayer::setEntityTransform(WebCore::TransformationMatrix transform)
+void PlaceholderModelPlayer::setEntityTransform(NodeIdentifier, TransformationMatrix transform)
 {
 #if ENABLE(MODEL_ELEMENT_STAGE_MODE)
     ASSERT(m_transformState->stageMode() == StageModeOperation::None);
@@ -128,17 +128,17 @@ bool PlaceholderModelPlayer::supportsTransform(WebCore::TransformationMatrix tra
 
 #if ENABLE(MODEL_ELEMENT_ANIMATIONS_CONTROL)
 
-void PlaceholderModelPlayer::setAutoplay(bool autoplay)
+void PlaceholderModelPlayer::setAutoplay(NodeIdentifier, bool autoplay)
 {
     m_animationState.setAutoplay(autoplay);
 }
 
-void PlaceholderModelPlayer::setLoop(bool loop)
+void PlaceholderModelPlayer::setLoop(NodeIdentifier, bool loop)
 {
     m_animationState.setLoop(loop);
 }
 
-void PlaceholderModelPlayer::setPlaybackRate(double playbackRate, CompletionHandler<void(double effectivePlaybackRate)>&& completionHandler)
+void PlaceholderModelPlayer::setPlaybackRate(NodeIdentifier, double playbackRate, CompletionHandler<void(double effectivePlaybackRate)>&& completionHandler)
 {
     if (m_animationState.effectivePlaybackRate() == playbackRate)
         return completionHandler(playbackRate);
@@ -149,17 +149,17 @@ void PlaceholderModelPlayer::setPlaybackRate(double playbackRate, CompletionHand
     completionHandler(effectivePlaybackRate ? *effectivePlaybackRate : 1.0);
 }
 
-double PlaceholderModelPlayer::duration() const
+double PlaceholderModelPlayer::duration(NodeIdentifier) const
 {
     return m_animationState.duration().seconds();
 }
 
-bool PlaceholderModelPlayer::paused() const
+bool PlaceholderModelPlayer::paused(NodeIdentifier) const
 {
     return m_animationState.paused();
 }
 
-void PlaceholderModelPlayer::setPaused(bool paused, CompletionHandler<void(bool succeeded)>&& completionHandler)
+void PlaceholderModelPlayer::setPaused(NodeIdentifier, bool paused, CompletionHandler<void(bool succeeded)>&& completionHandler)
 {
     if (m_animationState.paused() == paused)
         return completionHandler(true);
@@ -169,12 +169,12 @@ void PlaceholderModelPlayer::setPaused(bool paused, CompletionHandler<void(bool 
     completionHandler(true);
 }
 
-Seconds PlaceholderModelPlayer::currentTime() const
+Seconds PlaceholderModelPlayer::currentTime(NodeIdentifier) const
 {
     return m_animationState.currentTime();
 }
 
-void PlaceholderModelPlayer::setCurrentTime(Seconds currentTime, CompletionHandler<void()>&& completionHandler)
+void PlaceholderModelPlayer::setCurrentTime(NodeIdentifier, Seconds currentTime, CompletionHandler<void()>&& completionHandler)
 {
     double durationSeconds = m_animationState.duration().seconds();
     if (durationSeconds)
@@ -239,37 +239,37 @@ void PlaceholderModelPlayer::setCamera(WebCore::HTMLModelElementCamera, Completi
     completionHandler(false);
 }
 
-void PlaceholderModelPlayer::isPlayingAnimation(CompletionHandler<void(std::optional<bool>&&)>&& completionHandler)
+void PlaceholderModelPlayer::isPlayingAnimation(NodeIdentifier, CompletionHandler<void(std::optional<bool>&&)>&& completionHandler)
 {
     completionHandler(std::nullopt);
 }
 
-void PlaceholderModelPlayer::setAnimationIsPlaying(bool, CompletionHandler<void(bool success)>&& completionHandler)
+void PlaceholderModelPlayer::setAnimationIsPlaying(NodeIdentifier, bool, CompletionHandler<void(bool success)>&& completionHandler)
 {
     completionHandler(false);
 }
 
-void PlaceholderModelPlayer::isLoopingAnimation(CompletionHandler<void(std::optional<bool>&&)>&& completionHandler)
+void PlaceholderModelPlayer::isLoopingAnimation(NodeIdentifier, CompletionHandler<void(std::optional<bool>&&)>&& completionHandler)
 {
     completionHandler(std::nullopt);
 }
 
-void PlaceholderModelPlayer::setIsLoopingAnimation(bool, CompletionHandler<void(bool success)>&& completionHandler)
+void PlaceholderModelPlayer::setIsLoopingAnimation(NodeIdentifier, bool, CompletionHandler<void(bool success)>&& completionHandler)
 {
     completionHandler(false);
 }
 
-void PlaceholderModelPlayer::animationDuration(CompletionHandler<void(std::optional<Seconds>&&)>&& completionHandler)
+void PlaceholderModelPlayer::animationDuration(NodeIdentifier, CompletionHandler<void(std::optional<Seconds>&&)>&& completionHandler)
 {
     completionHandler(std::nullopt);
 }
 
-void PlaceholderModelPlayer::animationCurrentTime(CompletionHandler<void(std::optional<Seconds>&&)>&& completionHandler)
+void PlaceholderModelPlayer::animationCurrentTime(NodeIdentifier, CompletionHandler<void(std::optional<Seconds>&&)>&& completionHandler)
 {
     completionHandler(std::nullopt);
 }
 
-void PlaceholderModelPlayer::setAnimationCurrentTime(Seconds, CompletionHandler<void(bool success)>&& completionHandler)
+void PlaceholderModelPlayer::setAnimationCurrentTime(NodeIdentifier, Seconds, CompletionHandler<void(bool success)>&& completionHandler)
 {
     completionHandler(false);
 }

--- a/Source/WebCore/Modules/model-element/PlaceholderModelPlayer.h
+++ b/Source/WebCore/Modules/model-element/PlaceholderModelPlayer.h
@@ -42,31 +42,31 @@ private:
     // ModelPlayer overrides.
     ModelPlayerIdentifier identifier() const final { return m_id; }
     bool isPlaceholder() const final { return true; }
-    std::optional<ModelPlayerAnimationState> currentAnimationState() const final;
-    std::optional<std::unique_ptr<ModelPlayerTransformState>> currentTransformState() const final;
-    void NODELETE load(Model&, LayoutSize, bool) final;
-    void NODELETE reload(Model&, LayoutSize, ModelPlayerAnimationState&, std::unique_ptr<ModelPlayerTransformState>&&) final;
+    std::optional<ModelPlayerAnimationState> currentAnimationState(NodeIdentifier) const final;
+    std::optional<std::unique_ptr<ModelPlayerTransformState>> currentTransformState(NodeIdentifier) const final;
+    void NODELETE load(NodeIdentifier, Model&, LayoutSize, bool) final;
+    void NODELETE reload(NodeIdentifier, Model&, LayoutSize, ModelPlayerAnimationState&, std::unique_ptr<ModelPlayerTransformState>&&) final;
 
 #if ENABLE(MODEL_ELEMENT_BOUNDING_BOX)
-    std::optional<FloatPoint3D> boundingBoxCenter() const final;
-    std::optional<FloatPoint3D> boundingBoxExtents() const final;
+    std::optional<FloatPoint3D> boundingBoxCenter(NodeIdentifier) const final;
+    std::optional<FloatPoint3D> boundingBoxExtents(NodeIdentifier) const final;
 #endif
 
 #if ENABLE(MODEL_ELEMENT_ENTITY_TRANSFORM)
-    std::optional<TransformationMatrix> entityTransform() const final;
-    void setEntityTransform(TransformationMatrix) final;
+    std::optional<TransformationMatrix> entityTransform(NodeIdentifier) const final;
+    void setEntityTransform(NodeIdentifier, TransformationMatrix) final;
     bool supportsTransform(TransformationMatrix) final;
 #endif
 
 #if ENABLE(MODEL_ELEMENT_ANIMATIONS_CONTROL)
-    void setAutoplay(bool) final;
-    void setLoop(bool) final;
-    void setPlaybackRate(double playbackRate, CompletionHandler<void(double effectivePlaybackRate)>&&) final;
-    double duration() const final;
-    bool paused() const final;
-    void setPaused(bool, CompletionHandler<void(bool succeeded)>&&) final;
-    Seconds currentTime() const final;
-    void setCurrentTime(Seconds, CompletionHandler<void()>&&) final;
+    void setAutoplay(NodeIdentifier, bool) final;
+    void setLoop(NodeIdentifier, bool) final;
+    void setPlaybackRate(NodeIdentifier, double playbackRate, CompletionHandler<void(double effectivePlaybackRate)>&&) final;
+    double duration(NodeIdentifier) const final;
+    bool paused(NodeIdentifier) const final;
+    void setPaused(NodeIdentifier, bool, CompletionHandler<void(bool succeeded)>&&) final;
+    Seconds currentTime(NodeIdentifier) const final;
+    void setCurrentTime(NodeIdentifier, Seconds, CompletionHandler<void()>&&) final;
 #endif
 
 #if ENABLE(MODEL_ELEMENT_PORTAL)
@@ -92,13 +92,13 @@ private:
 
     void getCamera(CompletionHandler<void(std::optional<WebCore::HTMLModelElementCamera>&&)>&&) final;
     void setCamera(WebCore::HTMLModelElementCamera, CompletionHandler<void(bool success)>&&) final;
-    void isPlayingAnimation(CompletionHandler<void(std::optional<bool>&&)>&&) final;
-    void setAnimationIsPlaying(bool, CompletionHandler<void(bool success)>&&) final;
-    void isLoopingAnimation(CompletionHandler<void(std::optional<bool>&&)>&&) final;
-    void setIsLoopingAnimation(bool, CompletionHandler<void(bool success)>&&) final;
-    void animationDuration(CompletionHandler<void(std::optional<Seconds>&&)>&&) final;
-    void animationCurrentTime(CompletionHandler<void(std::optional<Seconds>&&)>&&) final;
-    void setAnimationCurrentTime(Seconds, CompletionHandler<void(bool success)>&&) final;
+    void isPlayingAnimation(NodeIdentifier, CompletionHandler<void(std::optional<bool>&&)>&&) final;
+    void setAnimationIsPlaying(NodeIdentifier, bool, CompletionHandler<void(bool success)>&&) final;
+    void isLoopingAnimation(NodeIdentifier, CompletionHandler<void(std::optional<bool>&&)>&&) final;
+    void setIsLoopingAnimation(NodeIdentifier, bool, CompletionHandler<void(bool success)>&&) final;
+    void animationDuration(NodeIdentifier, CompletionHandler<void(std::optional<Seconds>&&)>&&) final;
+    void animationCurrentTime(NodeIdentifier, CompletionHandler<void(std::optional<Seconds>&&)>&&) final;
+    void setAnimationCurrentTime(NodeIdentifier, Seconds, CompletionHandler<void(bool success)>&&) final;
 #if ENABLE(MODEL_ELEMENT_ACCESSIBILITY)
     ModelPlayerAccessibilityChildren accessibilityChildren() final;
 #endif

--- a/Source/WebCore/Modules/model-element/dummy/DummyModelPlayer.cpp
+++ b/Source/WebCore/Modules/model-element/dummy/DummyModelPlayer.cpp
@@ -46,10 +46,10 @@ DummyModelPlayer::DummyModelPlayer(ModelPlayerClient& client)
 
 DummyModelPlayer::~DummyModelPlayer() = default;
 
-void DummyModelPlayer::load(Model& model, LayoutSize, bool)
+void DummyModelPlayer::load(NodeIdentifier nodeIdentifier, Model& model, LayoutSize, bool)
 {
     if (RefPtr client = m_client)
-        client->didFailLoading(*this, ResourceError { errorDomainWebKitInternal, 0, model.url(), "Trying to load model via DummyModelPlayer"_s });
+        client->didFailLoading(*this, nodeIdentifier, ResourceError { errorDomainWebKitInternal, 0, model.url(), "Trying to load model via DummyModelPlayer"_s });
 }
 
 void DummyModelPlayer::configureGraphicsLayer(GraphicsLayer&, ModelPlayerGraphicsLayerConfiguration&&)
@@ -84,31 +84,31 @@ void DummyModelPlayer::setCamera(WebCore::HTMLModelElementCamera, CompletionHand
 {
 }
 
-void DummyModelPlayer::isPlayingAnimation(CompletionHandler<void(std::optional<bool>&&)>&&)
+void DummyModelPlayer::isPlayingAnimation(NodeIdentifier, CompletionHandler<void(std::optional<bool>&&)>&&)
 {
 }
 
-void DummyModelPlayer::setAnimationIsPlaying(bool, CompletionHandler<void(bool success)>&&)
+void DummyModelPlayer::setAnimationIsPlaying(NodeIdentifier, bool, CompletionHandler<void(bool success)>&&)
 {
 }
 
-void DummyModelPlayer::isLoopingAnimation(CompletionHandler<void(std::optional<bool>&&)>&&)
+void DummyModelPlayer::isLoopingAnimation(NodeIdentifier, CompletionHandler<void(std::optional<bool>&&)>&&)
 {
 }
 
-void DummyModelPlayer::setIsLoopingAnimation(bool, CompletionHandler<void(bool success)>&&)
+void DummyModelPlayer::setIsLoopingAnimation(NodeIdentifier, bool, CompletionHandler<void(bool success)>&&)
 {
 }
 
-void DummyModelPlayer::animationDuration(CompletionHandler<void(std::optional<Seconds>&&)>&&)
+void DummyModelPlayer::animationDuration(NodeIdentifier, CompletionHandler<void(std::optional<Seconds>&&)>&&)
 {
 }
 
-void DummyModelPlayer::animationCurrentTime(CompletionHandler<void(std::optional<Seconds>&&)>&&)
+void DummyModelPlayer::animationCurrentTime(NodeIdentifier, CompletionHandler<void(std::optional<Seconds>&&)>&&)
 {
 }
 
-void DummyModelPlayer::setAnimationCurrentTime(Seconds, CompletionHandler<void(bool success)>&&)
+void DummyModelPlayer::setAnimationCurrentTime(NodeIdentifier, Seconds, CompletionHandler<void(bool success)>&&)
 {
 }
 

--- a/Source/WebCore/Modules/model-element/dummy/DummyModelPlayer.h
+++ b/Source/WebCore/Modules/model-element/dummy/DummyModelPlayer.h
@@ -45,7 +45,7 @@ private:
 
     // ModelPlayer overrides.
     ModelPlayerIdentifier identifier() const final { return m_id; }
-    void load(Model&, LayoutSize, bool) override;
+    void load(NodeIdentifier, Model&, LayoutSize, bool) override;
     void NODELETE configureGraphicsLayer(GraphicsLayer&, ModelPlayerGraphicsLayerConfiguration&&) override;
     void NODELETE sizeDidChange(LayoutSize) override;
     void NODELETE enterFullscreen() override;
@@ -54,13 +54,13 @@ private:
     void NODELETE handleMouseUp(const LayoutPoint&, MonotonicTime) override;
     void NODELETE getCamera(CompletionHandler<void(std::optional<WebCore::HTMLModelElementCamera>&&)>&&) override;
     void NODELETE setCamera(WebCore::HTMLModelElementCamera, CompletionHandler<void(bool success)>&&) override;
-    void NODELETE isPlayingAnimation(CompletionHandler<void(std::optional<bool>&&)>&&) override;
-    void NODELETE setAnimationIsPlaying(bool, CompletionHandler<void(bool success)>&&) override;
-    void NODELETE isLoopingAnimation(CompletionHandler<void(std::optional<bool>&&)>&&) override;
-    void NODELETE setIsLoopingAnimation(bool, CompletionHandler<void(bool success)>&&) override;
-    void NODELETE animationDuration(CompletionHandler<void(std::optional<Seconds>&&)>&&) override;
-    void NODELETE animationCurrentTime(CompletionHandler<void(std::optional<Seconds>&&)>&&) override;
-    void NODELETE setAnimationCurrentTime(Seconds, CompletionHandler<void(bool success)>&&) override;
+    void NODELETE isPlayingAnimation(NodeIdentifier, CompletionHandler<void(std::optional<bool>&&)>&&) override;
+    void NODELETE setAnimationIsPlaying(NodeIdentifier, bool, CompletionHandler<void(bool success)>&&) override;
+    void NODELETE isLoopingAnimation(NodeIdentifier, CompletionHandler<void(std::optional<bool>&&)>&&) override;
+    void NODELETE setIsLoopingAnimation(NodeIdentifier, bool, CompletionHandler<void(bool success)>&&) override;
+    void NODELETE animationDuration(NodeIdentifier, CompletionHandler<void(std::optional<Seconds>&&)>&&) override;
+    void NODELETE animationCurrentTime(NodeIdentifier, CompletionHandler<void(std::optional<Seconds>&&)>&&) override;
+    void NODELETE setAnimationCurrentTime(NodeIdentifier, Seconds, CompletionHandler<void(bool success)>&&) override;
 #if ENABLE(MODEL_ELEMENT_ACCESSIBILITY)
     ModelPlayerAccessibilityChildren accessibilityChildren() override;
 #endif

--- a/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.h
+++ b/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.h
@@ -73,9 +73,11 @@ public:
 #include <WebCore/ModelPlayer.h>
 #include <WebCore/ModelPlayerAnimationState.h>
 #include <WebCore/ModelPlayerIdentifier.h>
+#include <WebCore/NodeIdentifier.h>
 #include <WebCore/StageModeOperations.h>
 #include <WebCore/TransformationMatrix.h>
 #include <simd/simd.h>
+#include <wtf/Markable.h>
 #include <wtf/RefPtr.h>
 #include <wtf/RunLoop.h>
 #include <wtf/TZoneMalloc.h>
@@ -123,8 +125,8 @@ public:
 
     // Messages
     void createLayer();
-    void loadModel(Ref<WebCore::Model>&&, WebCore::LayoutSize, bool);
-    void reloadModel(Ref<WebCore::Model>&&, WebCore::LayoutSize, std::optional<WebCore::TransformationMatrix> transformToRestore, std::optional<WebCore::ModelPlayerAnimationState> animationStateToRestore);
+    void loadModel(WebCore::NodeIdentifier, Ref<WebCore::Model>&&, WebCore::LayoutSize, bool);
+    void reloadModel(WebCore::NodeIdentifier, Ref<WebCore::Model>&&, WebCore::LayoutSize, std::optional<WebCore::TransformationMatrix> transformToRestore, std::optional<WebCore::ModelPlayerAnimationState> animationStateToRestore);
     void modelVisibilityDidChange(bool isVisible);
 
     // WebCore::REModelLoaderClient overrides.
@@ -133,10 +135,10 @@ public:
 
     // WebCore::ModelPlayer overrides.
     WebCore::ModelPlayerIdentifier identifier() const final { return m_id; }
-    void load(WebCore::Model&, WebCore::LayoutSize, bool) final;
+    void load(WebCore::NodeIdentifier, WebCore::Model&, WebCore::LayoutSize, bool) final;
     void sizeDidChange(WebCore::LayoutSize) final;
     void configureGraphicsLayer(WebCore::GraphicsLayer&, WebCore::ModelPlayerGraphicsLayerConfiguration&&) final;
-    void setEntityTransform(WebCore::TransformationMatrix) final;
+    void setEntityTransform(WebCore::NodeIdentifier, WebCore::TransformationMatrix) final;
     void enterFullscreen() final;
     bool supportsMouseInteraction() final;
     bool supportsDragging() final;
@@ -146,22 +148,22 @@ public:
     void handleMouseUp(const WebCore::LayoutPoint&, MonotonicTime) final;
     void getCamera(CompletionHandler<void(std::optional<WebCore::HTMLModelElementCamera>&&)>&&) final;
     void setCamera(WebCore::HTMLModelElementCamera, CompletionHandler<void(bool success)>&&) final;
-    void isPlayingAnimation(CompletionHandler<void(std::optional<bool>&&)>&&) final;
-    void setAnimationIsPlaying(bool, CompletionHandler<void(bool success)>&&) final;
-    void isLoopingAnimation(CompletionHandler<void(std::optional<bool>&&)>&&) final;
-    void setIsLoopingAnimation(bool, CompletionHandler<void(bool success)>&&) final;
-    void animationDuration(CompletionHandler<void(std::optional<Seconds>&&)>&&) final;
-    void animationCurrentTime(CompletionHandler<void(std::optional<Seconds>&&)>&&) final;
-    void setAnimationCurrentTime(Seconds, CompletionHandler<void(bool success)>&&) final;
+    void isPlayingAnimation(WebCore::NodeIdentifier, CompletionHandler<void(std::optional<bool>&&)>&&) final;
+    void setAnimationIsPlaying(WebCore::NodeIdentifier, bool, CompletionHandler<void(bool success)>&&) final;
+    void isLoopingAnimation(WebCore::NodeIdentifier, CompletionHandler<void(std::optional<bool>&&)>&&) final;
+    void setIsLoopingAnimation(WebCore::NodeIdentifier, bool, CompletionHandler<void(bool success)>&&) final;
+    void animationDuration(WebCore::NodeIdentifier, CompletionHandler<void(std::optional<Seconds>&&)>&&) final;
+    void animationCurrentTime(WebCore::NodeIdentifier, CompletionHandler<void(std::optional<Seconds>&&)>&&) final;
+    void setAnimationCurrentTime(WebCore::NodeIdentifier, Seconds, CompletionHandler<void(bool success)>&&) final;
     WebCore::ModelPlayerAccessibilityChildren accessibilityChildren() final;
-    void setAutoplay(bool) final;
-    void setLoop(bool) final;
-    void setPlaybackRate(double, CompletionHandler<void(double effectivePlaybackRate)>&&) final;
-    double duration() const final;
-    bool paused() const final;
-    void setPaused(bool, CompletionHandler<void(bool succeeded)>&&) final;
-    Seconds currentTime() const final;
-    void setCurrentTime(Seconds, CompletionHandler<void()>&&) final;
+    void setAutoplay(WebCore::NodeIdentifier, bool) final;
+    void setLoop(WebCore::NodeIdentifier, bool) final;
+    void setPlaybackRate(WebCore::NodeIdentifier, double, CompletionHandler<void(double effectivePlaybackRate)>&&) final;
+    double duration(WebCore::NodeIdentifier) const final;
+    bool paused(WebCore::NodeIdentifier) const final;
+    void setPaused(WebCore::NodeIdentifier, bool, CompletionHandler<void(bool succeeded)>&&) final;
+    Seconds currentTime(WebCore::NodeIdentifier) const final;
+    void setCurrentTime(WebCore::NodeIdentifier, Seconds, CompletionHandler<void()>&&) final;
     void setEnvironmentMap(Ref<WebCore::SharedBuffer>&& data) final;
     void setHasPortal(bool) final;
     void setStageMode(WebCore::StageModeOperation) final;
@@ -200,6 +202,7 @@ private:
     int entityMemoryLimit(bool) const;
 
     WebCore::ModelPlayerIdentifier m_id;
+    Markable<WebCore::NodeIdentifier> m_nodeID;
     bool m_isVisible { true };
     Ref<IPC::Connection> m_webProcessConnection;
     WeakPtr<ModelProcessModelPlayerManagerProxy> m_manager;

--- a/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.messages.in
+++ b/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.messages.in
@@ -30,19 +30,19 @@
 ]
 messages -> ModelProcessModelPlayerProxy {
     CreateLayer()
-    ReloadModel(Ref<WebCore::Model> model, WebCore::LayoutSize layoutSize, std::optional<WebCore::TransformationMatrix> entityTransformToRestore, std::optional<WebCore::ModelPlayerAnimationState> animationStateToRestore)
+    ReloadModel(WebCore::NodeIdentifier nodeID, Ref<WebCore::Model> model, WebCore::LayoutSize layoutSize, std::optional<WebCore::TransformationMatrix> entityTransformToRestore, std::optional<WebCore::ModelPlayerAnimationState> animationStateToRestore)
     ModelVisibilityDidChange(bool isVisible)
     [EnabledBy=AllowTestOnlyIPC] DisableUnloadDelayForTesting()
     
     # WebCore::ModelPlayer
-    LoadModel(Ref<WebCore::Model> url, WebCore::LayoutSize layoutSize, bool isForImmersive)
+    LoadModel(WebCore::NodeIdentifier nodeID, Ref<WebCore::Model> url, WebCore::LayoutSize layoutSize, bool isForImmersive)
     SizeDidChange(WebCore::LayoutSize layoutSize)
-    SetEntityTransform(WebCore::TransformationMatrix transform)
-    SetAutoplay(bool autoplay)
-    SetLoop(bool loop)
-    SetPlaybackRate(double playbackRate) -> (double effectivePlaybackRate) Async
-    SetPaused(bool paused) -> (bool succeeded) Async
-    SetCurrentTime(Seconds currentTime) -> () Async
+    SetEntityTransform(WebCore::NodeIdentifier nodeID, WebCore::TransformationMatrix transform)
+    SetAutoplay(WebCore::NodeIdentifier nodeID, bool autoplay)
+    SetLoop(WebCore::NodeIdentifier nodeID, bool loop)
+    SetPlaybackRate(WebCore::NodeIdentifier nodeID, double playbackRate) -> (double effectivePlaybackRate) Async
+    SetPaused(WebCore::NodeIdentifier nodeID, bool paused) -> (bool succeeded) Async
+    SetCurrentTime(WebCore::NodeIdentifier nodeID, Seconds currentTime) -> () Async
     SetEnvironmentMap(Ref<WebCore::SharedBuffer> data)
     SetHasPortal(bool hasPortal)
     SetStageMode(enum:bool WebCore::StageModeOperation stagemodeOp)

--- a/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm
+++ b/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm
@@ -408,14 +408,16 @@ void ModelProcessModelPlayerProxy::createLayer()
         send(Messages::ModelProcessModelPlayer::DidCreateLayer(contextID.value()));
 }
 
-void ModelProcessModelPlayerProxy::loadModel(Ref<WebCore::Model>&& model, WebCore::LayoutSize layoutSize, bool isForImmersive)
+void ModelProcessModelPlayerProxy::loadModel(WebCore::NodeIdentifier nodeID, Ref<WebCore::Model>&& model, WebCore::LayoutSize layoutSize, bool isForImmersive)
 {
     dispatch_assert_queue(mainDispatchQueueSingleton());
+
+    m_nodeID = nodeID;
 
 #if HAVE(CORE_RE)
     if (model->mimeType() != usdzMIMEType) {
         Ref<WebCore::SharedBuffer> modelData = model->data();
-        RKUSDModelLoadScheduler::singleton().scheduleModelConversion(WTF::move(modelData), ThreadSafeWeakPtr { *this }, [model = WTF::move(model), layoutSize, isForImmersive](ModelProcessModelPlayerProxy& proxy, RetainPtr<NSData>&& usdzData) mutable {
+        RKUSDModelLoadScheduler::singleton().scheduleModelConversion(WTF::move(modelData), ThreadSafeWeakPtr { *this }, [model = WTF::move(model), layoutSize, isForImmersive, nodeID](ModelProcessModelPlayerProxy& proxy, RetainPtr<NSData>&& usdzData) mutable {
             dispatch_assert_queue(mainDispatchQueueSingleton());
 
             if (usdzData) {
@@ -425,23 +427,24 @@ void ModelProcessModelPlayerProxy::loadModel(Ref<WebCore::Model>&& model, WebCor
                 proxy.send(Messages::ModelProcessModelPlayer::DidConvertModelData(convertedBuffer.copyRef(), usdzMIMEType));
 
                 auto convertedModel = WebCore::Model::create(WTF::move(convertedBuffer), usdzMIMEType, model->url());
-                proxy.load(convertedModel, layoutSize, isForImmersive);
+                proxy.load(nodeID, convertedModel, layoutSize, isForImmersive);
                 return;
             }
 
             RELEASE_LOG_ERROR(ModelElement, "%p - ModelProcessModelPlayerProxy::loadModel(): Model conversion failed, continuing with original data", &proxy);
-            proxy.load(model, layoutSize, isForImmersive);
+            proxy.load(nodeID, model, layoutSize, isForImmersive);
         });
         return;
     }
 #endif
 
     // FIXME: Change the IPC message to land on load() directly
-    load(model, layoutSize, isForImmersive);
+    load(nodeID, model, layoutSize, isForImmersive);
 }
 
-void ModelProcessModelPlayerProxy::reloadModel(Ref<WebCore::Model>&& model, WebCore::LayoutSize layoutSize, std::optional<WebCore::TransformationMatrix> entityTransformToRestore, std::optional<WebCore::ModelPlayerAnimationState> animationStateToRestore)
+void ModelProcessModelPlayerProxy::reloadModel(WebCore::NodeIdentifier nodeID, Ref<WebCore::Model>&& model, WebCore::LayoutSize layoutSize, std::optional<WebCore::TransformationMatrix> entityTransformToRestore, std::optional<WebCore::ModelPlayerAnimationState> animationStateToRestore)
 {
+    m_nodeID = nodeID;
     m_entityTransformToRestore = WTF::move(entityTransformToRestore);
     m_animationStateToRestore = WTF::move(animationStateToRestore);
     if (m_animationStateToRestore) {
@@ -455,7 +458,7 @@ void ModelProcessModelPlayerProxy::reloadModel(Ref<WebCore::Model>&& model, WebC
 #if ENABLE(MODEL_ELEMENT_IMMERSIVE)
     isForImmersive = m_immersivePresentation;
 #endif
-    load(model, layoutSize, isForImmersive);
+    load(nodeID, model, layoutSize, isForImmersive);
 }
 
 void ModelProcessModelPlayerProxy::modelVisibilityDidChange(bool isVisible)
@@ -618,10 +621,13 @@ void ModelProcessModelPlayerProxy::computeTransform(bool setDefaultRotation)
 
 void ModelProcessModelPlayerProxy::notifyModelPlayerOfEntityTransformChange()
 {
+    if (!m_nodeID)
+        return;
+
     RESRT newSRT = modelStandardizedTransformSRT(m_transformSRT);
     simd_float4x4 matrix = RESRTMatrix(newSRT);
     WebCore::TransformationMatrix transform = WebCore::TransformationMatrix(matrix);
-    send(Messages::ModelProcessModelPlayer::DidUpdateEntityTransform(transform));
+    send(Messages::ModelProcessModelPlayer::DidUpdateEntityTransform(*m_nodeID, transform));
 }
 
 void ModelProcessModelPlayerProxy::updateTransform()
@@ -668,12 +674,16 @@ void ModelProcessModelPlayerProxy::startAnimating()
 
 void ModelProcessModelPlayerProxy::animationPlaybackStateDidUpdate()
 {
-    bool isPaused = paused();
+    if (!m_nodeID)
+        return;
+
+    auto nodeID = *m_nodeID;
+    bool isPaused = paused(nodeID);
     float playbackRate = [m_modelRKEntity playbackRate];
-    NSTimeInterval duration = this->duration();
-    NSTimeInterval currentTime = this->currentTime().seconds();
+    NSTimeInterval duration = this->duration(nodeID);
+    NSTimeInterval currentTime = this->currentTime(nodeID).seconds();
     RELEASE_LOG_DEBUG(ModelElement, "%p - ModelProcessModelPlayerProxy: did update animation playback state: paused: %d, playbackRate: %f, duration: %f, currentTime: %f", this, isPaused, playbackRate, duration, currentTime);
-    send(Messages::ModelProcessModelPlayer::DidUpdateAnimationPlaybackState(isPaused, playbackRate, Seconds(duration), Seconds(currentTime), MonotonicTime::now()));
+    send(Messages::ModelProcessModelPlayer::DidUpdateAnimationPlaybackState(nodeID, isPaused, playbackRate, Seconds(duration), Seconds(currentTime), MonotonicTime::now()));
 }
 
 #if HAVE(CORE_RE)
@@ -691,6 +701,11 @@ void ModelProcessModelPlayerProxy::didFinishLoading(WebCore::REModelLoader& load
     ASSERT(&loader == m_loader.get());
 
     m_loader = nullptr;
+
+    if (!m_nodeID)
+        return;
+
+    auto nodeID = *m_nodeID;
 
 #if HAVE(CORE_RE)
     bool canLoadWithRealityKit = [getWKRKEntityClassSingleton() isLoadFromDataAvailable];
@@ -750,7 +765,7 @@ void ModelProcessModelPlayerProxy::didFinishLoading(WebCore::REModelLoader& load
 #endif // HAVE(CORE_RE)
 
     if (m_entityTransformToRestore) {
-        setEntityTransform(*m_entityTransformToRestore);
+        setEntityTransform(nodeID, *m_entityTransformToRestore);
         notifyModelPlayerOfEntityTransformChange();
         m_entityTransformToRestore = std::nullopt;
     } else {
@@ -777,7 +792,7 @@ void ModelProcessModelPlayerProxy::didFinishLoading(WebCore::REModelLoader& load
 #endif
     });
 
-    send(Messages::ModelProcessModelPlayer::DidFinishLoading(WebCore::FloatPoint3D(m_originalBoundingBoxCenter.x, m_originalBoundingBoxCenter.y, m_originalBoundingBoxCenter.z), WebCore::FloatPoint3D(m_originalBoundingBoxExtents.x, m_originalBoundingBoxExtents.y, m_originalBoundingBoxExtents.z)));
+    send(Messages::ModelProcessModelPlayer::DidFinishLoading(nodeID, WebCore::FloatPoint3D(m_originalBoundingBoxCenter.x, m_originalBoundingBoxCenter.y, m_originalBoundingBoxCenter.z), WebCore::FloatPoint3D(m_originalBoundingBoxExtents.x, m_originalBoundingBoxExtents.y, m_originalBoundingBoxExtents.z)));
 }
 
 void ModelProcessModelPlayerProxy::didFailLoading(WebCore::REModelLoader& loader, const WebCore::ResourceError& error)
@@ -793,7 +808,10 @@ void ModelProcessModelPlayerProxy::didFailLoading(WebCore::REModelLoader& loader
     triggerModelLoadedCallbacks(false);
 #endif
 
-    send(Messages::ModelProcessModelPlayer::DidFailLoading());
+    if (!m_nodeID)
+        return;
+
+    send(Messages::ModelProcessModelPlayer::DidFailLoading(*m_nodeID));
 }
 
 // MARK: - WebCore::ModelPlayer
@@ -833,9 +851,11 @@ private:
 };
 #endif
 
-void ModelProcessModelPlayerProxy::load(WebCore::Model& model, WebCore::LayoutSize layoutSize, bool isForImmersive)
+void ModelProcessModelPlayerProxy::load(WebCore::NodeIdentifier nodeID, WebCore::Model& model, WebCore::LayoutSize layoutSize, bool isForImmersive)
 {
     dispatch_assert_queue(mainDispatchQueueSingleton());
+
+    m_nodeID = nodeID;
 
 #if ENABLE(MODEL_ELEMENT_IMMERSIVE)
     m_currentModel = &model;
@@ -909,7 +929,7 @@ std::optional<WebCore::LayerHostingContextIdentifier> ModelProcessModelPlayerPro
     return WebCore::LayerHostingContextIdentifier(m_layerHostingContext->contextID());
 }
 
-void ModelProcessModelPlayerProxy::setEntityTransform(WebCore::TransformationMatrix transform)
+void ModelProcessModelPlayerProxy::setEntityTransform(WebCore::NodeIdentifier, WebCore::TransformationMatrix transform)
 {
     RESRT newSRT = REMakeSRTFromMatrix(transform);
     m_transformSRT = modelLocalizedTransformSRT(newSRT);
@@ -957,37 +977,37 @@ void ModelProcessModelPlayerProxy::setCamera(WebCore::HTMLModelElementCamera cam
     completionHandler(false);
 }
 
-void ModelProcessModelPlayerProxy::isPlayingAnimation(CompletionHandler<void(std::optional<bool>&&)>&& completionHandler)
+void ModelProcessModelPlayerProxy::isPlayingAnimation(WebCore::NodeIdentifier, CompletionHandler<void(std::optional<bool>&&)>&& completionHandler)
 {
     completionHandler(std::nullopt);
 }
 
-void ModelProcessModelPlayerProxy::setAnimationIsPlaying(bool isPlaying, CompletionHandler<void(bool success)>&& completionHandler)
+void ModelProcessModelPlayerProxy::setAnimationIsPlaying(WebCore::NodeIdentifier, bool isPlaying, CompletionHandler<void(bool success)>&& completionHandler)
 {
     completionHandler(false);
 }
 
-void ModelProcessModelPlayerProxy::isLoopingAnimation(CompletionHandler<void(std::optional<bool>&&)>&& completionHandler)
+void ModelProcessModelPlayerProxy::isLoopingAnimation(WebCore::NodeIdentifier, CompletionHandler<void(std::optional<bool>&&)>&& completionHandler)
 {
     completionHandler(std::nullopt);
 }
 
-void ModelProcessModelPlayerProxy::setIsLoopingAnimation(bool isLooping, CompletionHandler<void(bool success)>&& completionHandler)
+void ModelProcessModelPlayerProxy::setIsLoopingAnimation(WebCore::NodeIdentifier, bool isLooping, CompletionHandler<void(bool success)>&& completionHandler)
 {
     completionHandler(false);
 }
 
-void ModelProcessModelPlayerProxy::animationDuration(CompletionHandler<void(std::optional<Seconds>&&)>&& completionHandler)
+void ModelProcessModelPlayerProxy::animationDuration(WebCore::NodeIdentifier, CompletionHandler<void(std::optional<Seconds>&&)>&& completionHandler)
 {
     completionHandler(std::nullopt);
 }
 
-void ModelProcessModelPlayerProxy::animationCurrentTime(CompletionHandler<void(std::optional<Seconds>&&)>&& completionHandler)
+void ModelProcessModelPlayerProxy::animationCurrentTime(WebCore::NodeIdentifier, CompletionHandler<void(std::optional<Seconds>&&)>&& completionHandler)
 {
     completionHandler(std::nullopt);
 }
 
-void ModelProcessModelPlayerProxy::setAnimationCurrentTime(Seconds currentTime, CompletionHandler<void(bool success)>&& completionHandler)
+void ModelProcessModelPlayerProxy::setAnimationCurrentTime(WebCore::NodeIdentifier, Seconds currentTime, CompletionHandler<void(bool success)>&& completionHandler)
 {
     completionHandler(false);
 }
@@ -997,46 +1017,46 @@ WebCore::ModelPlayerAccessibilityChildren ModelProcessModelPlayerProxy::accessib
     return { };
 }
 
-void ModelProcessModelPlayerProxy::setAutoplay(bool autoplay)
+void ModelProcessModelPlayerProxy::setAutoplay(WebCore::NodeIdentifier, bool autoplay)
 {
     m_autoplay = autoplay;
 }
 
-void ModelProcessModelPlayerProxy::setLoop(bool loop)
+void ModelProcessModelPlayerProxy::setLoop(WebCore::NodeIdentifier, bool loop)
 {
     m_loop = loop;
     [m_modelRKEntity setLoop:m_loop];
 }
 
-void ModelProcessModelPlayerProxy::setPlaybackRate(double playbackRate, CompletionHandler<void(double effectivePlaybackRate)>&& completionHandler)
+void ModelProcessModelPlayerProxy::setPlaybackRate(WebCore::NodeIdentifier, double playbackRate, CompletionHandler<void(double effectivePlaybackRate)>&& completionHandler)
 {
     m_playbackRate = playbackRate;
     [m_modelRKEntity setPlaybackRate:m_playbackRate];
     completionHandler(m_modelRKEntity ? [m_modelRKEntity playbackRate] : 1.0);
 }
 
-double ModelProcessModelPlayerProxy::duration() const
+double ModelProcessModelPlayerProxy::duration(WebCore::NodeIdentifier) const
 {
     return [m_modelRKEntity duration];
 }
 
-bool ModelProcessModelPlayerProxy::paused() const
+bool ModelProcessModelPlayerProxy::paused(WebCore::NodeIdentifier) const
 {
     return [m_modelRKEntity paused];
 }
 
-void ModelProcessModelPlayerProxy::setPaused(bool paused, CompletionHandler<void(bool succeeded)>&& completionHandler)
+void ModelProcessModelPlayerProxy::setPaused(WebCore::NodeIdentifier, bool paused, CompletionHandler<void(bool succeeded)>&& completionHandler)
 {
     [m_modelRKEntity setPaused:paused];
     completionHandler(paused == [m_modelRKEntity paused]);
 }
 
-Seconds ModelProcessModelPlayerProxy::currentTime() const
+Seconds ModelProcessModelPlayerProxy::currentTime(WebCore::NodeIdentifier) const
 {
     return Seconds([m_modelRKEntity currentTime]);
 }
 
-void ModelProcessModelPlayerProxy::setCurrentTime(Seconds currentTime, CompletionHandler<void()>&& completionHandler)
+void ModelProcessModelPlayerProxy::setCurrentTime(WebCore::NodeIdentifier, Seconds currentTime, CompletionHandler<void()>&& completionHandler)
 {
     [m_modelRKEntity setCurrentTime:currentTime.seconds()];
     completionHandler();
@@ -1253,9 +1273,10 @@ void ModelProcessModelPlayerProxy::teardownEntity()
 
 void ModelProcessModelPlayerProxy::captureStateForReload()
 {
-    if (m_modelRKEntity) {
-        m_animationStateToRestore = WebCore::ModelPlayerAnimationState(m_autoplay, m_loop, paused(), Seconds(duration()),
-            std::optional<double> { m_playbackRate }, std::optional<Seconds> { Seconds(currentTime()) }, std::optional<MonotonicTime> { MonotonicTime::now() });
+    if (m_modelRKEntity && m_nodeID) {
+        auto nodeID = *m_nodeID;
+        m_animationStateToRestore = WebCore::ModelPlayerAnimationState(m_autoplay, m_loop, paused(nodeID), Seconds(duration(nodeID)),
+            std::optional<double> { m_playbackRate }, std::optional<Seconds> { Seconds(currentTime(nodeID)) }, std::optional<MonotonicTime> { MonotonicTime::now() });
     }
 
     // Re-stage the env map for the post-reload entity. Entity transform is intentionally NOT captured:
@@ -1276,10 +1297,10 @@ void ModelProcessModelPlayerProxy::ensureImmersivePresentation(CompletionHandler
 
     setImmersivePresentation(true);
 
-    if (m_currentModel && (m_modelRKEntity || m_loader) && !atTargetLimit) {
+    if (m_nodeID && m_currentModel && (m_modelRKEntity || m_loader) && !atTargetLimit) {
         RELEASE_LOG(ModelElement, "%p - ModelProcessModelPlayerProxy::ensureImmersivePresentation: reloading at %dMB id=%" PRIu64, this, targetLimit, m_id.toUInt64());
         teardownEntity();
-        load(*m_currentModel, m_layoutSize, true);
+        load(*m_nodeID, *m_currentModel, m_layoutSize, true);
     }
 
     ensureModelLoaded([weakThis = WeakPtr { *this }, completion = WTF::move(completion)] (bool loaded) mutable {
@@ -1306,10 +1327,10 @@ void ModelProcessModelPlayerProxy::exitImmersivePresentation(CompletionHandler<v
 
     setImmersivePresentation(false);
 
-    if (m_currentModel && (m_modelRKEntity || m_loader) && !atTargetLimit) {
+    if (m_nodeID && m_currentModel && (m_modelRKEntity || m_loader) && !atTargetLimit) {
         RELEASE_LOG(ModelElement, "%p - ModelProcessModelPlayerProxy::exitImmersivePresentation: reloading at %dMB id=%" PRIu64, this, targetLimit, m_id.toUInt64());
         teardownEntity();
-        load(*m_currentModel, m_layoutSize, false);
+        load(*m_nodeID, *m_currentModel, m_layoutSize, false);
         ensureModelLoaded([completion = WTF::move(completion)] (bool) mutable {
             completion();
         });

--- a/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.cpp
+++ b/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.cpp
@@ -98,7 +98,7 @@ void ModelProcessModelPlayer::didCreateLayer(WebCore::LayerHostingContextIdentif
     protect(client())->didUpdate(*this);
 }
 
-void ModelProcessModelPlayer::didFinishLoading(const WebCore::FloatPoint3D& boundingBoxCenter, const WebCore::FloatPoint3D& boundingBoxExtents)
+void ModelProcessModelPlayer::didFinishLoading(WebCore::NodeIdentifier nodeID, const WebCore::FloatPoint3D& boundingBoxCenter, const WebCore::FloatPoint3D& boundingBoxExtents)
 {
     RELEASE_LOG(ModelElement, "%p - ModelProcessModelPlayer didFinishLoading id=%" PRIu64, this, m_id.toUInt64());
     RELEASE_ASSERT(modelProcessEnabled());
@@ -107,8 +107,8 @@ void ModelProcessModelPlayer::didFinishLoading(const WebCore::FloatPoint3D& boun
     m_boundingBoxExtents = boundingBoxExtents;
 
     RefPtr client = m_client.get();
-    client->didFinishLoading(*this);
-    client->didUpdateBoundingBox(*this, boundingBoxCenter, boundingBoxExtents);
+    client->didFinishLoading(*this, nodeID);
+    client->didUpdateBoundingBox(*this, nodeID, boundingBoxCenter, boundingBoxExtents);
 }
 
 void ModelProcessModelPlayer::didConvertModelData(Ref<WebCore::SharedBuffer>&& convertedData, const String& convertedMIMEType)
@@ -119,25 +119,25 @@ void ModelProcessModelPlayer::didConvertModelData(Ref<WebCore::SharedBuffer>&& c
     protect(client())->didConvertModelData(*this, WTF::move(convertedData), convertedMIMEType);
 }
 
-void ModelProcessModelPlayer::didFailLoading()
+void ModelProcessModelPlayer::didFailLoading(WebCore::NodeIdentifier nodeID)
 {
     RELEASE_LOG(ModelElement, "%p - ModelProcessModelPlayer didFailLoading id=%" PRIu64, this, m_id.toUInt64());
     RELEASE_ASSERT(modelProcessEnabled());
 
-    protect(client())->didFailLoading(*this, WebCore::ResourceError { WebCore::errorDomainWebKitInternal, 0, { }, "Failed to load model data"_s });
+    protect(client())->didFailLoading(*this, nodeID, WebCore::ResourceError { WebCore::errorDomainWebKitInternal, 0, { }, "Failed to load model data"_s });
 }
 
 /// This comes from Model Process side, so that Web Process has the most up-to-date knowledge about the transform actually applied to the entity.
 /// Not to be confused with setEntityTransform().
-void ModelProcessModelPlayer::didUpdateEntityTransform(const WebCore::TransformationMatrix& transform)
+void ModelProcessModelPlayer::didUpdateEntityTransform(WebCore::NodeIdentifier nodeID, const WebCore::TransformationMatrix& transform)
 {
     RELEASE_ASSERT(modelProcessEnabled());
 
     m_entityTransform = transform;
-    protect(client())->didUpdateEntityTransform(*this, transform);
+    protect(client())->didUpdateEntityTransform(*this, nodeID, transform);
 }
 
-void ModelProcessModelPlayer::didUpdateAnimationPlaybackState(bool isPaused, double playbackRate, Seconds duration, Seconds currentTime, MonotonicTime clockTimestamp)
+void ModelProcessModelPlayer::didUpdateAnimationPlaybackState(WebCore::NodeIdentifier, bool isPaused, double playbackRate, Seconds duration, Seconds currentTime, MonotonicTime clockTimestamp)
 {
     RELEASE_ASSERT(modelProcessEnabled());
 
@@ -156,7 +156,7 @@ void ModelProcessModelPlayer::didFinishEnvironmentMapLoading(bool succeeded)
 
 // MARK: - WebCore::ModelPlayer
 
-std::optional<WebCore::ModelPlayerAnimationState> ModelProcessModelPlayer::currentAnimationState() const
+std::optional<WebCore::ModelPlayerAnimationState> ModelProcessModelPlayer::currentAnimationState(WebCore::NodeIdentifier) const
 {
     // Has no current state to return if the model load hasn't returned with its extents.
     if (!m_boundingBoxExtents)
@@ -165,7 +165,7 @@ std::optional<WebCore::ModelPlayerAnimationState> ModelProcessModelPlayer::curre
     return m_animationState;
 }
 
-std::optional<std::unique_ptr<WebCore::ModelPlayerTransformState>> ModelProcessModelPlayer::currentTransformState() const
+std::optional<std::unique_ptr<WebCore::ModelPlayerTransformState>> ModelProcessModelPlayer::currentTransformState(WebCore::NodeIdentifier) const
 {
     // Has no current state to return if the model load hasn't returned with its extents.
     if (!m_boundingBoxExtents)
@@ -174,7 +174,7 @@ std::optional<std::unique_ptr<WebCore::ModelPlayerTransformState>> ModelProcessM
     return ModelProcessModelPlayerTransformState::create(m_entityTransform, m_boundingBoxCenter, m_boundingBoxExtents, m_hasPortal, m_stageModeOperation);
 }
 
-void ModelProcessModelPlayer::load(WebCore::Model& model, WebCore::LayoutSize size, bool isForImmersive)
+void ModelProcessModelPlayer::load(WebCore::NodeIdentifier nodeID, WebCore::Model& model, WebCore::LayoutSize size, bool isForImmersive)
 {
     RELEASE_LOG(ModelElement, "%p - ModelProcessModelPlayer load model id=%" PRIu64, this, m_id.toUInt64());
 
@@ -184,7 +184,7 @@ void ModelProcessModelPlayer::load(WebCore::Model& model, WebCore::LayoutSize si
             client->logWarning(*this, makeString("Unexpected USDZ MIME type \""_s, model.mimeType(), "\" in <model> element. Expected \"model/vnd.usdz+zip\". Some features of <model> may not work properly. The model may fail to render in a future release."_s));
     }
 
-    send(Messages::ModelProcessModelPlayerProxy::LoadModel(model, size, isForImmersive));
+    send(Messages::ModelProcessModelPlayerProxy::LoadModel(nodeID, model, size, isForImmersive));
 }
 
 void ModelProcessModelPlayer::didUnload()
@@ -203,7 +203,7 @@ void ModelProcessModelPlayer::didUnload()
         client->didUnload(*this);
 }
 
-void ModelProcessModelPlayer::reload(WebCore::Model& model, WebCore::LayoutSize size, WebCore::ModelPlayerAnimationState& animationState, std::unique_ptr<WebCore::ModelPlayerTransformState>&& transformState)
+void ModelProcessModelPlayer::reload(WebCore::NodeIdentifier nodeID, WebCore::Model& model, WebCore::LayoutSize size, WebCore::ModelPlayerAnimationState& animationState, std::unique_ptr<WebCore::ModelPlayerTransformState>&& transformState)
 {
     RELEASE_LOG(ModelElement, "%p - ModelProcessModelPlayer reload model id=%" PRIu64, this, m_id.toUInt64());
 
@@ -215,7 +215,7 @@ void ModelProcessModelPlayer::reload(WebCore::Model& model, WebCore::LayoutSize 
     setHasPortal(transformStateToRestore->hasPortal());
     setStageMode(transformStateToRestore->stageMode());
     m_animationState = WebCore::ModelPlayerAnimationState(animationState);
-    send(Messages::ModelProcessModelPlayerProxy::ReloadModel(model, size, transformStateToRestore->entityTransform(), animationState));
+    send(Messages::ModelProcessModelPlayerProxy::ReloadModel(nodeID, model, size, transformStateToRestore->entityTransform(), animationState));
 }
 
 void ModelProcessModelPlayer::visibilityStateDidChange()
@@ -273,26 +273,26 @@ void ModelProcessModelPlayer::enterFullscreen()
 {
 }
 
-std::optional<WebCore::FloatPoint3D> ModelProcessModelPlayer::boundingBoxCenter() const
+std::optional<WebCore::FloatPoint3D> ModelProcessModelPlayer::boundingBoxCenter(WebCore::NodeIdentifier) const
 {
     return m_boundingBoxCenter;
 }
 
-std::optional<WebCore::FloatPoint3D> ModelProcessModelPlayer::boundingBoxExtents() const
+std::optional<WebCore::FloatPoint3D> ModelProcessModelPlayer::boundingBoxExtents(WebCore::NodeIdentifier) const
 {
     return m_boundingBoxExtents;
 }
 
-std::optional<WebCore::TransformationMatrix> ModelProcessModelPlayer::entityTransform() const
+std::optional<WebCore::TransformationMatrix> ModelProcessModelPlayer::entityTransform(WebCore::NodeIdentifier) const
 {
     return m_entityTransform;
 }
 
 /// This comes from JS side, so we need to tell Model Process about it. Not to be confused with didUpdateEntityTransform().
-void ModelProcessModelPlayer::setEntityTransform(WebCore::TransformationMatrix transform)
+void ModelProcessModelPlayer::setEntityTransform(WebCore::NodeIdentifier nodeID, WebCore::TransformationMatrix transform)
 {
     m_entityTransform = transform;
-    send(Messages::ModelProcessModelPlayerProxy::SetEntityTransform(transform));
+    send(Messages::ModelProcessModelPlayerProxy::SetEntityTransform(nodeID, transform));
 }
 
 bool ModelProcessModelPlayer::supportsTransform(WebCore::TransformationMatrix transform)
@@ -310,37 +310,37 @@ void ModelProcessModelPlayer::setCamera(WebCore::HTMLModelElementCamera camera, 
     completionHandler(false);
 }
 
-void ModelProcessModelPlayer::isPlayingAnimation(CompletionHandler<void(std::optional<bool>&&)>&& completionHandler)
+void ModelProcessModelPlayer::isPlayingAnimation(WebCore::NodeIdentifier, CompletionHandler<void(std::optional<bool>&&)>&& completionHandler)
 {
     completionHandler(false);
 }
 
-void ModelProcessModelPlayer::setAnimationIsPlaying(bool isPlaying, CompletionHandler<void(bool success)>&& completionHandler)
+void ModelProcessModelPlayer::setAnimationIsPlaying(WebCore::NodeIdentifier, bool isPlaying, CompletionHandler<void(bool success)>&& completionHandler)
 {
     completionHandler(false);
 }
 
-void ModelProcessModelPlayer::isLoopingAnimation(CompletionHandler<void(std::optional<bool>&&)>&& completionHandler)
+void ModelProcessModelPlayer::isLoopingAnimation(WebCore::NodeIdentifier, CompletionHandler<void(std::optional<bool>&&)>&& completionHandler)
 {
     completionHandler(std::nullopt);
 }
 
-void ModelProcessModelPlayer::setIsLoopingAnimation(bool isLooping, CompletionHandler<void(bool success)>&& completionHandler)
+void ModelProcessModelPlayer::setIsLoopingAnimation(WebCore::NodeIdentifier, bool isLooping, CompletionHandler<void(bool success)>&& completionHandler)
 {
     completionHandler(false);
 }
 
-void ModelProcessModelPlayer::animationDuration(CompletionHandler<void(std::optional<Seconds>&&)>&& completionHandler)
+void ModelProcessModelPlayer::animationDuration(WebCore::NodeIdentifier, CompletionHandler<void(std::optional<Seconds>&&)>&& completionHandler)
 {
     completionHandler(std::nullopt);
 }
 
-void ModelProcessModelPlayer::animationCurrentTime(CompletionHandler<void(std::optional<Seconds>&&)>&& completionHandler)
+void ModelProcessModelPlayer::animationCurrentTime(WebCore::NodeIdentifier, CompletionHandler<void(std::optional<Seconds>&&)>&& completionHandler)
 {
     completionHandler(std::nullopt);
 }
 
-void ModelProcessModelPlayer::setAnimationCurrentTime(Seconds currentTime, CompletionHandler<void(bool success)>&& completionHandler)
+void ModelProcessModelPlayer::setAnimationCurrentTime(WebCore::NodeIdentifier, Seconds currentTime, CompletionHandler<void(bool success)>&& completionHandler)
 {
     completionHandler(false);
 }
@@ -350,46 +350,46 @@ WebCore::ModelPlayerAccessibilityChildren ModelProcessModelPlayer::accessibility
     return { };
 }
 
-void ModelProcessModelPlayer::setAutoplay(bool autoplay)
+void ModelProcessModelPlayer::setAutoplay(WebCore::NodeIdentifier nodeID, bool autoplay)
 {
     if (m_animationState.autoplay() == autoplay)
         return;
 
     m_animationState.setAutoplay(autoplay);
-    send(Messages::ModelProcessModelPlayerProxy::SetAutoplay(autoplay));
+    send(Messages::ModelProcessModelPlayerProxy::SetAutoplay(nodeID, autoplay));
 }
 
-void ModelProcessModelPlayer::setLoop(bool loop)
+void ModelProcessModelPlayer::setLoop(WebCore::NodeIdentifier nodeID, bool loop)
 {
     if (m_animationState.loop() == loop)
         return;
 
     m_animationState.setLoop(loop);
-    send(Messages::ModelProcessModelPlayerProxy::SetLoop(loop));
+    send(Messages::ModelProcessModelPlayerProxy::SetLoop(nodeID, loop));
 }
 
-void ModelProcessModelPlayer::setPlaybackRate(double playbackRate, CompletionHandler<void(double effectivePlaybackRate)>&& completionHandler)
+void ModelProcessModelPlayer::setPlaybackRate(WebCore::NodeIdentifier nodeID, double playbackRate, CompletionHandler<void(double effectivePlaybackRate)>&& completionHandler)
 {
     m_requestedPlaybackRate = playbackRate;
-    sendWithAsyncReply(Messages::ModelProcessModelPlayerProxy::SetPlaybackRate(m_requestedPlaybackRate), WTF::move(completionHandler));
+    sendWithAsyncReply(Messages::ModelProcessModelPlayerProxy::SetPlaybackRate(nodeID, m_requestedPlaybackRate), WTF::move(completionHandler));
 }
 
-double ModelProcessModelPlayer::duration() const
+double ModelProcessModelPlayer::duration(WebCore::NodeIdentifier) const
 {
     return m_animationState.duration().seconds();
 }
 
-bool ModelProcessModelPlayer::paused() const
+bool ModelProcessModelPlayer::paused(WebCore::NodeIdentifier) const
 {
     return m_animationState.paused();
 }
 
-void ModelProcessModelPlayer::setPaused(bool paused, CompletionHandler<void(bool succeeded)>&& completionHandler)
+void ModelProcessModelPlayer::setPaused(WebCore::NodeIdentifier nodeID, bool paused, CompletionHandler<void(bool succeeded)>&& completionHandler)
 {
-    sendWithAsyncReply(Messages::ModelProcessModelPlayerProxy::SetPaused(paused), WTF::move(completionHandler));
+    sendWithAsyncReply(Messages::ModelProcessModelPlayerProxy::SetPaused(nodeID, paused), WTF::move(completionHandler));
 }
 
-Seconds ModelProcessModelPlayer::currentTime() const
+Seconds ModelProcessModelPlayer::currentTime(WebCore::NodeIdentifier) const
 {
     if (m_pendingCurrentTime)
         return *m_pendingCurrentTime;
@@ -397,10 +397,10 @@ Seconds ModelProcessModelPlayer::currentTime() const
     return m_animationState.currentTime();
 }
 
-void ModelProcessModelPlayer::setCurrentTime(Seconds currentTime, CompletionHandler<void()>&& completionHandler)
+void ModelProcessModelPlayer::setCurrentTime(WebCore::NodeIdentifier nodeID, Seconds currentTime, CompletionHandler<void()>&& completionHandler)
 {
     ASSERT(RunLoop::isMain());
-    double durationSeconds = duration();
+    double durationSeconds = duration(nodeID);
     if (!durationSeconds) {
         completionHandler();
         return;
@@ -410,7 +410,7 @@ void ModelProcessModelPlayer::setCurrentTime(Seconds currentTime, CompletionHand
     MonotonicTime timestamp = MonotonicTime::now();
     m_clockTimestampOfLastCurrentTimeSet = timestamp;
 
-    sendWithAsyncReply(Messages::ModelProcessModelPlayerProxy::SetCurrentTime(*m_pendingCurrentTime), [weakThis = WeakPtr { *this }, timestamp, completionHandler = WTF::move(completionHandler)]() mutable {
+    sendWithAsyncReply(Messages::ModelProcessModelPlayerProxy::SetCurrentTime(nodeID, *m_pendingCurrentTime), [weakThis = WeakPtr { *this }, timestamp, completionHandler = WTF::move(completionHandler)]() mutable {
         ASSERT(RunLoop::isMain());
         if (RefPtr protectedThis = weakThis.get()) {
             if (protectedThis->m_clockTimestampOfLastCurrentTimeSet && *(protectedThis->m_clockTimestampOfLastCurrentTimeSet) <= timestamp) {

--- a/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.h
+++ b/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.h
@@ -35,6 +35,7 @@
 #import <WebCore/ModelPlayerAnimationState.h>
 #import <WebCore/ModelPlayerClient.h>
 #import <WebCore/ModelPlayerIdentifier.h>
+#import <WebCore/NodeIdentifier.h>
 #import <WebCore/StageModeOperations.h>
 #import <wtf/Compiler.h>
 
@@ -73,49 +74,49 @@ private:
 
     // Messages
     void didCreateLayer(WebCore::LayerHostingContextIdentifier);
-    void didFinishLoading(const WebCore::FloatPoint3D&, const WebCore::FloatPoint3D&);
+    void didFinishLoading(WebCore::NodeIdentifier, const WebCore::FloatPoint3D&, const WebCore::FloatPoint3D&);
     void didConvertModelData(Ref<WebCore::SharedBuffer>&&, const String& convertedMIMEType);
-    void didFailLoading();
-    void didUpdateEntityTransform(const WebCore::TransformationMatrix&);
-    void didUpdateAnimationPlaybackState(bool isPaused, double playbackRate, Seconds duration, Seconds currentTime, MonotonicTime clockTimestamp);
+    void didFailLoading(WebCore::NodeIdentifier);
+    void didUpdateEntityTransform(WebCore::NodeIdentifier, const WebCore::TransformationMatrix&);
+    void didUpdateAnimationPlaybackState(WebCore::NodeIdentifier, bool isPaused, double playbackRate, Seconds duration, Seconds currentTime, MonotonicTime clockTimestamp);
     void didFinishEnvironmentMapLoading(bool succeeded);
 
     // WebCore::ModelPlayer overrides.
     WebCore::ModelPlayerIdentifier identifier() const final { return m_id; }
-    std::optional<WebCore::ModelPlayerAnimationState> currentAnimationState() const final;
-    std::optional<std::unique_ptr<WebCore::ModelPlayerTransformState>> currentTransformState() const final;
-    void load(WebCore::Model&, WebCore::LayoutSize, bool) final;
-    void reload(WebCore::Model&, WebCore::LayoutSize, WebCore::ModelPlayerAnimationState&, std::unique_ptr<WebCore::ModelPlayerTransformState>&&) final;
+    std::optional<WebCore::ModelPlayerAnimationState> currentAnimationState(WebCore::NodeIdentifier) const final;
+    std::optional<std::unique_ptr<WebCore::ModelPlayerTransformState>> currentTransformState(WebCore::NodeIdentifier) const final;
+    void load(WebCore::NodeIdentifier, WebCore::Model&, WebCore::LayoutSize, bool) final;
+    void reload(WebCore::NodeIdentifier, WebCore::Model&, WebCore::LayoutSize, WebCore::ModelPlayerAnimationState&, std::unique_ptr<WebCore::ModelPlayerTransformState>&&) final;
     void visibilityStateDidChange() final;
     void sizeDidChange(WebCore::LayoutSize) final;
     void configureGraphicsLayer(WebCore::GraphicsLayer&, WebCore::ModelPlayerGraphicsLayerConfiguration&&) final;
     void handleMouseDown(const WebCore::LayoutPoint&, MonotonicTime) final;
     void handleMouseMove(const WebCore::LayoutPoint&, MonotonicTime) final;
     void handleMouseUp(const WebCore::LayoutPoint&, MonotonicTime) final;
-    std::optional<WebCore::FloatPoint3D> boundingBoxCenter() const final;
-    std::optional<WebCore::FloatPoint3D> boundingBoxExtents() const final;
-    std::optional<WebCore::TransformationMatrix> entityTransform() const final;
-    void setEntityTransform(WebCore::TransformationMatrix) final;
+    std::optional<WebCore::FloatPoint3D> boundingBoxCenter(WebCore::NodeIdentifier) const final;
+    std::optional<WebCore::FloatPoint3D> boundingBoxExtents(WebCore::NodeIdentifier) const final;
+    std::optional<WebCore::TransformationMatrix> entityTransform(WebCore::NodeIdentifier) const final;
+    void setEntityTransform(WebCore::NodeIdentifier, WebCore::TransformationMatrix) final;
     bool supportsTransform(WebCore::TransformationMatrix) final;
     void enterFullscreen() final;
     void getCamera(CompletionHandler<void(std::optional<WebCore::HTMLModelElementCamera>&&)>&&) final;
     void setCamera(WebCore::HTMLModelElementCamera, CompletionHandler<void(bool success)>&&) final;
-    void isPlayingAnimation(CompletionHandler<void(std::optional<bool>&&)>&&) final;
-    void setAnimationIsPlaying(bool, CompletionHandler<void(bool success)>&&) final;
-    void isLoopingAnimation(CompletionHandler<void(std::optional<bool>&&)>&&) final;
-    void setIsLoopingAnimation(bool, CompletionHandler<void(bool success)>&&) final;
-    void animationDuration(CompletionHandler<void(std::optional<Seconds>&&)>&&) final;
-    void animationCurrentTime(CompletionHandler<void(std::optional<Seconds>&&)>&&) final;
-    void setAnimationCurrentTime(Seconds, CompletionHandler<void(bool success)>&&) final;
+    void isPlayingAnimation(WebCore::NodeIdentifier, CompletionHandler<void(std::optional<bool>&&)>&&) final;
+    void setAnimationIsPlaying(WebCore::NodeIdentifier, bool, CompletionHandler<void(bool success)>&&) final;
+    void isLoopingAnimation(WebCore::NodeIdentifier, CompletionHandler<void(std::optional<bool>&&)>&&) final;
+    void setIsLoopingAnimation(WebCore::NodeIdentifier, bool, CompletionHandler<void(bool success)>&&) final;
+    void animationDuration(WebCore::NodeIdentifier, CompletionHandler<void(std::optional<Seconds>&&)>&&) final;
+    void animationCurrentTime(WebCore::NodeIdentifier, CompletionHandler<void(std::optional<Seconds>&&)>&&) final;
+    void setAnimationCurrentTime(WebCore::NodeIdentifier, Seconds, CompletionHandler<void(bool success)>&&) final;
     WebCore::ModelPlayerAccessibilityChildren accessibilityChildren() final;
-    void setAutoplay(bool) final;
-    void setLoop(bool) final;
-    void setPlaybackRate(double, CompletionHandler<void(double effectivePlaybackRate)>&&) final;
-    double duration() const final;
-    bool paused() const final;
-    void setPaused(bool, CompletionHandler<void(bool succeeded)>&&) final;
-    Seconds currentTime() const final;
-    void setCurrentTime(Seconds, CompletionHandler<void()>&&) final;
+    void setAutoplay(WebCore::NodeIdentifier, bool) final;
+    void setLoop(WebCore::NodeIdentifier, bool) final;
+    void setPlaybackRate(WebCore::NodeIdentifier, double, CompletionHandler<void(double effectivePlaybackRate)>&&) final;
+    double duration(WebCore::NodeIdentifier) const final;
+    bool paused(WebCore::NodeIdentifier) const final;
+    void setPaused(WebCore::NodeIdentifier, bool, CompletionHandler<void(bool succeeded)>&&) final;
+    Seconds currentTime(WebCore::NodeIdentifier) const final;
+    void setCurrentTime(WebCore::NodeIdentifier, Seconds, CompletionHandler<void()>&&) final;
     void setEnvironmentMap(Ref<WebCore::SharedBuffer>&& data) final;
     void setHasPortal(bool) final;
     void setStageMode(WebCore::StageModeOperation) final;

--- a/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.messages.in
+++ b/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.messages.in
@@ -29,11 +29,11 @@
 ]
 messages -> ModelProcessModelPlayer {
     DidCreateLayer(WebCore::LayerHostingContextIdentifier identifier)
-    DidFinishLoading(WebCore::FloatPoint3D center, WebCore::FloatPoint3D extents)
+    DidFinishLoading(WebCore::NodeIdentifier nodeID, WebCore::FloatPoint3D center, WebCore::FloatPoint3D extents)
     DidConvertModelData(Ref<WebCore::SharedBuffer> convertedData, String convertedMIMEType)
-    DidFailLoading()
-    DidUpdateEntityTransform(WebCore::TransformationMatrix transform)
-    DidUpdateAnimationPlaybackState(bool isPaused, double playbackRate, Seconds duration, Seconds currentTime, MonotonicTime clockTimestamp)
+    DidFailLoading(WebCore::NodeIdentifier nodeID)
+    DidUpdateEntityTransform(WebCore::NodeIdentifier nodeID, WebCore::TransformationMatrix transform)
+    DidUpdateAnimationPlaybackState(WebCore::NodeIdentifier nodeID, bool isPaused, double playbackRate, Seconds duration, Seconds currentTime, MonotonicTime clockTimestamp)
     DidFinishEnvironmentMapLoading(bool succeeded)
     DidUnload()
 }

--- a/Source/WebKit/WebProcess/Model/WebModelPlayer.h
+++ b/Source/WebKit/WebProcess/Model/WebModelPlayer.h
@@ -34,10 +34,12 @@
 #include <WebCore/ModelPlayer.h>
 #include <WebCore/ModelPlayerAnimationState.h>
 #include <WebCore/ModelPlayerClient.h>
+#include <WebCore/NodeIdentifier.h>
 #include <WebCore/PlatformDynamicRangeLimit.h>
 #include <WebCore/PlatformScreen.h>
 #include <WebCore/StageModeOperations.h>
 #include <wtf/Forward.h>
+#include <wtf/Markable.h>
 #include <wtf/Observer.h>
 #include <wtf/RetainPtr.h>
 #include <wtf/TypeCasts.h>
@@ -83,7 +85,7 @@ private:
     void updateScene();
 
     // ModelPlayer finals.
-    void load(WebCore::Model&, WebCore::LayoutSize, bool) final;
+    void load(WebCore::NodeIdentifier, WebCore::Model&, WebCore::LayoutSize, bool) final;
     void sizeDidChange(WebCore::LayoutSize) final;
     void configureGraphicsLayer(WebCore::GraphicsLayer&, WebCore::ModelPlayerGraphicsLayerConfiguration&&) final;
     void adoptContentsDisplayDelegateFrom(WebCore::ModelPlayer&) final;
@@ -94,40 +96,40 @@ private:
     void handleMouseUp(const WebCore::LayoutPoint&, MonotonicTime) final;
     void getCamera(CompletionHandler<void(std::optional<WebCore::HTMLModelElementCamera>&&)>&&) final;
     void setCamera(WebCore::HTMLModelElementCamera, CompletionHandler<void(bool success)>&&) final;
-    void isPlayingAnimation(CompletionHandler<void(std::optional<bool>&&)>&&) final;
-    void setAnimationIsPlaying(bool, CompletionHandler<void(bool success)>&&) final;
-    void isLoopingAnimation(CompletionHandler<void(std::optional<bool>&&)>&&) final;
-    void setIsLoopingAnimation(bool, CompletionHandler<void(bool success)>&&) final;
-    void animationDuration(CompletionHandler<void(std::optional<Seconds>&&)>&&) final;
-    void animationCurrentTime(CompletionHandler<void(std::optional<Seconds>&&)>&&) final;
-    void setAnimationCurrentTime(Seconds, CompletionHandler<void(bool success)>&&) final;
+    void isPlayingAnimation(WebCore::NodeIdentifier, CompletionHandler<void(std::optional<bool>&&)>&&) final;
+    void setAnimationIsPlaying(WebCore::NodeIdentifier, bool, CompletionHandler<void(bool success)>&&) final;
+    void isLoopingAnimation(WebCore::NodeIdentifier, CompletionHandler<void(std::optional<bool>&&)>&&) final;
+    void setIsLoopingAnimation(WebCore::NodeIdentifier, bool, CompletionHandler<void(bool success)>&&) final;
+    void animationDuration(WebCore::NodeIdentifier, CompletionHandler<void(std::optional<Seconds>&&)>&&) final;
+    void animationCurrentTime(WebCore::NodeIdentifier, CompletionHandler<void(std::optional<Seconds>&&)>&&) final;
+    void setAnimationCurrentTime(WebCore::NodeIdentifier, Seconds, CompletionHandler<void(bool success)>&&) final;
     WebCore::ModelPlayerAccessibilityChildren accessibilityChildren() final;
 #if PLATFORM(COCOA)
-    std::optional<WebCore::TransformationMatrix> entityTransform() const final;
+    std::optional<WebCore::TransformationMatrix> entityTransform(WebCore::NodeIdentifier) const final;
 #endif
-    void setEntityTransform(WebCore::TransformationMatrix) final;
+    void setEntityTransform(WebCore::NodeIdentifier, WebCore::TransformationMatrix) final;
     bool supportsTransform(WebCore::TransformationMatrix) final;
     bool supportsMouseInteraction() final;
     void visibilityStateDidChange() final;
-    void reload(WebCore::Model&, WebCore::LayoutSize, WebCore::ModelPlayerAnimationState&, std::unique_ptr<WebCore::ModelPlayerTransformState>&&) final;
-    std::optional<WebCore::ModelPlayerAnimationState> currentAnimationState() const final;
-    std::optional<std::unique_ptr<WebCore::ModelPlayerTransformState>> currentTransformState() const final;
+    void reload(WebCore::NodeIdentifier, WebCore::Model&, WebCore::LayoutSize, WebCore::ModelPlayerAnimationState&, std::unique_ptr<WebCore::ModelPlayerTransformState>&&) final;
+    std::optional<WebCore::ModelPlayerAnimationState> currentAnimationState(WebCore::NodeIdentifier) const final;
+    std::optional<std::unique_ptr<WebCore::ModelPlayerTransformState>> currentTransformState(WebCore::NodeIdentifier) const final;
 
     std::pair<WebCore::FloatPoint3D, WebCore::FloatPoint3D> boundingBoxCenterAndExtents() const;
 
     const MachSendRight* displayBuffer() const;
     WebCore::GraphicsLayerContentsDisplayDelegate* contentsDisplayDelegate();
 
-    void setPlaybackRate(double, CompletionHandler<void(double effectivePlaybackRate)>&&) final;
-    void setAutoplay(bool) final;
-    void setLoop(bool) final;
-    void setPaused(bool, CompletionHandler<void(bool succeeded)>&&) final;
-    bool paused() const final;
-    Seconds currentTime() const final;
-    void setCurrentTime(Seconds, CompletionHandler<void()>&&) final;
+    void setPlaybackRate(WebCore::NodeIdentifier, double, CompletionHandler<void(double effectivePlaybackRate)>&&) final;
+    void setAutoplay(WebCore::NodeIdentifier, bool) final;
+    void setLoop(WebCore::NodeIdentifier, bool) final;
+    void setPaused(WebCore::NodeIdentifier, bool, CompletionHandler<void(bool succeeded)>&&) final;
+    bool paused(WebCore::NodeIdentifier) const final;
+    Seconds currentTime(WebCore::NodeIdentifier) const final;
+    void setCurrentTime(WebCore::NodeIdentifier, Seconds, CompletionHandler<void()>&&) final;
     void play(bool);
     bool simulate(float elapsedTime);
-    double duration() const final;
+    double duration(WebCore::NodeIdentifier) const final;
 
     void ensureOnMainThreadWithProtectedThis(Function<void(Ref<WebModelPlayer>)>&& task);
     void startUpdateLoopIfNeeded();
@@ -154,6 +156,7 @@ private:
     WeakPtr<WebCore::ModelPlayerClient> m_client;
 
     WebCore::ModelPlayerIdentifier m_id;
+    Markable<WebCore::NodeIdentifier> m_nodeID;
     RetainPtr<WKBridgeModelLoader> m_modelLoader;
     Vector<MachSendRight> m_displayBuffers;
     RefPtr<WebKit::Mesh> m_currentModel;

--- a/Source/WebKit/WebProcess/Model/WebModelPlayer.mm
+++ b/Source/WebKit/WebProcess/Model/WebModelPlayer.mm
@@ -168,7 +168,7 @@ void WebModelPlayer::ensureOnMainThreadWithProtectedThis(Function<void(Ref<WebMo
     });
 }
 
-double WebModelPlayer::duration() const
+double WebModelPlayer::duration(WebCore::NodeIdentifier) const
 {
     if (m_cachedAnimationState)
         return m_cachedAnimationState->duration().seconds();
@@ -194,8 +194,9 @@ static WebCore::ContentsFormat contentsFormatForDynamicRange(bool isStandard)
 
 // MARK: - ModelPlayer overrides.
 
-void WebModelPlayer::load(WebCore::Model& modelSource, WebCore::LayoutSize size, bool)
+void WebModelPlayer::load(WebCore::NodeIdentifier nodeID, WebCore::Model& modelSource, WebCore::LayoutSize size, bool)
 {
+    m_nodeID = nodeID;
     RefPtr corePage { m_page };
     if (!corePage)
         return;
@@ -253,7 +254,7 @@ void WebModelPlayer::load(WebCore::Model& modelSource, WebCore::LayoutSize size,
     m_modelLoader = adoptNS([allocWKBridgeModelLoaderInstance() initWithGPUFamily:MTLGPUFamilyApple7]);
     Ref protectedThis { *this };
     [m_modelLoader setCallbacksWithModelUpdatedCallback:^(NSArray<WKBridgeUpdateMesh *> *updateRequest) {
-        ensureOnMainThreadWithProtectedThis([updateRequest] (Ref<WebModelPlayer> protectedThis) {
+        ensureOnMainThreadWithProtectedThis([updateRequest, nodeID] (Ref<WebModelPlayer> protectedThis) {
             RefPtr model = protectedThis->m_currentModel;
             if (model) {
                 model->update(makeVector(updateRequest, [](WKBridgeUpdateMesh *update) {
@@ -270,7 +271,7 @@ void WebModelPlayer::load(WebCore::Model& modelSource, WebCore::LayoutSize size,
             if (RefPtr client = protectedThis->m_client; client && !protectedThis->m_didFinishLoading) {
                 protectedThis->m_didFinishLoading = true;
                 [protectedThis->m_modelLoader setLoop:protectedThis->m_isLooping];
-                protectedThis->m_cachedAnimationState = protectedThis->currentAnimationState();
+                protectedThis->m_cachedAnimationState = protectedThis->currentAnimationState(nodeID);
                 protectedThis->m_pendingClientFinishLoadingNotification = true;
             }
             protectedThis->startUpdateLoopIfNeeded();
@@ -311,18 +312,21 @@ void WebModelPlayer::load(WebCore::Model& modelSource, WebCore::LayoutSize size,
     if ([m_modelLoader loadModel:m_retainedData.get() mimeType:modelSource.mimeType().createNSString().get()])
         startUpdateLoopIfNeeded();
     else if (RefPtr client = m_client)
-        client->didFailLoading(protectedThis.get(), { });
+        client->didFailLoading(protectedThis.get(), nodeID, { });
 }
 
 void WebModelPlayer::notifyEntityTransformUpdated()
 {
+    if (!m_nodeID)
+        return;
+
     RefPtr model = m_currentModel;
     RefPtr client { m_client };
     if (!model || !client || !model->entityTransform())
         return;
 
     m_needsEntityTransformNotification = false;
-    client->didUpdateEntityTransform(*this, WebCore::TransformationMatrix(static_cast<simd_float4x4>(*model->entityTransform())));
+    client->didUpdateEntityTransform(*this, *m_nodeID, WebCore::TransformationMatrix(static_cast<simd_float4x4>(*model->entityTransform())));
 }
 
 void WebModelPlayer::sizeDidChange(WebCore::LayoutSize size)
@@ -377,12 +381,14 @@ void WebModelPlayer::handleMouseDown(const WebCore::LayoutPoint& startingPoint, 
     if (!m_orbitSimulator) {
         m_orbitSimulator = adoptNS([[WKStageModeOrbitSimulator alloc] init]);
         // Seed from the current pose so a gesture after reload doesn't snap to default.
-        if (auto transform = entityTransform()) {
-            auto matrix = static_cast<simd_float4x4>(*transform);
-            simd_float3 c0 = simd_normalize(simd_make_float3(matrix.columns[0]));
-            simd_float3 c1 = simd_normalize(simd_make_float3(matrix.columns[1]));
-            simd_float3 c2 = simd_normalize(simd_make_float3(matrix.columns[2]));
-            [m_orbitSimulator setCurrentYaw:std::atan2(-c2.x, c0.x) pitch:std::atan2(-c1.z, c1.y)];
+        if (m_nodeID) {
+            if (auto transform = entityTransform(*m_nodeID)) {
+                auto matrix = static_cast<simd_float4x4>(*transform);
+                simd_float3 c0 = simd_normalize(simd_make_float3(matrix.columns[0]));
+                simd_float3 c1 = simd_normalize(simd_make_float3(matrix.columns[1]));
+                simd_float3 c2 = simd_normalize(simd_make_float3(matrix.columns[2]));
+                [m_orbitSimulator setCurrentYaw:std::atan2(-c2.x, c0.x) pitch:std::atan2(-c1.z, c1.y)];
+            }
         }
     }
     [m_orbitSimulator gestureDidBegin];
@@ -433,35 +439,35 @@ void WebModelPlayer::setCamera(WebCore::HTMLModelElementCamera, CompletionHandle
 {
 }
 
-void WebModelPlayer::isPlayingAnimation(CompletionHandler<void(std::optional<bool>&&)>&&)
+void WebModelPlayer::isPlayingAnimation(WebCore::NodeIdentifier, CompletionHandler<void(std::optional<bool>&&)>&&)
 {
 }
 
-void WebModelPlayer::setAnimationIsPlaying(bool, CompletionHandler<void(bool success)>&&)
+void WebModelPlayer::setAnimationIsPlaying(WebCore::NodeIdentifier, bool, CompletionHandler<void(bool success)>&&)
 {
 }
 
-void WebModelPlayer::isLoopingAnimation(CompletionHandler<void(std::optional<bool>&&)>&& completion)
+void WebModelPlayer::isLoopingAnimation(WebCore::NodeIdentifier, CompletionHandler<void(std::optional<bool>&&)>&& completion)
 {
     completion(m_isLooping);
 }
 
-void WebModelPlayer::setIsLoopingAnimation(bool shouldLoop, CompletionHandler<void(bool success)>&& completion)
+void WebModelPlayer::setIsLoopingAnimation(WebCore::NodeIdentifier, bool shouldLoop, CompletionHandler<void(bool success)>&& completion)
 {
     m_isLooping = shouldLoop;
     completion(shouldLoop);
 }
 
-void WebModelPlayer::animationDuration(CompletionHandler<void(std::optional<Seconds>&&)>&& completion)
+void WebModelPlayer::animationDuration(WebCore::NodeIdentifier nodeID, CompletionHandler<void(std::optional<Seconds>&&)>&& completion)
 {
-    completion(Seconds(duration()));
+    completion(Seconds(duration(nodeID)));
 }
 
-void WebModelPlayer::animationCurrentTime(CompletionHandler<void(std::optional<Seconds>&&)>&&)
+void WebModelPlayer::animationCurrentTime(WebCore::NodeIdentifier, CompletionHandler<void(std::optional<Seconds>&&)>&&)
 {
 }
 
-void WebModelPlayer::setAnimationCurrentTime(Seconds, CompletionHandler<void(bool success)>&&)
+void WebModelPlayer::setAnimationCurrentTime(WebCore::NodeIdentifier, Seconds, CompletionHandler<void(bool success)>&&)
 {
 }
 
@@ -568,7 +574,7 @@ bool WebModelPlayer::simulate(float elapsedTime)
     return false;
 }
 
-void WebModelPlayer::setPlaybackRate(double newRate, CompletionHandler<void(double effectivePlaybackRate)>&& completion)
+void WebModelPlayer::setPlaybackRate(WebCore::NodeIdentifier, double newRate, CompletionHandler<void(double effectivePlaybackRate)>&& completion)
 {
     m_playbackRate = newRate;
     if (m_cachedAnimationState) {
@@ -609,25 +615,29 @@ void WebModelPlayer::scheduleUpdateIfNeeded()
 
 void WebModelPlayer::update()
 {
+    if (!m_nodeID)
+        return;
+
     if (!m_isUpdateLoopRunning || m_isUpdating)
         return;
 
     m_isUpdating = true;
 
+    auto nodeID = *m_nodeID;
     auto now = MonotonicTime::now();
     float elapsed = m_lastUpdateTime ? static_cast<float>((now - m_lastUpdateTime).seconds()) : (1.f / 60.f);
     float elapsedTime = std::clamp(elapsed, 1.f / 120.f, 1.f / 15.f);
     m_lastUpdateTime = now;
 
     bool stageModeActive = simulate(elapsedTime);
-    bool isAtRest = paused() && !stageModeActive;
+    bool isAtRest = paused(nodeID) && !stageModeActive;
 
-    auto timeDelta = paused() ? 0.f : (m_playbackRate * elapsedTime);
+    auto timeDelta = paused(nodeID) ? 0.f : (m_playbackRate * elapsedTime);
 
     [m_modelLoader update:timeDelta];
     double currentTime = [m_modelLoader currentTime];
     bool reachedEnd = m_playbackRate < 0 ? currentTime <= 0 : currentTime >= [m_modelLoader duration];
-    if (!m_isLooping && !paused() && reachedEnd) {
+    if (!m_isLooping && !paused(nodeID) && reachedEnd) {
         m_pauseState = PauseState::Paused;
         if (m_cachedAnimationState) {
             updateClockTimeOnAnimationState();
@@ -695,6 +705,9 @@ void WebModelPlayer::scheduleDisplayUpdate()
 
 void WebModelPlayer::notifyClientDidFinishLoading()
 {
+    if (!m_nodeID)
+        return;
+
     if (!m_pendingClientFinishLoadingNotification)
         return;
 
@@ -704,12 +717,13 @@ void WebModelPlayer::notifyClientDidFinishLoading()
 
     m_pendingClientFinishLoadingNotification = false;
 
+    auto nodeID = *m_nodeID;
     Ref protectedThis { *this };
-    client->didFinishLoading(protectedThis);
+    client->didFinishLoading(protectedThis, nodeID);
 
     if (m_currentModel) {
         auto [center, extents] = boundingBoxCenterAndExtents();
-        client->didUpdateBoundingBox(protectedThis, center, extents);
+        client->didUpdateBoundingBox(protectedThis, nodeID, center, extents);
     }
     notifyEntityTransformUpdated();
 
@@ -727,8 +741,12 @@ bool WebModelPlayer::supportsTransform(WebCore::TransformationMatrix transformat
 
 void WebModelPlayer::play(bool playing)
 {
+    if (!m_nodeID)
+        return;
+
     if (RefPtr model = m_currentModel) {
-        if (playing && !m_isLooping && currentTime() >= Seconds(duration())) {
+        auto nodeID = *m_nodeID;
+        if (playing && !m_isLooping && currentTime(nodeID) >= Seconds(duration(nodeID))) {
             [m_modelLoader setCurrentTime:0];
             if (m_cachedAnimationState)
                 m_cachedAnimationState->setCurrentTime(Seconds(0), MonotonicTime::now());
@@ -744,7 +762,7 @@ void WebModelPlayer::play(bool playing)
     }
 }
 
-void WebModelPlayer::setLoop(bool loop)
+void WebModelPlayer::setLoop(WebCore::NodeIdentifier, bool loop)
 {
     if (m_isLooping == loop)
         return;
@@ -756,7 +774,7 @@ void WebModelPlayer::setLoop(bool loop)
     startUpdateLoopIfNeeded();
 }
 
-void WebModelPlayer::setAutoplay(bool autoplay)
+void WebModelPlayer::setAutoplay(WebCore::NodeIdentifier, bool autoplay)
 {
     if (m_pauseState == PauseState::Paused)
         return;
@@ -770,18 +788,18 @@ void WebModelPlayer::setAutoplay(bool autoplay)
     }
 }
 
-void WebModelPlayer::setPaused(bool paused, CompletionHandler<void(bool succeeded)>&& completion)
+void WebModelPlayer::setPaused(WebCore::NodeIdentifier nodeID, bool paused, CompletionHandler<void(bool succeeded)>&& completion)
 {
     play(!paused);
-    completion(m_currentModel && (paused || duration() > 0));
+    completion(m_currentModel && (paused || duration(nodeID) > 0));
 }
 
-bool WebModelPlayer::paused() const
+bool WebModelPlayer::paused(WebCore::NodeIdentifier) const
 {
     return m_pauseState != PauseState::Playing;
 }
 
-Seconds WebModelPlayer::currentTime() const
+Seconds WebModelPlayer::currentTime(WebCore::NodeIdentifier) const
 {
     if (m_modelLoader)
         return Seconds([m_modelLoader currentTime]);
@@ -796,9 +814,9 @@ void WebModelPlayer::updateClockTimeOnAnimationState()
         m_cachedAnimationState->setCurrentTime(m_cachedAnimationState->currentTime(), MonotonicTime::now());
 }
 
-void WebModelPlayer::setCurrentTime(Seconds currentTime, CompletionHandler<void()>&& completion)
+void WebModelPlayer::setCurrentTime(WebCore::NodeIdentifier nodeID, Seconds currentTime, CompletionHandler<void()>&& completion)
 {
-    double clamped = std::clamp(currentTime.seconds(), 0.0, duration());
+    double clamped = std::clamp(currentTime.seconds(), 0.0, duration(nodeID));
     if (m_cachedAnimationState)
         m_cachedAnimationState->setCurrentTime(Seconds(clamped), MonotonicTime::now());
     [m_modelLoader setCurrentTime:clamped];
@@ -806,7 +824,7 @@ void WebModelPlayer::setCurrentTime(Seconds currentTime, CompletionHandler<void(
     completion();
 }
 
-std::optional<WebCore::TransformationMatrix> WebModelPlayer::entityTransform() const
+std::optional<WebCore::TransformationMatrix> WebModelPlayer::entityTransform(WebCore::NodeIdentifier) const
 {
 #if PLATFORM(COCOA)
     if (RefPtr model = m_currentModel) {
@@ -827,17 +845,17 @@ void WebModelPlayer::setStageMode(WebCore::StageModeOperation stageMode)
     }
 }
 
-void WebModelPlayer::setEntityTransform(WebCore::TransformationMatrix matrix)
+void WebModelPlayer::setEntityTransform(WebCore::NodeIdentifier, WebCore::TransformationMatrix transform)
 {
     if (RefPtr model = m_currentModel) {
-        model->setEntityTransform(static_cast<simd_float4x4>(matrix));
+        model->setEntityTransform(static_cast<simd_float4x4>(transform));
         notifyEntityTransformUpdated();
         startUpdateLoopIfNeeded();
         return;
     }
 
     if (m_cachedTransformState)
-        (*m_cachedTransformState)->setEntityTransform(matrix);
+        (*m_cachedTransformState)->setEntityTransform(transform);
 }
 
 void WebModelPlayer::setEnvironmentMap(Ref<WebCore::SharedBuffer>&& data)
@@ -891,8 +909,10 @@ void WebModelPlayer::visibilityStateDidChange()
         return;
 
     if (!client->isVisible()) {
-        m_cachedAnimationState = currentAnimationState();
-        m_cachedTransformState = currentTransformState();
+        if (m_nodeID) {
+            m_cachedAnimationState = currentAnimationState(*m_nodeID);
+            m_cachedTransformState = currentTransformState(*m_nodeID);
+        }
 
         // Model is no longer visible - release resources to save memory
         releaseModelResources();
@@ -902,37 +922,38 @@ void WebModelPlayer::visibilityStateDidChange()
     }
 }
 
-void WebModelPlayer::reload(WebCore::Model& modelSource, WebCore::LayoutSize size, WebCore::ModelPlayerAnimationState& animationState, std::unique_ptr<WebCore::ModelPlayerTransformState>&& transformState)
+void WebModelPlayer::reload(WebCore::NodeIdentifier nodeID, WebCore::Model& modelSource, WebCore::LayoutSize size, WebCore::ModelPlayerAnimationState& animationState, std::unique_ptr<WebCore::ModelPlayerTransformState>&& transformState)
 {
     if (disableReloading())
         return;
 
-    load(modelSource, size, false);
+    m_nodeID = nodeID;
+    load(nodeID, modelSource, size, false);
     m_cachedAnimationState = animationState;
     if (transformState) {
         setStageMode(transformState->stageMode());
         if (auto entityTransform = transformState->entityTransform())
-            setEntityTransform(*entityTransform);
+            setEntityTransform(nodeID, *entityTransform);
     }
 
-    setAutoplay(animationState.autoplay());
-    setLoop(animationState.loop());
-    setPaused(animationState.paused(), [] (bool) { });
+    setAutoplay(nodeID, animationState.autoplay());
+    setLoop(nodeID, animationState.loop());
+    setPaused(nodeID, animationState.paused(), [] (bool) { });
     if (auto playbackRate = animationState.effectivePlaybackRate())
-        setPlaybackRate(*playbackRate, [] (double) { });
-    setCurrentTime(animationState.currentTime(), [] { });
+        setPlaybackRate(nodeID, *playbackRate, [] (double) { });
+    setCurrentTime(nodeID, animationState.currentTime(), [] { });
 }
 
-std::optional<WebCore::ModelPlayerAnimationState> WebModelPlayer::currentAnimationState() const
+std::optional<WebCore::ModelPlayerAnimationState> WebModelPlayer::currentAnimationState(WebCore::NodeIdentifier nodeID) const
 {
     if (!m_currentModel)
         return m_cachedAnimationState;
 
     bool paused = m_pauseState != PauseState::Playing;
     bool autoplay = !paused;
-    Seconds animationDuration { duration() };
+    Seconds animationDuration { duration(nodeID) };
     std::optional<double> effectivePlaybackRate = m_playbackRate;
-    std::optional<Seconds> lastCachedCurrentTime = currentTime();
+    std::optional<Seconds> lastCachedCurrentTime = currentTime(nodeID);
     std::optional<MonotonicTime> lastCachedClockTimestamp = MonotonicTime::now();
 
     return WebCore::ModelPlayerAnimationState(autoplay, m_isLooping, paused, animationDuration, effectivePlaybackRate, lastCachedCurrentTime, lastCachedClockTimestamp);
@@ -946,7 +967,7 @@ std::pair<WebCore::FloatPoint3D, WebCore::FloatPoint3D> WebModelPlayer::bounding
     return { WebCore::FloatPoint3D(simdCenter.x, simdCenter.y, simdCenter.z), WebCore::FloatPoint3D(simdExtents.x, simdExtents.y, simdExtents.z) };
 }
 
-std::optional<std::unique_ptr<WebCore::ModelPlayerTransformState>> WebModelPlayer::currentTransformState() const
+std::optional<std::unique_ptr<WebCore::ModelPlayerTransformState>> WebModelPlayer::currentTransformState(WebCore::NodeIdentifier nodeID) const
 {
     if (!m_currentModel) {
         if (m_cachedTransformState)
@@ -954,7 +975,7 @@ std::optional<std::unique_ptr<WebCore::ModelPlayerTransformState>> WebModelPlaye
         return std::nullopt;
     }
 
-    std::optional<WebCore::TransformationMatrix> transform = entityTransform();
+    std::optional<WebCore::TransformationMatrix> transform = entityTransform(nodeID);
 
     auto [center, extents] = boundingBoxCenterAndExtents();
 
@@ -1053,6 +1074,9 @@ std::optional<double> WebModelPlayer::getEffectiveDynamicRangeLimitValue() const
 
 void WebModelPlayer::dynamicRangeLimitDidChange()
 {
+    if (!m_nodeID)
+        return;
+
     if (!m_cachedModelSource)
         return;
 
@@ -1060,15 +1084,15 @@ void WebModelPlayer::dynamicRangeLimitDidChange()
     if (newIsStandard == m_usingStandardDynamicRange)
         return;
 
-    auto animationState = currentAnimationState();
+    auto animationState = currentAnimationState(*m_nodeID);
     if (!animationState)
         return;
-    auto transformStateOpt = currentTransformState();
+    auto transformStateOpt = currentTransformState(*m_nodeID);
     std::unique_ptr<WebCore::ModelPlayerTransformState> transformState;
     if (transformStateOpt)
         transformState = WTF::move(*transformStateOpt);
 
-    reload(*m_cachedModelSource, m_lastLayoutSize, *animationState, WTF::move(transformState));
+    reload(*m_nodeID, *m_cachedModelSource, m_lastLayoutSize, *animationState, WTF::move(transformState));
 }
 #endif
 


### PR DESCRIPTION
#### 8c75aadf564cab15d87f0b76e64c3b219bb63f40
<pre>
Make ModelPlayer node-addressable for Multi-Model
<a href="https://bugs.webkit.org/show_bug.cgi?id=320168">https://bugs.webkit.org/show_bug.cgi?id=320168</a>
<a href="https://rdar.apple.com/182292637">rdar://182292637</a> (Expand ModelPlayer interface for Multi-Model)

Reviewed by Etienne Segonzac.

Foundational, behavior-preserving prep for Multi-Model: the per-model
surface of ModelPlayer / ModelPlayerClient (and the Model-process IPC)
now carries a WebCore::NodeIdentifier so one player can address a specific
model. Also adds an unload(NodeIdentifier) entry point.

* Source/WebCore/Modules/model-element/HTMLModelElement.cpp:
(WebCore::HTMLModelElement::didFinishLoading):
(WebCore::HTMLModelElement::didFailLoading):
(WebCore::HTMLModelElement::didUpdateEntityTransform):
(WebCore::HTMLModelElement::didUpdateBoundingBox):
(WebCore::HTMLModelElement::createModelPlayer):
(WebCore::HTMLModelElement::unloadModelPlayer):
(WebCore::HTMLModelElement::reloadModelPlayer):
(WebCore::HTMLModelElement::setEntityTransform):
(WebCore::HTMLModelElement::setPlaybackRate):
(WebCore::HTMLModelElement::duration const):
(WebCore::HTMLModelElement::paused const):
(WebCore::HTMLModelElement::setPaused):
(WebCore::HTMLModelElement::updateAutoplay):
(WebCore::HTMLModelElement::updateLoop):
(WebCore::HTMLModelElement::currentTime const):
(WebCore::HTMLModelElement::setCurrentTime):
(WebCore::HTMLModelElement::isPlayingAnimation):
(WebCore::HTMLModelElement::setAnimationIsPlaying):
(WebCore::HTMLModelElement::isLoopingAnimation):
(WebCore::HTMLModelElement::setIsLoopingAnimation):
(WebCore::HTMLModelElement::animationDuration):
(WebCore::HTMLModelElement::animationCurrentTime):
(WebCore::HTMLModelElement::setAnimationCurrentTime):
* Source/WebCore/Modules/model-element/HTMLModelElement.h:
* Source/WebCore/Modules/model-element/ModelPlayer.cpp:
(WebCore::ModelPlayer::currentAnimationState const):
(WebCore::ModelPlayer::currentTransformState const):
(WebCore::ModelPlayer::reload):
(WebCore::ModelPlayer::unload):
(WebCore::ModelPlayer::boundingBoxCenter const):
(WebCore::ModelPlayer::boundingBoxExtents const):
(WebCore::ModelPlayer::entityTransform const):
(WebCore::ModelPlayer::setEntityTransform):
(WebCore::ModelPlayer::setAutoplay):
(WebCore::ModelPlayer::setLoop):
(WebCore::ModelPlayer::setPlaybackRate):
(WebCore::ModelPlayer::duration const):
(WebCore::ModelPlayer::paused const):
(WebCore::ModelPlayer::setPaused):
(WebCore::ModelPlayer::currentTime const):
(WebCore::ModelPlayer::setCurrentTime):
* Source/WebCore/Modules/model-element/ModelPlayer.h:
* Source/WebCore/Modules/model-element/ModelPlayerClient.h:
* Source/WebCore/Modules/model-element/PlaceholderModelPlayer.cpp:
(WebCore::PlaceholderModelPlayer::currentAnimationState const):
(WebCore::PlaceholderModelPlayer::currentTransformState const):
(WebCore::PlaceholderModelPlayer::load):
(WebCore::PlaceholderModelPlayer::reload):
(WebCore::PlaceholderModelPlayer::boundingBoxCenter const):
(WebCore::PlaceholderModelPlayer::boundingBoxExtents const):
(WebCore::PlaceholderModelPlayer::entityTransform const):
(WebCore::PlaceholderModelPlayer::setEntityTransform):
(WebCore::PlaceholderModelPlayer::setAutoplay):
(WebCore::PlaceholderModelPlayer::setLoop):
(WebCore::PlaceholderModelPlayer::setPlaybackRate):
(WebCore::PlaceholderModelPlayer::duration const):
(WebCore::PlaceholderModelPlayer::paused const):
(WebCore::PlaceholderModelPlayer::setPaused):
(WebCore::PlaceholderModelPlayer::currentTime const):
(WebCore::PlaceholderModelPlayer::setCurrentTime):
(WebCore::PlaceholderModelPlayer::isPlayingAnimation):
(WebCore::PlaceholderModelPlayer::setAnimationIsPlaying):
(WebCore::PlaceholderModelPlayer::isLoopingAnimation):
(WebCore::PlaceholderModelPlayer::setIsLoopingAnimation):
(WebCore::PlaceholderModelPlayer::animationDuration):
(WebCore::PlaceholderModelPlayer::animationCurrentTime):
(WebCore::PlaceholderModelPlayer::setAnimationCurrentTime):
* Source/WebCore/Modules/model-element/PlaceholderModelPlayer.h:
* Source/WebCore/Modules/model-element/dummy/DummyModelPlayer.cpp:
(WebCore::DummyModelPlayer::load):
(WebCore::DummyModelPlayer::isPlayingAnimation):
(WebCore::DummyModelPlayer::setAnimationIsPlaying):
(WebCore::DummyModelPlayer::isLoopingAnimation):
(WebCore::DummyModelPlayer::setIsLoopingAnimation):
(WebCore::DummyModelPlayer::animationDuration):
(WebCore::DummyModelPlayer::animationCurrentTime):
(WebCore::DummyModelPlayer::setAnimationCurrentTime):
* Source/WebCore/Modules/model-element/dummy/DummyModelPlayer.h:
* Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.h:
* Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.messages.in:
* Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm:
(WebKit::ModelProcessModelPlayerProxy::loadModel):
(WebKit::ModelProcessModelPlayerProxy::reloadModel):
(WebKit::ModelProcessModelPlayerProxy::notifyModelPlayerOfEntityTransformChange):
(WebKit::ModelProcessModelPlayerProxy::animationPlaybackStateDidUpdate):
(WebKit::ModelProcessModelPlayerProxy::didFinishLoading):
(WebKit::ModelProcessModelPlayerProxy::didFailLoading):
(WebKit::ModelProcessModelPlayerProxy::load):
(WebKit::ModelProcessModelPlayerProxy::setEntityTransform):
(WebKit::ModelProcessModelPlayerProxy::isPlayingAnimation):
(WebKit::ModelProcessModelPlayerProxy::setAnimationIsPlaying):
(WebKit::ModelProcessModelPlayerProxy::isLoopingAnimation):
(WebKit::ModelProcessModelPlayerProxy::setIsLoopingAnimation):
(WebKit::ModelProcessModelPlayerProxy::animationDuration):
(WebKit::ModelProcessModelPlayerProxy::animationCurrentTime):
(WebKit::ModelProcessModelPlayerProxy::setAnimationCurrentTime):
(WebKit::ModelProcessModelPlayerProxy::setAutoplay):
(WebKit::ModelProcessModelPlayerProxy::setLoop):
(WebKit::ModelProcessModelPlayerProxy::setPlaybackRate):
(WebKit::ModelProcessModelPlayerProxy::duration const):
(WebKit::ModelProcessModelPlayerProxy::paused const):
(WebKit::ModelProcessModelPlayerProxy::setPaused):
(WebKit::ModelProcessModelPlayerProxy::currentTime const):
(WebKit::ModelProcessModelPlayerProxy::setCurrentTime):
(WebKit::ModelProcessModelPlayerProxy::captureStateForReload):
(WebKit::ModelProcessModelPlayerProxy::ensureImmersivePresentation):
(WebKit::ModelProcessModelPlayerProxy::exitImmersivePresentation):
* Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.cpp:
(WebKit::ModelProcessModelPlayer::didFinishLoading):
(WebKit::ModelProcessModelPlayer::didFailLoading):
(WebKit::ModelProcessModelPlayer::didUpdateEntityTransform):
(WebKit::ModelProcessModelPlayer::didUpdateAnimationPlaybackState):
(WebKit::ModelProcessModelPlayer::currentAnimationState const):
(WebKit::ModelProcessModelPlayer::currentTransformState const):
(WebKit::ModelProcessModelPlayer::load):
(WebKit::ModelProcessModelPlayer::reload):
(WebKit::ModelProcessModelPlayer::boundingBoxCenter const):
(WebKit::ModelProcessModelPlayer::boundingBoxExtents const):
(WebKit::ModelProcessModelPlayer::entityTransform const):
(WebKit::ModelProcessModelPlayer::setEntityTransform):
(WebKit::ModelProcessModelPlayer::isPlayingAnimation):
(WebKit::ModelProcessModelPlayer::setAnimationIsPlaying):
(WebKit::ModelProcessModelPlayer::isLoopingAnimation):
(WebKit::ModelProcessModelPlayer::setIsLoopingAnimation):
(WebKit::ModelProcessModelPlayer::animationDuration):
(WebKit::ModelProcessModelPlayer::animationCurrentTime):
(WebKit::ModelProcessModelPlayer::setAnimationCurrentTime):
(WebKit::ModelProcessModelPlayer::setAutoplay):
(WebKit::ModelProcessModelPlayer::setLoop):
(WebKit::ModelProcessModelPlayer::setPlaybackRate):
(WebKit::ModelProcessModelPlayer::duration const):
(WebKit::ModelProcessModelPlayer::paused const):
(WebKit::ModelProcessModelPlayer::setPaused):
(WebKit::ModelProcessModelPlayer::currentTime const):
(WebKit::ModelProcessModelPlayer::setCurrentTime):
* Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.h:
* Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.messages.in:
* Source/WebKit/WebProcess/Model/WebModelPlayer.h:
* Source/WebKit/WebProcess/Model/WebModelPlayer.mm:
(WebKit::WebModelPlayer::duration const):
(WebKit::WebModelPlayer::load):
(WebKit::WebModelPlayer::notifyEntityTransformUpdated):
(WebKit::WebModelPlayer::handleMouseDown):
(WebKit::WebModelPlayer::isPlayingAnimation):
(WebKit::WebModelPlayer::setAnimationIsPlaying):
(WebKit::WebModelPlayer::isLoopingAnimation):
(WebKit::WebModelPlayer::setIsLoopingAnimation):
(WebKit::WebModelPlayer::animationDuration):
(WebKit::WebModelPlayer::animationCurrentTime):
(WebKit::WebModelPlayer::setAnimationCurrentTime):
(WebKit::WebModelPlayer::setPlaybackRate):
(WebKit::WebModelPlayer::update):
(WebKit::WebModelPlayer::notifyClientDidFinishLoading):
(WebKit::WebModelPlayer::play):
(WebKit::WebModelPlayer::setLoop):
(WebKit::WebModelPlayer::setAutoplay):
(WebKit::WebModelPlayer::setPaused):
(WebKit::WebModelPlayer::paused const):
(WebKit::WebModelPlayer::currentTime const):
(WebKit::WebModelPlayer::setCurrentTime):
(WebKit::WebModelPlayer::entityTransform const):
(WebKit::WebModelPlayer::setEntityTransform):
(WebKit::WebModelPlayer::visibilityStateDidChange):
(WebKit::WebModelPlayer::reload):
(WebKit::WebModelPlayer::currentAnimationState const):
(WebKit::WebModelPlayer::currentTransformState const):
(WebKit::WebModelPlayer::dynamicRangeLimitDidChange):

Canonical link: <a href="https://commits.webkit.org/318114@main">https://commits.webkit.org/318114@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2f85fc8dabb934fd4fad985dd0c9d9339206f593

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177318 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51256 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45050 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186921 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140565 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/208dd9a3-0f2c-4228-8966-4e76d0da80b3) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179181 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52548 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50965 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138178 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140565 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ed8c4c90-2e28-4c3e-afcd-9f21ddfef862) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180274 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41692 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/158944 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118643 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/29f3663d-6224-4f62-a6d6-ed53e0b84343) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/40353 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/38724 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150761 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38441 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35389 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/43041 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/42957 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189350 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50922 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147275 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39577 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51605 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/35068 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147065 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41793 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123820 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118158 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50113 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13419 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49509 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49749 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49571 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->