### PR TITLE
lint-test-expectations never applies glib-specific TestExpectations override for GTK/WPE ports

### DIFF
--- a/Tools/Scripts/webkitpy/layout_tests/lint_test_expectations.py
+++ b/Tools/Scripts/webkitpy/layout_tests/lint_test_expectations.py
@@ -58,7 +58,7 @@ def lint(host, options, logging_stream):
         lint_failed = False
 
         for port_to_lint in ports_to_lint:
-            if port_to_lint in ['gtk', 'wpe']:
+            if port_to_lint.port_name in ['gtk', 'wpe']:
                 port_to_lint._options.additional_expectations = ['LayoutTests/platform/glib/TestExpectations']
             expectations_dict = port_to_lint.expectations_dict()
 

--- a/Tools/Scripts/webkitpy/layout_tests/lint_test_expectations_unittest.py
+++ b/Tools/Scripts/webkitpy/layout_tests/lint_test_expectations_unittest.py
@@ -40,6 +40,8 @@ class FakePort(object):
         self.host = host
         self.name = name
         self.path = path
+        self.port_name = name
+        self._options = optparse.Values({'additional_expectations': []})
 
     def test_configuration(self):
         return None
@@ -105,6 +107,23 @@ class LintTest(unittest.TestCase):
 
         self.assertEqual(res, 0)
         self.assertIn('Lint succeeded', logging_stream.getvalue())
+
+    def test_glib_additional_expectations(self):
+        host = MockHost()
+        host.ports_parsed = []
+        gtk_port = FakePort(host, 'gtk', 'path-to-gtk')
+        wpe_port = FakePort(host, 'wpe', 'path-to-wpe')
+        mac_port = FakePort(host, 'mac', 'path-to-mac')
+        host.port_factory = FakeFactory(host, (gtk_port, wpe_port, mac_port))
+
+        logging_stream = StringIO()
+        options = optparse.Values({'platform': None})
+        res = lint_test_expectations.lint(host, options, logging_stream)
+
+        self.assertEqual(res, 0)
+        self.assertEqual(gtk_port._options.additional_expectations, ['LayoutTests/platform/glib/TestExpectations'])
+        self.assertEqual(wpe_port._options.additional_expectations, ['LayoutTests/platform/glib/TestExpectations'])
+        self.assertEqual(mac_port._options.additional_expectations, [])
 
     def test_lint_test_files__errors(self):
         options = optparse.Values({'platform': 'test', 'debug_rwt_logging': False})


### PR DESCRIPTION
#### f72201f17442df3a97c0b5edc91b14e6157a51b3
<pre>
lint-test-expectations never applies glib-specific TestExpectations override for GTK/WPE ports
<a href="https://bugs.webkit.org/show_bug.cgi?id=320272">https://bugs.webkit.org/show_bug.cgi?id=320272</a>
<a href="https://rdar.apple.com/183191094">rdar://183191094</a>

Reviewed by Patrick Griffis.

lint_test_expectations.py compared the Port object itself against the
strings &apos;gtk&apos; and &apos;wpe&apos; instead of comparing port_to_lint.port_name.
Port has no __eq__, so the comparison was always False and the
glib-specific TestExpectations override (LayoutTests/platform/glib/
TestExpectations) was silently never added for either port.

* Tools/Scripts/webkitpy/layout_tests/lint_test_expectations.py:
(lint): Compare port_to_lint.port_name instead of port_to_lint.
* Tools/Scripts/webkitpy/layout_tests/lint_test_expectations_unittest.py:
(FakePort.__init__): Add port_name and _options so tests can exercise
the glib-expectations branch.
(LintTest.test_glib_additional_expectations): Added. Verifies gtk and
wpe ports get the glib TestExpectations override and other ports don&apos;t.

Canonical link: <a href="https://commits.webkit.org/317925@main">https://commits.webkit.org/317925@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1e2189d88c83d87e58a31764620fac63afd51b73

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176732 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50669 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44461 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186334 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/139968 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d180b44b-a6d4-4d85-b111-bb64899c295d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178595 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51962 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50355 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137675 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/139968 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8f9199da-8ee3-432b-82fe-5a36102f4456) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179688 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41178 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158462 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118149 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/399eb4cb-2b2e-482b-97e6-4a7b60b8dedd) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/176055 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39833 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38203 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150245 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37960 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34802 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42419 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188758 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50336 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146740 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39461 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51019 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34581 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146545 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41307 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117376 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49524 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12939 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48923 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49159 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48984 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->