### PR TITLE
[webkitpy] Commit step falls through silently after 3 failed attempts

### DIFF
--- a/Tools/Scripts/webkitpy/tool/steps/commit.py
+++ b/Tools/Scripts/webkitpy/tool/steps/commit.py
@@ -104,3 +104,6 @@ class Commit(AbstractStep):
                     password = self._tool.user.prompt_password("%s password for %s: " % (e.server_host, username), repeat=5)
                     if not password:
                         raise ScriptError("You need to specify the password for %s on %s to perform the commit." % (username, e.server_host))
+
+        if "commit_text" not in self._state:
+            raise ScriptError(message="Unable to commit after 3 attempts.")


### PR DESCRIPTION
#### 78355d29b77a45bf4972d104a5506c0efab086b9
<pre>
[webkitpy] Commit step falls through silently after 3 failed attempts
<a href="https://bugs.webkit.org/show_bug.cgi?id=320268">https://bugs.webkit.org/show_bug.cgi?id=320268</a>
<a href="https://rdar.apple.com/183190338">rdar://183190338</a>

Reviewed by NOBODY (OOPS!).

Commit.run()&apos;s retry loop only exits via a successful break or an
explicit raise from its exception handlers. Retrying on
AuthenticationError (interactive mode) re-prompts for credentials but
never raises if the new credentials are wrong again, so 3 consecutive
bad attempts exhaust the loop and fall through with no exception and
no state[&quot;commit_text&quot;] set. Downstream steps (ClosePatch,
CloseBugForLandDiff, ReopenBugAfterRevert) read state[&quot;commit_text&quot;]
unconditionally and hit a confusing KeyError instead of a clear
commit-failure error.

Raise a ScriptError if commit_text was never set after the loop.

* Tools/Scripts/webkitpy/tool/steps/commit.py:
(Commit.run):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/78355d29b77a45bf4972d104a5506c0efab086b9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176729 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50666 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44458 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186331 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/139965 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/805cc8aa-9ee5-452c-9e5e-b85d65b59774) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178592 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51959 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50352 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137672 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96265 "1 flakes 2 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2f307509-e4d6-417c-990a-b36c785179ba) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179685 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41179 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158468 "Found 1 new API test failure: TestWebKitAPI.ProcessSwap.Back (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118146 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a33f581c-115b-4c05-80c1-90dee994796c) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/176052 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39834 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38199 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150246 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37966 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34799 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42415 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188755 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50333 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146737 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51016 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34587 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/held.https.any.sharedworker.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146542 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41304 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117368 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49521 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12945 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48920 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49156 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48981 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->