### PR TITLE
[AppKit Gestures] Support directional scroll locking for diagonal scrolls

### DIFF
--- a/Source/WebCore/page/mac/WheelEventDeltaFilterMac.mm
+++ b/Source/WebCore/page/mac/WheelEventDeltaFilterMac.mm
@@ -81,6 +81,16 @@ void WheelEventDeltaFilterMac::updateFromEvent(const PlatformWheelEvent& event)
 
 void WheelEventDeltaFilterMac::updateCurrentVelocityFromEvent(const PlatformWheelEvent& event)
 {
+    if (event.inputSource() == MouseEventInputSource::Automation) {
+        // Automation events are already directionally locked upstream in WKAppKitGestureController; skip
+        // _NSScrollingPredominantAxisFilter (it would flatten intentional diagonals) and pass the delta and
+        // velocity straight through. The caller updateFromEvent() still updates m_lastIOHIDEventTimestamp.
+        m_currentFilteredDelta = event.delta();
+        auto deltaFromLastEvent = std::max(event.ioHIDEventTimestamp() - m_lastIOHIDEventTimestamp, 1_ms);
+        m_currentFilteredVelocity = event.delta() / deltaFromLastEvent.seconds();
+        return;
+    }
+
     // The absolute value of timestamp doesn't matter; the filter looks at deltas from the previous event.
     auto timestamp = event.timestamp() - m_initialMonotonicTime;
 

--- a/Source/WebCore/platform/mac/ScrollingEffectsController.mm
+++ b/Source/WebCore/platform/mac/ScrollingEffectsController.mm
@@ -236,8 +236,12 @@ bool ScrollingEffectsController::handleWheelEvent(const PlatformWheelEvent& whee
     delta += eventDelta;
 
     if (wheelEvent.isGestureEvent()) {
+        // Automation events are already directionally locked upstream in WKAppKitGestureController.
+        auto alreadyDirectionallyLocked = wheelEvent.inputSource() == MouseEventInputSource::Automation;
+
         // FIXME: This axis locking replicates what WheelEventDeltaFilter does. We should apply that to events in all phases, and remove axis locking here (webkit.org/b/231207).
-        delta = deltaAlignedToPredominantGestureAxis(wheelEvent.timestamp(), delta);
+        if (!alreadyDirectionallyLocked)
+            delta = deltaAlignedToPredominantGestureAxis(wheelEvent.timestamp(), delta);
     }
 
     auto momentumPhase = wheelEvent.momentumPhase();

--- a/Source/WebKit/PlatformMac.cmake
+++ b/Source/WebKit/PlatformMac.cmake
@@ -54,6 +54,7 @@ list(APPEND WebKit_SOURCES
     ${WEBKIT_DIR}/UIProcess/API/Cocoa/Logger+Extras.swift
     ${WEBKIT_DIR}/UIProcess/WebPageProxy.swift
     ${WEBKIT_DIR}/UIProcess/mac/WKAppKitGestureController.swift
+    ${WEBKIT_DIR}/UIProcess/mac/WKDirectionalScrollLockTracker.swift
     ${WEBKIT_DIR}/UIProcess/mac/WKFastScrollTracker.swift
     ${WEBKIT_DIR}/UIProcess/mac/WKTextSelectionController.swift
     ${WEBKIT_DIR}/UIProcess/PDF/WKPDFHUDView.swift

--- a/Source/WebKit/UIProcess/mac/WKAppKitGestureController.mm
+++ b/Source/WebKit/UIProcess/mac/WKAppKitGestureController.mm
@@ -234,6 +234,7 @@ static NSString *gestureLogDescription(NSGestureRecognizer *gesture)
 
     std::unique_ptr<WebKit::PositionInformationManager> _positionInformationManager;
     std::unique_ptr<WebKit::WKFastScrollTracker> _fastScrollTracker;
+    std::unique_ptr<WebKit::WKDirectionalScrollLockTracker> _directionalScrollLockTracker;
 }
 
 #if __has_include(<WebKitAdditions/WKAppKitGestureControllerAdditionsImpl.mm>)
@@ -251,6 +252,7 @@ static NSString *gestureLogDescription(NSGestureRecognizer *gesture)
     _viewImpl = viewImpl.get();
     _positionInformationManager = makeUnique<WebKit::PositionInformationManager>(page.get());
     _fastScrollTracker = makeUniqueWithoutFastMallocCheck<WebKit::WKFastScrollTracker>(WebKit::WKFastScrollTracker::init());
+    _directionalScrollLockTracker = makeUniqueWithoutFastMallocCheck<WebKit::WKDirectionalScrollLockTracker>(WebKit::WKDirectionalScrollLockTracker::init());
 
     [self setUpGestureRecognizers];
     [self addGesturesToWebView];
@@ -503,6 +505,7 @@ static NSString *gestureLogDescription(NSGestureRecognizer *gesture)
     if ([gesture state] == NSGestureRecognizerStateBegan) {
         viewImpl->dismissContentRelativeChildWindowsWithAnimation(false);
         _fastScrollTracker->didStartGesture([gesture locationInView:nil]);
+        _directionalScrollLockTracker->didStartGesture();
     }
 
 #if HAVE(NSREFRESHCONTROLLER)
@@ -516,6 +519,8 @@ static NSString *gestureLogDescription(NSGestureRecognizer *gesture)
     case NSGestureRecognizerStateEnded:
     case NSGestureRecognizerStateCancelled:
     case NSGestureRecognizerStateFailed:
+        // After the wheel and momentum events above, so both still see this gesture's locked axis.
+        _directionalScrollLockTracker->didEndGesture();
         [self _resetCaughtDeceleratingScroll];
         break;
     default:
@@ -1373,12 +1378,18 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
         return;
 
     auto timestamp = MonotonicTime::fromRawSeconds([gesture timestamp]);
-    WebCore::IntPoint position { [gesture locationInView:webView.get()] };
+    WebCore::FloatPoint locationInView { [gesture locationInView:webView] };
+    WebCore::IntPoint position { locationInView };
     auto globalPosition { WebCore::globalPoint([gesture locationInView:nil], [webView window]) };
     auto gestureDelta { translationInView(gesture, webView.get()) };
 
     if (std::exchange(_suppressNextPanScrollDelta, false))
         gestureDelta = { };
+
+    auto pinnedState = page->pinnedStateIncludingAncestorsAtPoint(locationInView);
+    bool canScrollHorizontally = [_panGestureRecognizer _canPanHorizontally] && !(pinnedState.left() && pinnedState.right());
+    bool canScrollVertically = [_panGestureRecognizer _canPanVertically] && !(pinnedState.top() && pinnedState.bottom());
+    gestureDelta = WebCore::FloatSize { _directionalScrollLockTracker->update(gestureDelta, canScrollHorizontally, canScrollVertically, [gesture timestamp]) };
 
     auto wheelTicks { gestureDelta.scaled(1. / static_cast<float>(WebCore::Scrollbar::pixelsPerLineStep())) };
     auto granularity = WebKit::WebWheelEvent::Granularity::ScrollByPixelWheelEvent;
@@ -1440,17 +1451,35 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
     if (gesture.state != NSGestureRecognizerStateEnded)
         return;
 
-    auto velocity = velocityInView(gesture, webView.get());
-    auto velocityMagnitude = std::max(std::abs(velocity.width()), std::abs(velocity.height()));
+    auto unfilteredVelocity = velocityInView(gesture, webView.get());
+
+    // Continue the scroll along the same axis the drag was locked to rather than reintroducing
+    // diagonal drift; also keeps _fastScrollTracker's velocity heuristics off-axis-clean.
+    auto velocity = WebCore::FloatSize { _directionalScrollLockTracker->filterVelocity(unfilteredVelocity) };
+
     static constexpr float minimumVelocityForMomentum = 20;
+
+    auto maximumComponentMagnitude = [](WebCore::FloatSize vector) {
+        return std::max(std::abs(vector.width()), std::abs(vector.height()));
+    };
+
+    // Advance the swipe chain for every gesture that was fast enough to be a swipe, judged on the
+    // unfiltered velocity: the user swiped even if the lock just zeroed the axis they swiped along, and
+    // the tracker has to see it to consume its caughtMomentum and advance its endTime. Slower gestures
+    // leave the tracker alone.
+    double fastScrollMultiplier = 1;
+    if (maximumComponentMagnitude(unfilteredVelocity) >= minimumVelocityForMomentum)
+        fastScrollMultiplier = _fastScrollTracker->update([gesture locationInView:nil], velocity, [gesture timestamp]);
+
+    // Suppressing the gesture itself is judged on the filtered velocity, which can only be smaller, so
+    // anything reaching this point has already been through the tracker above.
+    auto velocityMagnitude = maximumComponentMagnitude(velocity);
     if (velocityMagnitude < minimumVelocityForMomentum)
         return;
 
     auto timestamp = MonotonicTime::fromRawSeconds([gesture timestamp]);
     WebCore::IntPoint position { [gesture locationInView:webView.get()] };
     auto globalPosition = WebCore::globalPoint([gesture locationInView:nil], [webView window]);
-
-    auto fastScrollMultiplier = _fastScrollTracker->update([gesture locationInView:nil], velocity, [gesture timestamp]);
 
     WebKit::WebWheelEvent momentumEvent {
         { WebKit::WebEventType::Wheel, { }, timestamp, WTF::UUID::createVersion4() },
@@ -1501,6 +1530,7 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
         return;
 
     _fastScrollTracker->didCatchMomentum();
+    _directionalScrollLockTracker->didCatchMomentum();
     _caughtDeceleratingScroll = true;
     _suppressNextPanScrollDelta = true;
 
@@ -1571,6 +1601,7 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
     _isMomentumActive = false;
     [self _resetCaughtDeceleratingScroll];
     _fastScrollTracker->reset();
+    _directionalScrollLockTracker->reset();
     _isSuppressingSingleClickGestureForTextSelection = false;
     _latestClickID.reset();
     _layerTreeTransactionIdAtLastInteractionStart.reset();

--- a/Source/WebKit/UIProcess/mac/WKDirectionalScrollLockTracker.swift
+++ b/Source/WebKit/UIProcess/mac/WKDirectionalScrollLockTracker.swift
@@ -1,0 +1,153 @@
+// Copyright (C) 2026 Apple Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+
+#if HAVE_APPKIT_GESTURES_SUPPORT
+
+import Foundation
+import WebKit_Internal
+private import Spatial
+
+// A type to track directional scroll lock state. Drags within 20° of an axis lock to it; the ambiguous
+// 20°-70° band stays unlocked so both axes flow (free diagonal).
+//
+// The axis decision stays open for the first `panHysteresis` of each gesture, and re-opens after a
+// >= `pauseInterval` pause, but only a definite axis ever replaces an established lock: a user whose scroll is
+// locked can transition to the other axis, not scroll freely around.
+struct WKDirectionalScrollLockTracker {
+    private var lockedAxis: Axis?
+    private var lastLockedAxis: Axis?
+    private var lastEventTime: TimeInterval = 0
+    private var caughtMomentum = false
+    private var uncommittedTranslation = CGSize.zero // Translation accumulated since the axis decision was last opened.
+
+    init() {
+    }
+
+    // Takes one incremental (per-event) gesture delta and returns it with the locked-out axis zeroed,
+    // or unchanged while unlocked.
+    mutating func update(delta: CGSize, canScrollHorizontally: Bool, canScrollVertically: Bool, time: TimeInterval) -> CGSize {
+        // A long gap between events without mouse up re-opens the axis decision, but deliberately
+        // leaves any existing lock in place until a new definite axis replaces it below.
+        if lastEventTime != 0, time - lastEventTime >= Constants.pauseInterval {
+            uncommittedTranslation = .zero
+        }
+        lastEventTime = time
+
+        // The axis decision is reconsidered on each event until the gesture commits to a direction.
+        if hypot(uncommittedTranslation.width, uncommittedTranslation.height) < Constants.panHysteresis {
+            uncommittedTranslation.width += delta.width
+            uncommittedTranslation.height += delta.height
+
+            // A drag on both axes locks only if its angle is within `lockAngle` of one of them; a drag on
+            // a single axis locks to that axis outright. A zero translation carries no direction.
+            let dx = abs(uncommittedTranslation.width)
+            let dy = abs(uncommittedTranslation.height)
+
+            var newAxis: Axis?
+            if dx != 0, dy != 0 {
+                let dragAngle = Angle2D.atan(dy / dx)
+                if canScrollHorizontally, dragAngle <= Constants.lockAngle {
+                    newAxis = .horizontal
+                } else if canScrollVertically, dragAngle >= (.degrees(90) - Constants.lockAngle) {
+                    newAxis = .vertical
+                }
+                // Otherwise the ambiguous 20°-70° band: stay unlocked so both axes flow.
+            } else if dx != 0, canScrollHorizontally {
+                newAxis = .horizontal
+            } else if dy != 0, canScrollVertically {
+                newAxis = .vertical
+            }
+
+            // Only a definite axis replaces an established lock; the ambiguous band leaves it alone.
+            if let newAxis {
+                lockedAxis = newAxis
+            }
+        }
+
+        return Self.apply(lockedAxis, to: delta)
+    }
+
+    // Applies the current lock to a velocity vector without mutating state, so a locked drag continues
+    // its scroll on the locked axis rather than reintroducing diagonal drift.
+    func filterVelocity(_ velocity: CGSize) -> CGSize {
+        Self.apply(lockedAxis, to: velocity)
+    }
+
+    // A fresh gesture re-decides its axis, seeded from the previous drag's axis if it caught that
+    // drag's momentum, so the user cannot change direction immediately. The decision stays open for
+    // `panHysteresis`, so their actual direction can still supersede the seed.
+    mutating func didStartGesture() {
+        lockedAxis = exchange(&caughtMomentum, with: false) ? lastLockedAxis : nil
+        lastEventTime = 0
+        uncommittedTranslation = .zero
+    }
+
+    // Hands this gesture's final axis to `lastLockedAxis` for the next gesture to potentially catch.
+    mutating func didEndGesture() {
+        lastLockedAxis = lockedAxis
+        lockedAxis = nil
+        // A gesture that failed before it began never consumed the carry-over; drop it so it cannot
+        // seed an unrelated later gesture.
+        caughtMomentum = false
+    }
+
+    mutating func didCatchMomentum() {
+        caughtMomentum = true
+    }
+
+    mutating func reset() {
+        lockedAxis = nil
+        lastLockedAxis = nil
+        caughtMomentum = false
+        lastEventTime = 0
+        uncommittedTranslation = .zero
+    }
+
+    private static func apply(_ axis: Axis?, to vector: CGSize) -> CGSize {
+        switch axis {
+        case .horizontal:
+            CGSize(width: vector.width, height: 0)
+        case .vertical:
+            CGSize(width: 0, height: vector.height)
+        case nil:
+            vector
+        }
+    }
+}
+
+extension WKDirectionalScrollLockTracker {
+    fileprivate enum Axis {
+        case horizontal
+        case vertical
+    }
+}
+
+extension WKDirectionalScrollLockTracker {
+    fileprivate enum Constants {
+        static let lockAngle: Angle2D = .degrees(20)
+        static let pauseInterval: TimeInterval = 0.6
+        static let panHysteresis: CGFloat = 10
+    }
+}
+
+#endif // HAVE_APPKIT_GESTURES_SUPPORT

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -246,6 +246,7 @@
 		07E4BDC72A3A7089000D5509 /* _WKWebViewTextInputNotifications.h in Headers */ = {isa = PBXBuildFile; fileRef = 07E4BDC52A3A7089000D5509 /* _WKWebViewTextInputNotifications.h */; };
 		07E4BDC82A3A7089000D5509 /* _WKWebViewTextInputNotifications.mm in Sources */ = {isa = PBXBuildFile; fileRef = 07E4BDC62A3A7089000D5509 /* _WKWebViewTextInputNotifications.mm */; };
 		07F0337C30107D3900B69551 /* WKFastScrollTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07F0337B30107D3900B69551 /* WKFastScrollTracker.swift */; };
+		07F0337E3B2E1A0044AABBCC /* WKDirectionalScrollLockTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07F0337D3B2E1A0044AABBCC /* WKDirectionalScrollLockTracker.swift */; };
 		07F327F22CB09B74006D9918 /* _WKTextPreview.h in Headers */ = {isa = PBXBuildFile; fileRef = 07F327F02CB085A4006D9918 /* _WKTextPreview.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		07F6B5592D719323009F206D /* _WKRectEdge+Extras.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07F6B5582D719323009F206D /* _WKRectEdge+Extras.swift */; };
 		07FAA74B2CE947AA00128360 /* WebPage+Navigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07FAA74A2CE947AA00128360 /* WebPage+Navigation.swift */; };
@@ -3593,6 +3594,7 @@
 		07EF07592745A8160066EA04 /* DisplayCaptureSessionManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DisplayCaptureSessionManager.h; sourceTree = "<group>"; };
 		07EF24BE2E309EFE004429B6 /* WebKitInternalCxx.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebKitInternalCxx.h; sourceTree = "<group>"; };
 		07F0337B30107D3900B69551 /* WKFastScrollTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WKFastScrollTracker.swift; sourceTree = "<group>"; };
+		07F0337D3B2E1A0044AABBCC /* WKDirectionalScrollLockTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WKDirectionalScrollLockTracker.swift; sourceTree = "<group>"; };
 		07F1A2B52F900F010000DA03 /* WKWebView+RefreshControl.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "WKWebView+RefreshControl.swift"; sourceTree = "<group>"; };
 		07F327F02CB085A4006D9918 /* _WKTextPreview.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = _WKTextPreview.h; sourceTree = "<group>"; };
 		07F327F12CB085A4006D9918 /* _WKTextPreview.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = _WKTextPreview.mm; sourceTree = "<group>"; };
@@ -17058,6 +17060,7 @@
 				336E07462EBCC1C100B4D635 /* WKAppKitGestureController.h */,
 				336E07472EBCC1C100B4D635 /* WKAppKitGestureController.mm */,
 				073B19992FEFB66B00BD5D69 /* WKAppKitGestureController.swift */,
+				07F0337D3B2E1A0044AABBCC /* WKDirectionalScrollLockTracker.swift */,
 				07F0337B30107D3900B69551 /* WKFastScrollTracker.swift */,
 				CDCA85C7132ABA4E00E961DF /* WKFullScreenWindowController.h */,
 				CDCA85C6132ABA4E00E961DF /* WKFullScreenWindowController.mm */,
@@ -22520,6 +22523,7 @@
 				BE6818000000000000000001 /* WKContentWorld.swift in Sources */,
 				075C079A2D92125D00B3E900 /* WKContextMenuElementInfoAdapter.swift in Sources */,
 				079DD3032FAC583900592E03 /* WKDeferringGestureRecognizer.swift in Sources */,
+				07F0337E3B2E1A0044AABBCC /* WKDirectionalScrollLockTracker.swift in Sources */,
 				637281A321ADC744009E0DE6 /* WKDownloadProgress.mm in Sources */,
 				07F0337C30107D3900B69551 /* WKFastScrollTracker.swift in Sources */,
 				5CE9120D2293C219005BEC78 /* WKMain.mm in Sources */,

--- a/Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/BasicAppKitGesturesTests.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/BasicAppKitGesturesTests.swift
@@ -1264,27 +1264,6 @@ extension AppKitGesturesTests.Basic {
         let down = CGPoint(x: center.x, y: center.y - 250)
         let up = CGPoint(x: center.x, y: center.y + 250)
 
-        func settledScrollY() async throws -> Double {
-            var previous = try await page.callJavaScript(JavaScriptMessages.ScrollPosition()).y
-            var stableSamples = 0
-
-            for _ in 0..<60 {
-                try await Task.sleep(for: .milliseconds(100))
-                let current = try await page.callJavaScript(JavaScriptMessages.ScrollPosition()).y
-
-                if abs(current - previous) < 1 {
-                    stableSamples += 1
-                    if stableSamples >= 2 { return current }
-                } else {
-                    stableSamples = 0
-                }
-
-                previous = current
-            }
-
-            return previous
-        }
-
         func finalFlingDistance(flicks count: Int, reverseLast: Bool = false) async throws -> Double {
             try await page.load(html: html).wait()
             await page.waitForNextPresentationUpdate()
@@ -1300,8 +1279,8 @@ extension AppKitGesturesTests.Basic {
             }
 
             let flingStart = try await page.callJavaScript(JavaScriptMessages.ScrollPosition()).y
-            let settled = try await settledScrollY()
-            return Swift.abs(settled - flingStart)
+            let settled = try await settledScrollPosition()
+            return abs(settled.y - flingStart)
         }
 
         let single = try await finalFlingDistance(flicks: 1) // count 1 -> multiplier 1
@@ -1312,6 +1291,137 @@ extension AppKitGesturesTests.Basic {
         #expect(accelerated > single * 2)
         // Reversing the final swipe resets the chain, so that fling is not accelerated.
         #expect(accelerated > reversed * 2)
+    }
+
+    @Test
+    func diagonalScrollMovesBothAxes() async throws {
+        try await loadScrollableGrid()
+        await page.waitForNextPresentationUpdate()
+
+        try await page.callJavaScript { "window.scrollTo(2000, 8000);" }
+        await page.waitForNextPresentationUpdate()
+        let start = try await page.callJavaScript(JavaScriptMessages.ScrollPosition())
+
+        let center = screenBounds(ofPointInWindowCoordinates: window.frame.center)
+        await recap.play { composer in
+            // ~45°: neither axis is locked out.
+            composer._wk_scroll(
+                withStart: center,
+                end: CGPoint(x: center.x - 250, y: center.y - 250),
+                duration: .seconds(0.3)
+            )
+        }
+        await page.waitForNextPresentationUpdate()
+
+        let end = try await settledScrollPosition()
+
+        #expect(end.x - start.x > 20)
+        #expect(end.y - start.y > 20)
+    }
+
+    @Test
+    func shallowScrollLocksToHorizontalAxis() async throws {
+        try await loadScrollableGrid()
+        await page.waitForNextPresentationUpdate()
+
+        try await page.callJavaScript { "window.scrollTo(2000, 8000);" }
+        await page.waitForNextPresentationUpdate()
+        let start = try await page.callJavaScript(JavaScriptMessages.ScrollPosition())
+
+        let center = screenBounds(ofPointInWindowCoordinates: window.frame.center)
+        await recap.play { composer in
+            // ~7°: the vertical component is suppressed.
+            composer._wk_scroll(
+                withStart: center,
+                end: CGPoint(x: center.x - 250, y: center.y - 30),
+                duration: .seconds(0.3)
+            )
+        }
+        await page.waitForNextPresentationUpdate()
+
+        let end = try await settledScrollPosition()
+
+        #expect(end.x - start.x > 20)
+        #expect(abs(end.y - start.y) < 1)
+    }
+
+    @Test
+    func steepScrollLocksToVerticalAxis() async throws {
+        try await loadScrollableGrid()
+        await page.waitForNextPresentationUpdate()
+
+        try await page.callJavaScript { "window.scrollTo(2000, 8000);" }
+        await page.waitForNextPresentationUpdate()
+        let start = try await page.callJavaScript(JavaScriptMessages.ScrollPosition())
+
+        let center = screenBounds(ofPointInWindowCoordinates: window.frame.center)
+        await recap.play { composer in
+            // ~7° from vertical: the horizontal component is suppressed.
+            composer._wk_scroll(
+                withStart: center,
+                end: CGPoint(x: center.x - 30, y: center.y - 250),
+                duration: .seconds(0.3)
+            )
+        }
+        await page.waitForNextPresentationUpdate()
+
+        let end = try await settledScrollPosition()
+
+        #expect(end.y - start.y > 20)
+        #expect(abs(end.x - start.x) < 1)
+    }
+
+    @Test
+    func scrollCatchingMomentumCanChangeAxis() async throws {
+        try await loadScrollableGrid()
+        await page.waitForNextPresentationUpdate()
+
+        try await page.callJavaScript { "window.scrollTo(2000, 8000);" }
+        await page.waitForNextPresentationUpdate()
+
+        let center = screenBounds(ofPointInWindowCoordinates: window.frame.center)
+
+        await recap.play { composer in
+            composer._wk_scroll(withStart: center, end: CGPoint(x: center.x - 250, y: center.y), duration: .seconds(0.08))
+        }
+        await page.waitForNextPresentationUpdate()
+
+        let after = try await page.callJavaScript(JavaScriptMessages.ScrollPosition())
+
+        await recap.play { composer in
+            composer._wk_scroll(withStart: center, end: CGPoint(x: center.x, y: center.y - 250), duration: .seconds(0.3))
+        }
+        await page.waitForNextPresentationUpdate()
+
+        let end = try await settledScrollPosition()
+        #expect(end.y - after.y > 20)
+    }
+
+    @Test
+    func shallowScrollOnVerticalOnlyPageStillScrollsVertically() async throws {
+        try await loadScrollableText()
+        await page.waitForNextPresentationUpdate()
+
+        try await page.callJavaScript { "window.scrollTo(0, 1000);" }
+        await page.waitForNextPresentationUpdate()
+        let start = try await page.callJavaScript(JavaScriptMessages.ScrollPosition())
+
+        let center = screenBounds(ofPointInWindowCoordinates: window.frame.center)
+        await recap.play { composer in
+            // ~18°: shallow enough to be inside the horizontal lock band, but the page can't scroll
+            // horizontally, so that branch is skipped. The drag is not steep enough for the vertical
+            // branch either, so no lock is taken at all and both components flow — which is what lets
+            // the vertical one scroll here.
+            composer._wk_scroll(
+                withStart: center,
+                end: CGPoint(x: center.x - 250, y: center.y - 80),
+                duration: .seconds(0.3)
+            )
+        }
+        await page.waitForNextPresentationUpdate()
+
+        let end = try await settledScrollPosition()
+        #expect(end.y - start.y > 20)
     }
 }
 
@@ -1384,6 +1494,43 @@ extension AppKitGesturesTests.Basic {
             <div id="text" style="font-size: 60px; margin: 0;">\(lines)</div>
             """
         try await page.load(html: html).wait()
+    }
+
+    private func loadScrollableGrid() async throws {
+        let html = """
+            <body style="margin: 0; width: 5000px; height: 20000px;
+                         background: repeating-linear-gradient(45deg, blue 0 50px, white 50px 100px);">
+            </body>
+            """
+        try await page.load(html: html).wait()
+    }
+
+    private func settledScrollPosition() async throws -> CGPoint {
+        func read() async throws -> CGPoint {
+            try await CGPoint(page.callJavaScript(JavaScriptMessages.ScrollPosition()))
+        }
+
+        var previous = try await read()
+        var stableSamples = 0
+
+        for _ in 0..<60 {
+            try await Task.sleep(for: .milliseconds(100))
+            let current = try await read()
+
+            if abs(current.x - previous.x) < 1, abs(current.y - previous.y) < 1 {
+                stableSamples += 1
+                if stableSamples >= 2 {
+                    return current
+                }
+            } else {
+                stableSamples = 0
+            }
+
+            previous = current
+        }
+
+        Issue.record("scroll position never settled; last sample was \(previous)")
+        return previous
     }
 }
 


### PR DESCRIPTION
#### 0bde437173a5e888be34b3f95515b307fdee9a09
<pre>
[AppKit Gestures] Support directional scroll locking for diagonal scrolls
<a href="https://bugs.webkit.org/show_bug.cgi?id=320222">https://bugs.webkit.org/show_bug.cgi?id=320222</a>
<a href="https://rdar.apple.com/181047541">rdar://181047541</a>

Reviewed by Abrar Rahman Protyasha.

Add a custom directional scroll locking algorithm instead of the existing predominant
axis filter, which has no tolerance band.

A future PR will refactor and unify this logic along with the fast scroll tracker with WKPanGestureRecognizer.

Test: Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/BasicAppKitGesturesTests.swift

* Source/WebCore/page/mac/WheelEventDeltaFilterMac.mm:
(WebCore::WheelEventDeltaFilterMac::updateCurrentVelocityFromEvent):
* Source/WebCore/platform/mac/ScrollingEffectsController.mm:
(WebCore::ScrollingEffectsController::handleWheelEvent):

Opt-out of the existing mechanism when needed, since WKDirectionalScrollLockTracker now takes care of it.

* Source/WebKit/PlatformMac.cmake:
* Source/WebKit/UIProcess/mac/WKAppKitGestureController.mm:
(-[WKAppKitGestureController initWithPage:viewImpl:]):
(-[WKAppKitGestureController panGestureRecognized:]):
(-[WKAppKitGestureController sendWheelEventForGesture:]):
(-[WKAppKitGestureController startMomentumIfNeededForGesture:]):
(-[WKAppKitGestureController interruptMomentumIfNeeded]):
(-[WKAppKitGestureController reset]):

Set-up the tracker within WKAppKitGestureController like the existing fast scroll tracker.

* Source/WebKit/UIProcess/mac/WKDirectionalScrollLockTracker.swift: Added.
(WKDirectionalScrollLockTracker.lockedAxis):
(WKDirectionalScrollLockTracker.lastLockedAxis):
(WKDirectionalScrollLockTracker.lastEventTime):
(WKDirectionalScrollLockTracker.uncommittedTranslation):
(WKDirectionalScrollLockTracker.update(delta:canScrollHorizontally:canScrollVertically:time:)):
(WKDirectionalScrollLockTracker.filterVelocity(_:)):
(WKDirectionalScrollLockTracker.didStartGesture):
(WKDirectionalScrollLockTracker.didEndGesture):
(WKDirectionalScrollLockTracker.didCatchMomentum):
(WKDirectionalScrollLockTracker.reset):
(WKDirectionalScrollLockTracker.apply(_:to:)):
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:

Add another scroll tracker whose state mainly keeps track of the current locked axis. Generally,
this works by deciding which axis to lock to depending on the accumulated gesture translation within
a specific tolerance band.

* Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/BasicAppKitGesturesTests.swift:

Canonical link: <a href="https://commits.webkit.org/318029@main">https://commits.webkit.org/318029@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fd058ffc53e4ea8b06259b81bb32af49d1d5b903

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177100 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51037 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/44832 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186703 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140336 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2ef96b23-fd1f-48e9-ada6-44dfe893ecf5) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178963 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52330 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50723 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/137989 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140336 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/30a6a6f9-1d75-4738-99b7-50000ed49e8b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180056 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/41501 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/44832 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/118457 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/365a7755-e2e5-4fd5-a2e5-e9a41c7e02b9) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/40157 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/38523 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/44832 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/150567 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/44832 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35171 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/42812 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/42741 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189129 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50704 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/44832 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/147075 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39523 "Built successfully and passed tests") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/51387 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/44832 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/146867 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/51387 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/123601 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117888 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49892 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/44832 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/49291 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/49528 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49352 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->