### PR TITLE
Avoid unix.MallocSizeof static analyzer false positive in SegmentedVector::allocateSegment()

### DIFF
--- a/Source/WTF/wtf/SegmentedVector.h
+++ b/Source/WTF/wtf/SegmentedVector.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2008, 2026 Apple Inc. All rights reserved.
+ * Copyright (C) 2008-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -379,9 +379,10 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
         void allocateSegment()
         {
+            static_assert(!sizeof(Segment), "Segment must add no header for (sizeof(T) * segSize) to size the buffer");
             size_t segSize = sizeOfSegment(m_segments.size());
-            auto* ptr = static_cast<Segment*>(Malloc::malloc(sizeof(T) * segSize));
-            m_segments.append(SegmentPtr(ptr, { }));
+            auto* ptr = Malloc::malloc(sizeof(T) * segSize);
+            m_segments.append(SegmentPtr(static_cast<Segment*>(ptr), { }));
         }
 
         size_t m_size { 0 };


### PR DESCRIPTION
#### 4477de733d5b3aa1244d05fd21146678c82041a0
<pre>
Avoid unix.MallocSizeof static analyzer false positive in SegmentedVector::allocateSegment()
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=320260">https://bugs.webkit.org/show_bug.cgi?id=320260</a>&gt;
&lt;<a href="https://rdar.apple.com/183185724">rdar://183185724</a>&gt;

Reviewed by Zak Ridouh.

`SegmentedVector::Segment` is a flexible-array-member handle whose only
member is the trailing `T m_entries[0]`, so a segment is sized to hold
`segSize` elements of `T` and the buffer is reinterpreted as a
`Segment*`.  The unix.MallocSizeof checker flags this deliberate
`sizeof(T)` versus `Segment*` mismatch.  The checker has no
flexible-array-member exemption, and because it is an AST-based checker
its report is not silenced by `[[clang::suppress]]`, so the suppression
macros from `wtf/Compiler.h` do not apply here.

The checker only inspects a cast that syntactically wraps the
allocation call, so hold the result in its natural `void*` and cast at
the point of use instead.  Typed Memory Operations infer the allocation
type from the cast wherever it appears, so this keeps the same
`malloc_type_id_t` the compiler infers today.

Add a `static_assert` that `Segment` adds no header.  Nothing else ties
the allocation size to the overlay: were `Segment` to gain a member,
every element would shift past it and the last one would fall outside
the buffer.

No new tests since no change in behavior.

* Source/WTF/wtf/SegmentedVector.h:
(WTF::SegmentedVector::allocateSegment):

Canonical link: <a href="https://commits.webkit.org/317919@main">https://commits.webkit.org/317919@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/20e26166ff1ea731046dda193bdb4c678cb9180f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176722 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50659 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44451 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186324 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/139958 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/dc7f35b8-d550-4308-91e9-dabbd7c0c651) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51952 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50345 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137667 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/139958 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e72d5b43-3077-4897-a286-b0c0dcd55191) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179678 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41172 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158455 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118141 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/98fa0279-de65-4344-a6fe-d4746abebbe0) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39827 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38193 "Passed tests") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/251/builds/106 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/6962 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150239 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37953 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34792 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/37993 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42403 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42409 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188748 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50326 "Built successfully") | | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146730 "Found 1 new test failure: compositing/framesets/composited-frame-alignment.html (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51009 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34574 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146535 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26823 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41300 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123216 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117356 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49514 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12932 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48913 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49149 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48974 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->