### PR TITLE
WebResourceLoader constructor is crashing on GTK bots

### DIFF
--- a/Source/WebKit/WebProcess/Network/WebResourceLoader.cpp
+++ b/Source/WebKit/WebProcess/Network/WebResourceLoader.cpp
@@ -75,45 +75,52 @@ using namespace WebCore;
 
 Ref<WebResourceLoader> WebResourceLoader::create(Ref<ResourceLoader>&& coreLoader, const std::optional<TrackingParameters>& trackingParameters, RefPtr<PendingStreamState>&& state)
 {
-    return adoptRef(*new WebResourceLoader(WTF::move(coreLoader), trackingParameters, WTF::move(state)));
+    Ref loader = adoptRef(*new WebResourceLoader(WTF::move(coreLoader), trackingParameters, WTF::move(state)));
+    loader->initPendingStreamState();
+    return loader;
 }
 
 WebResourceLoader::WebResourceLoader(Ref<WebCore::ResourceLoader>&& coreLoader, const std::optional<TrackingParameters>& trackingParameters, RefPtr<PendingStreamState>&& state)
     : m_coreLoader(WTF::move(coreLoader))
     , m_trackingParameters(trackingParameters)
-    , m_pendingStreamState(state.get())
+    , m_pendingStreamState(WTF::move(state))
     , m_loadStart(MonotonicTime::now())
 {
     WEBRESOURCELOADER_RELEASE_LOG(WebResourceLoaderConstructor);
-    if (state) {
-        state->setDataAvailableHandler([weakThis = WeakPtr { *this }] {
-            ensureOnMainThread([weakThis] {
-                RefPtr protectedThis = weakThis.get();
-                if (!protectedThis || !protectedThis->m_pendingStreamState)
+}
+
+void WebResourceLoader::initPendingStreamState()
+{
+    RefPtr state = m_pendingStreamState;
+    if (!state)
+        return;
+    state->setDataAvailableHandler([weakThis = WeakPtr { *this }] {
+        ensureOnMainThread([weakThis] {
+            RefPtr protectedThis = weakThis.get();
+            if (!protectedThis || !protectedThis->m_pendingStreamState)
+                return;
+            Ref state = *protectedThis->m_pendingStreamState;
+            while (true) {
+                bool atEOF = false;
+                int errorCode = 0;
+                RefPtr chunk = state->takeNextChunk(atEOF, errorCode);
+                if (errorCode) {
+                    protectedThis->send(Messages::NetworkResourceLoader::PendingStreamError { });
+                    protectedThis->m_pendingStreamState = nullptr;
                     return;
-                Ref state = *protectedThis->m_pendingStreamState;
-                while (true) {
-                    bool atEOF = false;
-                    int errorCode = 0;
-                    RefPtr chunk = state->takeNextChunk(atEOF, errorCode);
-                    if (errorCode) {
-                        protectedThis->send(Messages::NetworkResourceLoader::PendingStreamError { });
-                        protectedThis->m_pendingStreamState = nullptr;
-                        return;
-                    }
-                    if (chunk)
-                        protectedThis->send(Messages::NetworkResourceLoader::PendingStreamAppendData { IPC::SharedBufferReference(*chunk) });
-                    if (atEOF) {
-                        protectedThis->send(Messages::NetworkResourceLoader::PendingStreamEnd { });
-                        protectedThis->m_pendingStreamState = nullptr;
-                        return;
-                    }
-                    if (!chunk)
-                        return;
                 }
-            });
+                if (chunk)
+                    protectedThis->send(Messages::NetworkResourceLoader::PendingStreamAppendData { IPC::SharedBufferReference(*chunk) });
+                if (atEOF) {
+                    protectedThis->send(Messages::NetworkResourceLoader::PendingStreamEnd { });
+                    protectedThis->m_pendingStreamState = nullptr;
+                    return;
+                }
+                if (!chunk)
+                    return;
+            }
         });
-    }
+    });
 }
 
 WebResourceLoader::~WebResourceLoader() = default;

--- a/Source/WebKit/WebProcess/Network/WebResourceLoader.h
+++ b/Source/WebKit/WebProcess/Network/WebResourceLoader.h
@@ -82,6 +82,8 @@ public:
 private:
     WebResourceLoader(Ref<WebCore::ResourceLoader>&&, const std::optional<TrackingParameters>&, RefPtr<WebCore::PendingStreamState>&&);
 
+    void initPendingStreamState();
+
     // IPC::MessageSender
     IPC::Connection* messageSenderConnection() const override;
     uint64_t messageSenderDestinationID() const override;


### PR DESCRIPTION
#### 5d23f731cb40ba88bd6f4a6aa048bda68c31e90b
<pre>
WebResourceLoader constructor is crashing on GTK bots
<a href="https://rdar.apple.com/183147333">rdar://183147333</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=320200">https://bugs.webkit.org/show_bug.cgi?id=320200</a>

Reviewed by Alex Christensen.

WebResourceLoader data available handler can be synchronously called when set.
We thus adoptRef WebResourceLoader and then set the data available handler.

Covered by existing tests.

* Source/WebKit/WebProcess/Network/WebResourceLoader.cpp:
(WebKit::WebResourceLoader::create):
(WebKit::WebResourceLoader::WebResourceLoader):
(WebKit::WebResourceLoader::initPendingStreamState):
* Source/WebKit/WebProcess/Network/WebResourceLoader.h:

Canonical link: <a href="https://commits.webkit.org/317918@main">https://commits.webkit.org/317918@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ae4fcae25d1917e3d59adb9eca3300f03d69705f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176633 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50570 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44362 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186235 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/139383 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/435e8b7f-782b-467f-9171-a61154913422) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51863 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50256 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137589 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/139383 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/37adf383-6ee3-4ba6-bd6d-f7b876a8068f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179589 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41087 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158370 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118063 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c2d9be44-0534-4cbb-acf4-b64264565a8c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39742 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38108 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150154 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37868 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34703 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42310 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42325 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188659 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50237 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146650 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39459 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50920 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34488 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146456 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41217 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123126 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117234 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49425 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12847 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48824 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49060 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48885 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->