### PR TITLE
IOSPort.default_baseline_search_path() crashes when device_version() is None

### DIFF
--- a/Tools/Scripts/webkitpy/port/ios.py
+++ b/Tools/Scripts/webkitpy/port/ios.py
@@ -59,7 +59,7 @@ class IOSPort(EmbeddedPort):
             wk_string = 'wk2'
 
         versions_to_fallback = []
-        if self.device_version().major == self.CURRENT_VERSION.major:
+        if self.device_version() and self.device_version().major == self.CURRENT_VERSION.major:
             versions_to_fallback = [self.CURRENT_VERSION]
         elif self.device_version():
             temp_version = Version(self.device_version().major)


### PR DESCRIPTION
#### 51daadd146daef403a1a50629bd81323e1bde4cf
<pre>
IOSPort.default_baseline_search_path() crashes when device_version() is None
<a href="https://bugs.webkit.org/show_bug.cgi?id=320270">https://bugs.webkit.org/show_bug.cgi?id=320270</a>
<a href="https://rdar.apple.com/183190296">rdar://183190296</a>

Reviewed by NOBODY (OOPS!).

default_baseline_search_path() dereferenced self.device_version().major
before checking whether device_version() was None, raising an
AttributeError on the very check meant to guard against it.

device_version() is abstract and both concrete implementations can
return None:
- EmbeddedDeviceMixin.device_version() (embedded_device.py) only
  assigns a version when a connected device matches
  _is_device_platform_match(); if none match, it returns None.
- EmbeddedSimulatorMixin.device_version() (embedded_simulator.py)
  falls back to host.platform.xcode_sdk_version(self.SDK), which can
  itself return None when the SDK version can&apos;t be determined.

Short-circuit on device_version() first so the None case falls
through without crashing.

* Tools/Scripts/webkitpy/port/ios.py:
(IOSPort.default_baseline_search_path):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/51daadd146daef403a1a50629bd81323e1bde4cf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176730 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50667 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44459 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186332 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/139966 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/33786565-3f2a-4fd9-be51-b1d6490b88a8) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178593 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51960 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50353 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137673 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96266 "1 flakes 4 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/51b16d34-72c2-4b6b-ba07-73b48df1007f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179686 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41175 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158459 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118147 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8e063240-972d-4e7a-8d20-bba997358467) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/176053 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39830 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38201 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150242 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37957 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-highlight-api/painting/custom-highlight-dynamic-font-metrics-001.html (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34800 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42417 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188756 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50334 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146738 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51017 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34578 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146543 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41305 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117369 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49522 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12936 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48921 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49157 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48982 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->