### PR TITLE
OfflineAudioContext noise injection hangs on feedback cycles in the audio graph

### DIFF
--- a/Source/WebCore/Modules/webaudio/OfflineAudioContext.cpp
+++ b/Source/WebCore/Modules/webaudio/OfflineAudioContext.cpp
@@ -98,9 +98,16 @@ void OfflineAudioContext::increaseNoiseMultiplierIfNeeded()
     if (!target)
         return;
 
+    // The graph may contain feedback cycles (which are legal in Web Audio as long as a
+    // DelayNode breaks the loop), and non-tree topologies may reach the same node via
+    // multiple paths. Track visited nodes so we neither loop forever nor double-count a
+    // node's noise multiplier.
+    HashSet<CheckedPtr<AudioNode>> visited;
     Vector<AudioConnectionRef<AudioNode>, 1> remainingNodes;
-    for (auto& node : referencedSourceNodes())
-        remainingNodes.append(node.copyRef());
+    for (auto& node : referencedSourceNodes()) {
+        if (visited.add(node.ptr()).isNewEntry)
+            remainingNodes.append(node.copyRef());
+    }
 
     while (!remainingNodes.isEmpty()) {
         auto node = remainingNodes.takeLast();
@@ -111,7 +118,8 @@ void OfflineAudioContext::increaseNoiseMultiplierIfNeeded()
                 continue;
 
             output->forEachInputNode([&](auto& inputNode) {
-                remainingNodes.append(inputNode);
+                if (visited.add(&inputNode).isNewEntry)
+                    remainingNodes.append(inputNode);
             });
         }
     }

--- a/Tools/TestWebKitAPI/Resources/cocoa/audio-fingerprinting.js
+++ b/Tools/TestWebKitAPI/Resources/cocoa/audio-fingerprinting.js
@@ -41,6 +41,41 @@ async function testOscillatorCompressor() {
     return combineSamples(renderedBuffer.getChannelData(0));
 }
 
+async function testFeedbackCycle() {
+    // Regression test for a hang while setting up noise injection: the graph walk in
+    // OfflineAudioContext::increaseNoiseMultiplierIfNeeded() tracked no visited nodes, so a
+    // feedback cycle (legal in Web Audio when a DelayNode breaks the loop) looped forever
+    // while holding the graph lock. Rendering this graph must complete; we return the
+    // rendered length (a fixed, always-serializable value) so the caller can confirm it did.
+    const length = 5000;
+    const context = new OfflineAudioContext(1, length, 44100);
+
+    const oscillator = context.createOscillator();
+    oscillator.type = "triangle";
+    oscillator.frequency.value = 1000;
+
+    const gain = context.createGain();
+    gain.gain.value = 0.5;
+
+    const delay = context.createDelay();
+    delay.delayTime.value = 0.01;
+
+    // Feedback cycle: gain -> delay -> gain, with the oscillator feeding gain and gain
+    // driving the destination.
+    oscillator.connect(gain);
+    gain.connect(delay);
+    delay.connect(gain);
+    gain.connect(context.destination);
+
+    oscillator.start();
+    const renderedBuffer = await context.startRendering();
+    oscillator.disconnect();
+    gain.disconnect();
+    delay.disconnect();
+
+    return renderedBuffer.length;
+}
+
 function testOscillatorCompressorWorklet() {
     return new Promise(async resolve => {
         const context = new AudioContext;

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/AdvancedPrivacyProtections.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/AdvancedPrivacyProtections.mm
@@ -1322,6 +1322,22 @@ TEST(AdvancedPrivacyProtections, AddNoiseToWebAudioAPIs)
     checkFingerprintForNoise(@"testLoopingOscillatorCompressorBiquadFilter");
 }
 
+TEST(AdvancedPrivacyProtections, WebAudioNoiseInjectionWithFeedbackCycle)
+{
+    // With advanced privacy protections enabled, OfflineAudioContext sets up noise injection
+    // by walking the node graph. That walk must terminate even when the graph contains a
+    // feedback cycle; otherwise rendering hangs while holding the graph lock. Confirm the
+    // render completes by checking it returns the expected rendered length.
+    auto testURL = [NSBundle.test_resourcesBundle URLForResource:@"audio-fingerprinting" withExtension:@"html"];
+    auto resourcesURL = NSBundle.test_resourcesBundle.resourceURL;
+
+    auto webView = createWebViewWithAdvancedPrivacyProtections();
+    [webView loadFileRequest:[NSURLRequest requestWithURL:testURL] allowingReadAccessToURL:resourcesURL];
+    [webView _test_waitForDidFinishNavigation];
+
+    EXPECT_EQ(5000, [[webView callAsyncJavaScriptAndWait:@"return testFeedbackCycle()"] intValue]);
+}
+
 TEST(AdvancedPrivacyProtections, AddNoiseToWebAudioAPIsAfterMultiplePSON)
 {
     [TestProtocol registerWithScheme:@"https"];


### PR DESCRIPTION
#### bf7ca923e061f649fde26415651ebd2409729f5f
<pre>
OfflineAudioContext noise injection hangs on feedback cycles in the audio graph
<a href="https://bugs.webkit.org/show_bug.cgi?id=320276">https://bugs.webkit.org/show_bug.cgi?id=320276</a>
<a href="https://rdar.apple.com/183194302">rdar://183194302</a>

Reviewed by Chris Dumez.

OfflineAudioContext::increaseNoiseMultiplierIfNeeded() sets up noise injection
by walking the node graph with a worklist seeded from referencedSourceNodes(),
following each node&apos;s outputs via AudioNodeOutput::forEachInputNode(). The walk
kept no record of visited nodes, so it appended every reached node to the
worklist unconditionally.

Web Audio permits cyclic (feedback) graphs, which are legal as long as a
DelayNode breaks the loop. On such a graph the walk never terminates: it keeps
re-appending the nodes in the cycle to the worklist, growing it without bound.
Because this runs under graphLock(), the result is a hung main thread and
runaway memory growth. Non-tree (diamond) topologies were also visited multiple
times, double-counting a node&apos;s noise-injection multiplier.

Track visited nodes in a HashSet and only enqueue a node the first time it is
reached. This guarantees termination on cyclic graphs and ensures each node
contributes its noise multiplier exactly once. Linear/tree graphs -- every
realistic audio-fingerprinting probe -- are unaffected.

* Source/WebCore/Modules/webaudio/OfflineAudioContext.cpp:
(WebCore::OfflineAudioContext::increaseNoiseMultiplierIfNeeded): Track visited
nodes so the graph walk neither loops forever on feedback cycles nor
double-counts a node reachable via multiple paths.
* Tools/TestWebKitAPI/Resources/cocoa/audio-fingerprinting.js:
(testFeedbackCycle): Added. Renders an OfflineAudioContext containing a
gain -&gt; delay -&gt; gain feedback cycle and returns the rendered length.
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/AdvancedPrivacyProtections.mm:
(TEST(AdvancedPrivacyProtections, WebAudioNoiseInjectionWithFeedbackCycle)):
Added. With advanced privacy protections enabled (so noise injection runs),
verifies the cyclic graph renders to completion instead of hanging.

Canonical link: <a href="https://commits.webkit.org/317950@main">https://commits.webkit.org/317950@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c549b05e1544eef266339f2b266e83f695748068

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176737 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50674 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44466 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186339 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/139973 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/deb8b70e-80ff-4997-bbd8-985d02940b1a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178600 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51967 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50360 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137680 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/139973 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f0cd6431-a766-4985-a7d7-7c116aaaac7d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179693 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41186 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158471 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118154 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/96b5f3c4-f45f-4822-9d4f-8723b36e1d2c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39840 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38208 "Passed tests") | | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150252 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; run-api-tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37969 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34807 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42418 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42424 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188763 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50341 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146796 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39476 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51024 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34638 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146550 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41314 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123232 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117382 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49529 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12948 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48928 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49164 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48989 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->