### PR TITLE
WebVTT cue overlap avoidance algorithm should always move cue shortest possible distance when snap-to-lines is false

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -636,6 +636,7 @@ webkit.org/b/290522 imported/w3c/web-platform-tests/html/canvas/offscreen/manual
 imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video [ ImageOnlyFailure ]
 
 # These are the WebVTT rendering WPT we are already passing.
+imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/2_cues_overlapping_partially_move_down.html [ Pass ]
 imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/2_tracks.html [ Pass ]
 imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/3_tracks.html [ Pass ]
 imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/audio_has_no_subtitles.html [ Pass ]

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/2_cues_overlapping_partially_move_down-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/2_cues_overlapping_partially_move_down-expected.html
@@ -16,16 +16,14 @@ body { margin:0 }
     top: 50%;
     left: 0;
     right: 0;
-    margin-top: -4.5px;
-    text-align: center
+    text-align: center;
 }
 #cue2 {
     position: absolute;
-    top: 50%;
+    top: 55%;
     left: 0;
     right: 0;
-    margin-top: 4.5px;
-    text-align: center
+    text-align: center;
 }
 .cue {
     font-family: Ahem, sans-serif;

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/2_cues_overlapping_partially_move_down-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/2_cues_overlapping_partially_move_down-ref.html
@@ -16,16 +16,14 @@ body { margin:0 }
     top: 50%;
     left: 0;
     right: 0;
-    margin-top: -4.5px;
-    text-align: center
+    text-align: center;
 }
 #cue2 {
     position: absolute;
-    top: 50%;
+    top: 55%;
     left: 0;
     right: 0;
-    margin-top: 4.5px;
-    text-align: center
+    text-align: center;
 }
 .cue {
     font-family: Ahem, sans-serif;

--- a/Source/WebCore/rendering/RenderVTTCue.cpp
+++ b/Source/WebCore/rendering/RenderVTTCue.cpp
@@ -351,45 +351,50 @@ bool RenderVTTCue::findNonOverlappingPosition(float& newX, float& newY) const
     newX = x();
     newY = y();
     FloatRect srcRect = unroundedAbsoluteBoundingBoxRect(*backdropBox);
-    FloatRect destRect = srcRect;
+    bool isHorizontal = m_cue->vertical() == VTTCue::DirectionSetting::Horizontal;
 
-    // Move the box up, looking for a non-overlapping position:
-    while (RenderVTTCue* cue = overlappingObjectForRect(destRect)) {
+    // Move the box up (or, for vertical writing directions, left), looking for a non-overlapping position.
+    FloatRect upRect = srcRect;
+    while (RenderVTTCue* cue = overlappingObjectForRect(upRect)) {
         auto* cueBackdropBox = cue->backdropBox();
         if (!cueBackdropBox)
             continue;
-        if (m_cue->vertical() == VTTCue::DirectionSetting::Horizontal)
-            destRect.setY(unroundedAbsoluteBoundingBoxRect(*cueBackdropBox).y() - destRect.height());
+        if (isHorizontal)
+            upRect.setY(unroundedAbsoluteBoundingBoxRect(*cueBackdropBox).y() - upRect.height());
         else
-            destRect.setX(unroundedAbsoluteBoundingBoxRect(*cueBackdropBox).x() - destRect.width());
+            upRect.setX(unroundedAbsoluteBoundingBoxRect(*cueBackdropBox).x() - upRect.width());
     }
+    bool upRectFits = rectIsWithinContainer(upRect);
 
-    if (rectIsWithinContainer(destRect)) {
-        newX += destRect.x() - srcRect.x();
-        newY += destRect.y() - srcRect.y();
-        return true;
-    }
-
-    destRect = srcRect;
-
-    // Move the box down, looking for a non-overlapping position:
-    while (RenderVTTCue* cue = overlappingObjectForRect(destRect)) {
+    // Move the box down (or, for vertical writing directions, right), looking for a non-overlapping position.
+    FloatRect downRect = srcRect;
+    while (RenderVTTCue* cue = overlappingObjectForRect(downRect)) {
         auto* cueBackdropBox = cue->backdropBox();
         if (!cueBackdropBox)
             continue;
-        if (m_cue->vertical() == VTTCue::DirectionSetting::Horizontal)
-            destRect.setY(unroundedAbsoluteBoundingBoxRect(*cueBackdropBox).maxY());
+        if (isHorizontal)
+            downRect.setY(unroundedAbsoluteBoundingBoxRect(*cueBackdropBox).maxY());
         else
-            destRect.setX(unroundedAbsoluteBoundingBoxRect(*cueBackdropBox).maxX());
+            downRect.setX(unroundedAbsoluteBoundingBoxRect(*cueBackdropBox).maxX());
     }
+    bool downRectFits = rectIsWithinContainer(downRect);
 
-    if (rectIsWithinContainer(destRect)) {
-        newX += destRect.x() - srcRect.x();
-        newY += destRect.y() - srcRect.y();
-        return true;
-    }
+    if (!upRectFits && !downRectFits) // The box does not fit in the container without overlapping other boxes.
+        return false;
 
-    return false;
+    FloatRect finalRect;
+    if (upRectFits && downRectFits) {
+        // Determine which box is closer (if equidistant then use upwardly moved box).
+        auto distance = [isHorizontal](const FloatRect& a, const FloatRect& b) {
+            return isHorizontal ? std::abs(a.y() - b.y()) : std::abs(a.x() - b.x());
+        };
+        finalRect = distance(srcRect, upRect) <= distance(srcRect, downRect) ? upRect : downRect;
+    } else
+        finalRect = upRectFits ? upRect : downRect;
+
+    newX += finalRect.x() - srcRect.x();
+    newY += finalRect.y() - srcRect.y();
+    return true;
 }
 
 void RenderVTTCue::repositionCueSnapToLinesSet()


### PR DESCRIPTION
#### 75881e26cd3acd585ac300d8add22a1fd1c826ef
<pre>
WebVTT cue overlap avoidance algorithm should always move cue shortest possible distance when snap-to-lines is false
<a href="https://bugs.webkit.org/show_bug.cgi?id=320205">https://bugs.webkit.org/show_bug.cgi?id=320205</a>
<a href="https://rdar.apple.com/183151333">rdar://183151333</a>

Reviewed by Eric Carlson.

The WebVTT positioning algorithm (7.2. Processing cue settings, step 10) asks that
when the snap-to-lines flag is false and a cue is overlapped with another, the
renderer moves the cue in the direction (up or down if horizontal, left or right
if vertical) that renders it the shortest distance from its original placement by
the VTT author.

The spec describes a different algorithm when snap-to-lines is true. In this case, the
renderer should first try moving the cue up (or to the left if vertical), and if the
edge of the video is hit before finding a non-overlapping position, then try again in the
opposite direction. Hence, when snap-to-lines is true, the cue is always moved up if there
is open space above regardless if there is a closer spot below.

WebKit&apos;s implementation of the snap-to-line == false path is incorrect because it only tries
moving the cue down if moving it up was unsuccessful. This patch changes it to check both
directions and to move the cue the shortest distance to avoid collision.

Also fixed bug in cues_overlapping_partially_move_down.html and marked it as passing. The test
incorrectly treated default line alignment as &quot;center&quot;, when the spec states it should be &quot;start.&quot;

* LayoutTests/TestExpectations:
* Source/WebCore/rendering/RenderVTTCue.cpp:
(WebCore::RenderVTTCue::findNonOverlappingPosition const):
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/2_cues_overlapping_partially_move_down-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/2_cues_overlapping_partially_move_down-ref.html:

Canonical link: <a href="https://commits.webkit.org/318012@main">https://commits.webkit.org/318012@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4a8dc6558e79cc4326542b581fbb02975674980c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176985 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50922 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44717 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186588 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140221 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/50b23f9b-dfc9-4770-b8f6-d9439f3726c1) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178848 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52215 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50608 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137897 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140221 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179941 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41410 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158688 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118366 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1e2f2cbc-1d47-402e-b77a-eb15ae13eded) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40066 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38431 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150476 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38188 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35056 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42675 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42649 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189011 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50589 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/158228 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146977 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51272 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/34812 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146773 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26852 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41531 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123485 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117773 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49777 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13168 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49176 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49413 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49237 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->