### PR TITLE
[Site Isolation] Cross-origin iframe stuck at about:blank after removal and re-insertion

### DIFF
--- a/LayoutTests/http/tests/site-isolation/iframe-reinsert-same-src-commits-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/iframe-reinsert-same-src-commits-expected.txt
@@ -1,0 +1,1 @@
+PASS: all 5 re-inserted cross-origin iframes committed.

--- a/LayoutTests/http/tests/site-isolation/iframe-reinsert-same-src-commits.html
+++ b/LayoutTests/http/tests/site-isolation/iframe-reinsert-same-src-commits.html
@@ -1,0 +1,62 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<!DOCTYPE html>
+<html>
+<body>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+const src = "http://localhost:8000/site-isolation/resources/frame-reports-commit-to-top.html";
+const totalIterations = 5;
+let reinsertCommits = 0;
+let done = false;
+
+function finish() {
+    if (done)
+        return;
+    done = true;
+    document.body.textContent = reinsertCommits === totalIterations
+        ? "PASS: all " + totalIterations + " re-inserted cross-origin iframes committed."
+        : "FAIL: only " + reinsertCommits + " of " + totalIterations + " re-inserted iframes committed (rest stuck at about:blank).";
+    if (window.testRunner)
+        testRunner.notifyDone();
+}
+
+function runIteration() {
+    const f = document.createElement("iframe");
+    let commitsForThisFrame = 0;
+
+    const onMessage = (event) => {
+        if (event.source !== f.contentWindow)
+            return;
+        if (typeof event.data !== "string" || !event.data.startsWith("committed:"))
+            return;
+
+        commitsForThisFrame++;
+        if (commitsForThisFrame === 1) {
+            f.remove();
+            document.body.appendChild(f);
+            f.src = src;
+        } else if (commitsForThisFrame === 2) {
+            window.removeEventListener("message", onMessage);
+            if (++reinsertCommits === totalIterations)
+                finish();
+        }
+    };
+    window.addEventListener("message", onMessage);
+
+    f.src = src;
+    document.body.appendChild(f);
+}
+
+onload = () => {
+    for (let i = 0; i < totalIterations; i++)
+        runIteration();
+
+    setTimeout(finish, 8000);
+};
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/site-isolation/resources/frame-reports-commit-to-top.html
+++ b/LayoutTests/http/tests/site-isolation/resources/frame-reports-commit-to-top.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<body style="margin: 0; padding: 0;">
+<p id="container">Hello from committed cross-origin iframe</p>
+<script>
+top.postMessage("committed:" + location.href, "*");
+</script>
+</body>
+</html>

--- a/Source/WebKit/UIProcess/ProvisionalFrameProxy.cpp
+++ b/Source/WebKit/UIProcess/ProvisionalFrameProxy.cpp
@@ -40,10 +40,11 @@ namespace WebKit {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(ProvisionalFrameProxy);
 
-ProvisionalFrameProxy::ProvisionalFrameProxy(WebFrameProxy& frame, Ref<FrameProcess>&& frameProcess, CommitTiming commitTiming)
+ProvisionalFrameProxy::ProvisionalFrameProxy(WebFrameProxy& frame, Ref<FrameProcess>&& frameProcess, CommitTiming commitTiming, WebCore::NavigationIdentifier navigationID)
     : m_frame(frame)
     , m_frameProcess(WTF::move(frameProcess))
     , m_visitedLinkStore(frame.page()->visitedLinkStore())
+    , m_navigationID(navigationID)
 {
     Ref process = this->process();
     process->markProcessAsRecentlyUsed();

--- a/Source/WebKit/UIProcess/ProvisionalFrameProxy.h
+++ b/Source/WebKit/UIProcess/ProvisionalFrameProxy.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "WebPageProxyIdentifier.h"
+#include <WebCore/NavigationIdentifier.h>
 #include <WebCore/PageIdentifier.h>
 #include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/TZoneMalloc.h>
@@ -42,12 +43,13 @@ enum class CommitTiming : bool;
 class ProvisionalFrameProxy : public RefCountedAndCanMakeWeakPtr<ProvisionalFrameProxy> {
     WTF_MAKE_TZONE_ALLOCATED(ProvisionalFrameProxy);
 public:
-    explicit ProvisionalFrameProxy(WebFrameProxy&, Ref<FrameProcess>&&, CommitTiming);
+    explicit ProvisionalFrameProxy(WebFrameProxy&, Ref<FrameProcess>&&, CommitTiming, WebCore::NavigationIdentifier);
 
     ~ProvisionalFrameProxy();
 
     WebFrameProxy& frame() const { return m_frame.get(); }
     WebProcessProxy& NODELETE process() const;
+    WebCore::NavigationIdentifier navigationID() const { return m_navigationID; }
 
     RefPtr<FrameProcess> takeFrameProcess();
 
@@ -55,6 +57,7 @@ private:
     WeakRef<WebFrameProxy> m_frame;
     RefPtr<FrameProcess> m_frameProcess;
     const Ref<VisitedLinkStore> m_visitedLinkStore;
+    const WebCore::NavigationIdentifier m_navigationID;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebFrameProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFrameProxy.cpp
@@ -590,7 +590,7 @@ void WebFrameProxy::prepareForProvisionalLoadInProcess(WebProcessProxy& process,
     CommitTiming commitTiming = effectiveOrigin ? CommitTiming::Immediately : CommitTiming::WaitForLoad;
 
     m_provisionalFrame = nullptr;
-    m_provisionalFrame = adoptRef(*new ProvisionalFrameProxy(*this, group.ensureProcessForSite(site, mainFrameSite, process, protect(page->preferences())), commitTiming));
+    m_provisionalFrame = adoptRef(*new ProvisionalFrameProxy(*this, group.ensureProcessForSite(site, mainFrameSite, process, protect(page->preferences())), commitTiming, navigation.navigationID()));
     Ref provisionalFrame = *m_provisionalFrame;
 
     page->inspectorController().didCreateProvisionalFrame(provisionalFrame);

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -8531,10 +8531,14 @@ void WebPageProxy::didFailProvisionalLoadForFrameShared(Ref<WebProcessProxy>&& p
     if (m_provisionalPage && m_provisionalPage->mainFrame() == &frame)
         m_provisionalPage = nullptr;
 
-    if (auto provisionalFrame = frame.takeProvisionalFrame()) {
+    if (RefPtr provisionalFrame = frame.provisionalFrame()) {
+        if (navigationID && provisionalFrame->navigationID() != *navigationID)
+            return;
+
         ASSERT(m_preferences->siteIsolationEnabled());
         ASSERT(!frame.isMainFrame());
-        ASSERT_UNUSED(provisionalFrame, provisionalFrame->process().coreProcessIdentifier() != frame.process().coreProcessIdentifier());
+        ASSERT(provisionalFrame->process().coreProcessIdentifier() != frame.process().coreProcessIdentifier());
+        frame.takeProvisionalFrame();
         frame.notifyParentOfLoadCompletion(process);
         frame.broadcastFrameTreeSyncData(FrameTreeSyncData::create());
     }


### PR DESCRIPTION
#### 0b53fc9713a27a7af61a06931ff125a4abe86af9
<pre>
[Site Isolation] Cross-origin iframe stuck at about:blank after removal and re-insertion
<a href="https://bugs.webkit.org/show_bug.cgi?id=320204">https://bugs.webkit.org/show_bug.cgi?id=320204</a>
<a href="https://rdar.apple.com/164521127">rdar://164521127</a>

Reviewed by Alex Christensen.

Under Site Isolation, removing a cross-origin &lt;iframe&gt; and re-inserting it with its src still set
can issue two navigations on the same frame in quick succession. The second navigation supersedes
the first, replacing the frame&apos;s provisional frame; the first navigation then reports a
cancellation (NSURLErrorCancelled).

didFailProvisionalLoadForFrameShared unconditionally tore down the frame&apos;s current provisional
frame on that cancellation, destroying the second (healthy) provisional frame that was still
loading. As a result the navigation never committed and the frame stayed stuck on its initial empty
document (about:blank), so cross-origin content such as a re-inserted media embed never loaded.

Tag each ProvisionalFrameProxy with the NavigationIdentifier it was created for and only tear down
the current provisional frame when the failing navigation is the one that owns it. A superseded
navigation&apos;s stale cancellation is now ignored, leaving the live provisional frame intact to
commit. This mirrors the existing supersession check in ProvisionalPageProxy::validateInput().

Test: http/tests/site-isolation/iframe-reinsert-same-src-commits.html

* LayoutTests/http/tests/site-isolation/iframe-reinsert-same-src-commits-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/iframe-reinsert-same-src-commits.html: Added.
* LayoutTests/http/tests/site-isolation/resources/frame-reports-commit-to-top.html: Added.
* Source/WebKit/UIProcess/ProvisionalFrameProxy.cpp:
(WebKit::ProvisionalFrameProxy::ProvisionalFrameProxy):
* Source/WebKit/UIProcess/ProvisionalFrameProxy.h:
(WebKit::ProvisionalFrameProxy::navigationID const):
* Source/WebKit/UIProcess/WebFrameProxy.cpp:
(WebKit::WebFrameProxy::prepareForProvisionalLoadInProcess):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::didFailProvisionalLoadForFrameShared):

Canonical link: <a href="https://commits.webkit.org/318289@main">https://commits.webkit.org/318289@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a4969b90a442afbe376dbc08f0efe85768c71e31

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176642 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50579 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44371 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186244 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/139402 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/54b68499-bfae-404f-8f01-642d1ff7eb48) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51872 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50265 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137595 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/139402 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6d26f284-b977-4eec-98a0-799df46f6d14) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179598 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41097 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158381 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118069 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5e89f9d4-c635-4caf-8c77-714398b83e4b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39752 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38118 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150164 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38638 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34712 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42319 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43372 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188668 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50246 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/157924 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146661 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39692 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50929 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34499 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146467 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41226 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123135 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117246 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49434 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12858 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48833 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49069 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48894 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->