### PR TITLE
[EvaluationTimeZoom] Remove support for style building time zoom

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -3047,20 +3047,6 @@ EnumeratingVisibleNetworkInterfacesEnabled:
     WebKit:
       default: true
 
-EvaluationTimeZoomEnabled:
-  category: css
-  type: bool
-  status: stable
-  humanReadableName: "Evaluation time zoom enabled"
-  humanReadableDescription: "Enables used zoom value to be applied during layout and avoid applying at style-build time"
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
-
 EventHandlerDrivenSmoothKeyboardScrollingEnabled:
   type: bool
   status: internal

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -2998,11 +2998,8 @@
                     "resolver": "bottom"
                 },
                 "accepts-quirky-length": true,
-                "style-builder-custom": "Initial",
                 "style-extractor-custom": true,
                 "disables-native-appearance": true,
-                "computed-style-initial-constexpr": true,
-                "computed-style-initial-custom": true,
                 "computed-style-storage-path": ["m_nonInheritedData", "surroundData", "border.widths()"],
                 "computed-style-storage-container": "physical-group",
                 "computed-style-storage-kind": "reference",
@@ -3560,11 +3557,8 @@
                     "resolver": "left"
                 },
                 "accepts-quirky-length": true,
-                "style-builder-custom": "Initial",
                 "style-extractor-custom": true,
                 "disables-native-appearance": true,
-                "computed-style-initial-constexpr": true,
-                "computed-style-initial-custom": true,
                 "computed-style-storage-path": ["m_nonInheritedData", "surroundData", "border.widths()"],
                 "computed-style-storage-container": "physical-group",
                 "computed-style-storage-kind": "reference",
@@ -3681,11 +3675,8 @@
                     "resolver": "right"
                 },
                 "accepts-quirky-length": true,
-                "style-builder-custom": "Initial",
                 "style-extractor-custom": true,
                 "disables-native-appearance": true,
-                "computed-style-initial-constexpr": true,
-                "computed-style-initial-custom": true,
                 "computed-style-storage-path": ["m_nonInheritedData", "surroundData", "border.widths()"],
                 "computed-style-storage-container": "physical-group",
                 "computed-style-storage-kind": "reference",
@@ -3907,11 +3898,8 @@
                     "resolver": "top"
                 },
                 "accepts-quirky-length": true,
-                "style-builder-custom": "Initial",
                 "style-extractor-custom": true,
                 "disables-native-appearance": true,
-                "computed-style-initial-constexpr": true,
-                "computed-style-initial-custom": true,
                 "computed-style-storage-path": ["m_nonInheritedData", "surroundData", "border.widths()"],
                 "computed-style-storage-container": "physical-group",
                 "computed-style-storage-kind": "reference",
@@ -7287,9 +7275,6 @@
                 "thick"
             ],
             "codegen-properties": {
-                "style-builder-custom": "Initial",
-                "computed-style-initial-constexpr": true,
-                "computed-style-initial-custom": true,
                 "computed-style-storage-path": ["m_nonInheritedData", "backgroundData", "outline"],
                 "computed-style-storage-container": "struct",
                 "computed-style-storage-kind": "reference",
@@ -10205,9 +10190,6 @@
                 "aliases": [
                     "-webkit-column-rule-width"
                 ],
-                "style-builder-custom": "Initial",
-                "computed-style-initial-constexpr": true,
-                "computed-style-initial-custom": true,
                 "computed-style-storage-name": "width",
                 "computed-style-storage-path": ["m_nonInheritedData", "miscData", "multiCol", "columnRule"],
                 "computed-style-storage-container": "struct",

--- a/Source/WebCore/css/CSSToLengthConversionData.cpp
+++ b/Source/WebCore/css/CSSToLengthConversionData.cpp
@@ -63,14 +63,12 @@ CSSToLengthConversionData::CSSToLengthConversionData(const Style::ComputedStyle&
 {
 }
 
-CSSToLengthConversionData::CSSToLengthConversionData(const Style::ComputedStyle& style, const Style::ComputedStyle* rootStyle, const Style::ComputedStyle* parentStyle, const RenderView* renderView, const Element* elementForContainerUnitResolution, CSS::RangeZoomOptions rangeZoomOptions)
+CSSToLengthConversionData::CSSToLengthConversionData(const Style::ComputedStyle& style, const Style::ComputedStyle* rootStyle, const Style::ComputedStyle* parentStyle, const RenderView* renderView, const Element* elementForContainerUnitResolution)
     : m_style(&style)
     , m_rootStyle(rootStyle)
     , m_parentStyle(parentStyle)
     , m_renderView(renderView)
     , m_elementForContainerUnitResolution(elementForContainerUnitResolution)
-    , m_zoom(1.f)
-    , m_rangeZoomOption(rangeZoomOptions)
 {
 }
 
@@ -90,7 +88,8 @@ std::optional<CSSToLengthConversionData> CSSToLengthConversionData::tryCreateFor
         elementRenderer->style(),
         documentElement->renderer() ? &documentElement->renderer()->style() : nullptr,
         elementParentRenderer ? &elementParentRenderer->style() : nullptr,
-        document->renderView()
+        document->renderView(),
+        nullptr
     };
 }
 
@@ -111,12 +110,6 @@ const FontCascade& CSSToLengthConversionData::fontCascadeForFontUnits() const
     }
     ASSERT(style());
     return style()->fontCascade();
-}
-
-
-float CSSToLengthConversionData::zoom() const
-{
-    return m_zoom.value_or(m_style ? m_style->usedZoom() : 1.f);
 }
 
 FloatSize CSSToLengthConversionData::defaultViewportFactor() const
@@ -167,12 +160,6 @@ void CSSToLengthConversionData::setUsesContainerUnits() const
 {
     if (m_styleBuilderState)
         m_styleBuilderState->setIsContainerDependent();
-}
-
-bool CSSToLengthConversionData::evaluationTimeZoomEnabled() const
-{
-    ASSERT(m_style);
-    return m_style->evaluationTimeZoomEnabled();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/css/CSSToLengthConversionData.h
+++ b/Source/WebCore/css/CSSToLengthConversionData.h
@@ -55,10 +55,8 @@ public:
     CSSToLengthConversionData(const CSSToLengthConversionData&);
     CSSToLengthConversionData(CSSToLengthConversionData&&);
 
-    // This is used during style building. The 'zoom' property is taken into account.
     CSSToLengthConversionData(const Style::ComputedStyle&, Style::BuilderState&);
-    // This constructor ignores the `zoom` property.
-    CSSToLengthConversionData(const Style::ComputedStyle&, const Style::ComputedStyle* rootStyle, const Style::ComputedStyle* parentStyle, const RenderView*, const Element* elementForContainerUnitResolution = nullptr, CSS::RangeZoomOptions = CSS::RangeZoomOptions::Default);
+    CSSToLengthConversionData(const Style::ComputedStyle&, const Style::ComputedStyle* rootStyle, const Style::ComputedStyle* parentStyle, const RenderView*, const Element* elementForContainerUnitResolution);
 
     // Used for resolutions that don't take place during normal style resolution.
     static std::optional<CSSToLengthConversionData> tryCreateForNonStyleBuildingResolution(Element&);
@@ -69,12 +67,9 @@ public:
     const Style::ComputedStyle* style() const { return m_style; }
     const Style::ComputedStyle* rootStyle() const { return m_rootStyle; }
     const Style::ComputedStyle* parentStyle() const { return m_parentStyle; }
-    float NODELETE zoom() const;
-    CSS::RangeZoomOptions rangeZoomOption() const { return m_rangeZoomOption; }
     bool computingFontSize() const { return m_propertyToCompute == CSSPropertyFontSize; }
     bool computingLineHeight() const { return m_propertyToCompute == CSSPropertyLineHeight; }
     CSSPropertyID propertyToCompute() const { return m_propertyToCompute.value_or(CSSPropertyInvalid); }
-    bool NODELETE evaluationTimeZoomEnabled() const;
     const RenderView* renderView() const { return m_renderView; }
     const Element* elementForContainerUnitResolution() const { return m_elementForContainerUnitResolution.get(); }
 
@@ -88,25 +83,14 @@ public:
     CSSToLengthConversionData copyForFontSize() const
     {
         CSSToLengthConversionData copy(*this);
-        copy.m_zoom = 1.f;
         copy.m_propertyToCompute = CSSPropertyFontSize;
         return copy;
     };
 
-    CSSToLengthConversionData copyWithAdjustedZoom(float zoom, CSS::RangeZoomOptions rangeZoomOption = CSS::RangeZoomOptions::Default) const
+    CSSToLengthConversionData copyForLineHeight() const
     {
         CSSToLengthConversionData copy(*this);
-        copy.m_zoom = zoom;
-        copy.m_rangeZoomOption = rangeZoomOption;
-        return copy;
-    }
-
-    CSSToLengthConversionData copyForLineHeight(float zoom) const
-    {
-        CSSToLengthConversionData copy(*this);
-        copy.m_zoom = zoom;
         copy.m_propertyToCompute = CSSPropertyLineHeight;
-        copy.m_rangeZoomOption = CSS::RangeZoomOptions::Unzoomed;
         return copy;
     }
 
@@ -120,10 +104,8 @@ private:
     const Style::ComputedStyle* m_parentStyle { nullptr };
     const RenderView* m_renderView { nullptr };
     RefPtr<const Element> m_elementForContainerUnitResolution;
-    std::optional<float> m_zoom;
     std::optional<CSSPropertyID> m_propertyToCompute;
     CheckedPtr<Style::BuilderState> m_styleBuilderState;
-    CSS::RangeZoomOptions m_rangeZoomOption { CSS::RangeZoomOptions::Default };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/css/parser/SizesAttributeParser.cpp
+++ b/Source/WebCore/css/parser/SizesAttributeParser.cpp
@@ -252,7 +252,7 @@ std::optional<CSSToLengthConversionData> SizesAttributeParser::conversionData() 
     // MediaQueries are defined to use the initial style, so that is passed
     // in as the "style", "parent style" and "root style". The `RenderView`
     // is passed in to resolve viewport relative units.
-    return CSSToLengthConversionData { document->initialStyle(), &document->initialStyle(), &document->initialStyle(), renderView.get() };
+    return CSSToLengthConversionData { document->initialStyle(), &document->initialStyle(), &document->initialStyle(), renderView.get(), nullptr };
 }
 
 } // namespace WebCore

--- a/Source/WebCore/css/query/MediaQueryEvaluator.cpp
+++ b/Source/WebCore/css/query/MediaQueryEvaluator.cpp
@@ -81,7 +81,7 @@ bool MediaQueryEvaluator::evaluate(const MediaQuery& query) const
         if (!document->view() || !document->documentElement())
             return EvaluationResult::Unknown;
 
-        FeatureEvaluationContext context { *document, { document->initialStyle(), &document->initialStyle(), &document->initialStyle(), document->renderView(), nullptr, CSS::RangeZoomOptions::Unzoomed }, nullptr };
+        FeatureEvaluationContext context { *document, { document->initialStyle(), &document->initialStyle(), &document->initialStyle(), document->renderView(), nullptr }, nullptr };
         return evaluateCondition(*query.condition, context);
     }();
 

--- a/Source/WebCore/css/values/primitives/CSSPrimitiveNumericRange.h
+++ b/Source/WebCore/css/values/primitives/CSSPrimitiveNumericRange.h
@@ -46,17 +46,6 @@ enum class RangeParseTimeBehavior {
     Ignore,
 };
 
-// Options to indicate how the primitive should consider its value with regards to zoom.
-// NOTE: This option is only meaningful for Style::Length`.
-// FIXME: These options are temporary while `zoom` is moving from style building time to use time.
-enum class RangeZoomOptions : bool {
-    // `Default` indicates the value held in the primitive has had zoom applied to it.
-    Default,
-
-    // `Unzoomed` indicates the value held in the primitive has NOT had zoom applied to it.
-    Unzoomed
-};
-
 // Representation for `CSS bracketed range notation`. Represents a closed range between (and including) `min` and `max`.
 // https://drafts.csswg.org/css-values-4/#numeric-ranges
 struct Range {

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -11594,7 +11594,6 @@ const Style::ComputedStyle& Document::initialStyle() const
         m_cachedInitialStyle = Style::ComputedStyle::createPtr();
 
         m_cachedInitialStyle->setZoom(zoom);
-        m_cachedInitialStyle->setEvaluationTimeZoomEnabled(settings().evaluationTimeZoomEnabled());
 
         auto initialFontFamily = FontFamily { standardFamily, FontFamilyKind::Generic };
         auto initialSpecifiedFontSize = Style::fontSizeForKeyword(CSSValueMedium, false, settingsValues(), inQuirksMode());
@@ -11608,7 +11607,6 @@ const Style::ComputedStyle& Document::initialStyle() const
         fontDescription.setSpecifiedSize(initialSpecifiedFontSize);
         fontDescription.setComputedSize(initialComputedFontSize, zoomForFontDescription);
         fontDescription.setShouldAllowUserInstalledFonts(allowUserInstalledFonts);
-        fontDescription.setEvaluationTimeZoomEnabled(settings().evaluationTimeZoomEnabled());
 
         m_cachedInitialStyle->setFontDescription(WTF::move(fontDescription));
     }

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
@@ -3287,7 +3287,7 @@ void CanvasRenderingContext2DBase::setLetterSpacing(const String& letterSpacing)
         return;
 
     CheckedRef fontCascade = fontProxy()->fontCascade();
-    double pixels = Style::computeUnzoomedNonCalcLengthDouble(rawLength->value, rawLength->unit, CSSPropertyLetterSpacing, fontCascade.ptr());
+    double pixels = Style::computeNonCalcLengthDouble(rawLength->value, rawLength->unit, CSSPropertyLetterSpacing, fontCascade, nullptr);
 
     modifiableState().letterSpacing = CSS::serializationForCSS(CSS::defaultSerializationContext(), *rawLength);
     modifiableState().font.setLetterSpacing(pixels);
@@ -3315,7 +3315,7 @@ void CanvasRenderingContext2DBase::setWordSpacing(const String& wordSpacing)
         return;
 
     CheckedRef fontCascade = fontProxy()->fontCascade();
-    double pixels = Style::computeUnzoomedNonCalcLengthDouble(rawLength->value, rawLength->unit, CSSPropertyWordSpacing, fontCascade.ptr());
+    double pixels = Style::computeNonCalcLengthDouble(rawLength->value, rawLength->unit, CSSPropertyWordSpacing, fontCascade, nullptr);
 
     modifiableState().wordSpacing = CSS::serializationForCSS(CSS::defaultSerializationContext(), *rawLength);
     modifiableState().font.setWordSpacing(pixels);

--- a/Source/WebCore/html/shadow/TextControlInnerElements.cpp
+++ b/Source/WebCore/html/shadow/TextControlInnerElements.cpp
@@ -138,7 +138,9 @@ std::optional<Style::UnadjustedStyle> TextControlInnerElement::resolveCustomStyl
         newStyle->setTextOverflow(TextOverflow::Clip);
         newStyle->setOverflowX(Overflow::Hidden);
         newStyle->setOverflowY(Overflow::Hidden);
-        newStyle->setFlexBasis(Style::FlexBasis::Fixed { static_cast<float>(Style::emToPx<int>(1, *newStyle)) });
+
+        // FIXME: This should probably use the unzoomed Style::emToPx conversion. Like this, zoom is being applied twice. Once now, once at use time.
+        newStyle->setFlexBasis(Style::FlexBasis::Fixed { static_cast<float>(Style::emToPxZoomed<int>(1, *newStyle)) });
     }
 
     return Style::UnadjustedStyle { WTF::move(newStyle) };

--- a/Source/WebCore/platform/graphics/FontDescription.cpp
+++ b/Source/WebCore/platform/graphics/FontDescription.cpp
@@ -67,7 +67,6 @@ FontDescription::FontDescription()
     , m_opticalSizing(std::to_underlying(FontOpticalSizing::Auto))
     , m_shouldAllowUserInstalledFonts(std::to_underlying(AllowUserInstalledFonts::No))
     , m_shouldDisableLigaturesForSpacing(false)
-    , m_evaluationTimeZoomEnabled(false)
 {
 }
 

--- a/Source/WebCore/platform/graphics/FontDescription.h
+++ b/Source/WebCore/platform/graphics/FontDescription.h
@@ -48,7 +48,6 @@ public:
 
     float computedSize() const { return m_computedSize; }
     float usedZoomFactor() const { return m_usedZoomFactor; }
-    float computedSizeForRangeZoomOption(CSS::RangeZoomOptions option) const { return (evaluationTimeZoomEnabled() && option == CSS::RangeZoomOptions::Unzoomed) ? unzoomedComputedSize() : computedSize(); }
     float unzoomedComputedSize() const { return m_computedSize / m_usedZoomFactor; }
     // Adjusted size regarding @font-face size-adjust but not regarding font-size-adjust. The latter adjustment is done with updateSizeWithFontSizeAdjust() after the font's creation.
     float NODELETE adjustedSizeForFontFace(float) const;
@@ -62,7 +61,6 @@ public:
     UScriptCode script() const { return static_cast<UScriptCode>(m_script); }
     const AtomString& computedLocale() const { return m_locale; } // This is what you should be using for things like text shaping and font fallback
     const AtomString& specifiedLocale() const { return m_specifiedLocale; } // This is what you should be using for web-exposed things like -webkit-locale
-    bool evaluationTimeZoomEnabled() const { return m_evaluationTimeZoomEnabled; }
 
     FontOrientation orientation() const { return static_cast<FontOrientation>(m_orientation); }
     NonCJKGlyphOrientation nonCJKGlyphOrientation() const { return static_cast<NonCJKGlyphOrientation>(m_nonCJKGlyphOrientation); }
@@ -152,8 +150,6 @@ public:
     void setShouldDisableLigaturesForSpacing(bool shouldDisableLigaturesForSpacing) { m_shouldDisableLigaturesForSpacing = shouldDisableLigaturesForSpacing; }
     void setFontPalette(const FontPalette& fontPalette) { m_fontPalette = fontPalette; }
     void setFontSizeAdjust(FontSizeAdjust fontSizeAdjust) { m_sizeAdjust = fontSizeAdjust; }
-    void setEvaluationTimeZoomEnabled(bool evaluationTimeZoomEnabled) { m_evaluationTimeZoomEnabled = evaluationTimeZoomEnabled; }
-
 
     static AtomString platformResolveGenericFamily(UScriptCode, const AtomString& locale, const AtomString& familyName);
 
@@ -204,7 +200,6 @@ private:
     PREFERRED_TYPE(FontOpticalSizing) unsigned m_opticalSizing : 1;
     PREFERRED_TYPE(AllowUserInstalledFonts) unsigned m_shouldAllowUserInstalledFonts : 1; // If this description is allowed to match a user-installed font
     PREFERRED_TYPE(bool) unsigned m_shouldDisableLigaturesForSpacing : 1; // If letter-spacing is nonzero, we need to disable ligatures, which affects font preparation
-    PREFERRED_TYPE(bool) unsigned m_evaluationTimeZoomEnabled : 1;
 };
 
 FontStyleAxis variationStyleAxis(const FontDescription&, const FontSelectionSpecifiedCapabilities& faceCapabilities);

--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -3456,8 +3456,7 @@ LayoutSize RenderBlock::intrinsicSize() const
 
     // CSS UI 4: widgets are replaced elements, but WebKit has them as RenderBlock with appearance (not RenderReplaced).
     // Provide intrinsic size from the theme so they participate in replaced-element sizing paths.
-    auto zoom = style().evaluationTimeZoomEnabled() ? 1.0f : style().usedZoom();
-    auto controlSize = theme().controlSize(style().usedAppearance(), style().fontCascade(), { Style::PreferredSize { CSS::Keyword::Auto { } }, Style::PreferredSize { CSS::Keyword::Auto { } } }, zoom);
+    auto controlSize = theme().controlSize(style().usedAppearance(), style().fontCascade(), { Style::PreferredSize { CSS::Keyword::Auto { } }, Style::PreferredSize { CSS::Keyword::Auto { } } }, 1.0f);
 
     auto width = LayoutUnit { };
     if (auto fixedWidth = controlSize.width().tryFixed())

--- a/Source/WebCore/rendering/RenderTheme.cpp
+++ b/Source/WebCore/rendering/RenderTheme.cpp
@@ -113,9 +113,9 @@ using namespace HTMLNames;
 RenderTheme::RenderTheme() = default;
 RenderTheme::~RenderTheme() = default;
 
-float RenderTheme::usedZoomForComputedStyle(const Style::ComputedStyle& renderStyle) const
+float RenderTheme::usedZoomForComputedStyle(const Style::ComputedStyle&) const
 {
-    return renderStyle.evaluationTimeZoomEnabled() ? 1.0f : renderStyle.usedZoom();
+    return 1.0f;
 }
 
 StyleAppearance RenderTheme::adjustAppearanceForElement(Style::ComputedStyle& style, const Style::ComputedStyle& parentStyle, const Element* element, StyleAppearance autoAppearance) const

--- a/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
+++ b/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
@@ -1911,14 +1911,6 @@ static bool NODELETE searchFieldCanBeCapsule(const RenderElement& box, const Flo
     return textGapEmSize * pixelsPerEm >= borderRadius;
 }
 
-static CSSToLengthConversionData conversionDataForStyle(const Style::ComputedStyle& style)
-{
-    CSSToLengthConversionData conversionData(style, nullptr, nullptr, nullptr);
-    if (style.evaluationTimeZoomEnabled())
-        return conversionData.copyWithAdjustedZoom(1.0f, CSS::RangeZoomOptions::Unzoomed);
-    return conversionData;
-}
-
 static RoundedShape shapeForSearchField(const RenderElement& box, const FloatRect& rect, ShouldComputePath computePath = ShouldComputePath::Yes)
 {
     CheckedRef style = box.style();
@@ -1930,7 +1922,7 @@ static RoundedShape shapeForSearchField(const RenderElement& box, const FloatRec
         supportsResults = input->maxResults() > 0;
 #endif
 
-    const auto pixelsPerEm = Style::emToPx<float>(1, style);
+    const auto pixelsPerEm = Style::emToPxZoomed<float>(1, style);
     const auto usingCapsuleShape = searchFieldCanBeCapsule(box, rect, pixelsPerEm, supportsResults);
 
     float rectRadius = 0.f;
@@ -2465,7 +2457,7 @@ bool RenderThemeCocoa::adjustInnerSpinButtonStyleForVectorBasedControls(Style::C
     // change according to the height of the inner container.
 
     const auto logicalWidthEm = style.writingMode().isVertical() ? 1.5f : 1.f;
-    const auto pixelsPerEm = Style::emToPx<float>(logicalWidthEm, conversionDataForStyle(style));
+    const auto pixelsPerEm = Style::emToPx<float>(logicalWidthEm, style);
 
     style.setLogicalWidth(Style::PreferredSize::Fixed { pixelsPerEm });
     style.setLogicalHeight(CSS::Keyword::Auto { });
@@ -2798,11 +2790,12 @@ static void applyEmPadding(Style::ComputedStyle& style, float paddingInlineEm, f
 {
     const auto usedZoom = style.usedZoomForLength().value;
 
+    // FIXME: These should probably use the unzoomed Style::emToPx conversion rather than applying zoom and then unapply zoom. Due to the truncation from the explicit int type, using Style::emToPx will result in slightly different metrics.
     const auto paddingInlinePixels = Style::PaddingEdge::Fixed {
-        static_cast<float>(Style::emToPx<int>(paddingInlineEm, style)) / usedZoom
+        static_cast<float>(Style::emToPxZoomed<int>(paddingInlineEm, style)) / usedZoom
     };
     const auto paddingBlockPixels = Style::PaddingEdge::Fixed {
-        static_cast<float>(Style::emToPx<int>(paddingBlockEm, style)) / usedZoom
+        static_cast<float>(Style::emToPxZoomed<int>(paddingBlockEm, style)) / usedZoom
     };
 
     const auto isVertical = !style.writingMode().isHorizontal();
@@ -2821,11 +2814,12 @@ static Style::PaddingBox paddingBoxForNumberField(const Style::ComputedStyle& st
 {
     const auto usedZoom = style.usedZoomForLength().value;
 
+    // FIXME: These should probably use the unzoomed Style::emToPx conversion rather than applying zoom and then unapply zoom. Due to the truncation from the explicit int type, using Style::emToPx will result in slightly different metrics.
     const auto paddingInlineStartPixels = Style::PaddingEdge::Fixed {
-        static_cast<float>(Style::emToPx<int>(standardTextControlInlinePaddingEm, style)) / usedZoom
+        static_cast<float>(Style::emToPxZoomed<int>(standardTextControlInlinePaddingEm, style)) / usedZoom
     };
     const auto paddingInlineEndAndBlockPixels = Style::PaddingEdge::Fixed {
-        static_cast<float>(Style::emToPx<int>(standardTextControlBlockPaddingEm, style)) / usedZoom
+        static_cast<float>(Style::emToPxZoomed<int>(standardTextControlBlockPaddingEm, style)) / usedZoom
     };
 
     Style::PaddingBox paddingBox { paddingInlineEndAndBlockPixels };
@@ -3150,8 +3144,10 @@ bool RenderThemeCocoa::paintTextAreaDecorationsForVectorBasedControls(const Rend
 static void applyCommonButtonPaddingToStyleForVectorBasedControls(Style::ComputedStyle& style)
 {
     const auto usedZoom = style.usedZoomForLength().value;
+
+    // FIXME: This should probably use the unzoomed Style::emToPx conversion rather than applying zoom and then unapply zoom. Due to the truncation from the explicit int type, using Style::emToPx will result in slightly different metrics.
     const auto pixels = Style::PaddingEdge::Fixed {
-        static_cast<float>(Style::emToPx<int>(0.5, style)) / usedZoom
+        static_cast<float>(Style::emToPxZoomed<int>(0.5, style)) / usedZoom
     };
 
     auto paddingBox = Style::PaddingBox { 0_css_px, pixels, 0_css_px, pixels };
@@ -3335,7 +3331,7 @@ bool RenderThemeCocoa::adjustButtonStyleForVectorBasedControls(Style::ComputedSt
     constexpr auto controlBaseFontSize = 11.0f;
 
     if (!style.logicalWidth().isSpecified() || style.logicalHeight().isAuto()) {
-        auto minimumHeight = controlBaseHeight / controlBaseFontSize * style.fontDescription().computedSizeForRangeZoomOption(CSS::RangeZoomOptions::Unzoomed);
+        auto minimumHeight = controlBaseHeight / controlBaseFontSize * style.fontDescription().unzoomedComputedSize();
         if (auto fixedValue = style.logicalMinHeight().tryFixed())
             minimumHeight = std::max(minimumHeight, fixedValue->resolveZoom(Style::ZoomFactor::none()));
         // FIXME: This may need to be a layout time adjustment to support various
@@ -3347,8 +3343,10 @@ bool RenderThemeCocoa::adjustButtonStyleForVectorBasedControls(Style::ComputedSt
         return true;
 
     const auto usedZoom = style.usedZoomForLength().value;
+
+    // FIXME: This should probably use the unzoomed Style::emToPx conversion rather than applying zoom and then unapply zoom. Due to the truncation from the explicit int type, using Style::emToPx will result in slightly different metrics.
     const auto pixels = Style::PaddingEdge::Fixed {
-        static_cast<float>(Style::emToPx<int>(1, style)) / usedZoom
+        static_cast<float>(Style::emToPxZoomed<int>(1, style)) / usedZoom
     };
     auto paddingBox = Style::PaddingBox { 0_css_px, pixels, 0_css_px, pixels };
 #else
@@ -3383,7 +3381,7 @@ bool RenderThemeCocoa::adjustMenuListButtonStyleForVectorBasedControls(Style::Co
     const float menuListBaseFontSize = 11;
 
     if (style.logicalHeight().isAuto())
-        style.setLogicalMinHeight(Style::MinimumSize::Fixed { static_cast<float>(std::max(menuListMinHeight, static_cast<int>(menuListBaseHeight / menuListBaseFontSize * style.fontDescription().computedSizeForRangeZoomOption(CSS::RangeZoomOptions::Unzoomed)))) });
+        style.setLogicalMinHeight(Style::MinimumSize::Fixed { static_cast<float>(std::max(menuListMinHeight, static_cast<int>(menuListBaseHeight / menuListBaseFontSize * style.fontDescription().unzoomedComputedSize()))) });
     else
         style.setLogicalMinHeight(Style::MinimumSize::Fixed { static_cast<float>(menuListMinHeight) });
 
@@ -3462,7 +3460,7 @@ bool RenderThemeCocoa::paintMenuListButtonDecorationsForVectorBasedControls(cons
         glyphPath.addBezierCurveTo({ 6.31419f, 19.9961f }, { 6.6506f, 20.1625f }, { 7.05356f, 20.1625f });
     }
 
-    const auto emPixels = Style::emToPx<float>(1, style);
+    const auto emPixels = Style::emToPxZoomed<float>(1, style);
     const auto glyphScale = 0.55f * emPixels / glyphSize.width();
     glyphSize = glyphScale * glyphSize;
 
@@ -4272,7 +4270,7 @@ bool RenderThemeCocoa::adjustSearchFieldCancelButtonStyleForVectorBasedControls(
     if (!formControlRefreshEnabled(element))
         return false;
 
-    auto pixelsPerEm = Style::emToPx<float>(1, conversionDataForStyle(style));
+    auto pixelsPerEm = Style::emToPx<float>(1, style);
     style.setWidth(Style::PreferredSize::Fixed { searchFieldDecorationEmSize * pixelsPerEm });
     style.setHeight(Style::PreferredSize::Fixed { searchFieldDecorationEmSize * pixelsPerEm });
     return true;
@@ -4365,7 +4363,7 @@ bool RenderThemeCocoa::adjustSearchFieldDecorationPartStyleForVectorBasedControl
     if (!formControlRefreshEnabled(element))
         return false;
 
-    auto pixelsPerEm = Style::emToPx<float>(1, conversionDataForStyle(style));
+    auto pixelsPerEm = Style::emToPx<float>(1, style);
 
 #if PLATFORM(MAC)
     RefPtr input = dynamicDowncast<HTMLInputElement>(element->shadowHost());

--- a/Source/WebCore/rendering/ios/RenderThemeIOS.mm
+++ b/Source/WebCore/rendering/ios/RenderThemeIOS.mm
@@ -392,7 +392,7 @@ static Style::PaddingEdge toTruncatedPaddingEdge(auto value)
 
 Style::PaddingBox RenderThemeIOS::platformPopupInternalPaddingBox(const Style::ComputedStyle& style) const
 {
-    const auto padding = Style::emToPx<float>(1, style);
+    const auto padding = Style::emToPxZoomed<float>(1, style);
 
     if (style.usedAppearance() == StyleAppearance::MenulistButton) {
         // FIXME: Reduce code duplication with toTruncatedPaddingEdge.
@@ -454,7 +454,8 @@ void RenderThemeIOS::adjustRoundBorderRadius(Style::ComputedStyle& style, Render
 
 static void applyCommonButtonPaddingToStyle(Style::ComputedStyle& style)
 {
-    auto edge = toTruncatedPaddingEdge(Style::emToPx<int>(0.5, style));
+    // FIXME: This should probably use the unzoomed Style::emToPx conversion. Like this, zoom is being applied twice. Once now, once at use time.
+    auto edge = toTruncatedPaddingEdge(Style::emToPxZoomed<int>(0.5, style));
 
     auto paddingBox = Style::PaddingBox { 0_css_px, edge, 0_css_px, edge };
     if (!style.writingMode().isHorizontal())
@@ -615,7 +616,7 @@ void RenderThemeIOS::paintMenuListButtonDecorations(const RenderBox& box, const 
         glyphPath.addBezierCurveTo({ 29.4179f, 71.8f }, { 30.541f, 72.3867f }, { 31.8593f, 72.3867 });
     }
 
-    auto emPixels = Style::emToPx<float>(1, style);
+    auto emPixels = Style::emToPxZoomed<float>(1, style);
     auto glyphScale = 0.65f * emPixels / glyphSize.width();
     glyphSize = glyphScale * glyphSize;
 
@@ -973,7 +974,8 @@ void RenderThemeIOS::adjustButtonStyle(Style::ComputedStyle& style, const Elemen
 
     // Set padding: 0 1.0em; on buttons.
 
-    auto edge = toTruncatedPaddingEdge(Style::emToPx<int>(1, style));
+    // FIXME: This should probably use the unzoomed Style::emToPx conversion. Like this, zoom is being applied twice. Once now, once at use time.
+    auto edge = toTruncatedPaddingEdge(Style::emToPxZoomed<int>(1, style));
 
     auto paddingBox = Style::PaddingBox { 0_css_px, edge, 0_css_px, edge };
     if (!style.writingMode().isHorizontal())
@@ -1923,7 +1925,8 @@ void RenderThemeIOS::adjustSearchFieldDecorationPartStyle(Style::ComputedStyle& 
     constexpr auto searchFieldDecorationEmSize = 1.0f;
     constexpr auto searchFieldDecorationMargin = 4_css_px;
 
-    auto size = Style::PreferredSize::Fixed { Style::emToPx<float>(searchFieldDecorationEmSize, style) };
+    // FIXME: This should probably use the unzoomed Style::emToPx conversion. Like this, zoom is being applied twice. Once now, once at use time.
+    auto size = Style::PreferredSize::Fixed { Style::emToPxZoomed<float>(searchFieldDecorationEmSize, style) };
 
     style.setWidth(size);
     style.setHeight(size);

--- a/Source/WebCore/rendering/mac/RenderThemeMac.mm
+++ b/Source/WebCore/rendering/mac/RenderThemeMac.mm
@@ -1195,10 +1195,6 @@ static NSControlSize controlSizeForFont(const Style::ComputedStyle& style)
 
 static IntSize sizeForFont(const Style::ComputedStyle& style, std::span<const IntSize, 4> sizes)
 {
-    if (style.usedZoom() != 1.0f && !style.evaluationTimeZoomEnabled()) {
-        IntSize result = sizes[controlSizeForFont(style)];
-        return IntSize(result.width() * style.usedZoom(), result.height() * style.usedZoom());
-    }
     return sizes[controlSizeForFont(style)];
 }
 
@@ -1228,8 +1224,8 @@ static void setFontFromControlSize(Style::ComputedStyle& style, NSControlSize co
 
     NSFont* font = [NSFont systemFontOfSize:[NSFont systemFontSizeForControlSize:controlSize]];
     fontDescription.setOneFamily("-apple-system"_s);
-    fontDescription.setComputedSize([font pointSize] * style.usedZoom());
-    fontDescription.setSpecifiedSize([font pointSize] * style.usedZoom());
+    fontDescription.setComputedSize([font pointSize] * style.usedZoom(), style.usedZoom());
+    fontDescription.setSpecifiedSize([font pointSize]);
 
     // Reset line height
     style.setLineHeight(Style::ComputedStyle::initialLineHeight());
@@ -1641,8 +1637,8 @@ std::optional<FontCascadeDescription> RenderThemeMac::controlFont(StyleAppearanc
 
         NSFont* nsFont = [NSFont systemFontOfSize:[NSFont systemFontSizeForControlSize:controlSizeForFont(font)]];
         fontDescription.setOneFamily("-apple-system"_s);
-        fontDescription.setComputedSize([nsFont pointSize] * zoomFactor);
-        fontDescription.setSpecifiedSize([nsFont pointSize] * zoomFactor);
+        fontDescription.setComputedSize([nsFont pointSize] * zoomFactor, zoomFactor);
+        fontDescription.setSpecifiedSize([nsFont pointSize]);
         return fontDescription;
     }
     default:

--- a/Source/WebCore/rendering/mathml/RenderMathMLBlock.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLBlock.cpp
@@ -118,11 +118,8 @@ LayoutUnit toUserUnits(const MathMLElement::Length& length, const Style::Compute
     // Zoom for logical units is accounted for either in the font info or referenceValue.
     case MathMLElement::LengthType::Em:
         return LayoutUnit(length.value * style.fontCascade().size());
-    case MathMLElement::LengthType::Ex: {
-        // When evaluation-time zoom is enabled, font metrics already include the zoom factor.
-        auto zoomFactor = style.fontDescription().evaluationTimeZoomEnabled() ? 1.0f : style.usedZoom();
-        return LayoutUnit(length.value * style.metricsOfPrimaryFont().xHeight().value_or(0) * zoomFactor);
-    }
+    case MathMLElement::LengthType::Ex:
+        return LayoutUnit(length.value * style.metricsOfPrimaryFont().xHeight().value_or(0));
     case MathMLElement::LengthType::MathUnit:
         return LayoutUnit(length.value * style.fontCascade().size() / 18);
     case MathMLElement::LengthType::Percentage:

--- a/Source/WebCore/style/StyleBuilderCustom.h
+++ b/Source/WebCore/style/StyleBuilderCustom.h
@@ -105,17 +105,10 @@ public:
     static void applyInitialZoom(BuilderState&);
     static void applyValueZoom(BuilderState&, CSSValue&);
 
-    // Custom handling of initial setting only.
-    static void applyInitialBorderTopWidth(BuilderState&);
-    static void applyInitialBorderRightWidth(BuilderState&);
-    static void applyInitialBorderBottomWidth(BuilderState&);
-    static void applyInitialBorderLeftWidth(BuilderState&);
-    static void applyInitialOutlineWidth(BuilderState&);
-    static void applyInitialColumnRuleWidth(BuilderState&);
     static void applyInitialColor(BuilderState&);
+    static void applyValueColor(BuilderState&, CSSValue&);
 
     // Custom handling of value setting only.
-    static void applyValueColor(BuilderState&, CSSValue&);
     static void applyValueWebkitLocale(BuilderState&, CSSValue&);
     static void applyValueTextOrientation(BuilderState&, CSSValue&);
 #if ENABLE(TEXT_AUTOSIZING)
@@ -458,54 +451,6 @@ inline void BuilderCustom::applyValueFontFamily(BuilderState& builderState, CSSV
         if (CSSValueID sizeIdentifier = fontDescription.keywordSizeAsIdentifier())
             builderState.setFontDescriptionFontSize(fontSizeForKeyword(sizeIdentifier, !oldFamilyUsedFixedDefaultSize, builderState.document()));
     }
-}
-
-inline void BuilderCustom::applyInitialBorderTopWidth(BuilderState& builderState)
-{
-    if (!builderState.cssToLengthConversionData().evaluationTimeZoomEnabled())
-        builderState.style().setBorderTopWidth(LineWidth::snapLengthAsBorderWidth(3.0f * builderState.style().usedZoom(), builderState.style().deviceScaleFactor()));
-    else
-        builderState.style().setBorderTopWidth(ComputedStyle::initialBorderTopWidth());
-}
-
-inline void BuilderCustom::applyInitialBorderRightWidth(BuilderState& builderState)
-{
-    if (!builderState.cssToLengthConversionData().evaluationTimeZoomEnabled())
-        builderState.style().setBorderRightWidth(LineWidth::snapLengthAsBorderWidth(3.0f * builderState.style().usedZoom(), builderState.style().deviceScaleFactor()));
-    else
-        builderState.style().setBorderRightWidth(ComputedStyle::initialBorderRightWidth());
-}
-
-inline void BuilderCustom::applyInitialBorderBottomWidth(BuilderState& builderState)
-{
-    if (!builderState.cssToLengthConversionData().evaluationTimeZoomEnabled())
-        builderState.style().setBorderBottomWidth(LineWidth::snapLengthAsBorderWidth(3.0f * builderState.style().usedZoom(), builderState.style().deviceScaleFactor()));
-    else
-        builderState.style().setBorderBottomWidth(ComputedStyle::initialBorderBottomWidth());
-}
-
-inline void BuilderCustom::applyInitialBorderLeftWidth(BuilderState& builderState)
-{
-    if (!builderState.cssToLengthConversionData().evaluationTimeZoomEnabled())
-        builderState.style().setBorderLeftWidth(LineWidth::snapLengthAsBorderWidth(3.0f * builderState.style().usedZoom(), builderState.style().deviceScaleFactor()));
-    else
-        builderState.style().setBorderLeftWidth(ComputedStyle::initialBorderLeftWidth());
-}
-
-inline void BuilderCustom::applyInitialOutlineWidth(BuilderState& builderState)
-{
-    if (!builderState.cssToLengthConversionData().evaluationTimeZoomEnabled())
-        builderState.style().setOutlineWidth(LineWidth::snapLengthAsBorderWidth(3.0f * builderState.style().usedZoom(), builderState.style().deviceScaleFactor()));
-    else
-        builderState.style().setOutlineWidth(ComputedStyle::initialOutlineWidth());
-}
-
-inline void BuilderCustom::applyInitialColumnRuleWidth(BuilderState& builderState)
-{
-    if (!builderState.cssToLengthConversionData().evaluationTimeZoomEnabled())
-        builderState.style().setColumnRuleWidth(LineWidth::snapLengthAsBorderWidth(3.0f * builderState.style().usedZoom(), builderState.style().deviceScaleFactor()));
-    else
-        builderState.style().setColumnRuleWidth(ComputedStyle::initialColumnRuleWidth());
 }
 
 inline void BuilderCustom::applyInitialFontSize(BuilderState& builderState)

--- a/Source/WebCore/style/StyleBuilderState.cpp
+++ b/Source/WebCore/style/StyleBuilderState.cpp
@@ -99,12 +99,9 @@ const CSSRegisteredCustomProperty* BuilderState::registeredProperty(const AtomSt
 
 float BuilderState::zoomWithTextZoomFactor()
 {
-    if (auto* frame = document().frame()) {
-        float textZoomFactor = style().textZoom() != TextZoom::Reset ? frame->textZoomFactor() : 1.0f;
-        float usedZoom = evaluationTimeZoomEnabled(*this) ? 1.0f : style().usedZoom();
-        return usedZoom * textZoomFactor;
-    }
-    return cssToLengthConversionData().zoom();
+    if (auto* frame = document().frame())
+        return style().textZoom() != TextZoom::Reset ? frame->textZoomFactor() : 1.0f;
+    return 1.0f;
 }
 
 // SVG handles zooming in a different way compared to CSS. The whole document is scaled instead

--- a/Source/WebCore/style/StyleExtractorCustom.h
+++ b/Source/WebCore/style/StyleExtractorCustom.h
@@ -284,7 +284,7 @@ public:
     static void extractMarkerShorthandSerialization(ExtractorState&, StringBuilder&, const CSS::SerializationContext&);
 };
 
-template<typename T, typename U> auto unzoomedIfEvaluationTimeZoomEnabled(ExtractorState& state, U value) -> T
+template<typename T, typename U> auto unzoomed(ExtractorState& state, U value) -> T
 {
     return T { value / state.style.usedZoomForLength().value };
 }
@@ -327,7 +327,7 @@ template<CSSPropertyID propertyID> struct InsetEdgeSharedAdaptor {
                         containingBlockSize = box->containingBlockLogicalWidthForContent();
                 }
             }
-            return functor(unzoomedIfEvaluationTimeZoomEnabled<Length<>>(state, evaluate<LayoutUnit>(value, containingBlockSize, state.style.usedZoomForLength())));
+            return functor(unzoomed<Length<>>(state, evaluate<LayoutUnit>(value, containingBlockSize, state.style.usedZoomForLength())));
         }
 
         // Return a "computed value" length.
@@ -360,7 +360,7 @@ template<CSSPropertyID propertyID> struct InsetEdgeSharedAdaptor {
 
         // The property won't be over-constrained if its computed value is "auto", so the "used value" can be returned.
         if (box->isRelativelyPositioned())
-            return functor(unzoomedIfEvaluationTimeZoomEnabled<Length<>>(state, insetUsedStyleRelative(*box)));
+            return functor(unzoomed<Length<>>(state, insetUsedStyleRelative(*box)));
 
         auto insetUsedStyleOutOfFlowPositioned = [&](auto& container, auto& box) {
             // For out-of-flow positioned boxes, the inset is how far an box's margin
@@ -402,7 +402,7 @@ template<CSSPropertyID propertyID> struct InsetEdgeSharedAdaptor {
         };
 
         if (containingBlock && box->isOutOfFlowPositioned())
-            return functor(unzoomedIfEvaluationTimeZoomEnabled<Length<>>(state, insetUsedStyleOutOfFlowPositioned(*containingBlock, *box)));
+            return functor(unzoomed<Length<>>(state, insetUsedStyleOutOfFlowPositioned(*containingBlock, *box)));
 
         return functor(CSS::Keyword::Auto { });
     }
@@ -496,7 +496,7 @@ template<CSSPropertyID propertyID> struct MarginEdgeSharedAdaptor {
 
         if constexpr (propertyID == CSSPropertyMarginRight) {
             if (rendererCanHaveTrimmedMargin(*box) && box->hasTrimmedMargin(toMarginTrimSide(*box)))
-                return functor(unzoomedIfEvaluationTimeZoomEnabled<Length<>>(state, usedValue(*box)));
+                return functor(unzoomed<Length<>>(state, usedValue(*box)));
 
             if (value.isFixed())
                 return functor(value);
@@ -505,11 +505,11 @@ template<CSSPropertyID propertyID> struct MarginEdgeSharedAdaptor {
                 // RenderBox gives a marginRight() that is the distance between the right-edge of the child box
                 // and the right-edge of the containing box, when display == DisplayType::BlockFlow. Let's calculate the absolute
                 // value of the specified margin-right % instead of relying on RenderBox's marginRight() value.
-                return functor(unzoomedIfEvaluationTimeZoomEnabled<Length<>>(state, evaluateMinimum<float>(value, box->containingBlockLogicalWidthForContent(), state.style.usedZoomForLength())));
+                return functor(unzoomed<Length<>>(state, evaluateMinimum<float>(value, box->containingBlockLogicalWidthForContent(), state.style.usedZoomForLength())));
             }
         }
 
-        return functor(unzoomedIfEvaluationTimeZoomEnabled<Length<>>(state, usedValue(*box)));
+        return functor(unzoomed<Length<>>(state, usedValue(*box)));
     }
 };
 
@@ -531,7 +531,7 @@ template<CSSPropertyID propertyID> struct PaddingEdgeSharedAdaptor {
                 return box.computedCSSPaddingLeft();
         };
 
-        return functor(unzoomedIfEvaluationTimeZoomEnabled<Length<>>(state, usedValue(*box)));
+        return functor(unzoomed<Length<>>(state, usedValue(*box)));
     }
 };
 
@@ -570,19 +570,10 @@ template<CSSPropertyID propertyID> struct PreferredSizeSharedAdaptor {
                 // happens via SVGLengthContext's non-numeric fallback path.
                 if (RefPtr svgElement = dynamicDowncast<SVGElement>(state.element.get())) {
                     SVGLengthContext lengthContext(svgElement.get());
-                    if (!state.style.evaluationTimeZoomEnabled()) {
-                        // When evaluationTimeZoomEnabled() is false, Length<> will be unconditionally
-                        // divided by usedZoom on serialization so pre-multiply to round-trip the value.
-                        if constexpr (propertyID == CSSPropertyWidth)
-                            return functor(Length<> { lengthContext.valueForLength(state.style.width(), ZoomFactor::none(), SVGLengthMode::Width) * state.style.usedZoom() });
-                        else if constexpr (propertyID == CSSPropertyHeight)
-                            return functor(Length<> { lengthContext.valueForLength(state.style.height(), ZoomFactor::none(), SVGLengthMode::Height) * state.style.usedZoom() });
-                    } else {
-                        if constexpr (propertyID == CSSPropertyWidth)
-                            return functor(Length<> { lengthContext.valueForLength(state.style.width(), ZoomFactor::none(), SVGLengthMode::Width) });
-                        else if constexpr (propertyID == CSSPropertyHeight)
-                            return functor(Length<> { lengthContext.valueForLength(state.style.height(), ZoomFactor::none(), SVGLengthMode::Height) });
-                    }
+                    if constexpr (propertyID == CSSPropertyWidth)
+                        return functor(Length<> { lengthContext.valueForLength(state.style.width(), ZoomFactor::none(), SVGLengthMode::Width) });
+                    else if constexpr (propertyID == CSSPropertyHeight)
+                        return functor(Length<> { lengthContext.valueForLength(state.style.height(), ZoomFactor::none(), SVGLengthMode::Height) });
                 }
             } else if (!state.renderer->isSVGRenderer() || state.renderer->isRenderOrLegacyRenderSVGRoot() || state.renderer->isRenderOrLegacyRenderSVGForeignObject()) {
                 // For non-SVG elements (and SVG root / foreignObject which are proper RenderBox
@@ -590,9 +581,9 @@ template<CSSPropertyID propertyID> struct PreferredSizeSharedAdaptor {
                 // not apply for non-replaced inline elements.
                 if (!isNonReplacedInline(*state.renderer)) {
                     if constexpr (propertyID == CSSPropertyHeight)
-                        return functor(unzoomedIfEvaluationTimeZoomEnabled<Length<>>(state, sizingBox(*state.renderer).height()));
+                        return functor(unzoomed<Length<>>(state, sizingBox(*state.renderer).height()));
                     else if constexpr (propertyID == CSSPropertyWidth)
-                        return functor(unzoomedIfEvaluationTimeZoomEnabled<Length<>>(state, sizingBox(*state.renderer).width()));
+                        return functor(unzoomed<Length<>>(state, sizingBox(*state.renderer).width()));
                 }
             }
         }
@@ -781,7 +772,7 @@ template<> struct PropertyExtractorAdaptor<CSSPropertyLineHeight> {
                 // for how high to be in pixels does include things like minimum font size and the zoom factor.
                 // On the other hand, since font-size doesn't include the zoom factor, we really can't do
                 // that here either.
-                return functor(Length<CSS::Nonnegative> { percentage.value * state.style.fontDescription().computedSizeForRangeZoomOption(CSS::RangeZoomOptions::Unzoomed) / 100 });
+                return functor(Length<CSS::Nonnegative> { percentage.value * state.style.fontDescription().unzoomedComputedSize() / 100 });
             },
             [&](const LineHeight::Calc& calc) {
                 // FIXME: We pass ZoomFactor::none() but it really is not clear why we are even evaluating calc
@@ -805,7 +796,7 @@ template<> struct PropertyExtractorAdaptor<CSSPropertyFontFamily> {
 template<> struct PropertyExtractorAdaptor<CSSPropertyFontSize> {
     template<typename F> decltype(auto) computedValue(ExtractorState& state, F&& functor) const
     {
-        return functor(Length<CSS::Nonnegative> { state.style.fontDescription().computedSizeForRangeZoomOption(CSS::RangeZoomOptions::Unzoomed) });
+        return functor(Length<CSS::Nonnegative> { state.style.fontDescription().unzoomedComputedSize() });
     }
 };
 
@@ -1201,8 +1192,8 @@ template<> struct PropertyExtractorAdaptor<CSSPropertyPerspectiveOrigin> {
             auto box = state.renderer->transformReferenceBoxRect(state.style);
             auto zoom = state.style.usedZoomForLength();
 
-            auto perspectiveOriginX = unzoomedIfEvaluationTimeZoomEnabled<Length<>>(state, evaluate<float>(state.style.perspectiveOriginX(), box.width(), zoom));
-            auto perspectiveOriginY = unzoomedIfEvaluationTimeZoomEnabled<Length<>>(state, evaluate<float>(state.style.perspectiveOriginY(), box.height(), zoom));
+            auto perspectiveOriginX = unzoomed<Length<>>(state, evaluate<float>(state.style.perspectiveOriginX(), box.width(), zoom));
+            auto perspectiveOriginY = unzoomed<Length<>>(state, evaluate<float>(state.style.perspectiveOriginY(), box.height(), zoom));
 
             return functor(SpaceSeparatedTuple { perspectiveOriginX, perspectiveOriginY });
         }
@@ -1288,8 +1279,8 @@ template<> struct PropertyExtractorAdaptor<CSSPropertyTransformOrigin> {
             auto box = state.renderer->transformReferenceBoxRect(state.style);
             auto zoom = state.style.usedZoomForLength();
 
-            auto transformOriginX = unzoomedIfEvaluationTimeZoomEnabled<Length<>>(state, evaluate<float>(state.style.transformOriginX(), box.width(), zoom));
-            auto transformOriginY = unzoomedIfEvaluationTimeZoomEnabled<Length<>>(state, evaluate<float>(state.style.transformOriginY(), box.height(), zoom));
+            auto transformOriginX = unzoomed<Length<>>(state, evaluate<float>(state.style.transformOriginX(), box.width(), zoom));
+            auto transformOriginY = unzoomed<Length<>>(state, evaluate<float>(state.style.transformOriginY(), box.height(), zoom));
 
             if (auto transformOriginZ = state.style.transformOriginZ(); !transformOriginZ.isZero())
                 return functor(SpaceSeparatedTuple { transformOriginX, transformOriginY, transformOriginZ });
@@ -1457,7 +1448,7 @@ template<GridTrackSizingDirection direction> Ref<CSSValue> extractGridTemplateVa
 
             trackList.value.value.append(CSS::GridTrackSize { CSS::GridTrackBreadth {
                 toCSS(LengthPercentage<CSS::Nonnegative> {
-                    unzoomedIfEvaluationTimeZoomEnabled<Length<CSS::Nonnegative>>(state, computedTrackSizes[i])
+                    unzoomed<Length<CSS::Nonnegative>>(state, computedTrackSizes[i])
                 }, state.style)
             } });
         }
@@ -2978,7 +2969,7 @@ inline RefPtr<CSSValue> ExtractorCustom::extractFontShorthand(ExtractorState& st
     if (!propertiesResetByShorthandAreExpressible())
         return computedFont;
 
-    computedFont->size = createCSSValue(state.pool, state.style, Length<> { description.computedSizeForRangeZoomOption(CSS::RangeZoomOptions::Unzoomed) });
+    computedFont->size = createCSSValue(state.pool, state.style, Length<> { description.unzoomedComputedSize() });
 
     auto computedLineHeight = ExtractorGenerated::extractValue(state, CSSPropertyLineHeight);
     if (computedLineHeight && !isValueID(*computedLineHeight, CSSValueNormal))

--- a/Source/WebCore/style/StyleResolveForDocument.cpp
+++ b/Source/WebCore/style/StyleResolveForDocument.cpp
@@ -48,7 +48,6 @@
 #include "StyleResolver.h"
 
 namespace WebCore {
-
 namespace Style {
 
 Style::ComputedStyle resolveForDocument(const Document& document)
@@ -91,8 +90,6 @@ Style::ComputedStyle resolveForDocument(const Document& document)
         fontDescription.setSpecifiedLocale(document.contentLanguage());
         fontDescription.setOneFamily(WebCore::FontFamily { standardFamily, FontFamilyKind::Generic });
         fontDescription.setShouldAllowUserInstalledFonts(settings.shouldAllowUserInstalledFonts() ? AllowUserInstalledFonts::Yes : AllowUserInstalledFonts::No);
-        // FIXME: We need evaluationTimeZoomEnabled to be accessible from FontDescription, not only from Style::ComputedStyle. Would it be weird to move it to FontDescription (which is already accessible from Style::ComputedStyle)?
-        fontDescription.setEvaluationTimeZoomEnabled(document.settings().evaluationTimeZoomEnabled());
 
         fontDescription.setKeywordSizeFromIdentifier(CSSValueMedium);
         int size = fontSizeForKeyword(CSSValueMedium, false, document);
@@ -114,11 +111,10 @@ Style::ComputedStyle resolveForDocument(const Document& document)
     fontCascade.update(WTF::move(fontSelector));
     documentStyle.setFontCascade(WTF::move(fontCascade));
 
-    documentStyle.setEvaluationTimeZoomEnabled(document.settings().evaluationTimeZoomEnabled());
     documentStyle.setDeviceScaleFactor(document.deviceScaleFactor());
 
     return documentStyle;
 }
 
-}
-}
+} // namespace Style
+} // namespace WebCore

--- a/Source/WebCore/style/StyleResolveForFont.cpp
+++ b/Source/WebCore/style/StyleResolveForFont.cpp
@@ -275,7 +275,7 @@ static ResolvedFontSize fontSizeFromUnresolvedFontSize(const CSSPropertyParserHe
 
                             RefPtr document = dynamicDowncast<Document>(context);
                             return {
-                                .size = static_cast<float>(Style::computeUnzoomedNonCalcLengthDouble(lengthPercentage.value, lengthUnit, CSSPropertyFontSize, &fontCascade, CSS::RangeZoomOptions::Default, document ? document->renderView() : nullptr)),
+                                .size = static_cast<float>(Style::computeNonCalcLengthDouble(lengthPercentage.value, lengthUnit, CSSPropertyFontSize, fontCascade, document ? document->renderView() : nullptr)),
                                 .keyword = CSSValueInvalid
                             };
                         }

--- a/Source/WebCore/style/computed/StyleComputedStyleBase+GettersInlines.h
+++ b/Source/WebCore/style/computed/StyleComputedStyleBase+GettersInlines.h
@@ -302,11 +302,6 @@ inline const CustomPropertyData& ComputedStyleBase::nonInheritedCustomProperties
 
 // MARK: - Zoom
 
-inline bool ComputedStyleBase::evaluationTimeZoomEnabled() const
-{
-    return m_inheritedRareData->evaluationTimeZoomEnabled;
-}
-
 inline bool ComputedStyleBase::useSVGZoomRulesForLength() const
 {
     return m_nonInheritedData->rareData->useSVGZoomRulesForLength;
@@ -331,10 +326,7 @@ inline ZoomFactor ComputedStyleBase::usedZoomForLength() const
     if (useSVGZoomRulesForLength())
         return unzoomed;
 
-    if (evaluationTimeZoomEnabled())
-        return ZoomFactor(usedZoom());
-
-    return unzoomed;
+    return ZoomFactor(usedZoom());
 }
 
 // MARK: - Fonts

--- a/Source/WebCore/style/computed/StyleComputedStyleBase+SettersInlines.h
+++ b/Source/WebCore/style/computed/StyleComputedStyleBase+SettersInlines.h
@@ -237,11 +237,6 @@ inline void ComputedStyleBase::setPseudoElementIdentifier(std::optional<PseudoEl
 
 // MARK: - Zoom
 
-inline void ComputedStyleBase::setEvaluationTimeZoomEnabled(bool value)
-{
-    SET(m_inheritedRareData, evaluationTimeZoomEnabled, value);
-}
-
 inline void ComputedStyleBase::setUseSVGZoomRulesForLength(bool value)
 {
     SET_NESTED(m_nonInheritedData, rareData, useSVGZoomRulesForLength, value);

--- a/Source/WebCore/style/computed/StyleComputedStyleBase.h
+++ b/Source/WebCore/style/computed/StyleComputedStyleBase.h
@@ -614,9 +614,6 @@ public:
 
     // MARK: - Zoom
 
-    inline bool evaluationTimeZoomEnabled() const;
-    inline void setEvaluationTimeZoomEnabled(bool);
-
     inline bool useSVGZoomRulesForLength() const;
     inline void setUseSVGZoomRulesForLength(bool);
 

--- a/Source/WebCore/style/computed/StyleComputedStyleProperties+InitialCustomInlines.h
+++ b/Source/WebCore/style/computed/StyleComputedStyleProperties+InitialCustomInlines.h
@@ -95,36 +95,6 @@
 namespace WebCore {
 namespace Style {
 
-constexpr LineWidth ComputedStyleProperties::initialBorderBottomWidth()
-{
-    return LineWidth { 3.0f };
-}
-
-constexpr LineWidth ComputedStyleProperties::initialBorderLeftWidth()
-{
-    return LineWidth { 3.0f };
-}
-
-constexpr LineWidth ComputedStyleProperties::initialBorderRightWidth()
-{
-    return LineWidth { 3.0f };
-}
-
-constexpr LineWidth ComputedStyleProperties::initialBorderTopWidth()
-{
-    return LineWidth { 3.0f };
-}
-
-constexpr LineWidth ComputedStyleProperties::initialColumnRuleWidth()
-{
-    return LineWidth { 3.0f };
-}
-
-constexpr LineWidth ComputedStyleProperties::initialOutlineWidth()
-{
-    return LineWidth { 3.0f };
-}
-
 constexpr WebkitLineBoxContain ComputedStyleProperties::initialLineBoxContain()
 {
     return { WebkitLineBoxContainValue::Block, WebkitLineBoxContainValue::Inline, WebkitLineBoxContainValue::Replaced };

--- a/Source/WebCore/style/computed/data/StyleInheritedRareData.cpp
+++ b/Source/WebCore/style/computed/data/StyleInheritedRareData.cpp
@@ -132,7 +132,6 @@ InheritedRareData::InheritedRareData()
     , autoRevealsWhenFound(false)
     , insideDefaultButton(false)
     , insideSubmitButton(false)
-    , evaluationTimeZoomEnabled(true)
 #if HAVE(CORE_MATERIAL)
     , usedAppleVisualEffectForSubtree(static_cast<unsigned>(AppleVisualEffect::None))
 #endif
@@ -239,7 +238,6 @@ inline InheritedRareData::InheritedRareData(const InheritedRareData& o)
     , autoRevealsWhenFound(o.autoRevealsWhenFound)
     , insideDefaultButton(o.insideDefaultButton)
     , insideSubmitButton(o.insideSubmitButton)
-    , evaluationTimeZoomEnabled(o.evaluationTimeZoomEnabled)
 #if HAVE(CORE_MATERIAL)
     , usedAppleVisualEffectForSubtree(o.usedAppleVisualEffectForSubtree)
 #endif
@@ -356,7 +354,6 @@ bool InheritedRareData::operator==(const InheritedRareData& o) const
         && listStyleImage == o.listStyleImage
         && listStyleType == o.listStyleType
         && blockEllipsis == o.blockEllipsis
-        && evaluationTimeZoomEnabled == o.evaluationTimeZoomEnabled
         && mathDepth == o.mathDepth;
 }
 
@@ -507,8 +504,6 @@ void InheritedRareData::dumpDifferences(TextStream& ts, const InheritedRareData&
 
     LOG_IF_DIFFERENT(listStyleType);
     LOG_IF_DIFFERENT(blockEllipsis);
-
-    LOG_IF_DIFFERENT(evaluationTimeZoomEnabled);
 
     LOG_IF_DIFFERENT(mathDepth);
 }

--- a/Source/WebCore/style/computed/data/StyleInheritedRareData.h
+++ b/Source/WebCore/style/computed/data/StyleInheritedRareData.h
@@ -224,7 +224,6 @@ public:
     PREFERRED_TYPE(bool) unsigned autoRevealsWhenFound : 1;
     PREFERRED_TYPE(bool) unsigned insideDefaultButton : 1;
     PREFERRED_TYPE(bool) unsigned insideSubmitButton : 1;
-    PREFERRED_TYPE(bool) unsigned evaluationTimeZoomEnabled : 1;
 #if HAVE(CORE_MATERIAL)
     PREFERRED_TYPE(AppleVisualEffect) unsigned usedAppleVisualEffectForSubtree : 5;
 #endif

--- a/Source/WebCore/style/values/backgrounds/StyleLineWidth.cpp
+++ b/Source/WebCore/style/values/backgrounds/StyleLineWidth.cpp
@@ -73,35 +73,17 @@ LineWidth::Length LineWidth::snapLengthAsBorderWidth(LineWidth::Length length, f
 
 auto CSSValueConversion<LineWidth>::operator()(BuilderState& state, const CSSValue& value) -> LineWidth
 {
-    if (!state.document().settings().evaluationTimeZoomEnabled()) {
-        if (RefPtr keywordValue = dynamicDowncast<CSSKeywordValue>(value)) {
-            switch (keywordValue->valueID()) {
-            case CSSValueThin:
-                return LineWidth::snapLengthAsBorderWidth(1.0f * state.style().usedZoom(), state.style().deviceScaleFactor());
-            case CSSValueMedium:
-                return LineWidth::snapLengthAsBorderWidth(3.0f * state.style().usedZoom(), state.style().deviceScaleFactor());
-            case CSSValueThick:
-                return LineWidth::snapLengthAsBorderWidth(5.0f * state.style().usedZoom(), state.style().deviceScaleFactor());
-            default:
-                state.setCurrentPropertyInvalidAtComputedValueTime();
-                return LineWidth::Length { 3.0f };
-            }
-        }
-
-        return LineWidth::snapLengthAsBorderWidth(toStyleFromCSSValue<LineWidth::Length>(state, value), state.style().deviceScaleFactor());
-    }
-
     if (RefPtr keywordValue = dynamicDowncast<CSSKeywordValue>(value)) {
         switch (keywordValue->valueID()) {
         case CSSValueThin:
-            return LineWidth { 1.0f };
+            return CSS::Keyword::Thin { };
         case CSSValueMedium:
-            return LineWidth { 3.0f };
+            return CSS::Keyword::Medium { };
         case CSSValueThick:
-            return LineWidth { 5.0f };
+            return CSS::Keyword::Thick { };
         default:
             state.setCurrentPropertyInvalidAtComputedValueTime();
-            return LineWidth { 3.0f };
+            return CSS::Keyword::Medium { };
         }
     }
 

--- a/Source/WebCore/style/values/backgrounds/StyleLineWidth.h
+++ b/Source/WebCore/style/values/backgrounds/StyleLineWidth.h
@@ -46,6 +46,10 @@ struct LineWidth {
     constexpr LineWidth(Length length) : value { length } { }
     constexpr LineWidth(CSS::ValueLiteral<CSS::LengthUnit::Px> literal) : value { literal } { }
 
+    constexpr LineWidth(CSS::Keyword::Thin) : value { 1 } { }
+    constexpr LineWidth(CSS::Keyword::Medium) : value { 3 } { }
+    constexpr LineWidth(CSS::Keyword::Thick) : value { 5 } { }
+
     static Length snapLengthAsBorderWidth(float, float deviceScaleFactor);
     static Length snapLengthAsBorderWidth(Length, float deviceScaleFactor);
 

--- a/Source/WebCore/style/values/inline/StyleLineHeight.cpp
+++ b/Source/WebCore/style/values/inline/StyleLineHeight.cpp
@@ -55,21 +55,12 @@ auto CSSValueConversion<LineHeight>::operator()(BuilderState& state, const CSSVa
 
     auto conversionData = state
         .cssToLengthConversionData()
-        .copyForLineHeight(state.zoomWithTextZoomFactor());
+        .copyForLineHeight();
 
-    // If EvaluationTimeZoom is not enabled then we will scale the lengths in the
-    // calc values when we create the CalculationValue below by using the zoom from conversionData.
-    // To avoid double zooming when we evaluate the calc expression we need to make sure
-    // we have a ZoomFactor of 1.0. Otherwise, we defer to whatever is on the conversionData
-    // since EvaluationTimeZoom will set the appropriate value.
-    auto zoomFactor = [&] {
-        if (!state.style().evaluationTimeZoomEnabled())
-            return Style::ZoomFactor { 1.0f };
-        return Style::ZoomFactor { conversionData.zoom() };
-    };
+    auto zoomFactor = Style::ZoomFactor { state.zoomWithTextZoomFactor() };
 
     auto percentageBasis = [&] {
-        return state.style().fontDescription().computedSizeForRangeZoomOption(conversionData.rangeZoomOption());
+        return state.style().fontDescription().unzoomedComputedSize();
     };
 
     using StyleSpecified = typename LineHeight::Specified;
@@ -95,11 +86,11 @@ auto CSSValueConversion<LineHeight>::operator()(BuilderState& state, const CSSVa
         // FIXME: percentage should not be restricted to an integer here.
         auto percentageValue = static_cast<int>(percentage.value);
 
-        return LineHeight::Fixed { CSS::clampToRangeOf<LineHeight::Fixed>((percentageValue * percentageBasis() * zoomFactor().value) / 100.0) };
+        return LineHeight::Fixed { CSS::clampToRangeOf<LineHeight::Fixed>((percentageValue * percentageBasis() * zoomFactor.value) / 100.0) };
     };
 
     auto handleCalc = [&](const StyleSpecified::Calc& calc) {
-        return LineHeight::Fixed { CSS::clampToRangeOf<LineHeight::Fixed>(calc.evaluate(percentageBasis(), zoomFactor()) * multiplier) };
+        return LineHeight::Fixed { CSS::clampToRangeOf<LineHeight::Fixed>(calc.evaluate(percentageBasis(), zoomFactor) * multiplier) };
     };
 
     auto handleNumber = [&](const StyleNumber& number) {

--- a/Source/WebCore/style/values/non-standard/StyleWebKitTextStrokeWidth.cpp
+++ b/Source/WebCore/style/values/non-standard/StyleWebKitTextStrokeWidth.cpp
@@ -41,8 +41,9 @@ auto CSSValueConversion<WebkitTextStrokeWidth>::operator()(BuilderState& state, 
     using namespace CSS::Literals;
 
     if (RefPtr keywordValue = dynamicDowncast<CSSKeywordValue>(value)) {
+        // FIXME: This should probably use the unzoomed Style::emToPx conversion. Like this, zoom is being applied twice. Once now, once at use time.
         auto convertFromEms = [&](auto ems) -> WebkitTextStrokeWidth::Length {
-            return emToPx<float>(ems, state.renderStyle());
+            return emToPxZoomed<float>(ems, state.renderStyle());
         };
 
         switch (keywordValue->valueID()) {

--- a/Source/WebCore/style/values/primitives/StyleLengthResolution.cpp
+++ b/Source/WebCore/style/values/primitives/StyleLengthResolution.cpp
@@ -50,12 +50,8 @@ namespace Style {
 
 static double NODELETE adjustValueForPageZoom(double dimension, const CSSToLengthConversionData& conversionData)
 {
-    if (conversionData.rangeZoomOption() != CSS::RangeZoomOptions::Unzoomed)
-        return dimension;
-
-    auto* style = conversionData.style();
     auto* renderView = conversionData.renderView();
-    if (!renderView || !style || !evaluationTimeZoomEnabled(*style))
+    if (!renderView)
         return dimension;
 
     return dimension / renderView->pageZoomFactor();
@@ -85,25 +81,17 @@ static double NODELETE lengthOfViewportPhysicalAxisForLogicalAxis(LogicalBoxAxis
     return lengthOfViewportPhysicalAxisForLogicalAxis(logicalAxis, size, rootElement->renderStyle());
 }
 
-// Raw font metrics include the usedZoomFactor. In evaluation-time zoom mode with the Unzoomed
-// range option, normalize by usedZoomFactor so that font-relative units (ex, cap, ch, ic) scale
-// consistently with em.
-static double unzoomFontMetricIfNeeded(double metric, const FontDescription& fontDescription, CSS::RangeZoomOptions rangeZoomOption)
+// Raw font metrics include the usedZoomFactor and must be normalized.
+static double unzoomFontMetricIfNeeded(double metric, const FontDescription& fontDescription)
 {
-    if (fontDescription.evaluationTimeZoomEnabled() && rangeZoomOption == CSS::RangeZoomOptions::Unzoomed) {
-        if (auto usedZoomFactor = fontDescription.usedZoomFactor(); usedZoomFactor > 0)
-            return metric / usedZoomFactor;
-    }
+    if (auto usedZoomFactor = fontDescription.usedZoomFactor(); usedZoomFactor > 0)
+        return metric / usedZoomFactor;
     return metric;
 }
 
-double computeUnzoomedNonCalcLengthDouble(double value, CSS::LengthUnit lengthUnit, CSSPropertyID propertyToCompute, const FontCascade* fontCascadeForUnit, CSS::RangeZoomOptions rangeZoomOption, const RenderView* renderView)
+double computeNonCalcLengthDouble(double value, CSS::LengthUnit lengthUnit, CSSPropertyID propertyToCompute, const FontCascade& fontCascadeForUnit, const RenderView* renderView)
 {
     using enum CSS::LengthUnit;
-
-    auto effectiveRangeZoomOption = (propertyToCompute == CSSPropertyFontSize)
-        ? CSS::RangeZoomOptions::Unzoomed
-        : rangeZoomOption;
 
     switch (lengthUnit) {
     case Px:
@@ -126,42 +114,37 @@ double computeUnzoomedNonCalcLengthDouble(double value, CSS::LengthUnit lengthUn
     case Em:
     case QuirkyEm:
     case Rem: {
-        ASSERT(fontCascadeForUnit);
-        auto& fontDescription = fontCascadeForUnit->fontDescription();
-        return ((propertyToCompute == CSSPropertyFontSize) ? fontDescription.specifiedSize() :  fontDescription.computedSizeForRangeZoomOption(effectiveRangeZoomOption)) * value;
+        auto& fontDescription = fontCascadeForUnit.fontDescription();
+        return ((propertyToCompute == CSSPropertyFontSize) ? fontDescription.specifiedSize() :  fontDescription.unzoomedComputedSize()) * value;
     }
     case Ex:
     case Rex: {
-        ASSERT(fontCascadeForUnit);
-        auto& fontDescription = fontCascadeForUnit->fontDescription();
-        auto& fontMetrics = fontCascadeForUnit->metricsOfPrimaryFont();
+        auto& fontDescription = fontCascadeForUnit.fontDescription();
+        auto& fontMetrics = fontCascadeForUnit.metricsOfPrimaryFont();
         if (fontMetrics.xHeight())
-            return unzoomFontMetricIfNeeded(fontMetrics.xHeight().value(), fontDescription, effectiveRangeZoomOption) * value;
-        return ((propertyToCompute == CSSPropertyFontSize) ? fontDescription.specifiedSize() : fontDescription.computedSizeForRangeZoomOption(effectiveRangeZoomOption)) / 2.0 * value;
+            return unzoomFontMetricIfNeeded(fontMetrics.xHeight().value(), fontDescription) * value;
+        return ((propertyToCompute == CSSPropertyFontSize) ? fontDescription.specifiedSize() : fontDescription.unzoomedComputedSize()) / 2.0 * value;
     }
     case Cap:
     case Rcap: {
-        ASSERT(fontCascadeForUnit);
-        auto& fontDescription = fontCascadeForUnit->fontDescription();
-        auto& fontMetrics = fontCascadeForUnit->metricsOfPrimaryFont();
+        auto& fontDescription = fontCascadeForUnit.fontDescription();
+        auto& fontMetrics = fontCascadeForUnit.metricsOfPrimaryFont();
         if (fontMetrics.capHeight())
-            return unzoomFontMetricIfNeeded(fontMetrics.capHeight().value(), fontDescription, effectiveRangeZoomOption) * value;
-        return unzoomFontMetricIfNeeded(fontMetrics.intAscent(), fontDescription, effectiveRangeZoomOption) * value;
+            return unzoomFontMetricIfNeeded(fontMetrics.capHeight().value(), fontDescription) * value;
+        return unzoomFontMetricIfNeeded(fontMetrics.intAscent(), fontDescription) * value;
     }
     case Ch:
     case Rch: {
-        ASSERT(fontCascadeForUnit);
-        auto& fontDescription = fontCascadeForUnit->fontDescription();
-        return unzoomFontMetricIfNeeded(fontCascadeForUnit->zeroWidth(), fontDescription, effectiveRangeZoomOption) * value;
+        auto& fontDescription = fontCascadeForUnit.fontDescription();
+        return unzoomFontMetricIfNeeded(fontCascadeForUnit.zeroWidth(), fontDescription) * value;
     }
     case Ic:
     case Ric: {
-        ASSERT(fontCascadeForUnit);
-        auto& fontDescription = fontCascadeForUnit->fontDescription();
-        auto ideogramWidth = fontCascadeForUnit->metricsOfPrimaryFont().ideogramWidth();
+        auto& fontDescription = fontCascadeForUnit.fontDescription();
+        auto ideogramWidth = fontCascadeForUnit.metricsOfPrimaryFont().ideogramWidth();
         if (!ideogramWidth)
-            return fontDescription.computedSizeForRangeZoomOption(effectiveRangeZoomOption) * value;
-        return unzoomFontMetricIfNeeded(ideogramWidth.value(), fontDescription, effectiveRangeZoomOption) * value;
+            return fontDescription.unzoomedComputedSize() * value;
+        return unzoomFontMetricIfNeeded(ideogramWidth.value(), fontDescription) * value;
     }
 
     // MARK: "viewport percentage" resolution
@@ -230,32 +213,16 @@ double computeUnzoomedNonCalcLengthDouble(double value, CSS::LengthUnit lengthUn
     RELEASE_ASSERT_NOT_REACHED();
 }
 
-static double adjustZoomStateForFontRelativeUnitsIfNeeded(double value, const CSSToLengthConversionData& conversionData)
+static double applyTextZoom(double value, const CSSToLengthConversionData& conversionData)
 {
-    // Apply text zoom for font-relative units when evaluationTimeZoomEnabled with unzoomed range option.
-    // computedSizeForRangeZoomOption returns unzoomed font size when rangeZoomOption is Unzoomed,
-    // so we need to multiply by text zoom to get the correct final value.
-    // We explicitly use zoomWithTextZoomFactor() here instead of conversionData.zoom() because
-    // zoomWithTextZoomFactor() is guaranteed to return only the text zoom factor (not page zoom or other zoom types)
-    // when evaluationTimeZoomEnabled is true. This ensures font-relative units scale correctly with text zoom
-    // while remaining independent of other zoom mechanisms.
-    if (conversionData.evaluationTimeZoomEnabled() && conversionData.rangeZoomOption() == CSS::RangeZoomOptions::Unzoomed) {
-        if (CheckedPtr builderState = conversionData.styleBuilderState()) {
-            auto textZoom = builderState->zoomWithTextZoomFactor();
-            return value * textZoom;
-        }
-    }
+    if (CheckedPtr builderState = conversionData.styleBuilderState())
+        return value * builderState->zoomWithTextZoomFactor();
     return value;
 }
 
 double computeCanonicalNonCalcLengthDouble(double value, CSS::LengthUnit lengthUnit, const CSSToLengthConversionData& conversionData)
 {
-    // We are only interested in canonicalizing to `px`, not adjusting for zoom, which will be handled later. When computing font-size, zoom is not applied in the same way, so must be special cased here.
-    auto computedValue = computeNonCalcLengthDouble(value, lengthUnit, conversionData);
-    if (conversionData.computingFontSize() || (conversionData.evaluationTimeZoomEnabled() && conversionData.rangeZoomOption() == CSS::RangeZoomOptions::Unzoomed))
-        return computedValue;
-
-    return computedValue / conversionData.style()->usedZoom();
+    return computeNonCalcLengthDouble(value, lengthUnit, conversionData);
 }
 
 double computeNonCalcLengthDouble(double value, CSS::LengthUnit lengthUnit, const CSSToLengthConversionData& conversionData)
@@ -323,8 +290,8 @@ double computeNonCalcLengthDouble(double value, CSS::LengthUnit lengthUnit, cons
     case Cap:
     case Ch:
     case Ic:
-        value = computeUnzoomedNonCalcLengthDouble(value, lengthUnit, conversionData.propertyToCompute(), &conversionData.fontCascadeForFontUnits(), conversionData.rangeZoomOption());
-        value = adjustZoomStateForFontRelativeUnitsIfNeeded(value, conversionData);
+        value = computeNonCalcLengthDouble(value, lengthUnit, conversionData.propertyToCompute(), conversionData.fontCascadeForFontUnits(), nullptr);
+        value = applyTextZoom(value, conversionData);
         break;
 
     case Lh:
@@ -333,9 +300,9 @@ double computeNonCalcLengthDouble(double value, CSS::LengthUnit lengthUnit, cons
             value *= conversionData.parentStyle() ? conversionData.parentStyle()->computedLineHeight() : conversionData.fontCascadeForFontUnits().metricsOfPrimaryFont().intLineSpacing();
         } else {
             auto* style = conversionData.style();
-            auto computedFontSize = style->fontDescription().computedSizeForRangeZoomOption(conversionData.rangeZoomOption());
+            auto computedFontSize = style->fontDescription().unzoomedComputedSize();
             Style::LineHeightEvaluationContext context { computedFontSize, style->metricsOfPrimaryFont().lineSpacing() };
-            value *= Style::evaluate<float>(style->lineHeight(), context, Style::ZoomFactor { conversionData.zoom() });
+            value *= Style::evaluate<float>(style->lineHeight(), context, Style::ZoomFactor { 1.0f });
         }
         break;
 
@@ -346,8 +313,8 @@ double computeNonCalcLengthDouble(double value, CSS::LengthUnit lengthUnit, cons
     case Rem:
     case Rex:
     case Ric:
-        value = computeUnzoomedNonCalcLengthDouble(value, lengthUnit, conversionData.propertyToCompute(), conversionData.rootStyle() ? &conversionData.rootStyle()->fontCascade() : &conversionData.fontCascadeForFontUnits(), conversionData.rangeZoomOption());
-        value = adjustZoomStateForFontRelativeUnitsIfNeeded(value, conversionData);
+        value = computeNonCalcLengthDouble(value, lengthUnit, conversionData.propertyToCompute(), conversionData.rootStyle() ? conversionData.rootStyle()->fontCascade() : conversionData.fontCascadeForFontUnits(), nullptr);
+        value = applyTextZoom(value, conversionData);
         break;
 
     case Rlh:
@@ -355,9 +322,9 @@ double computeNonCalcLengthDouble(double value, CSS::LengthUnit lengthUnit, cons
             if (conversionData.computingLineHeight() || conversionData.computingFontSize())
                 value *= Style::evaluate<float>(rootStyle->specifiedLineHeight(), Style::LineHeightEvaluationContext { rootStyle->computedFontSize(), rootStyle->metricsOfPrimaryFont().lineSpacing() }, rootStyle->usedZoomForLength());
             else {
-                auto computedFontSize = rootStyle->fontDescription().computedSizeForRangeZoomOption(conversionData.rangeZoomOption());
+                auto computedFontSize = rootStyle->fontDescription().unzoomedComputedSize();
                 Style::LineHeightEvaluationContext context { computedFontSize, rootStyle->metricsOfPrimaryFont().lineSpacing() };
-                value *= Style::evaluate<float>(rootStyle->lineHeight(), context, Style::ZoomFactor { conversionData.zoom() });
+                value *= Style::evaluate<float>(rootStyle->lineHeight(), context, Style::ZoomFactor { 1.0f });
             }
         }
         break;
@@ -473,13 +440,10 @@ double computeNonCalcLengthDouble(double value, CSS::LengthUnit lengthUnit, cons
         return std::min(computeNonCalcLengthDouble(value, Cqb, conversionData), computeNonCalcLengthDouble(value, Cqi, conversionData));
     }
 
-    // We do not apply the zoom factor when we are computing the value of the font-size property. The zooming
-    // for font sizes is much more complicated, since we have to worry about enforcing the minimum font size preference
-    // as well as enforcing the implicit "smart minimum."
-    if (conversionData.computingFontSize() || isFontOrRootFontRelativeLength(lengthUnit))
-        return value;
+    if (conversionData.computingLineHeight() && !isFontOrRootFontRelativeLength(lengthUnit))
+        return applyTextZoom(value, conversionData);
 
-    return value * conversionData.zoom();
+    return value;
 }
 
 bool equalForLengthResolution(const Style::ComputedStyle& styleA, const Style::ComputedStyle& styleB)
@@ -504,12 +468,23 @@ bool equalForLengthResolution(const Style::ComputedStyle& styleA, const Style::C
 
 double emToPxDouble(double value, const CSSToLengthConversionData& conversionData)
 {
-    return computeNonCalcLengthDouble(value, CSS::LengthUnit::Em, conversionData);
+    return applyTextZoom(value * conversionData.fontCascadeForFontUnits().fontDescription().unzoomedComputedSize(), conversionData);
 }
 
-double emToPxDouble(double value, const Style::ComputedStyle& style)
+double emToPxDouble(double value, const ComputedStyle& style)
 {
-    return computeNonCalcLengthDouble(value, CSS::LengthUnit::Em, CSSToLengthConversionData(style, nullptr, nullptr, nullptr));
+    return emToPxDouble(value, CSSToLengthConversionData(style, nullptr, nullptr, nullptr, nullptr));
+}
+
+double emToPxDoubleZoomed(double value, const CSSToLengthConversionData& conversionData)
+{
+    // Text zoom is not applied here as it is already included in the FontDescription's computedSize().
+    return value * conversionData.fontCascadeForFontUnits().fontDescription().computedSize();
+}
+
+double emToPxDoubleZoomed(double value, const ComputedStyle& style)
+{
+    return emToPxDoubleZoomed(value, CSSToLengthConversionData(style, nullptr, nullptr, nullptr, nullptr));
 }
 
 } // namespace Style

--- a/Source/WebCore/style/values/primitives/StyleLengthResolution.h
+++ b/Source/WebCore/style/values/primitives/StyleLengthResolution.h
@@ -46,7 +46,7 @@ class ComputedStyle;
 
 // FIXME: These functions have odd names and invariants and could use improvements.
 
-// NOTE: `computeUnzoomedNonCalcLengthDouble` has the following restrictions:
+// NOTE: `computeNonCalcLengthDouble` has the following restrictions:
 //
 // It can never be called with the following LengthUnits:
 //    Lh, Rlh, Cqw, Cqh, Cqi, Cqb, Cqmin, Cqmax (line height, and container-percentage units)
@@ -56,7 +56,7 @@ class ComputedStyle;
 //
 // If `RenderView` is nullptr, the following LengthUnits will all cause a return value of zero:
 //    Vw, Vh, Vmin, Vmax, Vb, Vi, Svw, Svh, Svmin, Svmax, Svb, Svi, Lvw, Lvh, Lvmin, Lvmax, Lvb, Lvi, Dvw, Dvh, Dvmin, Dvmax, Dvb, Dvi (viewport-percentage units)
-double computeUnzoomedNonCalcLengthDouble(double value, CSS::LengthUnit, CSSPropertyID, const FontCascade* fontCascadeForUnit = nullptr, CSS::RangeZoomOptions = CSS::RangeZoomOptions::Default, const RenderView* = nullptr);
+double computeNonCalcLengthDouble(double value, CSS::LengthUnit, CSSPropertyID, const FontCascade& fontCascadeForUnit, const RenderView*);
 double computeNonCalcLengthDouble(double value, CSS::LengthUnit, const CSSToLengthConversionData&);
 double computeCanonicalNonCalcLengthDouble(double value, CSS::LengthUnit, const CSSToLengthConversionData&);
 
@@ -67,6 +67,8 @@ bool equalForLengthResolution(const Style::ComputedStyle&, const Style::Computed
 
 double emToPxDouble(double value, const CSSToLengthConversionData&);
 double emToPxDouble(double value, const Style::ComputedStyle&);
+double emToPxDoubleZoomed(double value, const CSSToLengthConversionData&);
+double emToPxDoubleZoomed(double value, const Style::ComputedStyle&);
 
 template<typename T> inline T emToPx(double value, const CSSToLengthConversionData& conversionData)
 {
@@ -83,6 +85,23 @@ template<typename T> inline T emToPx(double value, const Style::ComputedStyle& s
         return static_cast<T>(emToPxDouble(value, style));
     else if constexpr (std::integral<T>)
         return roundForImpreciseConversion<T>(emToPxDouble(value, style));
+}
+
+template<typename T> inline T emToPxZoomed(double value, const CSSToLengthConversionData& conversionData)
+{
+    if constexpr (std::floating_point<T>)
+        return static_cast<T>(emToPxDoubleZoomed(value, conversionData));
+    else if constexpr (std::integral<T>)
+        return roundForImpreciseConversion<T>(emToPxDoubleZoomed(value, conversionData));
+}
+
+template<typename T> inline T emToPxZoomed(double value, const Style::ComputedStyle& style)
+{
+    // For `em`, we only need the element's style, so we can overload this to take just a `ComputedStyle`.
+    if constexpr (std::floating_point<T>)
+        return static_cast<T>(emToPxDoubleZoomed(value, style));
+    else if constexpr (std::integral<T>)
+        return roundForImpreciseConversion<T>(emToPxDoubleZoomed(value, style));
 }
 
 } // namespace Style

--- a/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Conversions.cpp
+++ b/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Conversions.cpp
@@ -45,22 +45,5 @@ double canonicalizeLength(double value, CSS::LengthUnit unit, const CSSToLengthC
     return computeNonCalcLengthDouble(value, unit, conversionData);
 }
 
-// MARK: ToCSS utilities
-
-float adjustForZoom(float value, const Style::ComputedStyle& style)
-{
-    return adjustFloatForAbsoluteZoom(value, style);
-}
-
-bool evaluationTimeZoomEnabled(const Style::ComputedStyle& style)
-{
-    return style.evaluationTimeZoomEnabled();
-}
-
-bool evaluationTimeZoomEnabled(const BuilderState& state)
-{
-    return state.document().settings().evaluationTimeZoomEnabled();
-}
-
 } // namespace Style
 } // namespace WebCore

--- a/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Conversions.h
+++ b/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Conversions.h
@@ -40,48 +40,12 @@ namespace Style {
 // Out of line to avoid additional includes.
 double canonicalizeLength(double, CSS::LengthUnit, NoConversionDataRequiredToken);
 double canonicalizeLength(double, CSS::LengthUnit, const CSSToLengthConversionData&);
-float NODELETE adjustForZoom(float, const ComputedStyle&);
-bool NODELETE evaluationTimeZoomEnabled(const ComputedStyle&);
-bool NODELETE evaluationTimeZoomEnabled(const BuilderState&);
 
-// MARK: Conversion Data specialization
+// MARK: Conversion Data Access
 
-template<typename T> struct ConversionDataSpecializer {
-    CSSToLengthConversionData operator()(const BuilderState& state)
-    {
-        return state.cssToLengthConversionData();
-    }
-};
-
-template<auto R, typename V> struct ConversionDataSpecializer<Length<R, V>> {
-    CSSToLengthConversionData operator()(const BuilderState& state)
-    {
-        if (!evaluationTimeZoomEnabled(state)) [[unlikely]] {
-            return state.useSVGZoomRulesForLength()
-                ? state.cssToLengthConversionData().copyWithAdjustedZoom(1.0f)
-                : state.cssToLengthConversionData();
-        }
-
-        return state.cssToLengthConversionData().copyWithAdjustedZoom(1.0f, CSS::RangeZoomOptions::Unzoomed);
-    }
-};
-
-template<auto R, typename V> struct ConversionDataSpecializer<LengthPercentage<R, V>> {
-    CSSToLengthConversionData operator()(const BuilderState& state)
-    {
-        if (!evaluationTimeZoomEnabled(state)) [[unlikely]] {
-            return state.useSVGZoomRulesForLength()
-                ? state.cssToLengthConversionData().copyWithAdjustedZoom(1.0f)
-                : state.cssToLengthConversionData();
-        }
-
-        return state.cssToLengthConversionData().copyWithAdjustedZoom(1.0f, CSS::RangeZoomOptions::Unzoomed);
-    }
-};
-
-template<typename T> CSSToLengthConversionData conversionData(const BuilderState& state)
+template<typename> CSSToLengthConversionData conversionData(const BuilderState& state)
 {
-    return ConversionDataSpecializer<T>{}(state);
+    return state.cssToLengthConversionData();
 }
 
 // MARK: - Type maps
@@ -180,13 +144,10 @@ template<auto R, typename V, typename... Rest> LengthPercentage<R, V> canonicali
 
 // MARK: - Conversion from "Style to "CSS"
 
-// Length requires a specialized implementation due to zoom adjustment.
+// Length requires a specialized implementation due to unresolvedValue() usage.
 template<auto R, typename V> struct ToCSS<Length<R, V>> {
-    auto operator()(const Length<R, V>& value, const ComputedStyle& style) -> CSS::Length<R, V>
+    auto operator()(const Length<R, V>& value, const ComputedStyle&) -> CSS::Length<R, V>
     {
-        if (!evaluationTimeZoomEnabled(style)) [[unlikely]]
-            return CSS::LengthRaw<R, V> { value.unit, adjustForZoom(value.unresolvedValue(), style) };
-
         return CSS::LengthRaw<R, V> { value.unit, value.unresolvedValue() };
     }
 };
@@ -228,9 +189,6 @@ template<auto R, typename V> struct ToCSS<LengthPercentage<R, V>> {
     {
         return WTF::switchOn(value,
             [&](const typename LengthPercentage<R, V>::Dimension& length) -> CSS::LengthPercentage<R, V> {
-                if (!evaluationTimeZoomEnabled(style)) [[unlikely]]
-                    return typename CSS::LengthPercentage<R, V>::Raw { length.unit, adjustForZoom(length.unresolvedValue(), style) };
-
                 return typename CSS::LengthPercentage<R, V>::Raw { length.unit, length.unresolvedValue() };
             },
             [&](const typename LengthPercentage<R, V>::Percentage& percentage) -> CSS::LengthPercentage<R, V> {

--- a/Source/WebCore/style/values/sizing/StyleContainIntrinsicSize.cpp
+++ b/Source/WebCore/style/values/sizing/StyleContainIntrinsicSize.cpp
@@ -47,7 +47,7 @@ auto CSSValueConversion<ContainIntrinsicSize>::operator()(BuilderState& state, c
     }
 
     if (auto* primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value))
-        return toStyleFromCSSValue<ContainIntrinsicSize::Length>(state.cssToLengthConversionData().copyWithAdjustedZoom(1.0f), *primitiveValue);
+        return toStyleFromCSSValue<ContainIntrinsicSize::Length>(state, *primitiveValue);
 
     auto pair = requiredPairDowncast<CSSKeywordValue, CSSValue>(state, value);
     if (!pair)
@@ -71,7 +71,7 @@ auto CSSValueConversion<ContainIntrinsicSize>::operator()(BuilderState& state, c
     if (RefPtr primitiveSecondValue = dynamicDowncast<CSSPrimitiveValue>(pair->second)) {
         return {
             CSS::Keyword::Auto { },
-            toStyleFromCSSValue<ContainIntrinsicSize::Length>(state.cssToLengthConversionData().copyWithAdjustedZoom(1.0f), *primitiveSecondValue),
+            toStyleFromCSSValue<ContainIntrinsicSize::Length>(state, *primitiveSecondValue),
         };
     }
 

--- a/Source/WebCore/style/values/text/StyleLetterSpacing.cpp
+++ b/Source/WebCore/style/values/text/StyleLetterSpacing.cpp
@@ -46,16 +46,7 @@ auto CSSValueConversion<LetterSpacing>::operator()(BuilderState& state, const CS
     if (!primitiveValue)
         return CSS::Keyword::Normal { };
 
-    auto conversionData = [](BuilderState& state) -> CSSToLengthConversionData {
-        if (state.useSVGZoomRulesForLength())
-            return state.cssToLengthConversionData().copyWithAdjustedZoom(1.0f);
-        auto zoom = state.zoomWithTextZoomFactor();
-        if (zoom == state.cssToLengthConversionData().zoom())
-            return state.cssToLengthConversionData();
-        return state.cssToLengthConversionData().copyWithAdjustedZoom(zoom, CSS::RangeZoomOptions::Unzoomed);
-    };
-
-    return toStyleFromCSSValue<LetterSpacing::Wrapped>(conversionData(state), *primitiveValue);
+    return toStyleFromCSSValue<LetterSpacing::Wrapped>(state, *primitiveValue);
 }
 
 } // namespace Style

--- a/Source/WebCore/style/values/text/StyleWordSpacing.cpp
+++ b/Source/WebCore/style/values/text/StyleWordSpacing.cpp
@@ -46,16 +46,7 @@ auto CSSValueConversion<WordSpacing>::operator()(BuilderState& state, const CSSV
     if (!primitiveValue)
         return CSS::Keyword::Normal { };
 
-    auto conversionData = [](BuilderState& state) -> CSSToLengthConversionData {
-        if (state.useSVGZoomRulesForLength())
-            return state.cssToLengthConversionData().copyWithAdjustedZoom(1.0f);
-        auto zoom = state.zoomWithTextZoomFactor();
-        if (zoom == state.cssToLengthConversionData().zoom())
-            return state.cssToLengthConversionData();
-        return state.cssToLengthConversionData().copyWithAdjustedZoom(zoom, CSS::RangeZoomOptions::Unzoomed);
-    };
-
-    return toStyleFromCSSValue<WordSpacing::Wrapped>(conversionData(state), *primitiveValue);
+    return toStyleFromCSSValue<WordSpacing::Wrapped>(state, *primitiveValue);
 }
 
 } // namespace Style

--- a/Source/WebCore/style/values/transforms/StylePerspective.cpp
+++ b/Source/WebCore/style/values/transforms/StylePerspective.cpp
@@ -55,11 +55,8 @@ auto CSSValueConversion<Perspective>::operator()(BuilderState& state, const CSSV
     if (primitiveValue->isLength())
         return toStyleFromCSSValue<Perspective::Length>(state, *primitiveValue);
 
-    if (primitiveValue->isNumber()) {
-        if (!state.cssToLengthConversionData().evaluationTimeZoomEnabled())
-            return Perspective::Length { toStyleFromCSSValue<Number<CSS::Nonnegative, float>>(state, *primitiveValue).value * state.cssToLengthConversionData().zoom() };
+    if (primitiveValue->isNumber())
         return Perspective::Length { toStyleFromCSSValue<Number<CSS::Nonnegative, float>>(state, *primitiveValue).value };
-    }
 
     state.setCurrentPropertyInvalidAtComputedValueTime();
     return CSS::Keyword::None { };

--- a/Source/WebCore/style/values/transforms/StyleTransformFunction.cpp
+++ b/Source/WebCore/style/values/transforms/StyleTransformFunction.cpp
@@ -69,18 +69,6 @@ static RefPtr<const TransformFunctionBase> createMatrixTransformFunction(const C
     if (!function)
         return { };
 
-    if (auto conversionData = state.cssToLengthConversionData(); !conversionData.evaluationTimeZoomEnabled()) {
-        auto zoom = conversionData.zoom();
-        return MatrixTransformFunction::create(
-            toStyleFromCSSValue<Number<>>(state, protect(function->item(0))).value,
-            toStyleFromCSSValue<Number<>>(state, protect(function->item(1))).value,
-            toStyleFromCSSValue<Number<>>(state, protect(function->item(2))).value,
-            toStyleFromCSSValue<Number<>>(state, protect(function->item(3))).value,
-            toStyleFromCSSValue<Number<>>(state, protect(function->item(4))).value * zoom,
-            toStyleFromCSSValue<Number<>>(state, protect(function->item(5))).value * zoom
-        );
-    }
-
     return MatrixTransformFunction::create(
         toStyleFromCSSValue<Number<>>(state, protect(function->item(0))).value,
         toStyleFromCSSValue<Number<>>(state, protect(function->item(1))).value,
@@ -100,7 +88,7 @@ static RefPtr<const TransformFunctionBase> createMatrix3dTransformFunction(const
     if (!function)
         return { };
 
-    TransformationMatrix matrix(
+    return Matrix3DTransformFunction::create(TransformationMatrix(
         toStyleFromCSSValue<Number<>>(state, protect(function->item(0))).value,
         toStyleFromCSSValue<Number<>>(state, protect(function->item(1))).value,
         toStyleFromCSSValue<Number<>>(state, protect(function->item(2))).value,
@@ -117,12 +105,7 @@ static RefPtr<const TransformFunctionBase> createMatrix3dTransformFunction(const
         toStyleFromCSSValue<Number<>>(state, protect(function->item(13))).value,
         toStyleFromCSSValue<Number<>>(state, protect(function->item(14))).value,
         toStyleFromCSSValue<Number<>>(state, protect(function->item(15))).value
-    );
-
-    if (auto conversionData = state.cssToLengthConversionData(); !conversionData.evaluationTimeZoomEnabled())
-        matrix.zoom(conversionData.zoom());
-
-    return Matrix3DTransformFunction::create(WTF::move(matrix));
+    ));
 }
 
 // MARK: Rotate
@@ -455,8 +438,6 @@ static RefPtr<const TransformFunctionBase> createPerspectiveTransformFunction(co
         return PerspectiveTransformFunction::create(toStyleFromCSSValue<Length<CSS::Nonnegative>>(state, *primitiveValue));
 
     // FIXME: Support for <number> parameters for `perspective` is a quirk that should go away when 3d transforms are finalized.
-    if (auto conversionData = state.cssToLengthConversionData(); !conversionData.evaluationTimeZoomEnabled())
-        return PerspectiveTransformFunction::create(Length<CSS::Nonnegative> { toStyleFromCSSValue<Number<CSS::Nonnegative, float>>(state, *primitiveValue).value * conversionData.zoom() });
     return PerspectiveTransformFunction::create(Length<CSS::Nonnegative> { toStyleFromCSSValue<Number<CSS::Nonnegative, float>>(state, *primitiveValue).value });
 }
 
@@ -635,16 +616,12 @@ auto CSSValueCreation<TransformFunction>::operator()(CSSValuePool& pool, const S
     return createCSSValue(pool, style, CSS::Keyword::None { });
 }
 
-auto CSSValueCreation<TransformationMatrix>::operator()(CSSValuePool&, const Style::ComputedStyle& style, const TransformationMatrix& transform) -> Ref<CSSValue>
+auto CSSValueCreation<TransformationMatrix>::operator()(CSSValuePool&, const Style::ComputedStyle&, const TransformationMatrix& transform) -> Ref<CSSValue>
 {
     if (transform.isAffine()) {
-        auto values = [&] -> std::array<double, 6> {
-            if (!style.evaluationTimeZoomEnabled()) {
-                auto zoom = style.usedZoom();
-                return { transform.a(), transform.b(), transform.c(), transform.d(), transform.e() / zoom, transform.f() / zoom };
-            }
-            return { transform.a(), transform.b(), transform.c(), transform.d(), transform.e(), transform.f() };
-        }();
+        auto values = std::array<double, 6> {
+            transform.a(), transform.b(), transform.c(), transform.d(), transform.e(), transform.f(),
+        };
 
         CSSValueListBuilder arguments;
         for (auto value : values)
@@ -652,24 +629,12 @@ auto CSSValueCreation<TransformationMatrix>::operator()(CSSValuePool&, const Sty
         return CSSFunctionValue::create(CSSValueMatrix, WTF::move(arguments));
     }
 
-    auto values = [&] -> std::array<double, 16> {
-        if (!style.evaluationTimeZoomEnabled()) {
-            auto zoom = style.usedZoom();
-            return {
-                transform.m11(), transform.m12(), transform.m13(), transform.m14() * zoom,
-                transform.m21(), transform.m22(), transform.m23(), transform.m24() * zoom,
-                transform.m31(), transform.m32(), transform.m33(), transform.m34() * zoom,
-                transform.m41() / zoom, transform.m42() / zoom, transform.m43() / zoom, transform.m44(),
-            };
-        }
-
-        return {
-            transform.m11(), transform.m12(), transform.m13(), transform.m14(),
-            transform.m21(), transform.m22(), transform.m23(), transform.m24(),
-            transform.m31(), transform.m32(), transform.m33(), transform.m34(),
-            transform.m41(), transform.m42(), transform.m43(), transform.m44(),
-        };
-    }();
+    auto values = std::array<double, 16> {
+        transform.m11(), transform.m12(), transform.m13(), transform.m14(),
+        transform.m21(), transform.m22(), transform.m23(), transform.m24(),
+        transform.m31(), transform.m32(), transform.m33(), transform.m34(),
+        transform.m41(), transform.m42(), transform.m43(), transform.m44(),
+    };
 
     CSSValueListBuilder arguments;
     for (auto value : values)
@@ -856,40 +821,24 @@ void Serialize<TransformFunction>::operator()(StringBuilder& builder, const CSS:
     RELEASE_ASSERT_NOT_REACHED();
 }
 
-void Serialize<TransformationMatrix>::operator()(StringBuilder& builder, const CSS::SerializationContext& context, const Style::ComputedStyle& style, const TransformationMatrix& transform)
+void Serialize<TransformationMatrix>::operator()(StringBuilder& builder, const CSS::SerializationContext& context, const Style::ComputedStyle&, const TransformationMatrix& transform)
 {
     if (transform.isAffine()) {
-        auto values = [&] -> std::array<double, 6> {
-            if (!style.evaluationTimeZoomEnabled()) {
-                auto zoom = style.usedZoom();
-                return { transform.a(), transform.b(), transform.c(), transform.d(), transform.e() / zoom, transform.f() / zoom };
-            }
-            return { transform.a(), transform.b(), transform.c(), transform.d(), transform.e(), transform.f() };
-        }();
+        auto values = std::array<double, 6> {
+            transform.a(), transform.b(), transform.c(), transform.d(), transform.e(), transform.f(),
+        };
         builder.append(nameLiteral(CSSValueMatrix), '(', interleave(values, [&](auto& builder, auto& value) {
             CSS::serializationForCSS(builder, context, CSS::NumberRaw<> { value });
         }, ", "_s), ')');
         return;
     }
 
-    auto values = [&] -> std::array<double, 16> {
-        if (!style.evaluationTimeZoomEnabled()) {
-            auto zoom = style.usedZoom();
-            return {
-                transform.m11(), transform.m12(), transform.m13(), transform.m14() * zoom,
-                transform.m21(), transform.m22(), transform.m23(), transform.m24() * zoom,
-                transform.m31(), transform.m32(), transform.m33(), transform.m34() * zoom,
-                transform.m41() / zoom, transform.m42() / zoom, transform.m43() / zoom, transform.m44(),
-            };
-        }
-
-        return {
-            transform.m11(), transform.m12(), transform.m13(), transform.m14(),
-            transform.m21(), transform.m22(), transform.m23(), transform.m24(),
-            transform.m31(), transform.m32(), transform.m33(), transform.m34(),
-            transform.m41(), transform.m42(), transform.m43(), transform.m44(),
-        };
-    }();
+    auto values = std::array<double, 16> {
+        transform.m11(), transform.m12(), transform.m13(), transform.m14(),
+        transform.m21(), transform.m22(), transform.m23(), transform.m24(),
+        transform.m31(), transform.m32(), transform.m33(), transform.m34(),
+        transform.m41(), transform.m42(), transform.m43(), transform.m44(),
+    };
     builder.append(nameLiteral(CSSValueMatrix3d), '(', interleave(values, [&](auto& builder, auto& value) {
         CSS::serializationForCSS(builder, context, CSS::NumberRaw<> { value });
     }, ", "_s), ')');

--- a/Source/WebCore/svg/SVGLengthContext.cpp
+++ b/Source/WebCore/svg/SVGLengthContext.cpp
@@ -199,39 +199,7 @@ float SVGLengthContext::computeNonCalcLength(float inputValue, CSS::LengthUnit u
         return 0.0f;
     }
 
-    auto resolvedValue = clampTo<float>(Style::computeNonCalcLengthDouble(inputValue, unit, *conversionData));
-
-    // "Font dependent" or "Root font dependent" resolve against computed font sizes, which may include
-    // CSS zoom scaling. However, lengths within the SVG subtree shall be resolved
-    // excluding zoom, because the (anonymous) RenderSVGViewportContainer applies zooming
-    // for the whole SVG subtree as an affine transform. Therefore any font-relative length
-    // within the SVG subtree needs to exclude the 'zoom' information.
-    if (CSS::isFontOrRootFontRelativeLength(unit))
-        resolvedValue = removeZoomFromFontOrRootFontRelativeLength(resolvedValue, unit);
-
-    return resolvedValue;
-}
-
-float SVGLengthContext::removeZoomFromFontOrRootFontRelativeLength(float value, CSS::LengthUnit unit) const
-{
-    auto* svgElement = m_context->isOutermostSVGSVGElement()
-        ? downcast<SVGSVGElement>(m_context.get())
-        : dynamicDowncast<SVGSVGElement>(m_context->viewportElement());
-
-    if (!svgElement || !svgElement->renderer())
-        return value;
-
-    float usedZoom = 1.0f;
-
-    if (CSS::isFontRelativeLength(unit))
-        usedZoom = svgElement->renderer()->style().usedZoom();
-    else if (CSS::isRootFontRelativeLength(unit)) {
-        auto* rootElement = svgElement->document().documentElement();
-        if (rootElement && rootElement->renderer())
-            usedZoom = rootElement->renderer()->style().usedZoom();
-    }
-
-    return (usedZoom != 1.0f) ? value / usedZoom : value;
+    return clampTo<float>(Style::computeNonCalcLengthDouble(inputValue, unit, *conversionData));
 }
 
 ExceptionOr<float> SVGLengthContext::resolveValueToUserUnits(float value, const CSS::LengthPercentageUnit& targetUnit, SVGLengthMode lengthMode) const

--- a/Source/WebCore/svg/SVGLengthContext.h
+++ b/Source/WebCore/svg/SVGLengthContext.h
@@ -89,7 +89,6 @@ private:
 
     std::optional<FloatSize> computeViewportSize() const;
     float computeNonCalcLength(float, CSS::LengthUnit) const;
-    float NODELETE removeZoomFromFontOrRootFontRelativeLength(float value, CSS::LengthUnit) const;
 
     std::optional<CSSToLengthConversionData> cssConversionData() const;
 


### PR DESCRIPTION
#### 25f5e8ba2895f8c061081bdc45764d0c88223922
<pre>
[EvaluationTimeZoom] Remove support for style building time zoom
<a href="https://bugs.webkit.org/show_bug.cgi?id=320235">https://bugs.webkit.org/show_bug.cgi?id=320235</a>

Reviewed by Darin Adler.

Now that all &lt;length&gt; and &lt;length-percentage&gt; values can use evaluation time zoom,
we no longer have anything that requires style building time zoom. That means its
a good time to remove the EvaluationTimeZoomEnabled setting, as we can get the complete
benefit from its removal now.

Along with removing the setting, all the zoom state on CSSToLengthConversionData can
be remove.

One place that zoom was still being used was in the theme code when using the version
of emToPx that takes a Style::ComputedStyle. Its very unclear from call sites that it
is distinct, so a new function, emToPxZoomed was added for those callers, and now the
normal emToPx is always unzoomed. There is quite a bit of cleanup in the theme code
around zoom that can be done, but that is not handled in this change.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/css/CSSToLengthConversionData.cpp:
* Source/WebCore/css/CSSToLengthConversionData.h:
* Source/WebCore/css/parser/SizesAttributeParser.cpp:
* Source/WebCore/css/query/MediaQueryEvaluator.cpp:
* Source/WebCore/css/values/primitives/CSSPrimitiveNumericRange.h:
* Source/WebCore/dom/Document.cpp:
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
* Source/WebCore/html/shadow/TextControlInnerElements.cpp:
* Source/WebCore/platform/graphics/FontDescription.cpp:
* Source/WebCore/platform/graphics/FontDescription.h:
* Source/WebCore/rendering/RenderBlock.cpp:
* Source/WebCore/rendering/RenderTheme.cpp:
* Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm:
* Source/WebCore/rendering/ios/RenderThemeIOS.mm:
* Source/WebCore/rendering/mac/RenderThemeMac.mm:
* Source/WebCore/rendering/mathml/RenderMathMLBlock.cpp:
* Source/WebCore/style/StyleBuilderCustom.h:
* Source/WebCore/style/StyleBuilderState.cpp:
* Source/WebCore/style/StyleExtractorCustom.h:
* Source/WebCore/style/StyleResolveForDocument.cpp:
* Source/WebCore/style/StyleResolveForFont.cpp:
* Source/WebCore/style/computed/StyleComputedStyleBase+GettersInlines.h:
* Source/WebCore/style/computed/StyleComputedStyleBase+SettersInlines.h:
* Source/WebCore/style/computed/StyleComputedStyleBase.h:
* Source/WebCore/style/computed/StyleComputedStyleProperties+InitialCustomInlines.h:
* Source/WebCore/style/computed/data/StyleInheritedRareData.cpp:
* Source/WebCore/style/computed/data/StyleInheritedRareData.h:
* Source/WebCore/style/values/backgrounds/StyleLineWidth.cpp:
* Source/WebCore/style/values/backgrounds/StyleLineWidth.h:
* Source/WebCore/style/values/inline/StyleLineHeight.cpp:
* Source/WebCore/style/values/non-standard/StyleWebKitTextStrokeWidth.cpp:
* Source/WebCore/style/values/primitives/StyleLengthResolution.cpp:
* Source/WebCore/style/values/primitives/StyleLengthResolution.h:
* Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Conversions.cpp:
* Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Conversions.h:
* Source/WebCore/style/values/sizing/StyleContainIntrinsicSize.cpp:
* Source/WebCore/style/values/text/StyleLetterSpacing.cpp:
* Source/WebCore/style/values/text/StyleWordSpacing.cpp:
* Source/WebCore/style/values/transforms/StylePerspective.cpp:
* Source/WebCore/style/values/transforms/StyleTransformFunction.cpp:
* Source/WebCore/svg/SVGLengthContext.cpp:
* Source/WebCore/svg/SVGLengthContext.h:

Canonical link: <a href="https://commits.webkit.org/318173@main">https://commits.webkit.org/318173@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/85f2bd68a0f8596ab0b237dee706c726a46c3692

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177516 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51454 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45248 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187120 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140763 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179379 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52746 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51163 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/138355 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140763 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180472 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41857 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159101 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Checked out pull request; 1 api test failed or timed out") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118820 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40518 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/38893 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/789 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/7600 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150925 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38598 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35587 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/38787 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/43239 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/43127 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189548 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51121 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/158635 "") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147451 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39609 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51803 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/35226 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147243 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41959 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124018 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118422 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50311 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13577 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49707 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49947 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49769 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->