### PR TITLE
Editor::Command::execute() re-entrancy check is a permanent tautology, no longer detects frame changes during layout

### DIFF
--- a/Source/WebCore/editing/EditorCommand.cpp
+++ b/Source/WebCore/editing/EditorCommand.cpp
@@ -1923,9 +1923,10 @@ bool Editor::Command::execute(const String& parameter, Event* triggeringEvent) c
             return false;
     }
 
+    RefPtr frameBeforeLayout = this->frame();
     protect(m_document)->updateLayoutIgnorePendingStylesheets();
     RefPtr frame = this->frame();
-    if (m_document->frame() != frame.get())
+    if (frame != frameBeforeLayout)
         return false;
     if (!frame)
         return false;


### PR DESCRIPTION
#### e7237c0f884c4215715f8dd9901155d986525ea8
<pre>
Editor::Command::execute() re-entrancy check is a permanent tautology, no longer detects frame changes during layout
<a href="https://bugs.webkit.org/show_bug.cgi?id=320192">https://bugs.webkit.org/show_bug.cgi?id=320192</a>
<a href="https://rdar.apple.com/183139946">rdar://183139946</a>

Reviewed by Chris Dumez.

Editor::Command::execute() calls updateLayoutIgnorePendingStylesheets(),
which can run arbitrary script and detach or reparent m_document. The
code was meant to guard against this by comparing the frame before and
after the layout call, bailing out if it changed.

However, Command::frame() is just a live forwarding accessor for
m_document-&gt;frame(). execute() called it once after the layout call
and compared it against another read of m_document-&gt;frame() taken
immediately after, with nothing in between able to change the result.
The check was `X != X`, which can never be true, so the guard never
fired.

This regressed in 289096@main, which removed the m_frame member
captured at Command construction time and replaced it with
Command::frame(), collapsing both sides of the comparison into
back-to-back reads of the same live value.

Fix this by capturing the frame before calling
updateLayoutIgnorePendingStylesheets(), so the comparison actually
reflects state before vs. after the potentially script-running call.

No new tests: the restored guard is only observably different from the
current code when the document&apos;s frame changes from one live frame to a
different live frame across the layout call. Document::observeFrame() is
the only mutator of that value, and it only ever goes frame &lt;-&gt; null
(attachToCachedFrame/detachFromCachedFrame/detachFromFrame), never frame
A -&gt; frame B. A null starting frame cannot reach the layout call at all,
since both Command::isEnabled() and Command::allowExecutionWhenDisabled()
return false without a frame. That leaves frame -&gt; null as the only
reachable change, and the following `if (!frame)` check already returned
false for it. The fix restores the guard&apos;s intent rather than changing
behavior for any reachable state.

* Source/WebCore/editing/EditorCommand.cpp:
(WebCore::Editor::Command::execute const):

Canonical link: <a href="https://commits.webkit.org/317966@main">https://commits.webkit.org/317966@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6ae37b0dbdc5fc4b0150f012cde263609da8e468

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176880 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50817 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44609 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186483 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140116 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4681d9cf-37ec-43ff-81ae-79ff2dd228dd) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178743 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52110 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50503 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137799 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140116 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/aab1036b-e07c-44a3-95c5-f9a6c5266ab8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179836 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41309 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158589 "Found 1 new API test failure: TestWebKitAPI.UnifiedPDF.PDFHUDMultiplePluginsDoNotInterceptHitTesting (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118273 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a0fe9d77-6b6e-4d96-8909-9067b545e5a8) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39963 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38331 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150375 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38088 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34950 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42563 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42546 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188906 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50484 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146874 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39491 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51167 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34712 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Checked out pull request; Running run-layout-tests-in-stress-mode; Ignored 4 pre-existing failure based on results-db; Uploaded test results") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146675 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41437 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123375 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117608 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49672 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13069 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49071 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49307 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49132 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->