### PR TITLE
Make iframes switch processes on reload in Site Isolation after Storage Access returns NoModificationAllowedError.

### DIFF
--- a/LayoutTests/http/tests/storageAccess/request-throw-exception-on-grant-until-reload-site-isolation-expected.txt
+++ b/LayoutTests/http/tests/storageAccess/request-throw-exception-on-grant-until-reload-site-isolation-expected.txt
@@ -1,0 +1,15 @@
+Tests that requestStorageAccess throws exception on cross-site iframe until iframe is reloaded
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS iframe 1 and iframe 2 are in the same process
+PASS iframe 1 is in a different process from the main frame
+PASS requestStorageAccess result: NoModificationAllowedError
+PASS iframe 1 was reloaded into a different process
+PASS iframe 1 is still in a different process from the main frame after reload
+PASS requestStorageAccess result: Granted
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/storageAccess/request-throw-exception-on-grant-until-reload-site-isolation.html
+++ b/LayoutTests/http/tests/storageAccess/request-throw-exception-on-grant-until-reload-site-isolation.html
@@ -1,3 +1,4 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
 <!DOCTYPE html>
 <html>
 <head>
@@ -9,6 +10,9 @@
         jsTestIsAsync = true;
         testEnded = false;
         testStarted = false;
+        var mainFramePid = window.internals ? String(window.internals.processIdentifier) : null;
+        var iframe2Pid = null;
+        var iframe1PidBefore = null;
 
         function endTest() {
             if (testEnded)
@@ -25,12 +29,46 @@
                 endTest();
                 return;
             }
-            
-            if (event.data.startsWith("iframe 1 pid: "))
+
+            if (event.data.startsWith("iframe 2 pid: ")) {
+                iframe2Pid = event.data.substring("iframe 2 pid: ".length);
                 return;
+            }
+            
+            if (event.data.startsWith("iframe 1 pid: ")) {
+                var pid = event.data.substring("iframe 1 pid: ".length);
+                if (iframe1PidBefore === null) {
+                    iframe1PidBefore = pid;
+                    if (iframe2Pid !== null) {
+                        if (iframe1PidBefore === iframe2Pid)
+                            testPassed("iframe 1 and iframe 2 are in the same process");
+                        else
+                            testFailed("iframe 1 and iframe 2 are not in the same process");
+                    }
+                    if (mainFramePid !== null) {
+                        if (iframe1PidBefore !== mainFramePid)
+                            testPassed("iframe 1 is in a different process from the main frame");
+                        else
+                            testFailed("iframe 1 is in the same process as the main frame");
+                    }
+                } else {
+                    if (pid !== iframe1PidBefore)
+                        testPassed("iframe 1 was reloaded into a different process");
+                    else
+                        testFailed("iframe 1 was not reloaded into a different process");
+                    if (mainFramePid !== null) {
+                        if (pid !== mainFramePid)
+                            testPassed("iframe 1 is still in a different process from the main frame after reload");
+                        else
+                            testFailed("iframe 1 is in the same process as the main frame after reload");
+                    }
+                }
+                return;
+            }
 
             if (event.data == "NoModificationAllowedError") {
                 testPassed("requestStorageAccess result: " + event.data);
+                pidMessage = true;
                 return;
             }
 
@@ -83,6 +121,7 @@
     </script>
 </head>
 <body>
+    <iframe src="http://localhost:8000/storageAccess/resources/pid-iframe.html"></iframe>
     <iframe sandbox="allow-storage-access-by-user-activation allow-scripts allow-same-origin allow-modals" onload="frameLoaded()" id="TheIframeThatRequestsStorageAccess" src="http://localhost:8000/storageAccess/resources/request-throw-exception-on-grant-until-reload-iframe.html"></iframe>
 </body>
 </html>

--- a/LayoutTests/http/tests/storageAccess/resources/pid-iframe.html
+++ b/LayoutTests/http/tests/storageAccess/resources/pid-iframe.html
@@ -1,0 +1,10 @@
+<html>
+<head>
+    <script>
+        function messageToTop(message) {
+            top.postMessage("iframe 2 pid: " + window.internals.processIdentifier, "http://127.0.0.1:8000");
+        }
+    </script>
+</head>
+<body onload="messageToTop()"></body>
+</html>

--- a/LayoutTests/http/tests/storageAccess/resources/request-throw-exception-on-grant-until-reload-iframe.html
+++ b/LayoutTests/http/tests/storageAccess/resources/request-throw-exception-on-grant-until-reload-iframe.html
@@ -11,6 +11,7 @@
         }
 
         function messageToTop(message) {
+            top.postMessage("iframe 1 pid: " + window.internals.processIdentifier, "http://127.0.0.1:8000");
             top.postMessage(message, "http://127.0.0.1:8000");
         }
 

--- a/Source/WebKit/NetworkProcess/Classifier/WebResourceLoadStatisticsStore.cpp
+++ b/Source/WebKit/NetworkProcess/Classifier/WebResourceLoadStatisticsStore.cpp
@@ -463,9 +463,15 @@ void WebResourceLoadStatisticsStore::requestStorageAccess(RegistrableDomain&& su
             protect(networkSession->networkProcess().parentProcessConnection())->sendWithAsyncReply(Messages::NetworkProcessProxy::RequestStorageAccessConfirm(webPageProxyID, frameID, subFrameDomain, topFrameDomain, storageAccessQuirk), WTF::move(requestConfirmationCompletionHandler));
             return;
         }
-        case StorageAccessStatus::HasAccess:
-            completionHandler({ storageAccessWasGrantedValueForFrame(frameID, subFrameDomain), StorageAccessPromptWasShown::No, scope, topFrameDomain, subFrameDomain });
+        case StorageAccessStatus::HasAccess: {
+            auto wasGranted = storageAccessWasGrantedValueForFrame(frameID, subFrameDomain);
+            // If YesWithException, the grant is recorded so a reloaded frame in a new process
+            // (Site Isolation) can re-request without a user gesture.
+            if (wasGranted == StorageAccessWasGranted::YesWithException)
+                wasGrantedStorageAccessPermissionInPage(webPageProxyID, topFrameDomain, subFrameDomain);
+            completionHandler({ wasGranted, StorageAccessPromptWasShown::No, scope, topFrameDomain, subFrameDomain });
             return;
+        }
         }
     };
 
@@ -1676,13 +1682,23 @@ void WebResourceLoadStatisticsStore::recordFrameLoadForStorageAccess(WebPageProx
 
 void WebResourceLoadStatisticsStore::clearFrameLoadRecordsForStorageAccess(WebCore::FrameIdentifier frameID)
 {
+    // Preserve records where a storage access request was already made: the timestamp is needed
+    // for storageAccessWasGrantedValueForFrame to correctly return Yes after a Site Isolation
+    // process swap reload, even if this clear races with the new process's ScheduleResourceLoad.
     m_storageAccessRequestRecords.removeIf([&](auto& record) {
-        return record.key.first == frameID;
+        return record.key.first == frameID && !record.value.lastRequestTime;
+    });
+    m_framesAwaitingStorageAccessReload.removeIf([&](auto& key) {
+        return key.first == frameID;
     });
 }
 
 void WebResourceLoadStatisticsStore::clearFrameLoadRecordsForStorageAccess(WebPageProxyIdentifier webPageProxyID)
 {
+    m_framesAwaitingStorageAccessReload.removeIf([&](auto& key) {
+        auto iter = m_storageAccessRequestRecords.find(key);
+        return iter != m_storageAccessRequestRecords.end() && iter->value.webPageProxyID == webPageProxyID;
+    });
     m_storageAccessRequestRecords.removeIf([&](auto& record) {
         return record.value.webPageProxyID == webPageProxyID;
     });
@@ -1699,7 +1715,23 @@ StorageAccessWasGranted WebResourceLoadStatisticsStore::storageAccessWasGrantedV
     if (!value.lastRequestTime)
         value.lastRequestTime = WallTime::now();
 
-    return value.lastRequestTime.value() < value.lastLoadTime ? StorageAccessWasGranted::Yes : StorageAccessWasGranted::YesWithException;
+    if (value.lastRequestTime.value() < value.lastLoadTime)
+        return StorageAccessWasGranted::Yes;
+
+    if (auto pageProxyID = iter->value.webPageProxyID) {
+        bool isNew = m_framesAwaitingStorageAccessReload.add(StorageAccessRequestRecordKey { frameID, domain }).isNewEntry;
+        if (isNew) {
+            if (CheckedPtr networkSession = m_networkSession.get())
+                protect(networkSession->networkProcess().parentProcessConnection())->send(Messages::NetworkProcessProxy::StorageAccessReloadableFrameRecorded(*pageProxyID), 0);
+        }
+    }
+    return StorageAccessWasGranted::YesWithException;
+}
+
+bool WebResourceLoadStatisticsStore::needsProcessSwapForStorageAccessReload(WebCore::FrameIdentifier frameID, const WebCore::RegistrableDomain& domain)
+{
+    StorageAccessRequestRecordKey key { frameID, domain };
+    return m_framesAwaitingStorageAccessReload.remove(key);
 }
 
 void WebResourceLoadStatisticsStore::setStorageAccessPermissionForTesting(bool granted, WebPageProxyIdentifier webPageProxyID, RegistrableDomain&& topFrameDomain, RegistrableDomain&& subFrameDomain, CompletionHandler<void()>&& completionHandler)

--- a/Source/WebKit/NetworkProcess/Classifier/WebResourceLoadStatisticsStore.h
+++ b/Source/WebKit/NetworkProcess/Classifier/WebResourceLoadStatisticsStore.h
@@ -231,6 +231,7 @@ public:
     void recordFrameLoadForStorageAccess(WebPageProxyIdentifier, WebCore::FrameIdentifier, const WebCore::RegistrableDomain&);
     void clearFrameLoadRecordsForStorageAccess(WebCore::FrameIdentifier);
     void clearFrameLoadRecordsForStorageAccess(WebPageProxyIdentifier);
+    bool needsProcessSwapForStorageAccessReload(WebCore::FrameIdentifier, const WebCore::RegistrableDomain&);
 
     void setStorageAccessPermissionForTesting(bool, WebPageProxyIdentifier, RegistrableDomain&& topFrameDomain, RegistrableDomain&& subFrameDomain, CompletionHandler<void()>&&);
     void wasRevokedStorageAccessPermissionInPage(WebPageProxyIdentifier);
@@ -284,6 +285,7 @@ private:
     };
     using StorageAccessRequestRecordKey = std::pair<WebCore::FrameIdentifier, RegistrableDomain>;
     HashMap<StorageAccessRequestRecordKey, StorageAccessRequestRecordValue> m_storageAccessRequestRecords;
+    HashSet<StorageAccessRequestRecordKey> m_framesAwaitingStorageAccessReload;
     HashMap<std::pair<RegistrableDomain, RegistrableDomain>, WeakHashSet<StorageAccessPermissionChangeObserver>> m_storageAccessPermissionChangeObservers;
 };
 

--- a/Source/WebKit/NetworkProcess/NetworkProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.cpp
@@ -3592,4 +3592,16 @@ void NetworkProcess::isEnhancedSecurityLink(const URL& url, CompletionHandler<vo
 }
 #endif
 
+void NetworkProcess::needsProcessSwapForStorageAccessReload(PAL::SessionID sessionID, WebCore::FrameIdentifier frameID, const WebCore::RegistrableDomain& domain, CompletionHandler<void(bool)>&& completionHandler)
+{
+    CheckedPtr session = networkSession(sessionID);
+    if (!session)
+        return completionHandler(false);
+
+    if (RefPtr resourceLoadStatistics = session->resourceLoadStatistics())
+        return completionHandler(resourceLoadStatistics->needsProcessSwapForStorageAccessReload(frameID, domain));
+
+    completionHandler(false);
+}
+
 } // namespace WebKit

--- a/Source/WebKit/NetworkProcess/NetworkProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.h
@@ -504,6 +504,7 @@ public:
 #if HAVE(ENHANCED_SECURITY_LINKS)
     void isEnhancedSecurityLink(const URL&, CompletionHandler<void(bool)>&&);
 #endif
+    void needsProcessSwapForStorageAccessReload(PAL::SessionID, WebCore::FrameIdentifier, const WebCore::RegistrableDomain&, CompletionHandler<void(bool)>&&);
 
 private:
     explicit NetworkProcess(AuxiliaryProcessInitializationParameters&&);

--- a/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
@@ -309,4 +309,6 @@ messages -> NetworkProcess : AuxiliaryProcess WantsAsyncDispatchMessage {
 #if HAVE(ENHANCED_SECURITY_LINKS)
     IsEnhancedSecurityLink(URL url) -> (bool isEnhancedSecurityLink)
 #endif
+
+    NeedsProcessSwapForStorageAccessReload(PAL::SessionID sessionID, WebCore::FrameIdentifier frameID, WebCore::RegistrableDomain subFrameDomain) -> (bool needsSwap)
 }

--- a/Source/WebKit/UIProcess/API/APINavigation.h
+++ b/Source/WebKit/UIProcess/API/APINavigation.h
@@ -209,6 +209,9 @@ public:
     void setIsEnhancedSecurityLinkForCurrentSite(bool isEnhancedSecurityLink) { m_isEnhancedSecurityLinkForCurrentSite = isEnhancedSecurityLink; }
     bool isEnhancedSecurityLinkForCurrentSite() const { return m_isEnhancedSecurityLinkForCurrentSite; }
 
+    void setNeedsProcessSwapForStorageAccessReload(bool value) { m_needsProcessSwapForStorageAccessReload = value; }
+    bool needsProcessSwapForStorageAccessReload() const { return m_needsProcessSwapForStorageAccessReload; }
+
     WebKit::FrameState* backForwardFrameState() const { return m_backForwardFrameState.get(); }
     void setBackForwardFrameState(RefPtr<WebKit::FrameState>&& frameState) { m_backForwardFrameState = WTF::move(frameState); }
 
@@ -248,6 +251,7 @@ private:
     bool m_hadSafeBrowsingWarning : 1 { false };
     bool m_hasStorageForCurrentSite : 1 { false };
     bool m_isEnhancedSecurityLinkForCurrentSite : 1 { false };
+    bool m_needsProcessSwapForStorageAccessReload : 1 { false };
     RefPtr<API::WebsitePolicies> m_websitePolicies;
     std::optional<OptionSet<WebCore::AdvancedPrivacyProtections>> m_originatorAdvancedPrivacyProtections;
     MonotonicTime m_requestStart { MonotonicTime::now() };

--- a/Source/WebKit/UIProcess/BrowsingContextGroup.cpp
+++ b/Source/WebKit/UIProcess/BrowsingContextGroup.cpp
@@ -105,7 +105,7 @@ void BrowsingContextGroup::sharedProcessForSite(WebsiteDataStore& websiteDataSto
     });
 }
 
-Ref<FrameProcess> BrowsingContextGroup::ensureProcessForSite(const Site& site, const Site& mainFrameSite, WebProcessProxy& process, const WebPreferences& preferences, LoadedWebArchive loadedWebArchive, BrowsingContextGroupUpdate browsingContextGroupUpdate)
+Ref<FrameProcess> BrowsingContextGroup::ensureProcessForSite(const Site& site, const Site& mainFrameSite, WebProcessProxy& process, const WebPreferences& preferences, LoadedWebArchive loadedWebArchive, BrowsingContextGroupUpdate browsingContextGroupUpdate, bool forceReplaceExistingProcess)
 {
     if (preferences.siteIsolationEnabled()) {
         if ((m_sharedProcess && m_sharedProcessSites.contains(site)) || process.isSharedProcess()) {
@@ -115,6 +115,15 @@ Ref<FrameProcess> BrowsingContextGroup::ensureProcessForSite(const Site& site, c
         if (RefPtr existingProcess = processForSite(site)) {
             if (existingProcess->process().coreProcessIdentifier() == process.coreProcessIdentifier())
                 return existingProcess.releaseNonNull();
+        }
+        // When a storage access reload forces a new process for the same site, evict the old entry
+        // so addFrameProcessWithoutInjectingPageContext can register the new one. The old FrameProcess
+        // remains alive (held by WebFrameProxy) and its destructor will skip the map removal since it
+        // is no longer the current entry.
+        if (forceReplaceExistingProcess) {
+            if (RefPtr existingFrameProcess = m_processMap.get(site))
+                existingFrameProcess->markEvictedFromProcessMap();
+            m_processMap.remove(site);
         }
     }
 
@@ -225,10 +234,10 @@ void BrowsingContextGroup::removeFrameProcess(FrameProcess& process)
         m_sharedProcessSites.clear();
     } else {
         auto& site = *process.site();
-        // Either we are still the current entry for this site (normal teardown), or a
-        // later navigation already replaced us under the same conditions used by
-        // addFrameProcess.
-        ASSERT(m_processMap.get(site) == &process || canReplaceFrameProcessInProcessMap(site, process));
+        // Either we are still the current entry for this site (normal teardown), a later navigation
+        // already replaced us under the same conditions used by addFrameProcess, or we were
+        // explicitly evicted by a storage access reload process swap.
+        ASSERT(m_processMap.get(site) == &process || canReplaceFrameProcessInProcessMap(site, process) || process.wasEvictedFromProcessMap());
         if (m_processMap.get(site) == &process)
             m_processMap.remove(site);
     }

--- a/Source/WebKit/UIProcess/BrowsingContextGroup.h
+++ b/Source/WebKit/UIProcess/BrowsingContextGroup.h
@@ -68,7 +68,7 @@ public:
     WebCore::BrowsingContextGroupIdentifier identifier() const { return m_identifier; }
 
     void sharedProcessForSite(WebsiteDataStore&, API::WebsitePolicies*, const WebPreferences&, const WebCore::Site&, const WebCore::Site& mainFrameSite, WebProcessProxy::LockdownMode, EnhancedSecurity, API::PageConfiguration&, IsMainFrame, CompletionHandler<void(FrameProcess*)>&&);
-    Ref<FrameProcess> ensureProcessForSite(const WebCore::Site&, const WebCore::Site& mainFrameSite, WebProcessProxy&, const WebPreferences&, LoadedWebArchive = LoadedWebArchive::No, BrowsingContextGroupUpdate = BrowsingContextGroupUpdate::AddProcessAndInjectBrowsingContext);
+    Ref<FrameProcess> ensureProcessForSite(const WebCore::Site&, const WebCore::Site& mainFrameSite, WebProcessProxy&, const WebPreferences&, LoadedWebArchive = LoadedWebArchive::No, BrowsingContextGroupUpdate = BrowsingContextGroupUpdate::AddProcessAndInjectBrowsingContext, bool forceReplaceExistingProcess = false);
     RefPtr<FrameProcess> processForSite(const WebCore::Site&);
     void addFrameProcess(FrameProcess&);
     void addFrameProcessAndInjectPageContextIf(FrameProcess&, Function<bool(WebPageProxy&)>);

--- a/Source/WebKit/UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.cpp
+++ b/Source/WebKit/UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.cpp
@@ -243,7 +243,12 @@ bool DrawingAreaProxyCoordinatedGraphics::alwaysUseCompositing() const
 
 void DrawingAreaProxyCoordinatedGraphics::enterAcceleratedCompositingMode(const LayerTreeContext& layerTreeContext)
 {
-    ASSERT(!isInAcceleratedCompositingMode());
+    // Under Site Isolation, a process swap within an iframe may send EnterAcceleratedCompositingMode
+    // while the drawing area is already compositing (from the previous process). Treat it as an update.
+    if (isInAcceleratedCompositingMode()) {
+        updateAcceleratedCompositingMode(layerTreeContext);
+        return;
+    }
 #if !PLATFORM(WPE) && !PLATFORM(GTK)
     m_backingStore = nullptr;
 #endif

--- a/Source/WebKit/UIProcess/FrameProcess.h
+++ b/Source/WebKit/UIProcess/FrameProcess.h
@@ -57,6 +57,11 @@ public:
     void decrementFrameCount() { m_frameCount--; }
     unsigned frameCount() const { return m_frameCount; }
 
+    // Set when a storage access reload forced a new process for the same site, evicting this
+    // FrameProcess from BrowsingContextGroup's process map before it was destroyed.
+    void markEvictedFromProcessMap() { m_evictedFromProcessMap = true; }
+    bool wasEvictedFromProcessMap() const { return m_evictedFromProcessMap; }
+
 private:
     friend class BrowsingContextGroup; // FrameProcess should not be created except by BrowsingContextGroup.
     static Ref<FrameProcess> create(WebProcessProxy& process, BrowsingContextGroup& group, const std::optional<WebCore::Site>& site, const WebCore::Site& mainFrameSite,
@@ -72,6 +77,7 @@ private:
     const WebCore::Site m_mainFrameSite;
     bool m_isArchiveProcess;
     Checked<unsigned> m_frameCount { 0 };
+    bool m_evictedFromProcessMap { false };
 };
 
 }

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
@@ -1089,6 +1089,12 @@ void NetworkProcessProxy::requestStorageAccessConfirm(WebPageProxyIdentifier pag
     page->requestStorageAccessConfirm(subFrameDomain, topFrameDomain, frameID, WTF::move(organizationStorageAccessPromptQuirk), WTF::move(completionHandler));
 }
 
+void NetworkProcessProxy::storageAccessReloadableFrameRecorded(WebPageProxyIdentifier pageID)
+{
+    if (RefPtr page = WebProcessProxy::webPage(pageID))
+        page->storageAccessReloadableFrameRecorded();
+}
+
 void NetworkProcessProxy::getAllStorageAccessEntries(PAL::SessionID sessionID, CompletionHandler<void(Vector<String> domains)>&& completionHandler)
 {
     if (!canSendMessage()) {

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
@@ -432,6 +432,8 @@ private:
 
     void considerProcessSwapForNavigationResponse(WebPageProxyIdentifier, WebCore::NavigationIdentifier, WebCore::BrowsingContextGroupSwitchDecision, WebCore::NavigationResponseProcessSwapReason, const WebCore::Site& responseSite, NetworkResourceLoadIdentifier existingNetworkResourceLoadIdentifierToResume, CompletionHandler<void(bool success)>&&);
 
+    void storageAccessReloadableFrameRecorded(WebPageProxyIdentifier);
+
     void requestStorageSpace(PAL::SessionID, const WebCore::ClientOrigin&, uint64_t quota, uint64_t currentSize, uint64_t spaceRequired, CompletionHandler<void(std::optional<uint64_t> quota)>&&);
     void increaseQuota(PAL::SessionID, const WebCore::ClientOrigin&, QuotaIncreaseRequestIdentifier, uint64_t currentQuota, uint64_t currentUsage, uint64_t spaceRequested);
 

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.messages.in
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.messages.in
@@ -79,6 +79,8 @@ messages -> NetworkProcessProxy WantsDispatchMessage {
 
     ConsiderProcessSwapForNavigationResponse(WebKit::WebPageProxyIdentifier pageIdentifier, WebCore::NavigationIdentifier navigationID, enum:uint8_t WebCore::BrowsingContextGroupSwitchDecision browsingContextGroupSwitchDecision, enum:uint8_t WebCore::NavigationResponseProcessSwapReason reason, WebCore::Site responseSite, WebKit::NetworkResourceLoadIdentifier existingNetworkResourceLoadIdentifierToResume) -> (bool success)
 
+    StorageAccessReloadableFrameRecorded(WebKit::WebPageProxyIdentifier pageIdentifier)
+
 #if USE(SOUP)
     DidExceedMemoryLimit()
 #endif

--- a/Source/WebKit/UIProcess/WebFramePolicyListenerProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFramePolicyListenerProxy.cpp
@@ -35,7 +35,7 @@
 
 namespace WebKit {
 
-WebFramePolicyListenerProxy::WebFramePolicyListenerProxy(Reply&& reply, ShouldExpectSafeBrowsingResult expectSafeBrowsingResult, ShouldExpectAppBoundDomainResult expectAppBoundDomainResult, ShouldWaitForInitialLinkDecorationFilteringData shouldWaitForInitialLinkDecorationFilteringData, ShouldWaitForSiteHasStorageCheck shouldWaitForSiteHasStorageCheck, ShouldWaitForEnhancedSecurityLinkCheck shouldWaitForEnhancedSecurityLinkCheck)
+WebFramePolicyListenerProxy::WebFramePolicyListenerProxy(Reply&& reply, ShouldExpectSafeBrowsingResult expectSafeBrowsingResult, ShouldExpectAppBoundDomainResult expectAppBoundDomainResult, ShouldWaitForInitialLinkDecorationFilteringData shouldWaitForInitialLinkDecorationFilteringData, ShouldWaitForSiteHasStorageCheck shouldWaitForSiteHasStorageCheck, ShouldWaitForEnhancedSecurityLinkCheck shouldWaitForEnhancedSecurityLinkCheck, ShouldWaitForStorageAccessReloadCheck shouldWaitForStorageAccessReloadCheck)
     : m_reply(WTF::move(reply))
 {
     if (expectSafeBrowsingResult == ShouldExpectSafeBrowsingResult::No)
@@ -48,6 +48,8 @@ WebFramePolicyListenerProxy::WebFramePolicyListenerProxy(Reply&& reply, ShouldEx
         didReceiveSiteHasStorageResults();
     if (shouldWaitForEnhancedSecurityLinkCheck == ShouldWaitForEnhancedSecurityLinkCheck::No)
         didReceiveEnhancedSecurityLinkResults();
+    if (shouldWaitForStorageAccessReloadCheck == ShouldWaitForStorageAccessReloadCheck::No)
+        didReceiveStorageAccessReloadCheckResults();
 }
 
 WebFramePolicyListenerProxy::~WebFramePolicyListenerProxy() = default;
@@ -56,7 +58,7 @@ void WebFramePolicyListenerProxy::didReceiveAppBoundDomainResult(std::optional<N
 {
     ASSERT(RunLoop::isMain());
 
-    if (m_policyResult && m_doneWaitingForSafeBrowsing && m_doneWaitingForLinkDecorationFilteringData && m_doneWaitingForSiteHasStorage && m_doneWaitingForEnhancedSecurityLink) {
+    if (m_policyResult && m_doneWaitingForSafeBrowsing && m_doneWaitingForLinkDecorationFilteringData && m_doneWaitingForSiteHasStorage && m_doneWaitingForEnhancedSecurityLink && m_doneWaitingForStorageAccessReloadCheck) {
         if (m_reply)
             m_reply(WebCore::PolicyAction::Use, m_policyResult->first.get(), m_policyResult->second, isNavigatingToAppBoundDomain, WasNavigationIntercepted::No);
     } else
@@ -66,7 +68,7 @@ void WebFramePolicyListenerProxy::didReceiveAppBoundDomainResult(std::optional<N
 void WebFramePolicyListenerProxy::didReceiveSafeBrowsingResults()
 {
     ASSERT(isMainRunLoop());
-    if (m_policyResult && m_isNavigatingToAppBoundDomain && m_doneWaitingForLinkDecorationFilteringData && m_doneWaitingForSiteHasStorage && m_doneWaitingForEnhancedSecurityLink) {
+    if (m_policyResult && m_isNavigatingToAppBoundDomain && m_doneWaitingForLinkDecorationFilteringData && m_doneWaitingForSiteHasStorage && m_doneWaitingForEnhancedSecurityLink && m_doneWaitingForStorageAccessReloadCheck) {
         if (m_reply)
             m_reply(WebCore::PolicyAction::Use, m_policyResult->first.get(), m_policyResult->second, *m_isNavigatingToAppBoundDomain, WasNavigationIntercepted::No);
     }
@@ -79,7 +81,7 @@ void WebFramePolicyListenerProxy::didReceiveInitialLinkDecorationFilteringData()
     ASSERT(RunLoop::isMain());
     ASSERT(!m_doneWaitingForLinkDecorationFilteringData);
 
-    if (m_policyResult && m_isNavigatingToAppBoundDomain && m_doneWaitingForSafeBrowsing && m_doneWaitingForSiteHasStorage && m_doneWaitingForEnhancedSecurityLink) {
+    if (m_policyResult && m_isNavigatingToAppBoundDomain && m_doneWaitingForSafeBrowsing && m_doneWaitingForSiteHasStorage && m_doneWaitingForEnhancedSecurityLink && m_doneWaitingForStorageAccessReloadCheck) {
         if (m_reply)
             m_reply(WebCore::PolicyAction::Use, m_policyResult->first.get(), m_policyResult->second, *m_isNavigatingToAppBoundDomain, WasNavigationIntercepted::No);
         return;
@@ -93,7 +95,7 @@ void WebFramePolicyListenerProxy::didReceiveSiteHasStorageResults()
     ASSERT(RunLoop::isMain());
     ASSERT(!m_doneWaitingForSiteHasStorage);
 
-    if (m_policyResult && m_doneWaitingForSafeBrowsing && m_isNavigatingToAppBoundDomain && m_doneWaitingForLinkDecorationFilteringData && m_doneWaitingForEnhancedSecurityLink) {
+    if (m_policyResult && m_doneWaitingForSafeBrowsing && m_isNavigatingToAppBoundDomain && m_doneWaitingForLinkDecorationFilteringData && m_doneWaitingForEnhancedSecurityLink && m_doneWaitingForStorageAccessReloadCheck) {
         if (m_reply)
             m_reply(WebCore::PolicyAction::Use, m_policyResult->first.get(), m_policyResult->second, *m_isNavigatingToAppBoundDomain, WasNavigationIntercepted::No);
         return;
@@ -107,7 +109,7 @@ void WebFramePolicyListenerProxy::didReceiveEnhancedSecurityLinkResults()
     ASSERT(RunLoop::isMain());
     ASSERT(!m_doneWaitingForEnhancedSecurityLink);
 
-    if (m_policyResult && m_doneWaitingForSafeBrowsing && m_isNavigatingToAppBoundDomain && m_doneWaitingForLinkDecorationFilteringData && m_doneWaitingForSiteHasStorage) {
+    if (m_policyResult && m_doneWaitingForSafeBrowsing && m_isNavigatingToAppBoundDomain && m_doneWaitingForLinkDecorationFilteringData && m_doneWaitingForSiteHasStorage && m_doneWaitingForStorageAccessReloadCheck) {
         if (m_reply)
             m_reply(WebCore::PolicyAction::Use, m_policyResult->first.get(), m_policyResult->second, *m_isNavigatingToAppBoundDomain, WasNavigationIntercepted::No);
         return;
@@ -116,9 +118,23 @@ void WebFramePolicyListenerProxy::didReceiveEnhancedSecurityLinkResults()
     m_doneWaitingForEnhancedSecurityLink = true;
 }
 
+void WebFramePolicyListenerProxy::didReceiveStorageAccessReloadCheckResults()
+{
+    ASSERT(RunLoop::isMain());
+    ASSERT(!m_doneWaitingForStorageAccessReloadCheck);
+
+    if (m_policyResult && m_doneWaitingForSafeBrowsing && m_isNavigatingToAppBoundDomain && m_doneWaitingForLinkDecorationFilteringData && m_doneWaitingForSiteHasStorage && m_doneWaitingForEnhancedSecurityLink) {
+        if (m_reply)
+            m_reply(WebCore::PolicyAction::Use, m_policyResult->first.get(), m_policyResult->second, *m_isNavigatingToAppBoundDomain, WasNavigationIntercepted::No);
+        return;
+    }
+
+    m_doneWaitingForStorageAccessReloadCheck = true;
+}
+
 void WebFramePolicyListenerProxy::use(API::WebsitePolicies* policies, ProcessSwapRequestedByClient processSwapRequestedByClient)
 {
-    if (m_doneWaitingForSafeBrowsing && m_isNavigatingToAppBoundDomain && m_doneWaitingForLinkDecorationFilteringData && m_doneWaitingForSiteHasStorage && m_doneWaitingForEnhancedSecurityLink) {
+    if (m_doneWaitingForSafeBrowsing && m_isNavigatingToAppBoundDomain && m_doneWaitingForLinkDecorationFilteringData && m_doneWaitingForSiteHasStorage && m_doneWaitingForEnhancedSecurityLink && m_doneWaitingForStorageAccessReloadCheck) {
         if (m_reply)
             m_reply(WebCore::PolicyAction::Use, policies, processSwapRequestedByClient, *m_isNavigatingToAppBoundDomain, WasNavigationIntercepted::No);
     } else if (!m_policyResult)

--- a/Source/WebKit/UIProcess/WebFramePolicyListenerProxy.h
+++ b/Source/WebKit/UIProcess/WebFramePolicyListenerProxy.h
@@ -45,15 +45,16 @@ enum class ShouldExpectAppBoundDomainResult : bool { No, Yes };
 enum class ShouldWaitForInitialLinkDecorationFilteringData : bool { No, Yes };
 enum class ShouldWaitForSiteHasStorageCheck : bool { No, Yes };
 enum class ShouldWaitForEnhancedSecurityLinkCheck : bool { No, Yes };
+enum class ShouldWaitForStorageAccessReloadCheck : bool { No, Yes };
 enum class WasNavigationIntercepted : bool { No, Yes };
 
 class WebFramePolicyListenerProxy : public API::ObjectImpl<API::Object::Type::FramePolicyListener>, public CanMakeWeakPtr<WebFramePolicyListenerProxy> {
 public:
 
     using Reply = CompletionHandler<void(WebCore::PolicyAction, API::WebsitePolicies*, ProcessSwapRequestedByClient, std::optional<NavigatingToAppBoundDomain>, WasNavigationIntercepted)>;
-    static Ref<WebFramePolicyListenerProxy> create(Reply&& reply, ShouldExpectSafeBrowsingResult expectSafeBrowsingResult, ShouldExpectAppBoundDomainResult expectAppBoundDomainResult, ShouldWaitForInitialLinkDecorationFilteringData shouldWaitForInitialLinkDecorationFilteringData, ShouldWaitForSiteHasStorageCheck shouldWaitForSiteHasStorageCheck, ShouldWaitForEnhancedSecurityLinkCheck shouldWaitForEnhancedSecurityLinkCheck)
+    static Ref<WebFramePolicyListenerProxy> create(Reply&& reply, ShouldExpectSafeBrowsingResult expectSafeBrowsingResult, ShouldExpectAppBoundDomainResult expectAppBoundDomainResult, ShouldWaitForInitialLinkDecorationFilteringData shouldWaitForInitialLinkDecorationFilteringData, ShouldWaitForSiteHasStorageCheck shouldWaitForSiteHasStorageCheck, ShouldWaitForEnhancedSecurityLinkCheck shouldWaitForEnhancedSecurityLinkCheck, ShouldWaitForStorageAccessReloadCheck shouldWaitForStorageAccessReloadCheck)
     {
-        return adoptRef(*new WebFramePolicyListenerProxy(WTF::move(reply), expectSafeBrowsingResult, expectAppBoundDomainResult, shouldWaitForInitialLinkDecorationFilteringData, shouldWaitForSiteHasStorageCheck, shouldWaitForEnhancedSecurityLinkCheck));
+        return adoptRef(*new WebFramePolicyListenerProxy(WTF::move(reply), expectSafeBrowsingResult, expectAppBoundDomainResult, shouldWaitForInitialLinkDecorationFilteringData, shouldWaitForSiteHasStorageCheck, shouldWaitForEnhancedSecurityLinkCheck, shouldWaitForStorageAccessReloadCheck));
     }
     ~WebFramePolicyListenerProxy();
 
@@ -67,9 +68,10 @@ public:
     void didReceiveInitialLinkDecorationFilteringData();
     void didReceiveSiteHasStorageResults();
     void didReceiveEnhancedSecurityLinkResults();
+    void didReceiveStorageAccessReloadCheckResults();
 
 private:
-    WebFramePolicyListenerProxy(Reply&&, ShouldExpectSafeBrowsingResult, ShouldExpectAppBoundDomainResult, ShouldWaitForInitialLinkDecorationFilteringData, ShouldWaitForSiteHasStorageCheck, ShouldWaitForEnhancedSecurityLinkCheck);
+    WebFramePolicyListenerProxy(Reply&&, ShouldExpectSafeBrowsingResult, ShouldExpectAppBoundDomainResult, ShouldWaitForInitialLinkDecorationFilteringData, ShouldWaitForSiteHasStorageCheck, ShouldWaitForEnhancedSecurityLinkCheck, ShouldWaitForStorageAccessReloadCheck);
 
     std::optional<std::pair<RefPtr<API::WebsitePolicies>, ProcessSwapRequestedByClient>> m_policyResult;
     std::optional<std::optional<NavigatingToAppBoundDomain>> m_isNavigatingToAppBoundDomain;
@@ -77,6 +79,7 @@ private:
     bool m_doneWaitingForSiteHasStorage { false };
     bool m_doneWaitingForEnhancedSecurityLink { false };
     bool m_doneWaitingForLinkDecorationFilteringData { false };
+    bool m_doneWaitingForStorageAccessReloadCheck { false };
     Reply m_reply;
 };
 

--- a/Source/WebKit/UIProcess/WebFrameProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFrameProxy.cpp
@@ -396,7 +396,7 @@ void WebFrameProxy::didChangeTitle(String&& title)
     m_title = WTF::move(title);
 }
 
-WebFramePolicyListenerProxy& WebFrameProxy::setUpPolicyListenerProxy(CompletionHandler<void(PolicyAction, API::WebsitePolicies*, ProcessSwapRequestedByClient, std::optional<NavigatingToAppBoundDomain>, WasNavigationIntercepted)>&& completionHandler, ShouldExpectSafeBrowsingResult expectSafeBrowsingResult, ShouldExpectAppBoundDomainResult expectAppBoundDomainResult, ShouldWaitForInitialLinkDecorationFilteringData shouldWaitForInitialLinkDecorationFilteringData, ShouldWaitForSiteHasStorageCheck shouldWaitForSiteHasStorageCheck, ShouldWaitForEnhancedSecurityLinkCheck shouldWaitForEnhancedSecurityLinkCheck)
+WebFramePolicyListenerProxy& WebFrameProxy::setUpPolicyListenerProxy(CompletionHandler<void(PolicyAction, API::WebsitePolicies*, ProcessSwapRequestedByClient, std::optional<NavigatingToAppBoundDomain>, WasNavigationIntercepted)>&& completionHandler, ShouldExpectSafeBrowsingResult expectSafeBrowsingResult, ShouldExpectAppBoundDomainResult expectAppBoundDomainResult, ShouldWaitForInitialLinkDecorationFilteringData shouldWaitForInitialLinkDecorationFilteringData, ShouldWaitForSiteHasStorageCheck shouldWaitForSiteHasStorageCheck, ShouldWaitForEnhancedSecurityLinkCheck shouldWaitForEnhancedSecurityLinkCheck, ShouldWaitForStorageAccessReloadCheck shouldWaitForStorageAccessReloadCheck)
 {
     if (RefPtr previousListener = m_activeListener)
         previousListener->ignore();
@@ -406,7 +406,7 @@ WebFramePolicyListenerProxy& WebFrameProxy::setUpPolicyListenerProxy(CompletionH
 
         completionHandler(action, policies, processSwapRequestedByClient, isNavigatingToAppBoundDomain, wasNavigationIntercepted);
         m_activeListener = nullptr;
-    }, expectSafeBrowsingResult, expectAppBoundDomainResult, shouldWaitForInitialLinkDecorationFilteringData, shouldWaitForSiteHasStorageCheck, shouldWaitForEnhancedSecurityLinkCheck);
+    }, expectSafeBrowsingResult, expectAppBoundDomainResult, shouldWaitForInitialLinkDecorationFilteringData, shouldWaitForSiteHasStorageCheck, shouldWaitForEnhancedSecurityLinkCheck, shouldWaitForStorageAccessReloadCheck);
     return *m_activeListener;
 }
 
@@ -590,7 +590,7 @@ void WebFrameProxy::prepareForProvisionalLoadInProcess(WebProcessProxy& process,
     CommitTiming commitTiming = effectiveOrigin ? CommitTiming::Immediately : CommitTiming::WaitForLoad;
 
     m_provisionalFrame = nullptr;
-    m_provisionalFrame = adoptRef(*new ProvisionalFrameProxy(*this, group.ensureProcessForSite(site, mainFrameSite, process, protect(page->preferences())), commitTiming));
+    m_provisionalFrame = adoptRef(*new ProvisionalFrameProxy(*this, group.ensureProcessForSite(site, mainFrameSite, process, protect(page->preferences()), LoadedWebArchive::No, BrowsingContextGroupUpdate::AddProcessAndInjectBrowsingContext, navigation.needsProcessSwapForStorageAccessReload()), commitTiming));
     Ref provisionalFrame = *m_provisionalFrame;
 
     page->inspectorController().didCreateProvisionalFrame(provisionalFrame);

--- a/Source/WebKit/UIProcess/WebFrameProxy.h
+++ b/Source/WebKit/UIProcess/WebFrameProxy.h
@@ -123,6 +123,7 @@ enum class ShouldExpectAppBoundDomainResult : bool;
 enum class ShouldWaitForInitialLinkDecorationFilteringData : bool;
 enum class ShouldWaitForSiteHasStorageCheck : bool;
 enum class ShouldWaitForEnhancedSecurityLinkCheck : bool;
+enum class ShouldWaitForStorageAccessReloadCheck : bool;
 enum class ProcessSwapRequestedByClient : bool;
 enum class WasNavigationIntercepted : bool;
 
@@ -210,7 +211,7 @@ public:
     void didSameDocumentNavigation(URL&&); // eg. anchor navigation, session state change.
     void didChangeTitle(String&&);
 
-    WebFramePolicyListenerProxy& setUpPolicyListenerProxy(CompletionHandler<void(WebCore::PolicyAction, API::WebsitePolicies*, ProcessSwapRequestedByClient, std::optional<NavigatingToAppBoundDomain>, WasNavigationIntercepted)>&&, ShouldExpectSafeBrowsingResult, ShouldExpectAppBoundDomainResult, ShouldWaitForInitialLinkDecorationFilteringData, ShouldWaitForSiteHasStorageCheck, ShouldWaitForEnhancedSecurityLinkCheck);
+    WebFramePolicyListenerProxy& setUpPolicyListenerProxy(CompletionHandler<void(WebCore::PolicyAction, API::WebsitePolicies*, ProcessSwapRequestedByClient, std::optional<NavigatingToAppBoundDomain>, WasNavigationIntercepted)>&&, ShouldExpectSafeBrowsingResult, ShouldExpectAppBoundDomainResult, ShouldWaitForInitialLinkDecorationFilteringData, ShouldWaitForSiteHasStorageCheck, ShouldWaitForEnhancedSecurityLinkCheck, ShouldWaitForStorageAccessReloadCheck);
 
 #if ENABLE(CONTENT_FILTERING)
     void contentFilterDidBlockLoad(WebCore::ContentFilterUnblockHandler contentFilterUnblockHandler) { m_contentFilterUnblockHandler = WTF::move(contentFilterUnblockHandler); }

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -5977,6 +5977,8 @@ void WebPageProxy::receivedNavigationActionPolicyDecision(WebProcessProxy& proce
         websiteDataStore = websiteDataStore.copyRef(),
         continueWithProcessForNavigation = WTF::move(continueWithProcessForNavigation)
     ](FrameProcess* sharedProcess) mutable {
+        if (sharedProcess && navigation->needsProcessSwapForStorageAccessReload())
+            sharedProcess = nullptr;
         if (sharedProcess) {
             navigation->setPendingSharedProcess(*sharedProcess);
             ASSERT(!sharedProcess->process().isInProcessCache());
@@ -8421,6 +8423,7 @@ void WebPageProxy::didFailProvisionalLoadForFrameShared(Ref<WebProcessProxy>&& p
         if (navigation)
             navigation->setClientNavigationActivity({ });
 
+        m_pendingStorageAccessReloadFrameCount = 0;
         callLoadCompletionHandlersIfNecessary(false);
 
         // Update current main frame when provisional main frame load fails, because it
@@ -8583,6 +8586,9 @@ void WebPageProxy::didCommitLoadForFrame(IPC::Connection& connection, FrameIdent
     }
 
     WEBPAGEPROXY_RELEASE_LOG(Loading, "didCommitLoadForFrame: frameID=%" PRIu64 ", isMainFrame=%d", frameID.toUInt64(), frame->isMainFrame());
+
+    if (frame->isMainFrame())
+        m_pendingStorageAccessReloadFrameCount = 0;
 
     // FIXME: We should message check that navigationID is not zero here, but it's currently zero for some navigations through the back/forward cache.
     RefPtr<API::Navigation> navigation;
@@ -9721,6 +9727,9 @@ void WebPageProxy::decidePolicyForNavigationAction(Ref<WebProcessProxy>&& proces
     else if (m_needsInitialLinkDecorationFilteringData)
         sendCachedLinkDecorationFilteringData();
 #endif
+    ShouldWaitForStorageAccessReloadCheck shouldWaitForStorageAccessReloadCheck = ShouldWaitForStorageAccessReloadCheck::No;
+    if (!frame.isMainFrame() && protect(preferences())->siteIsolationEnabled() && m_pendingStorageAccessReloadFrameCount)
+        shouldWaitForStorageAccessReloadCheck = ShouldWaitForStorageAccessReloadCheck::Yes;
 
     transaction = std::nullopt;
 
@@ -9910,7 +9919,7 @@ void WebPageProxy::decidePolicyForNavigationAction(Ref<WebProcessProxy>&& proces
         }
         completionHandlerWrapper(policyAction);
 
-    }, ShouldExpectSafeBrowsingResult::No, shouldExpectAppBoundDomainResult, shouldWaitForInitialLinkDecorationFilteringData, shouldWaitForSiteHasStorageCheck, shouldWaitForEnhancedSecurityLink);
+    }, ShouldExpectSafeBrowsingResult::No, shouldExpectAppBoundDomainResult, shouldWaitForInitialLinkDecorationFilteringData, shouldWaitForSiteHasStorageCheck, shouldWaitForEnhancedSecurityLink, shouldWaitForStorageAccessReloadCheck);
     if (shouldExpectSafeBrowsingResult == ShouldExpectSafeBrowsingResult::Yes)
         beginSafeBrowsingCheck(request.url(), *navigation, frame.isMainFrame());
     if (shouldWaitForInitialLinkDecorationFilteringData == ShouldWaitForInitialLinkDecorationFilteringData::Yes)
@@ -9921,6 +9930,8 @@ void WebPageProxy::decidePolicyForNavigationAction(Ref<WebProcessProxy>&& proces
     if (shouldWaitForEnhancedSecurityLink == ShouldWaitForEnhancedSecurityLinkCheck::Yes)
         beginEnhancedSecurityLinkCheck(request.url(), *navigation, listener);
 #endif
+    if (shouldWaitForStorageAccessReloadCheck == ShouldWaitForStorageAccessReloadCheck::Yes)
+        beginStorageAccessReloadCheck(frame.frameID(), RegistrableDomain { request.url() }, *navigation, listener);
 #if ENABLE(APP_BOUND_DOMAINS)
     bool shouldSendSecurityOriginData = !frame.isMainFrame() && shouldTreatURLProtocolAsAppBound(request.url(), websiteDataStore().configuration().enableInAppBrowserPrivacyForTesting());
     auto host = shouldSendSecurityOriginData ? frameInfo.securityOrigin.host() : request.url().host();
@@ -10089,7 +10100,7 @@ void WebPageProxy::decidePolicyForNewWindowAction(IPC::Connection& connection, N
         RELEASE_ASSERT(processSwapRequestedByClient == ProcessSwapRequestedByClient::No);
 
         receivedPolicyDecision(policyAction, nullptr, std::nullopt, WTF::move(navigationAction), WillContinueLoadInNewProcess::No, std::nullopt, std::nullopt, WTF::move(completionHandler));
-    }, ShouldExpectSafeBrowsingResult::No, ShouldExpectAppBoundDomainResult::No, ShouldWaitForInitialLinkDecorationFilteringData::No, ShouldWaitForSiteHasStorageCheck::No, ShouldWaitForEnhancedSecurityLinkCheck::No);
+    }, ShouldExpectSafeBrowsingResult::No, ShouldExpectAppBoundDomainResult::No, ShouldWaitForInitialLinkDecorationFilteringData::No, ShouldWaitForSiteHasStorageCheck::No, ShouldWaitForEnhancedSecurityLinkCheck::No, ShouldWaitForStorageAccessReloadCheck::No);
 
     if (m_policyClient)
         m_policyClient->decidePolicyForNewWindowAction(*this, *frame, navigationAction.get(), request, frameName, WTF::move(listener));
@@ -10270,7 +10281,7 @@ void WebPageProxy::decidePolicyForResponseShared(Ref<WebProcessProxy>&& process,
         }
 #endif
         completionHandlerWrapper(policyAction);
-    }, expectSafeBrowsing , ShouldExpectAppBoundDomainResult::No, ShouldWaitForInitialLinkDecorationFilteringData::No, ShouldWaitForSiteHasStorageCheck::No, ShouldWaitForEnhancedSecurityLinkCheck::No);
+    }, expectSafeBrowsing , ShouldExpectAppBoundDomainResult::No, ShouldWaitForInitialLinkDecorationFilteringData::No, ShouldWaitForSiteHasStorageCheck::No, ShouldWaitForEnhancedSecurityLinkCheck::No, ShouldWaitForStorageAccessReloadCheck::No);
     if (expectSafeBrowsing == ShouldExpectSafeBrowsingResult::Yes && navigation) {
         navigation->whenSafeBrowsingCheckCompletes([listener] mutable {
             listener->didReceiveSafeBrowsingResults();
@@ -13873,6 +13884,8 @@ void WebPageProxy::resetState(ResetStateReason resetStateReason)
 
     m_nowPlayingMetadataObservers.clear();
     m_nowPlayingMetadataObserverForTesting = nullptr;
+
+    m_pendingStorageAccessReloadFrameCount = 0;
 
     if (RefPtr pageClient = this->pageClient())
         pageClient->hasActiveNowPlayingSessionChanged(false);
@@ -18617,6 +18630,30 @@ void WebPageProxy::beginEnhancedSecurityLinkCheck(const URL& url, API::Navigatio
         networkProcess->sendWithAsyncReply(Messages::NetworkProcess::IsEnhancedSecurityLink(url), WTF::move(completionHandler));
 }
 #endif
+
+void WebPageProxy::beginStorageAccessReloadCheck(WebCore::FrameIdentifier frameID, const WebCore::RegistrableDomain& domain, API::Navigation& navigation, WebFramePolicyListenerProxy& listener)
+{
+    ASSERT(m_pendingStorageAccessReloadFrameCount);
+    m_pendingStorageAccessReloadFrameCount--;
+
+    auto url = navigation.currentRequest().url();
+    auto completionHandler = [navigation = protect(navigation), url, listener = protect(listener)] (bool needsSwap) {
+        if (url == navigation->currentRequest().url()) {
+            navigation->setNeedsProcessSwapForStorageAccessReload(needsSwap);
+            listener->didReceiveStorageAccessReloadCheckResults();
+        }
+    };
+
+    if (RefPtr networkProcess = websiteDataStore().networkProcessIfExists())
+        networkProcess->sendWithAsyncReply(Messages::NetworkProcess::NeedsProcessSwapForStorageAccessReload(websiteDataStore().sessionID(), frameID, domain), WTF::move(completionHandler));
+    else
+        completionHandler(false);
+}
+
+void WebPageProxy::storageAccessReloadableFrameRecorded()
+{
+    m_pendingStorageAccessReloadFrameCount++;
+}
 
 #if ENABLE(ACCESSIBILITY_ANIMATION_CONTROL)
 void WebPageProxy::pauseAllAnimations(CompletionHandler<void()>&& completionHandler)

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2301,6 +2301,7 @@ public:
 #endif // ENABLE(WRITING_TOOLS)
 
     void requestStorageAccessConfirm(const WebCore::RegistrableDomain& subFrameDomain, const WebCore::RegistrableDomain& topFrameDomain, WebCore::FrameIdentifier, std::optional<WebCore::OrganizationStorageAccessPromptQuirk>&&, CompletionHandler<void(bool)>&&);
+    void storageAccessReloadableFrameRecorded();
     void didCommitCrossSiteLoadWithDataTransferFromPrevalentResource();
     void getLoadedSubresourceDomains(CompletionHandler<void(Vector<WebCore::RegistrableDomain>&&)>&&);
     void clearLoadedSubresourceDomains();
@@ -3745,6 +3746,7 @@ private:
 
     void beginSiteHasStorageCheck(const URL&, API::Navigation&, WebFramePolicyListenerProxy&);
     void beginEnhancedSecurityLinkCheck(const URL&, API::Navigation&, WebFramePolicyListenerProxy&);
+    void beginStorageAccessReloadCheck(WebCore::FrameIdentifier, const WebCore::RegistrableDomain&, API::Navigation&, WebFramePolicyListenerProxy&);
 
     Ref<BrowsingContextGroup> browsingContextGroupForNavigation(WebFrameProxy&, API::Navigation&, WebsiteDataStore&, ProcessSwapRequestedByClient);
 
@@ -4331,6 +4333,7 @@ private:
     RefPtr<WebPageProxyTesting> m_pageForTesting;
 
     bool m_hasNetworkRequestsInProgress { false };
+    unsigned m_pendingStorageAccessReloadFrameCount { 0 };
 
     HashSet<CheckedRef<WebProcessProxy>> m_unresponsiveProcesses;
 } SWIFT_SHARED_REFERENCE(refWebPageProxy, derefWebPageProxy) SWIFT_RETURNED_AS_UNRETAINED_BY_DEFAULT;

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -2218,7 +2218,7 @@ void WebProcessPool::processForNavigation(WebPageProxy& page, WebFrameProxy& fra
         RefPtr<WebProcessProxy> process;
         if (RefPtr frameProcess = browsingContextGroup.processForSite(site))
             process = &frameProcess->process();
-        if (process && process->websiteDataStore() == dataStore.ptr() && process->websiteDataStore() == &page.websiteDataStore() && !process->isInProcessCache() && process->lockdownMode() == lockdownMode && enhancedSecurityStatesAreConsistent(process->enhancedSecurity(), enhancedSecurity)) {
+        if (process && process->websiteDataStore() == dataStore.ptr() && process->websiteDataStore() == &page.websiteDataStore() && !process->isInProcessCache() && process->lockdownMode() == lockdownMode && enhancedSecurityStatesAreConsistent(process->enhancedSecurity(), enhancedSecurity) && !navigation.needsProcessSwapForStorageAccessReload()) {
             protect(dataStore->networkProcess())->addAllowedFirstPartyForCookies(*process, mainFrameSite.domain(), LoadedWebArchive::No, [completionHandler = WTF::move(completionHandler), process, preventProcessShutdownScope = process->shutdownPreventingScope()] () mutable {
                 completionHandler(process.releaseNonNull(), nullptr, "Found process for the same site"_s);
             });
@@ -2310,6 +2310,9 @@ std::tuple<Ref<WebProcessProxy>, RefPtr<SuspendedPageProxy>, ASCIILiteral> WebPr
 
     if (processSwapRequestedByClient == ProcessSwapRequestedByClient::Yes)
         return { createNewProcess(), nullptr, "Process swap was requested by the client"_s };
+
+    if (navigation.needsProcessSwapForStorageAccessReload())
+        return { createNewProcess(), nullptr, "Process swap for storage access reload"_s };
 
     if (!m_configuration->processSwapsOnNavigation())
         return { WTF::move(sourceProcess), nullptr, "Feature is disabled"_s };


### PR DESCRIPTION
#### 22aeae2145f8c3b848957176f2697f47b1c16afd
<pre>
Make iframes switch processes on reload in Site Isolation after Storage Access returns NoModificationAllowedError.
<a href="https://rdar.apple.com/116200563">rdar://116200563</a>

Reviewed by NOBODY (OOPS!).

NoModificationAllowedError indicates that the iframe must reload to gain storage access so that it can be loaded in a new process, not shared with other iframes that shouldn&apos;t have storage access.
This is modeled after existing checks like enhanced security links.
To reduce unnecessary IPCs, the UI process only messages the network process for the new check on reload if an iframe on that page has previously requested storage access.
The new test also revealed a latent bug where a cross-origin iframe in site isolation swapping processes would call enterAcceleratedCompositingMode a second time on the same drawing area, causing the assert to fail.

This commit was partially written by Claude, with human review.

* LayoutTests/http/tests/storageAccess/request-throw-exception-on-grant-until-reload-site-isolation-expected.txt: Added.
* LayoutTests/http/tests/storageAccess/request-throw-exception-on-grant-until-reload-site-isolation.html: Copied from LayoutTests/http/tests/storageAccess/request-throw-exception-on-grant-until-reload.html.
* LayoutTests/http/tests/storageAccess/request-throw-exception-on-grant-until-reload.html:
* LayoutTests/http/tests/storageAccess/resources/pid-iframe.html: Added.
* LayoutTests/http/tests/storageAccess/resources/request-throw-exception-on-grant-until-reload-iframe.html:
* Source/WebKit/NetworkProcess/Classifier/WebResourceLoadStatisticsStore.cpp:
(WebKit::WebResourceLoadStatisticsStore::requestStorageAccess):
(WebKit::WebResourceLoadStatisticsStore::clearFrameLoadRecordsForStorageAccess):
(WebKit::WebResourceLoadStatisticsStore::storageAccessWasGrantedValueForFrame):
(WebKit::WebResourceLoadStatisticsStore::needsProcessSwapForStorageAccessReload):
* Source/WebKit/NetworkProcess/Classifier/WebResourceLoadStatisticsStore.h:
* Source/WebKit/NetworkProcess/NetworkProcess.cpp:
(WebKit::NetworkProcess::needsProcessSwapForStorageAccessReload):
* Source/WebKit/NetworkProcess/NetworkProcess.h:
* Source/WebKit/NetworkProcess/NetworkProcess.messages.in:
* Source/WebKit/UIProcess/API/APINavigation.h:
(API::Navigation::setNeedsProcessSwapForStorageAccessReload):
(API::Navigation::needsProcessSwapForStorageAccessReload const):
* Source/WebKit/UIProcess/BrowsingContextGroup.cpp:
(WebKit::BrowsingContextGroup::ensureProcessForSite):
(WebKit::BrowsingContextGroup::removeFrameProcess):
* Source/WebKit/UIProcess/BrowsingContextGroup.h:
* Source/WebKit/UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.cpp:
(WebKit::DrawingAreaProxyCoordinatedGraphics::enterAcceleratedCompositingMode):
* Source/WebKit/UIProcess/FrameProcess.h:
(WebKit::FrameProcess::markEvictedFromProcessMap):
(WebKit::FrameProcess::wasEvictedFromProcessMap const):
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp:
(WebKit::NetworkProcessProxy::storageAccessReloadableFrameRecorded):
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.h:
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.messages.in:
* Source/WebKit/UIProcess/WebFramePolicyListenerProxy.cpp:
(WebKit::WebFramePolicyListenerProxy::WebFramePolicyListenerProxy):
(WebKit::WebFramePolicyListenerProxy::didReceiveAppBoundDomainResult):
(WebKit::WebFramePolicyListenerProxy::didReceiveSafeBrowsingResults):
(WebKit::WebFramePolicyListenerProxy::didReceiveInitialLinkDecorationFilteringData):
(WebKit::WebFramePolicyListenerProxy::didReceiveSiteHasStorageResults):
(WebKit::WebFramePolicyListenerProxy::didReceiveEnhancedSecurityLinkResults):
(WebKit::WebFramePolicyListenerProxy::didReceiveStorageAccessReloadCheckResults):
(WebKit::WebFramePolicyListenerProxy::use):
* Source/WebKit/UIProcess/WebFramePolicyListenerProxy.h:
(WebKit::WebFramePolicyListenerProxy::create):
* Source/WebKit/UIProcess/WebFrameProxy.cpp:
(WebKit::WebFrameProxy::setUpPolicyListenerProxy):
(WebKit::WebFrameProxy::prepareForProvisionalLoadInProcess):
* Source/WebKit/UIProcess/WebFrameProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::receivedNavigationActionPolicyDecision):
(WebKit::WebPageProxy::didFailProvisionalLoadForFrameShared):
(WebKit::WebPageProxy::didCommitLoadForFrame):
(WebKit::WebPageProxy::decidePolicyForNavigationAction):
(WebKit::WebPageProxy::decidePolicyForNewWindowAction):
(WebKit::WebPageProxy::decidePolicyForResponseShared):
(WebKit::WebPageProxy::resetState):
(WebKit::WebPageProxy::beginStorageAccessReloadCheck):
(WebKit::WebPageProxy::storageAccessReloadableFrameRecorded):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::processForNavigation):
(WebKit::WebProcessPool::processForNavigationInternal):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/22aeae2145f8c3b848957176f2697f47b1c16afd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177603 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51541 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45335 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187207 "Built successfully") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/140850 "Failed to checkout and rebase branch from PR 70156") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4928e41f-a028-4645-9606-586c129bbd6d) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52833 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51250 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138429 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/140850 "Failed to checkout and rebase branch from PR 70156") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/88af0b5b-588b-4d88-a26b-78dbf7c4b980) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180559 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41937 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159170 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118893 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1fead822-1359-4e23-b4c8-a7556442f368) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40598 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38965 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151005 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38666 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35674 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/43326 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43200 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189636 "Built successfully") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51208 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/158701 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147528 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51890 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35294 "Too many flaky failures: http/tests/misc/resource-timing-navigation-in-restored-iframe-2.html, http/tests/navigation/redirect-to-random-url-versus-memory-cache.html, http/tests/resourceLoadStatistics/only-partitioned-cookies-after-redirect.html, http/tests/security/canvas-cors-with-two-hosts.html, http/tests/security/contentSecurityPolicy/1.1/scriptnonce-allowed-by-enforced-policy-and-blocked-by-report-policy.py, http/tests/security/contentSecurityPolicy/report-blocked-uri-after-multiple-redirects.html, http/tests/security/mixedContent/redirect-http-to-https-script-in-iframe-UpgradeMixedContent.html, http/tests/websocket/tests/hybi/invalid-encode-length.html, http/tests/workers/service/controller-change.html, http/tests/xmlhttprequest/access-control-and-redirects.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147319 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42032 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124105 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/118518 "The change is no longer eligible for processing.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50398 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13643 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49794 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50034 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49856 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->