### PR TITLE
Potential crash under WebViewImpl::insertText() with a zero-length attributed string

### DIFF
--- a/Source/WebCore/editing/mac/TextAlternativeWithRange.mm
+++ b/Source/WebCore/editing/mac/TextAlternativeWithRange.mm
@@ -46,6 +46,8 @@ TextAlternativeWithRange::TextAlternativeWithRange(PlatformTextAlternatives *tex
 void collectDictationTextAlternatives(NSAttributedString *string, Vector<TextAlternativeWithRange>& alternatives) {
     NSRange effectiveRange = NSMakeRange(0, 0);
     NSUInteger length = [string length];
+    if (!length)
+        return;
     do {
         RetainPtr<NSDictionary> attributes = [string attributesAtIndex:effectiveRange.location effectiveRange:&effectiveRange];
         if (!attributes)

--- a/Source/WebCore/editing/mac/TextUndoInsertionMarkupMac.mm
+++ b/Source/WebCore/editing/mac/TextUndoInsertionMarkupMac.mm
@@ -35,6 +35,8 @@ namespace WebCore {
     
 bool shouldRegisterInsertionUndoGroup(NSAttributedString *string)
 {
+    if (![string length])
+        return false;
     return [string attribute:NSTextInsertionUndoableAttributeName atIndex:0 effectiveRange:nil];
 }
     

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/WKWebViewMacEditingTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/WKWebViewMacEditingTests.mm
@@ -34,6 +34,7 @@
 #import "Helpers/cocoa/TestProtocol.h"
 #import "Helpers/cocoa/TestWKWebView.h"
 #import "Helpers/cocoa/WKWebViewConfigurationExtras.h"
+#import <AppKit/NSTextAlternatives.h>
 #import <WebCore/Color.h>
 #import <WebKit/WKPreferencesPrivate.h>
 #import <WebKit/WKProcessPoolPrivate.h>
@@ -1145,6 +1146,52 @@ TEST(WKWebViewMacEditingTests, FirstRectForCharacterRangeInTextArea)
     EXPECT_GT(rectAfterTyping.size.height, 0);
     EXPECT_EQ(rangeAfterTyping.location, 1U);
     EXPECT_EQ(rangeAfterTyping.length, 0U);
+}
+
+TEST(WKWebViewMacEditingTests, InsertEmptyAttributedStringDoesNotCrash)
+{
+    RetainPtr webView = adoptNS([[TestWKWebView<NSTextInputClient> alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    [webView synchronouslyLoadHTMLString:@"<body contenteditable>hello</body>"];
+    [webView stringByEvaluatingJavaScript:@"document.body.focus()"];
+    [webView _synchronouslyExecuteEditCommand:@"MoveToEndOfDocument" argument:nil];
+    [webView waitForNextPresentationUpdate];
+
+    [webView insertText:adoptNS([[NSMutableAttributedString alloc] init]).get() replacementRange:NSMakeRange(NSNotFound, 0)];
+    [webView waitForNextPresentationUpdate];
+
+    EXPECT_WK_STREQ("hello", [webView stringByEvaluatingJavaScript:@"document.body.textContent"]);
+
+    // The web view is still usable for text input after the empty insertion.
+    [webView insertText:@"!" replacementRange:NSMakeRange(NSNotFound, 0)];
+    [webView waitForNextPresentationUpdate];
+
+    EXPECT_WK_STREQ("hello!", [webView stringByEvaluatingJavaScript:@"document.body.textContent"]);
+}
+
+TEST(WKWebViewMacEditingTests, InsertEmptyAttributedStringWithAttributesDoesNotCrash)
+{
+    RetainPtr webView = adoptNS([[TestWKWebView<NSTextInputClient> alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    [webView synchronouslyLoadHTMLString:@"<body contenteditable>hello</body>"];
+    [webView stringByEvaluatingJavaScript:@"document.body.focus()"];
+    [webView _synchronouslyExecuteEditCommand:@"MoveToEndOfDocument" argument:nil];
+    [webView waitForNextPresentationUpdate];
+
+    RetainPtr alternatives = adoptNS([[NSTextAlternatives alloc] initWithPrimaryString:@"" alternativeStrings:@[ @"yellow" ]]);
+    RetainPtr string = adoptNS([[NSMutableAttributedString alloc] init]);
+    [string addAttribute:NSTextAlternativesAttributeName value:alternatives.get() range:NSMakeRange(0, 0)];
+    [string addAttribute:NSTextInsertionUndoableAttributeName value:@YES range:NSMakeRange(0, 0)];
+    EXPECT_EQ(0U, [string length]);
+
+    [webView insertText:string.get() replacementRange:NSMakeRange(NSNotFound, 0)];
+    [webView waitForNextPresentationUpdate];
+
+    EXPECT_WK_STREQ("hello", [webView stringByEvaluatingJavaScript:@"document.body.textContent"]);
+
+    // Replacing a range with an empty attributed string should delete that range rather than crash.
+    [webView insertText:string.get() replacementRange:NSMakeRange(0, 1)];
+    [webView waitForNextPresentationUpdate];
+
+    EXPECT_WK_STREQ("ello", [webView stringByEvaluatingJavaScript:@"document.body.textContent"]);
 }
 
 TEST(WKWebViewMacEditingTests, FirstRectForCharacterRangeWithNewlinesAndWrapping)


### PR DESCRIPTION
#### 63d08dbe5305b4f63a3d7aad95bb207dd59b8ee6
<pre>
Potential crash under WebViewImpl::insertText() with a zero-length attributed string
<a href="https://bugs.webkit.org/show_bug.cgi?id=320263">https://bugs.webkit.org/show_bug.cgi?id=320263</a>
<a href="https://rdar.apple.com/183187277">rdar://183187277</a>

Reviewed by Wenson Hsieh.

collectDictationTextAlternatives() and shouldRegisterInsertionUndoGroup()
both unconditionally read attributes at index 0 of the NSAttributedString
passed to WebViewImpl::insertText(id, NSRange), without checking the
string&apos;s length first. An empty NSMutableAttributedString raises
NSRangeException for such an access, so passing a zero-length attributed
string (e.g. from an input method committing a composition down to nothing,
or from the Character Viewer) crashed. Guard both functions with a length
check.

Note that an empty immutable NSAttributedString happens not to raise, so
the new tests use NSMutableAttributedString to exercise the crashing path.

The equivalent WebHTMLView insertText: path in WebKitLegacy has a third
unguarded index-0 read of NSTextInputReplacementRangeAttributeName that
this change does not address.

* Source/WebCore/editing/mac/TextAlternativeWithRange.mm:
(WebCore::collectDictationTextAlternatives):
* Source/WebCore/editing/mac/TextUndoInsertionMarkupMac.mm:
(WebCore::shouldRegisterInsertionUndoGroup):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/WKWebViewMacEditingTests.mm:
(TestWebKitAPI::TEST(WKWebViewMacEditingTests, InsertEmptyAttributedStringDoesNotCrash)):
(TestWebKitAPI::TEST(WKWebViewMacEditingTests, InsertEmptyAttributedStringWithAttributesDoesNotCrash)):

Canonical link: <a href="https://commits.webkit.org/317932@main">https://commits.webkit.org/317932@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/64fe106cec444fce01de0742e51e81664ed0a190

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176793 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50730 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44522 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186395 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140029 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a6a7f424-c8b7-4c02-9fa9-f0708b9e8759) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178656 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52023 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50416 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/137724 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140029 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8c7759ba-2962-49db-a758-6c26c8d5e335) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179749 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41227 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158508 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118198 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9ef6f15a-5c05-460b-b790-4373b5116dae) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39881 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/38251 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/150293 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38007 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34863 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42475 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/42466 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188819 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50397 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146789 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39463 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51080 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/34628 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146594 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41356 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123288 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117473 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49585 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12985 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48984 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49220 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49045 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->