### PR TITLE
[Scroll snap] Fix css/css-scroll-snap/capturing-snap-positions.html

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/capturing-snap-positions-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/capturing-snap-positions-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL The third item should be snapped to by default, not the second's child. assert_equals: expected 200 but got 100
+PASS The third item should be snapped to by default, not the second's child.
 

--- a/Source/WebCore/page/scrolling/ScrollSnapOffsetsInfo.cpp
+++ b/Source/WebCore/page/scrolling/ScrollSnapOffsetsInfo.cpp
@@ -433,7 +433,7 @@ void updateSnapOffsetsForScrollableArea(ScrollableArea& scrollableArea, const Re
     LOG_WITH_STREAM(ScrollSnap, stream << "Computing scroll snap offsets for " << scrollableArea << " in snap port " << scrollSnapPort);
 
     for (CheckedRef child : boxesWithScrollSnapPositions) {
-        if (child->enclosingScrollableContainer() != &scrollingElementBox || !child->element())
+        if (child->enclosingScrollSnapContainer() != &scrollingElementBox || !child->element())
             continue;
 
         // The bounds of the child element's snap area, where the top left of the scrolling container's border box is the origin.

--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -510,7 +510,23 @@ RenderBox* RenderObject::enclosingScrollableContainer() const
             return downcast<RenderBox>(candidate);
     }
 
-    // If we reach the root, then the root element is the scrolling container.
+    return document().documentElement() ? document().documentElement()->renderBox() : nullptr;
+}
+
+RenderBox* RenderObject::enclosingScrollSnapContainer() const
+{
+    for (auto* candidate = container(); candidate; candidate = candidate->container()) {
+        // Currently the RenderView can look like it has scrollable overflow, but we never
+        // want to return this as our container. Instead we should use the root element.
+        if (candidate->isRenderView())
+            break;
+
+        if (auto* candidateBox = dynamicDowncast<RenderBox>(*candidate)) {
+            if (candidateBox->hasPotentiallyScrollableOverflow() || !candidateBox->style().scrollSnapType().isNone())
+                return candidateBox;
+        }
+    }
+
     return document().documentElement() ? document().documentElement()->renderBox() : nullptr;
 }
 

--- a/Source/WebCore/rendering/RenderObject.h
+++ b/Source/WebCore/rendering/RenderObject.h
@@ -397,7 +397,9 @@ public:
 
     WEBCORE_EXPORT RenderBox& NODELETE enclosingBox() const;
     RenderBoxModelObject& NODELETE enclosingBoxModelObject() const;
+
     RenderBox* enclosingScrollableContainer() const;
+    RenderBox* enclosingScrollSnapContainer() const;
 
     // Return our enclosing flow thread if we are contained inside one. Follows the containing block chain.
     RenderFragmentedFlow* enclosingFragmentedFlow() const;


### PR DESCRIPTION
#### b0c306763ca13765980b34b7b1bc56b6dd3716f4
<pre>
[Scroll snap] Fix css/css-scroll-snap/capturing-snap-positions.html
<a href="https://bugs.webkit.org/show_bug.cgi?id=320241">https://bugs.webkit.org/show_bug.cgi?id=320241</a>
<a href="https://rdar.apple.com/183171023">rdar://183171023</a>

Reviewed by NOBODY (OOPS!).

The spec[1] says:
&quot;A box captures snap positions if it is a scroll container or has a value other than none for scroll-snap-type.&quot;

We failed to implement the latter clause so fix that. `enclosingScrollSnapContainer()` mirrors
`enclosingScrollableContainer()` but also checks the scroll snap type.

[1] <a href="https://drafts.csswg.org/css-scroll-snap/#captures-snap-positions">https://drafts.csswg.org/css-scroll-snap/#captures-snap-positions</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/capturing-snap-positions-expected.txt:
* Source/WebCore/page/scrolling/ScrollSnapOffsetsInfo.cpp:
(WebCore::updateSnapOffsetsForScrollableArea):
* Source/WebCore/rendering/RenderObject.cpp:
(WebCore::RenderObject::enclosingScrollableContainer const):
(WebCore::RenderObject::enclosingScrollSnapContainer const):
* Source/WebCore/rendering/RenderObject.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b0c306763ca13765980b34b7b1bc56b6dd3716f4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176694 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50631 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44423 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186296 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/139574 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4ae04ca3-e129-4ee2-a953-e16ca3134f8d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178557 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51924 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50317 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137641 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-scroll-snap/snap-area-capturing-add-scroll-container.html imported/w3c/web-platform-tests/css/css-scroll-snap/snap-area-capturing-remove-scroll-container.html (failure)") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/139574 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/63cf5346-365c-4e2d-afec-f2cca9c6950d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179650 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41144 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158432 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118115 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a305e92b-feae-4d65-9b7e-374a63c8a643) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39799 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-scroll-snap/snap-area-capturing-add-scroll-container.html imported/w3c/web-platform-tests/css/css-scroll-snap/snap-area-capturing-remove-scroll-container.html (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38167 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150211 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37930 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-scroll-snap/snap-area-capturing-add-scroll-container.html imported/w3c/web-platform-tests/css/css-scroll-snap/snap-area-capturing-remove-scroll-container.html (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34764 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42371 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42383 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-scroll-snap/snap-area-capturing-add-scroll-container.html imported/w3c/web-platform-tests/css/css-scroll-snap/snap-area-capturing-remove-scroll-container.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188720 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50298 "Built successfully") | | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146704 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-scroll-snap/snap-area-capturing-remove-scroll-container.html (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50981 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34551 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-scroll-snap/snap-area-capturing-add-scroll-container.html imported/w3c/web-platform-tests/css/css-scroll-snap/snap-area-capturing-remove-scroll-container.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146509 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41274 "Passed tests") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123187 "Found 1 new failure in wasm/WasmConstExprGenerator.cpp") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117317 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49486 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12909 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48885 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49121 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48946 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->