### PR TITLE
[JSC][YARR] Extend first-character filter more

### DIFF
--- a/JSTests/stress/regexp-anchored-first-char-filter-inverted-class-and-groups.js
+++ b/JSTests/stress/regexp-anchored-first-char-filter-inverted-class-and-groups.js
@@ -1,0 +1,101 @@
+// Verify that the anchored (^, non-multiline) RegExp first-character fast-fail filter now covers
+// inverted leading character classes ([^...], \D, \S, \W) and patterns that begin with a
+// quantified capturing group ((...){n}). These must be filtered when input[0] cannot begin a match
+// and must never wrongly fast-fail a subject the pattern would actually match. Empty-matchable
+// leading atoms (e.g. [...]*, (...)?) must still fall back and never be filtered.
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error("bad value: " + actual + " expected: " + expected);
+}
+
+function step() {
+    // Inverted leading class: [^X] matches byte c iff c not in X.
+    shouldBe(/^[^\d\W]\w*/.test("hello"), true);   // 'h' passes filter, matches
+    shouldBe(/^[^\d\W]\w*/.test("1abc"), false);   // '1' filtered ('1' in \d)
+    shouldBe(/^[^\d\W]\w*/.test("!x"), false);     // '!' filtered ('!' in \W)
+    shouldBe(/^[^\d\W]\w*/.test("_id"), true);     // '_' is a word char, not a digit
+
+    shouldBe(/^[^a-z]/.test("A"), true);           // 'A' not in a-z
+    shouldBe(/^[^a-z]/.test("a"), false);          // 'a' filtered
+    shouldBe(/^[^a-z]/.test("9"), true);
+    shouldBe(/^[^a-z]/.test("z"), false);          // 'z' filtered
+
+    // Inverted builtin classes.
+    shouldBe(/^\D/.test("x"), true);
+    shouldBe(/^\D/.test("5"), false);              // digit filtered
+    shouldBe(/^\S/.test("y"), true);
+    shouldBe(/^\S/.test(" "), false);              // space filtered
+    shouldBe(/^\S/.test("\t"), false);             // tab filtered
+    shouldBe(/^\W/.test("."), true);
+    shouldBe(/^\W/.test("a"), false);              // word char filtered
+    shouldBe(/^\W/.test("_"), false);              // '_' is a word char
+
+    // Inverted high range: complement over Latin-1 must include all bytes < 0x100 that are not in
+    // the (entirely non-Latin1) range, so ASCII inputs must pass the filter. Note the resulting
+    // bitmap is FULL here, so no filter is installed at all - the partial cases below are the ones
+    // that actually exercise the complement arithmetic.
+    shouldBe(/^[^\u0100-\uffff]/.test("a"), true);
+    shouldBe(/^[^\u0100-\uffff]/.test("\xff"), true);
+
+    // Partial complements: exactly one byte survives, and exactly the low half survives.
+    shouldBe(/^[^\x00-\xfe]/.test("\xff"), true);
+    shouldBe(/^[^\x00-\xfe]/.test("a"), false);      // 'a' filtered
+    shouldBe(/^[^\x00-\xfe]/.test("\xfe"), false);   // 0xfe filtered
+    shouldBe(/^[^\u0080-\uffff]/.test("a"), true);
+    shouldBe(/^[^\u0080-\uffff]/.test("\x7f"), true);
+    shouldBe(/^[^\u0080-\uffff]/.test("\x80"), false);  // 0x80 filtered
+    shouldBe(/^[^\u0080-\uffff]/.test("\xff"), false);  // 0xff filtered
+
+    // Inverted classes under the u and v flags reach the same builder.
+    shouldBe(/^[^\d]/u.test("x"), true);
+    shouldBe(/^[^\d]/u.test("7"), false);            // digit filtered
+    shouldBe(/^[^\p{L}]/u.test("!"), true);
+    shouldBe(/^[^\p{L}]/u.test("q"), false);         // letter filtered
+    shouldBe(/^[^a-z]/v.test("A"), true);
+    shouldBe(/^[^a-z]/v.test("m"), false);           // 'm' filtered
+
+    // Case-insensitive inverted class.
+    shouldBe(/^[^a-f]/i.test("G"), true);
+    shouldBe(/^[^a-f]/i.test("A"), false);         // 'A' folds into a-f, filtered
+    shouldBe(/^[^a-f]/i.test("f"), false);
+
+    // Quantified leading capturing group ((...){n}) is now filterable: the group's fixed repeat
+    // guarantees a first character drawn from the inner class.
+    shouldBe(/^([0-9a-fA-F]){16}$/.test("0123456789abcdef"), true);
+    shouldBe(/^([0-9a-fA-F]){16}$/.test("zzzzzzzzzzzzzzzz"), false);  // 'z' filtered
+    shouldBe(/^([0-9a-fA-F]){12}$/.test("0123456789ab"), true);
+    shouldBe(/^([0-9a-fA-F]){12}$/.test("!23456789abc"), false);      // '!' filtered
+    shouldBe(/^(ab)/.test("abc"), true);
+    shouldBe(/^(ab)/.test("xyz"), false);                            // 'x' filtered
+    shouldBe(/^(([0-9])){3}/.test("123"), true);
+    shouldBe(/^(([0-9])){3}/.test("abc"), false);                    // 'a' filtered
+
+    // Empty-matchable leading atoms must NOT be filtered (they can match empty at position 0).
+    shouldBe(/^[gmsiyu]*$/.test(""), true);
+    shouldBe(/^[gmsiyu]*$/.test("gmi"), true);
+    shouldBe(/^[gmsiyu]*$/.test("xyz"), false);   // correctly false, but must not be fast-failed wrongly
+    shouldBe(/^(abc)?/.test("abc"), true);
+    shouldBe(/^(abc)?/.test("zzz"), true);        // optional group matches empty -> true
+    shouldBe(/^\s*$/.test(""), true);
+    shouldBe(/^\s*$/.test("   "), true);
+    shouldBe(/^\s*$/.test("x"), false);
+    // ... including the ones whose minimum size is 0 for a reason other than a quantifier.
+    shouldBe(/^a{0}/.test("b"), true);
+    shouldBe(/^\b/.test("b"), true);
+    shouldBe(/^\b/.test(" b"), false);            // no word boundary at index 0 of " b"
+    shouldBe(/^(?:)/.test("z"), true);
+    shouldBe(/^$/.test(""), true);
+    shouldBe(/^$/.test("z"), false);
+    shouldBe(/^(?=a)/.test("ab"), true);
+    shouldBe(/^(?=a)/.test("b"), false);
+    shouldBe(/^(a*)/.test("zzz"), true);
+    shouldBe(/^a|/.test("zzz"), true);
+
+    // Alternation where one alternative starts with an inverted class.
+    shouldBe(/^(?:[^0-9]|abc)/.test("x"), true);
+    shouldBe(/^(?:[^0-9]|abc)/.test("5"), false); // '5' filtered (both alts reject leading '5')
+}
+
+for (var i = 0; i < testLoopCount; ++i)
+    step();

--- a/JSTests/stress/regexp-first-char-filter-anchoring-soundness.js
+++ b/JSTests/stress/regexp-first-char-filter-anchoring-soundness.js
@@ -1,0 +1,69 @@
+// A pattern can look ^-anchored without every match beginning at index 0, and the first-character
+// fast-fail filter (DFG/FTL, position 0) must reject those on its own rather than trusting
+// PatternAlternative::m_startsWithBOL, which is a Yarr optimization hint maintained far away from
+// here. The case that matters: optimizeDotStarWrappedExpressions() rewrites /^.*X.*$/ by DELETING
+// the leading ^ and .* and appending a DotStarEnclosure, so the first surviving term is no longer
+// where the match begins.
+//
+// Every case must produce the same answer in every tier, so each runs in a loop long enough to tier
+// up. Cases that must NOT match are included so a "never filter anything" regression is caught too.
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error("bad value: " + actual + " expected: " + expected);
+}
+
+function check(re, string, expectedTest, expectedMatch, expectedIndex) {
+    re.lastIndex = 0;
+    shouldBe(re.test(string), expectedTest);
+    re.lastIndex = 0;
+    const result = re.exec(string);
+    if (expectedMatch === null) {
+        shouldBe(result, null);
+        return;
+    }
+    shouldBe(result[0], expectedMatch);
+    shouldBe(result.index, expectedIndex);
+}
+
+// Dot-star wrapped expressions: the leading .* means the match starts at 0 even though the first
+// surviving term appears later in the subject, so no bitmap built from that term may be applied.
+function dotStarWrapped() {
+    check(/^.*[^x].*$/, "xa", true, "xa", 0);
+    check(/^.*foo.*$/, "xfoo", true, "xfoo", 0);
+    check(/^.*foo.*/, "xfoo", true, "xfoo", 0);
+    check(/^.*[abc].*$/, "xa", true, "xa", 0);
+    check(/^.*\D.*$/, "1a", true, "1a", 0);
+    check(/^.*\W.*$/, "a!", true, "a!", 0);
+    check(/^.*[^0-9].*$/, "9a", true, "9a", 0);
+    check(/^.*(?:[^q]).*$/, "qa", true, "qa", 0);
+    check(/^.*foo.*$/, "xbar", false, null);
+
+    // The rewrite needs both a leading and a trailing .*; without the trailing one the leading .*
+    // survives as a term and folding it into the bitmap is sound.
+    check(/^.*foo/, "xfoo", true, "xfoo", 0);
+    check(/^.*foo/, "xbar", false, null);
+
+    // A capturing term blocks the rewrite entirely.
+    check(/^.*(x).*$/, "yx", true, "yx", 0);
+
+    // Multiline is rejected before the filter is even considered.
+    check(/^.*foo.*$/m, "x\nfoo", true, "foo", 2);
+}
+
+// A genuinely anchored pattern must still be filtered, and must still be right.
+function genuinelyAnchored() {
+    check(/^foo/, "foobar", true, "foo", 0);
+    check(/^foo/, "xfoobar", false, null);
+    check(/^[^x]/, "ya", true, "y", 0);
+    check(/^[^x]/, "xa", false, null);
+    check(/^(?:a|b)c/, "bc", true, "bc", 0);
+    check(/^(?:a|b)c/, "zbc", false, null);
+    check(/^(?:^a)b/, "ab", true, "ab", 0);
+    check(/^(?:^a)b/, "zab", false, null);
+}
+
+for (var i = 0; i < testLoopCount; ++i) {
+    dotStarWrapped();
+    genuinelyAnchored();
+}

--- a/JSTests/stress/regexp-test-anchored-first-char-filter.js
+++ b/JSTests/stress/regexp-test-anchored-first-char-filter.js
@@ -1,7 +1,7 @@
 // Verify the anchored (^, non-multiline) RegExp.test first-character fast-fail filter: a filtered
 // no-match must equal the operation's result, non-anchored patterns must never be wrongly filtered,
 // case-insensitive folds must be reflected in the bitmap, and a .compile() that changes the pattern
-// must be handled (the runtime identity guard falls back).
+// must be handled (the recompile watchpoint jettisons the code holding the stale bitmap).
 
 function shouldBe(actual, expected) {
     if (actual !== expected)
@@ -51,8 +51,9 @@ function step() {
 for (var i = 0; i < testLoopCount; ++i)
     step();
 
-// A .compile() that changes the pattern must be handled by the identity guard: the filter for the
-// old pattern must not produce wrong answers for the new one.
+// A .compile() that changes the pattern fires the realm's RegExp-recompiled watchpoint, jettisoning
+// the code that baked the old bitmap: the old filter must not produce wrong answers for the new
+// pattern.
 (function () {
     var re = /^a+/;
     function check(a, b) { shouldBe(re.test(a), b); }

--- a/JSTests/stress/regexp-test-sticky-first-char-filter.js
+++ b/JSTests/stress/regexp-test-sticky-first-char-filter.js
@@ -1,0 +1,187 @@
+// Verify the sticky RegExp.test first-character fast-fail filter: a filtered no-match must behave
+// exactly like the operation - reset lastIndex to 0, return false, and leave RegExp's global match
+// state (RegExp.$1, lastMatch, input, contexts) untouched.
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error("bad value: " + actual + " expected: " + expected);
+}
+
+function shouldThrow(fn, name) {
+    let threw = false;
+    try { fn(); } catch (e) { threw = true; shouldBe(e.constructor.name, name); }
+    if (!threw)
+        throw new Error("expected " + name);
+}
+
+// A capturing sticky regexp that cannot match empty: first char must be a digit.
+const re = /(\d)(\d)?/y;
+const input = "a12b3";
+
+function step() {
+    // Prior success at index 1 ("12"), which records global state and advances lastIndex.
+    re.lastIndex = 1;
+    shouldBe(re.test(input), true);
+    shouldBe(re.lastIndex, 3);
+    const savedLastMatch = RegExp.lastMatch;   // "12"
+    const savedParen1 = RegExp.$1;              // "1"
+    const savedParen2 = RegExp.$2;              // "2"
+    const savedLeft = RegExp.leftContext;       // "a"
+    const savedRight = RegExp.rightContext;     // "b3"
+    const savedInput = RegExp.input;            // input
+    shouldBe(savedLastMatch, "12");
+    shouldBe(savedParen1, "1");
+    shouldBe(savedParen2, "2");
+
+    // No-match at index 0 ('a' is not a digit): this is the filtered fast-fail path.
+    re.lastIndex = 0;
+    shouldBe(re.test(input), false);
+    shouldBe(re.lastIndex, 0);                  // sticky no-match resets lastIndex to 0.
+    // Global state must be UNCHANGED by the failed test.
+    shouldBe(RegExp.lastMatch, savedLastMatch);
+    shouldBe(RegExp.$1, savedParen1);
+    shouldBe(RegExp.$2, savedParen2);
+    shouldBe(RegExp.leftContext, savedLeft);
+    shouldBe(RegExp.rightContext, savedRight);
+    shouldBe(RegExp.input, savedInput);
+
+    // No-match at a filtered position past the last digit ('b' at index 3).
+    re.lastIndex = 3;
+    shouldBe(re.test(input), false);
+    shouldBe(re.lastIndex, 0);
+
+    // lastIndex beyond the end: false + reset, matching operationRegExpTestString.
+    re.lastIndex = 100;
+    shouldBe(re.test(input), false);
+    shouldBe(re.lastIndex, 0);
+
+    // A match at a byte that passes the filter (digit "3" at index 4) advances lastIndex.
+    re.lastIndex = 4;
+    shouldBe(re.test(input), true);
+    shouldBe(re.lastIndex, 5);
+}
+
+for (let i = 0; i < testLoopCount; ++i)
+    step();
+
+// Inverted leading class and quantified leading group are now filterable for sticky test too.
+(function () {
+    const reInv = /[^a-z]/y;
+    const reGrp = /([0-9a-fA-F]){4}/y;
+    for (let i = 0; i < testLoopCount; ++i) {
+        reInv.lastIndex = 0;
+        shouldBe(reInv.test("Abc"), true);   // 'A' not in a-z
+        shouldBe(reInv.lastIndex, 1);
+        reInv.lastIndex = 0;
+        shouldBe(reInv.test("abc"), false);  // 'a' filtered
+        shouldBe(reInv.lastIndex, 0);
+
+        reGrp.lastIndex = 0;
+        shouldBe(reGrp.test("dead"), true);
+        shouldBe(reGrp.lastIndex, 4);
+        reGrp.lastIndex = 0;
+        shouldBe(reGrp.test("zzzz"), false); // 'z' filtered
+        shouldBe(reGrp.lastIndex, 0);
+    }
+})();
+
+// Negative lastIndex is not isUInt32; the filter must delegate to the operation, which clamps and
+// searches from 0. Here index 0 is 'a' (no match) so the result is false with lastIndex reset.
+(function () {
+    const re2 = /(\d)(\d)?/y;
+    for (let i = 0; i < testLoopCount; ++i) {
+        re2.lastIndex = -5;
+        shouldBe(re2.test("a12"), false);
+        shouldBe(re2.lastIndex, 0);
+    }
+})();
+
+// A non-writable lastIndex must make a failing sticky test throw a TypeError (Set(...,,true)); the
+// filter guards on the writable flag and delegates to the operation, which throws.
+(function () {
+    for (let i = 0; i < testLoopCount; ++i) {
+        const re3 = /\d+/y;
+        re3.lastIndex = 0;
+        Object.defineProperty(re3, "lastIndex", { writable: false });
+        shouldThrow(() => re3.test("abc"), "TypeError");
+    }
+})();
+
+// 16-bit (non-Latin-1) subject strings must still behave correctly (filter is 8-bit only, so this
+// exercises the delegated path). The digit "5" is Latin-1 but the string is 16-bit.
+(function () {
+    const re4 = /\d/y;
+    const wide = "\u3042\u3044" + "5";   // forces a 16-bit string
+    for (let i = 0; i < testLoopCount; ++i) {
+        re4.lastIndex = 0;
+        shouldBe(re4.test(wide), false);   // first char is a wide non-digit
+        shouldBe(re4.lastIndex, 0);
+        re4.lastIndex = 2;
+        shouldBe(re4.test(wide), true);
+        shouldBe(re4.lastIndex, 3);
+    }
+})();
+
+// A .compile() that changes the pattern fires the realm's RegExp-recompiled watchpoint, jettisoning
+// the code that baked the old bitmap: the old filter must not produce wrong answers for the new
+// pattern.
+(function () {
+    const re5 = /a+/y;
+    function check(s, expected) { re5.lastIndex = 0; shouldBe(re5.test(s), expected); }
+    for (let i = 0; i < testLoopCount; ++i) { check("abc", true); check("zzz", false); }
+    re5.compile("z+", "y");
+    for (let i = 0; i < testLoopCount; ++i) { check("zzz", true); check("abc", false); }
+})();
+
+// An empty-matchable sticky pattern matches empty AT lastIndex whatever byte is there, so it must
+// never be filtered - and a match (even an empty one) must not reset lastIndex to 0. This is what
+// the builder's `consumes` propagation protects; every other test here uses a pattern with a minimum
+// size of at least 1, so nothing else would notice if that propagation were lost.
+(function () {
+    // [pattern, expected test("b") at lastIndex 0, expected lastIndex afterwards]
+    const emptyMatchable = [
+        [/a*/y, true, 0], [/x?/y, true, 0], [/(a)?/y, true, 0], [/(?:)/y, true, 0],
+        [/a|/y, true, 0], [/(a*)/y, true, 0], [/\b/y, true, 0],
+        [/$/y, false, 0],      // "b" has no end-of-input at index 0
+        [/(?=a)/y, false, 0],  // the lookahead fails, so this is a real no-match
+    ];
+    for (let i = 0; i < testLoopCount; ++i) {
+        for (const [re, expectedTest, expectedLastIndex] of emptyMatchable) {
+            re.lastIndex = 0;
+            shouldBe(re.test("b"), expectedTest);
+            shouldBe(re.lastIndex, expectedLastIndex);
+        }
+
+        // The same at a non-zero lastIndex: the empty match happens there, so lastIndex stays put.
+        const star = /q*/y;
+        star.lastIndex = 2;
+        shouldBe(star.test("abc"), true);
+        shouldBe(star.lastIndex, 2);
+    }
+})();
+
+// The `gy` combination is filterable too, and takes the same path: a sticky match must begin at
+// lastIndex, and RegExpBuiltinExec resets lastIndex to 0 on failure for global as well as for sticky,
+// which is what the inline no-match path stores.
+(function () {
+    const re6 = /\d+/gy;
+    const re7 = /[^a-z]/gy;
+    for (let i = 0; i < testLoopCount; ++i) {
+        re6.lastIndex = 0;
+        shouldBe(re6.test("42x"), true);
+        shouldBe(re6.lastIndex, 2);
+        shouldBe(re6.test("42x"), false);   // 'x' at lastIndex 2 is filtered
+        shouldBe(re6.lastIndex, 0);
+
+        re6.lastIndex = 1;
+        shouldBe(re6.test("a1"), true);
+        shouldBe(re6.lastIndex, 2);
+
+        re7.lastIndex = 0;
+        shouldBe(re7.test("Abc"), true);
+        shouldBe(re7.lastIndex, 1);
+        re7.lastIndex = 0;
+        shouldBe(re7.test("abc"), false);   // 'a' filtered
+        shouldBe(re7.lastIndex, 0);
+    }
+})();

--- a/Source/JavaScriptCore/dfg/DFGCommonData.h
+++ b/Source/JavaScriptCore/dfg/DFGCommonData.h
@@ -45,7 +45,6 @@
 #include "RecordedStatuses.h"
 #include "YarrJIT.h"
 #include <wtf/Bag.h>
-#include <wtf/BitSet.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/text/StringSearch.h>
 
@@ -139,7 +138,6 @@ public:
     Bag<OptimizingCallLinkInfo> m_callLinkInfos;
     Bag<DirectCallLinkInfo> m_directCallLinkInfos;
     Yarr::YarrBoyerMooreData m_boyerMooreData;
-    Bag<WTF::BitSet<256>> m_regExpFirstCharacterBitmaps;
 
     ScratchBuffer* catchOSREntryBuffer;
     RefPtr<Profiler::Compilation> compilation;

--- a/Source/JavaScriptCore/dfg/DFGGraph.cpp
+++ b/Source/JavaScriptCore/dfg/DFGGraph.cpp
@@ -53,6 +53,7 @@
 #include "MaxFrameExtentForSlowPathCall.h"
 #include "OperandsInlines.h"
 #include "ProfilerSupport.h"
+#include "RegExpObject.h"
 #include "SlotVisitorInlines.h"
 #include "Snippet.h"
 #include "StackAlignment.h"
@@ -1583,6 +1584,57 @@ ObjectPropertyConditionSet Graph::tryEnsureAbsence(JSGlobalObject* globalObject,
             return ObjectPropertyConditionSet::invalid();
     }
     return result;
+}
+
+const WTF::BitSet<256>* Graph::tryGetConstantRegExpFirstCharacterBitmap(Node* node, FirstCharacterFilterPosition position)
+{
+    JSGlobalObject* globalObject = nullptr;
+    RegExp* regExp = nullptr;
+    if (RegExpObject* regExpObject = node->dynamicCastConstant<RegExpObject*>()) {
+        globalObject = regExpObject->realm();
+        regExp = regExpObject->regExp();
+    } else if (node->op() == NewRegExp) {
+        globalObject = globalObjectFor(node->origin.semantic);
+        regExp = node->castOperand<RegExp*>();
+    }
+
+    if (!globalObject || !regExp)
+        return nullptr;
+
+    // The filter reads one fixed position, so the flags must guarantee a match can only begin there.
+    switch (position) {
+    case FirstCharacterFilterPosition::AtStart:
+        if (regExp->globalOrSticky())
+            return nullptr;
+        break;
+    case FirstCharacterFilterPosition::AtLastIndex:
+        if (!regExp->sticky())
+            return nullptr;
+        break;
+    }
+
+    if (globalObject->isRegExpRecompiled())
+        return nullptr;
+
+    const WTF::BitSet<256>* bitmap = regExpFirstCharacterBitmap(regExp, position);
+    if (!bitmap)
+        return nullptr;
+
+    // Only now that a filter will really be emitted is it worth constraining this compilation to the
+    // realm's RegExp-recompiled watchpoint. Registering it earlier would let any .compile() in the
+    // realm jettison code that baked no bitmap at all.
+    watchpoints().addLazily(globalObject->regExpRecompiledWatchpointSet());
+    return bitmap;
+}
+
+const WTF::BitSet<256>* Graph::regExpFirstCharacterBitmap(RegExp* regExp, FirstCharacterFilterPosition position)
+{
+    const WTF::BitSet<256>* bitmap = regExp->firstCharacterBitmap(position);
+    if (!bitmap)
+        return nullptr;
+
+    m_plan.weakReferences().addLazily(regExp);
+    return bitmap;
 }
 
 void Graph::registerFrozenValues()

--- a/Source/JavaScriptCore/dfg/DFGGraph.h
+++ b/Source/JavaScriptCore/dfg/DFGGraph.h
@@ -41,6 +41,7 @@
 #include "JITScannable.h"
 #include "JumpTable.h"
 #include "MethodOfGettingAValueProfile.h"
+#include <wtf/BitSet.h>
 #include <wtf/BitVector.h>
 #include <wtf/GenericHashKey.h>
 #include <wtf/HashMap.h>
@@ -58,6 +59,9 @@ namespace JSC {
 class CodeBlock;
 class CallFrame;
 class IRDumpDebugInfo;
+class RegExp;
+
+enum class FirstCharacterFilterPosition : uint8_t;
 
 namespace DFG {
 
@@ -1091,6 +1095,9 @@ public:
 
     DesiredIdentifiers& identifiers() LIFETIME_BOUND { return m_plan.identifiers(); }
     DesiredWatchpoints& watchpoints() LIFETIME_BOUND { return m_plan.watchpoints(); }
+
+    const WTF::BitSet<256>* tryGetConstantRegExpFirstCharacterBitmap(Node*, FirstCharacterFilterPosition);
+    const WTF::BitSet<256>* regExpFirstCharacterBitmap(RegExp*, FirstCharacterFilterPosition);
 
     // Returns false if the key is already invalid or unwatchable. If this is a Presence condition,
     // this also makes it cheap to query if the condition holds. Also makes sure that the GC knows

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -14138,16 +14138,8 @@ void SpeculativeJIT::compileRegExpTest(Node* node)
 #if CPU(ARM64) || CPU(X86_64)
             // Anchored RegExp.test(string) fast-fail on a constant RegExpObject; tests input[0].
             {
-                RegExp* regExp = nullptr;
-                if (RegExpObject* regExpObject = node->child2()->dynamicCastConstant<RegExpObject*>())
-                    regExp = regExpObject->regExp();
-                else if (node->child2()->op() == NewRegExp)
-                    regExp = node->child2()->castOperand<RegExp*>();
-                std::optional<WTF::BitSet<256>> localBitmap;
-                if (regExp && !regExp->globalOrSticky())
-                    localBitmap = Yarr::computeAnchoredFirstCharacterBitmap(regExp->pattern(), regExp->flags());
-                if (localBitmap) {
-                    const uint8_t* bitmap = jitCode()->common.m_regExpFirstCharacterBitmaps.add(*localBitmap)->storageBytes().data();
+                if (const auto* localBitmap = m_graph.tryGetConstantRegExpFirstCharacterBitmap(node->child2().node(), FirstCharacterFilterPosition::AtStart)) {
+                    const uint8_t* bitmap = localBitmap->storageBytes().data();
 
                     GPRTemporary result(this);
                     GPRTemporary scratch1(this);
@@ -14162,20 +14154,41 @@ void SpeculativeJIT::compileRegExpTest(Node* node)
                     JumpList slowCases;
                     JumpList doneCases;
 
-                    // The object must still wrap the expected RegExp (guards against .compile()).
-                    loadPtr(Address(baseGPR, RegExpObject::offsetOfRegExpAndFlags()), scratch1GPR);
-                    and64(TrustedImm64(RegExpObject::regExpMask), scratch1GPR);
-                    slowCases.append(branchLinkableConstant(NotEqual, scratch1GPR, LinkableConstant(*this, regExp)));
+                    emitRegExpAnchoredFirstCharacterFilterGuards(bitmap, argumentGPR, scratch1GPR, scratch2GPR, resultGPR, slowCases);
 
-                    loadPtr(Address(argumentGPR, JSString::offsetOfValue()), scratch1GPR);
-                    slowCases.append(branchIfRopeStringImpl(scratch1GPR));
-                    slowCases.append(branchTest32(Zero, Address(scratch1GPR, StringImpl::flagsOffset()), TrustedImm32(StringImpl::flagIs8Bit())));
-                    slowCases.append(branchTest32(Zero, Address(scratch1GPR, StringImpl::lengthMemoryOffset())));
+                    move(TrustedImm32(0), resultGPR);
+                    doneCases.append(jump());
 
-                    loadPtr(Address(scratch1GPR, StringImpl::dataOffset()), scratch1GPR);
-                    load8(Address(scratch1GPR), scratch2GPR);
-                    emitFirstCharacterBitmapMatch(bitmap, scratch2GPR, scratch1GPR, resultGPR, slowCases);
+                    slowCases.link(this);
+                    callOperation(operationRegExpTestString, resultGPR, globalObjectGPR, baseGPR, argumentGPR);
 
+                    doneCases.link(this);
+                    unblessedBooleanResult(resultGPR, node);
+                    return;
+                }
+            }
+
+            // Sticky RegExp.test(string) fast-fail on a constant RegExpObject; tests input[lastIndex].
+            {
+                if (const auto* localBitmap = m_graph.tryGetConstantRegExpFirstCharacterBitmap(node->child2().node(), FirstCharacterFilterPosition::AtLastIndex)) {
+                    const uint8_t* bitmap = localBitmap->storageBytes().data();
+
+                    GPRTemporary result(this);
+                    GPRTemporary scratch1(this);
+                    GPRTemporary scratch2(this);
+                    GPRReg resultGPR = result.gpr();
+                    GPRReg scratch1GPR = scratch1.gpr();
+                    GPRReg scratch2GPR = scratch2.gpr();
+
+                    flushRegisters();
+
+                    JumpList slowCases;
+                    JumpList doneCases;
+
+                    emitRegExpStickyFirstCharacterFilterGuards(bitmap, baseGPR, argumentGPR, scratch1GPR, scratch2GPR, resultGPR, slowCases);
+
+                    // The byte cannot begin a match: reset lastIndex to 0 and return false.
+                    store64(TrustedImm64(JSValue::encode(jsNumber(0))), Address(baseGPR, RegExpObject::offsetOfLastIndex()));
                     move(TrustedImm32(0), resultGPR);
                     doneCases.append(jump());
 
@@ -14406,33 +14419,24 @@ void SpeculativeJIT::compileRegExpExecNonGlobalOrSticky(Node* node)
     // Anchored non-sticky exec fast-fail; tests input[0].
     {
         RegExp* regExp = node->castOperand<RegExp*>();
-        if (auto localBitmap = Yarr::computeAnchoredFirstCharacterBitmap(regExp->pattern(), regExp->flags())) {
-            const uint8_t* bitmap = jitCode()->common.m_regExpFirstCharacterBitmaps.add(*localBitmap)->storageBytes().data();
+        ASSERT(!regExp->globalOrSticky());
+        if (const auto* localBitmap = m_graph.regExpFirstCharacterBitmap(regExp, FirstCharacterFilterPosition::AtStart)) {
+            const uint8_t* bitmap = localBitmap->storageBytes().data();
 
             GPRTemporary result(this);
             GPRTemporary scratch1(this);
             GPRTemporary scratch2(this);
-            GPRTemporary scratch3(this);
 
             GPRReg resultGPR = result.gpr();
             GPRReg scratch1GPR = scratch1.gpr();
             GPRReg scratch2GPR = scratch2.gpr();
-            GPRReg scratch3GPR = scratch3.gpr();
 
             flushRegisters();
 
             JumpList slowCases;
             JumpList doneCases;
 
-            loadPtr(Address(argumentGPR, JSString::offsetOfValue()), scratch1GPR);
-            slowCases.append(branchIfRopeStringImpl(scratch1GPR));
-            slowCases.append(branchTest32(Zero, Address(scratch1GPR, StringImpl::flagsOffset()), TrustedImm32(StringImpl::flagIs8Bit())));
-            // An anchored pattern cannot match empty, so delegate an empty string to the operation.
-            slowCases.append(branchTest32(Zero, Address(scratch1GPR, StringImpl::lengthMemoryOffset())));
-
-            loadPtr(Address(scratch1GPR, StringImpl::dataOffset()), scratch1GPR);
-            load8(Address(scratch1GPR), scratch2GPR);
-            emitFirstCharacterBitmapMatch(bitmap, scratch2GPR, scratch1GPR, scratch3GPR, slowCases);
+            emitRegExpAnchoredFirstCharacterFilterGuards(bitmap, argumentGPR, scratch1GPR, scratch2GPR, resultGPR, slowCases);
 
             move(TrustedImm64(JSValue::encode(jsNull())), resultGPR);
             doneCases.append(jump());
@@ -14474,18 +14478,16 @@ void SpeculativeJIT::compileRegExpExecSticky(Node* node)
     // return null inline.
     {
         RegExp* regExp = node->castOperand<RegExp*>();
-        auto localBitmap = Yarr::computeStickyFirstCharacterBitmap(regExp->pattern(), regExp->flags());
-        if (localBitmap) {
-            const uint8_t* bitmap = jitCode()->common.m_regExpFirstCharacterBitmaps.add(*localBitmap)->storageBytes().data();
+        ASSERT(regExp->sticky() && !regExp->global());
+        if (const auto* localBitmap = m_graph.regExpFirstCharacterBitmap(regExp, FirstCharacterFilterPosition::AtLastIndex)) {
+            const uint8_t* bitmap = localBitmap->storageBytes().data();
 
             GPRTemporary result(this);
             GPRTemporary scratch1(this);
             GPRTemporary scratch2(this);
-            GPRTemporary scratch3(this);
             GPRReg resultGPR = result.gpr();
             GPRReg scratch1GPR = scratch1.gpr();
             GPRReg scratch2GPR = scratch2.gpr();
-            GPRReg scratch3GPR = scratch3.gpr();
 
             // baseGPR/argumentGPR/globalObjectGPR are preserved across flushRegisters for the
             // slow-path operation call; the scratch registers are free to clobber.
@@ -14494,27 +14496,7 @@ void SpeculativeJIT::compileRegExpExecSticky(Node* node)
             JumpList slowCases;
             JumpList doneCases;
 
-            // The string must be a resolved 8-bit string.
-            loadPtr(Address(argumentGPR, JSString::offsetOfValue()), scratch1GPR);
-            slowCases.append(branchIfRopeStringImpl(scratch1GPR));
-            slowCases.append(branchTest32(Zero, Address(scratch1GPR, StringImpl::flagsOffset()), TrustedImm32(StringImpl::flagIs8Bit())));
-
-            // lastIndex must be writable so the inline no-match path can reset it to 0.
-            slowCases.append(branchTest32(NonZero, Address(baseGPR, RegExpObject::offsetOfRegExpAndFlags()), TrustedImm32(RegExpObject::lastIndexIsNotWritableFlag)));
-
-            // lastIndex must be an Int32.
-            load64(Address(baseGPR, RegExpObject::offsetOfLastIndex()), scratch2GPR);
-            slowCases.append(branchIfNotInt32(scratch2GPR));
-            zeroExtend32ToWord(scratch2GPR, scratch2GPR);
-
-            // Need 0 <= lastIndex < length. An unsigned compare rejects negatives too.
-            load32(Address(scratch1GPR, StringImpl::lengthMemoryOffset()), scratch3GPR);
-            slowCases.append(branch32(AboveOrEqual, scratch2GPR, scratch3GPR));
-
-            // character = input[lastIndex] (scratch1GPR becomes the data pointer).
-            loadPtr(Address(scratch1GPR, StringImpl::dataOffset()), scratch1GPR);
-            load8(BaseIndex(scratch1GPR, scratch2GPR, TimesOne), scratch3GPR);
-            emitFirstCharacterBitmapMatch(bitmap, scratch3GPR, scratch1GPR, scratch2GPR, slowCases);
+            emitRegExpStickyFirstCharacterFilterGuards(bitmap, baseGPR, argumentGPR, scratch1GPR, scratch2GPR, resultGPR, slowCases);
 
             // The byte cannot begin a match: reset lastIndex to 0 and return null.
             store64(TrustedImm64(JSValue::encode(jsNumber(0))), Address(baseGPR, RegExpObject::offsetOfLastIndex()));

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
@@ -1731,6 +1731,8 @@ public:
     void compileRegExpExecNonGlobalOrSticky(Node*);
     void compileRegExpExecSticky(Node*);
     void emitFirstCharacterBitmapMatch(const uint8_t* bitmap, GPRReg characterGPR, GPRReg scratch1GPR, GPRReg scratch2GPR, JumpList& matchMaybeCases);
+    void emitRegExpAnchoredFirstCharacterFilterGuards(const uint8_t* bitmap, GPRReg argumentGPR, GPRReg scratch1GPR, GPRReg scratch2GPR, GPRReg scratch3GPR, JumpList& slowCases);
+    void emitRegExpStickyFirstCharacterFilterGuards(const uint8_t* bitmap, GPRReg baseGPR, GPRReg argumentGPR, GPRReg scratch1GPR, GPRReg scratch2GPR, GPRReg scratch3GPR, JumpList& slowCases);
     void compileRegExpMatchFast(Node*);
     void compileRegExpMatchFastGlobal(Node*);
     void compileRegExpSplitFast(Node*);

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
@@ -9995,6 +9995,48 @@ void SpeculativeJIT::emitFirstCharacterBitmapMatch(const uint8_t* bitmap, GPRReg
 #endif
 }
 
+void SpeculativeJIT::emitRegExpAnchoredFirstCharacterFilterGuards(const uint8_t* bitmap, GPRReg argumentGPR, GPRReg scratch1GPR, GPRReg scratch2GPR, GPRReg scratch3GPR, JumpList& slowCases)
+{
+    ASSERT(noOverlap(argumentGPR, scratch1GPR, scratch2GPR, scratch3GPR));
+
+    // The string must be a resolved 8-bit string.
+    loadPtr(Address(argumentGPR, JSString::offsetOfValue()), scratch1GPR);
+    slowCases.append(branchIfRopeStringImpl(scratch1GPR));
+    slowCases.append(branchTest32(Zero, Address(scratch1GPR, StringImpl::flagsOffset()), TrustedImm32(StringImpl::flagIs8Bit())));
+
+    // An anchored pattern that reaches here cannot match empty, so delegate an empty string.
+    slowCases.append(branchTest32(Zero, Address(scratch1GPR, StringImpl::lengthMemoryOffset())));
+
+    loadPtr(Address(scratch1GPR, StringImpl::dataOffset()), scratch1GPR);
+    load8(Address(scratch1GPR), scratch2GPR);
+    emitFirstCharacterBitmapMatch(bitmap, scratch2GPR, scratch1GPR, scratch3GPR, slowCases);
+}
+
+void SpeculativeJIT::emitRegExpStickyFirstCharacterFilterGuards(const uint8_t* bitmap, GPRReg baseGPR, GPRReg argumentGPR, GPRReg scratch1GPR, GPRReg scratch2GPR, GPRReg scratch3GPR, JumpList& slowCases)
+{
+    ASSERT(noOverlap(baseGPR, argumentGPR, scratch1GPR, scratch2GPR, scratch3GPR));
+
+    // The string must be a resolved 8-bit string.
+    loadPtr(Address(argumentGPR, JSString::offsetOfValue()), scratch1GPR);
+    slowCases.append(branchIfRopeStringImpl(scratch1GPR));
+    slowCases.append(branchTest32(Zero, Address(scratch1GPR, StringImpl::flagsOffset()), TrustedImm32(StringImpl::flagIs8Bit())));
+
+    // lastIndex must be writable so the inline no-match path can reset it to 0.
+    slowCases.append(branchTest32(NonZero, Address(baseGPR, RegExpObject::offsetOfRegExpAndFlags()), TrustedImm32(RegExpObject::lastIndexIsNotWritableFlag)));
+
+    load64(Address(baseGPR, RegExpObject::offsetOfLastIndex()), scratch2GPR);
+    slowCases.append(branchIfNotInt32(scratch2GPR));
+    zeroExtend32ToWord(scratch2GPR, scratch2GPR);
+
+    // Need 0 <= lastIndex < length.
+    load32(Address(scratch1GPR, StringImpl::lengthMemoryOffset()), scratch3GPR);
+    slowCases.append(branch32(AboveOrEqual, scratch2GPR, scratch3GPR));
+
+    loadPtr(Address(scratch1GPR, StringImpl::dataOffset()), scratch1GPR);
+    load8(BaseIndex(scratch1GPR, scratch2GPR, TimesOne), scratch3GPR);
+    emitFirstCharacterBitmapMatch(bitmap, scratch3GPR, scratch1GPR, scratch2GPR, slowCases);
+}
+
 #endif
 
 } } // namespace JSC::DFG

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -19341,25 +19341,15 @@ IGNORE_CLANG_WARNINGS_END
         return m_out.testNonZero32(bitmapByte, bit);
     }
 
-    // Anchored non-sticky exec fast-fail; tests input[0].
-    bool compileRegExpExecNonGlobalOrStickyAnchoredFilter(LValue globalObject, LValue argument)
+    void emitAnchoredFirstCharacterGuardChain(LValue argument, Edge argumentEdge, const uint8_t* bitmap, LBasicBlock operationCase, LBasicBlock noMatchCase)
     {
-        RegExp* regExp = uncheckedDowncast<RegExp>(m_node->cellOperand()->value());
-        auto localBitmap = Yarr::computeAnchoredFirstCharacterBitmap(regExp->pattern(), regExp->flags());
-        if (!localBitmap)
-            return false;
-        const uint8_t* bitmap = m_ftlState.jitCode->dfgCommon()->m_regExpFirstCharacterBitmaps.add(*localBitmap)->storageBytes().data();
-
         LBasicBlock check8Bit = m_out.newBlock();
         LBasicBlock checkLength = m_out.newBlock();
         LBasicBlock filterCase = m_out.newBlock();
-        LBasicBlock noMatchCase = m_out.newBlock();
-        LBasicBlock operationCase = m_out.newBlock();
-        LBasicBlock continuation = m_out.newBlock();
 
-        m_out.branch(isRopeString(argument, m_node->child2()), rarely(operationCase), usually(check8Bit));
+        m_out.branch(isRopeString(argument, argumentEdge), rarely(operationCase), usually(check8Bit));
 
-        LBasicBlock lastNext = m_out.appendTo(check8Bit, checkLength);
+        m_out.appendTo(check8Bit, checkLength);
         LValue stringImpl = m_out.loadPtr(argument, m_heaps.JSString_value);
         m_out.branch(
             m_out.testIsZero32(
@@ -19367,7 +19357,7 @@ IGNORE_CLANG_WARNINGS_END
                 m_out.constInt32(StringImpl::flagIs8Bit())),
             rarely(operationCase), usually(checkLength));
 
-        // An anchored pattern cannot match empty, so delegate an empty string to the operation.
+        // An anchored pattern that reaches here cannot match empty, so delegate an empty string.
         m_out.appendTo(checkLength, filterCase);
         m_out.branch(m_out.equal(m_out.load32(stringImpl, m_heaps.StringImpl_length), m_out.int32Zero), rarely(operationCase), usually(filterCase));
 
@@ -19375,6 +19365,25 @@ IGNORE_CLANG_WARNINGS_END
         LValue stringData = m_out.loadPtr(stringImpl, m_heaps.StringImpl_data);
         LValue character = m_out.load8ZeroExt32(m_out.baseIndex(m_heaps.characters8, stringData, m_out.constIntPtr(0)));
         m_out.branch(firstCharacterBitmapContains(character, bitmap), unsure(operationCase), unsure(noMatchCase));
+    }
+
+    // Anchored non-sticky exec fast-fail; tests input[0].
+    bool compileRegExpExecNonGlobalOrStickyAnchoredFilter(LValue globalObject, LValue argument)
+    {
+        RegExp* regExp = uncheckedDowncast<RegExp>(m_node->cellOperand()->value());
+        ASSERT(!regExp->globalOrSticky());
+
+        auto* localBitmap = m_graph.regExpFirstCharacterBitmap(regExp, FirstCharacterFilterPosition::AtStart);
+        if (!localBitmap)
+            return false;
+        const uint8_t* bitmap = localBitmap->storageBytes().data();
+
+        LBasicBlock noMatchCase = m_out.newBlock();
+        LBasicBlock operationCase = m_out.newBlock();
+        LBasicBlock continuation = m_out.newBlock();
+
+        LBasicBlock lastNext = m_out.insertNewBlocksBefore(noMatchCase);
+        emitAnchoredFirstCharacterGuardChain(argument, m_node->child2(), bitmap, operationCase, noMatchCase);
 
         m_out.appendTo(noMatchCase, operationCase);
         ValueFromBlock nullResult = m_out.anchor(m_out.constInt64(JSValue::encode(jsNull())));
@@ -19402,30 +19411,17 @@ IGNORE_CLANG_WARNINGS_END
         setJSValue(result);
     }
 
-    // Sticky exec fast-fail; when input[lastIndex] cannot begin a match, reset lastIndex to 0 and
-    // return null inline.
-    bool compileRegExpExecStickyFirstCharFilter(LValue globalObject, LValue base, LValue argument)
+    void emitStickyFirstCharacterGuardChain(LValue base, LValue argument, Edge argumentEdge, const uint8_t* bitmap, LBasicBlock operationCase, LBasicBlock noMatchCase)
     {
-        RegExp* regExp = uncheckedDowncast<RegExp>(m_node->cellOperand()->value());
-        ASSERT(regExp->sticky() && !regExp->global());
-
-        auto localBitmap = Yarr::computeStickyFirstCharacterBitmap(regExp->pattern(), regExp->flags());
-        if (!localBitmap)
-            return false;
-        const uint8_t* bitmap = m_ftlState.jitCode->dfgCommon()->m_regExpFirstCharacterBitmaps.add(*localBitmap)->storageBytes().data();
-
         LBasicBlock check8Bit = m_out.newBlock();
         LBasicBlock checkWritable = m_out.newBlock();
         LBasicBlock checkInt32 = m_out.newBlock();
         LBasicBlock checkInBounds = m_out.newBlock();
         LBasicBlock filterCase = m_out.newBlock();
-        LBasicBlock noMatchCase = m_out.newBlock();
-        LBasicBlock operationCase = m_out.newBlock();
-        LBasicBlock continuation = m_out.newBlock();
 
-        m_out.branch(isRopeString(argument, m_node->child3()), rarely(operationCase), usually(check8Bit));
+        m_out.branch(isRopeString(argument, argumentEdge), rarely(operationCase), usually(check8Bit));
 
-        LBasicBlock lastNext = m_out.appendTo(check8Bit, checkWritable);
+        m_out.appendTo(check8Bit, checkWritable);
         LValue stringImpl = m_out.loadPtr(argument, m_heaps.JSString_value);
         m_out.branch(
             m_out.testIsZero32(
@@ -19455,6 +19451,25 @@ IGNORE_CLANG_WARNINGS_END
         LValue stringData = m_out.loadPtr(stringImpl, m_heaps.StringImpl_data);
         LValue character = m_out.load8ZeroExt32(m_out.baseIndex(m_heaps.characters8, stringData, m_out.zeroExtPtr(lastIndex)));
         m_out.branch(firstCharacterBitmapContains(character, bitmap), unsure(operationCase), unsure(noMatchCase));
+    }
+
+    // Sticky exec fast-fail; when input[lastIndex] cannot begin a match, reset lastIndex to 0 and return null inline.
+    bool compileRegExpExecStickyFirstCharFilter(LValue globalObject, LValue base, LValue argument)
+    {
+        RegExp* regExp = uncheckedDowncast<RegExp>(m_node->cellOperand()->value());
+        ASSERT(regExp->sticky() && !regExp->global());
+
+        auto* localBitmap = m_graph.regExpFirstCharacterBitmap(regExp, FirstCharacterFilterPosition::AtLastIndex);
+        if (!localBitmap)
+            return false;
+        const uint8_t* bitmap = localBitmap->storageBytes().data();
+
+        LBasicBlock noMatchCase = m_out.newBlock();
+        LBasicBlock operationCase = m_out.newBlock();
+        LBasicBlock continuation = m_out.newBlock();
+
+        LBasicBlock lastNext = m_out.insertNewBlocksBefore(noMatchCase);
+        emitStickyFirstCharacterGuardChain(base, argument, m_node->child3(), bitmap, operationCase, noMatchCase);
 
         m_out.appendTo(noMatchCase, operationCase);
         m_out.store64(m_out.constInt64(JSValue::encode(jsNumber(0))), base, m_heaps.RegExpObject_lastIndex);
@@ -19508,6 +19523,8 @@ IGNORE_CLANG_WARNINGS_END
                 LValue argument = lowString(m_node->child3());
                 if (compileRegExpTestAnchoredFilter(globalObject, base, argument))
                     return;
+                if (compileRegExpTestStickyFilter(globalObject, base, argument))
+                    return;
                 LValue result = vmCall(Int32, operationRegExpTestString, globalObject, base, argument);
                 setBoolean(result);
                 return;
@@ -19525,52 +19542,52 @@ IGNORE_CLANG_WARNINGS_END
         setBoolean(result);
     }
 
-    // Anchored RegExp.test(string) fast-fail on a constant RegExpObject; tests input[0]. A runtime
-    // guard (below) keeps it correct across .compile() without a recompile watchpoint.
+    // Anchored RegExp.test(string) fast-fail on a constant RegExpObject; tests input[0].
     bool compileRegExpTestAnchoredFilter(LValue globalObject, LValue base, LValue argument)
     {
-        RegExp* regExp = nullptr;
-        if (RegExpObject* regExpObject = m_node->child2()->dynamicCastConstant<RegExpObject*>())
-            regExp = regExpObject->regExp();
-        else if (m_node->child2()->op() == NewRegExp)
-            regExp = m_node->child2()->castOperand<RegExp*>();
-        if (!regExp || regExp->globalOrSticky())
-            return false;
-        auto localBitmap = Yarr::computeAnchoredFirstCharacterBitmap(regExp->pattern(), regExp->flags());
+        auto* localBitmap = m_graph.tryGetConstantRegExpFirstCharacterBitmap(m_node->child2().node(), FirstCharacterFilterPosition::AtStart);
         if (!localBitmap)
             return false;
-        const uint8_t* bitmap = m_ftlState.jitCode->dfgCommon()->m_regExpFirstCharacterBitmaps.add(*localBitmap)->storageBytes().data();
+        const uint8_t* bitmap = localBitmap->storageBytes().data();
 
-        LBasicBlock checkRope = m_out.newBlock();
-        LBasicBlock check8Bit = m_out.newBlock();
-        LBasicBlock checkLength = m_out.newBlock();
-        LBasicBlock filterCase = m_out.newBlock();
         LBasicBlock falseCase = m_out.newBlock();
         LBasicBlock operationCase = m_out.newBlock();
         LBasicBlock continuation = m_out.newBlock();
 
-        // The object must still wrap the RegExp whose bitmap we baked (guards against .compile()).
-        LValue currentRegExp = m_out.bitAnd(m_out.loadPtr(base, m_heaps.RegExpObject_regExpAndFlags), m_out.constIntPtr(RegExpObject::regExpMask));
-        m_out.branch(m_out.equal(currentRegExp, frozenPointer(m_graph.freeze(regExp))), usually(checkRope), rarely(operationCase));
-
-        LBasicBlock lastNext = m_out.appendTo(checkRope, check8Bit);
-        m_out.branch(isRopeString(argument, m_node->child3()), rarely(operationCase), usually(check8Bit));
-
-        m_out.appendTo(check8Bit, checkLength);
-        LValue stringImpl = m_out.loadPtr(argument, m_heaps.JSString_value);
-        m_out.branch(
-            m_out.testIsZero32(m_out.load32(stringImpl, m_heaps.StringImpl_hashAndFlags), m_out.constInt32(StringImpl::flagIs8Bit())),
-            rarely(operationCase), usually(checkLength));
-
-        m_out.appendTo(checkLength, filterCase);
-        m_out.branch(m_out.equal(m_out.load32(stringImpl, m_heaps.StringImpl_length), m_out.int32Zero), rarely(operationCase), usually(filterCase));
-
-        m_out.appendTo(filterCase, falseCase);
-        LValue stringData = m_out.loadPtr(stringImpl, m_heaps.StringImpl_data);
-        LValue character = m_out.load8ZeroExt32(m_out.baseIndex(m_heaps.characters8, stringData, m_out.constIntPtr(0)));
-        m_out.branch(firstCharacterBitmapContains(character, bitmap), unsure(operationCase), unsure(falseCase));
+        LBasicBlock lastNext = m_out.insertNewBlocksBefore(falseCase);
+        emitAnchoredFirstCharacterGuardChain(argument, m_node->child3(), bitmap, operationCase, falseCase);
 
         m_out.appendTo(falseCase, operationCase);
+        ValueFromBlock falseResult = m_out.anchor(m_out.int32Zero);
+        m_out.jump(continuation);
+
+        m_out.appendTo(operationCase, continuation);
+        ValueFromBlock operationResult = m_out.anchor(vmCall(Int32, operationRegExpTestString, globalObject, base, argument));
+        m_out.jump(continuation);
+
+        m_out.appendTo(continuation, lastNext);
+        setBoolean(m_out.phi(Int32, falseResult, operationResult));
+        return true;
+    }
+
+    // Sticky RegExp.test(string) fast-fail on a constant RegExpObject; tests input[lastIndex]. `gy`
+    // qualifies too: on a failed match RegExpBuiltinExec resets lastIndex to 0 for global as well as sticky.
+    bool compileRegExpTestStickyFilter(LValue globalObject, LValue base, LValue argument)
+    {
+        auto* localBitmap = m_graph.tryGetConstantRegExpFirstCharacterBitmap(m_node->child2().node(), FirstCharacterFilterPosition::AtLastIndex);
+        if (!localBitmap)
+            return false;
+        const uint8_t* bitmap = localBitmap->storageBytes().data();
+
+        LBasicBlock falseCase = m_out.newBlock();
+        LBasicBlock operationCase = m_out.newBlock();
+        LBasicBlock continuation = m_out.newBlock();
+
+        LBasicBlock lastNext = m_out.insertNewBlocksBefore(falseCase);
+        emitStickyFirstCharacterGuardChain(base, argument, m_node->child3(), bitmap, operationCase, falseCase);
+
+        m_out.appendTo(falseCase, operationCase);
+        m_out.store64(m_out.constInt64(JSValue::encode(jsNumber(0))), base, m_heaps.RegExpObject_lastIndex);
         ValueFromBlock falseResult = m_out.anchor(m_out.int32Zero);
         m_out.jump(continuation);
 

--- a/Source/JavaScriptCore/runtime/RegExp.cpp
+++ b/Source/JavaScriptCore/runtime/RegExp.cpp
@@ -27,6 +27,7 @@
 #include "RegExpCache.h"
 #include "RegExpInlines.h"
 #include "YarrJIT.h"
+#include "YarrPattern.h"
 #include <wtf/Assertions.h>
 #include <wtf/Atomics.h>
 #include <wtf/DataLog.h>
@@ -207,6 +208,8 @@ size_t RegExp::estimatedSize(JSCell* cell, VM& vm)
         regexDataSize += jitCode->size();
 #endif
     regexDataSize += thisObject->m_ovector.capacity() * sizeof(int);
+    if (thisObject->m_firstCharacterBitmap.get())
+        regexDataSize += sizeof(WTF::BitSet<256>);
     return Base::estimatedSize(cell, vm) + regexDataSize;
 }
 
@@ -340,6 +343,24 @@ void RegExp::compile(VM* vm, Yarr::CharSize charSize, std::optional<StringView> 
         m_state = ParseError;
         return;
     }
+}
+
+const WTF::BitSet<256>* RegExp::firstCharacterBitmap(FirstCharacterFilterPosition position)
+{
+    ASSERT_UNUSED(position, position == FirstCharacterFilterPosition::AtStart ? !globalOrSticky() : sticky());
+    const auto& result = m_firstCharacterBitmap.ensure([&] {
+        auto bitmap = Yarr::computeFirstCharacterBitmap(m_patternString, m_flags);
+        if (!bitmap || bitmap->isFull()) {
+            WTF::BitSet<256> full;
+            full.setAll();
+            return makeUnique<WTF::BitSet<256>>(WTF::move(full));
+        }
+        return makeUnique<WTF::BitSet<256>>(*bitmap);
+    });
+
+    if (result.isFull())
+        return nullptr;
+    return &result;
 }
 
 int RegExp::match(JSGlobalObject* globalObject, StringView s, unsigned startOffset, std::span<int> ovector)

--- a/Source/JavaScriptCore/runtime/RegExp.h
+++ b/Source/JavaScriptCore/runtime/RegExp.h
@@ -26,7 +26,10 @@
 #include <JavaScriptCore/Structure.h>
 #include <JavaScriptCore/Yarr.h>
 #include <JavaScriptCore/YarrErrorCode.h>
+#include <wtf/Atomics.h>
+#include <wtf/BitSet.h>
 #include <wtf/Forward.h>
+#include <wtf/ThreadSafeLazyUniquePtr.h>
 #include <wtf/text/WTFString.h>
 
 #if ENABLE(YARR_JIT)
@@ -37,6 +40,14 @@ namespace JSC {
 
 struct RegExpRepresentation;
 class VM;
+
+// Where a first-character fast-fail filter reads the byte it tests.
+enum class FirstCharacterFilterPosition : uint8_t {
+    // Reads input[0]. Sound only when every match must begin at index 0.
+    AtStart,
+    // Reads input[lastIndex]. Sound only for a sticky pattern.
+    AtLastIndex,
+};
 
 class RegExp final : public JSCell {
     friend class CachedRegExp;
@@ -178,6 +189,8 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     const String& atom() const LIFETIME_BOUND { return m_atom; }
     Yarr::SpecificPattern specificPattern() const { return m_specificPattern; }
 
+    const WTF::BitSet<256>* firstCharacterBitmap(FirstCharacterFilterPosition);
+
 private:
     friend class RegExpCache;
     RegExp(VM&, const String&, OptionSet<Yarr::Flags>);
@@ -238,6 +251,7 @@ private:
 #endif
     std::unique_ptr<RareData> m_rareData;
     Vector<int> m_ovector;
+    mutable ThreadSafeLazyUniquePtr<const WTF::BitSet<256>> m_firstCharacterBitmap;
 #if ENABLE(REGEXP_TRACING)
     double m_rtMatchOnlyTotalSubjectStringLen { 0.0 };
     double m_rtMatchTotalSubjectStringLen { 0.0 };

--- a/Source/JavaScriptCore/yarr/YarrPattern.cpp
+++ b/Source/JavaScriptCore/yarr/YarrPattern.cpp
@@ -3488,19 +3488,43 @@ private:
             m_bitmap.set(c);
     }
 
-    void addCharacterClass(const CharacterClass* cc)
+    // Collects X's Latin-1 members into `target`. Every entry is clamped to 0..0xff: BitSet::set()
+    // is unchecked, so an out-of-range member would be a wild write.
+    bool collectLatin1Members(const CharacterClass* cc, WTF::BitSet<256>& target)
     {
         if (cc->m_anyCharacter || !cc->m_strings.isEmpty()) {
             m_gaveUp = true;
-            return;
+            return false;
         }
-        for (char32_t c : cc->m_matches8)
-            setBit(c);
+        for (char32_t c : cc->m_matches8) {
+            ASSERT(isLatin1(c));
+            if (c <= 0xff)
+                target.set(c);
+        }
         for (auto& range : cc->m_ranges8) {
+            ASSERT(isLatin1(range.begin));
             char32_t end = std::min<char32_t>(range.end, 0xff);
             for (char32_t c = range.begin; c <= end; ++c)
-                setBit(c);
+                target.set(c);
         }
+        return true;
+    }
+
+    void addCharacterClass(const CharacterClass* cc)
+    {
+        collectLatin1Members(cc, m_bitmap);
+    }
+
+    void addInvertedCharacterClass(const CharacterClass* cc)
+    {
+        // For an 8-bit subject, [^X] matches byte c iff c is not in X. matches8/ranges8 fully
+        // describe X's Latin-1 membership even when an m_table is also present, so the complement
+        // over 0..0xff is a sound filter.
+        WTF::BitSet<256> positive;
+        if (!collectLatin1Members(cc, positive))
+            return;
+        positive.invert();
+        m_bitmap.merge(positive);
     }
 
     // Sets `consumes` when the term definitely consumes >= 1 character, so it fully determines the
@@ -3532,12 +3556,11 @@ private:
             consumes = term.quantityMinCount > 0;
             return;
         case Type::CharacterClass:
-            // Classes are already case-folded at construction. An inverted class is not a useful filter.
-            if (term.invert()) {
-                m_gaveUp = true;
-                return;
-            }
-            addCharacterClass(term.characterClass);
+            // Classes are already case-folded at construction.
+            if (term.invert())
+                addInvertedCharacterClass(term.characterClass);
+            else
+                addCharacterClass(term.characterClass);
             consumes = term.quantityMinCount > 0;
             return;
         case Type::ParenthesesSubpattern: {
@@ -3555,24 +3578,45 @@ private:
         }
     }
 
-    void addAlternative(PatternAlternative* alternative, unsigned depth)
+    // Returns true when the alternative definitely consumes >= 1 character. A false return with
+    // m_gaveUp unset means the alternative can complete without consuming anything (matches empty).
+    bool addAlternative(PatternAlternative* alternative, unsigned depth)
     {
+        bool consumes = false;
         for (auto& term : alternative->m_terms) {
-            bool consumes = false;
+            if (consumes) {
+                // The first character is already pinned down, so no later term can add to the
+                // bitmap - with one exception. A DotStarEnclosure is the residue left behind by
+                // optimizeDotStarWrappedExpressions(), which DELETED a leading `^` and `.*` from
+                // this alternative. The surviving first term is therefore not where the match
+                // begins, so the bitmap we just built is a lie.
+                if (term.type == PatternTerm::Type::DotStarEnclosure) {
+                    m_gaveUp = true;
+                    return false;
+                }
+                continue;
+            }
             addTerm(term, consumes, depth);
             if (m_gaveUp)
-                return;
-            if (consumes)
-                return;
+                return false;
         }
+        return consumes;
     }
 
     void addDisjunction(PatternDisjunction* disjunction, unsigned depth)
     {
         for (auto& alternative : disjunction->m_alternatives) {
-            addAlternative(alternative.get(), depth);
+            bool consumes = addAlternative(alternative.get(), depth);
             if (m_gaveUp)
                 return;
+            // A top-level alternative that can complete without consuming any character means the
+            // pattern can match empty at position 0, so no first-character filter is sound. Nested
+            // paren disjunctions are allowed to match empty; the enclosing paren term's own
+            // `consumes` flag decides whether it contributes a guaranteed character.
+            if (!depth && !consumes) {
+                m_gaveUp = true;
+                return;
+            }
         }
     }
 
@@ -3580,33 +3624,30 @@ private:
     bool m_gaveUp { false };
 };
 
-std::optional<WTF::BitSet<256>> computeStickyFirstCharacterBitmap(StringView patternString, OptionSet<Flags> flags)
+// Computes the Latin-1 first-character fast-fail bitmap for a pattern. The bitmap content is the
+// same in every mode; only the precondition on where it may be applied differs, and that is
+// selected from the flags here.
+std::optional<WTF::BitSet<256>> computeFirstCharacterBitmap(StringView patternString, OptionSet<Flags> flags)
 {
     ErrorCode errorCode = ErrorCode::NoError;
     YarrPattern pattern(patternString, flags, errorCode);
-    if (hasError(errorCode) || !pattern.m_body || pattern.m_body->m_minimumSize < 1)
+    if (hasError(errorCode) || !pattern.m_body)
         return std::nullopt;
-    WTF::BitSet<256> bitmap;
-    FirstCharacterBitmapBuilder builder(bitmap);
-    if (!builder.build(pattern.m_body))
-        return std::nullopt;
-    return bitmap;
-}
-
-std::optional<WTF::BitSet<256>> computeAnchoredFirstCharacterBitmap(StringView patternString, OptionSet<Flags> flags)
-{
-    ErrorCode errorCode = ErrorCode::NoError;
-    YarrPattern pattern(patternString, flags, errorCode);
-    if (hasError(errorCode) || !pattern.m_body || pattern.m_body->m_minimumSize < 1)
-        return std::nullopt;
-    // The bitmap describes position 0, so it is only sound when every match must begin there:
-    // ^-anchored at the start of every alternative, and neither multiline nor a modifier group can
-    // make that ^ match after a newline.
-    if (pattern.multiline() || pattern.m_containsModifiers)
-        return std::nullopt;
-    for (auto& alternative : pattern.m_body->m_alternatives) {
-        if (!alternative->m_startsWithBOL)
+    if (!pattern.sticky()) {
+        if (pattern.global())
             return std::nullopt;
+        if (pattern.multiline() || pattern.m_containsModifiers)
+            return std::nullopt;
+        // Check the leading term rather than PatternAlternative::m_startsWithBOL: the parser sets
+        // that flag optimistically and recomputeStartsWithBOL() corrects it, but here an over-eager
+        // flag is a wrong answer rather than a lost optimization.
+        for (auto& alternative : pattern.m_body->m_alternatives) {
+            if (alternative->m_terms.isEmpty())
+                return std::nullopt;
+            const PatternTerm& firstTerm = alternative->m_terms[0];
+            if (firstTerm.type != PatternTerm::Type::AssertionBOL || firstTerm.m_matchDirection != Forward)
+                return std::nullopt;
+        }
     }
     WTF::BitSet<256> bitmap;
     FirstCharacterBitmapBuilder builder(bitmap);

--- a/Source/JavaScriptCore/yarr/YarrPattern.h
+++ b/Source/JavaScriptCore/yarr/YarrPattern.h
@@ -46,10 +46,10 @@ struct YarrPattern;
 struct PatternDisjunction;
 
 // Superset of the Latin-1 bytes that can begin a match (a clear bit guarantees no match begins
-// there), or nullopt when not useful. computeAnchored additionally requires the pattern be
-// ^-anchored at position 0 (not multiline). Safe to call on a compiler thread.
-std::optional<WTF::BitSet<256>> computeStickyFirstCharacterBitmap(StringView, OptionSet<Flags>);
-std::optional<WTF::BitSet<256>> computeAnchoredFirstCharacterBitmap(StringView, OptionSet<Flags>);
+// there), or nullopt when no sound filter exists. The filter position is selected from the flags:
+// sticky filters at lastIndex; a non-global non-sticky pattern filters at position 0 (only when
+// ^-anchored and not multiline); any other pattern has no filter. Safe to call on a compiler thread.
+std::optional<WTF::BitSet<256>> computeFirstCharacterBitmap(StringView, OptionSet<Flags>);
 
 enum class CompileMode : uint8_t {
     Legacy,

--- a/Source/WTF/wtf/BitSet.h
+++ b/Source/WTF/wtf/BitSet.h
@@ -141,7 +141,7 @@ public:
     std::span<WordType> storage() LIFETIME_BOUND { return bits; }
     std::span<const WordType> storage() const LIFETIME_BOUND { return bits; }
 
-    constexpr size_t storageLengthInBytes() { return sizeof(bits); }
+    constexpr size_t storageLengthInBytes() const { return sizeof(bits); }
 
     std::span<uint8_t> storageBytes() LIFETIME_BOUND { return unsafeMakeSpan(reinterpret_cast<uint8_t*>(bits.data()), storageLengthInBytes()); }
     std::span<const uint8_t> storageBytes() const LIFETIME_BOUND { return unsafeMakeSpan(reinterpret_cast<const uint8_t*>(bits.data()), storageLengthInBytes()); }


### PR DESCRIPTION
#### 1e43057f135a31c9c9c893ab4efe2874cef8e426
<pre>
[JSC][YARR] Extend first-character filter more
<a href="https://bugs.webkit.org/show_bug.cgi?id=320258">https://bugs.webkit.org/show_bug.cgi?id=320258</a>
<a href="https://rdar.apple.com/183182586">rdar://183182586</a>

Reviewed by Yijia Huang.

This patch extends first-character fast-fail filter in DFG / FTL.

1. Inverted character class is supported. Just collecting the set
   and inverted set is merged.
2. Add filter for sticky RegExp#test(string) pattern as the same to
   RegExp#exec(string).
3. Move BitSet to RegExp so we can compile and store it per-RegExp cell
   basis. Concurrently compiling and storing the data and we can reuse
   this by anchoring RegExp cell from DFG::Graph.
4. Expand first-character collection into parentheses, like ((^a)|(^b)).

Tests: JSTests/stress/regexp-anchored-first-char-filter-inverted-class-and-groups.js
       JSTests/stress/regexp-first-char-filter-anchoring-soundness.js
       JSTests/stress/regexp-test-sticky-first-char-filter.js

* JSTests/stress/regexp-anchored-first-char-filter-inverted-class-and-groups.js: Added.
(shouldBe):
(step):
* JSTests/stress/regexp-first-char-filter-anchoring-soundness.js: Added.
(shouldBe):
(check):
(dotStarWrapped):
(genuinelyAnchored):
* JSTests/stress/regexp-test-anchored-first-char-filter.js:
* JSTests/stress/regexp-test-sticky-first-char-filter.js: Added.
(shouldBe):
(shouldThrow):
(step):
(const.reGrp):
(check):
* Source/JavaScriptCore/dfg/DFGCommonData.h:
* Source/JavaScriptCore/dfg/DFGGraph.cpp:
(JSC::DFG::Graph::tryGetConstantRegExpFirstCharacterBitmap):
(JSC::DFG::Graph::regExpFirstCharacterBitmap):
* Source/JavaScriptCore/dfg/DFGGraph.h:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp:
(JSC::DFG::SpeculativeJIT::emitRegExpAnchoredFirstCharacterFilterGuards):
(JSC::DFG::SpeculativeJIT::emitRegExpStickyFirstCharacterFilterGuards):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileCompareStrictEq):
* Source/JavaScriptCore/runtime/RegExp.cpp:
(JSC::RegExp::estimatedSize):
(JSC::RegExp::firstCharacterBitmap):
* Source/JavaScriptCore/runtime/RegExp.h:
* Source/JavaScriptCore/yarr/YarrPattern.cpp:
(JSC::Yarr::FirstCharacterBitmapBuilder::collectLatin1Members):
(JSC::Yarr::FirstCharacterBitmapBuilder::addCharacterClass):
(JSC::Yarr::FirstCharacterBitmapBuilder::addInvertedCharacterClass):
(JSC::Yarr::FirstCharacterBitmapBuilder::addTerm):
(JSC::Yarr::FirstCharacterBitmapBuilder::addAlternative):
(JSC::Yarr::FirstCharacterBitmapBuilder::addDisjunction):
(JSC::Yarr::computeFirstCharacterBitmap):
(JSC::Yarr::computeStickyFirstCharacterBitmap): Deleted.
(JSC::Yarr::computeAnchoredFirstCharacterBitmap): Deleted.
* Source/JavaScriptCore/yarr/YarrPattern.h:
* Source/WTF/wtf/BitSet.h:

Canonical link: <a href="https://commits.webkit.org/318022@main">https://commits.webkit.org/318022@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3b9f6b766a495863ffb34297f89799fc07a5a557

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177049 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50986 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44781 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186652 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140285 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ed31fbed-cca7-4e5f-a5a7-015e18672d1a) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52279 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50672 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/137967 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140285 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8d02d4c8-21de-4a49-af5c-9a2fcd168f0b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180005 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41462 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/158732 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118436 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f297567d-cace-411c-af0a-ab448bca7a86) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40118 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/38482 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/251/builds/405 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/7237 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150528 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38232 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35120 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/38320 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/42760 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/42700 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189076 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50653 "Built successfully") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/147034 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51336 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/34856 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146825 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26856 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41579 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123550 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117837 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49841 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13212 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49240 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49477 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49301 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->