### PR TITLE
OscillatorNode with a-rate automation ignores sub-sample start time and begins out of phase

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-oscillatornode-interface/sub-sample-start-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-oscillatornode-interface/sub-sample-start-expected.txt
@@ -1,0 +1,12 @@
+
+PASS # AUDIT TASK RUNNER STARTED.
+PASS Executing "a-rate oscillator honors sub-sample start offset"
+PASS Audit report
+PASS > [a-rate oscillator honors sub-sample start offset]
+PASS   reference[0:5] contains only the constant 0.
+PASS   a-rate[0:5] contains only the constant 0.
+PASS   Max |a-rate - reference| after start is less than or equal to 0.000001.
+PASS   a-rate[6:] equals [expected array] with an element-wise tolerance of {"absoluteThreshold":0.000001,"relativeThreshold":0}.
+PASS < [a-rate oscillator honors sub-sample start offset] All assertions passed. (total 4 assertions)
+PASS # AUDIT TASK RUNNER FINISHED: 1 tasks ran successfully.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-oscillatornode-interface/sub-sample-start.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-oscillatornode-interface/sub-sample-start.html
@@ -1,0 +1,105 @@
+<!doctype html>
+<html>
+  <head>
+    <title>
+      Test Sub-Sample Accurate Start With a-rate Automation
+    </title>
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <script src="/webaudio/resources/audit-util.js"></script>
+    <script src="/webaudio/resources/audit.js"></script>
+  </head>
+  <body>
+    <script>
+      // Power of two so there's no roundoff converting from integer frames to
+      // time.
+      const sampleRate = 32768;
+
+      const audit = Audit.createTaskRunner();
+
+      // An oscillator started at a sub-sample-accurate time must begin at the
+      // correct sub-sample phase. The sub-sample phase compensation applied at
+      // start scales the fractional start offset by the oscillator's phase
+      // increment. If an implementation derives that increment from the k-rate
+      // frequency value only, it can drop the compensation whenever a-rate
+      // frequency (or detune) automation is active, starting the oscillator out
+      // of phase.
+      //
+      // This renders two identical sine oscillators started at the same
+      // fractional frame:
+      //   channel 0 (reference): constant frequency, no automation.
+      //   channel 1 (a-rate):    the same constant frequency expressed via a
+      //                          linear ramp from f to f, forcing the a-rate
+      //                          path. The per-sample phase increments are
+      //                          identical to the constant-frequency increment,
+      //                          so the two outputs must match sample-for-sample.
+      audit.define(
+          'a-rate oscillator honors sub-sample start offset',
+          (task, should) => {
+            const frequency = 1000;
+
+            // Start half a sample past frame 5, so the start frame rounds up to
+            // 6 and the fractional start offset is non-zero.
+            const startSample = 5.5;
+            const firstOutputFrame = Math.ceil(startSample);
+            const startTime = startSample / sampleRate;
+
+            const context = new OfflineAudioContext(
+                {numberOfChannels: 2, length: 256, sampleRate: sampleRate});
+            const merger = new ChannelMergerNode(
+                context, {numberOfInputs: 2});
+            merger.connect(context.destination);
+
+            // Reference: constant frequency, no timeline events.
+            const oscRef = new OscillatorNode(context, {frequency});
+            oscRef.connect(merger, 0, 0);
+
+            // Test: a-rate automation that holds the same constant frequency.
+            const oscARate = new OscillatorNode(context, {frequency});
+            oscARate.frequency.setValueAtTime(frequency, 0);
+            oscARate.frequency.linearRampToValueAtTime(
+                frequency, context.length / sampleRate);
+            oscARate.connect(merger, 0, 1);
+
+            oscRef.start(startTime);
+            oscARate.start(startTime);
+
+            context.startRendering()
+                .then(buffer => {
+                  const reference = buffer.getChannelData(0);
+                  const aRate = buffer.getChannelData(1);
+
+                  // Both oscillators must be silent up to the rounded-up start
+                  // frame.
+                  should(
+                      reference.slice(0, firstOutputFrame),
+                      `reference[0:${firstOutputFrame - 1}]`)
+                      .beConstantValueOf(0);
+                  should(
+                      aRate.slice(0, firstOutputFrame),
+                      `a-rate[0:${firstOutputFrame - 1}]`)
+                      .beConstantValueOf(0);
+
+                  // Diagnostic: largest sample difference after the start frame.
+                  let maxDiff = 0;
+                  for (let k = firstOutputFrame; k < reference.length; ++k)
+                    maxDiff = Math.max(maxDiff, Math.abs(aRate[k] - reference[k]));
+                  should(maxDiff, 'Max |a-rate - reference| after start')
+                      .beLessThanOrEqualTo(1e-6);
+
+                  // The a-rate output must match the constant-frequency
+                  // reference (same frequency, same fractional start).
+                  should(
+                      aRate.slice(firstOutputFrame),
+                      `a-rate[${firstOutputFrame}:]`)
+                      .beCloseToArray(
+                          reference.slice(firstOutputFrame),
+                          {absoluteThreshold: 1e-6});
+                })
+                .then(() => task.done());
+          });
+
+      audit.run();
+    </script>
+  </body>
+</html>

--- a/Source/WebCore/Modules/webaudio/OscillatorNode.cpp
+++ b/Source/WebCore/Modules/webaudio/OscillatorNode.cpp
@@ -410,13 +410,18 @@ void OscillatorNode::process(size_t framesToProcess)
     // start at quantumFrameOffset, but just past that time. Adjust destination and n
     // to reflect that, and adjust virtualReadIndex to start the value at
     // startFrameOffset.
+    // The phase increment for the first rendered frame is phaseIncrements[0]
+    // when we have sample-accurate values; otherwise frequency stays 0 (it is
+    // only assigned in the !hasSampleAccurateValues branch above), so fall back
+    // to frequency * rateScale for the k-rate case.
+    double firstPhaseIncrement = hasSampleAccurateValues ? phaseIncrements[0] : frequency * rateScale;
     if (startFrameOffset > 0) {
         skip(destination, 1);
         --n;
-        virtualReadIndex += (1 - startFrameOffset) * frequency * rateScale;
+        virtualReadIndex += (1 - startFrameOffset) * firstPhaseIncrement;
         ASSERT(virtualReadIndex < m_periodicWave->periodicWaveSize());
     } else if (startFrameOffset < 0)
-        virtualReadIndex = -startFrameOffset * frequency * rateScale;
+        virtualReadIndex = -startFrameOffset * firstPhaseIncrement;
 
     if (hasSampleAccurateValues)
         virtualReadIndex = processARate(n, destination, virtualReadIndex, phaseIncrements);


### PR DESCRIPTION
#### 27d3de8f8b2289fbcba9812b6eb37d16a3db96fd
<pre>
OscillatorNode with a-rate automation ignores sub-sample start time and begins out of phase
<a href="https://bugs.webkit.org/show_bug.cgi?id=320277">https://bugs.webkit.org/show_bug.cgi?id=320277</a>
<a href="https://rdar.apple.com/183194827">rdar://183194827</a>

Reviewed by Chris Dumez.

This patch aligns WebKit with Gecko / Firefox.

When an oscillator is started at a sub-sample-accurate time,
OscillatorNode::process() advances the initial virtualReadIndex by the
fractional start offset scaled by one phase increment, so the oscillator
begins at the correct sub-sample phase. That compensation was written as
`startFrameOffset * frequency * rateScale`, but `frequency` is a local
that is only assigned in the k-rate (!hasSampleAccurateValues) branch.
Whenever a-rate frequency or detune automation is active, `frequency`
stays 0, so the compensation term is 0 and the oscillator starts on the
frame boundary instead of at the requested sub-sample offset, i.e.
audibly out of phase.

Use the first sample-accurate phase increment (phaseIncrements[0]) for
the compensation when hasSampleAccurateValues is true, falling back to
frequency * rateScale for the k-rate case. For a constant frequency the
two are identical, so this only changes behavior when automation is
active.

This matches the k-rate path, which already advances by
`frequency * rateScale` per frame.

Test: imported/w3c/web-platform-tests/webaudio/the-audio-api/the-oscillatornode-interface/sub-sample-start.html

* LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-oscillatornode-interface/sub-sample-start-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-oscillatornode-interface/sub-sample-start.html: Added.
* Source/WebCore/Modules/webaudio/OscillatorNode.cpp:
(WebCore::OscillatorNode::process):

Canonical link: <a href="https://commits.webkit.org/317953@main">https://commits.webkit.org/317953@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d7ddbb8c7de335beff26a1cf761ef42800ffd1b9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176739 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50676 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44468 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186341 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/139975 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fd7565ef-5209-46b0-958c-bfb9eb75f93f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178602 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51969 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50362 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137682 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/139975 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6617a6b2-be44-413a-b6e4-2b01c0342ead) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179695 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41189 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158472 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118156 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d66aed9b-8054-4893-b2ba-4bdc92aeb056) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39843 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38210 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150255 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37970 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34809 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42420 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42426 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188765 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50343 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/158015 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146747 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39479 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51026 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34591 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146552 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41316 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123234 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117384 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49531 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12949 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48930 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49166 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48991 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->