### PR TITLE
createContextualFragment() leaves nested <head>/<body> behind when stripping a stray <html> element

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/domparsing/createContextualFragment-xhtml-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/domparsing/createContextualFragment-xhtml-expected.txt
@@ -1,0 +1,6 @@
+
+PASS A <body> element must be stripped, preserving its children
+PASS The <head> and <body> nested inside a stray <html> element must be stripped too
+PASS Stripping must recurse through nested <html> elements
+PASS <html>, <head> and <body> in a different namespace must not be special
+

--- a/LayoutTests/imported/w3c/web-platform-tests/domparsing/createContextualFragment-xhtml.xhtml
+++ b/LayoutTests/imported/w3c/web-platform-tests/domparsing/createContextualFragment-xhtml.xhtml
@@ -1,0 +1,64 @@
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+  <title>createContextualFragment() in XML documents</title>
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<div id="log"></div>
+<script><![CDATA[
+// Unlike the HTML fragment parser, the XML fragment parser happily returns
+// html, head and body elements, so createContextualFragment() has to pop them
+// off the returned fragment while preserving their children.
+
+const HTML_NS = "http://www.w3.org/1999/xhtml";
+
+function contextualFragment(markup) {
+  const range = document.createRange();
+  range.setStart(document.documentElement, 0);
+  return range.createContextualFragment(markup);
+}
+
+test(function() {
+  const fragment = contextualFragment("<body xmlns='" + HTML_NS + "'><p>Hello world</p></body>");
+
+  assert_equals(fragment.childNodes.length, 1);
+  assert_equals(fragment.firstChild.localName, "p");
+  assert_equals(fragment.firstChild.textContent, "Hello world");
+}, "A <body> element must be stripped, preserving its children");
+
+test(function() {
+  const fragment = contextualFragment("<html xmlns='" + HTML_NS + "'><head><title>hi</title></head><body><div id='inner'>content</div></body></html>");
+
+  assert_equals(fragment.querySelector("html"), null, "<html> must be stripped");
+  assert_equals(fragment.querySelector("head"), null, "the nested <head> must be stripped");
+  assert_equals(fragment.querySelector("body"), null, "the nested <body> must be stripped");
+
+  assert_equals(fragment.childNodes.length, 2);
+  assert_equals(fragment.firstChild.localName, "title");
+  assert_equals(fragment.firstChild.textContent, "hi");
+  assert_equals(fragment.lastChild.localName, "div");
+  assert_equals(fragment.lastChild.textContent, "content");
+}, "The <head> and <body> nested inside a stray <html> element must be stripped too");
+
+test(function() {
+  const fragment = contextualFragment("<html xmlns='" + HTML_NS + "'><html><body><p>Hello world</p></body></html></html>");
+
+  assert_equals(fragment.childNodes.length, 1);
+  assert_equals(fragment.firstChild.localName, "p");
+  assert_equals(fragment.firstChild.textContent, "Hello world");
+}, "Stripping must recurse through nested <html> elements");
+
+test(function() {
+  const fragment = contextualFragment("<html xmlns='http://fake-namespace'><head><title>hi</title></head></html>");
+
+  assert_equals(fragment.childNodes.length, 1);
+  const html = fragment.firstChild;
+  assert_equals(html.localName, "html");
+  assert_equals(html.namespaceURI, "http://fake-namespace");
+  assert_equals(html.childNodes.length, 1);
+  assert_equals(html.firstChild.localName, "head");
+}, "<html>, <head> and <body> in a different namespace must not be special");
+]]></script>
+</body>
+</html>

--- a/Source/WebCore/editing/markup.cpp
+++ b/Source/WebCore/editing/markup.cpp
@@ -1695,7 +1695,7 @@ static Vector<Ref<HTMLElement>> collectElementsToRemoveFromFragment(ContainerNod
     for (Ref element : childrenOfType<HTMLElement>(container)) {
         if (is<HTMLHtmlElement>(element)) {
             toRemove.append(element);
-            collectElementsToRemoveFromFragment(WTF::move(element));
+            toRemove.appendVector(collectElementsToRemoveFromFragment(element));
             continue;
         }
         if (isAnyOf<HTMLHeadElement, HTMLBodyElement>(element))


### PR DESCRIPTION
#### a2af12e3970773ee05a85ed0ffa09939df2510b7
<pre>
createContextualFragment() leaves nested &lt;head&gt;/&lt;body&gt; behind when stripping a stray &lt;html&gt; element
<a href="https://bugs.webkit.org/show_bug.cgi?id=320228">https://bugs.webkit.org/show_bug.cgi?id=320228</a>
<a href="https://rdar.apple.com/183163523">rdar://183163523</a>

Reviewed by Chris Dumez.

This patch aligns WebKit with Blink / Chromium.

collectElementsToRemoveFromFragment() recurses into a stray &lt;html&gt;
element to find any nested &lt;head&gt;/&lt;body&gt; elements that also need to
be stripped, but discarded the recursive call&apos;s return value, so
those nested elements were never added to the removal list and
survived fragment sanitization.

Fold the recursive result into the outer list instead of discarding it.

Test: imported/w3c/web-platform-tests/domparsing/createContextualFragment-xhtml.xhtml

* LayoutTests/imported/w3c/web-platform-tests/domparsing/createContextualFragment-xhtml-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/domparsing/createContextualFragment-xhtml.xhtml: Added.
* Source/WebCore/editing/markup.cpp:
(WebCore::collectElementsToRemoveFromFragment):

Canonical link: <a href="https://commits.webkit.org/317962@main">https://commits.webkit.org/317962@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d025a44d5270dca675ac064082d28744b4d2a461

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176875 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50812 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44604 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186478 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140111 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/046d5e68-134b-47d4-97c6-35fd3fe10e5e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178738 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52105 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50498 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137794 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140111 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f45d455c-4833-4d29-a274-b0df4e23d27e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179831 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41304 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158583 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118268 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ebe7c62d-4b83-419e-9152-e9481afe911b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39958 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38326 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150370 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38082 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34945 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42557 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42541 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188901 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50479 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146868 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39486 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51162 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34706 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146669 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41433 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123370 "Build is in progress. Recent messages:OS: Tahoe (26.3.1), Xcode: 26.2; Checked out pull request; Found 27340 issues") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117601 "Build is in progress. Recent messages:Printed configuration; Checked out pull request; Compiled WebKit") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49667 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13063 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49066 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49302 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49127 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->