### PR TITLE
[git-webkit] Handle non-JSON responses when printing user hints for GitHub API errors

### DIFF
--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/__init__.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/__init__.py
@@ -50,7 +50,7 @@ except ImportError:
         "See https://github.com/WebKit/WebKit/tree/main/Tools/Scripts/libraries/webkitcorepy"
     )
 
-version = Version(0, 15, 3)
+version = Version(0, 15, 4)
 
 from .user import User
 from .issue import Issue

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/github.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/github.py
@@ -161,6 +161,13 @@ with 'repo' and 'workflow' access and appropriate 'Expiration' for your {host} u
         )
 
     @classmethod
+    def decode_json(cls, response):
+        try:
+            return response.json()
+        except ValueError:
+            return {}
+
+    @classmethod
     def api_error_hint(cls, response) -> str:
         status_code = response.status_code
         if status_code in (403, 429) and (
@@ -202,7 +209,7 @@ with 'repo' and 'workflow' access and appropriate 'Expiration' for your {host} u
             if error_message:
                 sys.stderr.write("{}\n".format(error_message))
             sys.stderr.write("Request to '{}' returned status code '{}'\n".format(url, response.status_code))
-            message = response.json().get('message')
+            message = self.decode_json(response).get('message')
             if message:
                 sys.stderr.write('Message: {}\n'.format(message))
             if auth:
@@ -232,7 +239,7 @@ with 'repo' and 'workflow' access and appropriate 'Expiration' for your {host} u
         )
         if response.status_code // 100 != 2:
             sys.stderr.write("Request to '{}' returned status code '{}'\n".format(url, response.status_code))
-            message = response.json().get('message')
+            message = self.decode_json(response).get('message')
             if message:
                 sys.stderr.write('Message: {}\n'.format(message))
             sys.stderr.write(self.api_error_hint(response))

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/github_unittest.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/github_unittest.py
@@ -66,6 +66,20 @@ class TestGitHub(unittest.TestCase):
         self.assertEqual(github.Tracker.api_error_hint(resp(404)), '')
         self.assertEqual(github.Tracker.api_error_hint(resp(422)), '')
 
+    def test_decode_json(self):
+        class Response(object):
+            def __init__(self, payload):
+                self.payload = payload
+
+            def json(self):
+                if self.payload is None:
+                    raise json.JSONDecodeError('Expecting value', '', 0)
+                return self.payload
+
+        self.assertEqual(github.Tracker.decode_json(Response({'message': 'Server Error'})), {'message': 'Server Error'})
+        self.assertEqual(github.Tracker.decode_json(Response(None)), {})
+        self.assertEqual(github.Tracker.decode_json(Response(None)).get('message'), None)
+
     def test_users(self):
         with mocks.GitHub(self.URL.split('://')[1], users=mocks.USERS):
             tracker = github.Tracker(self.URL)

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
@@ -57,7 +57,7 @@ AutoInstall.register(Package('markupsafe', Version(3, 0, 3), pypi_name='MarkupSa
 AutoInstall.register(Package('jinja2', Version(3, 1, 4), implicit_deps=['markupsafe']))
 AutoInstall.register(Package('monotonic', Version(1, 5)))
 AutoInstall.register(Package('xmltodict', Version(0, 11, 0)))
-AutoInstall.register(Package('webkitbugspy', Version(0, 15, 3)), local=True)
+AutoInstall.register(Package('webkitbugspy', Version(0, 15, 4)), local=True)
 
 if sys.version_info >= (3, 10):
     AutoInstall.register(Package('rapidfuzz', Version(3, 14, 3), wheel=True))

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/git_hub.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/git_hub.py
@@ -165,11 +165,11 @@ class GitHub(Scm):
                 json=params,
             )
             if response.status_code == 422:
-                sys.stderr.write(self.repository.tracker.parse_error(response.json()))
+                sys.stderr.write(self.repository.tracker.parse_error(Tracker.decode_json(response)))
                 return None
             if response.status_code // 100 != 2:
                 sys.stderr.write("Request to '{}' returned status code '{}'\n".format(url, response.status_code))
-                sys.stderr.write(self.repository.tracker.parse_error(response.json()))
+                sys.stderr.write(self.repository.tracker.parse_error(Tracker.decode_json(response)))
                 sys.stderr.write(Tracker.api_error_hint(response))
                 return None
             result = self.PullRequest(response.json())
@@ -210,12 +210,12 @@ class GitHub(Scm):
                 json=updates,
             )
             if response.status_code == 422:
-                sys.stderr.write(self.repository.tracker.parse_error(response.json()))
+                sys.stderr.write(self.repository.tracker.parse_error(Tracker.decode_json(response)))
                 pull_request._opened = False
                 return pull_request
             if response.status_code // 100 != 2:
                 sys.stderr.write("Request to '{}' returned status code '{}'\n".format(url, response.status_code))
-                sys.stderr.write(self.repository.tracker.parse_error(response.json()))
+                sys.stderr.write(self.repository.tracker.parse_error(Tracker.decode_json(response)))
                 sys.stderr.write(Tracker.api_error_hint(response))
                 return None
             data = response.json()
@@ -402,7 +402,7 @@ class GitHub(Scm):
             )
             if response.status_code // 100 != 2:
                 sys.stderr.write("Request to '{}' returned status code '{}'\n".format(url, response.status_code))
-                sys.stderr.write(self.repository.tracker.parse_error(response.json()))
+                sys.stderr.write(self.repository.tracker.parse_error(Tracker.decode_json(response)))
                 sys.stderr.write(Tracker.api_error_hint(response))
                 return False
             return True
@@ -470,7 +470,7 @@ class GitHub(Scm):
 
             if response.status_code // 100 != 2:
                 sys.stderr.write("Request to '{}' returned status code '{}'\n".format(url, response.status_code))
-                sys.stderr.write(self.repository.tracker.parse_error(response.json()))
+                sys.stderr.write(self.repository.tracker.parse_error(Tracker.decode_json(response)))
                 sys.stderr.write(Tracker.api_error_hint(response))
                 return None
 
@@ -641,7 +641,7 @@ class GitHub(Scm):
         )
         if response.status_code != 200:
             sys.stderr.write("Request to '{}' returned status code '{}'\n".format(url, response.status_code))
-            message = response.json().get('message')
+            message = Tracker.decode_json(response).get('message')
             if message:
                 sys.stderr.write('Message: {}\n'.format(message))
             sys.stderr.write(Tracker.api_error_hint(response))


### PR DESCRIPTION
#### 3f78363de00ec5adf1989421af24156ef4eb7f77
<pre>
[git-webkit] Handle non-JSON responses when printing user hints for GitHub API errors
<a href="https://bugs.webkit.org/show_bug.cgi?id=320229">https://bugs.webkit.org/show_bug.cgi?id=320229</a>
<a href="https://rdar.apple.com/problem/183163928">rdar://problem/183163928</a>

Reviewed by Aakash Jain.

The improvement to the git-webkit user hints for GitHub API errors in 317643@main did not
account for non-JSON responses. The 500 errors seen today caused the script to exit due to
json.decoder.JSONDecodeError instead of printing the hint.

* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/__init__.py: Bump version to 0.15.4 since
webkitscmpy will now call the new Tracker.decode_json() functions
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/github.py:
(Tracker.decode_json): Add helper that decodes the response body, returning {} on invalid JSON.
(Tracker.request): Route the error-path message read through decode_json().
(Tracker.user): Ditto.
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/github_unittest.py:
(TestGitHub.test_decode_json): Add new test.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py: Bump version to 7.0.4 and
require webkitbugspy 0.15.4.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/git_hub.py:
(PullRequests.create): Route parse_error() through Tracker.decode_json().
(PullRequests.update): Ditto.
(GitHub._make_comment): Ditto.
(GitHub.review): Ditto.
(GitHub.graphql): Route the error-path message read through Tracker.decode_json().

Canonical link: <a href="https://commits.webkit.org/318262@main">https://commits.webkit.org/318262@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/01524729dd0f5f2c1e5e8ca7cf10c83c53925cab

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176670 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50607 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/44399 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186272 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/139550 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/932cfd61-2933-4e0d-99bc-ee24ea64f871) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178533 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51900 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50293 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/137619 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/139550 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/55c737f8-fd7b-4fad-a624-eea88c78f790) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179626 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/41124 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/158409 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [⏳ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/API-Tests-WPE-EWS "Waiting to run tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0ec95717-0a41-4ad7-ac6c-8946b614b9bd) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/175993 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/39779 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/38146 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/150191 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/37907 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34740 "Built successfully") | | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/42362 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188696 "Built successfully") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/176073 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50274 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/157952 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/146683 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50957 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/34528 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146488 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26958 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/41253 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117293 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49462 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/12886 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48861 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49097 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48922 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->