### PR TITLE
Cherry-pick 317769@main (cfde6a8041f4). https://bugs.webkit.org/show_bug.cgi?id=319949

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -5479,10 +5479,6 @@ webkit.org/b/319950 imported/w3c/web-platform-tests/css/css-pseudo/marker-hit-te
 # WebTransport is Cocoa-only (non-Cocoa ports are a stub). https://bugs.webkit.org/show_bug.cgi?id=319008
 imported/w3c/web-platform-tests/webtransport/ [ Skip ]
 
-# Crashes on both GLib ports since 317427@main (Remove DidReceiveEventIPC): thread-affinity assertion (threadLikeAssertion.isCurrent()) in EventDispatcher::dispatchWheelEvent.
-webkit.org/b/319949 fast/events/wheel/wheel-event-destroys-frame.html [ Crash ]
-webkit.org/b/319949 fast/events/wheel/wheelevent-basic.html [ Crash ]
-
 # End: Common failures between GTK and WPE.
 
 #////////////////////////////////////////////////////////////////////////////////////////

--- a/LayoutTests/platform/gtk/TestExpectations
+++ b/LayoutTests/platform/gtk/TestExpectations
@@ -1326,8 +1326,3 @@ webkit.org/b/319319 [ Debug ] imported/w3c/web-platform-tests/css/css-contain/co
 webkit.org/b/319323 imported/w3c/web-platform-tests/css/css-scroll-snap/input/keyboard-snap-interruption.html [ Failure Pass ]
 webkit.org/b/319324 inspector/canvas/create-context-webgl.html [ Failure Pass ]
 webkit.org/b/319325 fast/body-propagation/background-color/010.html [ ImageOnlyFailure Pass ]
-
-# crash since 317427@main (Remove DidReceiveEventIPC), thread-affinity assertion in EventDispatcher::dispatchWheelEvent. Same root cause as the glib wheel entries.
-webkit.org/b/319949 pointer-lock/mouse-event-delivery.html [ Crash ]
-webkit.org/b/319949 swipe/swipe-back-with-active-wheel-listener-and-scroller.html [ Crash ]
-webkit.org/b/319949 swipe/swipe-back-with-passive-wheel-listener-and-scroller.html [ Crash ]

--- a/Source/WebKit/WebProcess/WebPage/EventDispatcher.cpp
+++ b/Source/WebKit/WebProcess/WebPage/EventDispatcher.cpp
@@ -183,7 +183,7 @@ void EventDispatcher::internalWheelEvent(PageIdentifier pageID, const WebWheelEv
                     dispatchWheelEventViaMainThread(pageID, wheelEvent, result.steps, WTF::move(completionHandler));
                     return;
                 }
-                dispatchWheelEventViaMainThread(pageID, wheelEvent, result.steps, [](bool) { });
+                dispatchWheelEventViaMainThread(pageID, wheelEvent, result.steps, CompletionHandler<void(bool)>([](bool) { }, CompletionHandlerCallThread::AnyThread));
             }
 
             // If we scrolled on the scrolling thread (even if we send the event to the main thread for passive event handlers)


### PR DESCRIPTION
#### 4cd590db9366d7be7ea2829704a286cde0a3fc64
<pre>
Cherry-pick <a href="https://commits.webkit.org/317769@main">317769@main</a> (cfde6a8041f4). <a href="https://bugs.webkit.org/show_bug.cgi?id=319949">https://bugs.webkit.org/show_bug.cgi?id=319949</a>

    REGRESSION(<a href="https://commits.webkit.org/317427@main">317427@main</a>): [GLIB] Wheel events crash with an assertion in EventDispatcher::dispatchWheelEvent
    <a href="https://bugs.webkit.org/show_bug.cgi?id=319949">https://bugs.webkit.org/show_bug.cgi?id=319949</a>

    Reviewed by Charlie Wolfe.

    A wheel event is usually handled across several threads: a background thread
    receives it, a scrolling thread can do the scroll on its own to keep scrolling
    smooth, and the main thread runs the page JavaScript wheel listeners.

    Since <a href="https://commits.webkit.org/317427@main">317427@main</a> the &quot;was the event handled&quot; answer is returned as an async
    reply to the WheelEvent message via a CompletionHandler instead of as a
    separate DidReceiveEventIPC message.

    And every CompletionHandler asserts that it is executed on the thread where
    it was created (unless specified otherwise via the AnyThread parameter).

    The main reply handler (the one carrying the answer back to the UIProcess)
    is already correctly created as AnyThread, because depending on the path
    it gets called either from the scrolling thread or from the main thread.

    The problem is in the passive scrolling path, there the reply is sent from
    the scrolling thread as soon as the scrolling is done without waiting for
    the main thread ACK, but the event still has to be forwarded to the main
    thread after completed so the passive DOM listeners run.
    The result of forwarding this to the main thread is not used because the
    main reply handler already finished, so a no-op CompletionHandler is passed,
    which is created on the scrolling thread but executed on the main thread,
    therefore the assertion hits.
    The fix is to simply mark this no-op CompletionHandler as AnyThread.

    This is not a problem on the Mac port because it runs the scrolling thread
    in the UIProcess and doesn&apos;t exercise this codepath, however in the GTK
    and WPE case the scrolling thread runs in the WebProcess and wheel events
    are routed through this EventDispatcher.

    * LayoutTests/platform/glib/TestExpectations:
    * LayoutTests/platform/gtk/TestExpectations:
    * LayoutTests/platform/wpe/TestExpectations:
    * Source/WebKit/WebProcess/WebPage/EventDispatcher.cpp:
      (WebKit::EventDispatcher::internalWheelEvent):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4cd590db9366d7be7ea2829704a286cde0a3fc64

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176582 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/50517 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/44307 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186183 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/139056 "Build is in progress. Recent messages:") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/51809 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/50201 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137552 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/139056 "Build is in progress. Recent messages:") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179538 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/51809 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/44307 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118027 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/51809 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/50201 "The change is no longer eligible for processing.") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/44307 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/51809 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/44307 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34651 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/42252 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/50201 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188607 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/50182 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/44307 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146608 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/50866 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/44307 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146417 "Passed tests") | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26800 "Failed to checkout and rebase branch from PR 70108") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/50866 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/123070 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/117149 "The change is no longer eligible for processing.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/49370 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/44307 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/48772 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/49006 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/48831 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->