### PR TITLE
[GFC] Remove orphaned constraints from inline-axis grid item sizing functions

### DIFF
--- a/Source/WebCore/layout/formattingContexts/grid/GridItemSizingFunctions.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/GridItemSizingFunctions.cpp
@@ -33,17 +33,17 @@ namespace Layout {
 
 GridItemSizingFunctions GridItemSizingFunctions::inlineAxis(const IntegrationUtils& integrationUtils)
 {
-    // FIXME: blockAxisConstraint is unused by the inline-axis contribution functions; remove the stale parameter in a follow-up.
+    // The opposite-axis constraint is part of the shared callback signature (blockAxis() uses it), but
+    // inline-axis intrinsic sizes don't depend on it while grid items with a preferred aspect ratio are unsupported.
     return {
-        [&integrationUtils](const PlacedGridItem& gridItem, LayoutUnit blockAxisConstraint) {
-            return GridLayoutUtils::inlineAxisMinContentContribution(gridItem, blockAxisConstraint, integrationUtils);
+        [&integrationUtils](const PlacedGridItem& gridItem, LayoutUnit) {
+            return GridLayoutUtils::inlineAxisMinContentContribution(gridItem, integrationUtils);
         },
-        [&integrationUtils](const PlacedGridItem& gridItem, LayoutUnit blockAxisConstraint) {
-            return GridLayoutUtils::inlineAxisMaxContentContribution(gridItem, blockAxisConstraint, integrationUtils);
+        [&integrationUtils](const PlacedGridItem& gridItem, LayoutUnit) {
+            return GridLayoutUtils::inlineAxisMaxContentContribution(gridItem, integrationUtils);
         },
-        [&integrationUtils](const PlacedGridItem& gridItem, const TrackSizingFunctionsList& trackSizingFunctions, LayoutUnit borderAndPadding, LayoutUnit availableSpace, LayoutUnit blockAxisConstraint) {
-            UNUSED_PARAM(blockAxisConstraint);
-            return GridLayoutUtils::inlineMinimumSize(gridItem, trackSizingFunctions, borderAndPadding, availableSpace, 0_lu, integrationUtils);
+        [&integrationUtils](const PlacedGridItem& gridItem, const TrackSizingFunctionsList& trackSizingFunctions, LayoutUnit borderAndPadding, LayoutUnit availableSpace, LayoutUnit) {
+            return GridLayoutUtils::inlineMinimumSize(gridItem, trackSizingFunctions, borderAndPadding, availableSpace, /*gridAreaInlineSize=*/0_lu, integrationUtils);
         }
     };
 }

--- a/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.cpp
@@ -577,15 +577,13 @@ LayoutUnit gridAreaDimensionSize(size_t startLine, size_t endLine, const TrackSi
     return sumOfTrackSizes + (numberOfInteriorGaps * gap);
 }
 
-LayoutUnit inlineAxisMinContentContribution(const PlacedGridItem& gridItem, LayoutUnit blockAxisConstraint, const IntegrationUtils& integrationUtils)
+LayoutUnit inlineAxisMinContentContribution(const PlacedGridItem& gridItem, const IntegrationUtils& integrationUtils)
 {
-    UNUSED_PARAM(blockAxisConstraint);
     return BorderBoxSize::fromIntegrationFunction(integrationUtils.minContentLogicalWidthContribution(gridItem.layoutBox())).value;
 }
 
-LayoutUnit inlineAxisMaxContentContribution(const PlacedGridItem& gridItem, LayoutUnit blockAxisConstraint, const IntegrationUtils& integrationUtils)
+LayoutUnit inlineAxisMaxContentContribution(const PlacedGridItem& gridItem, const IntegrationUtils& integrationUtils)
 {
-    UNUSED_PARAM(blockAxisConstraint);
     return BorderBoxSize::fromIntegrationFunction(integrationUtils.maxContentLogicalWidthContribution(gridItem.layoutBox())).value;
 }
 

--- a/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.h
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.h
@@ -67,8 +67,8 @@ LayoutUnit blockUsedSize(const PlacedGridItem&, const TrackSizingFunctionsList&,
 LayoutUnit computeGridLinePosition(size_t gridLineIndex, const TrackSizes&, LayoutUnit gap);
 LayoutUnit gridAreaDimensionSize(size_t startLine, size_t endLine, const TrackSizes&, LayoutUnit gap);
 
-LayoutUnit inlineAxisMinContentContribution(const PlacedGridItem&, LayoutUnit blockAxisConstraint, const IntegrationUtils&);
-LayoutUnit inlineAxisMaxContentContribution(const PlacedGridItem&, LayoutUnit blockAxisConstraint, const IntegrationUtils&);
+LayoutUnit inlineAxisMinContentContribution(const PlacedGridItem&, const IntegrationUtils&);
+LayoutUnit inlineAxisMaxContentContribution(const PlacedGridItem&, const IntegrationUtils&);
 
 LayoutUnit blockAxisMinContentContribution(const PlacedGridItem&, LayoutUnit inlineAxisConstraint, const GridFormattingContext&);
 LayoutUnit blockAxisMaxContentContribution(const PlacedGridItem&, LayoutUnit inlineAxisConstraint, const GridFormattingContext&);


### PR DESCRIPTION
#### ead85dd00157fddcdf9444d6deb167ea871b580f
<pre>
[GFC] Remove orphaned constraints from inline-axis grid item sizing functions
<a href="https://bugs.webkit.org/show_bug.cgi?id=320126">https://bugs.webkit.org/show_bug.cgi?id=320126</a>
<a href="https://rdar.apple.com/183065634">rdar://183065634</a>

Reviewed by Sammy Gill.

Remove blockAxisConstraint parameter which is not needed for intrinsic
track sizing.

* Source/WebCore/layout/formattingContexts/grid/GridItemSizingFunctions.cpp:
(WebCore::Layout::GridItemSizingFunctions::inlineAxis):
* Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.cpp:
(WebCore::Layout::GridLayoutUtils::inlineAxisMinContentContribution):
(WebCore::Layout::GridLayoutUtils::inlineAxisMaxContentContribution):
* Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.h:

Canonical link: <a href="https://commits.webkit.org/317901@main">https://commits.webkit.org/317901@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4db5badb2b88c5237706010d9d29d7eb5c4dc76b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176673 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50610 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44402 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186275 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/139553 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b3ec8562-f364-47a4-9fa4-76652ff12a21) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178536 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51903 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50296 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137620 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/139553 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a290439c-1067-4a78-8ee2-225eb533aeab) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179629 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41135 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/158412 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118094 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/73b0ce06-9c3b-42df-81f5-fdd9cd44bfa6) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39790 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38149 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150202 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37910 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34743 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42350 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/42365 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188699 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50277 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146684 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50960 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/34531 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146489 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26817 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41255 "Passed tests") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123166 "Found 1 new failure in wasm/WasmConstExprGenerator.cpp") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117296 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49465 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12889 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48864 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49100 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48925 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->