### PR TITLE
Populate replacement data for MockParentalControlsURLFilter

### DIFF
--- a/Source/WebCore/testing/MockParentalControlsURLFilter.h
+++ b/Source/WebCore/testing/MockParentalControlsURLFilter.h
@@ -38,17 +38,18 @@ class MockParentalControlsURLFilter final : public ParentalControlsURLFilter {
 public:
     // FIXME: This class should compile with WebCoreTestSupport, and then these export macros
     // should be WEBCORE_TESTSUPPORT_EXPORT.
-    WEBCORE_EXPORT static Ref<MockParentalControlsURLFilter> create(Vector<URL>&& blockedURLs);
+    WEBCORE_EXPORT static Ref<MockParentalControlsURLFilter> create(Vector<URL>&& blockedURLs, std::span<const uint8_t> replacementData);
     WEBCORE_EXPORT ~MockParentalControlsURLFilter();
 
 private:
-    explicit MockParentalControlsURLFilter(Vector<URL>&& blockedURLs);
+    MockParentalControlsURLFilter(Vector<URL>&& blockedURLs, std::span<const uint8_t> replacementData);
 
     bool isEnabledImpl() const final;
     void isURLAllowedImpl(IsMainFrameLoad, const URL& mainDocumentURL, const URL&, CompletionHandler<void(bool, NSData *)>&&) final;
     void allowURL(const URL&, CompletionHandler<void(bool)>&&) final;
 
     HashSet<URL> m_blockedURLs;
+    RetainPtr<NSData> m_replacementData;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/testing/MockParentalControlsURLFilter.mm
+++ b/Source/WebCore/testing/MockParentalControlsURLFilter.mm
@@ -32,15 +32,17 @@
 #import <wtf/MainThread.h>
 #import <wtf/URL.h>
 #import <wtf/WorkQueue.h>
+#import <wtf/cocoa/SpanCocoa.h>
 
 namespace WebCore {
 
-Ref<MockParentalControlsURLFilter> MockParentalControlsURLFilter::create(Vector<URL>&& blockedURLs)
+Ref<MockParentalControlsURLFilter> MockParentalControlsURLFilter::create(Vector<URL>&& blockedURLs, std::span<const uint8_t> replacementData)
 {
-    return adoptRef(*new MockParentalControlsURLFilter(WTF::move(blockedURLs)));
+    return adoptRef(*new MockParentalControlsURLFilter(WTF::move(blockedURLs), replacementData));
 }
 
-MockParentalControlsURLFilter::MockParentalControlsURLFilter(Vector<URL>&& blockedURLs)
+MockParentalControlsURLFilter::MockParentalControlsURLFilter(Vector<URL>&& blockedURLs, std::span<const uint8_t> replacementData)
+    : m_replacementData(WTF::toNSData(replacementData))
 {
     for (auto& url : blockedURLs)
         m_blockedURLs.add(WTF::move(url));
@@ -59,8 +61,9 @@ void MockParentalControlsURLFilter::isURLAllowedImpl(IsMainFrameLoad, const URL&
 
     bool isBlocked = m_blockedURLs.contains(url) || (!mainDocumentURL.isEmpty() && m_blockedURLs.contains(mainDocumentURL));
 
-    workQueueSingleton().dispatch([completionHandler = WTF::move(completionHandler), isAllowed = !isBlocked]() mutable {
-        completionHandler(isAllowed, nullptr);
+    // If no replacement data is populated, the shield is null & renders as blank.
+    workQueueSingleton().dispatch([completionHandler = WTF::move(completionHandler), replacementData = m_replacementData, isAllowed = !isBlocked]() mutable {
+        completionHandler(isAllowed, replacementData.get());
     });
 }
 

--- a/Source/WebKit/NetworkProcess/NetworkProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.cpp
@@ -3574,9 +3574,9 @@ void NetworkProcess::allowEvaluatedURL(const WebCore::ParentalControlsURLFilterP
 #endif
 }
 
-void NetworkProcess::installMockParentalControlsURLFilterForTesting(Vector<URL>&& blockedURLs, CompletionHandler<void()>&& completionHandler)
+void NetworkProcess::installMockParentalControlsURLFilterForTesting(Vector<URL>&& blockedURLs, std::span<const uint8_t> replacementData, CompletionHandler<void()>&& completionHandler)
 {
-    Ref mock = WebCore::MockParentalControlsURLFilter::create(WTF::move(blockedURLs));
+    Ref mock = WebCore::MockParentalControlsURLFilter::create(WTF::move(blockedURLs), replacementData);
     WebCore::ParentalControlsURLFilter::setFilterForTesting(WTF::move(mock));
     completionHandler();
 }

--- a/Source/WebKit/NetworkProcess/NetworkProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.h
@@ -498,7 +498,7 @@ public:
 
 #if HAVE(WEBCONTENTRESTRICTIONS)
     void allowEvaluatedURL(const WebCore::ParentalControlsURLFilterParameters&, CompletionHandler<void(bool)>&&);
-    void installMockParentalControlsURLFilterForTesting(Vector<URL>&& blockedURLs, CompletionHandler<void()>&&);
+    void installMockParentalControlsURLFilterForTesting(Vector<URL>&& blockedURLs, std::span<const uint8_t> replacementData, CompletionHandler<void()>&&);
 #endif
 
 #if HAVE(ENHANCED_SECURITY_LINKS)

--- a/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
@@ -303,7 +303,7 @@ messages -> NetworkProcess : AuxiliaryProcess WantsAsyncDispatchMessage {
 
 #if HAVE(WEBCONTENTRESTRICTIONS)
     AllowEvaluatedURL(struct WebCore::ParentalControlsURLFilterParameters parameters) -> (bool allowed)
-    InstallMockParentalControlsURLFilterForTesting(Vector<URL> blockedURLs) -> ()
+    InstallMockParentalControlsURLFilterForTesting(Vector<URL> blockedURLs, std::span<const uint8_t> replacementData) -> ()
 #endif
 
 #if HAVE(ENHANCED_SECURITY_LINKS)

--- a/Source/WebKit/Scripts/webkit/opaque_ipc_types.tracking.in
+++ b/Source/WebKit/Scripts/webkit/opaque_ipc_types.tracking.in
@@ -196,6 +196,7 @@
     [NotSentFromWebContent] MessageParam RTCDataChannelRemoteManager.ReceiveData data
     [NotSentFromWebContent] MessageParam RTCDataChannelRemoteManager.SendData text
     [NotSentFromWebContent] MessageParam NetworkProcessProxy.DataTaskDidReceiveData data
+    [NotSentFromWebContent] MessageParam NetworkProcess.InstallMockParentalControlsURLFilterForTesting replacementData
     [NotSentFromWebContent] MessageParam NetworkProcess.PublishDownloadProgress activityAccessToken
     [NotSentFromWebContent] MessageParam NetworkProcess.PublishDownloadProgress bookmarkData
     [NotSentFromWebContent] MessageParam NetworkProcess.ResumeDownload activityAccessToken

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
@@ -1600,10 +1600,15 @@ struct WKWebsiteData {
 
 - (void)_installMockParentalControlsURLFilterForTestingWithBlockedURLs:(NSArray<NSURL *> *)blockedURLs completionHandler:(void(^)(void))completionHandler
 {
+    [self _installMockParentalControlsURLFilterForTestingWithBlockedURLs:blockedURLs replacementData:nil completionHandler:completionHandler];
+}
+
+- (void)_installMockParentalControlsURLFilterForTestingWithBlockedURLs:(NSArray<NSURL *> *)blockedURLs replacementData:(NSData *)replacementData completionHandler:(void(^)(void))completionHandler
+{
 #if HAVE(WEBCONTENTRESTRICTIONS)
     auto urls = makeVector<URL>(blockedURLs);
 
-    protect(*_websiteDataStore)->installMockParentalControlsURLFilterForTesting(WTF::move(urls), [completionHandler = makeBlockPtr(completionHandler)] {
+    protect(*_websiteDataStore)->installMockParentalControlsURLFilterForTesting(WTF::move(urls), span(replacementData), [completionHandler = makeBlockPtr(completionHandler)] {
         completionHandler();
     });
 #else

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStorePrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStorePrivate.h
@@ -165,6 +165,7 @@ typedef NS_ENUM(uint8_t, _WKRestrictedOpenerType) {
 - (void)_isStorageSuspendedForTesting:(WK_SWIFT_UI_ACTOR void(^)(BOOL))completionHandler WK_API_AVAILABLE(macos(26.4), ios(26.4), visionos(26.4));
 
 - (void)_installMockParentalControlsURLFilterForTestingWithBlockedURLs:(NSArray<NSURL *> *)blockedURLs completionHandler:(void(^)(void))completionHandler WK_API_AVAILABLE(macos(27.0), ios(27.0));
+- (void)_installMockParentalControlsURLFilterForTestingWithBlockedURLs:(NSArray<NSURL *> *)blockedURLs replacementData:(NSData * _Nullable)replacementData completionHandler:(void(^)(void))completionHandler WK_API_AVAILABLE(macos(27.0), ios(27.0));
 
 @end
 

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
@@ -2141,9 +2141,9 @@ void NetworkProcessProxy::allowEvaluatedURL(const WebCore::ParentalControlsURLFi
     sendWithAsyncReply(Messages::NetworkProcess::AllowEvaluatedURL(parameters), WTF::move(completionHandler));
 }
 
-void NetworkProcessProxy::installMockParentalControlsURLFilterForTesting(Vector<URL>&& blockedURLs, CompletionHandler<void()>&& completionHandler)
+void NetworkProcessProxy::installMockParentalControlsURLFilterForTesting(Vector<URL>&& blockedURLs, std::span<const uint8_t> replacementData, CompletionHandler<void()>&& completionHandler)
 {
-    sendWithAsyncReply(Messages::NetworkProcess::InstallMockParentalControlsURLFilterForTesting(WTF::move(blockedURLs)), WTF::move(completionHandler));
+    sendWithAsyncReply(Messages::NetworkProcess::InstallMockParentalControlsURLFilterForTesting { WTF::move(blockedURLs), replacementData }, WTF::move(completionHandler));
 }
 #endif
 

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
@@ -364,7 +364,7 @@ public:
 
 #if HAVE(WEBCONTENTRESTRICTIONS)
     void allowEvaluatedURL(const WebCore::ParentalControlsURLFilterParameters&, CompletionHandler<void(bool)>&&);
-    void installMockParentalControlsURLFilterForTesting(Vector<URL>&& blockedURLs, CompletionHandler<void()>&&);
+    void installMockParentalControlsURLFilterForTesting(Vector<URL>&& blockedURLs, std::span<const uint8_t> replacementData, CompletionHandler<void()>&&);
 #endif
 
     void flushNetworkProcessIPC(CompletionHandler<void()>&&);

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
@@ -2980,9 +2980,9 @@ void WebsiteDataStore::isStorageSuspendedForTesting(CompletionHandler<void(bool)
 }
 
 #if HAVE(WEBCONTENTRESTRICTIONS)
-void WebsiteDataStore::installMockParentalControlsURLFilterForTesting(Vector<URL>&& blockedURLs, CompletionHandler<void()>&& completionHandler)
+void WebsiteDataStore::installMockParentalControlsURLFilterForTesting(Vector<URL>&& blockedURLs, std::span<const uint8_t> replacementData, CompletionHandler<void()>&& completionHandler)
 {
-    protect(networkProcess())->installMockParentalControlsURLFilterForTesting(WTF::move(blockedURLs), WTF::move(completionHandler));
+    protect(networkProcess())->installMockParentalControlsURLFilterForTesting(WTF::move(blockedURLs), replacementData, WTF::move(completionHandler));
 }
 #endif
 

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
@@ -529,7 +529,7 @@ public:
     void isStorageSuspendedForTesting(CompletionHandler<void(bool)>&&) const;
 
 #if HAVE(WEBCONTENTRESTRICTIONS)
-    void installMockParentalControlsURLFilterForTesting(Vector<URL>&& blockedURLs, CompletionHandler<void()>&&);
+    void installMockParentalControlsURLFilterForTesting(Vector<URL>&& blockedURLs, std::span<const uint8_t> replacementData, CompletionHandler<void()>&&);
 #endif
 
     void trackEnhancedSecurityForDomain(WebCore::RegistrableDomain&&, EnhancedSecurity);

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ParentalControlsContentFilteringTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ParentalControlsContentFilteringTests.mm
@@ -39,10 +39,14 @@ using namespace TestWebKitAPI;
 
 TEST(ParentalControlsContentFilteringTests, BlockedURL)
 {
+    NSData *shieldHTML = [@"<script>"
+    "window.webkit.messageHandlers.testHandler.postMessage('SHIELD_IFRAME_READY', '*');"
+    "</script>" dataUsingEncoding:NSUTF8StringEncoding];
+
     RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
     auto blockedURL = [NSURL URLWithString:@"https://example.com"];
     __block bool mockInstalled = false;
-    [[webView configuration].websiteDataStore _installMockParentalControlsURLFilterForTestingWithBlockedURLs:@[blockedURL] completionHandler:^{
+    [[webView configuration].websiteDataStore _installMockParentalControlsURLFilterForTestingWithBlockedURLs:@[blockedURL] replacementData:shieldHTML completionHandler:^{
         mockInstalled = true;
     }];
     Util::run(&mockInstalled);
@@ -57,9 +61,16 @@ TEST(ParentalControlsContentFilteringTests, BlockedURL)
     }];
     [webView setNavigationDelegate:navigationDelegate.get()];
 
+    __block bool iframeShieldDidLoad = false;
+    [webView performAfterReceivingAnyMessage:^(NSString *message) {
+        if ([message isEqualToString:@"SHIELD_IFRAME_READY"])
+            iframeShieldDidLoad = true;
+    }];
+
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com"]]];
 
     Util::run(&didFail);
+    Util::run(&iframeShieldDidLoad);
 }
 
 


### PR DESCRIPTION
#### 3210023b22e24d67e19c08be04b26c1dec7c4c2d
<pre>
Populate replacement data for MockParentalControlsURLFilter
<a href="https://bugs.webkit.org/show_bug.cgi?id=320217">https://bugs.webkit.org/show_bug.cgi?id=320217</a>
<a href="https://rdar.apple.com/183160090">rdar://183160090</a>

Reviewed by Chris Dumez and Alex Christensen.

MockParentalControlsURLFilter currently returns no substitute data if a URL is blocked.
It may be useful to populate this for testing.

No new tests needed.

* Source/WebCore/testing/MockParentalControlsURLFilter.h:
* Source/WebCore/testing/MockParentalControlsURLFilter.mm:
(WebCore::MockParentalControlsURLFilter::create):
(WebCore::MockParentalControlsURLFilter::MockParentalControlsURLFilter):
(WebCore::MockParentalControlsURLFilter::isURLAllowedImpl):
* Source/WebKit/NetworkProcess/NetworkProcess.cpp:
(WebKit::NetworkProcess::installMockParentalControlsURLFilterForTesting):
* Source/WebKit/NetworkProcess/NetworkProcess.h:
* Source/WebKit/NetworkProcess/NetworkProcess.messages.in:
* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm:
(-[WKWebsiteDataStore _installMockParentalControlsURLFilterForTestingWithBlockedURLs:completionHandler:]):
(-[WKWebsiteDataStore _installMockParentalControlsURLFilterForTestingWithBlockedURLs:replacementData:completionHandler:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStorePrivate.h:
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp:
(WebKit::NetworkProcessProxy::installMockParentalControlsURLFilterForTesting):
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.h:
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp:
(WebKit::WebsiteDataStore::installMockParentalControlsURLFilterForTesting):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h:

Canonical link: <a href="https://commits.webkit.org/318039@main">https://commits.webkit.org/318039@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f8d2a31019afb382b2cc36d8ed44ea5c1eebeff2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177129 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51066 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44861 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186732 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140365 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178992 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52359 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50752 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138009 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140365 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/54fc2123-6524-4f68-8760-33f0cfdb0f08) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180085 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41518 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/158772 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118476 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/217cb5c5-d246-41d5-a85e-dc4922fbbca8) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/176452 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40174 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38546 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150584 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38271 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35200 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/42843 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/42764 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189158 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50733 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147096 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51416 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/34895 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146889 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26866 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41622 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123630 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117917 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49921 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13251 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49320 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49557 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49381 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->