### PR TITLE
[JSC] Assemble diagnostic data when getDirect returns an all-zero JSValue during llint_slow_path_get_by_id

### DIFF
--- a/Source/JavaScriptCore/heap/BlockDirectory.cpp
+++ b/Source/JavaScriptCore/heap/BlockDirectory.cpp
@@ -195,6 +195,18 @@ void BlockDirectory::removeBlock(MarkedBlock::Handle* block, WillDeleteBlock wil
         block->didRemoveFromDirectory();
 }
 
+bool BlockDirectory::isFreeListedCell(const void* cell)
+{
+    Locker locker { m_localAllocatorsLock };
+    bool result = false;
+    m_localAllocators.forEach(
+        [&] (LocalAllocator* allocator) {
+            if (allocator->isFreeListedCell(cell))
+                result = true;
+        });
+    return result;
+}
+
 void BlockDirectory::stopAllocating()
 {
     dataLogLnIf(BlockDirectoryInternal::verbose, RawPointer(this), ": BlockDirectory::stopAllocating!");

--- a/Source/JavaScriptCore/heap/BlockDirectory.h
+++ b/Source/JavaScriptCore/heap/BlockDirectory.h
@@ -80,7 +80,10 @@ public:
 
     inline void forEachBlock(const std::invocable<MarkedBlock::Handle*> auto&);
     inline void forEachNotEmptyBlock(const std::invocable<MarkedBlock::Handle*> auto&);
-    
+
+    // Intended for diagnostics only (rdar://157153895)
+    bool isFreeListedCell(const void*);
+
     RefPtr<SharedTask<MarkedBlock::Handle*()>> parallelNotEmptyBlockSource();
     
     void addBlock(MarkedBlock::Handle*);

--- a/Source/JavaScriptCore/heap/LocalAllocator.cpp
+++ b/Source/JavaScriptCore/heap/LocalAllocator.cpp
@@ -52,6 +52,20 @@ void LocalAllocator::reset()
     m_allocationCursor = 0;
 }
 
+bool LocalAllocator::isFreeListedCell(const void* target) const
+{
+    // Because the free list describes only those cells within the block this allocator is
+    // currently allocating from, a match implies target lives in that (freelisted) block.
+    if (!m_currentBlock)
+        return false;
+    bool found = false;
+    m_freeList.forEach([&] (auto* cell) {
+        if (static_cast<const void*>(cell) == target)
+            found = true;
+    });
+    return found;
+}
+
 LocalAllocator::~LocalAllocator()
 {
     if (isOnList()) {

--- a/Source/JavaScriptCore/heap/LocalAllocator.h
+++ b/Source/JavaScriptCore/heap/LocalAllocator.h
@@ -57,6 +57,9 @@ public:
 
     BlockDirectory& directory() const { return *m_directory; }
 
+    // Intended for diagnostics only (rdar://157153895)
+    bool isFreeListedCell(const void*) const;
+
 private:
     friend class BlockDirectory;
     

--- a/Source/JavaScriptCore/llint/LLIntSlowPaths.cpp
+++ b/Source/JavaScriptCore/llint/LLIntSlowPaths.cpp
@@ -854,7 +854,7 @@ static JSValue performLLIntGetByID(BytecodeIndex bytecodeIndex, CodeBlock* codeB
     auto throwScope = DECLARE_THROW_SCOPE(vm);
     PropertySlot slot(baseValue, PropertySlot::PropertySlot::InternalMethodType::Get);
 
-    JSValue result = baseValue.get(globalObject, ident, slot);
+    JSValue result = baseValue.get<true>(globalObject, ident, slot);
     RETURN_IF_EXCEPTION(throwScope, { });
 
     if (Options::useLLIntICs()

--- a/Source/JavaScriptCore/runtime/JSCJSValue.h
+++ b/Source/JavaScriptCore/runtime/JSCJSValue.h
@@ -309,6 +309,7 @@ public:
 
     // Object operations, with the toObject operation included.
     inline JSValue get(JSGlobalObject*, PropertyName) const; // Defined in JSCJSValuePropertyInlines.h
+    template<bool debugLLIntGetById = false>
     inline JSValue get(JSGlobalObject*, PropertyName, PropertySlot&) const; // Defined in JSCJSValuePropertyInlines.h
     inline JSValue get(JSGlobalObject*, unsigned propertyName) const; // Defined in JSCJSValuePropertyInlines.h
     inline JSValue get(JSGlobalObject*, unsigned propertyName, PropertySlot&) const; // Defined in JSCJSValuePropertyInlines.h
@@ -317,6 +318,7 @@ public:
     template<typename T, typename PropertyNameType>
     inline T getAs(JSGlobalObject*, PropertyNameType) const; // Defined in JSCJSValuePropertyInlines.h
 
+    template<bool debugLLIntGetById = false>
     inline bool getPropertySlot(JSGlobalObject*, PropertyName, PropertySlot&) const; // Defined in JSCJSValuePropertyInlines.h
     template<typename CallbackWhenNoException> inline typename std::invoke_result<CallbackWhenNoException, bool, PropertySlot&>::type getPropertySlot(JSGlobalObject*, PropertyName, CallbackWhenNoException) const; // Defined in JSCJSValuePropertyInlines.h
     template<typename CallbackWhenNoException> inline typename std::invoke_result<CallbackWhenNoException, bool, PropertySlot&>::type getPropertySlot(JSGlobalObject*, PropertyName, PropertySlot&, CallbackWhenNoException) const; // Defined in JSCJSValuePropertyInlines.h

--- a/Source/JavaScriptCore/runtime/JSCJSValuePropertyInlines.h
+++ b/Source/JavaScriptCore/runtime/JSCJSValuePropertyInlines.h
@@ -44,10 +44,11 @@ ALWAYS_INLINE JSValue JSValue::get(JSGlobalObject* globalObject, PropertyName pr
     return get(globalObject, propertyName, slot);
 }
 
+template<bool debugLLIntGetById>
 ALWAYS_INLINE JSValue JSValue::get(JSGlobalObject* globalObject, PropertyName propertyName, PropertySlot& slot) const
 {
     auto scope = DECLARE_THROW_SCOPE(getVM(globalObject));
-    bool hasSlot = getPropertySlot(globalObject, propertyName, slot);
+    bool hasSlot = getPropertySlot<debugLLIntGetById>(globalObject, propertyName, slot);
     EXCEPTION_ASSERT(!scope.exception() || !hasSlot);
     if (!hasSlot)
         return jsUndefined();
@@ -70,6 +71,7 @@ ALWAYS_INLINE typename std::invoke_result<CallbackWhenNoException, bool, Propert
     RELEASE_AND_RETURN(scope, callback(found, slot));
 }
 
+template<bool debugLLIntGetById>
 ALWAYS_INLINE bool JSValue::getPropertySlot(JSGlobalObject* globalObject, PropertyName propertyName, PropertySlot& slot) const
 {
     auto scope = DECLARE_THROW_SCOPE(getVM(globalObject));
@@ -90,7 +92,7 @@ ALWAYS_INLINE bool JSValue::getPropertySlot(JSGlobalObject* globalObject, Proper
     } else
         object = asObject(asCell());
 
-    RELEASE_AND_RETURN(scope, object->getPropertySlot(globalObject, propertyName, slot));
+    RELEASE_AND_RETURN(scope, (object->getPropertySlot<false, debugLLIntGetById>(globalObject, propertyName, slot)));
 }
 
 ALWAYS_INLINE bool JSValue::getOwnPropertySlot(JSGlobalObject* globalObject, PropertyName propertyName, PropertySlot& slot) const

--- a/Source/JavaScriptCore/runtime/JSObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSObject.cpp
@@ -25,6 +25,8 @@
 #include "JSObject.h"
 
 #include "AllocationFailureMode.h"
+#include "BlockDirectory.h"
+#include "CompleteSubspace.h"
 #include "CustomGetterSetter.h"
 #include "Exception.h"
 #include "GCDeferralContextInlines.h"
@@ -38,6 +40,7 @@
 #include "JSCustomSetterFunction.h"
 #include "JSFunction.h"
 #include "Lookup.h"
+#include "MarkedSpace.h"
 #include "PropertyDescriptor.h"
 #include "PropertyNameArray.h"
 #include "ProxyObject.h"
@@ -4338,6 +4341,424 @@ ASCIILiteral JSObject::putDirectToDictionaryWithoutExtensibility(VM& vm, Propert
     }
 
     return NonExtensibleObjectPropertyDefineError;
+}
+
+#if CPU(ARM64) && CPU(ADDRESS64)
+template <size_t N>
+static uint64_t saturate(uint64_t value)
+{
+    static_assert(N < 64);
+    if (value < (1ul << N))
+        return value;
+    return (1ul << N) - 1;
+}
+
+// Formal nibble layout of the crash-info registers filled in below and passed to WTFCrashWithInfo.
+// Every field occupies whole nibbles and no two fields share a nibble, so each reads straight out of
+// the hex register dump. The constants are nibble indices (the low nibble of each field);
+// nibbleShift() turns an index into a bit shift. reg3 (raw cell header) and reg6 (this) aren't packed.
+namespace EmptyValueCrashLayout {
+
+constexpr unsigned nibbleShift(unsigned nibbleIndex) { return nibbleIndex * 4; }
+
+// Per-object GC state returned by gcStateFor(), one nibble per boolean (nibbles 0-5).
+namespace GCState {
+constexpr unsigned isPreciseAllocation = 0;
+constexpr unsigned isMarked = 1;
+constexpr unsigned isNewlyAllocated = 2; // meaningful while marking
+constexpr unsigned isFreeListed = 3; // MarkedBlock only: block still being allocated out of
+constexpr unsigned isAllocated = 4; // MarkedBlock only: block was allocated from, now full
+constexpr unsigned isOnFreeList = 5; // MarkedBlock + freeListed only: cell is a free (dead) cell
+constexpr unsigned nibbleCount = 6;
+}
+
+// reg1: offending offset + bad-object data validity + butterfly state.
+namespace Reg1 {
+constexpr unsigned propertyOffset = 0; // nibbles 0-3 (16 bits)
+constexpr unsigned offsetIsInline = 4; // 0 => out-of-line (in the butterfly)
+constexpr unsigned structureIDMapsToValidStructure = 5; // this->structureID().tryDecode() != null
+constexpr unsigned structureOfStructureIsStructureStructure = 6;
+constexpr unsigned badObjectIsZeroFilled = 7; // every word of the cell is zero
+constexpr unsigned blockHeaderVMPointerState = 8; // MarkedBlock only: 0 => zero, 1 => non-null but not equal to structure's VM, 2 => equal to structure's VM
+constexpr unsigned butterflyIsNull = 9; // out-of-line only
+constexpr unsigned butterflyInButterflySpace = 10; // out-of-line only: in vm.auxiliarySpace()
+constexpr unsigned butterflyOutOfLineStorageIsZeroFilled = 11; // out-of-line only
+constexpr unsigned blockPayloadZeroByteCount = 12; // nibbles 12-15 (16 bits): number of zero bytes in the block payload, MarkedBlock only
+}
+
+// reg2: sizes/counts, 16 bits (4 nibbles) each.
+namespace Reg2 {
+constexpr unsigned blankCellWordCount = 0; // nibbles 0-3: zero 8-byte words in the cell
+constexpr unsigned outOfLineSize = 4; // nibbles 4-7: structure's out-of-line slot count
+constexpr unsigned butterflyPublicLength = 8; // nibbles 8-11: out-of-line + indexed only
+constexpr unsigned butterflyVectorLength = 12; // nibbles 12-15: out-of-line + indexed only
+}
+
+// reg4: GC state of the bad object and its prototype-chain child.
+namespace Reg4 {
+constexpr unsigned badObjectGCState = 0; // nibbles 0-5
+constexpr unsigned previousInChainGCState = GCState::nibbleCount; // nibbles 6-11
+constexpr unsigned blockHeaderZeroByteCount = 12; // nibbles 12-15 (16 bits): number of zero bytes in the block header, MarkedBlock only
+}
+
+// reg5: GC state of the base object + global GC state + chain metadata.
+namespace Reg5 {
+constexpr unsigned bottomOfChainGCState = 0; // nibbles 0-5
+constexpr unsigned isMarking = 6; // MarkedSpace::isMarking()
+constexpr unsigned previousInChainIsNull = 7;
+constexpr unsigned badObjectIsBottomOfChain = 8;
+constexpr unsigned chainDepth = 9; // nibbles 9-10 (8 bits); 0xff => not reached within cap
+constexpr unsigned collectionScope = 11; // 0 => none, 1 => eden, 2 => full
+constexpr unsigned worldIsStopped = 12;
+constexpr unsigned mutatorState = 13; // 0 => running, 1 => allocating, 2 => sweeping, 3 => collecting
+constexpr unsigned previousSlotClassification = 14; // see classifySlotWord
+constexpr unsigned nextSlotClassification = 15; // ditto
+}
+
+// The layout must stay nibble-aligned with no field overlapping the next.
+static_assert(Reg4::previousInChainGCState == Reg4::badObjectGCState + GCState::nibbleCount);
+static_assert(Reg5::isMarking == Reg5::bottomOfChainGCState + GCState::nibbleCount);
+static_assert(Reg5::chainDepth + 2 <= Reg5::collectionScope); // chainDepth spans 2 nibbles
+static_assert(Reg5::nextSlotClassification <= 15);
+static_assert(Reg5::nextSlotClassification == Reg5::previousSlotClassification + 1);
+static_assert(Reg1::offsetIsInline == Reg1::propertyOffset + 4); // propertyOffset spans 4 nibbles
+static_assert(Reg2::outOfLineSize == Reg2::blankCellWordCount + 4); // 16-bit fields span 4 nibbles
+static_assert(Reg2::butterflyPublicLength == Reg2::outOfLineSize + 4);
+static_assert(Reg2::butterflyVectorLength + 4 <= 16);
+static_assert(Reg4::blockHeaderZeroByteCount == Reg4::previousInChainGCState + GCState::nibbleCount);
+static_assert(Reg4::blockHeaderZeroByteCount + 4 <= 16); // 16-bit count spans 4 nibbles
+static_assert(Reg1::blockPayloadZeroByteCount + 4 <= 16); // 16-bit count spans 4 nibbles
+static_assert(Reg1::butterflyOutOfLineStorageIsZeroFilled < Reg1::blockPayloadZeroByteCount);
+
+}
+#endif
+
+NO_RETURN_DUE_TO_CRASH NEVER_INLINE void JSObject::crashDueToEmptyValueAtValidOffset(Structure* structure, PropertyName propertyName, PropertyOffset offset, JSObject* bottomOfChain, JSObject* previousInChain, unsigned attributes, int line, const char* filename, const char* function_name)
+{
+#if CPU(ARM64) && CPU(ADDRESS64)
+    register volatile uint64_t reg1 __asm__(CRASH_GPR1) { };
+    register volatile uint64_t reg2 __asm__(CRASH_GPR2) { };
+    register volatile uint64_t reg3 __asm__(CRASH_GPR3) { };
+    register volatile uint64_t reg4 __asm__(CRASH_GPR4) { };
+    register volatile uint64_t reg5 __asm__(CRASH_GPR5) { };
+    register volatile uint64_t reg6 __asm__(CRASH_GPR6) { };
+    register volatile uint64_t dumpState __asm__("x28") { };
+#define updateDumpState(newState) do { \
+        WTF::compilerFence(); \
+        __asm__ volatile("" :: "r"(reg1), "r"(reg2), "r"(reg3), "r"(reg4), "r"(reg5), "r"(reg6)); \
+        __asm__ volatile( \
+            "mov %0, #" #newState "\n\t" \
+            "orr %0, %0, #0xffffffffffff0000" \
+            : "=r"(dumpState)); \
+        WTF::compilerFence(); \
+    } while (false)
+
+    updateDumpState(0x5700);
+
+    reg6 = reinterpret_cast<uint64_t>(this);
+
+    // Fields are appended from least likely to fault while computing to most likely, so if we crash
+    // partway through, every append so far is preserved in the crash registers. reg6 = this (the bad
+    // object); reg3 = its raw first 8 bytes (m_structureID & m_blob). The nibble layout of the packed
+    // registers is captured formally in the EmptyValueCrashLayout namespace above; the shifts below
+    // are derived from it via nibbleShift().
+    using namespace EmptyValueCrashLayout;
+
+    JSObject* badObject = this;
+    VM* vm = std::bit_cast<uint64_t>(structure) > 0x10000 ? &structure->vm() : nullptr;
+
+    reg3 = *std::bit_cast<uint64_t*>(badObject); // raw cell header: m_structureID + m_blob
+
+    updateDumpState(0x5701);
+
+    reg1 |= saturate<16>(offset) << nibbleShift(Reg1::propertyOffset);
+    reg1 |= static_cast<uint64_t>(isInlineOffset(offset)) << nibbleShift(Reg1::offsetIsInline);
+
+    updateDumpState(0x5702);
+
+    // Global GC state: Are we marking? What is the collection scope? Is the world stopped? What is the mutator doing?
+    // This could catch a concurrent-collector race that could clear a slot.
+    bool heapIsMarking = vm != nullptr && vm->heap.objectSpace().isMarking();
+    reg5 |= static_cast<uint64_t>(heapIsMarking) << nibbleShift(Reg5::isMarking);
+    if (vm) {
+        std::optional<CollectionScope> collectionScope = vm->heap.collectionScope();
+        uint64_t collectionScopeCode = !collectionScope ? 0 : (*collectionScope == CollectionScope::Eden ? 1 : 2);
+        reg5 |= collectionScopeCode << nibbleShift(Reg5::collectionScope);
+        reg5 |= static_cast<uint64_t>(vm->heap.worldIsStopped()) << nibbleShift(Reg5::worldIsStopped);
+        reg5 |= static_cast<uint64_t>(vm->heap.mutatorState()) << nibbleShift(Reg5::mutatorState);
+    }
+
+    // Allocation kind, mark/newly-allocated state, and (for MarkedBlock cells)
+    // whether the block is still being allocated out of and whether the cell is
+    // itself a free (dead) cell on the allocator's free list.
+    auto gcStateFor = [](JSCell* cell) -> uint64_t {
+        if (!cell)
+            return 0;
+        uint64_t state = 0;
+        if (cell->isPreciseAllocation()) {
+            auto& allocation = cell->preciseAllocation();
+            state |= 1ull << nibbleShift(GCState::isPreciseAllocation); // isPreciseAllocation() == true
+            state |= static_cast<uint64_t>(allocation.isMarked()) << nibbleShift(GCState::isMarked);
+            state |= static_cast<uint64_t>(allocation.isNewlyAllocated()) << nibbleShift(GCState::isNewlyAllocated);
+        } else {
+            auto& block = cell->markedBlock();
+            auto& handle = block.handle();
+            state |= static_cast<uint64_t>(block.isMarked(cell)) << nibbleShift(GCState::isMarked);
+            state |= static_cast<uint64_t>(block.isNewlyAllocated(cell)) << nibbleShift(GCState::isNewlyAllocated);
+            bool freeListed = handle.isFreeListed();
+            state |= static_cast<uint64_t>(freeListed) << nibbleShift(GCState::isFreeListed);
+            state |= static_cast<uint64_t>(handle.isAllocated()) << nibbleShift(GCState::isAllocated);
+            if (freeListed) {
+                if (BlockDirectory* directory = handle.directory())
+                    state |= static_cast<uint64_t>(directory->isFreeListedCell(cell)) << nibbleShift(GCState::isOnFreeList);
+            }
+        }
+        return state;
+    };
+
+    updateDumpState(0x5703);
+
+    uint64_t badObjectState = gcStateFor(badObject);
+    reg4 |= badObjectState << nibbleShift(Reg4::badObjectGCState);
+
+    updateDumpState(0x5704);
+
+    uint64_t previousState = gcStateFor(previousInChain);
+    reg4 |= previousState << nibbleShift(Reg4::previousInChainGCState);
+
+    updateDumpState(0x5705);
+
+    uint64_t bottomState = gcStateFor(bottomOfChain);
+    reg5 |= bottomState << nibbleShift(Reg5::bottomOfChainGCState);
+
+    reg5 |= static_cast<uint64_t>(!previousInChain) << nibbleShift(Reg5::previousInChainIsNull);
+    reg5 |= static_cast<uint64_t>(bottomOfChain == badObject) << nibbleShift(Reg5::badObjectIsBottomOfChain);
+
+    updateDumpState(0x5706);
+
+    // Backtrack the prototype chain from the original baseValue to discover how far up the bad
+    // object manifests. 0xff means we did not reach it within the cap (corrupt/cyclic chain).
+    uint64_t chainDepth = 0;
+    JSObject* chainCursor = bottomOfChain;
+    {
+        constexpr uint64_t maxDepth = 0xff;
+        while (chainCursor && chainCursor != badObject && chainDepth < maxDepth) {
+            Structure* cursorStructure = chainCursor->structureID().tryDecode();
+            if (!cursorStructure)
+                break;
+            JSValue prototype = cursorStructure->storedPrototype(chainCursor);
+            if (!prototype.isObject())
+                break;
+            chainCursor = asObject(prototype);
+            ++chainDepth;
+        }
+        if (chainCursor != badObject)
+            chainDepth = maxDepth;
+    }
+    reg5 |= saturate<8>(chainDepth) << nibbleShift(Reg5::chainDepth);
+
+    updateDumpState(0x5707);
+
+    // Validate the bad object's structure: does its StructureID decode to an allocated Structure,
+    // and is that Structure itself described by the canonical structureStructure?
+    StructureID badStructureID = badObject->structureID();
+    Structure* decodedStructure = badStructureID.tryDecode();
+    reg1 |= static_cast<uint64_t>(decodedStructure != nullptr) << nibbleShift(Reg1::structureIDMapsToValidStructure);
+
+    updateDumpState(0x5708);
+
+    Structure* metaStructure = nullptr;
+    bool structureOfStructureIsStructureStructure = false;
+    if (decodedStructure) {
+        metaStructure = decodedStructure->structureID().tryDecode();
+        structureOfStructureIsStructureStructure = metaStructure && vm != nullptr && metaStructure == vm->structureStructure.get();
+    }
+    reg1 |= static_cast<uint64_t>(structureOfStructureIsStructureStructure) << nibbleShift(Reg1::structureOfStructureIsStructureStructure);
+
+    updateDumpState(0x5709);
+
+    // Is the bad object zero-filled? Count its zero 8-byte words.
+    std::array<char, 8> emptyWord { };
+    uint64_t blankCellWords = 0;
+    size_t cellWords = badObject->cellSize() / 8;
+    {
+        auto* wordBase = reinterpret_cast<const char*>(badObject);
+        for (size_t i = 0; i < cellWords; ++i) {
+            if (equalSpans(unsafeMakeSpan(wordBase + i * 8, 8), std::span(emptyWord)))
+                ++blankCellWords;
+        }
+    }
+    reg1 |= static_cast<uint64_t>(cellWords && blankCellWords == cellWords) << nibbleShift(Reg1::badObjectIsZeroFilled);
+    reg2 |= saturate<16>(blankCellWords) << nibbleShift(Reg2::blankCellWordCount);
+
+    updateDumpState(0x570a);
+
+    // If the bad object lives in a MarkedBlock, how zeroed-out is that block?
+    // The header holds some words that are written non-zero even after the
+    // payload is zero-filled. So instead, count zero bytes separately for the
+    // header and payload, and capture the header's VM pointer, mirroring
+    // MarkedBlock::analyzeInvalidHandleAndCrash().
+    if (!badObject->isPreciseAllocation()) {
+        MarkedBlock& block = badObject->markedBlock();
+        auto* blockStart = reinterpret_cast<const char*>(&block);
+
+        auto countZeroBytes = [](const char* begin, const char* end) -> uint64_t {
+            uint64_t zeros = 0;
+            for (auto* p = begin; p < end; ++p) {
+                if (!*p)
+                    ++zeros;
+            }
+            return zeros;
+        };
+        uint64_t headerZeroBytes = countZeroBytes(blockStart + MarkedBlock::offsetOfHeader, blockStart + MarkedBlock::offsetOfHeader + MarkedBlock::headerSize);
+        uint64_t payloadZeroBytes = countZeroBytes(blockStart + MarkedBlock::offsetOfHeader + MarkedBlock::headerSize, blockStart + MarkedBlock::blockSize);
+        reg4 |= saturate<16>(headerZeroBytes) << nibbleShift(Reg4::blockHeaderZeroByteCount);
+        reg1 |= saturate<16>(payloadZeroBytes) << nibbleShift(Reg1::blockPayloadZeroByteCount);
+
+        // Is a critical value like the header's VM pointer zeroed out?
+        // 0 => zeroed, 1 => non-null but not this structure's VM, 2 => matches `vm` from from the `structure` argument.
+        VM* blockVM = *std::bit_cast<VM* const*>(blockStart + MarkedBlock::offsetOfHeader + MarkedBlock::Header::offsetOfVM());
+        uint64_t blockVMState = !blockVM ? 0 : (blockVM == vm ? 2 : 1);
+        reg1 |= blockVMState << nibbleShift(Reg1::blockHeaderVMPointerState);
+
+        updateDumpState(0x570b);
+    }
+
+    // Classify a raw slot word read as a JSValue without dereferencing it:
+    // 0 => empty,
+    // 1 => non-cell value,
+    // 2 => cell-tagged and pointing at a live heap cell (MarkedBlock or precise allocation),
+    // 3 => cell-tagged but not a valid heap object,
+    // 4 => cell-tagged precise-looking cell but the VM isn't available to find the precise-allocation set,
+    // 5 => cell-tagged precise-looking cell but the precise-allocation set isn't available to verify.
+    auto classifySlotWord = [&](uint64_t word) -> uint64_t {
+        JSValue value = JSValue::decode(std::bit_cast<EncodedJSValue>(word));
+        if (!value)
+            return 0;
+        if (!value.isCell())
+            return 1;
+        if (!vm)
+            return 4;
+        JSCell* candidate = value.asCell();
+        if (candidate->isPreciseAllocation()) {
+            auto& preciseSet = vm->heap.objectSpace().preciseAllocationSet();
+            if (!preciseSet)
+                return 5;
+            return preciseSet->contains(candidate) ? 2 : 3;
+        }
+        if (!MarkedBlock::isAtomAligned(candidate))
+            return 3;
+        MarkedBlock* candidateBlock = MarkedBlock::blockFor(candidate);
+        return vm->heap.objectSpace().blocks().set().contains(candidateBlock) ? 2 : 3;
+    };
+
+    // For an out-of-line offending offset, inspect the butterfly the null was fetched from.
+    if (isOutOfLineOffset(offset)) {
+        unsigned outOfLineSize = structure->outOfLineSize();
+        reg2 |= saturate<16>(outOfLineSize) << nibbleShift(Reg2::outOfLineSize);
+
+        Butterfly* butterfly = badObject->butterfly();
+        reg1 |= static_cast<uint64_t>(!butterfly) << nibbleShift(Reg1::butterflyIsNull);
+
+        updateDumpState(0x570c);
+
+        // Is the butterfly in butterfly (auxiliary) space? Locate its MarkedBlock without
+        // dereferencing the butterfly, and trust it only if that's a known live block.
+        MarkedBlock* butterflyBlock = butterfly ? MarkedBlock::blockFor(butterfly) : nullptr;
+        bool butterflyInButterflySpace = false;
+        if (butterfly && vm) {
+            const auto& blockSet = vm->heap.objectSpace().blocks().set();
+            if (blockSet.contains(butterflyBlock))
+                butterflyInButterflySpace = butterflyBlock->subspace() == &vm->auxiliarySpace();
+        }
+        reg1 |= static_cast<uint64_t>(butterflyInButterflySpace) << nibbleShift(Reg1::butterflyInButterflySpace);
+
+        updateDumpState(0x570d);
+
+        // Only read butterfly contents once we know it is a real butterfly.
+        if (butterfly && butterflyInButterflySpace) {
+            auto* storageBase = reinterpret_cast<const char*>(butterfly->propertyStorage());
+            auto* blockStart = reinterpret_cast<const char*>(butterflyBlock);
+            const char* blockEnd = blockStart + MarkedBlock::blockSize;
+
+            // Out-of-line slots live at negative offsets from the property-storage base.
+            // Is the whole out-of-line storage zero-filled? Stay within the block.
+            if (outOfLineSize) {
+                bool allZero = true;
+                for (unsigned i = 1; i <= outOfLineSize; ++i) {
+                    auto* slot = storageBase - i * 8;
+                    if (slot < blockStart)
+                        break;
+                    if (!equalSpans(unsafeMakeSpan(slot, 8), std::span(emptyWord))) {
+                        allZero = false;
+                        break;
+                    }
+                }
+                reg1 |= static_cast<uint64_t>(allZero) << nibbleShift(Reg1::butterflyOutOfLineStorageIsZeroFilled);
+            }
+
+            // Butterfly indexing header lengths.
+            // Meaningful only when the object has an indexing header, which sits immediately before the property-storage base.
+            if (structure->hasIndexingHeader(badObject)) {
+                IndexingHeader* header = butterfly->indexingHeader();
+                reg2 |= saturate<16>(header->publicLength()) << nibbleShift(Reg2::butterflyPublicLength);
+                reg2 |= saturate<16>(header->vectorLength()) << nibbleShift(Reg2::butterflyVectorLength);
+            }
+
+            updateDumpState(0x570e);
+
+            // The offending slot itself and its immediate neighbors. Re-reading the slot now can
+            // reveal a race (it was empty when getDirect saw it). A neighbor that is cell-tagged
+            // but doesn't resolve to a live heap cell is a strong corruption signal, so classify
+            // each neighbor.
+            const char* slot = storageBase + offsetInOutOfLineStorage(offset) * 8;
+            uint64_t offendingWord = 0;
+            uint64_t prevWord = 0;
+            uint64_t nextWord = 0;
+            if (slot >= blockStart && slot + 8 <= blockEnd)
+                memcpySpan(asMutableByteSpan(offendingWord), unsafeMakeSpan(reinterpret_cast<const uint8_t*>(slot), 8));
+            if (slot - 8 >= blockStart)
+                memcpySpan(asMutableByteSpan(prevWord), unsafeMakeSpan(reinterpret_cast<const uint8_t*>(slot - 8), 8));
+            if (slot + 16 <= blockEnd)
+                memcpySpan(asMutableByteSpan(nextWord), unsafeMakeSpan(reinterpret_cast<const uint8_t*>(slot + 8), 8));
+            reg5 |= classifySlotWord(prevWord) << nibbleShift(Reg5::previousSlotClassification);
+            reg5 |= classifySlotWord(nextWord) << nibbleShift(Reg5::nextSlotClassification);
+            updateDumpState(0x570f);
+        } else
+            updateDumpState(0x5710);
+    } else if (isInlineOffset(offset)) {
+        // Inline offending slot: read it and its neighbors, bounded by the containing cell.
+        auto* slot = reinterpret_cast<const char*>(badObject->inlineStorage()) + offsetInInlineStorage(offset) * 8;
+        auto* cellStart = reinterpret_cast<const char*>(badObject);
+        const char* cellEnd = cellStart + badObject->cellSize();
+        uint64_t offendingWord = 0;
+        uint64_t prevWord = 0;
+        uint64_t nextWord = 0;
+        if (slot >= cellStart && slot + 8 <= cellEnd)
+            memcpySpan(asMutableByteSpan(offendingWord), unsafeMakeSpan(reinterpret_cast<const uint8_t*>(slot), 8));
+        if (slot - 8 >= cellStart)
+            memcpySpan(asMutableByteSpan(prevWord), unsafeMakeSpan(reinterpret_cast<const uint8_t*>(slot - 8), 8));
+        if (slot + 16 <= cellEnd)
+            memcpySpan(asMutableByteSpan(nextWord), unsafeMakeSpan(reinterpret_cast<const uint8_t*>(slot + 8), 8));
+        reg5 |= classifySlotWord(prevWord) << nibbleShift(Reg5::previousSlotClassification);
+        reg5 |= classifySlotWord(nextWord) << nibbleShift(Reg5::nextSlotClassification);
+        updateDumpState(0x5711);
+    }
+
+    updateDumpState(0x5712);
+
+    UNUSED_PARAM(propertyName);
+    UNUSED_PARAM(attributes);
+    WTFCrashWithInfo(line, filename, function_name, 0x900d0ff5e7bad, reg1, reg2, reg3, reg4, reg5, reg6);
+#else
+    UNUSED_PARAM(structure);
+    UNUSED_PARAM(propertyName);
+    UNUSED_PARAM(offset);
+    UNUSED_PARAM(bottomOfChain);
+    UNUSED_PARAM(previousInChain);
+    UNUSED_PARAM(attributes);
+    WTFCrashWithInfo(line, filename, function_name, 0x900d0ff5e7bad);
+#endif
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/JSObject.h
+++ b/Source/JavaScriptCore/runtime/JSObject.h
@@ -89,6 +89,14 @@ class JSFinalObject;
 #define JS_EXPORT_PRIVATE_IF_ASSERT_ENABLED
 #endif
 
+// Debug-only information handed to getOwnNonIndexPropertySlot on the debugLLIntGetById=true path (rdar://157153895)
+struct PrototypeChainDebugData {
+    // The original base value where getPropertySlot began the prototype walk
+    class JSObject* bottomOfChain;
+    // The prototype-chain child of the object being examined (null if it's the base)
+    class JSObject* previousInChain;
+};
+
 class JSObject : public JSCell {
     friend class BatchedTransitionOptimizer;
     friend class JIT;
@@ -153,7 +161,7 @@ public:
     template<typename T, typename PropertyNameType>
     inline T getAs(JSGlobalObject*, PropertyNameType) const; // Defined in JSObjectInlines.h
 
-    template<bool checkNullStructure = false>
+    template<bool checkNullStructure = false, bool debugLLIntGetById = false>
     bool getPropertySlot(JSGlobalObject*, PropertyName, PropertySlot&);
     bool getPropertySlot(JSGlobalObject*, unsigned propertyName, PropertySlot&);
     bool getPropertySlot(JSGlobalObject*, uint64_t propertyName, PropertySlot&);
@@ -642,7 +650,8 @@ public:
 
     DECLARE_EXPORT_INFO;
 
-    bool getOwnNonIndexPropertySlot(VM&, Structure*, PropertyName, PropertySlot&);
+    template <bool debugLLIntGetById = false>
+    bool getOwnNonIndexPropertySlot(VM&, Structure*, PropertyName, PropertySlot&, const PrototypeChainDebugData* = nullptr);
     bool getNonIndexPropertySlot(JSGlobalObject*, PropertyName, PropertySlot&);
 
     JS_EXPORT_PRIVATE NEVER_INLINE bool putInlineSlow(JSGlobalObject*, PropertyName, JSValue, PutPropertySlot&);
@@ -818,6 +827,8 @@ private:
     JS_EXPORT_PRIVATE ArrayStorage* ensureArrayStorageSlow(VM&);
 
     PropertyOffset prepareToPutDirectWithoutTransition(VM&, PropertyName, unsigned attributes, StructureID, Structure*);
+
+    NO_RETURN_DUE_TO_CRASH NEVER_INLINE void crashDueToEmptyValueAtValidOffset(Structure*, PropertyName, PropertyOffset, JSObject* bottomOfChain, JSObject* previousInChain, unsigned attributes, int line, const char* filename, const char* function_name);
 };
 
 // JSObjectWithButterfly is a JSObject that has out-of-line property storage (butterfly).
@@ -1103,7 +1114,8 @@ inline JSValue JSObject::getDirectConcurrently(Locker<JSCellLock>&, Structure* e
 
 // It is safe to call this method with a PropertyName that is actually an index,
 // but if so will always return false (doesn't search index storage).
-ALWAYS_INLINE bool JSObject::getOwnNonIndexPropertySlot(VM& vm, Structure* structure, PropertyName propertyName, PropertySlot& slot)
+template<bool debugLLIntGetById>
+ALWAYS_INLINE bool JSObject::getOwnNonIndexPropertySlot(VM& vm, Structure* structure, PropertyName propertyName, PropertySlot& slot, const PrototypeChainDebugData* debugData)
 {
     unsigned attributes;
     PropertyOffset offset = structure->get(vm, propertyName, attributes);
@@ -1117,6 +1129,12 @@ ALWAYS_INLINE bool JSObject::getOwnNonIndexPropertySlot(VM& vm, Structure* struc
     ASSERT(!parseIndex(propertyName));
 
     JSValue value = getDirect(offset);
+
+    if constexpr (debugLLIntGetById) {
+        if (!value)
+            crashDueToEmptyValueAtValidOffset(structure, propertyName, offset, debugData->bottomOfChain, debugData->previousInChain, attributes, __LINE__, __FILE__, WTF_PRETTY_FUNCTION);
+    }
+
     if (value.isCell()) {
         ASSERT(value);
         JSCell* cell = value.asCell();
@@ -1180,11 +1198,12 @@ ALWAYS_INLINE bool JSObject::getOwnPropertySlot(JSObject* object, JSGlobalObject
 
 // It may seem crazy to inline a function this large but it makes a big difference
 // since this is function very hot in variable lookup
-template<bool checkNullStructure>
+template<bool checkNullStructure, bool debugLLIntGetById>
 ALWAYS_INLINE bool JSObject::getPropertySlot(JSGlobalObject* globalObject, PropertyName propertyName, PropertySlot& slot)
 {
     VM& vm = getVM(globalObject);
     JSObject* object = this;
+    JSObject* previous = nullptr;
     while (true) {
         if (TypeInfo::overridesGetOwnPropertySlot(object->inlineTypeFlags())) [[unlikely]] {
             // If propertyName is an index then we may have missed it (as this loop is using
@@ -1205,13 +1224,21 @@ ALWAYS_INLINE bool JSObject::getPropertySlot(JSGlobalObject* globalObject, Prope
                 CRASH_WITH_INFO(object->type(), object->structureID().bits());
         }
 #endif
-        if (object->getOwnNonIndexPropertySlot(vm, structure, propertyName, slot))
-            return true;
+        if constexpr (debugLLIntGetById) {
+            PrototypeChainDebugData debugData { .bottomOfChain = this, .previousInChain = previous };
+            if (object->getOwnNonIndexPropertySlot<debugLLIntGetById>(vm, structure, propertyName, slot, &debugData))
+                return true;
+        } else {
+            if (object->getOwnNonIndexPropertySlot<debugLLIntGetById>(vm, structure, propertyName, slot))
+                return true;
+        }
         // FIXME: This doesn't look like it's following the specification:
         // https://bugs.webkit.org/show_bug.cgi?id=172572
         JSValue prototype = structure->storedPrototype(object);
         if (!prototype.isObject())
             break;
+        if constexpr (debugLLIntGetById)
+            previous = object;
         object = asObject(prototype);
     }
 


### PR DESCRIPTION
#### 4f54300b848acb86f95da242cbd1d7538c5d0cf9
<pre>
[JSC] Assemble diagnostic data when getDirect returns an all-zero JSValue during llint_slow_path_get_by_id
<a href="https://bugs.webkit.org/show_bug.cgi?id=320240">https://bugs.webkit.org/show_bug.cgi?id=320240</a>
<a href="https://rdar.apple.com/183368480">rdar://183368480</a>

Reviewed by Mark Lam.

In a case where we&apos;d crash anyway, stuff some useful data into
registers first to make debugging easier in the absence of a repro.

No new tests because we don&apos;t have a repro that can trigger this path.

* Source/JavaScriptCore/heap/BlockDirectory.cpp:
(JSC::BlockDirectory::isFreeListedCell):
* Source/JavaScriptCore/heap/BlockDirectory.h:
* Source/JavaScriptCore/heap/LocalAllocator.cpp:
(JSC::LocalAllocator::isFreeListedCell const):
* Source/JavaScriptCore/heap/LocalAllocator.h:
* Source/JavaScriptCore/llint/LLIntSlowPaths.cpp:
(JSC::LLInt::performLLIntGetByID):
* Source/JavaScriptCore/runtime/JSCJSValue.h:
* Source/JavaScriptCore/runtime/JSCJSValuePropertyInlines.h:
(JSC::JSValue::get const):
(JSC::JSValue::getPropertySlot const):
* Source/JavaScriptCore/runtime/JSObject.cpp:
(JSC::saturate):
(JSC::EmptyValueCrashLayout::nibbleShift):
(JSC::JSObject::crashDueToEmptyValueAtValidOffset):
* Source/JavaScriptCore/runtime/JSObject.h:
(JSC::JSObject::getOwnNonIndexPropertySlot):
(JSC::JSObject::getPropertySlot):

Canonical link: <a href="https://commits.webkit.org/318194@main">https://commits.webkit.org/318194@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/45f3c1b438c79dcec415b96f9b3c3ed62b0f76c3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177586 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51524 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45318 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187190 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140833 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52816 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51233 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/138427 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140833 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180542 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/41928 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/159164 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118891 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/40589 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/38955 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/251/builds/860 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/218/builds/7660 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150996 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38660 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35657 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/38857 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/43309 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/43190 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189619 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51191 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147510 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39621 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51873 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/35288 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147302 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42022 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124088 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118501 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50381 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13637 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49777 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50017 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49839 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->