### PR TITLE
Begin implementing datagram queues for WebTransport

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/datagrams.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/datagrams.https.any-expected.txt
@@ -3,10 +3,10 @@ PASS Datagrams are echoed successfully
 PASS Successfully reading datagrams with BYOB reader.
 PASS Reading datagrams with BYOB reader without datagramsReadableType should fail.
 PASS Reading datagrams with insufficient buffer should be rejected.
-FAIL Transfer max-size datagram promise_test: Unhandled rejection with value: object "NetworkError:  A network error occurred."
-FAIL Fail to transfer max-size+1 datagram, handle PMTUD increases promise_test: Unhandled rejection with value: object "NetworkError:  A network error occurred."
+PASS Transfer max-size datagram
+PASS Fail to transfer max-size+1 datagram, handle PMTUD increases
 PASS Sending and receiving datagrams is ready to use before session is established
-FAIL Datagram's outgoingMaxBufferedDatagrams correctly regulates written datagrams assert_true: expected true got false
+PASS Datagram's outgoingMaxBufferedDatagrams correctly regulates written datagrams
 PASS Datagrams read is less than or equal to the incomingMaxBufferedDatagrams
 PASS Datagram MaxAge getters/setters work correctly
 PASS Datagram MaxBufferedDatagrams getters/setters work correctly

--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/datagrams.https.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/datagrams.https.any.serviceworker-expected.txt
@@ -3,10 +3,10 @@ PASS Datagrams are echoed successfully
 PASS Successfully reading datagrams with BYOB reader.
 PASS Reading datagrams with BYOB reader without datagramsReadableType should fail.
 PASS Reading datagrams with insufficient buffer should be rejected.
-FAIL Transfer max-size datagram promise_test: Unhandled rejection with value: object "NetworkError:  A network error occurred."
-FAIL Fail to transfer max-size+1 datagram, handle PMTUD increases promise_test: Unhandled rejection with value: object "NetworkError:  A network error occurred."
+PASS Transfer max-size datagram
+PASS Fail to transfer max-size+1 datagram, handle PMTUD increases
 PASS Sending and receiving datagrams is ready to use before session is established
-FAIL Datagram's outgoingMaxBufferedDatagrams correctly regulates written datagrams assert_true: expected true got false
+PASS Datagram's outgoingMaxBufferedDatagrams correctly regulates written datagrams
 PASS Datagrams read is less than or equal to the incomingMaxBufferedDatagrams
 PASS Datagram MaxAge getters/setters work correctly
 PASS Datagram MaxBufferedDatagrams getters/setters work correctly

--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/datagrams.https.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/datagrams.https.any.sharedworker-expected.txt
@@ -3,10 +3,10 @@ PASS Datagrams are echoed successfully
 PASS Successfully reading datagrams with BYOB reader.
 PASS Reading datagrams with BYOB reader without datagramsReadableType should fail.
 PASS Reading datagrams with insufficient buffer should be rejected.
-FAIL Transfer max-size datagram promise_test: Unhandled rejection with value: object "NetworkError:  A network error occurred."
-FAIL Fail to transfer max-size+1 datagram, handle PMTUD increases promise_test: Unhandled rejection with value: object "NetworkError:  A network error occurred."
+PASS Transfer max-size datagram
+PASS Fail to transfer max-size+1 datagram, handle PMTUD increases
 PASS Sending and receiving datagrams is ready to use before session is established
-FAIL Datagram's outgoingMaxBufferedDatagrams correctly regulates written datagrams assert_true: expected true got false
+PASS Datagram's outgoingMaxBufferedDatagrams correctly regulates written datagrams
 PASS Datagrams read is less than or equal to the incomingMaxBufferedDatagrams
 PASS Datagram MaxAge getters/setters work correctly
 PASS Datagram MaxBufferedDatagrams getters/setters work correctly

--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/datagrams.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/datagrams.https.any.worker-expected.txt
@@ -3,10 +3,10 @@ PASS Datagrams are echoed successfully
 PASS Successfully reading datagrams with BYOB reader.
 PASS Reading datagrams with BYOB reader without datagramsReadableType should fail.
 PASS Reading datagrams with insufficient buffer should be rejected.
-FAIL Transfer max-size datagram promise_test: Unhandled rejection with value: object "NetworkError:  A network error occurred."
-FAIL Fail to transfer max-size+1 datagram, handle PMTUD increases promise_test: Unhandled rejection with value: object "NetworkError:  A network error occurred."
+PASS Transfer max-size datagram
+PASS Fail to transfer max-size+1 datagram, handle PMTUD increases
 PASS Sending and receiving datagrams is ready to use before session is established
-FAIL Datagram's outgoingMaxBufferedDatagrams correctly regulates written datagrams assert_true: expected true got false
+PASS Datagram's outgoingMaxBufferedDatagrams correctly regulates written datagrams
 PASS Datagrams read is less than or equal to the incomingMaxBufferedDatagrams
 PASS Datagram MaxAge getters/setters work correctly
 PASS Datagram MaxBufferedDatagrams getters/setters work correctly

--- a/Source/WebCore/Modules/webtransport/DatagramSink.cpp
+++ b/Source/WebCore/Modules/webtransport/DatagramSink.cpp
@@ -32,6 +32,7 @@
 #include "JSDOMPromiseDeferred.h"
 #include "ScriptExecutionContextInlines.h"
 #include "WebTransport.h"
+#include "WebTransportDatagramDuplexStream.h"
 #include "WebTransportDatagramsWritable.h"
 #include "WebTransportSendGroup.h"
 #include "WebTransportSession.h"
@@ -39,8 +40,8 @@
 
 namespace WebCore {
 
-DatagramSink::DatagramSink(WebTransportSession* session)
-    : m_session(session) { }
+DatagramSink::DatagramSink(WebTransport* transport)
+    : m_transport(transport) { }
 
 DatagramSink::~DatagramSink() = default;
 
@@ -48,6 +49,32 @@ void DatagramSink::attachTo(WebTransportDatagramsWritable& datagrams)
 {
     ASSERT(!m_datagrams);
     m_datagrams = datagrams;
+}
+
+void DatagramSink::resolveBufferedDatagramsWithRoom()
+{
+    RefPtr transport = m_transport.get();
+    uint32_t max = transport ? transport->datagrams().outgoingMaxBufferedDatagrams() : std::numeric_limits<uint32_t>::max();
+    uint32_t index = 0;
+    for (auto& datagram : m_outgoingQueue) {
+        if (index++ >= max)
+            break;
+        if (!datagram.settled) {
+            datagram.settled = true;
+            datagram.promise.resolve();
+        }
+    }
+}
+
+void DatagramSink::datagramSent()
+{
+    ASSERT(!m_outgoingQueue.isEmpty());
+    if (m_outgoingQueue.isEmpty())
+        return;
+    auto sent = m_outgoingQueue.takeFirst();
+    if (!sent.settled)
+        sent.promise.resolve();
+    resolveBufferedDatagramsWithRoom();
 }
 
 void DatagramSink::write(ScriptExecutionContext& context, JSC::JSValue value, DOMPromiseDeferred<void>&& promise)
@@ -65,8 +92,8 @@ void DatagramSink::write(ScriptExecutionContext& context, JSC::JSValue value, DO
     if (bufferSource.hasException(scope)) [[unlikely]]
         return promise.settle(Exception { ExceptionCode::ExistingExceptionError });
 
-    RefPtr session = m_session.get();
-    if (!session)
+    RefPtr transport = m_transport.get();
+    if (!transport)
         return promise.settle(Exception { ExceptionCode::InvalidStateError });
 
     RefPtr datagrams = m_datagrams.get();
@@ -74,13 +101,24 @@ void DatagramSink::write(ScriptExecutionContext& context, JSC::JSValue value, DO
     auto identifier = sendGroup ? std::optional(sendGroup->identifier()) : std::nullopt;
 
     WTF::switchOn(bufferSource.releaseReturnValue(), [&](auto&& arrayBufferOrView) {
-        context.enqueueTaskWhenSettled(session->sendDatagram(identifier, arrayBufferOrView->span()), WebCore::TaskSource::Networking, [promise = WTF::move(promise)] (auto&& exception) mutable {
-            if (!exception)
-                promise.settle(Exception { ExceptionCode::NetworkError });
-            else if (*exception)
-                promise.settle(WTF::move(**exception));
-            else
-                promise.resolve();
+        auto span = arrayBufferOrView->span();
+
+        // https://www.w3.org/TR/webtransport/#writedatagrams
+        // silently drop datagrams that exceed the maximum size.
+        if (span.size() > transport->datagrams().maxDatagramSize())
+            return promise.resolve();
+
+        // Enqueue the datagram into [[OutgoingDatagramsQueue]] and resolve its promise immediately if there
+        // is still room in the outgoing buffer; otherwise leave it pending to apply backpressure to the writer.
+        m_outgoingQueue.append(OutgoingDatagram { WTF::move(promise), false });
+        if (m_outgoingQueue.size() < transport->datagrams().outgoingMaxBufferedDatagrams()) {
+            m_outgoingQueue.last().settled = true;
+            m_outgoingQueue.last().promise.resolve();
+        }
+
+        Ref session = transport->session();
+        context.enqueueTaskWhenSettled(session->sendDatagram(identifier, span), WebCore::TaskSource::Networking, [protectedThis = Ref { *this }] (auto&&) {
+            protectedThis->datagramSent();
         });
     });
 }

--- a/Source/WebCore/Modules/webtransport/DatagramSink.h
+++ b/Source/WebCore/Modules/webtransport/DatagramSink.h
@@ -25,29 +25,40 @@
 
 #pragma once
 
+#include "JSDOMPromiseDeferred.h"
 #include "WritableStreamSink.h"
+#include <wtf/Deque.h>
 #include <wtf/ThreadSafeWeakPtr.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
 
+class WebTransport;
 class WebTransportDatagramsWritable;
-class WebTransportSession;
 
 class DatagramSink : public WritableStreamSink {
 public:
-    static Ref<DatagramSink> create(WebTransportSession* session) { return adoptRef(*new DatagramSink(session)); }
+    static Ref<DatagramSink> create(WebTransport* transport) { return adoptRef(*new DatagramSink(transport)); }
     ~DatagramSink();
 
     void NODELETE attachTo(WebTransportDatagramsWritable&);
 
 private:
-    DatagramSink(WebTransportSession*);
+    explicit DatagramSink(WebTransport*);
 
     void write(ScriptExecutionContext&, JSC::JSValue, DOMPromiseDeferred<void>&&) final;
     void close(JSDOMGlobalObject&) final { m_isClosed = true; }
 
-    ThreadSafeWeakPtr<WebTransportSession> m_session;
+    void datagramSent();
+    void resolveBufferedDatagramsWithRoom();
+
+    struct OutgoingDatagram {
+        DOMPromiseDeferred<void> promise;
+        bool settled { false };
+    };
+    Deque<OutgoingDatagram> m_outgoingQueue;
+
+    ThreadSafeWeakPtr<WebTransport> m_transport;
     WeakPtr<WebTransportDatagramsWritable> m_datagrams;
     bool m_isClosed { false };
 };

--- a/Source/WebCore/Modules/webtransport/DatagramSource.cpp
+++ b/Source/WebCore/Modules/webtransport/DatagramSource.cpp
@@ -27,6 +27,8 @@
 #include "DatagramSource.h"
 
 #include "Exception.h"
+#include "WebTransport.h"
+#include "WebTransportDatagramDuplexStream.h"
 #include <JavaScriptCore/ArrayBuffer.h>
 #include <wtf/StdLibExtras.h>
 
@@ -35,6 +37,54 @@ namespace WebCore {
 DatagramDefaultSource::DatagramDefaultSource() = default;
 
 DatagramDefaultSource::~DatagramDefaultSource() = default;
+
+void DatagramDefaultSource::setTransport(WebTransport& transport)
+{
+    m_transport = transport;
+}
+
+uint32_t DatagramDefaultSource::incomingMaxBufferedDatagrams() const
+{
+    if (RefPtr transport = m_transport.get())
+        return transport->datagrams().incomingMaxBufferedDatagrams();
+    return 1;
+}
+
+bool DatagramDefaultSource::deliverDatagram()
+{
+    ASSERT(!m_incomingQueue.isEmpty());
+    if (controller().enqueue(m_incomingQueue.takeFirst())) {
+        pullFinished();
+        return true;
+    }
+    doCancel();
+    pullFinished();
+    return false;
+}
+
+void DatagramDefaultSource::doStart()
+{
+    startFinished();
+}
+
+void DatagramDefaultSource::doPull()
+{
+    if (m_isCancelled || m_isClosed)
+        return;
+
+    // FIXME: Check if datagrams are too old according to incomingMaxAge.
+    if (!m_incomingQueue.isEmpty()) {
+        if (!deliverDatagram())
+            return;
+        if (m_finReceived && m_incomingQueue.isEmpty() && !m_isClosed) {
+            m_isClosed = true;
+            controller().close();
+        }
+        return;
+    }
+
+    m_pullPending = true;
+}
 
 void DatagramDefaultSource::receiveDatagram(std::span<const uint8_t> datagram, bool withFin, std::optional<Exception>&& exception)
 {
@@ -46,22 +96,30 @@ void DatagramDefaultSource::receiveDatagram(std::span<const uint8_t> datagram, b
         return;
     }
     if (datagram.size()) {
-        auto arrayBuffer = ArrayBuffer::tryCreateUninitialized(datagram.size(), 1);
-        if (arrayBuffer)
+        if (auto arrayBuffer = ArrayBuffer::tryCreateUninitialized(datagram.size(), 1)) {
             memcpySpan(arrayBuffer->mutableSpan(), datagram);
-        if (!controller().enqueue(WTF::move(arrayBuffer)))
-            doCancel({ });
+            while (m_incomingQueue.size() >= incomingMaxBufferedDatagrams())
+                m_incomingQueue.removeFirst();
+            // FIXME: We should remove datagrams that are too old based on IncomingDatagramsExpirationDuration.
+            m_incomingQueue.append(WTF::move(arrayBuffer));
+            if (std::exchange(m_pullPending, false))
+                deliverDatagram();
+        }
     }
     if (withFin) {
-        m_isClosed = true;
-        controller().close();
-        clean();
+        m_finReceived = true;
+        if (m_incomingQueue.isEmpty() && !m_isClosed) {
+            m_isClosed = true;
+            controller().close();
+            clean();
+        }
     }
 }
 
 void DatagramDefaultSource::doCancel()
 {
     m_isCancelled = true;
+    m_incomingQueue.clear();
     cancelFinished();
 }
 

--- a/Source/WebCore/Modules/webtransport/DatagramSource.h
+++ b/Source/WebCore/Modules/webtransport/DatagramSource.h
@@ -28,8 +28,11 @@
 #include "Exception.h"
 #include "ReadableStreamSource.h"
 #include <wtf/AbstractRefCounted.h>
+#include <wtf/Deque.h>
+#include <wtf/ThreadSafeWeakPtr.h>
 
 namespace JSC {
+class ArrayBuffer;
 class JSGlobalObject;
 class JSValue;
 }
@@ -44,6 +47,7 @@ public:
     virtual ~DatagramSource() = default;
     virtual void receiveDatagram(std::span<const uint8_t>, bool, std::optional<Exception>&&) = 0;
     virtual void error(JSC::JSGlobalObject&, JSC::JSValue) = 0;
+    virtual void setTransport(WebTransport&) { }
 };
 
 class DatagramDefaultSource final : public DatagramSource, public RefCountedReadableStreamSource {
@@ -59,15 +63,22 @@ private:
 
     void receiveDatagram(std::span<const uint8_t>, bool, std::optional<Exception>&&) final;
     void error(JSC::JSGlobalObject&, JSC::JSValue) final;
+    void setTransport(WebTransport&) final;
 
     void setActive() final { }
     void setInactive() final { }
-    void doStart() final { }
-    void doPull() final { }
+    void doStart() final;
+    void doPull() final;
     void doCancel(JSC::JSValue) final { doCancel(); }
 
     void doCancel();
+    bool deliverDatagram();
+    uint32_t incomingMaxBufferedDatagrams() const;
 
+    ThreadSafeWeakPtr<WebTransport> m_transport;
+    Deque<RefPtr<JSC::ArrayBuffer>> m_incomingQueue;
+    bool m_pullPending { false };
+    bool m_finReceived { false };
     bool m_isCancelled { false };
     bool m_isClosed { false };
 };

--- a/Source/WebCore/Modules/webtransport/WebTransport.cpp
+++ b/Source/WebCore/Modules/webtransport/WebTransport.cpp
@@ -137,7 +137,8 @@ ExceptionOr<Ref<WebTransport>> WebTransport::create(ScriptExecutionContext& cont
         datagramSource = WTF::move(datagramByteSource);
     } else {
         Ref datagramDefaultSource = DatagramDefaultSource::create();
-        auto readableOrException = ReadableStream::create(domGlobalObject, datagramDefaultSource.copyRef());
+        constexpr double highWaterMark { 0 };
+        auto readableOrException = ReadableStream::create(domGlobalObject, datagramDefaultSource.copyRef(), highWaterMark);
         if (readableOrException.hasException())
             return readableOrException.releaseException();
         incomingDatagrams = readableOrException.releaseReturnValue();
@@ -177,6 +178,7 @@ WebTransport::WebTransport(ScriptExecutionContext& context, JSDOMGlobalObject& g
     , m_bidirectionalStreamSource(WTF::move(bidirectionalStreamSource))
 {
     m_datagrams->attachTo(*this);
+    m_datagramSource->setTransport(*this);
     context.enqueueTaskWhenSettled(m_session->initialize(context, url, options, WebCore::clientOrigin(context)), WebCore::TaskSource::Networking, [weakThis = WeakPtr { *this }] (auto&& info) mutable {
         RefPtr strongThis = weakThis.get();
         if (!strongThis)

--- a/Source/WebCore/Modules/webtransport/WebTransportDatagramDuplexStream.cpp
+++ b/Source/WebCore/Modules/webtransport/WebTransportDatagramDuplexStream.cpp
@@ -48,6 +48,13 @@ WebTransportDatagramDuplexStream::WebTransportDatagramDuplexStream(Ref<ReadableS
 
 WebTransportDatagramDuplexStream::~WebTransportDatagramDuplexStream() = default;
 
+unsigned WebTransportDatagramDuplexStream::maxDatagramSize() const
+{
+    // Chrome currently uses 1024, and it's close to 1200, the minimum max datagram size for quic.
+    // FIXME: Adopt rdar://182433814 when it's ready instead.
+    return 1024;
+}
+
 void WebTransportDatagramDuplexStream::attachTo(WebTransport& transport)
 {
     ASSERT(!m_transport.get());

--- a/Source/WebCore/Modules/webtransport/WebTransportDatagramDuplexStream.h
+++ b/Source/WebCore/Modules/webtransport/WebTransportDatagramDuplexStream.h
@@ -51,7 +51,7 @@ public:
 
     ReadableStream& readable() { return m_readable; }
     ExceptionOr<Ref<WebTransportDatagramsWritable>> createWritable(ScriptExecutionContext&, WebTransportSendOptions&&);
-    unsigned maxDatagramSize() const { return std::numeric_limits<uint16_t>::max(); }
+    unsigned maxDatagramSize() const;
     std::optional<double> incomingMaxAge() const { return m_incomingMaxAge; }
     std::optional<double> outgoingMaxAge() const { return m_outgoingMaxAge; }
     uint32_t incomingMaxBufferedDatagrams() const { return m_incomingMaxBufferedDatagrams; }
@@ -69,8 +69,8 @@ private:
     RefPtr<WebTransportSession> session();
 
     const Ref<ReadableStream> m_readable;
-    uint32_t m_incomingMaxBufferedDatagrams { std::numeric_limits<uint32_t>::max() };
-    uint32_t m_outgoingMaxBufferedDatagrams { std::numeric_limits<uint32_t>::max() };
+    uint32_t m_incomingMaxBufferedDatagrams { 1 };
+    uint32_t m_outgoingMaxBufferedDatagrams { 1 };
     std::optional<double> m_incomingMaxAge;
     std::optional<double> m_outgoingMaxAge;
     ThreadSafeWeakPtr<WebTransport> m_transport;

--- a/Source/WebCore/Modules/webtransport/WebTransportDatagramsWritable.cpp
+++ b/Source/WebCore/Modules/webtransport/WebTransportDatagramsWritable.cpp
@@ -49,7 +49,8 @@ ExceptionOr<Ref<WebTransportDatagramsWritable>> WebTransportDatagramsWritable::c
     }
     auto& domGlobalObject = *downcast<JSDOMGlobalObject>(globalObject);
 
-    Ref datagramSink = DatagramSink::create(transport ? transport->session().ptr() : nullptr);
+    // FIXME: Reject if transport is nullptr and pass a reference instead of a pointer here.
+    Ref datagramSink = DatagramSink::create(transport.get());
     auto internal = createInternalWritableStream(domGlobalObject, datagramSink.copyRef());
     if (internal.hasException())
         return internal.releaseException();

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebTransport.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebTransport.mm
@@ -249,9 +249,9 @@ TEST(WebTransport, Datagram)
         port];
     [webView loadHTMLString:html baseURL:[NSURL URLWithString:@"https://webkit.org/"]];
     if (!canLoadnw_webtransport_metadata_get_transport_mode())
-        EXPECT_WK_STREQ([webView _test_waitForAlert], "successfully read abc, group sent 3 bytes, maxDatagramSize 65535, reliability pending");
+        EXPECT_WK_STREQ([webView _test_waitForAlert], "successfully read abc, group sent 3 bytes, maxDatagramSize 1024, reliability pending");
     else
-        EXPECT_WK_STREQ([webView _test_waitForAlert], "successfully read abc, group sent 3 bytes, maxDatagramSize 65535, reliability supports-unreliable");
+        EXPECT_WK_STREQ([webView _test_waitForAlert], "successfully read abc, group sent 3 bytes, maxDatagramSize 1024, reliability supports-unreliable");
     EXPECT_TRUE(challenged);
 }
 


### PR DESCRIPTION
#### fc590f32814ad0a3f3d01883947dc1e23c414b50
<pre>
Begin implementing datagram queues for WebTransport
<a href="https://bugs.webkit.org/show_bug.cgi?id=320246">https://bugs.webkit.org/show_bug.cgi?id=320246</a>
<a href="https://rdar.apple.com/183175125">rdar://183175125</a>

Reviewed by Youenn Fablet.

Also update maxDatagramSize to 1024, a bit below the minimum max datagram size for QUIC.
Chrome seems to have 1024.  This change makes the &quot;Transfer max-size datagram&quot;
test pass, and is a reasonable max datagram size.

* LayoutTests/imported/w3c/web-platform-tests/webtransport/datagrams.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webtransport/datagrams.https.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webtransport/datagrams.https.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webtransport/datagrams.https.any.worker-expected.txt:
* Source/WebCore/Modules/webtransport/DatagramSink.cpp:
(WebCore::DatagramSink::DatagramSink):
(WebCore::DatagramSink::resolveBufferedDatagramsWithRoom):
(WebCore::DatagramSink::datagramSent):
(WebCore::DatagramSink::write):
* Source/WebCore/Modules/webtransport/DatagramSink.h:
(WebCore::DatagramSink::create):
* Source/WebCore/Modules/webtransport/DatagramSource.cpp:
(WebCore::DatagramDefaultSource::setTransport):
(WebCore::DatagramDefaultSource::incomingMaxBufferedDatagrams const):
(WebCore::DatagramDefaultSource::deliverDatagram):
(WebCore::DatagramDefaultSource::doStart):
(WebCore::DatagramDefaultSource::doPull):
(WebCore::DatagramDefaultSource::receiveDatagram):
(WebCore::DatagramDefaultSource::doCancel):
* Source/WebCore/Modules/webtransport/DatagramSource.h:
(WebCore::DatagramSource::setTransport):
* Source/WebCore/Modules/webtransport/WebTransport.cpp:
(WebCore::WebTransport::create):
(WebCore::WebTransport::WebTransport):
* Source/WebCore/Modules/webtransport/WebTransportDatagramDuplexStream.cpp:
(WebCore::WebTransportDatagramDuplexStream::maxDatagramSize const):
* Source/WebCore/Modules/webtransport/WebTransportDatagramDuplexStream.h:
(WebCore::WebTransportDatagramDuplexStream::maxDatagramSize const):
* Source/WebCore/Modules/webtransport/WebTransportDatagramsWritable.cpp:
(WebCore::WebTransportDatagramsWritable::create):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebTransport.mm:
(TestWebKitAPI::TEST(WebTransport, Datagram)):

Canonical link: <a href="https://commits.webkit.org/318101@main">https://commits.webkit.org/318101@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a9ea967bf72dcc102434bcfef63c28955e52109d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177310 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51248 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45042 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186913 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140557 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bcc4c680-e762-4e32-8f73-cc7cbfb6585c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179173 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52540 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50937 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/138171 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140557 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/089c943b-56a1-42c9-906a-6005d3502193) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180266 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41673 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/158931 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118636 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5ff2adcb-cf1c-4afc-827b-9580a26a5cd6) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40334 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/38718 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/150742 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38428 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35381 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/43033 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/42932 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189342 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50914 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147263 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51597 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/35055 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147054 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26893 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41777 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123812 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118148 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50105 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13406 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49501 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49741 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49563 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->