### PR TITLE
[JSC] Allocate DFG `BasicBlock::intersectionOfPastValuesAtHead` only for OSR entry targets

### DIFF
--- a/Source/JavaScriptCore/dfg/DFGBasicBlock.cpp
+++ b/Source/JavaScriptCore/dfg/DFGBasicBlock.cpp
@@ -59,7 +59,6 @@ BasicBlock::BasicBlock(BytecodeIndex bytecodeBegin, unsigned numArguments, unsig
     , variablesAtTail(numArguments, numLocals, numTmps)
     , valuesAtHead(numArguments, numLocals, numTmps)
     , valuesAtTail(numArguments, numLocals, numTmps)
-    , intersectionOfPastValuesAtHead(numArguments, numLocals, numTmps, AbstractValue::fullTop())
     , executionCount(executionCount)
 {
 }
@@ -72,7 +71,8 @@ void BasicBlock::ensureLocals(unsigned newNumLocals)
     variablesAtTail.ensureLocals(newNumLocals);
     valuesAtHead.ensureLocals(newNumLocals);
     valuesAtTail.ensureLocals(newNumLocals);
-    intersectionOfPastValuesAtHead.ensureLocals(newNumLocals, AbstractValue::fullTop());
+    if (intersectionOfPastValuesAtHead.size())
+        intersectionOfPastValuesAtHead.ensureLocals(newNumLocals, AbstractValue::fullTop());
 }
 
 void BasicBlock::ensureTmps(unsigned newNumTmps)
@@ -81,7 +81,16 @@ void BasicBlock::ensureTmps(unsigned newNumTmps)
     variablesAtTail.ensureTmps(newNumTmps);
     valuesAtHead.ensureTmps(newNumTmps);
     valuesAtTail.ensureTmps(newNumTmps);
-    intersectionOfPastValuesAtHead.ensureTmps(newNumTmps, AbstractValue::fullTop());
+    if (intersectionOfPastValuesAtHead.size())
+        intersectionOfPastValuesAtHead.ensureTmps(newNumTmps, AbstractValue::fullTop());
+}
+
+Operands<AbstractValue>& BasicBlock::ensureIntersectionOfPastValuesAtHead()
+{
+    if (!intersectionOfPastValuesAtHead.size())
+        intersectionOfPastValuesAtHead = Operands<AbstractValue>(OperandsLike, variablesAtHead, AbstractValue::fullTop());
+    ASSERT(intersectionOfPastValuesAtHead.size() == variablesAtHead.size());
+    return intersectionOfPastValuesAtHead;
 }
 
 void BasicBlock::replaceTerminal(Graph& graph, Node* node)

--- a/Source/JavaScriptCore/dfg/DFGBasicBlock.h
+++ b/Source/JavaScriptCore/dfg/DFGBasicBlock.h
@@ -60,7 +60,9 @@ public:
     
     void ensureLocals(unsigned newNumLocals);
     void ensureTmps(unsigned newNumTmps);
-    
+
+    Operands<AbstractValue>& ensureIntersectionOfPastValuesAtHead();
+
     size_t size() const { return m_nodes.size(); }
     bool isEmpty() const { return !size(); }
     Node*& at(size_t i) { return m_nodes[i]; }
@@ -240,7 +242,7 @@ public:
     // would not be a productive optimization: it would make setting up a basic block more
     // expensive and would only benefit bizarre pathological cases.
     Operands<AbstractValue> intersectionOfPastValuesAtHead;
-    
+
     float executionCount;
     
     struct SSAData {

--- a/Source/JavaScriptCore/dfg/DFGCFAPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGCFAPhase.cpp
@@ -138,14 +138,19 @@ public:
                     continue;
                 
                 block->intersectionOfCFAHasVisited &= block->cfaHasVisited;
-                for (unsigned i = block->intersectionOfPastValuesAtHead.size(); i--;) {
+
+                if (!block->isOSRTarget || !block->intersectionOfCFAHasVisited)
+                    continue;
+
+                Operands<AbstractValue>& intersection = block->ensureIntersectionOfPastValuesAtHead();
+                for (unsigned i = intersection.size(); i--;) {
                     AbstractValue value = block->valuesAtHead[i];
                     // We need to guarantee that when we do an OSR entry, we validate the incoming
                     // value as if it could be live past an invalidation point. Otherwise, we may
                     // OSR enter with a value with the wrong structure, and an InvalidationPoint's
                     // promise of filtering the structure set of certain values is no longer upheld.
                     value.m_structure.observeInvalidationPoint();
-                    block->intersectionOfPastValuesAtHead[i].filter(value);
+                    intersection[i].filter(value);
                 }
             }
         }

--- a/Source/JavaScriptCore/dfg/DFGGraph.cpp
+++ b/Source/JavaScriptCore/dfg/DFGGraph.cpp
@@ -633,7 +633,7 @@ void Graph::dump(PrintStream& out, DumpContext* context)
                 out.print("<empty>");
             out.print("\n");
             out.print(prefix, "  Intersected Vars Before: ");
-            if (block->intersectionOfCFAHasVisited)
+            if (block->intersectionOfCFAHasVisited && block->intersectionOfPastValuesAtHead.size())
                 out.print(inContext(block->intersectionOfPastValuesAtHead, context));
             else
                 out.print("<empty>");

--- a/Source/JavaScriptCore/dfg/DFGJITCompiler.cpp
+++ b/Source/JavaScriptCore/dfg/DFGJITCompiler.cpp
@@ -460,6 +460,7 @@ void JITCompiler::noticeOSREntry(BasicBlock& basicBlock, JITCompiler::Label bloc
     entry.m_bytecodeIndex = basicBlock.bytecodeBegin;
     entry.m_machineCode = linkBuffer.locationOf<OSREntryPtrTag>(blockHead);
 
+    ASSERT(basicBlock.intersectionOfPastValuesAtHead.size() == basicBlock.variablesAtHead.size());
     FixedOperands<AbstractValue> expectedValues(basicBlock.intersectionOfPastValuesAtHead);
     Vector<OSREntryReshuffling> reshufflings;
 


### PR DESCRIPTION
#### 83540481435f16b21495a8463bc3c0bf79c670a1
<pre>
[JSC] Allocate DFG `BasicBlock::intersectionOfPastValuesAtHead` only for OSR entry targets
<a href="https://bugs.webkit.org/show_bug.cgi?id=320177">https://bugs.webkit.org/show_bug.cgi?id=320177</a>

Reviewed by Yusuke Suzuki.

Every DFG BasicBlock allocates intersectionOfPastValuesAtHead, an
Operands&lt;AbstractValue&gt; costing 32 bytes per operand, but its only
consumer is JITCompiler::noticeOSREntry, which reads it to build the
OSR entry&apos;s expected values. Only the entry block and non-inlined loop
headers are OSR entry targets, so for the vast majority of blocks the
array is written on every CFA run and never read.

Allocate it lazily in CFAPhase instead, only for OSR target blocks that
CFA has reached. noticeOSREntry now reads the field directly and asserts
it is populated and sized like variablesAtHead.

Peak RSS on Apple Silicon: a synthetic function with 1200 branches and
128 locals goes from 236.4MB to 219.4MB (-7.2%), and 8 iterations of
Octane/typescript go from 578.6MB to 564.2MB (-2.5%).

* Source/JavaScriptCore/dfg/DFGBasicBlock.cpp:
(JSC::DFG::BasicBlock::BasicBlock):
(JSC::DFG::BasicBlock::ensureLocals):
(JSC::DFG::BasicBlock::ensureTmps):
(JSC::DFG::BasicBlock::ensureIntersectionOfPastValuesAtHead):
* Source/JavaScriptCore/dfg/DFGBasicBlock.h:
* Source/JavaScriptCore/dfg/DFGCFAPhase.cpp:
(JSC::DFG::CFAPhase::run):
* Source/JavaScriptCore/dfg/DFGGraph.cpp:
(JSC::DFG::Graph::dump):
* Source/JavaScriptCore/dfg/DFGJITCompiler.cpp:
(JSC::DFG::JITCompiler::noticeOSREntry):

Canonical link: <a href="https://commits.webkit.org/318060@main">https://commits.webkit.org/318060@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8b0a44da615f388ad75f64155b98b72ea3316314

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176580 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50515 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44305 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186181 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/139052 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51807 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50199 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137548 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/139052 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179536 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41042 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158326 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118023 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39692 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38067 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/6835 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150107 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37824 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34649 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/37864 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42250 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42284 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188606 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50180 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146604 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39549 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50864 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34447 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146413 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41173 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123068 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117147 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49368 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12799 "") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48770 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49004 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48829 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->