### PR TITLE
[Site Isolation] Define a MediaSessionManagerClient to route audio-session activation and NowPlaying

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -2416,6 +2416,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/audio/AudioSourceProviderClient.h
     platform/audio/AudioStreamDescription.h
     platform/audio/AudioUtilities.h
+    platform/audio/MediaSessionManagerClient.h
     platform/audio/MediaSessionManagerInterface.h
     platform/audio/NowPlayingInfo.h
     platform/audio/NowPlayingMetadataObserver.h

--- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
+++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
@@ -148,6 +148,7 @@
 		072D3D6B2AAD4FA600ED82C5 /* JSMeteringMode.h in Headers */ = {isa = PBXBuildFile; fileRef = 072D3D692AAD4FA600ED82C5 /* JSMeteringMode.h */; };
 		072F696D2E74FC2100281FC5 /* TextListParser.h in Headers */ = {isa = PBXBuildFile; fileRef = 072F696C2E74FC2100281FC5 /* TextListParser.h */; };
 		072F696F2E755BFA00281FC5 /* TextListParser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 072F696E2E755BFA00281FC5 /* TextListParser.cpp */; };
+		EDB1CA5E2E0000000000AC02 /* MediaSessionManagerClient.h in Headers */ = {isa = PBXBuildFile; fileRef = EDB1CA5E2E0000000000AC01 /* MediaSessionManagerClient.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		07307B7A2DA07F8D00A5EF65 /* MediaSessionManagerInterface.h in Headers */ = {isa = PBXBuildFile; fileRef = 07307B792DA06AEC00A5EF65 /* MediaSessionManagerInterface.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		07307B922DA4B5C500A5EF65 /* PlatformMediaSessionInterface.h in Headers */ = {isa = PBXBuildFile; fileRef = 07307B912DA4B5C500A5EF65 /* PlatformMediaSessionInterface.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		07354A282CD11FD100D229CB /* MediaSourceConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = 07354A272CD11FAC00D229CB /* MediaSourceConfiguration.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -7930,6 +7931,7 @@
 		072DBC0725DC6EDA00A1350E /* JSMediaSessionCoordinator.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = JSMediaSessionCoordinator.cpp; sourceTree = "<group>"; };
 		072F696C2E74FC2100281FC5 /* TextListParser.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TextListParser.h; sourceTree = "<group>"; };
 		072F696E2E755BFA00281FC5 /* TextListParser.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = TextListParser.cpp; sourceTree = "<group>"; };
+		EDB1CA5E2E0000000000AC01 /* MediaSessionManagerClient.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MediaSessionManagerClient.h; sourceTree = "<group>"; };
 		07307B792DA06AEC00A5EF65 /* MediaSessionManagerInterface.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MediaSessionManagerInterface.h; sourceTree = "<group>"; };
 		07307B912DA4B5C500A5EF65 /* PlatformMediaSessionInterface.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PlatformMediaSessionInterface.h; sourceTree = "<group>"; };
 		07354A272CD11FAC00D229CB /* MediaSourceConfiguration.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MediaSourceConfiguration.h; sourceTree = "<group>"; };
@@ -43740,6 +43742,7 @@
 				FD31606B12B026F700C1A359 /* HRTFPanner.h */,
 				839BE6D424F58755004DF50F /* IIRFilter.cpp */,
 				839BE6D224F58755004DF50F /* IIRFilter.h */,
+				EDB1CA5E2E0000000000AC01 /* MediaSessionManagerClient.h */,
 				07FDA6B32E16CA53008482F8 /* MediaSessionManagerInterface.cpp */,
 				07307B792DA06AEC00A5EF65 /* MediaSessionManagerInterface.h */,
 				FDB1700314A2BAB200A2B5D9 /* MultiChannelResampler.cpp */,
@@ -47433,6 +47436,7 @@
 				416ECAE525B58CC400B34DA5 /* MediaSessionGroupIdentifier.h in Headers */,
 				CDA9593F2412BAE000910EEF /* MediaSessionHelperIOS.h in Headers */,
 				414460A22412994500814BE7 /* MediaSessionIdentifier.h in Headers */,
+				EDB1CA5E2E0000000000AC02 /* MediaSessionManagerClient.h in Headers */,
 				417F7AEF2139BF6F00FBA7EC /* MediaSessionManagerCocoa.h in Headers */,
 				07307B7A2DA07F8D00A5EF65 /* MediaSessionManagerInterface.h in Headers */,
 				07638A991884487200E15A1B /* MediaSessionManagerIOS.h in Headers */,

--- a/Source/WebCore/platform/audio/MediaSessionManagerClient.h
+++ b/Source/WebCore/platform/audio/MediaSessionManagerClient.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+namespace WebCore {
+
+class PlatformMediaSessionInterface;
+
+// Abstracts the environment-coupled operations a MediaSessionManager performs, so that a manager
+// which does not have a local WebCore::Page (e.g. the UI-process RemoteMediaSessionManagerProxy,
+// which aggregates sessions from many web processes) can route them appropriately instead of
+// reaching a WebCore::Page directly.
+class MediaSessionManagerClient {
+public:
+    virtual ~MediaSessionManagerClient() = default;
+
+    // Notify the environment (the owning page) that the active NowPlaying session changed.
+    virtual void hasActiveNowPlayingSessionChanged(PlatformMediaSessionInterface*) = 0;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/platform/audio/MediaSessionManagerInterface.cpp
+++ b/Source/WebCore/platform/audio/MediaSessionManagerInterface.cpp
@@ -29,7 +29,9 @@
 #include "AudioSession.h"
 #include "Document.h"
 #include "Logging.h"
+#include "MediaSessionManagerClient.h"
 #include "NowPlayingInfo.h"
+#include "Page.h"
 #include "PlatformMediaSession.h"
 #include <algorithm>
 #include <ranges>
@@ -45,13 +47,37 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(MediaSessionManagerInterface);
 
+class PageMediaSessionManagerClient final : public MediaSessionManagerClient {
+    WTF_MAKE_TZONE_ALLOCATED(PageMediaSessionManagerClient);
+public:
+    explicit PageMediaSessionManagerClient(std::optional<PageIdentifier> pageIdentifier)
+        : m_pageIdentifier(pageIdentifier) { }
+
+private:
+    void hasActiveNowPlayingSessionChanged(PlatformMediaSessionInterface*) final
+    {
+        if (RefPtr page = m_pageIdentifier ? Page::fromPageIdentifier(*m_pageIdentifier) : nullptr)
+            page->hasActiveNowPlayingSessionChanged();
+    }
+
+    Markable<PageIdentifier> m_pageIdentifier;
+};
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(PageMediaSessionManagerClient);
+
 MediaSessionManagerInterface::MediaSessionManagerInterface(std::optional<PageIdentifier> pageIdentifier)
     : m_pageIdentifier(pageIdentifier)
+    , m_client(makeUnique<PageMediaSessionManagerClient>(pageIdentifier))
 #if !RELEASE_LOG_DISABLED
     , m_stateLogTimer(makeUniqueRef<Timer>(*this, &MediaSessionManagerInterface::dumpSessionStates))
     , m_logger(AggregateLogger::create(this))
 #endif
 {
+}
+
+MediaSessionManagerClient& MediaSessionManagerInterface::client() const
+{
+    return *m_client;
 }
 
 MediaSessionManagerInterface::~MediaSessionManagerInterface()

--- a/Source/WebCore/platform/audio/MediaSessionManagerInterface.h
+++ b/Source/WebCore/platform/audio/MediaSessionManagerInterface.h
@@ -44,6 +44,7 @@
 
 namespace WebCore {
 
+class MediaSessionManagerClient;
 class Page;
 class PlatformMediaSessionInterface;
 struct NowPlayingMetadata;
@@ -177,6 +178,8 @@ public:
 protected:
     explicit MediaSessionManagerInterface(std::optional<PageIdentifier>);
 
+    MediaSessionManagerClient& client() const;
+
     virtual WeakListHashSet<PlatformMediaSessionInterface>& sessions() const = 0;
     virtual Vector<WeakPtr<PlatformMediaSessionInterface>> copySessionsToVector() const = 0;
 
@@ -226,6 +229,7 @@ private:
     TaskCancellationGroup m_taskGroup;
 
     Markable<PageIdentifier> m_pageIdentifier;
+    const std::unique_ptr<MediaSessionManagerClient> m_client;
 #if !RELEASE_LOG_DISABLED
     UniqueRef<Timer> m_stateLogTimer;
     const Ref<AggregateLogger> m_logger;

--- a/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm
+++ b/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm
@@ -33,6 +33,7 @@
 #import "ImageAdapter.h"
 #import "Logging.h"
 #import "MediaPlayer.h"
+#import "MediaSessionManagerClient.h"
 #import "MediaStrategy.h"
 #import "NowPlayingInfo.h"
 #import "Page.h"
@@ -313,9 +314,7 @@ void MediaSessionManagerCocoa::removeSession(PlatformMediaSessionInterface& sess
 
     if (session.isActiveNowPlayingSession()) {
         session.setActiveNowPlayingSession(false);
-        // FIXME: Make a better abstraction so we don't need to access a WebCore::Page from a PlatformMediaSessionManager.
-        if (RefPtr page = pageIdentifier() ? Page::fromPageIdentifier(*pageIdentifier()) : nullptr)
-            page->hasActiveNowPlayingSessionChanged();
+        client().hasActiveNowPlayingSessionChanged(&session);
     }
 
     if (hasNoSession()) {
@@ -526,9 +525,7 @@ void MediaSessionManagerCocoa::updateActiveNowPlayingSession(RefPtr<PlatformMedi
     });
 
     if (activeSessionChanged) {
-        // FIXME: Make a better abstraction so we don't need to access a WebCore::Page from a PlatformMediaSessionManager.
-        if (RefPtr page = pageIdentifier() ? Page::fromPageIdentifier(*pageIdentifier()) : nullptr)
-            page->hasActiveNowPlayingSessionChanged();
+        client().hasActiveNowPlayingSessionChanged(activeNowPlayingSession.get());
 
         adjustNowPlayingUpdateInterval();
     }


### PR DESCRIPTION
#### 3ec8c62695a2acc1bd7470b552d105b350cc7943
<pre>
[Site Isolation] Define a MediaSessionManagerClient to route audio-session activation and NowPlaying
<a href="https://bugs.webkit.org/show_bug.cgi?id=320247">https://bugs.webkit.org/show_bug.cgi?id=320247</a>
<a href="https://rdar.apple.com/183175861">rdar://183175861</a>

Reviewed by Jean-Yves Avenard.

MediaSessionManagerCocoa notifies the active NowPlaying session changing by looking up a
WebCore::Page via Page::fromPageIdentifier() and calling hasActiveNowPlayingSessionChanged()
on it. That does not work for the UI-process RemoteMediaSessionManagerProxy, which has no
WebCore::Page and aggregates media sessions from many web processes; when that class was
made a singleton in 317396@main the dependency was side-stepped by making the
PageIdentifier optional, with a note that a better abstraction was needed in a follow-up
to use a client of some sort.

This adds that abstraction. MediaSessionManagerClient is a small interface for the
environment-coupled NowPlaying notification. MediaSessionManagerInterface owns one,
defaulting to PageMediaSessionManagerClient, which reproduces the existing behavior
(resolve the PageIdentifier to a WebCore::Page and forward the call), so there is no
behavior change. A follow-up will let the UI-process singleton install its own client
that routes the notification to the right page.

No new tests; this is a behavior-preserving refactor covered by existing media tests.

* Source/WebCore/Headers.cmake:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/audio/MediaSessionManagerClient.h: Added.
* Source/WebCore/platform/audio/MediaSessionManagerInterface.cpp:
(WebCore::MediaSessionManagerInterface::MediaSessionManagerInterface):
(WebCore::MediaSessionManagerInterface::client const):
* Source/WebCore/platform/audio/MediaSessionManagerInterface.h:
* Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm:
(WebCore::MediaSessionManagerCocoa::removeSession):
(WebCore::MediaSessionManagerCocoa::updateActiveNowPlayingSession):

Canonical link: <a href="https://commits.webkit.org/317977@main">https://commits.webkit.org/317977@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3eecd235d5466d0165c2decb2d98c427757c8512

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176942 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50879 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44674 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186545 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140178 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6d9727c6-a251-4cdb-b68e-ca6478613fd4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178805 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52172 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50565 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/137863 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140178 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5f2f1999-3fab-4591-8111-4168eecac9bf) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179898 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41373 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/158653 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118332 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0f1786f3-e899-4d99-820a-e4c89fcd7122) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/40029 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38394 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150439 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38153 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35013 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42630 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/42612 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188968 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50546 "Built successfully") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/146938 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39498 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51229 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/34777 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146735 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41496 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123442 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117720 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49734 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13133 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49133 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49370 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49194 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->