### PR TITLE
Do not allow network fallback in case of a disturbed fetch event request body

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/fetch-event.https.h2-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/fetch-event.https.h2-expected.txt
@@ -2,7 +2,7 @@
 PASS global setup
 PASS The streaming request body is readable in the service worker.
 PASS Network fallback for streaming upload.
-FAIL When the streaming request body is used, network fallback fails. assert_unreached: Should have rejected: undefined Reached unreachable code
+PASS When the streaming request body is used, network fallback fails.
 PASS Running clone() in the service worker does not prevent network fallback.
 PASS restore global state
 

--- a/Source/WebCore/workers/service/context/ServiceWorkerFetch.cpp
+++ b/Source/WebCore/workers/service/context/ServiceWorkerFetch.cpp
@@ -175,7 +175,9 @@ void dispatchFetchEvent(Ref<Client>&& client, ServiceWorkerGlobalScope& globalSc
 
     RefPtr formData = request.httpBody();
     std::optional<FetchBody> body;
+    bool isPendingStream = false;
     if (formData && !formData->isEmpty()) {
+        isPendingStream = formData->isPendingStream();
         body = FetchBody::fromFormData(globalScope, formData.releaseNonNull());
         if (!body) {
             client->didNotHandle();
@@ -226,10 +228,17 @@ void dispatchFetchEvent(Ref<Client>&& client, ServiceWorkerGlobalScope& globalSc
     globalScope.dispatchEvent(event);
 
     if (!event->respondWithEntered()) {
-        if (event->defaultPrevented()) {
-            ResourceError error { errorDomainWebKitInternal, 0, requestURL, "Fetch event was canceled"_s, ResourceError::Type::General, ResourceError::IsSanitized::Yes };
+        auto errorCallback = [&](ResourceError&& error) {
             client->didFail(error);
             deferredPromise->reject(Exception { ExceptionCode::NetworkError });
+        };
+        if (event->defaultPrevented()) {
+            errorCallback({ errorDomainWebKitInternal, 0, requestURL, "Fetch event was canceled"_s, ResourceError::Type::General, ResourceError::IsSanitized::Yes });
+            return;
+        }
+
+        if (isPendingStream && protect(event->request())->isDisturbed()) {
+            errorCallback({ errorDomainWebKitInternal, 0, requestURL, "Fetch request body is disturbed"_s, ResourceError::Type::General, ResourceError::IsSanitized::Yes });
             return;
         }
         client->didNotHandle();


### PR DESCRIPTION
#### 4c947c1f3ca35596cfcb36fafd267f0d33caeabd
<pre>
Do not allow network fallback in case of a disturbed fetch event request body
<a href="https://rdar.apple.com/183125740">rdar://183125740</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=320183">https://bugs.webkit.org/show_bug.cgi?id=320183</a>

Reviewed by Alex Christensen.

If the fetch event request body is read, even partially, we can no longer provide the data to the network if data comes from a ReadableStream originally.
In that case, we fail the load.

Covered by rebased test.

* LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/fetch-event.https.h2-expected.txt:
* Source/WebCore/workers/service/context/ServiceWorkerFetch.cpp:
(WebCore::ServiceWorkerFetch::dispatchFetchEvent):

Canonical link: <a href="https://commits.webkit.org/318042@main">https://commits.webkit.org/318042@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dcbb775a51460b1b3c021c449e5ec42c8248229b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176937 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50874 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44669 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186540 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140173 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/940795ef-4126-4c39-930d-fc3d7a15681f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178800 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52167 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50560 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137859 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140173 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7160d7f5-bab2-49c4-8543-679d6bf4205e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179893 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41369 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158648 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118328 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/38b73a76-ba23-440e-b445-6f9366f7a688) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40025 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38390 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150435 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38148 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35008 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42625 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42608 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188963 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50541 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146934 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39532 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51224 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34772 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146731 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41492 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123437 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117708 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49729 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13128 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49128 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49365 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49189 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->