### PR TITLE
Safari main thread can block under RemoteLayerTreeEventDispatcher::mainThreadDisplayDidRefresh()

### DIFF
--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.h
@@ -106,7 +106,7 @@ private:
 
     std::optional<DisplayLinkObserverID> m_displayRefreshObserverID;
     std::optional<DisplayLinkObserverID> m_fullSpeedUpdateObserverID;
-    const UniqueRef<RemoteLayerTreeDisplayLinkClient> m_displayLinkClient;
+    const Ref<RemoteLayerTreeDisplayLinkClient> m_displayLinkClient;
     const WeakPtr<WebProcessPool> m_processPool;
 
     Markable<WebCore::PlatformLayerIdentifier> m_pageScalingLayerID;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.mm
@@ -48,6 +48,7 @@
 #import <WebCore/ScrollView.h>
 #import <pal/spi/cocoa/QuartzCoreSPI.h>
 #import <pal/spi/mac/NSScrollerImpSPI.h>
+#import <wtf/ApproximateTime.h>
 #import <wtf/BlockObjCExceptions.h>
 #import <wtf/TZoneMallocInlines.h>
 
@@ -63,20 +64,26 @@ static NSString * const transientClipSizeAnimationKey = @"wkTransientClipSize";
 static NSString * const transientScrolledContentsPositionAnimationKey = @"wkTransientScrolledContentsPosition";
 static NSString * const transientZoomScrollPositionOverrideAnimationKey = @"wkScrollPositionOverride";
 
-class RemoteLayerTreeDisplayLinkClient final : public DisplayLink::Client {
-public:
+class RemoteLayerTreeDisplayLinkClient final : public DisplayLink::Client, public ThreadSafeRefCounted<RemoteLayerTreeDisplayLinkClient> {
     WTF_MAKE_TZONE_ALLOCATED(RemoteLayerTreeDisplayLinkClient);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RemoteLayerTreeDisplayLinkClient);
 public:
+    static Ref<RemoteLayerTreeDisplayLinkClient> create(WebPageProxyIdentifier pageID)
+    {
+        return adoptRef(*new RemoteLayerTreeDisplayLinkClient(pageID));
+    }
+
+private:
     explicit RemoteLayerTreeDisplayLinkClient(WebPageProxyIdentifier pageID)
         : m_pageIdentifier(pageID)
     {
     }
 
-private:
     void displayLinkFired(WebCore::PlatformDisplayID, WebCore::DisplayUpdate, bool wantsFullSpeedUpdates, bool anyObserverWantsCallback) override;
 
     WebPageProxyIdentifier m_pageIdentifier;
+    // NaN means no pending dispatch. Otherwise, stores the ApproximateTime when the pending dispatch was posted.
+    std::atomic<double> m_pendingMainThreadDispatchTime { std::numeric_limits<double>::quiet_NaN() };
 };
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteLayerTreeDisplayLinkClient);
@@ -84,13 +91,32 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteLayerTreeDisplayLinkClient);
 // This is called off the main thread.
 void RemoteLayerTreeDisplayLinkClient::displayLinkFired(WebCore::PlatformDisplayID /* displayID */, WebCore::DisplayUpdate /* displayUpdate */, bool /* wantsFullSpeedUpdates */, bool /* anyObserverWantsCallback */)
 {
-    RunLoop::mainSingleton().dispatch([pageIdentifier = m_pageIdentifier]() {
-        RefPtr page = WebProcessProxy::webPage(pageIdentifier);
+    auto now = ApproximateTime::now().secondsSinceEpoch().value();
+    auto existingTime = m_pendingMainThreadDispatchTime.load(std::memory_order_relaxed);
+
+    if (!std::isnan(existingTime)) {
+        auto pendingDuration = Seconds(now - existingTime);
+        static constexpr auto timeoutDuration = 500_ms;
+        if (pendingDuration < timeoutDuration)
+            return;
+
+        RELEASE_LOG_ERROR(DisplayLink, "RemoteLayerTreeDisplayLinkClient %p: pending main thread dispatch stuck for %.2fs, forcing dispatch", this, pendingDuration.value());
+    }
+
+    m_pendingMainThreadDispatchTime.store(now, std::memory_order_relaxed);
+
+    RunLoop::mainSingleton().dispatch([this, protectedThis = Ref { *this }]() {
+        m_pendingMainThreadDispatchTime.store(std::numeric_limits<double>::quiet_NaN(), std::memory_order_relaxed);
+
+        RefPtr page = WebProcessProxy::webPage(m_pageIdentifier);
         if (!page)
             return;
 
-        if (RefPtr drawingArea = dynamicDowncast<RemoteLayerTreeDrawingAreaProxy>(page->drawingArea()))
-            drawingArea->didRefreshDisplay();
+        RefPtr drawingArea = dynamicDowncast<RemoteLayerTreeDrawingAreaProxy>(page->drawingArea());
+        if (!drawingArea)
+            return;
+
+        drawingArea->didRefreshDisplay();
     });
 }
 
@@ -101,7 +127,7 @@ Ref<RemoteLayerTreeDrawingAreaProxyMac> RemoteLayerTreeDrawingAreaProxyMac::crea
 
 RemoteLayerTreeDrawingAreaProxyMac::RemoteLayerTreeDrawingAreaProxyMac(WebPageProxy& pageProxy, WebProcessProxy& webProcessProxy)
     : RemoteLayerTreeDrawingAreaProxy(pageProxy, webProcessProxy)
-    , m_displayLinkClient(makeUniqueRef<RemoteLayerTreeDisplayLinkClient>(pageProxy.identifier()))
+    , m_displayLinkClient(RemoteLayerTreeDisplayLinkClient::create(pageProxy.identifier()))
     , m_processPool(pageProxy.configuration().processPool())
 {
 }


### PR DESCRIPTION
#### 7369e2faf2790fb25ef0736579f8eb1d0b9c6d2d
<pre>
Safari main thread can block under RemoteLayerTreeEventDispatcher::mainThreadDisplayDidRefresh()
<a href="https://bugs.webkit.org/show_bug.cgi?id=320209">https://bugs.webkit.org/show_bug.cgi?id=320209</a>
<a href="https://rdar.apple.com/182918397">rdar://182918397</a>

Reviewed by Tim Horton.

`RemoteLayerTreeDisplayLinkClient::displayLinkFired()` is called off the main thread from
a CVDisplayLink callback, and does a `RunLoop::mainSingleton().dispatch()`. If the main
thread is busy for some reason (either CPU bound, or perhaps in some scenarios involving
machine sleep or certain window configurations), then the main thread dispatches pile up.
When the main thread finally wakes up, it may have a huge queue of callbacks to process.
My my testing, things like window resize and printing could result in queued callbacks.

As noted in my earlier fix in this area (313360@main), each call to the drawing area&apos;s
`didRefreshDisplay()` can block for about 4ms because it&apos;s trying to sync with the
scrolling thread, so this pile of callbacks can take a long time to process, resulting
in user-perceived hangs.

Fix by coalescing the main thread dispatches via an atomic timestamp on `RemoteLayerTreeDisplayLinkClient`.
In order to clear this inside the callback, make `RemoteLayerTreeDisplayLinkClient`
thread-safe refcounted with a create function.

Because getting stuck never calling `didRefreshDisplay()` on a drawing area would be
catastrophic, be paranoid and call it anyway if it&apos;s been over 500ms since the previous
successful call, with some release logging.

* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.h:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.mm:
(WebKit::RemoteLayerTreeDisplayLinkClient::displayLinkFired):
(WebKit::RemoteLayerTreeDrawingAreaProxyMac::RemoteLayerTreeDrawingAreaProxyMac):

Canonical link: <a href="https://commits.webkit.org/317920@main">https://commits.webkit.org/317920@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/16d6348237eb7cc766ee9179382b8c9e7c4598c3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176704 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50641 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44433 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186306 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/139681 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d58a540a-df31-4b49-83e9-91bf1b258a1a) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51934 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50327 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137649 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/139681 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fb3ff03d-1255-412f-aa96-b3f8a27b9660) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179660 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41157 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158438 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118123 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39812 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38175 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150224 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37936 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34774 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42381 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42391 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188730 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50308 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146713 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39460 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50991 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34557 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146518 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41285 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123197 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117327 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49496 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12915 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48895 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49131 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48956 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->