### PR TITLE
EWS.builders() cache check compares URL against int-keyed dict, causing cache to never hit

### DIFF
--- a/Tools/Scripts/webkitpy/common/net/bugzilla/ews.py
+++ b/Tools/Scripts/webkitpy/common/net/bugzilla/ews.py
@@ -43,7 +43,7 @@ class EWS(object):
         return cls(urlunsplit(split))
 
     def builders(self, invalidate_cache=False):
-        if not invalidate_cache and self.buildbot_url in self._builders:
+        if not invalidate_cache and self._builders:
             return self._builders
 
         r = self._session.get(urljoin(self._api_v2_url, "builders"))


### PR DESCRIPTION
#### bde5bd60bcc9b6d72fd9dd28e6037769ce020677
<pre>
EWS.builders() cache check compares URL against int-keyed dict, causing cache to never hit
<a href="https://bugs.webkit.org/show_bug.cgi?id=320271">https://bugs.webkit.org/show_bug.cgi?id=320271</a>
<a href="https://rdar.apple.com/183190773">rdar://183190773</a>

Reviewed by NOBODY (OOPS!).

self._builders is keyed by builderid (int), but the cache-hit check
tested `self.buildbot_url in self._builders`, comparing a URL string
against int keys. This is never true, so every call to builders()
re-fetched <a href="https://.../api/v2/builders">https://.../api/v2/builders</a> over the network regardless of
the invalidate_cache flag, defeating the cache entirely.

* Tools/Scripts/webkitpy/common/net/bugzilla/ews.py:
(EWS.builders): Check whether self._builders is already populated
instead of comparing the buildbot URL against its keys.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bde5bd60bcc9b6d72fd9dd28e6037769ce020677

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176731 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50668 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44460 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186333 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/139967 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d000cfa1-99e8-4458-86c9-a051f8ee75d4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178594 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51961 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50354 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137674 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96267 "1 flakes 3 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1b996066-6f78-4eba-8958-dc8e2dedfd02) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179687 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41177 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158461 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118148 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b5ed04ba-0768-4c6b-a526-828f040b2d28) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/176054 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39832 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38202 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150244 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37959 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34801 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42418 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188757 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50335 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146739 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51018 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34580 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Checked out pull request; Running run-layout-tests-in-stress-mode; Ignored 4 pre-existing failure based on results-db; Uploaded test results") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146544 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41303 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117372 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49523 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12938 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48922 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49158 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48983 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->