### PR TITLE
[WKCI][WPE] Race condition when trying to use podman meanwhile the directory of shared SDK images is getting updated

### DIFF
--- a/Tools/Scripts/webkitpy/port/linux_container_sdk_utils.py
+++ b/Tools/Scripts/webkitpy/port/linux_container_sdk_utils.py
@@ -27,7 +27,7 @@ import shutil
 import socket
 import subprocess
 import sys
-
+from time import sleep
 
 WKDEV_CONTAINER_NAME = 'wkdev-build'
 WKDEV_SDK_VERSION_FILENAME = '.wkdev-sdk-version'
@@ -427,6 +427,27 @@ _EPHEMERAL_ENTRYPOINT_SCRIPT = (
 )
 
 
+# This is used to avoid a race condition: when the CI is updating the images on the shared directory
+# (pull_cycle that runs each 5 minutes) we need to wait for it to finish or podman will have issues.
+def maybe_wait_for_ci_pull_cycle_sdk_images():
+    podman_shared_sdk_images_dir = os.environ.get('PODMAN_SHARED_SDK_IMAGES_DIR', None)
+    if podman_shared_sdk_images_dir is None:
+        return
+    if not os.path.isdir(podman_shared_sdk_images_dir):
+        print(f"WARNING: Can't find the directory '{podman_shared_sdk_images_dir}' defined in the env var 'PODMAN_SHARED_SDK_IMAGES_DIR'", file=sys.stderr)
+        return
+    podman_shared_sdk_images_ongoing = os.path.join(podman_shared_sdk_images_dir, '.pull_cycle_ongoing')
+    i = 0
+    while os.path.isfile(podman_shared_sdk_images_ongoing):
+        if i >= 1200:
+            print('WARNING: The pull cycle has not finished in 20 minutes. Something seems wrong. Stop waiting.', file=sys.stderr)
+            return
+        if i % 10 == 0:
+            print(f'Waiting for pull cycle to finish on the shared SDK images directory at "{podman_shared_sdk_images_dir}"')
+        sleep(1)
+        i += 1
+
+
 def maybe_enter_webkit_container_sdk(argv=None):
     """If invoked on the host (outside a wkdev-sdk container), re-execute the
     current command inside an ephemeral wkdev-build container at the SDK
@@ -530,6 +551,7 @@ def maybe_enter_webkit_container_sdk(argv=None):
         container_command,
     ] + argv[1:]
 
+    maybe_wait_for_ci_pull_cycle_sdk_images()
     print('Launching WebKit Container SDK wkdev-build {}.'.format(pinned_version), file=sys.stderr)
     sys.stdout.flush()
     sys.stderr.flush()


### PR DESCRIPTION
#### a5df88cab3c6dd423a3b16a5cd9958d3c9bcd930
<pre>
[WKCI][WPE] Race condition when trying to use podman meanwhile the directory of shared SDK images is getting updated
<a href="https://bugs.webkit.org/show_bug.cgi?id=320178">https://bugs.webkit.org/show_bug.cgi?id=320178</a>

Reviewed by Nikolas Zimmermann.

There is a race condition when a WPE/GTK bot tries to auto-launch podman to run
inside the SDK environment but the cache of podman images is getting updated at
that very same time by a daemonset/cronjob that runs each 5 minutes.

To avoid this race condition, the infra will signal when that process is
happening by touching and deleting a specific file at the start and end of the
process. Then the WebKit tooling can simply wait in case of detecting that
file sentinel before executing podman.

* Tools/Scripts/webkitpy/port/linux_container_sdk_utils.py:
(maybe_wait_for_ci_pull_cycle_sdk_images):
(maybe_enter_webkit_container_sdk):

Canonical link: <a href="https://commits.webkit.org/318894@main">https://commits.webkit.org/318894@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/48f3aedcfbd10932b278f3d821b4e4060d9014d4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179802 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/53748 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/47540 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189641 "Failed to checkout and rebase branch from PR 70150") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/144121 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181665 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/55035 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/53464 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/189641 "Failed to checkout and rebase branch from PR 70150") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/144121 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182759 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/55035 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/47540 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/189641 "Failed to checkout and rebase branch from PR 70150") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/179127 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/55035 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/53464 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/5/builds/189641 "Failed to checkout and rebase branch from PR 70150") | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/47540 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/55035 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/47540 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 gtk3-gcc~~](https://ews-build.webkit.org/#/builders/284/builds/1167 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/53464 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191860 "Failed to checkout and rebase branch from PR 70150") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/53415 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/47540 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/191860 "Failed to checkout and rebase branch from PR 70150") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/54092 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/47540 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/191860 "Failed to checkout and rebase branch from PR 70150") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27298 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/54092 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/121406 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/52617 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/47540 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/52000 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/52237 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/52064 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->