### PR TITLE
[site-isolation] media/media-play-promise-reject-pause-abort.html is a permanent timeout

### DIFF
--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -611,6 +611,7 @@ HTMLMediaElement::HTMLMediaElement(const QualifiedName& tagName, Document& docum
     , m_seekToPlaybackPositionEndedTimer(*this, &HTMLMediaElement::seekToPlaybackPositionEndedTimerFired)
     , m_checkPlaybackTargetCompatibilityTimer(*this, &HTMLMediaElement::checkPlaybackTargetCompatibility)
     , m_seekRequest(NativePromiseRequest::create())
+    , m_playRequest(NativePromiseRequest::create())
     , m_currentIdentifier(MediaUniqueIdentifier::generate())
     , m_lastTimeUpdateEventMovieTime(MediaTime::positiveInfiniteTime())
     , m_firstTimePlaying(true)
@@ -781,6 +782,9 @@ HTMLMediaElement::~HTMLMediaElement()
 
     if (m_seekRequest->hasCallback())
         m_seekRequest->disconnect();
+
+    if (m_playRequest->hasCallback())
+        m_playRequest->disconnect();
 
     invalidateWatchtimeTimer();
     invalidateBufferingStopwatch();
@@ -4697,41 +4701,36 @@ void HTMLMediaElement::playInternal()
     // other tasks queued during the async session-admission window.
     bool shouldNotifyAboutPlaying = didTransitionFromPaused && m_readyState > HAVE_CURRENT_DATA;
     bool shouldResolvePromises = !didTransitionFromPaused && m_readyState >= HAVE_FUTURE_DATA;
+    // True if the admission completion handler below is guaranteed to settle
+    // m_pendingPlayPromises itself, even if pause() races the in-flight admission.
+    m_playPromiseSettlementGuaranteed = shouldNotifyAboutPlaying || shouldResolvePromises;
     if (didTransitionFromPaused && m_readyState <= HAVE_CURRENT_DATA)
         scheduleEvent(eventNames().waitingEvent);
 
-    // Set m_canBeginPlaybackInFlight to suppress pauseInternal()'s
-    // scheduleRejectPendingPlayPromises while admission is in flight. This
-    // keeps m_pendingPlayPromises in the element so that setReadyState's
-    // natural scheduleNotifyAboutPlaying transition (line ~3373) can pick
-    // them up if readyState transitions to HAVE_FUTURE_DATA during the
-    // admission window. Pre-branch behavior relied on this natural
-    // mechanism — capturing promises into the lambda would hide them from
-    // setReadyState. The flag is cleared in the admission callback before
-    // any other handling runs.
-    m_canBeginPlaybackInFlight = true;
+    if (m_playRequest->hasCallback())
+        m_playRequest->disconnect();
 
-    CompletionHandler<void (bool)> canBeginPlaybackCompletion = [weakThis = WeakPtr { *this }, didTransitionFromPaused, shouldNotifyAboutPlaying, shouldResolvePromises, logSiteIdentifier = WTF::move(logSiteIdentifier)](bool canBegin) mutable {
+    auto onAdmissionSettled = [weakThis = WeakPtr { *this }, didTransitionFromPaused, shouldNotifyAboutPlaying, shouldResolvePromises, logSiteIdentifier](bool canBegin) {
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis)
             return;
-
-        protectedThis->m_canBeginPlaybackInFlight = false;
 
         if (!canBegin) {
             ALWAYS_LOG_WITH_THIS(protectedThis, logSiteIdentifier, "returning because of interruption");
             if (didTransitionFromPaused) {
                 // Revert the synchronous transition since playback was not permitted.
                 // pauseInternal() fires the pause event (balancing the play event we
-                // already scheduled). With m_canBeginPlaybackInFlight cleared above,
-                // pauseInternal will reject pending play promises if !m_paused.
+                // already scheduled) and rejects the pending play promises.
                 protectedThis->pauseInternal();
             }
-            // If pauseInternal didn't reject (e.g., m_paused was already true
-            // because pause() was called during the admission window),
-            // explicitly reject here.
-            if (!protectedThis->m_pendingPlayPromises.isEmpty())
-                protectedThis->rejectPendingPlayPromises(WTF::move(protectedThis->m_pendingPlayPromises), DOMException::create(ExceptionCode::AbortError));
+            // pauseInternal() above only runs (and rejects) when didTransitionFromPaused
+            // is true. When play() is called on an already-playing element and this
+            // admission is later denied (e.g. an interruption or audio session
+            // activation failure), didTransitionFromPaused is false, pauseInternal()
+            // is skipped, and this promise from that play() call would otherwise
+            // never settle. Safe to call unconditionally: already-drained promises
+            // make this a no-op (see scheduleRejectPendingPlayPromises).
+            protectedThis->scheduleRejectPendingPlayPromises(DOMException::create(ExceptionCode::AbortError));
             return;
         }
 
@@ -4757,7 +4756,28 @@ void HTMLMediaElement::playInternal()
         protectedThis->completePlayInternal();
     };
 
-    mediaSession->clientWillBeginPlayback(WTF::move(canBeginPlaybackCompletion));
+    // Already admitted (e.g. resuming after endInterruption() restores state() to Playing): run inline instead of deferring through whenSettled().
+    if (mediaSession->state() == PlatformMediaSession::State::Playing) {
+        onAdmissionSettled(true);
+        return;
+    }
+
+    GenericPromise::Producer producer;
+    Ref promise = producer.promise();
+    mediaSession->clientWillBeginPlayback([producer = WTF::move(producer)](bool canBegin) mutable {
+        if (canBegin)
+            producer.resolve();
+        else
+            producer.reject();
+    });
+
+    promise->whenSettled(RunLoop::mainSingleton(), [weakThis = WeakPtr { *this }, onAdmissionSettled = WTF::move(onAdmissionSettled)](auto&& result) {
+        RefPtr protectedThis = weakThis.get();
+        if (!protectedThis)
+            return;
+        protectedThis->m_playRequest->complete();
+        onAdmissionSettled(!!result);
+    })->track(m_playRequest);
 }
 
 void HTMLMediaElement::pause()
@@ -4818,17 +4838,17 @@ void HTMLMediaElement::pauseInternal()
 
     setAutoplayEventPlaybackState(AutoplayEventPlaybackState::None);
 
+    // A pause() racing an in-flight play() admission must not preempt a settlement
+    // that the admission's own callback is already guaranteed to deliver (see m_playPromiseSettlementGuaranteed).
+    bool hadInFlightPlayRequest = m_playRequest->hasCallback();
+    if (hadInFlightPlayRequest && !m_playPromiseSettlementGuaranteed)
+        m_playRequest->disconnect();
+
     if (!m_paused && !m_pausedInternal) {
         setPaused(true);
         scheduleTimeupdateEvent(false);
         scheduleEvent(eventNames().pauseEvent);
-        // Suppress promise rejection while an in-flight play() admission is
-        // pending. The admission completion handler resolves promises via
-        // scheduleNotifyAboutPlaying on success, or rejects them on denial.
-        // Without this guard, a pause from an onplay handler (or from the
-        // ended-path's setPaused-then-clientWillPausePlayback) would
-        // spuriously reject the play() promise that has not yet been admitted.
-        if (!m_canBeginPlaybackInFlight)
+        if (!hadInFlightPlayRequest || !m_playPromiseSettlementGuaranteed)
             scheduleRejectPendingPlayPromises(DOMException::create(ExceptionCode::AbortError));
         if (MemoryPressureHandler::singleton().isUnderMemoryPressure())
             purgeBufferedDataIfPossible();

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -1225,7 +1225,9 @@ private:
     TaskCancellationGroup m_periodicTimeupdateCancellationGroup;
     TaskCancellationGroup m_volumeRevertTaskCancellationGroup;
 
+    const Ref<NativePromiseRequest> m_playRequest;
     PlayPromiseVector m_pendingPlayPromises;
+    bool m_playPromiseSettlementGuaranteed { false };
 
     double m_requestedPlaybackRate { 1 };
     double m_reportedPlaybackRate { 1 };
@@ -1344,18 +1346,6 @@ private:
     bool m_sentEndEvent : 1;
 
     bool m_pausedInternal : 1;
-
-    // True between playInternal()'s clientWillBeginPlayback call and its
-    // completion handler. While set, pauseInternal() suppresses
-    // scheduleRejectPendingPlayPromises() so that an in-flight play()'s
-    // pending promises are not rejected with AbortError when (e.g.) the
-    // play event handler synchronously calls pause(), or the player's
-    // mediaPlayerTimeChanged ended-path triggers setPaused(true) +
-    // clientWillPausePlayback. The play promise is resolved by
-    // scheduleNotifyAboutPlaying (queued from setReadyState's natural
-    // transition or from the admission completion handler) on success,
-    // or rejected by the admission completion handler's denial path.
-    bool m_canBeginPlaybackInFlight : 1 { false };
 
     bool m_closedCaptionsVisible : 1;
     bool m_completelyLoaded : 1;


### PR DESCRIPTION
#### 05aab377dd33755b8a6c34c3c53a275f5daaed83
<pre>
[site-isolation] media/media-play-promise-reject-pause-abort.html is a permanent timeout
<a href="https://bugs.webkit.org/show_bug.cgi?id=320173">https://bugs.webkit.org/show_bug.cgi?id=320173</a>
<a href="https://rdar.apple.com/183108599">rdar://183108599</a>

Reviewed by Eric Carlson.

play(); pause(); play(); sequence could leave play() promise permanently unsettled.

play() sent an admission request to the media session (clientWillBeginPlayback)
and settled the pending play promises from its plain CompletionHandler, guarded
by a bool flag (m_canBeginPlaybackInFlight) so a same-tick pause() wouldn&apos;t
reject them out from under it. That flag only suppressed the reject call; it
did nothing to cancel the in-flight admission itself. If pause() ran while
admission was pending, clientWillBeginPlayback&apos;s own race handling would still
resolve canBegin true, but with the paused/no-readyState booleans captured at
play() time now stale, the completion handler settled nothing and the play()
promise hung forever under Site Isolation&apos;s async admission path.

Replaced the flag with a NativePromiseRequest (m_playRequest) that tracks the
in-flight admission as a cancellable GenericPromise. pauseInternal() now
disconnects m_playRequest before touching m_paused, so a pause() during
admission cancels the stale continuation outright instead of just muting one
side effect of it, and the plain !m_paused guard reliably rejects the pending
promises. Also handles play() called again on an already-playing element
getting denied on re-admission, situation which the old flag didn&apos;t cover
either.

Made the disconnect/reject conditional on a new m_playPromiseSettlementGuaranteed
flag, captured alongside shouldNotifyAboutPlaying/shouldResolvePromises: when
either of those was already true at play() time, the admission&apos;s own completion
handler is guaranteed to settle the promise itself, so pauseInternal() must
leave it alone instead of preempting it with a spurious AbortError.

Covered by existing test.

* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::~HTMLMediaElement):
(WebCore::HTMLMediaElement::playInternal):
(WebCore::HTMLMediaElement::pauseInternal):
* Source/WebCore/html/HTMLMediaElement.h:

Canonical link: <a href="https://commits.webkit.org/317907@main">https://commits.webkit.org/317907@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/778c83ae6139163ea765b40746825b9cf58aaa50

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176608 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50545 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44337 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186210 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/139328 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e63867f3-420a-4164-a1d5-98960d186a13) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178471 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51838 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50231 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137572 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/139328 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ab4e5810-cba7-4ea0-b472-1a0b643c3c5f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179564 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41067 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158352 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118046 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/34dbedb0-e39e-4be1-81db-8cf13d511aac) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39722 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38089 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150134 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37850 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34678 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42285 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42306 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188634 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50212 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146630 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39453 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50895 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34470 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146437 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41197 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123101 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117196 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49400 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12828 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48799 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49035 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48860 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->