### PR TITLE
Service workers should be able to get stream upload data

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/fetch-event.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/fetch-event.https-expected.txt
@@ -19,7 +19,7 @@ FAIL Service Worker responds to fetch event with the correct cache types assert_
 PASS Service Worker should intercept EventSource
 PASS Service Worker responds to fetch event with the correct integrity_metadata
 PASS FetchEvent#body is a string
-FAIL FetchEvent#body is a ReadableStream promise_test: Unhandled rejection with value: object "TypeError: FetchEvent.respondWith received an error: NotSupportedError: Stream upload reading is not yet supported"
+PASS FetchEvent#body is a ReadableStream
 PASS FetchEvent#body is a string and is passed to network fallback
 PASS FetchEvent#body is a none Uint8Array ReadableStream and is passed to a service worker
 PASS FetchEvent#body is a string, used and passed to network fallback

--- a/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/fetch-event.https.h2-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/fetch-event.https.h2-expected.txt
@@ -1,6 +1,6 @@
 
 PASS global setup
-FAIL The streaming request body is readable in the service worker. promise_test: Unhandled rejection with value: object "TypeError: FetchEvent.respondWith received an error: NotSupportedError: Stream upload reading is not yet supported"
+PASS The streaming request body is readable in the service worker.
 PASS Network fallback for streaming upload.
 FAIL When the streaming request body is used, network fallback fails. assert_unreached: Should have rejected: undefined Reached unreachable code
 PASS Running clone() in the service worker does not prevent network fallback.

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/service-workers/service-worker/fetch-event.https.h2-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/service-workers/service-worker/fetch-event.https.h2-expected.txt
@@ -1,6 +1,6 @@
 
 PASS global setup
-FAIL The streaming request body is readable in the service worker. promise_test: Unhandled rejection with value: object "TypeError: FetchEvent.respondWith received an error: NotSupportedError: Stream upload reading is not yet supported"
+PASS The streaming request body is readable in the service worker.
 FAIL Network fallback for streaming upload. promise_test: Unhandled rejection with value: object "TypeError: Load failed"
 PASS When the streaming request body is used, network fallback fails.
 FAIL Running clone() in the service worker does not prevent network fallback. promise_test: Unhandled rejection with value: object "TypeError: Load failed"

--- a/Source/WebCore/Modules/fetch/FetchResponse.h
+++ b/Source/WebCore/Modules/fetch/FetchResponse.h
@@ -171,8 +171,6 @@ private:
         NotificationCallback takeNotificationCallback() { return WTF::move(m_responseCallback); }
         ConsumeDataByChunkCallback takeConsumeDataCallback() { return WTF::move(m_consumeDataCallback); }
 
-        void setUploadSink(Ref<ReadableStreamToSharedBufferSink>&& sink) { m_uploadSink = WTF::move(sink); }
-
     private:
         Loader(FetchResponse&, NotificationCallback&&, RefPtr<ReadableStreamToSharedBufferSink>&&);
 
@@ -186,7 +184,6 @@ private:
         NotificationCallback m_responseCallback;
         ConsumeDataByChunkCallback m_consumeDataCallback;
         RefPtr<FetchLoader> m_loader;
-        RefPtr<ReadableStreamToSharedBufferSink> m_uploadSink;
         const Ref<PendingActivity<FetchResponse>> m_pendingActivity;
         FetchOptions::Credentials m_credentials;
         bool m_shouldStartStreaming { false };

--- a/Source/WebCore/Modules/fetch/FormDataConsumer.cpp
+++ b/Source/WebCore/Modules/fetch/FormDataConsumer.cpp
@@ -29,6 +29,9 @@
 #include "BlobLoader.h"
 #include "ExceptionOr.h"
 #include "FormData.h"
+#include "PendingStreamState.h"
+#include "SWContextManager.h"
+#include "SharedBuffer.h"
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/WorkQueue.h>
 
@@ -42,9 +45,15 @@ FormDataConsumer::FormDataConsumer(const FormData& formData, ScriptExecutionCont
     , m_callback(WTF::move(callback))
     , m_fileQueue(WorkQueue::create("FormDataConsumer file queue"_s))
 {
+    // We explicitly copy pendingStreamState as FormData::copy does not, to limit the risk of trying to consume mulitple times the same pendingStreamState.
+    if (RefPtr state = formData.pendingStreamState())
+        m_formData->setPendingStreamState(state.releaseNonNull());
 }
 
-FormDataConsumer::~FormDataConsumer() = default;
+FormDataConsumer::~FormDataConsumer()
+{
+    ASSERT(!m_pendingStreamState);
+}
 
 void FormDataConsumer::read()
 {
@@ -67,8 +76,11 @@ void FormDataConsumer::read()
     }, [this](const FormDataElement::EncodedBlobData& blobData) {
         consumeBlob(blobData.url);
     }, [this](const FormDataElement::PendingStreamData&) {
-        // FIXME: Allow reading from PendingStreamData.
-        didFail(Exception { ExceptionCode::NotSupportedError, "Stream upload reading is not yet supported"_s });
+        if (RefPtr state = m_formData->pendingStreamState()) {
+            consumePendingStream(*state);
+            return;
+        }
+        didFail(Exception { ExceptionCode::InvalidStateError, "Stream upload is missing state"_s });
     });
 }
 
@@ -124,6 +136,78 @@ void FormDataConsumer::consumeBlob(const URL& blobURL)
     didFail(Exception { ExceptionCode::InvalidStateError, "Unable to read form data blob"_s });
 }
 
+void FormDataConsumer::consumePendingStream(PendingStreamState& state)
+{
+    RefPtr context = m_context;
+    if (!context) {
+        didFail(Exception { ExceptionCode::InvalidStateError, "Context is gone"_s });
+        return;
+    }
+
+    m_pendingStreamState = &state;
+    state.setDataAvailableHandler([weakThis = WeakPtr { *this }, contextIdentifier = context->identifier()] {
+        ScriptExecutionContext::postTaskTo(contextIdentifier, [weakThis](auto&) {
+            if (RefPtr protectedThis = weakThis.get())
+                protectedThis->drainPendingStream();
+        });
+    });
+
+    if (!m_hasRequestedPendingStream) {
+        ASSERT(state.serviceWorkerFetchIdentifier());
+        m_hasRequestedPendingStream = true;
+        ensureOnMainThread([state = Ref { state }] {
+            if (RefPtr connection = SWContextManager::singleton().connection())
+                connection->startPendingStreamUploadForwarding(state.get());
+        });
+    }
+
+    drainPendingStream();
+}
+
+void FormDataConsumer::drainPendingStream()
+{
+    if (isCancelled())
+        return;
+
+    RefPtr state = m_pendingStreamState;
+    if (!state)
+        return;
+
+    while (m_callback) {
+        bool atEOF = false;
+        int errorCode = 0;
+        RefPtr chunk = state->takeNextChunk(atEOF, errorCode);
+
+        if (errorCode) {
+            didFail(Exception { ExceptionCode::NetworkError, "Stream upload failed"_s });
+            return;
+        }
+
+        if (chunk) {
+            if (!m_callback(chunk->span())) {
+                cancel();
+                return;
+            }
+            if (!m_callback)
+                return;
+        }
+
+        if (atEOF) {
+            state->clearDataAvailableHandler();
+            m_pendingStreamState = nullptr;
+
+            auto callback = std::exchange(m_callback, nullptr);
+            callback(std::span<const uint8_t> { });
+            return;
+        }
+
+        if (!chunk) {
+            // No chunk and not at EOF — wait for the data-available handler to run.
+            return;
+        }
+    }
+}
+
 void FormDataConsumer::consume(std::span<const uint8_t> content)
 {
     if (!m_callback)
@@ -156,6 +240,15 @@ void FormDataConsumer::cancel()
     m_callback = nullptr;
     if (auto loader = std::exchange(m_blobLoader, { }))
         loader->cancel();
+    if (RefPtr state = std::exchange(m_pendingStreamState, { })) {
+        state->clearDataAvailableHandler();
+        if (m_hasRequestedPendingStream) {
+            ensureOnMainThread([state = state.releaseNonNull()] {
+                if (RefPtr connection = SWContextManager::singleton().connection())
+                    connection->cancelPendingStreamUploadForwarding(state.get());
+            });
+        }
+    }
     m_isReadingFile = false;
     m_context = nullptr;
 }

--- a/Source/WebCore/Modules/fetch/FormDataConsumer.h
+++ b/Source/WebCore/Modules/fetch/FormDataConsumer.h
@@ -38,6 +38,7 @@ namespace WebCore {
 class BlobLoader;
 class Exception;
 class FormData;
+class PendingStreamState;
 class ScriptExecutionContext;
 template<typename> class ExceptionOr;
 
@@ -51,7 +52,7 @@ public:
     void start() { read(); }
     void cancel();
 
-    bool hasPendingActivity() const { return !!m_blobLoader || m_isReadingFile; }
+    bool hasPendingActivity() const { return !!m_blobLoader || m_isReadingFile || !!m_pendingStreamState; }
 
 private:
     FormDataConsumer(const FormData&, ScriptExecutionContext&, Callback&&);
@@ -59,6 +60,8 @@ private:
     void consumeData(const Vector<uint8_t>&);
     void consumeFile(const String&);
     void consumeBlob(const URL&);
+    void consumePendingStream(PendingStreamState&);
+    void drainPendingStream();
 
     void consume(std::span<const uint8_t>);
     void read();
@@ -72,7 +75,9 @@ private:
     size_t m_currentElementIndex { 0 };
     const Ref<WorkQueue> m_fileQueue;
     RefPtr<BlobLoader> m_blobLoader;
+    RefPtr<PendingStreamState> m_pendingStreamState;
     bool m_isReadingFile { false };
+    bool m_hasRequestedPendingStream { false };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/network/PendingStreamState.cpp
+++ b/Source/WebCore/platform/network/PendingStreamState.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "PendingStreamState.h"
 
+#include "Logging.h"
 #include "SharedBuffer.h"
 #include <wtf/Locker.h>
 #include <wtf/StdLibExtras.h>
@@ -117,6 +118,7 @@ void PendingStreamState::setDataAvailableHandler(Function<void()>&& handler)
     invokeHandlerIfNeeded([&] -> RefPtr<DataAvailableHandler> {
         Locker locker { m_lock };
         ASSERT(!m_dataAvailableHandler);
+        RELEASE_LOG_ERROR_IF(m_dataAvailableHandler, Network, "Trying to get upload stream data twice");
         m_dataAvailableHandler = DataAvailableHandler::create(WTF::move(handler));
         if (!m_chunks.isEmpty() || m_ended || m_errorCode)
             return m_dataAvailableHandler;

--- a/Source/WebCore/platform/network/PendingStreamState.h
+++ b/Source/WebCore/platform/network/PendingStreamState.h
@@ -25,12 +25,14 @@
 
 #pragma once
 
+#include <WebCore/FetchIdentifier.h>
 #include <WebCore/PendingStreamIdentifier.h>
 #include <span>
 #include <wtf/Deque.h>
 #include <wtf/Forward.h>
 #include <wtf/Function.h>
 #include <wtf/Lock.h>
+#include <wtf/Markable.h>
 #include <wtf/Ref.h>
 #include <wtf/ThreadSafeRefCounted.h>
 
@@ -52,9 +54,13 @@ public:
 
     WEBCORE_EXPORT void appendData(Ref<SharedBuffer>&&);
     WEBCORE_EXPORT void endStream();
+    // FIXME: Provide meaningful PendingStreamState errors.
     WEBCORE_EXPORT void errorStream(int errorCode);
 
     WEBCORE_EXPORT void setHTTPVersionProbe(HTTPVersionProbe&&);
+
+    void setServiceWorkerFetchIdentifier(FetchIdentifier fetchIdentifier) { m_serviceWorkerFetchIdentifier = fetchIdentifier; }
+    Markable<FetchIdentifier> serviceWorkerFetchIdentifier() const { return m_serviceWorkerFetchIdentifier; }
 
     WEBCORE_EXPORT void setDataAvailableHandler(Function<void()>&&);
     WEBCORE_EXPORT void clearDataAvailableHandler();
@@ -78,6 +84,7 @@ private:
     int m_errorCode WTF_GUARDED_BY_LOCK(m_lock) { 0 };
     RefPtr<DataAvailableHandler> m_dataAvailableHandler WTF_GUARDED_BY_LOCK(m_lock);
     HTTPVersionProbe m_httpVersionProbe WTF_GUARDED_BY_LOCK(m_lock);
+    Markable<FetchIdentifier> m_serviceWorkerFetchIdentifier;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/workers/service/context/SWContextManager.h
+++ b/Source/WebCore/workers/service/context/SWContextManager.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <WebCore/BackgroundFetchInformation.h>
+#include <WebCore/FetchIdentifier.h>
 #include <WebCore/PageIdentifier.h>
 #include <WebCore/PushSubscriptionData.h>
 #include <WebCore/ServiceWorkerClientData.h>
@@ -41,6 +42,7 @@
 
 namespace WebCore {
 
+class PendingStreamState;
 class SecurityOriginData;
 class SerializedScriptValue;
 class ServiceWorkerGlobalScope;
@@ -93,6 +95,9 @@ public:
         bool isClosed() const { return m_isClosed; }
 
         virtual void removeNavigationFetch(SWServerConnectionIdentifier, FetchIdentifier) = 0;
+
+        virtual void startPendingStreamUploadForwarding(PendingStreamState&) = 0;
+        virtual void cancelPendingStreamUploadForwarding(PendingStreamState&) = 0;
 
         virtual bool isWebSWContextManagerConnection() const { return false; }
 

--- a/Source/WebCore/workers/service/context/ServiceWorkerFetch.cpp
+++ b/Source/WebCore/workers/service/context/ServiceWorkerFetch.cpp
@@ -223,7 +223,6 @@ void dispatchFetchEvent(Ref<Client>&& client, ServiceWorkerGlobalScope& globalSc
     event->onResponse([client, mode, redirect, requestURL, certificateInfo = WTF::move(certificateInfo), deferredPromise]<typename Result> (Result&& result) mutable {
         processResponse(WTF::move(client), std::forward<Result>(result), mode, redirect, requestURL, WTF::move(certificateInfo), deferredPromise.get());
     });
-
     globalScope.dispatchEvent(event);
 
     if (!event->respondWithEntered()) {

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.h
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.h
@@ -124,6 +124,8 @@ public:
     void pendingStreamEnd();
     void pendingStreamError();
 
+    WebCore::PendingStreamState* pendingStreamState() const { return m_pendingStreamState.get(); }
+
     void setResponse(WebCore::ResourceResponse&& response) { m_response = WTF::move(response); }
     const WebCore::ResourceResponse& response() const LIFETIME_BOUND { return m_response; }
 

--- a/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.cpp
@@ -160,6 +160,11 @@ ServiceWorkerFetchTask::~ServiceWorkerFetchTask()
     cancelPreloadIfNecessary();
 }
 
+NetworkResourceLoader* ServiceWorkerFetchTask::loader() const
+{
+    return m_loader.get();
+}
+
 RefPtr<IPC::Connection> ServiceWorkerFetchTask::serviceWorkerConnection()
 {
     auto* serviceWorkerConnection = m_serviceWorkerConnection.get();

--- a/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.h
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.h
@@ -87,6 +87,8 @@ public:
     WebCore::FetchIdentifier fetchIdentifier() const { return m_fetchIdentifier; }
     std::optional<WebCore::ServiceWorkerIdentifier> serviceWorkerIdentifier() const { return m_serviceWorkerIdentifier; }
 
+    NetworkResourceLoader* loader() const;
+
     WebCore::ResourceRequest takeRequest() { return WTF::move(m_currentRequest); }
 
     void cannotHandle();

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.cpp
@@ -32,13 +32,16 @@
 #include "NetworkConnectionToWebProcess.h"
 #include "NetworkProcess.h"
 #include "NetworkProcessProxyMessages.h"
+#include "NetworkResourceLoader.h"
 #include "NetworkSession.h"
 #include "ServiceWorkerFetchTask.h"
 #include "ServiceWorkerFetchTaskMessages.h"
+#include "SharedBufferReference.h"
 #include "WebSWContextManagerConnectionMessages.h"
 #include "WebSWServerConnection.h"
 #include <WebCore/NotificationData.h>
 #include <WebCore/NotificationPayload.h>
+#include <WebCore/PendingStreamState.h>
 #include <WebCore/SWServer.h>
 #include <WebCore/SWServerWorker.h>
 #include <WebCore/ServiceWorkerContextData.h>
@@ -388,6 +391,78 @@ void WebSWServerToContextConnection::setThrottleState(bool isThrottleable)
 void WebSWServerToContextConnection::startFetch(ServiceWorkerFetchTask& task)
 {
     task.start(*this);
+}
+
+void WebSWServerToContextConnection::startPendingStreamUploadForwarding(WebCore::FetchIdentifier fetchIdentifier)
+{
+    auto errorCallback = [&]() {
+        protect(ipcConnection())->send(Messages::WebSWContextManagerConnection::ForwardPendingStreamUploadError { fetchIdentifier }, 0);
+    };
+
+    RefPtr fetch = m_ongoingFetches.get(fetchIdentifier);
+    if (!fetch) {
+        errorCallback();
+        return;
+    }
+    RefPtr loader = fetch->loader();
+    if (!loader) {
+        RELEASE_LOG_ERROR(ServiceWorker, "StartPendingStreamUpload no loader");
+        errorCallback();
+        return;
+    }
+    RefPtr state = loader->pendingStreamState();
+    if (!state) {
+        RELEASE_LOG_ERROR(ServiceWorker, "StartPendingStreamUpload no pendingStreamState");
+        errorCallback();
+        return;
+    }
+
+    m_requestPendingStreamStates.add(fetchIdentifier, *state);
+
+    state->setDataAvailableHandler([weakThis = WeakPtr { *this }, fetchIdentifier] {
+        if (RefPtr protectedThis = weakThis)
+            protectedThis->pendingStreamDataAvailable(fetchIdentifier);
+    });
+}
+
+void WebSWServerToContextConnection::pendingStreamDataAvailable(WebCore::FetchIdentifier fetchIdentifier)
+{
+    RefPtr connection = this->ipcConnection();
+    if (!connection)
+        return;
+
+    RefPtr state = m_requestPendingStreamStates.get(fetchIdentifier);
+    if (!state)
+        return;
+
+    while (true) {
+        bool atEOF = false;
+        int errorCode = 0;
+        RefPtr chunk = state->takeNextChunk(atEOF, errorCode);
+        if (errorCode) {
+            connection->send(Messages::WebSWContextManagerConnection::ForwardPendingStreamUploadError { fetchIdentifier }, 0);
+            state->clearDataAvailableHandler();
+            m_requestPendingStreamStates.remove(fetchIdentifier);
+            return;
+        }
+        if (chunk)
+            connection->send(Messages::WebSWContextManagerConnection::ForwardPendingStreamUploadData { fetchIdentifier, IPC::SharedBufferReference { *chunk } }, 0);
+        if (atEOF) {
+            connection->send(Messages::WebSWContextManagerConnection::ForwardPendingStreamUploadEnd { fetchIdentifier }, 0);
+            state->clearDataAvailableHandler();
+            m_requestPendingStreamStates.remove(fetchIdentifier);
+            return;
+        }
+        if (!chunk)
+            return;
+    }
+}
+
+void WebSWServerToContextConnection::cancelPendingStreamUploadForwarding(WebCore::FetchIdentifier fetchIdentifier)
+{
+    // FIXME: We might want to let know the source stream we no longer care about getting any data.
+    if (RefPtr state = m_requestPendingStreamStates.take(fetchIdentifier))
+        state->clearDataAvailableHandler();
 }
 
 void WebSWServerToContextConnection::didReceiveFetchTaskMessage(IPC::Connection& connection, IPC::Decoder& decoder)

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.h
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.h
@@ -39,6 +39,7 @@
 namespace WebCore {
 struct FetchOptions;
 struct MessageWithMessagePorts;
+class PendingStreamState;
 class ResourceRequest;
 class Site;
 }
@@ -77,7 +78,6 @@ public:
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
 
     void startFetch(ServiceWorkerFetchTask&);
-    void cancelFetch(WebCore::SWServerConnectionIdentifier, WebCore::FetchIdentifier, WebCore::ServiceWorkerIdentifier);
 
     void didReceiveFetchTaskMessage(IPC::Connection&, IPC::Decoder&);
 
@@ -137,6 +137,9 @@ private:
     void terminateDueToUnresponsiveness() final;
     void openWindow(WebCore::ServiceWorkerIdentifier, const URL&, OpenWindowCallback&&) final;
     void reportConsoleMessage(WebCore::ServiceWorkerIdentifier, MessageSource, MessageLevel, const String& message, uint64_t requestIdentifier);
+    void startPendingStreamUploadForwarding(WebCore::FetchIdentifier);
+    void pendingStreamDataAvailable(WebCore::FetchIdentifier);
+    void cancelPendingStreamUploadForwarding(WebCore::FetchIdentifier);
 
     void connectionClosed();
 
@@ -148,6 +151,7 @@ private:
     WeakPtr<NetworkConnectionToWebProcess> m_connection;
     HashMap<WebCore::FetchIdentifier, WeakPtr<ServiceWorkerFetchTask>> m_ongoingFetches;
     HashMap<WebCore::FetchIdentifier, ThreadSafeWeakPtr<ServiceWorkerDownloadTask>> m_ongoingDownloads;
+    HashMap<WebCore::FetchIdentifier, Ref<WebCore::PendingStreamState>> m_requestPendingStreamStates;
     bool m_isThrottleable { true };
     WebPageProxyIdentifier m_webPageProxyID;
     size_t m_processingFunctionalEventCount { 0 };

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.messages.in
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.messages.in
@@ -47,4 +47,7 @@ messages -> WebSWServerToContextConnection {
 
     [EnabledBy=ServiceWorkersEnabled] OpenWindow(WebCore::ServiceWorkerIdentifier identifier, URL url) -> (Expected<std::optional<WebCore::ServiceWorkerClientData>, WebCore::ExceptionData> newClientData)
     [EnabledBy=ServiceWorkersEnabled] ReportConsoleMessage(WebCore::ServiceWorkerIdentifier identifier, enum:uint8_t JSC::MessageSource messageSource, enum:uint8_t JSC::MessageLevel messageLevel, String message, uint64_t requestIdentifier);
+
+    [EnabledBy=ServiceWorkersEnabled] StartPendingStreamUploadForwarding(WebCore::FetchIdentifier fetchIdentifier)
+    [EnabledBy=ServiceWorkersEnabled] CancelPendingStreamUploadForwarding(WebCore::FetchIdentifier fetchIdentifier)
 }

--- a/Source/WebKit/Scripts/webkit/opaque_ipc_types.tracking.in
+++ b/Source/WebKit/Scripts/webkit/opaque_ipc_types.tracking.in
@@ -420,6 +420,7 @@
 
     [NotSentFromWebContent] MessageParam WebResourceLoader.DidReceiveData data
     [NotSentFromWebContent] MessageParam WebSWClientConnection.NotifyRecordResponseBodyChunk data
+    [NotSentFromWebContent] MessageParam WebSWContextManagerConnection.ForwardPendingStreamUploadData chunk
     [NotSentFromWebContent] MessageParam GPUProcess.ConsumeAudioComponentRegistrations registrationData
     [NotSentFromWebContent] MessageParam WebPage.UpdateAttachmentAttributes associatedElementData
 }

--- a/Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.cpp
+++ b/Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.cpp
@@ -36,6 +36,7 @@
 #include "RemoteWorkerInitializationData.h"
 #include "RemoteWorkerLibWebRTCProvider.h"
 #include "ServiceWorkerFetchTaskMessages.h"
+#include "SharedBufferReference.h"
 #include "WebBadgeClient.h"
 #include "WebBroadcastChannelRegistry.h"
 #include "WebCacheStorageProvider.h"
@@ -64,6 +65,7 @@
 #include <WebCore/MessageWithMessagePorts.h>
 #include <WebCore/NotificationData.h>
 #include <WebCore/PageConfiguration.h>
+#include <WebCore/PendingStreamState.h>
 #include <WebCore/RemoteFrameClient.h>
 #include <WebCore/ScriptExecutionContextIdentifier.h>
 #include <WebCore/SerializedScriptValue.h>
@@ -325,6 +327,11 @@ void WebSWContextManagerConnection::startFetch(SWServerConnectionIdentifier serv
         m_ongoingNavigationFetchTasks.add({ serverConnectionIdentifier, fetchIdentifier }, Ref { client });
 
     request.setHTTPBody(formData.takeData());
+    if (RefPtr body = request.httpBody(); body && body->isPendingStream()) {
+        Ref pendingStreamState = WebCore::PendingStreamState::create();
+        pendingStreamState->setServiceWorkerFetchIdentifier(fetchIdentifier);
+        body->setPendingStreamState(WTF::move(pendingStreamState));
+    }
     serviceWorkerThreadProxy->startFetch(serverConnectionIdentifier, fetchIdentifier, WTF::move(client), WTF::move(request), WTF::move(referrer), WTF::move(options), isServiceWorkerNavigationPreloadEnabled, WTF::move(clientIdentifier), WTF::move(resultingClientIdentifier));
 }
 
@@ -643,6 +650,65 @@ void WebSWContextManagerConnection::removeNavigationFetch(WebCore::SWServerConne
         assertIsCurrent(protectedThis->m_queue.get());
         protectedThis->m_ongoingNavigationFetchTasks.remove({ serverConnectionIdentifier, fetchIdentifier });
     });
+}
+
+void WebSWContextManagerConnection::startPendingStreamUploadForwarding(WebCore::PendingStreamState& state)
+{
+    auto fetchIdentifier = state.serviceWorkerFetchIdentifier();
+    ASSERT(fetchIdentifier);
+    if (!fetchIdentifier) {
+        state.errorStream(-1);
+        return;
+    }
+
+    m_queue->dispatch([protectedThis = Ref { *this }, state = Ref { state }, fetchIdentifier = *fetchIdentifier]() mutable {
+        assertIsCurrent(protectedThis->m_queue.get());
+        protectedThis->m_requestPendingStreamStates.add(fetchIdentifier, WTF::move(state));
+        protectedThis->m_connectionToNetworkProcess->send(Messages::WebSWServerToContextConnection::StartPendingStreamUploadForwarding { fetchIdentifier }, 0);
+    });
+}
+
+void WebSWContextManagerConnection::cancelPendingStreamUploadForwarding(WebCore::PendingStreamState& state)
+{
+    auto fetchIdentifier = state.serviceWorkerFetchIdentifier();
+    if (!fetchIdentifier)
+        return;
+
+    m_queue->dispatch([protectedThis = Ref { *this }, fetchIdentifier = *fetchIdentifier] {
+        assertIsCurrent(protectedThis->m_queue.get());
+        if (!protectedThis->m_requestPendingStreamStates.remove(fetchIdentifier))
+            return;
+        protectedThis->m_connectionToNetworkProcess->send(Messages::WebSWServerToContextConnection::CancelPendingStreamUploadForwarding { fetchIdentifier }, 0);
+    });
+}
+
+void WebSWContextManagerConnection::forwardPendingStreamUploadData(WebCore::FetchIdentifier fetchIdentifier, IPC::SharedBufferReference&& chunk)
+{
+    assertIsCurrent(m_queue.get());
+
+    RefPtr state = m_requestPendingStreamStates.get(fetchIdentifier);
+    if (!state)
+        return;
+    RefPtr buffer = chunk.unsafeBuffer();
+    if (!buffer)
+        return;
+    state->appendData(buffer.releaseNonNull());
+}
+
+void WebSWContextManagerConnection::forwardPendingStreamUploadEnd(WebCore::FetchIdentifier fetchIdentifier)
+{
+    assertIsCurrent(m_queue.get());
+
+    if (RefPtr state = m_requestPendingStreamStates.take(fetchIdentifier))
+        state->endStream();
+}
+
+void WebSWContextManagerConnection::forwardPendingStreamUploadError(WebCore::FetchIdentifier fetchIdentifier)
+{
+    assertIsCurrent(m_queue.get());
+
+    if (RefPtr state = m_requestPendingStreamStates.take(fetchIdentifier))
+        state->errorStream(-1);
 }
 
 #if ENABLE(REMOTE_INSPECTOR) && PLATFORM(COCOA)

--- a/Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.h
+++ b/Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.h
@@ -42,9 +42,11 @@
 
 namespace IPC {
 class FormDataReference;
+class SharedBufferReference;
 }
 
 namespace WebCore {
+class PendingStreamState;
 class ResourceRequest;
 class Site;
 
@@ -100,6 +102,8 @@ private:
     void stop() final;
     void reportConsoleMessage(WebCore::ServiceWorkerIdentifier, MessageSource, MessageLevel, const String& message, unsigned long requestIdentifier) final;
     void removeNavigationFetch(WebCore::SWServerConnectionIdentifier, WebCore::FetchIdentifier) final;
+    void startPendingStreamUploadForwarding(WebCore::PendingStreamState&) final;
+    void cancelPendingStreamUploadForwarding(WebCore::PendingStreamState&) final;
 
     // IPC messages.
     void updatePreferencesStore(WebPreferencesStore&&);
@@ -110,6 +114,9 @@ private:
     void startFetch(WebCore::SWServerConnectionIdentifier, WebCore::ServiceWorkerIdentifier, WebCore::FetchIdentifier, WebCore::ResourceRequest&&, WebCore::FetchOptions&&, IPC::FormDataReference&&, String&& referrer, bool isServiceWorkerNavigationPreloadEnabled, String&& clientIdentifier, String&& resultingClientIdentifier);
     void cancelFetch(WebCore::SWServerConnectionIdentifier, WebCore::ServiceWorkerIdentifier, WebCore::FetchIdentifier);
     void continueDidReceiveFetchResponse(WebCore::SWServerConnectionIdentifier, WebCore::ServiceWorkerIdentifier, WebCore::FetchIdentifier);
+    void forwardPendingStreamUploadData(WebCore::FetchIdentifier, IPC::SharedBufferReference&&);
+    void forwardPendingStreamUploadEnd(WebCore::FetchIdentifier);
+    void forwardPendingStreamUploadError(WebCore::FetchIdentifier);
     void postMessageToServiceWorker(WebCore::ServiceWorkerIdentifier destinationIdentifier, WebCore::MessageWithMessagePorts&&, WebCore::ServiceWorkerOrClientData&& sourceData);
     void fireInstallEvent(WebCore::ServiceWorkerIdentifier);
     void fireActivateEvent(WebCore::ServiceWorkerIdentifier);
@@ -162,6 +169,7 @@ private:
 
     using FetchKey = std::pair<WebCore::SWServerConnectionIdentifier, WebCore::FetchIdentifier>;
     HashMap<FetchKey, Ref<WebServiceWorkerFetchTaskClient>> m_ongoingNavigationFetchTasks WTF_GUARDED_BY_CAPABILITY(m_queue.get());
+    HashMap<WebCore::FetchIdentifier, Ref<WebCore::PendingStreamState>> m_requestPendingStreamStates WTF_GUARDED_BY_CAPABILITY(m_queue.get());
     bool isWebSWContextManagerConnection() const final { return true; }
 #if ENABLE(REMOTE_INSPECTOR) && PLATFORM(COCOA)
     HashMap<WebCore::ServiceWorkerIdentifier, Ref<ServiceWorkerDebuggableFrontendChannel>> m_channels WTF_GUARDED_BY_CAPABILITY(mainRunLoop);

--- a/Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.messages.in
+++ b/Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.messages.in
@@ -31,6 +31,11 @@ messages -> WebSWContextManagerConnection {
     StartFetch(WebCore::ProcessIdentifier serverConnectionIdentifier, WebCore::ServiceWorkerIdentifier serviceWorkerIdentifier, WebCore::FetchIdentifier fetchIdentifier, WebCore::ResourceRequest request, struct WebCore::FetchOptions options, IPC::FormDataReference requestBody, String referrer, bool isServiceWorkerNavigationPreloadEnabled, String clientIdentifier, String resutlingClientIdentifier)
     CancelFetch(WebCore::ProcessIdentifier serverConnectionIdentifier, WebCore::ServiceWorkerIdentifier serviceWorkerIdentifier, WebCore::FetchIdentifier fetchIdentifier)
     ContinueDidReceiveFetchResponse(WebCore::ProcessIdentifier serverConnectionIdentifier, WebCore::ServiceWorkerIdentifier serviceWorkerIdentifier, WebCore::FetchIdentifier fetchIdentifier)
+
+    ForwardPendingStreamUploadData(WebCore::FetchIdentifier fetchIdentifier, IPC::SharedBufferReference chunk)
+    ForwardPendingStreamUploadEnd(WebCore::FetchIdentifier fetchIdentifier)
+    ForwardPendingStreamUploadError(WebCore::FetchIdentifier fetchIdentifier)
+
     PostMessageToServiceWorker(WebCore::ServiceWorkerIdentifier destinationIdentifier, struct WebCore::MessageWithMessagePorts message, WebCore::ServiceWorkerOrClientData sourceData)
     FireInstallEvent(WebCore::ServiceWorkerIdentifier identifier)
     FireActivateEvent(WebCore::ServiceWorkerIdentifier identifier)


### PR DESCRIPTION
#### e4afe2dda27977d441e69736fd7b6d356ef41fb4
<pre>
Service workers should be able to get stream upload data
<a href="https://rdar.apple.com/183108477">rdar://183108477</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=320171">https://bugs.webkit.org/show_bug.cgi?id=320171</a>

Reviewed by Alex Christensen.

When a fetch handler reads event.request.body, the request may carry a pending upload stream that only exists on the initiating WebProcess.
We wire the service worker WebProcess to pull the body from the network process on demand.

On the SW WebProcess side, WebSWContextManagerConnection::startFetch attaches a fresh PendingStreamState to the request body when it carries a pending stream identifier, tagged with the FetchIdentifier.
When the SW reads the request body, FormDataConsumer routes the PendingStreamData element to consumePendingStream.
This installs a data-available handler and asks the network process (via SWContextManager::Connection::startPendingStreamUploadForwarding) to start forwarding.

On the network process side, WebSWServerToContextConnection looks up the corresponding NetworkResourceLoader&apos;s PendingStreamState.
It keeps it alive in its own FetchIdentifier-keyed map, and installs a handler that drains chunks over IPC.

FormDataConsumer::cancel notifies the network process via cancelPendingStreamUploadForwarding so the NP-side handler tears down and the map entry is removed if the SW gives up before EOF.

Covered by existing tests.

* LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/fetch-event.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/fetch-event.https.h2-expected.txt:
* Source/WebCore/Modules/fetch/FetchResponse.h:
* Source/WebCore/Modules/fetch/FormDataConsumer.cpp:
(WebCore::FormDataConsumer::FormDataConsumer):
(WebCore::FormDataConsumer::~FormDataConsumer):
(WebCore::FormDataConsumer::read):
(WebCore::FormDataConsumer::consumePendingStream):
(WebCore::FormDataConsumer::drainPendingStream):
(WebCore::FormDataConsumer::cancel):
* Source/WebCore/Modules/fetch/FormDataConsumer.h:
(WebCore::FormDataConsumer::hasPendingActivity const):
* Source/WebCore/platform/network/PendingStreamState.cpp:
(WebCore::PendingStreamState::setDataAvailableHandler):
* Source/WebCore/platform/network/PendingStreamState.h:
(WebCore::PendingStreamState::setServiceWorkerFetchIdentifier):
(WebCore::PendingStreamState::serviceWorkerFetchIdentifier const):
* Source/WebCore/workers/service/context/SWContextManager.h:
* Source/WebCore/workers/service/context/ServiceWorkerFetch.cpp:
(WebCore::ServiceWorkerFetch::dispatchFetchEvent):
* Source/WebKit/NetworkProcess/NetworkResourceLoader.h:
* Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.cpp:
(WebKit::ServiceWorkerFetchTask::loader const):
* Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.h:
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.cpp:
(WebKit::WebSWServerToContextConnection::startPendingStreamUploadForwarding):
(WebKit::WebSWServerToContextConnection::pendingStreamDataAvailable):
(WebKit::WebSWServerToContextConnection::cancelPendingStreamUploadForwarding):
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.h:
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.messages.in:
* Source/WebKit/Scripts/webkit/opaque_ipc_types.tracking.in:
* Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.cpp:
(WebKit::WebSWContextManagerConnection::startFetch):
(WebKit::WebSWContextManagerConnection::startPendingStreamUploadForwarding):
(WebKit::WebSWContextManagerConnection::cancelPendingStreamUploadForwarding):
(WebKit::WebSWContextManagerConnection::forwardPendingStreamUploadData):
(WebKit::WebSWContextManagerConnection::forwardPendingStreamUploadEnd):
(WebKit::WebSWContextManagerConnection::forwardPendingStreamUploadError):
* Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.h:
* Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.messages.in:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/service-workers/service-worker/fetch-event.https.h2-expected.txt:

Canonical link: <a href="https://commits.webkit.org/317964@main">https://commits.webkit.org/317964@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d77ca2d01c6baccd77ac9047192360428c93c187

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176896 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50833 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44625 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186499 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140132 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4e91a13d-3e69-482c-997a-1ccea94f180c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178759 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52126 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50519 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/137817 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140132 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/dfbe4740-caaf-4d8f-af17-360b247ce6d7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179852 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41327 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158606 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118291 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ce4b7c17-d9d6-49b9-b6d1-9c0b079efd11) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/176219 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39981 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/38349 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150393 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38105 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34966 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42579 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/42564 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188922 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50500 "Built successfully") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/146892 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39489 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51183 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/34730 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146692 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41455 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123391 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117633 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49688 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/13091 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49087 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49323 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49148 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->