### PR TITLE
[Scroll snap] Fix css/css-scroll-snap/snap-after-relayout/multiple-aligned-targets/prefer-focused-element.html

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/snap-after-relayout/multiple-aligned-targets/prefer-focused-element-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/snap-after-relayout/multiple-aligned-targets/prefer-focused-element-expected.txt
@@ -2,5 +2,5 @@ top lefttop rightbottom leftbottom right
 
 PASS scroller selects focused target from aligned choices on snap
 PASS out-of-viewport focused element is not the selected snap target.
-FAIL scroller follows selected snap target through layout shift,regardless of focus assert_equals: scroller followed bottomleft in y axis after layout change expected 500 but got 400
+PASS scroller follows selected snap target through layout shift,regardless of focus
 

--- a/Source/WebCore/platform/ScrollSnapAnimatorState.cpp
+++ b/Source/WebCore/platform/ScrollSnapAnimatorState.cpp
@@ -99,38 +99,67 @@ float ScrollSnapAnimatorState::adjustedScrollDestination(ScrollEventAxis axis, F
     return offset * pageScale;
 }
 
-// Returns whether the snap point is changed or not
-bool ScrollSnapAnimatorState::preserveCurrentTargetForAxis(ScrollEventAxis axis, NodeIdentifier boxID)
+// Returns the index of the snap offset that nodeID contributes to, if any.
+std::optional<unsigned> ScrollSnapAnimatorState::snapOffsetIndexForNode(ScrollEventAxis axis, NodeIdentifier nodeID) const
 {
-    auto snapOffsets = snapOffsetsForAxis(axis);
+    const auto& snapOffsets = snapOffsetsForAxis(axis);
 
     // A single snap offset can be shared by several snap areas, but only one of them is recorded
     // as the offset's representative snapTargetID. Our box may be one of the other areas at that
     // offset, so check every area contributing to the offset, not just snapTargetID.
     auto offsetContainsBox = [&](const SnapOffset<LayoutUnit>& offset) {
-        if (offset.snapTargetID && *offset.snapTargetID == boxID)
+        if (offset.snapTargetID == nodeID)
             return true;
         for (auto areaIndex : offset.snapAreaIndices) {
-            if (areaIndex < m_snapOffsetsInfo.snapAreasIDs.size() && m_snapOffsetsInfo.snapAreasIDs[areaIndex] == boxID)
+            if (areaIndex < m_snapOffsetsInfo.snapAreasIDs.size() && m_snapOffsetsInfo.snapAreasIDs[areaIndex] == nodeID)
                 return true;
         }
         return false;
     };
 
-    auto found = std::ranges::find_if(snapOffsets, offsetContainsBox);
-    if (found == snapOffsets.end()) {
+    auto found = snapOffsets.findIf(offsetContainsBox);
+    if (found == notFound)
+        return std::nullopt;
+    return found;
+}
+
+// Returns whether the snap point is changed or not
+bool ScrollSnapAnimatorState::preserveCurrentTargetForAxis(ScrollEventAxis axis, NodeIdentifier nodeID)
+{
+    auto index = snapOffsetIndexForNode(axis, nodeID);
+    if (!index) {
         setActiveSnapIndexForAxis(axis, std::nullopt);
         return false;
     }
 
-    setActiveSnapIndexForAxis(axis, std::distance(snapOffsets.begin(), found));
+    setActiveSnapIndexForAxis(axis, *index);
     return true;
+}
+
+// The focused (then fragment-targeted) box among all of this axis's snap offsets, evaluated fresh so
+// a focus/:target change can be detected. Unlike focusedOrTargetedBox() this is not restricted to the
+// currently-snapped boxes and does not apply the cross-axis visibility filter: it is only a change
+// signal, not a selection.
+Markable<NodeIdentifier> ScrollSnapAnimatorState::focusedOrTargetedNodeForAxis(ScrollEventAxis axis) const
+{
+    const auto& offsets = snapOffsetsForAxis(axis);
+    auto findFlagged = [&](bool SnapOffset<LayoutUnit>::*flag) -> Markable<NodeIdentifier> {
+        for (const auto& offset : offsets) {
+            if (offset.*flag && offset.snapTargetID)
+                return offset.snapTargetID;
+        }
+        return { };
+    };
+
+    if (auto box = findFlagged(&SnapOffset<LayoutUnit>::isFocused))
+        return box;
+    return findFlagged(&SnapOffset<LayoutUnit>::isTarget);
 }
 
 Vector<SnapOffset<LayoutUnit>> ScrollSnapAnimatorState::currentlySnappedOffsetsForAxis(ScrollEventAxis axis) const
 {
     Vector<SnapOffset<LayoutUnit>> currentlySnappedOffsets;
-    auto snapOffsets = snapOffsetsForAxis(axis);
+    const auto& snapOffsets = snapOffsetsForAxis(axis);
     auto activeIndex = activeSnapIndexForAxis(axis);
     
     if (activeIndex && *activeIndex < snapOffsets.size())
@@ -140,24 +169,24 @@ Vector<SnapOffset<LayoutUnit>> ScrollSnapAnimatorState::currentlySnappedOffsetsF
 
 HashSet<NodeIdentifier> ScrollSnapAnimatorState::currentlySnappedBoxes(const Vector<SnapOffset<LayoutUnit>>& horizontalOffsets, const Vector<SnapOffset<LayoutUnit>>& verticalOffsets) const
 {
-    HashSet<NodeIdentifier> snappedBoxIDs;
-        
+    HashSet<NodeIdentifier> snappedNodeIDs;
+
     for (auto offset : horizontalOffsets) {
         if (!offset.snapTargetID)
             continue;
-        snappedBoxIDs.add(*offset.snapTargetID);
+        snappedNodeIDs.add(*offset.snapTargetID);
         for (auto i : offset.snapAreaIndices)
-            snappedBoxIDs.add(m_snapOffsetsInfo.snapAreasIDs[i]);
+            snappedNodeIDs.add(m_snapOffsetsInfo.snapAreasIDs[i]);
     }
     
     for (auto offset : verticalOffsets) {
         if (!offset.snapTargetID)
             continue;
-        snappedBoxIDs.add(*offset.snapTargetID);
+        snappedNodeIDs.add(*offset.snapTargetID);
         for (auto i : offset.snapAreaIndices)
-            snappedBoxIDs.add(m_snapOffsetsInfo.snapAreasIDs[i]);
+            snappedNodeIDs.add(m_snapOffsetsInfo.snapAreasIDs[i]);
     }
-    return snappedBoxIDs;
+    return snappedNodeIDs;
 }
 
 void ScrollSnapAnimatorState::setActiveSnapIndexForAxis(ScrollEventAxis axis, std::optional<unsigned> index)
@@ -310,15 +339,22 @@ std::optional<NodeIdentifier> ScrollSnapAnimatorState::focusedOrTargetedBox(Scro
 
 bool ScrollSnapAnimatorState::resnapAfterLayout(ScrollOffset scrollOffset, const ScrollExtents& scrollExtents, float pageScale)
 {
-    bool snapPointChanged = false;
     m_lastLayoutScrollOffset = LayoutPoint(scrollOffset.x() / pageScale, scrollOffset.y() / pageScale);
     m_lastViewportSize = LayoutSize(scrollExtents.viewportSize);
+
     auto activeHorizontalIndex = activeSnapIndexForAxis(ScrollEventAxis::Horizontal);
     auto activeVerticalIndex = activeSnapIndexForAxis(ScrollEventAxis::Vertical);
+
     auto previouslySnappedBoxes = std::exchange(m_currentlySnappedBoxes, { });
     auto previousSnapTargetForHorizontalAxis = std::exchange(m_currentSnapTargetForHorizontalAxis, { });
     auto previousSnapTargetForVerticalAxis = std::exchange(m_currentSnapTargetForVerticalAxis, { });
 
+    auto currentFocusedOrTargetedNodeX = focusedOrTargetedNodeForAxis(ScrollEventAxis::Horizontal);
+    auto currentFocusedOrTargetedNodeY = focusedOrTargetedNodeForAxis(ScrollEventAxis::Vertical);
+    bool focusOrTargetChangedX = currentFocusedOrTargetedNodeX != std::exchange(m_lastFocusedOrTargetedNodeX, currentFocusedOrTargetedNodeX);
+    bool focusOrTargetChangedY = currentFocusedOrTargetedNodeY != std::exchange(m_lastFocusedOrTargetedNodeY, currentFocusedOrTargetedNodeY);
+
+    bool snapPointChanged = false;
     // Check if we need to set the current indices
     if (!activeVerticalIndex || *activeVerticalIndex >= snapOffsetsForAxis(ScrollEventAxis::Vertical).size())
         snapPointChanged |= setNearestScrollSnapIndexForAxisAndOffsetInternal(ScrollEventAxis::Vertical, scrollOffset, scrollExtents, pageScale);
@@ -329,37 +365,42 @@ bool ScrollSnapAnimatorState::resnapAfterLayout(ScrollOffset scrollOffset, const
     LOG_WITH_STREAM(ScrollSnap, stream << "ScrollSnapAnimatorState::resnapAfterLayout() - previouslySnappedBoxes " << previouslySnappedBoxes << " m_currentlySnappedBoxes " << m_currentlySnappedBoxes);
 
     // Re-snap each axis independently to its selected box, following it to its post-layout offset.
-    // Focused/targeted boxes are re-evaluated fresh; otherwise the box recorded before the layout
-    // change (innermost / first-in-tree) is used. Per-axis selection keeps a box tied only in the
-    // other axis from dragging this axis off its snap position.
-    if (previouslySnappedBoxes.size() > 1) {
-        auto targetForAxis = [&](ScrollEventAxis axis, const Markable<NodeIdentifier>& recordedTarget) -> std::optional<NodeIdentifier> {
+    // When the focus/:target changed we honor that new preference among the previously-snapped boxes;
+    // otherwise we keep the box recorded before the layout change (focused/targeted / innermost /
+    // first-in-tree). Per-axis selection keeps a box tied only in the other axis from dragging this
+    // axis off its snap position.
+    auto targetForAxis = [&](ScrollEventAxis axis, const Markable<NodeIdentifier>& recordedTarget, bool focusOrTargetChanged) -> std::optional<NodeIdentifier> {
+        if (focusOrTargetChanged) {
             if (auto box = focusedOrTargetedBox(axis, previouslySnappedBoxes))
                 return box;
-            return recordedTarget ? std::optional<NodeIdentifier> { *recordedTarget } : std::nullopt;
-        };
+        }
+        // Keep the recorded target only if it is still a snap target for this axis; otherwise fall
+        // through so the nearest-offset selection made above stands.
+        if (recordedTarget && snapOffsetIndexForNode(axis, *recordedTarget))
+            return recordedTarget;
+        return std::nullopt;
+    };
 
-        auto targetForHorizontalAxis = targetForAxis(ScrollEventAxis::Horizontal, previousSnapTargetForHorizontalAxis);
-        auto targetForVerticalAxis = targetForAxis(ScrollEventAxis::Vertical, previousSnapTargetForVerticalAxis);
+    auto targetForHorizontalAxis = targetForAxis(ScrollEventAxis::Horizontal, previousSnapTargetForHorizontalAxis, focusOrTargetChangedX);
+    auto targetForVerticalAxis = targetForAxis(ScrollEventAxis::Vertical, previousSnapTargetForVerticalAxis, focusOrTargetChangedY);
 
-        if (targetForHorizontalAxis)
-            snapPointChanged |= preserveCurrentTargetForAxis(ScrollEventAxis::Horizontal, *targetForHorizontalAxis);
-        if (targetForVerticalAxis)
-            snapPointChanged |= preserveCurrentTargetForAxis(ScrollEventAxis::Vertical, *targetForVerticalAxis);
+    if (targetForHorizontalAxis)
+        snapPointChanged |= preserveCurrentTargetForAxis(ScrollEventAxis::Horizontal, *targetForHorizontalAxis);
+    if (targetForVerticalAxis)
+        snapPointChanged |= preserveCurrentTargetForAxis(ScrollEventAxis::Vertical, *targetForVerticalAxis);
 
-        updateCurrentlySnappedBoxes();
+    updateCurrentlySnappedBoxes();
 
-        // Keep the box we actually followed as this axis's recorded target. updateCurrentlySnappedBoxes()
-        // re-runs selection, which could pick a different aligned box (first-in-tree, or one that is now
-        // common to both axes) and cause the scroller to abandon its tracked target on a later layout
-        // change. The followed box is authoritative, so restore it when it is still snapped.
-        if (targetForHorizontalAxis && m_currentlySnappedBoxes.contains(*targetForHorizontalAxis))
-            m_currentSnapTargetForHorizontalAxis = *targetForHorizontalAxis;
-        if (targetForVerticalAxis && m_currentlySnappedBoxes.contains(*targetForVerticalAxis))
-            m_currentSnapTargetForVerticalAxis = *targetForVerticalAxis;
+    // Keep the box we actually followed as this axis's recorded target. updateCurrentlySnappedBoxes()
+    // re-runs selection, which could pick a different aligned box (first-in-tree, or one that is now
+    // common to both axes) and cause the scroller to abandon its tracked target on a later layout
+    // change. The followed box is authoritative, so restore it when it is still snapped.
+    if (targetForHorizontalAxis && m_currentlySnappedBoxes.contains(*targetForHorizontalAxis))
+        m_currentSnapTargetForHorizontalAxis = *targetForHorizontalAxis;
+    if (targetForVerticalAxis && m_currentlySnappedBoxes.contains(*targetForVerticalAxis))
+        m_currentSnapTargetForVerticalAxis = *targetForVerticalAxis;
 
-        LOG_WITH_STREAM(ScrollSnap, stream << "ScrollSnapAnimatorState::resnapAfterLayout() - multiple boxes snapped; chose H " << targetForHorizontalAxis << " V " << targetForVerticalAxis << " (changed " << snapPointChanged << ") m_currentlySnappedBoxes " << m_currentlySnappedBoxes);
-    }
+    LOG_WITH_STREAM(ScrollSnap, stream << "ScrollSnapAnimatorState::resnapAfterLayout() - chose H " << targetForHorizontalAxis << " V " << targetForVerticalAxis << " (changed " << snapPointChanged << ") m_currentlySnappedBoxes " << m_currentlySnappedBoxes);
 
     return snapPointChanged;
 }

--- a/Source/WebCore/platform/ScrollSnapAnimatorState.h
+++ b/Source/WebCore/platform/ScrollSnapAnimatorState.h
@@ -102,6 +102,9 @@ private:
 
     bool preserveCurrentTargetForAxis(ScrollEventAxis, NodeIdentifier);
 
+    std::optional<unsigned> snapOffsetIndexForNode(ScrollEventAxis, NodeIdentifier) const;
+    Markable<NodeIdentifier> focusedOrTargetedNodeForAxis(ScrollEventAxis) const;
+
     Vector<SnapOffset<LayoutUnit>> currentlySnappedOffsetsForAxis(ScrollEventAxis) const;
     HashSet<NodeIdentifier> currentlySnappedBoxes(const Vector<SnapOffset<LayoutUnit>>& horizontalOffsets, const Vector<SnapOffset<LayoutUnit>>& verticalOffsets) const;
 
@@ -144,6 +147,11 @@ private:
     HashSet<NodeIdentifier> m_currentlySnappedBoxes;
     Markable<NodeIdentifier> m_currentSnapTargetForHorizontalAxis;
     Markable<NodeIdentifier> m_currentSnapTargetForVerticalAxis;
+
+    // The focused/targeted box seen at the last re-snap, per axis, so we can tell a focus/:target
+    // change (a snap-target selection trigger) apart from a pure layout change.
+    Markable<NodeIdentifier> m_lastFocusedOrTargetedNodeX;
+    Markable<NodeIdentifier> m_lastFocusedOrTargetedNodeY;
 
     // Scroll offset and viewport size from the last snap/re-snap, for cross-axis
     // visibility checks.


### PR DESCRIPTION
#### 61b6b90764790d3bbe166e2cba379e396e455d7f
<pre>
[Scroll snap] Fix css/css-scroll-snap/snap-after-relayout/multiple-aligned-targets/prefer-focused-element.html
<a href="https://bugs.webkit.org/show_bug.cgi?id=320197">https://bugs.webkit.org/show_bug.cgi?id=320197</a>
<a href="https://rdar.apple.com/183146768">rdar://183146768</a>

Reviewed by Abrar Rahman Protyasha.

The test exercises the &quot;resnap after layout&quot; logic[1], testing that a focused node only becomes the snap
candidate if it&apos;s newly focused; the existing code would aways prefer a focused candidate.

Fix by computing whether focus or target node changed on each axis, and having the `targetForAxis`
lambda check this.

Start migrating from &quot;box&quot; to &quot;node&quot; terminology for things referenced by NodeIdentifier.

[1] <a href="https://drafts.csswg.org/css-scroll-snap/">https://drafts.csswg.org/css-scroll-snap/</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/snap-after-relayout/multiple-aligned-targets/prefer-focused-element-expected.txt:
* Source/WebCore/platform/ScrollSnapAnimatorState.cpp:
(WebCore::ScrollSnapAnimatorState::snapOffsetIndexForNode const):
(WebCore::ScrollSnapAnimatorState::preserveCurrentTargetForAxis):
(WebCore::ScrollSnapAnimatorState::focusedOrTargetedNodeForAxis const):
(WebCore::ScrollSnapAnimatorState::currentlySnappedOffsetsForAxis const):
(WebCore::ScrollSnapAnimatorState::currentlySnappedBoxes const):
(WebCore::ScrollSnapAnimatorState::resnapAfterLayout):
* Source/WebCore/platform/ScrollSnapAnimatorState.h:

Canonical link: <a href="https://commits.webkit.org/317892@main">https://commits.webkit.org/317892@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/05620867758ac6600b35b8717c99491fb7b5aacd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176630 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50567 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44359 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186232 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/139376 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fae53c5a-9c0d-4d24-ae70-7fd662f83b5f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178493 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51860 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50253 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137587 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/139376 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ae4fce5e-5f17-4587-9219-a413772a08e7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179586 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41089 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158374 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118061 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/afa5df59-7150-4e8d-8fec-5c353e0cdeab) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39744 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38109 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150156 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37872 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34700 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42307 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42326 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188656 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50234 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146647 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39442 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50917 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/34492 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146454 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41216 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123123 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117230 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49422 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12851 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48821 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49057 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48882 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->