### PR TITLE
Crash in NavigateEvent::finish when document element is removed inside navigate handler

### DIFF
--- a/LayoutTests/navigation-api/navigation-api-remove-document-element-in-navigate-handler-crash-expected.txt
+++ b/LayoutTests/navigation-api/navigation-api-remove-document-element-in-navigate-handler-crash-expected.txt
@@ -1,0 +1,4 @@
+Tests that removing the document element inside an intercepted navigate handler does not crash. WebKit should not hit assertions or crash under ASAN.
+
+
+PASS

--- a/LayoutTests/navigation-api/navigation-api-remove-document-element-in-navigate-handler-crash.html
+++ b/LayoutTests/navigation-api/navigation-api-remove-document-element-in-navigate-handler-crash.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<body>
+<p>Tests that removing the document element inside an intercepted navigate handler does not crash. WebKit should not hit assertions or crash under ASAN.</p>
+<iframe src="resources/navigation-api-remove-document-element-in-navigate-handler-crash-inner.html"></iframe>
+<div id="result"></div>
+<script>
+
+if (window.testRunner) {
+  testRunner.waitUntilDone();
+  testRunner.dumpAsText();
+}
+
+function scheduleFinish() {
+  setTimeout(() => {
+    result.textContent = 'PASS';
+    if (window.testRunner)
+      testRunner.notifyDone();
+  }, 0);
+}
+
+</script>
+</body>
+</html>

--- a/LayoutTests/navigation-api/resources/navigation-api-remove-document-element-in-navigate-handler-crash-inner.html
+++ b/LayoutTests/navigation-api/resources/navigation-api-remove-document-element-in-navigate-handler-crash-inner.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script>
+
+navigation.onnavigate = function (event) {
+  event.intercept({
+    handler: function () {
+      document.documentElement.remove();
+      return Promise.resolve();
+    }
+  });
+};
+
+window.onload = function () {
+  navigation.navigate('#anchor');
+  parent.scheduleFinish();
+};
+
+</script>
+</body>
+</html>

--- a/Source/WebCore/page/NavigateEvent.cpp
+++ b/Source/WebCore/page/NavigateEvent.cpp
@@ -213,16 +213,15 @@ void NavigateEvent::finish(Document& document, InterceptionHandlersDidFulfill di
 
     ASSERT(m_interceptionState == InterceptionState::Committed || m_interceptionState == InterceptionState::Scrolled);
     if (focusChanged == FocusDidChange::No && m_focusReset != NavigationFocusReset::Manual) {
-        RefPtr documentElement = document.documentElement();
-        ASSERT(documentElement);
+        if (RefPtr documentElement = document.documentElement()) {
+            RefPtr<Element> focusTarget = documentElement->findAutofocusDelegate();
+            if (!focusTarget)
+                focusTarget = document.body();
+            if (!focusTarget)
+                focusTarget = WTF::move(documentElement);
 
-        RefPtr<Element> focusTarget = documentElement->findAutofocusDelegate();
-        if (!focusTarget)
-            focusTarget = document.body();
-        if (!focusTarget)
-            focusTarget = documentElement;
-
-        document.setFocusedElement(focusTarget.get());
+            document.setFocusedElement(focusTarget.get());
+        }
     }
 
     if (didFulfill == InterceptionHandlersDidFulfill::Yes)


### PR DESCRIPTION
#### e5d3b562ec6fc7d6d4e75ce47c6b7a6979251ca5
<pre>
Crash in NavigateEvent::finish when document element is removed inside navigate handler
<a href="https://bugs.webkit.org/show_bug.cgi?id=320242">https://bugs.webkit.org/show_bug.cgi?id=320242</a>
<a href="https://rdar.apple.com/182122186">rdar://182122186</a>

Reviewed by Chris Dumez.

When a navigate handler removes document.documentElement, NavigateEvent::finish called findAutofocusDelegate() on the null return value of documentElement(), dereferencing a null
pointer. The fix guards that call so focus reset is simply skipped when there is no document element.

Test: navigation-api/navigation-api-remove-document-element-in-navigate-handler-crash.html

* LayoutTests/navigation-api/navigation-api-remove-document-element-in-navigate-handler-crash-expected.txt: Added.
* LayoutTests/navigation-api/navigation-api-remove-document-element-in-navigate-handler-crash.html: Added.
* LayoutTests/navigation-api/resources/navigation-api-remove-document-element-in-navigate-handler-crash-inner.html: Added.
* Source/WebCore/page/NavigateEvent.cpp:
(WebCore::NavigateEvent::finish):

Canonical link: <a href="https://commits.webkit.org/318041@main">https://commits.webkit.org/318041@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9b43fff2d97640b71198ea4098049d050cd78424

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177147 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51084 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44879 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186750 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140383 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fdf99966-6c63-4a1d-b007-144a770d4a0a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179010 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52377 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50770 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138033 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140383 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/317c9e7b-af69-4520-a416-8ed803a2d89d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180103 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41533 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158791 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118500 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/803af417-afe6-4eb5-93e8-3819e16bfe7b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40189 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/38563 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150599 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38290 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35218 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/42862 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/42781 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189176 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50751 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/158330 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147115 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39531 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51434 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/34914 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146909 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41639 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123648 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117942 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49939 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13270 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49338 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49575 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49399 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->