### PR TITLE
Aborting a fetch load should abort the upload stream

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/api/basic/request-upload.h2.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/api/basic/request-upload.h2.any-expected.txt
@@ -1,7 +1,5 @@
 web-platform.test:9000 - didReceiveAuthenticationChallenge - ProtectionSpaceAuthenticationSchemeHTTPBasic - Simulating cancelled authentication sheet
 
-Harness Error (FAIL), message = Unhandled rejection: promise_rejects_exactly: function "function() { throw e; }" threw object "AbortError: Fetch is aborted" but we expected it to throw "foo abort"
-
 PASS Fetch with POST with empty ReadableStream
 PASS Fetch with POST with ReadableStream
 PASS Fetch with POST with ReadableStream on 421 response should return the response and not retry.
@@ -13,5 +11,5 @@ PASS Streaming upload with body containing a String
 PASS Streaming upload with body containing null
 PASS Streaming upload with body containing a number
 FAIL Streaming upload should fail on a 401 response assert_unreached: Should have rejected: undefined Reached unreachable code
-FAIL ReadbleStream should be closed on signal.abort promise_test: Unhandled rejection with value: "streamCancelPromise timed out"
+PASS ReadbleStream should be closed on signal.abort
 

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/api/basic/request-upload.h2.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/api/basic/request-upload.h2.any.serviceworker-expected.txt
@@ -1,7 +1,5 @@
 web-platform.test:9000 - didReceiveAuthenticationChallenge - ProtectionSpaceAuthenticationSchemeHTTPBasic - Simulating cancelled authentication sheet
 
-Harness Error (FAIL), message = Unhandled rejection: promise_rejects_exactly: function "function() { throw e; }" threw object "AbortError: Fetch is aborted" but we expected it to throw "foo abort"
-
 PASS Fetch with POST with empty ReadableStream
 PASS Fetch with POST with ReadableStream
 PASS Fetch with POST with ReadableStream on 421 response should return the response and not retry.
@@ -13,5 +11,5 @@ PASS Streaming upload with body containing a String
 PASS Streaming upload with body containing null
 PASS Streaming upload with body containing a number
 FAIL Streaming upload should fail on a 401 response assert_unreached: Should have rejected: undefined Reached unreachable code
-FAIL ReadbleStream should be closed on signal.abort promise_test: Unhandled rejection with value: "streamCancelPromise timed out"
+PASS ReadbleStream should be closed on signal.abort
 

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/api/basic/request-upload.h2.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/api/basic/request-upload.h2.any.sharedworker-expected.txt
@@ -1,7 +1,5 @@
 web-platform.test:9000 - didReceiveAuthenticationChallenge - ProtectionSpaceAuthenticationSchemeHTTPBasic - Simulating cancelled authentication sheet
 
-Harness Error (FAIL), message = Unhandled rejection: promise_rejects_exactly: function "function() { throw e; }" threw object "AbortError: Fetch is aborted" but we expected it to throw "foo abort"
-
 PASS Fetch with POST with empty ReadableStream
 PASS Fetch with POST with ReadableStream
 PASS Fetch with POST with ReadableStream on 421 response should return the response and not retry.
@@ -13,5 +11,5 @@ PASS Streaming upload with body containing a String
 PASS Streaming upload with body containing null
 PASS Streaming upload with body containing a number
 FAIL Streaming upload should fail on a 401 response assert_unreached: Should have rejected: undefined Reached unreachable code
-FAIL ReadbleStream should be closed on signal.abort promise_test: Unhandled rejection with value: "streamCancelPromise timed out"
+PASS ReadbleStream should be closed on signal.abort
 

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/api/basic/request-upload.h2.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/api/basic/request-upload.h2.any.worker-expected.txt
@@ -1,7 +1,5 @@
 web-platform.test:9000 - didReceiveAuthenticationChallenge - ProtectionSpaceAuthenticationSchemeHTTPBasic - Simulating cancelled authentication sheet
 
-Harness Error (FAIL), message = Unhandled rejection: promise_rejects_exactly: function "function() { throw e; }" threw object "AbortError: Fetch is aborted" but we expected it to throw "foo abort"
-
 PASS Fetch with POST with empty ReadableStream
 PASS Fetch with POST with ReadableStream
 PASS Fetch with POST with ReadableStream on 421 response should return the response and not retry.
@@ -13,5 +11,5 @@ PASS Streaming upload with body containing a String
 PASS Streaming upload with body containing null
 PASS Streaming upload with body containing a number
 FAIL Streaming upload should fail on a 401 response assert_unreached: Should have rejected: undefined Reached unreachable code
-FAIL ReadbleStream should be closed on signal.abort promise_test: Unhandled rejection with value: "streamCancelPromise timed out"
+PASS ReadbleStream should be closed on signal.abort
 

--- a/Source/WebCore/Modules/fetch/FetchResponse.cpp
+++ b/Source/WebCore/Modules/fetch/FetchResponse.cpp
@@ -227,7 +227,7 @@ ExceptionOr<Ref<FetchResponse>> FetchResponse::clone(JSDOMGlobalObject& globalOb
 void FetchResponse::addAbortSteps(Ref<AbortSignal>&& signal)
 {
     m_abortSignal = signal.copyRef();
-    signal->addAlgorithm([weakThis = WeakPtr { *this }](JSC::JSValue) {
+    signal->addAlgorithm([weakThis = WeakPtr { *this }](JSC::JSValue value) {
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis)
             return;
@@ -252,14 +252,19 @@ void FetchResponse::addAbortSteps(Ref<AbortSignal>&& signal)
         if (protectedThis->m_body)
             protectedThis->m_body->loadingFailed(*protectedThis->loadingException());
 
-        if (RefPtr loader = std::exchange(protectedThis->m_loader, nullptr))
+        if (RefPtr loader = std::exchange(protectedThis->m_loader, nullptr)) {
+            RefPtr context = protectedThis->scriptExecutionContext();
+            auto* globalObject = context ? context->globalObject() : nullptr;
+            if (globalObject)
+                loader->abortUpload(*downcast<JSDOMGlobalObject>(globalObject), value);
             loader->stop();
+        }
         if (auto bodyLoader = std::exchange(protectedThis->m_bodyLoader, nullptr))
             bodyLoader->stop();
     });
 }
 
-Ref<FetchResponse> FetchResponse::createFetchResponse(ScriptExecutionContext& context, FetchRequest& request, NotificationCallback&& responseCallback)
+Ref<FetchResponse> FetchResponse::createFetchResponse(ScriptExecutionContext& context, FetchRequest& request, NotificationCallback&& responseCallback, RefPtr<ReadableStreamToSharedBufferSink>&& pendingUpload)
 {
     auto response = adoptRef(*new FetchResponse(&context, FetchBody { }, FetchHeaders::create(FetchHeaders::Guard::Immutable), { }));
     response->suspendIfNeeded();
@@ -268,7 +273,7 @@ Ref<FetchResponse> FetchResponse::createFetchResponse(ScriptExecutionContext& co
 
     response->addAbortSteps(request.signal());
 
-    response->m_loader = Loader::create(response.get(), WTF::move(responseCallback));
+    response->m_loader = Loader::create(response.get(), WTF::move(responseCallback), WTF::move(pendingUpload));
     return response;
 }
 
@@ -295,9 +300,7 @@ void FetchResponse::fetch(ScriptExecutionContext& context, FetchRequest& request
         return;
     }
 
-    Ref response = createFetchResponse(context, request, WTF::move(responseCallback));
-    if (uploadSink)
-        protect(response->m_loader)->setUploadSink(uploadSink.releaseNonNull());
+    Ref response = createFetchResponse(context, request, WTF::move(responseCallback), WTF::move(uploadSink));
     response->startLoader(context, request, initiator);
 }
 
@@ -378,15 +381,16 @@ void FetchResponse::setReceivedInternalResponse(const ResourceResponse& resource
     m_headers->filterAndFill(m_filteredResponse->httpHeaderFields(), FetchHeaders::Guard::Response);
 }
 
-Ref<FetchResponse::Loader> FetchResponse::Loader::create(FetchResponse& response, NotificationCallback&& responseCallback)
+Ref<FetchResponse::Loader> FetchResponse::Loader::create(FetchResponse& response, NotificationCallback&& responseCallback, RefPtr<ReadableStreamToSharedBufferSink>&& pendingUpload)
 {
-    return adoptRef(*new Loader(response, WTF::move(responseCallback)));
+    return adoptRef(*new Loader(response, WTF::move(responseCallback), WTF::move(pendingUpload)));
 }
 
-FetchResponse::Loader::Loader(FetchResponse& response, NotificationCallback&& responseCallback)
+FetchResponse::Loader::Loader(FetchResponse& response, NotificationCallback&& responseCallback, RefPtr<ReadableStreamToSharedBufferSink>&& pendingUpload)
     : m_response(response)
     , m_responseCallback(WTF::move(responseCallback))
     , m_pendingActivity(response.makePendingActivity(response))
+    , m_pendingUpload(WTF::move(pendingUpload))
 {
 }
 
@@ -456,6 +460,12 @@ bool FetchResponse::Loader::start(ScriptExecutionContext& context, const FetchRe
     }
 
     return true;
+}
+
+void FetchResponse::Loader::abortUpload(JSDOMGlobalObject& globalObject, JSC::JSValue value)
+{
+    if (m_pendingUpload)
+        m_pendingUpload->cancel(globalObject, value);
 }
 
 void FetchResponse::Loader::stop()

--- a/Source/WebCore/Modules/fetch/FetchResponse.h
+++ b/Source/WebCore/Modules/fetch/FetchResponse.h
@@ -73,7 +73,7 @@ public:
 
     using NotificationCallback = Function<void(ExceptionOr<Ref<FetchResponse>>&&)>;
     static void fetch(ScriptExecutionContext&, FetchRequest&, NotificationCallback&&, const String& initiator);
-    static Ref<FetchResponse> createFetchResponse(ScriptExecutionContext&, FetchRequest&, NotificationCallback&&);
+    static Ref<FetchResponse> createFetchResponse(ScriptExecutionContext&, FetchRequest&, NotificationCallback&&, RefPtr<ReadableStreamToSharedBufferSink>&& = { });
 
     void startConsumingStream(unsigned);
     void consumeChunk(Ref<JSC::Uint8Array>&&);
@@ -153,7 +153,7 @@ private:
     class Loader final : public RefCounted<Loader>, public FetchLoaderClient {
         WTF_MAKE_TZONE_ALLOCATED(Loader);
     public:
-        static Ref<Loader> create(FetchResponse&, NotificationCallback&&);
+        static Ref<Loader> create(FetchResponse&, NotificationCallback&&, RefPtr<ReadableStreamToSharedBufferSink>&&);
         ~Loader();
 
         // FetchLoaderClient.
@@ -162,7 +162,7 @@ private:
 
         bool start(ScriptExecutionContext&, const FetchRequest&, const String& initiator);
         void stop();
-
+        void abortUpload(JSDOMGlobalObject&, JSC::JSValue);
         void consumeDataByChunk(ConsumeDataByChunkCallback&&);
 
         bool hasLoader() const { return !!m_loader; }
@@ -174,7 +174,7 @@ private:
         void setUploadSink(Ref<ReadableStreamToSharedBufferSink>&& sink) { m_uploadSink = WTF::move(sink); }
 
     private:
-        Loader(FetchResponse&, NotificationCallback&&);
+        Loader(FetchResponse&, NotificationCallback&&, RefPtr<ReadableStreamToSharedBufferSink>&&);
 
         // FetchLoaderClient API
         void didSucceed(const NetworkLoadMetrics&) final;
@@ -190,6 +190,7 @@ private:
         const Ref<PendingActivity<FetchResponse>> m_pendingActivity;
         FetchOptions::Credentials m_credentials;
         bool m_shouldStartStreaming { false };
+        const RefPtr<ReadableStreamToSharedBufferSink> m_pendingUpload;
     };
 
     Loader* loader() const { return m_loader.get(); }

--- a/Source/WebCore/Modules/streams/ReadableStreamToSharedBufferSink.cpp
+++ b/Source/WebCore/Modules/streams/ReadableStreamToSharedBufferSink.cpp
@@ -33,6 +33,7 @@
 #include "ExceptionOr.h"
 #include "JSDOMConvertBufferSource.h"
 #include "JSDOMGlobalObject.h"
+#include "JSDOMPromise.h"
 #include "ReadableStream.h"
 #include "ReadableStreamDefaultReader.h"
 #include "ScriptExecutionContext.h"
@@ -201,6 +202,13 @@ void ReadableStreamToSharedBufferSink::clearCallback()
     m_reader = nullptr;
     m_readRequest = nullptr;
     m_callback = { };
+}
+
+void ReadableStreamToSharedBufferSink::cancel(JSDOMGlobalObject& globalObject, JSC::JSValue value)
+{
+    if (RefPtr reader = m_reader)
+        reader->cancel(globalObject, value);
+    clearCallback();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/streams/ReadableStreamToSharedBufferSink.h
+++ b/Source/WebCore/Modules/streams/ReadableStreamToSharedBufferSink.h
@@ -36,6 +36,7 @@
 
 namespace WebCore {
 
+class JSDOMGlobalObject;
 class ReadableStream;
 class ReadableStreamDefaultReader;
 class SinkReadRequest;
@@ -51,6 +52,7 @@ public:
     void pipeFrom(ReadableStream&);
     void clearCallback();
     bool hasCallback() const { return !!m_callback; }
+    void cancel(JSDOMGlobalObject&, JSC::JSValue);
 
 private:
     explicit ReadableStreamToSharedBufferSink(Callback&&);


### PR DESCRIPTION
#### 937062addbccda04d8cec47627fbcc567cfa64ad
<pre>
Aborting a fetch load should abort the upload stream
<a href="https://bugs.webkit.org/show_bug.cgi?id=320169">https://bugs.webkit.org/show_bug.cgi?id=320169</a>
<a href="https://rdar.apple.com/problem/183104731">rdar://problem/183104731</a>

Reviewed by Chris Dumez.

A fetch can be aborted by an AbortSignal.
When AbortSignal abort steps run (in FetchResponse::addAbortSteps), we tell the FetchResponse::Loader to abort.
FetchResponse::Loader will then abort the upload sink by cancelling the corresponding readablestream reader.

Covered by rebased tests.

* LayoutTests/imported/w3c/web-platform-tests/fetch/api/basic/request-upload.h2.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fetch/api/basic/request-upload.h2.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fetch/api/basic/request-upload.h2.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fetch/api/basic/request-upload.h2.any.worker-expected.txt:
* Source/WebCore/Modules/fetch/FetchResponse.cpp:
(WebCore::FetchResponse::addAbortSteps):
(WebCore::FetchResponse::createFetchResponse):
(WebCore::FetchResponse::fetch):
(WebCore::FetchResponse::Loader::create):
(WebCore::FetchResponse::Loader::Loader):
(WebCore::FetchResponse::Loader::abortUpload):
* Source/WebCore/Modules/fetch/FetchResponse.h:
* Source/WebCore/Modules/streams/ReadableStreamToSharedBufferSink.cpp:
(WebCore::ReadableStreamToSharedBufferSink::cancel):
* Source/WebCore/Modules/streams/ReadableStreamToSharedBufferSink.h:

Canonical link: <a href="https://commits.webkit.org/317851@main">https://commits.webkit.org/317851@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/71796a7fbee64ec53b8b4ce0c114d7e6c87497c6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176585 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50520 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44310 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186186 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/139064 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/056cde1e-89bb-4b5f-98a0-dff9a78c8df7) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178448 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51812 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50204 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/137555 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/139064 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7197aa6e-638c-412f-9a2e-1a448e9fe83e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179541 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/41052 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158333 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118030 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/927f29e3-8f28-4f3d-9068-83f1a3455fc3) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/39707 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/38071 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/150119 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/37831 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34654 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42256 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/42288 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188610 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50185 "Built successfully") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/146612 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39419 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50869 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/34453 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146420 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41180 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123073 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117153 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49374 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12805 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48775 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49009 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48834 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->