### PR TITLE
std::log2(AudioSession::bufferSize()) invokes undefined behavior when the session buffer size is 0

### DIFF
--- a/Source/WebCore/Modules/webaudio/BaseAudioContext.cpp
+++ b/Source/WebCore/Modules/webaudio/BaseAudioContext.cpp
@@ -367,8 +367,12 @@ ExceptionOr<Ref<ScriptProcessorNode>> BaseAudioContext::createScriptProcessor(si
     switch (bufferSize) {
     case 0:
 #if USE(AUDIO_SESSION)
-        // Pick a value between 256 (2^8) and 16384 (2^14), based on the buffer size of the current AudioSession:
-        bufferSize = 1 << std::max<size_t>(8, std::min<size_t>(14, std::log2(AudioSession::singleton().bufferSize())));
+        {
+            // Pick a value between 256 (2^8) and 16384 (2^14), based on the buffer size of the current AudioSession.
+            // Guard against a zero session buffer size: std::log2(0) is -infinity, and converting that to size_t is undefined behavior.
+            auto sessionBufferSize = AudioSession::singleton().bufferSize();
+            bufferSize = 1 << std::max<size_t>(8, std::min<size_t>(14, sessionBufferSize ? std::log2(sessionBufferSize) : 0));
+        }
 #else
         bufferSize = 2048;
 #endif


### PR DESCRIPTION
#### 1a7d999224fc00ad856f44e592bef7dab0cb726d
<pre>
std::log2(AudioSession::bufferSize()) invokes undefined behavior when the session buffer size is 0
<a href="https://bugs.webkit.org/show_bug.cgi?id=320275">https://bugs.webkit.org/show_bug.cgi?id=320275</a>
<a href="https://rdar.apple.com/183193218">rdar://183193218</a>

Reviewed by Chris Dumez.

BaseAudioContext::createScriptProcessor(0, ...) picks a buffer size based on
the current AudioSession&apos;s buffer size:

    bufferSize = 1 &lt;&lt; std::max&lt;size_t&gt;(8, std::min&lt;size_t&gt;(14, std::log2(AudioSession::singleton().bufferSize())));

On Cocoa platforms AudioSession::bufferSize() can legitimately return 0 through
ordinary paths: AudioSessionMac::bufferSize() returns m_bufferSize.value_or(0)
when the CoreAudio device property query fails (e.g. no default output device),
and AudioSessionIOS::bufferSize() computes IOBufferDuration * sampleRate(),
which is 0 before the audio session route is configured.

Per [1]:

    &quot;If the argument is ±0, -∞ is returned and FE_DIVBYZERO is raised.&quot;

Passing that -infinity to std::min&lt;size_t&gt; forces a float-to-size_t conversion
of an out-of-range value, which is undefined behavior.

Guard the zero case so std::log2 is never called with 0. When the session
buffer size is 0, the exponent falls through to the std::max&lt;size_t&gt;(8, ...)
floor, yielding 256 (2^8) — matching the spec&apos;s requirement that the chosen
value be a power of 2 between 256 and 16384. Behavior for all non-zero inputs
is unchanged.

[1] <a href="https://en.cppreference.com/cpp/numeric/math/log2">https://en.cppreference.com/cpp/numeric/math/log2</a>

* Source/WebCore/Modules/webaudio/BaseAudioContext.cpp:
(WebCore::BaseAudioContext::createScriptProcessor):

Canonical link: <a href="https://commits.webkit.org/317949@main">https://commits.webkit.org/317949@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a8bfb8c23f51911975a7623786aa9539d1e6b3c0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176736 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50673 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44465 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186338 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/139972 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c87e910f-df6b-46ca-8a54-57600abf291a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178599 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51966 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50359 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137679 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/139972 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3cdeee1c-9531-4053-9219-ebc04577a124) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179692 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41185 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158469 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118153 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/92e163bf-3ce2-4f94-aa12-f10da95c8938) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39839 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38207 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150251 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37967 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34806 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42417 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42423 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188762 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50340 "Built successfully") | | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146744 "Found 1 new test failure: compositing/color-matching/image-color-matching.html (failure)") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39475 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51023 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34588 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146549 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41313 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123231 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117381 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49528 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12946 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48927 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49163 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48988 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->