### PR TITLE
[Site Isolation] Expand test coverage for per-site camera, microphone, and autoplay policies in cross-origin frames

### DIFF
--- a/Tools/TestWebKitAPI/Helpers/cocoa/UserMediaCaptureUIDelegate.h
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/UserMediaCaptureUIDelegate.h
@@ -46,8 +46,10 @@
 -(void)setAudioDecision:(WKPermissionDecision)decision;
 -(void)setVideoDecision:(WKPermissionDecision)decision;
 -(void)setGetDisplayMediaDecision:(WKDisplayCapturePermissionDecision)decision;
+-(void)setDecision:(WKPermissionDecision)decision forFrameHost:(NSString *)host;
 
 @property (nonatomic, copy) WKWebView* (^createWebViewWithConfiguration)(WKWebViewConfiguration *, WKNavigationAction *, WKWindowFeatures *);
+@property (nonatomic, readonly, copy) NSString *lastRequestFrameHost;
 
 @end
 

--- a/Tools/TestWebKitAPI/Helpers/cocoa/UserMediaCaptureUIDelegate.mm
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/UserMediaCaptureUIDelegate.mm
@@ -35,6 +35,8 @@
 
 @implementation UserMediaCaptureUIDelegate {
     Vector<RetainPtr<WKWebView>> _createdWebViews;
+    RetainPtr<NSMutableDictionary<NSString *, NSNumber *>> _decisionByFrameHost;
+    RetainPtr<NSString> _lastRequestFrameHost;
 }
 @synthesize createWebViewWithConfiguration = _createWebViewWithConfiguration;
 @synthesize numberOfPrompts = _numberOfPrompts;
@@ -48,6 +50,7 @@
         _audioDecision = WKPermissionDecisionGrant;
         _videoDecision = WKPermissionDecisionGrant;
         _getDisplayMediaDecision = WKDisplayCapturePermissionDecisionDeny;
+        _decisionByFrameHost = adoptNS([[NSMutableDictionary alloc] init]);
     }
 
     return self;
@@ -78,6 +81,14 @@
     _getDisplayMediaDecision = decision;
 }
 
+-(void)setDecision:(WKPermissionDecision)decision forFrameHost:(NSString *)host {
+    [_decisionByFrameHost setObject:@(decision) forKey:host];
+}
+
+-(NSString *)lastRequestFrameHost {
+    return _lastRequestFrameHost.get();
+}
+
 - (void)_webView:(WKWebView *)webView queryPermission:(NSString*) name forOrigin:(WKSecurityOrigin *)origin completionHandler:(void (^)(WKPermissionDecision state))completionHandler {
     if ([name isEqualToString:@"camera"]) {
         completionHandler(_videoDecision);
@@ -94,6 +105,13 @@
 - (void)webView:(WKWebView *)webView requestMediaCapturePermissionForOrigin:(WKSecurityOrigin *)origin initiatedByFrame:(WKFrameInfo *)frame type:(WKMediaCaptureType)type decisionHandler:(void (^)(WKPermissionDecision decision))decisionHandler {
     ++_numberOfPrompts;
     _wasPrompted = true;
+    _lastRequestFrameHost = frame.securityOrigin.host;
+
+    if (NSNumber *frameHostDecision = [_decisionByFrameHost objectForKey:frame.securityOrigin.host]) {
+        decisionHandler(static_cast<WKPermissionDecision>(frameHostDecision.integerValue));
+        return;
+    }
+
     switch (type) {
     case WKMediaCaptureTypeCamera:
         if (_videoDecision == WKPermissionDecisionDeny) {

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
@@ -5892,7 +5892,126 @@ TEST(SiteIsolation, StopsMediaCaptureInRemoteFrame)
     assertCaptureState(_WKMediaCaptureStateDeprecatedActiveCamera);
 }
 
+TEST(SiteIsolation, MediaCapturePermissionUsesRemoteFrameOrigin)
+{
+    auto mainFrameHTML = "<iframe allow='camera *' src='https://webkit.org/subframe'></iframe>"_s;
+    auto subFrameHTML = "<script>"
+        "async function captureVideo() {"
+        "    try {"
+        "        const stream = await navigator.mediaDevices.getUserMedia({ audio: false, video: true });"
+        "        stream.getTracks().forEach(track => track.stop());"
+        "        return 'granted';"
+        "    } catch (error) {"
+        "        return error.name === 'NotAllowedError' ? 'denied' : `fail (${error.name})`;"
+        "    }"
+        "}"
+        "</script>"_s;
+
+    HTTPServer server({
+        { "/mainframe"_s, { { { "Content-Type"_s, "text/html"_s } }, mainFrameHTML } },
+        { "/subframe"_s, { { { "Content-Type"_s, "text/html"_s } }, subFrameHTML } },
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    RetainPtr configuration = server.httpsProxyConfiguration();
+    [configuration _setMediaCaptureEnabled:YES];
+
+    RetainPtr preferences = [configuration preferences];
+    [preferences _setMediaCaptureRequiresSecureConnection:NO];
+    [preferences _setMockCaptureDevicesEnabled:YES];
+    [preferences _setGetUserMediaRequiresFocus:NO];
+
+    auto [webView, navigationDelegate] = siteIsolatedViewAndDelegate(configuration, CGRectZero, false);
+    RetainPtr delegate = adoptNS([[UserMediaCaptureUIDelegate alloc] init]);
+    [webView setUIDelegate:delegate.get()];
+
+    [delegate setDecision:WKPermissionDecisionDeny forFrameHost:@"webkit.org"];
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/mainframe"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    auto captureResultInFrame = [&](WKFrameInfo *frame) -> RetainPtr<NSString> {
+        __block RetainPtr<NSString> result;
+        __block bool done = false;
+        [webView callAsyncJavaScript:@"return captureVideo()" arguments:nil inFrame:frame inContentWorld:WKContentWorld.pageWorld completionHandler:^(id value, NSError *error) {
+            result = (NSString *)value;
+            done = true;
+        }];
+        TestWebKitAPI::Util::run(&done);
+        return result;
+    };
+
+    RetainPtr childFrame = [webView firstChildFrame];
+    EXPECT_WK_STREQ([captureResultInFrame(childFrame.get()) UTF8String], "denied");
+    EXPECT_WK_STREQ([delegate lastRequestFrameHost], "webkit.org");
+}
+
 #endif // ENABLE(MEDIA_STREAM)
+
+TEST(SiteIsolation, AutoplayPolicyInRemoteFrameFollowsMainFrame)
+{
+    auto mainFrameHTML = "<script>"
+        "window.onmessage = (event) => window.webkit.messageHandlers.testHandler.postMessage('iframe:' + event.data);"
+        "function playMainVideo() {"
+        "    var video = document.getElementById('video');"
+        "    video.addEventListener('play', () => window.webkit.messageHandlers.testHandler.postMessage('main:autoplayed'));"
+        "    video.play().catch((error) => { if (error.name === 'NotAllowedError') window.webkit.messageHandlers.testHandler.postMessage('main:did-not-play'); });"
+        "}"
+        "</script>"
+        "<body onload='playMainVideo()'>"
+        "<video id='video' webkit-playsinline src='/video-with-audio.mp4'></video>"
+        "<iframe src='https://webkit.org/subframe'></iframe>"
+        "</body>"_s;
+    auto subFrameHTML = "<script>"
+        "function playSubframeVideo() {"
+        "    var video = document.getElementById('video');"
+        "    video.addEventListener('play', () => window.parent.postMessage('autoplayed', '*'));"
+        "    video.play().catch((error) => { if (error.name === 'NotAllowedError') window.parent.postMessage('did-not-play', '*'); });"
+        "}"
+        "</script>"
+        "<body onload='playSubframeVideo()'>"
+        "<video id='video' webkit-playsinline src='/video-with-audio.mp4'></video>"
+        "</body>"_s;
+
+    RetainPtr videoData = [NSData dataWithContentsOfFile:[NSBundle.test_resourcesBundle pathForResource:@"video-with-audio" ofType:@"mp4"] options:0 error:NULL];
+
+    HTTPServer server({
+        { "/mainframe"_s, { { { "Content-Type"_s, "text/html"_s } }, mainFrameHTML } },
+        { "/subframe"_s, { { { "Content-Type"_s, "text/html"_s } }, subFrameHTML } },
+        { "/video-with-audio.mp4"_s, { videoData.get() } },
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    RetainPtr configuration = server.httpsProxyConfiguration();
+#if PLATFORM(IOS_FAMILY)
+    [configuration setAllowsInlineMediaPlayback:YES];
+    [configuration _setInlineMediaPlaybackRequiresPlaysInlineAttribute:NO];
+#endif
+
+    __block _WKWebsiteAutoplayPolicy mainFramePolicy = _WKWebsiteAutoplayPolicyDeny;
+    __block _WKWebsiteAutoplayPolicy subframePolicy = _WKWebsiteAutoplayPolicyAllow;
+
+    auto [webView, navigationDelegate] = siteIsolatedViewAndDelegate(configuration);
+    [navigationDelegate setDecidePolicyForNavigationActionWithPreferences:^(WKNavigationAction *action, WKWebpagePreferences *preferences, void (^completionHandler)(WKNavigationActionPolicy, WKWebpagePreferences *)) {
+        [preferences _setAutoplayPolicy:[action.request.URL.host isEqualToString:@"webkit.org"] ? subframePolicy : mainFramePolicy];
+        completionHandler(WKNavigationActionPolicyAllow, preferences);
+    }];
+
+    RetainPtr<NSMutableSet<NSString *>> received = adoptNS([[NSMutableSet alloc] init]);
+    [webView performAfterReceivingAnyMessage:^(NSString *message) {
+        [received addObject:message];
+    }];
+    auto waitForBoth = [&](NSString *mainResult, NSString *iframeResult) {
+        while (![received containsObject:mainResult] || ![received containsObject:iframeResult])
+            TestWebKitAPI::Util::spinRunLoop(10);
+    };
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/mainframe"]]];
+    waitForBoth(@"main:did-not-play", @"iframe:did-not-play");
+
+    mainFramePolicy = _WKWebsiteAutoplayPolicyAllow;
+    subframePolicy = _WKWebsiteAutoplayPolicyDeny;
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/mainframe"]]];
+    waitForBoth(@"main:autoplayed", @"iframe:autoplayed");
+}
 
 TEST(SiteIsolation, FrameServerTrust)
 {


### PR DESCRIPTION
#### aba0a6a26b7555b95b7ee372625655a8661b0e4e
<pre>
[Site Isolation] Expand test coverage for per-site camera, microphone, and autoplay policies in cross-origin frames
<a href="https://bugs.webkit.org/show_bug.cgi?id=320203">https://bugs.webkit.org/show_bug.cgi?id=320203</a>
<a href="https://rdar.apple.com/183150290">rdar://183150290</a>

Reviewed by Eric Carlson.

Filled in two gaps in test coverage identified by Claude:
1. Test that -webView:requestMediaCapturePermissionForOrigin:initiatedByFrame:type:decisionHandler:
   is called with the correct frame info when permission is requested from a cross-origin frame,
   and that the delegate can deny such requests.
2. Test that the main frame&apos;s autoplay policy takes precedence when evaluating autoplay policy in a
   cross-origin frame.

* Tools/TestWebKitAPI/Helpers/cocoa/UserMediaCaptureUIDelegate.h:
* Tools/TestWebKitAPI/Helpers/cocoa/UserMediaCaptureUIDelegate.mm:
(-[UserMediaCaptureUIDelegate init]):
(-[UserMediaCaptureUIDelegate setDecision:forFrameHost:]):
(-[UserMediaCaptureUIDelegate lastRequestFrameHost]):
(-[UserMediaCaptureUIDelegate webView:requestMediaCapturePermissionForOrigin:initiatedByFrame:type:decisionHandler:]):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm:
(TestWebKitAPI::TEST(SiteIsolation, MediaCapturePermissionUsesRemoteFrameOrigin)):
(TestWebKitAPI::TEST(SiteIsolation, AutoplayPolicyInRemoteFrameFollowsMainFrame)):

Canonical link: <a href="https://commits.webkit.org/317913@main">https://commits.webkit.org/317913@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a4d259ed1a5ac2ea186bec9c39b494147bfe299b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176639 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50576 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44368 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186241 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/139396 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0f9dfcf6-1425-4f07-ad90-a5ac42430b6c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178502 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51869 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50262 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137594 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/139396 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1eae9e59-31cc-4487-a9e4-8ec770a4fd15) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179595 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41096 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158380 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118068 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6ff7715e-9507-446f-a6c9-39b25d504dcd) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39751 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38119 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150163 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37878 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34709 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42334 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188665 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50243 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146656 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39455 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50926 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34498 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146462 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41224 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117243 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49431 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12857 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48830 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49066 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48891 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->