### PR TITLE
[webkitbot] Orphaned .git/index.lock wedges reverts and the periodic pull

### DIFF
--- a/Tools/WebKitBot/src/WebKitBot.mjs
+++ b/Tools/WebKitBot/src/WebKitBot.mjs
@@ -23,7 +23,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import {stat} from "fs";
+import {stat, unlink} from "fs";
 import path from "path";
 import util from "util";
 import which from "which";
@@ -40,6 +40,7 @@ const defaultTimeoutForRevert = 60 * 1000 * 10;
 
 const execFileAsync = util.promisify(execFile);
 const statAsync = util.promisify(stat);
+const unlinkAsync = util.promisify(unlink);
 
 function parseBugId(string)
 {
@@ -567,8 +568,32 @@ Type \`help COMMAND\` for help on my individual commands.`,
         });
     }
 
+    // Remove orphaned *.lock files from a crashed git process; safe because the AsyncTaskQueue guarantees no git process is running here.
+    async clearStaleGitLocks()
+    {
+        const gitDir = path.join(process.env.webkitWorkingDirectory, ".git");
+        const lockPaths = [
+            path.join(gitDir, "index.lock"),
+            path.join(gitDir, "HEAD.lock"),
+            path.join(gitDir, "config.lock"),
+            path.join(gitDir, "packed-refs.lock"),
+            path.join(gitDir, "refs", "heads", "main.lock"),
+        ];
+        for (let lockPath of lockPaths) {
+            try {
+                await unlinkAsync(lockPath);
+                dataLogLn("Removed stale git lock: " + lockPath);
+            } catch (error) {
+                if (error.code !== "ENOENT")
+                    dataLogLn("Warning: could not remove git lock " + lockPath + ": " + error.message);
+            }
+        }
+    }
+
     async cleanUpWorkingCopy()
     {
+        await this.clearStaleGitLocks();
+
         dataLogLn("1. Resetting");
         await this.execInWebKitDirectorySimple("git", ["reset", "--hard"]);
 


### PR DESCRIPTION
#### 2e35f45980c66c3c13083b545aac8949bdad9752
<pre>
[webkitbot] Orphaned .git/index.lock wedges reverts and the periodic pull
<a href="https://bugs.webkit.org/show_bug.cgi?id=320219">https://bugs.webkit.org/show_bug.cgi?id=320219</a>
<a href="https://rdar.apple.com/183157526">rdar://183157526</a>

Reviewed by Ryan Haddad.

git creates .git/index.lock (and sibling *.lock files) while an index-mutating
command runs and removes it on exit. If the git process is killed mid-operation
the lock is orphaned, and every subsequent git command run by
cleanUpWorkingCopy() fails with &quot;Unable to create &apos;.../index.lock&apos;: File exists&quot;
(exit 128) -- wedging the bot so reverts and the periodic pull stop working
until the file is removed by hand.

Clear stale *.lock files at the start of cleanUpWorkingCopy(), before any git
command. This is safe because the AsyncTaskQueue serializes all work and each
git subprocess is awaited, so no bot-spawned git process is running at that
point.

* Tools/WebKitBot/src/WebKitBot.mjs:
(WebKitBot.prototype.clearStaleGitLocks): Added. Remove orphaned git lock files.
(WebKitBot.prototype.cleanUpWorkingCopy): Call clearStaleGitLocks() before resetting.

Canonical link: <a href="https://commits.webkit.org/317899@main">https://commits.webkit.org/317899@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ca4b37ad4c87c4ab6f0204b643bef5a8f4451118

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176687 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50624 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/44416 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186289 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/139567 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/de3df0eb-45a3-44d5-a026-826b55c41295) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178550 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51917 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50310 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/137631 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/139567 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2913f8cb-9135-4e6b-81d8-64f5eb10b793) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179643 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41132 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/158419 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118105 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d7c7b34b-8c15-4f75-b96d-393b1573386e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39787 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/38158 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150199 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/37917 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34757 "Built successfully") | | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/42374 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188713 "Built successfully") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/50291 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/157962 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/146696 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39450 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50974 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/34538 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146501 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41262 "Passed tests") | | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/117310 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49479 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/12896 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48878 "Built successfully") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/49114 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48939 "Failed to checkout and rebase branch from PR 70131") | | | | 
<!--EWS-Status-Bubble-End-->