### PR TITLE
[GFC] Crash when certain tracks get marked as inflexible

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/layout-algorithm/flexible-column-track-intrinsic-sizing-001-crash.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/layout-algorithm/flexible-column-track-intrinsic-sizing-001-crash.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#algo-find-fr-size">
+<meta name="assert" content="A grid whose first column is a flexible (fr) track can be sized under a max-content constraint when a grid item's max-content contribution is smaller than the flexible track's base size, without crashing.">
+<style>
+  #grid {
+    display: grid;
+    grid-template-columns: 1fr;
+    width: fit-content;
+  }
+  #grid > div {
+    height: 50px;
+    background: green;
+  }
+  #grid > div > div {
+    height: 50px;
+  }
+  .wide { width: 100px; }
+  .narrow { width: 40px; }
+</style>
+<p>Test passes if there is a filled green square.</p>
+<div id="grid">
+  <div><div class="wide"></div></div>
+  <div><div class="narrow"></div></div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/layout-algorithm/flexible-column-track-intrinsic-sizing-002-crash.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/layout-algorithm/flexible-column-track-intrinsic-sizing-002-crash.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#algo-flex-tracks">
+<meta name="assert" content="When a grid with multiple flexible (fr) columns is sized under a definite length, the leading track (column index 0) can be treated as inflexible while a later track stays flexible, without crashing.">
+<style>
+  #grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    width: 100px;
+  }
+  #grid > div {
+    height: 50px;
+    background: green;
+  }
+  #grid > div > div {
+    height: 50px;
+  }
+  .wide { width: 80px; }
+  .narrow { width: 10px; }
+</style>
+<p>Test passes if there is a filled green square.</p>
+<div id="grid">
+  <div><div class="wide"></div></div>
+  <div><div class="narrow"></div></div>
+  <div></div>
+  <div></div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/layout-algorithm/flexible-column-track-intrinsic-sizing-003-crash.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/layout-algorithm/flexible-column-track-intrinsic-sizing-003-crash.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#algo-find-fr-size">
+<meta name="assert" content="A grid whose first column is a flexible (fr) track can be sized under a max-content constraint when a grid item's max-content contribution is smaller than the flexible track's base size, without crashing.">
+<style>
+  #grid {
+    display: grid;
+    grid-template-columns: 1fr;
+    width: fit-content;
+    justify-items: stretch;
+  }
+  #grid > div {
+    height: 50px;
+    background: green;
+  }
+  #grid > div > div {
+    height: 50px;
+  }
+  .wide { width: 100px; }
+  .narrow { width: 40px; }
+</style>
+<p>Test passes if there is a filled green square.</p>
+<div id="grid">
+  <div><div class="wide"></div></div>
+  <div><div class="narrow"></div></div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/layout-algorithm/flexible-column-track-intrinsic-sizing-004-crash.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/layout-algorithm/flexible-column-track-intrinsic-sizing-004-crash.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#algo-flex-tracks">
+<meta name="assert" content="When a grid with multiple flexible (fr) columns is sized under a definite length, the leading track (column index 0) can be treated as inflexible while a later track stays flexible, without crashing.">
+<style>
+  #grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    width: 100px;
+    justify-items: stretch;
+  }
+  #grid > div {
+    height: 50px;
+    background: green;
+  }
+  #grid > div > div {
+    height: 50px;
+  }
+  .wide { width: 80px; }
+  .narrow { width: 10px; }
+</style>
+<p>Test passes if there is a filled green square.</p>
+<div id="grid">
+  <div><div class="wide"></div></div>
+  <div><div class="narrow"></div></div>
+  <div></div>
+  <div></div>
+</div>

--- a/Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.cpp
@@ -64,17 +64,17 @@ struct UnsizedTrack {
 using GridItemIndexes = Vector<size_t>;
 
 struct InflexibleTrackState {
-    HashSet<size_t> inflexibleTracks;
+    BitVector inflexibleTracks;
 
     bool isFlexible(size_t trackIndex, const UnsizedTrack& track) const
     {
         return track.trackSizingFunction.max.isFlex()
-            && !inflexibleTracks.contains(trackIndex);
+            && !inflexibleTracks.get(trackIndex);
     }
 
     void markAsInflexible(size_t trackIndex)
     {
-        inflexibleTracks.add(trackIndex);
+        inflexibleTracks.set(trackIndex);
     }
 };
 


### PR DESCRIPTION
#### 17ba5b9756932d0f55821fc832ca00549275a19a
<pre>
[GFC] Crash when certain tracks get marked as inflexible
<a href="https://bugs.webkit.org/show_bug.cgi?id=320233">https://bugs.webkit.org/show_bug.cgi?id=320233</a>
<a href="https://rdar.apple.com/problem/183166106">rdar://problem/183166106</a>

Reviewed by Cole Carley.

During the TrackSizingAlgorithm we use a HashSet&lt;size_t&gt; to keep track
of whether certain tracks are classified as inflexible. However, since
the first track can get into this state, we can end up crashing when the
HashTable attempts to validate its key since the value is 0.

We can fix this simply by replacing the HashSet with a BitVector which
is probably a better match for a data structure that we want to use in
this way.

* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/layout-algorithm/flexible-column-track-intrinsic-sizing-001-crash.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/layout-algorithm/flexible-column-track-intrinsic-sizing-002-crash.html: Added.
These tests actually do not crash on trunk because the commit that was
causing the crashes was reverted in 317889@main but will serve as
regression tests when we want to enable GFC for the same content again.

* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/layout-algorithm/flexible-column-track-intrinsic-sizing-003-crash.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/layout-algorithm/flexible-column-track-intrinsic-sizing-004-crash.html: Added.
These tests, however, do actually crash without our patch so we get a
little bit of extra coverage.

Canonical link: <a href="https://commits.webkit.org/317961@main">https://commits.webkit.org/317961@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d9fb0c0edafeee938d341f1e75cf11bdd8026cfe

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176698 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50635 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44427 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186300 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/139667 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e02aa223-8e60-40cb-b74e-6217824419cc) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178561 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51928 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50321 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137643 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/139667 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9126c2ed-da4e-4c76-a1d8-bdc7d27aefa8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179654 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41146 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158431 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118117 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39801 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38170 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150213 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37929 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34768 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42375 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42386 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188724 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50302 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/157974 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146707 "Passed tests") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39487 "Build is in progress. Recent messages:OS: Tahoe (26.5.1), Xcode: 26.5; Checked out pull request; Reviewed by Cole Carley; Compiled WebKit (warnings); Skipped layout-tests; Canonicalized commit; Pushed commit to WebKit repository") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50985 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34550 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146512 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41276 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123191 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117321 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49490 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12908 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48889 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49125 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48950 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->