### PR TITLE
[CMake] A no-op reconfigure dirties ~360 ninja edges

### DIFF
--- a/Source/WTF/wtf/CMakeLists.txt
+++ b/Source/WTF/wtf/CMakeLists.txt
@@ -849,15 +849,13 @@ if (NOT APPLE AND SWIFT_REQUIRED)
     # module.modulemap has "umbrella spi" for the wtf.SPI submodule; Clang requires
     # the umbrella directory to be non-empty or it fails with "cannot create includes file".
     # Provide a stub header so the directory has at least one entry.
-    file(MAKE_DIRECTORY "${WTF_HEADERS_DIR}/spi")
-    file(WRITE "${WTF_HEADERS_DIR}/spi/wtf_spi_stub.h" "")
+    file(CONFIGURE OUTPUT "${WTF_HEADERS_DIR}/spi/wtf_spi_stub.h" CONTENT "" @ONLY)
 
     # module.modulemap declares an explicit `WebCoreThread` submodule referencing
     # ios/WebCoreThread.h, which is Cocoa-only. Clang validates header existence
     # when parsing the modulemap even for unused explicit submodules, so provide
     # an empty stub.
-    file(MAKE_DIRECTORY "${WTF_HEADERS_DIR}/ios")
-    file(WRITE "${WTF_HEADERS_DIR}/ios/WebCoreThread.h" "")
+    file(CONFIGURE OUTPUT "${WTF_HEADERS_DIR}/ios/WebCoreThread.h" CONTENT "" @ONLY)
 endif ()
 
 WEBKIT_FRAMEWORK(WTF)

--- a/Source/WebCore/WebCoreMacros.cmake
+++ b/Source/WebCore/WebCoreMacros.cmake
@@ -106,19 +106,19 @@ function(GENERATE_BINDINGS target)
     foreach (f ${_abs_input_files} ${_abs_supplemental_files})
         set(content "${content}${f}\n")
     endforeach ()
-    file(WRITE ${idl_files_list} ${content})
+    file(CONFIGURE OUTPUT "${idl_files_list}" CONTENT "${content}" @ONLY)
 
     set(pp_content)
     foreach (f ${_abs_pp_input_files})
         set(pp_content "${pp_content}${f}\n")
     endforeach ()
-    file(WRITE ${pp_idl_files_list} ${pp_content})
+    file(CONFIGURE OUTPUT "${pp_idl_files_list}" CONTENT "${pp_content}" @ONLY)
 
     set(include_content)
     foreach (f ${_abs_input_files} ${_abs_supplemental_files} ${_abs_included_files})
         set(include_content "${include_content}${f}\n")
     endforeach ()
-    file(WRITE ${included_idl_files_list} ${include_content})
+    file(CONFIGURE OUTPUT "${included_idl_files_list}" CONTENT "${include_content}" @ONLY)
 
     set(args
         --defines ${arg_FEATURES}

--- a/Source/WebKit/PlatformCocoa.cmake
+++ b/Source/WebKit/PlatformCocoa.cmake
@@ -513,11 +513,11 @@ set(PRODUCT_BUNDLE_IDENTIFIER "com.apple.WebKit")
 configure_file(${WEBKIT_DIR}/Info.plist ${CMAKE_CURRENT_BINARY_DIR}/WebKit-Info.plist)
 execute_process(COMMAND plutil -convert binary1 ${CMAKE_CURRENT_BINARY_DIR}/WebKit-Info.plist)
 
-file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/WebKitLegacy.h
-    "#if defined(__has_include) && __has_include(<WebKitLegacy/WebKit.h>)\n"
-    "#import <WebKitLegacy/WebKit.h>\n"
-    "#endif\n"
-)
+file(CONFIGURE OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/WebKitLegacy.h" CONTENT
+"#if defined(__has_include) && __has_include(<WebKitLegacy/WebKit.h>)
+#import <WebKitLegacy/WebKit.h>
+#endif
+" @ONLY)
 set_source_files_properties(${CMAKE_CURRENT_BINARY_DIR}/WebKitLegacy.h PROPERTIES
     MACOSX_PACKAGE_LOCATION Headers
     GENERATED TRUE
@@ -652,15 +652,17 @@ endif ()
 # file and inject them before the final `}` closing `framework module
 # WebKit_Private` at build time.
 set(_private_modulemap_addendum "${CMAKE_BINARY_DIR}/WebKit/Modules/module.private.addendum.modulemap")
-file(WRITE "${_private_modulemap_addendum}"
+file(CONFIGURE OUTPUT "${_private_modulemap_addendum}" CONTENT
 "  explicit module WKWebViewPrivate {
     header \"WKWebViewPrivate.h\"
     export *
   }
-")
+" @ONLY)
 
 set(_private_modulemap_inject_script "${CMAKE_BINARY_DIR}/WebKit/Modules/inject-addendum.cmake")
-file(WRITE "${_private_modulemap_inject_script}"
+# @ONLY: the ${INPUT}/${ADDENDUM}/${OUTPUT} references below belong to the
+# generated script and must not be substituted while writing it.
+file(CONFIGURE OUTPUT "${_private_modulemap_inject_script}" CONTENT
 "file(READ \"\${INPUT}\" _content)
 file(READ \"\${ADDENDUM}\" _addendum)
 # Strip trailing whitespace, then replace the final `}` (closing
@@ -668,7 +670,7 @@ file(READ \"\${ADDENDUM}\" _addendum)
 string(REGEX REPLACE \"[ \\t\\r\\n]+$\" \"\" _content \"\${_content}\")
 string(REGEX REPLACE \"}$\" \"\${_addendum}}\\n\" _content \"\${_content}\")
 file(WRITE \"\${OUTPUT}\" \"\${_content}\")
-")
+" @ONLY)
 
 add_custom_command(
     OUTPUT "${_private_modulemap_output}"
@@ -804,7 +806,7 @@ unset(_migrate_out_count)
 unset(_migrate_last)
 unset(_migrated_excluded_for_ios)
 
-file(WRITE "${CMAKE_BINARY_DIR}/swift-vfs-overlay.yaml"
+file(CONFIGURE OUTPUT "${CMAKE_BINARY_DIR}/swift-vfs-overlay.yaml" CONTENT
 "{
   \"version\": 0,
   \"case-sensitive\": false,
@@ -821,7 +823,7 @@ file(WRITE "${CMAKE_BINARY_DIR}/swift-vfs-overlay.yaml"
     }
   ]
 }
-")
+" @ONLY)
 # Removed the SDK WebKit.framework -> cmake WebKit redirect: when the WebKit
 # Swift compile loads its own private modulemap via -fmodule-map-file= (and
 # again via -F /Debug auto-discovery), having a third path through the SDK's
@@ -850,7 +852,7 @@ file(WRITE "${CMAKE_BINARY_DIR}/swift-vfs-overlay.yaml"
 # avoids compiling the offending headers altogether. Bug 312083.
 set(WebKit_CMAKE_MODULEMAP_DIR "${CMAKE_BINARY_DIR}/WebKit/SwiftModules/Internal")
 file(MAKE_DIRECTORY "${WebKit_CMAKE_MODULEMAP_DIR}")
-file(WRITE "${WebKit_CMAKE_MODULEMAP_DIR}/module.modulemap"
+file(CONFIGURE OUTPUT "${WebKit_CMAKE_MODULEMAP_DIR}/module.modulemap" CONTENT
 "module WebKit_Internal [system] {
     module WKMaterialHostingSupport {
         requires objc
@@ -942,7 +944,7 @@ file(WRITE "${WebKit_CMAKE_MODULEMAP_DIR}/module.modulemap"
         export *
     }
 }
-")
+" @ONLY)
 set(WebKit_SWIFT_INTEROP_MODULE_PATH "${WebKit_CMAKE_MODULEMAP_DIR}")
 
 
@@ -1583,8 +1585,8 @@ add_custom_command(
 add_custom_target(WebKit_StageSwiftModule DEPENDS ${_webkit_staged_swiftmodule_artifacts})
 
 make_directory("${CMAKE_BINARY_DIR}/WebKit/Modules/WebKit.swiftcrossimport")
-file(WRITE "${CMAKE_BINARY_DIR}/WebKit/Modules/WebKit.swiftcrossimport/SwiftUI.swiftoverlay"
-"---\nversion: 1\nmodules:\n- name: _WebKit_SwiftUI\n")
+file(CONFIGURE OUTPUT "${CMAKE_BINARY_DIR}/WebKit/Modules/WebKit.swiftcrossimport/SwiftUI.swiftoverlay" CONTENT
+"---\nversion: 1\nmodules:\n- name: _WebKit_SwiftUI\n" @ONLY)
 
 target_link_options(WebKit PRIVATE
     "SHELL:-weak_framework BrowserEngineKit"
@@ -1719,16 +1721,9 @@ with open(sys.argv[2], 'wb') as f:
     endfunction()
 
     set(_sim_get_task_allow "${CMAKE_CURRENT_BINARY_DIR}/XPCService-get-task-allow.entitlements")
-    file(WRITE ${_sim_get_task_allow}
-        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
-        "<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">\n"
-        "<plist version=\"1.0\">\n"
-        "<dict>\n"
-        "\t<key>com.apple.security.get-task-allow</key>\n"
-        "\t<true/>\n"
-        "</dict>\n"
-        "</plist>\n"
-    )
+    file(CONFIGURE OUTPUT "${_sim_get_task_allow}" CONTENT
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">\n<plist version=\"1.0\">\n<dict>\n\t<key>com.apple.security.get-task-allow</key>\n\t<true/>\n</dict>\n</plist>\n"
+        @ONLY)
 
     string(REPLACE "." ";" _sdk_ver_parts "${CMAKE_OSX_DEPLOYMENT_TARGET}")
     list(GET _sdk_ver_parts 0 _sdk_major)

--- a/Source/WebKit/PlatformGTK.cmake
+++ b/Source/WebKit/PlatformGTK.cmake
@@ -478,14 +478,11 @@ if (ENABLE_WEB_AUDIO)
     )
 endif ()
 
-file(WRITE ${WebKitGTK_DERIVED_SOURCES_DIR}/WebKitResourcesGResourceBundle.xml
-    "<?xml version=1.0 encoding=UTF-8?>\n"
-    "<gresources>\n"
-    "    <gresource prefix=\"/org/webkitgtk/resources\">\n"
-    ${WebKitResources}
-    "    </gresource>\n"
-    "</gresources>\n"
-)
+list(JOIN WebKitResources "" _webkit_resources_entries)
+file(CONFIGURE OUTPUT "${WebKitGTK_DERIVED_SOURCES_DIR}/WebKitResourcesGResourceBundle.xml" CONTENT
+    "<?xml version=1.0 encoding=UTF-8?>\n<gresources>\n    <gresource prefix=\"/org/webkitgtk/resources\">\n${_webkit_resources_entries}    </gresource>\n</gresources>\n"
+    @ONLY)
+unset(_webkit_resources_entries)
 
 GLIB_COMPILE_RESOURCES(
     OUTPUT        ${WebKitGTK_DERIVED_SOURCES_DIR}/WebKitResourcesGResourceBundle.c

--- a/Source/WebKit/PlatformWPE.cmake
+++ b/Source/WebKit/PlatformWPE.cmake
@@ -391,14 +391,11 @@ if (ENABLE_WEB_AUDIO)
     )
 endif ()
 
-file(WRITE ${WebKit_DERIVED_SOURCES_DIR}/WebKitResourcesGResourceBundle.xml
-    "<?xml version=1.0 encoding=UTF-8?>\n"
-    "<gresources>\n"
-    "    <gresource prefix=\"/org/webkitwpe/resources\">\n"
-    ${WebKitResources}
-    "    </gresource>\n"
-    "</gresources>\n"
-)
+list(JOIN WebKitResources "" _webkit_resources_entries)
+file(CONFIGURE OUTPUT "${WebKit_DERIVED_SOURCES_DIR}/WebKitResourcesGResourceBundle.xml" CONTENT
+    "<?xml version=1.0 encoding=UTF-8?>\n<gresources>\n    <gresource prefix=\"/org/webkitwpe/resources\">\n${_webkit_resources_entries}    </gresource>\n</gresources>\n"
+    @ONLY)
+unset(_webkit_resources_entries)
 
 GLIB_COMPILE_RESOURCES(
     OUTPUT        ${WebKit_DERIVED_SOURCES_DIR}/WebKitResourcesGResourceBundle.c

--- a/Source/WebKitLegacy/PlatformCocoa.cmake
+++ b/Source/WebKitLegacy/PlatformCocoa.cmake
@@ -1177,11 +1177,11 @@ foreach (_file ${WebKitLegacy_LEGACY_FORWARDING_HEADERS_FILES})
     string(APPEND _wkl_modulemap_body "    header \"${_name}\"\n")
 endforeach ()
 string(APPEND _wkl_modulemap_body "    header \"WorkAround173516139.h\"\n")
-file(WRITE ${_wkl_fw}/Modules/module.private.modulemap
+file(CONFIGURE OUTPUT "${_wkl_fw}/Modules/module.private.modulemap" CONTENT
 "framework module WebKitLegacy [system] {
 ${_wkl_modulemap_body}    export *
 }
-")
+" @ONLY)
 unset(_wkl_modulemap_body)
 configure_file(${WEBKITLEGACY_DIR}/Modules/WorkAround173516139.h
                ${WebKitLegacy_FRAMEWORK_HEADERS_DIR}/WebKitLegacy/WorkAround173516139.h
@@ -1221,12 +1221,12 @@ foreach (_file ${WebKitLegacy_LEGACY_FORWARDING_HEADERS_FILES})
 endforeach ()
 list(JOIN _wkl_vfs_modules_entries "," _wkl_vfs_modules_str)
 list(JOIN _wkl_vfs_headers_entries "," _wkl_vfs_headers_str)
-file(WRITE "${_wkl_vfs}"
+file(CONFIGURE OUTPUT "${_wkl_vfs}" CONTENT
 "{\"case-sensitive\":\"false\",\"version\":0,\"roots\":[\
 {\"type\":\"directory\",\"name\":\"${_wkl_fw}/Modules\",\"contents\":[${_wkl_vfs_modules_str}]},\
 {\"type\":\"directory\",\"name\":\"${_wkl_fw}/PrivateHeaders\",\"contents\":[${_wkl_vfs_headers_str}]},\
 {\"type\":\"directory\",\"name\":\"${WebKitLegacy_FRAMEWORK_HEADERS_DIR}/WebKitLegacy\",\"contents\":[${_wkl_vfs_headers_str}]}\
-]}\n")
+]}\n" @ONLY)
 target_compile_options(WebKitLegacy PRIVATE
     "$<$<NOT:$<COMPILE_LANGUAGE:Swift>>:SHELL:-ivfsoverlay ${_wkl_vfs}>")
 unset(_wkl_vfs)

--- a/Source/cmake/OptionsCocoa.cmake
+++ b/Source/cmake/OptionsCocoa.cmake
@@ -237,7 +237,7 @@ find_package(Threads REQUIRED)
 if (NOT USE_APPLE_INTERNAL_SDK)
     set(_availability_overlay_dir "${CMAKE_SOURCE_DIR}/WebKitLibraries/AvailabilityOverlay")
     set(_availability_overlay_yaml "${CMAKE_BINARY_DIR}/availability-overlay.yaml")
-    file(WRITE "${_availability_overlay_yaml}.tmp"
+    file(CONFIGURE OUTPUT "${_availability_overlay_yaml}" CONTENT
     "{
       \"version\": 0,
       \"case-sensitive\": false,
@@ -254,8 +254,7 @@ if (NOT USE_APPLE_INTERNAL_SDK)
         }
       ]
     }
-    ")
-    file(COPY_FILE "${_availability_overlay_yaml}.tmp" ${_availability_overlay_yaml} ONLY_IF_DIFFERENT)
+    " @ONLY)
     add_compile_options("$<$<NOT:$<COMPILE_LANGUAGE:Swift>>:SHELL:-ivfsoverlay ${_availability_overlay_yaml}>")
     add_compile_options("$<$<COMPILE_LANGUAGE:Swift>:SHELL:-vfsoverlay ${_availability_overlay_yaml}>")
     # For the Platform.h preprocess steps, which don't inherit compile options.

--- a/Source/cmake/WebKitFeatures.cmake
+++ b/Source/cmake/WebKitFeatures.cmake
@@ -608,13 +608,11 @@ macro(CREATE_CONFIGURATION_HEADER)
     endforeach ()
     set(_file_contents "${_file_contents}\n#endif /* CMAKECONFIG_H */\n")
 
-    file(WRITE "${CMAKE_BINARY_DIR}/cmakeconfig.h.tmp" "${_file_contents}")
-    execute_process(COMMAND ${CMAKE_COMMAND}
-        -E copy_if_different
-        "${CMAKE_BINARY_DIR}/cmakeconfig.h.tmp"
-        "${CMAKE_BINARY_DIR}/cmakeconfig.h"
-    )
-    file(REMOVE "${CMAKE_BINARY_DIR}/cmakeconfig.h.tmp")
+    # file(CONFIGURE) leaves the header alone when nothing changed, so the ~1300
+    # compiles that include it stay up to date across a no-op reconfigure. It
+    # replaces a write-tmp / copy_if_different / remove-tmp sequence, dropping a
+    # cmake subprocess from every configure.
+    file(CONFIGURE OUTPUT "${CMAKE_BINARY_DIR}/cmakeconfig.h" CONTENT "${_file_contents}" @ONLY)
 endmacro()
 
 macro(GET_WEBKIT_CONFIG_VARIABLES _set_vars)

--- a/Source/cmake/WebKitMacros.cmake
+++ b/Source/cmake/WebKitMacros.cmake
@@ -29,7 +29,10 @@ macro(WEBKIT_COMPUTE_SOURCES _framework)
                   string(APPEND _filtered "${_line}\n")
               endif ()
           endforeach ()
-          file(WRITE "${_derivedSourcesPath}/${_sourcesListFile}" "${_filtered}")
+          # file(CONFIGURE) rather than file(WRITE) so an unchanged list keeps its
+          # mtime and doesn't re-run the generators that consume it, matching the
+          # configure_file() below.
+          file(CONFIGURE OUTPUT "${_derivedSourcesPath}/${_sourcesListFile}" CONTENT "${_filtered}" @ONLY)
       else ()
           configure_file("${_sourcesListInput}" "${_derivedSourcesPath}/${_sourcesListFile}" COPYONLY)
       endif ()
@@ -758,9 +761,14 @@ endmacro()
 
 # Delete staged files not in FILES, so a renamed or removed header drops its old
 # copy instead of lingering and colliding as a duplicate in a Clang umbrella
-# module. Only safe when the calling step owns the destination exclusively.
-# `flattened` matches by basename when TRUE, by relative path otherwise.
-function(WEBKIT_PRUNE_STALE_DESTINATION destination flattened)
+# module. `flattened` matches by basename when TRUE, by relative path otherwise.
+#
+# Only files ${target_name} staged itself are candidates, tracked through a
+# manifest of what it staged last time. Header destinations are co-owned (WebKit's
+# own headers and WebKitLegacy's forwarding headers land in the same directory),
+# and deleting whatever one target doesn't expect wipes the other owners' files on
+# every configure, which the next build then has to regenerate.
+function(WEBKIT_PRUNE_STALE_DESTINATION target_name destination flattened)
     set(_expected)
     foreach (file IN LISTS ARGN)
         if (flattened)
@@ -770,12 +778,26 @@ function(WEBKIT_PRUNE_STALE_DESTINATION destination flattened)
         endif ()
         list(APPEND _expected ${_rel})
     endforeach ()
-    file(GLOB_RECURSE _existing RELATIVE ${destination} ${destination}/*)
-    foreach (_entry IN LISTS _existing)
-        if (NOT _entry IN_LIST _expected)
-            file(REMOVE ${destination}/${_entry})
-        endif ()
+
+    set(_manifest "${CMAKE_BINARY_DIR}/CMakeFiles/${target_name}-staged-files.txt")
+    if (EXISTS "${_manifest}")
+        file(STRINGS "${_manifest}" _stale)
+    else ()
+        # Build directory predates the manifest, so sweep the destination once to
+        # clean stale files left by older configures.
+        file(GLOB_RECURSE _stale RELATIVE ${destination} ${destination}/*)
+    endif ()
+    # One list(REMOVE_ITEM) rather than a foreach with IN_LIST: the set difference
+    # runs inside CMake instead of as an O(files^2) interpreted loop.
+    if (_stale AND _expected)
+        list(REMOVE_ITEM _stale ${_expected})
+    endif ()
+    foreach (_entry IN LISTS _stale)
+        file(REMOVE ${destination}/${_entry})
     endforeach ()
+
+    list(JOIN _expected "\n" _manifest_content)
+    file(CONFIGURE OUTPUT "${_manifest}" CONTENT "${_manifest_content}\n" @ONLY)
 endfunction()
 
 function(_WEBKIT_CREATE_FRAMEWORK_BUNDLE_STRUCTURE _target)
@@ -806,7 +828,7 @@ function(WEBKIT_COPY_FILES target_name)
     set(dst_files)
 
     if (opt_PRUNE_STALE)
-        WEBKIT_PRUNE_STALE_DESTINATION(${opt_DESTINATION} "${opt_FLATTENED}" ${files})
+        WEBKIT_PRUNE_STALE_DESTINATION(${target_name} ${opt_DESTINATION} "${opt_FLATTENED}" ${files})
     endif ()
 
     foreach (file IN LISTS files)
@@ -853,7 +875,7 @@ function(WEBKIT_SYMLINK_FILES target_name)
     file(MAKE_DIRECTORY ${opt_DESTINATION})
 
     if (opt_PRUNE_STALE)
-        WEBKIT_PRUNE_STALE_DESTINATION(${opt_DESTINATION} "${opt_FLATTENED}" ${files})
+        WEBKIT_PRUNE_STALE_DESTINATION(${target_name} ${opt_DESTINATION} "${opt_FLATTENED}" ${files})
     endif ()
 
     foreach (file IN LISTS files)


### PR DESCRIPTION
#### 334468ec97776fb067d3050fed1cf4bee35bc4d7
<pre>
[CMake] A no-op reconfigure dirties ~360 ninja edges
<a href="https://bugs.webkit.org/show_bug.cgi?id=320269">https://bugs.webkit.org/show_bug.cgi?id=320269</a>
<a href="https://rdar.apple.com/183190235">rdar://183190235</a>

Reviewed by NOBODY (OOPS!).

Reconfiguring without changing anything left ~360 build edges dirty: 234 staged
header regenerations, 117 ObjC/ObjC++ recompiles that depend on them, and the
relinks that follow.

Two configure-time causes. First, WEBKIT_COPY_FILES(... PRUNE_STALE) deleted
everything in the destination that the calling target didn&apos;t expect, but header
destinations are co-owned: WebKit_CopyHeaders stages into WebKit.framework&apos;s
Headers and PrivateHeaders, and so do WebKitLegacy&apos;s forwarding-header targets,
so every configure wiped the 234 headers the other owner staged. WTF_CopyHeaders
did the same to the two module-map stub headers written next to it. Track what
each target staged in a manifest and prune only from that, so a target never
deletes files it didn&apos;t create; a build directory with no manifest yet still gets
one sweep so stale files from older configures are cleaned. This also removes the
need for the O(files^2) IN_LIST search, making the pruning pass about 0.8s
cheaper and the whole configure step slightly faster.

Second, file(WRITE) always bumps the mtime, so anything generated with it looked
new to ninja on every configure. file(CONFIGURE) only rewrites its output when
the content actually changes, so use it for the generated files that feed build
rules:

  - The IDL file lists and the unified-sources lists, which re-ran the bindings
    and unified-source generators.
  - WebKit_Private&apos;s module-map addendum and its injection script, which are
    explicit DEPENDS of the custom command that preprocesses
    module.private.modulemap, so both re-ran and invalidated every PCM built
    against the result.
  - The WebKit_Internal Swift module map, WebKitLegacy&apos;s module.private.modulemap
    and VFS overlay, the JavaScriptCore Swift VFS overlay, the SwiftUI cross-import
    overlay, the WebKitLegacy.h umbrella stub staged into WebKit.framework/Headers,
    the simulator get-task-allow entitlements, and the GTK/WPE GResource bundle
    XML that glib-compile-resources turns into a compiled source.
  - WTF&apos;s two module-map stub headers and the new staged-file manifest.

file(CONFIGURE) also creates the output&apos;s parent directories, so the
file(MAKE_DIRECTORY) calls that existed only for that are gone.

cmakeconfig.h and availability-overlay.yaml already avoided the mtime bump by
writing a .tmp beside the real file and copying it over only when different.
file(CONFIGURE) expresses that directly, which drops a cmake subprocess from
every configure for the former and stops leaving the .tmp behind for the latter.

@ONLY is passed everywhere so only @VAR@ is substituted and ${VAR} is left alone;
inject-addendum.cmake depends on that, since the ${INPUT}/${OUTPUT} references in
its body belong to the generated script. The generated bytes are unchanged in all
cases, including the @2x/@3x aliases in the GResource XML.

* Source/WTF/wtf/CMakeLists.txt:
* Source/WebCore/WebCoreMacros.cmake:
* Source/WebKit/PlatformCocoa.cmake:
* Source/WebKit/PlatformGTK.cmake:
* Source/WebKit/PlatformWPE.cmake:
* Source/WebKitLegacy/PlatformCocoa.cmake:
* Source/cmake/OptionsCocoa.cmake:
* Source/cmake/WebKitFeatures.cmake:
* Source/cmake/WebKitMacros.cmake:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/334468ec97776fb067d3050fed1cf4bee35bc4d7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177602 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51540 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45334 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187206 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140849 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3a27c111-3fd4-4be8-9aa9-41ee6b0401f1) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179465 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52832 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51249 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138424 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140849 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/df20cd9f-e66c-4683-9353-772e7c3828e4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180558 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41933 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159162 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118888 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1eb0f9cb-52f2-4c51-aba0-79336798ffb4) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40594 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38962 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/857 "Build is in progress. Recent messages:Printed configuration; Checked out pull request; Passed JSC tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/7658 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151001 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38658 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35673 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/38873 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/43325 "Built successfully") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43197 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; Skipped layout-tests; 339 new passes 12 flakes 14 failures; Uploaded test results; 339 new passes 19 flakes 14 failures; Compiled WebKit (warnings); layout-tests; Passed layout tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189635 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51207 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147524 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51889 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35286 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147315 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42030 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124104 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118517 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50397 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13635 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49793 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50033 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49855 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->