### PR TITLE
RealtimeAnalyser heap-allocates a temporary FFT buffer on every analysis pass

### DIFF
--- a/Source/WebCore/Modules/webaudio/RealtimeAnalyser.cpp
+++ b/Source/WebCore/Modules/webaudio/RealtimeAnalyser.cpp
@@ -66,6 +66,7 @@ bool RealtimeAnalyser::setFftSize(size_t size)
 
     if (m_fftSize != size) {
         m_analysisFrame = makeUnique<FFTFrame>(size);
+        m_temporaryBuffer.resize(size);
         // m_magnitudeBuffer has size = fftSize / 2 because it contains floats reduced from complex values in m_analysisFrame.
         m_magnitudeBuffer.resize(size / 2);
         m_fftSize = size;
@@ -106,16 +107,17 @@ void RealtimeAnalyser::writeInput(AudioBus& bus, size_t framesToProcess)
 
 namespace {
 
-void applyWindow(std::span<float> p, size_t n)
+void applyWindow(std::span<float> p)
 {
     ASSERT(isMainThread());
-    
+
     // Blackman window
     double alpha = 0.16;
     double a0 = 0.5 * (1 - alpha);
     double a1 = 0.5;
     double a2 = 0.5 * alpha;
-    
+
+    size_t n = p.size();
     for (unsigned i = 0; i < n; ++i) {
         double x = static_cast<double>(i) / static_cast<double>(n);
         double window = a0 - a1 * cos(2 * std::numbers::pi * x) + a2 * cos(4 * std::numbers::pi * x);
@@ -136,22 +138,22 @@ void RealtimeAnalyser::doFFTAnalysisIfNecessary()
 
     // Unroll the input buffer into a temporary buffer, where we'll apply an analysis window followed by an FFT.
     size_t fftSize = this->fftSize();
-    
-    AudioFloatArray temporaryBuffer(fftSize);
+
     auto inputBuffer = m_inputBuffer.span();
-    auto tempP = temporaryBuffer.span();
+    // m_temporaryBuffer is kept in sync with m_fftSize by setFftSize(); take only what this FFT needs.
+    auto tempP = m_temporaryBuffer.span().first(fftSize);
 
     // Take the previous fftSize values from the input buffer and copy into the temporary buffer.
     unsigned writeIndex = m_writeIndex;
     if (writeIndex < fftSize) {
         memcpySpan(tempP, inputBuffer.subspan(writeIndex - fftSize + InputBufferSize, fftSize - writeIndex));
         memcpySpan(tempP.subspan(fftSize - writeIndex), inputBuffer.first(writeIndex));
-    } else 
+    } else
         memcpySpan(tempP, inputBuffer.subspan(writeIndex - fftSize, fftSize));
 
-    
+
     // Window the input samples.
-    applyWindow(tempP, fftSize);
+    applyWindow(tempP);
     
     // Do the analysis.
     m_analysisFrame->doFFT(tempP);

--- a/Source/WebCore/Modules/webaudio/RealtimeAnalyser.h
+++ b/Source/WebCore/Modules/webaudio/RealtimeAnalyser.h
@@ -88,6 +88,9 @@ private:
     std::unique_ptr<FFTFrame> m_analysisFrame;
     void doFFTAnalysisIfNecessary();
     
+    // doFFTAnalysisIfNecessary() unrolls the input buffer here before windowing and doing the FFT.
+    AudioFloatArray m_temporaryBuffer { DefaultFFTSize };
+
     // doFFTAnalysisIfNecessary() stores the floating-point magnitude analysis data here.
     AudioFloatArray m_magnitudeBuffer { DefaultFFTSize / 2 };
     AudioFloatArray& magnitudeBuffer() LIFETIME_BOUND { return m_magnitudeBuffer; }


### PR DESCRIPTION
#### 71f03e43c748b03c7b9d9df377186009db45ccb2
<pre>
RealtimeAnalyser heap-allocates a temporary FFT buffer on every analysis pass
<a href="https://bugs.webkit.org/show_bug.cgi?id=320278">https://bugs.webkit.org/show_bug.cgi?id=320278</a>
<a href="https://rdar.apple.com/183195414">rdar://183195414</a>

Reviewed by Chris Dumez.

doFFTAnalysisIfNecessary() constructed a fresh AudioFloatArray on each
call to unroll the input buffer into. AudioArray&apos;s constructor does an
aligned malloc followed by a full zero-fill, and every one of those bytes
is then immediately overwritten by the unroll memcpy that follows, so the
zero-fill was pure waste. At the default fftSize of 2048 that is an 8KB
malloc/memset/free per pass, and 128KB at the maximum fftSize of 32768.

This runs once per render quantum whenever frequency data is being read,
so a typical requestAnimationFrame-driven visualizer hits it around 60
times a second.

Hold the scratch buffer as a member instead, sized alongside
m_magnitudeBuffer in setFftSize(), matching how the magnitude buffer is
already managed. The unroll writes every element it uses, so dropping the
per-call zero-initialization is not observable.

While here, change applyWindow() to derive its length from the span it is
given rather than taking a separate count, so the two cannot disagree.

* Source/WebCore/Modules/webaudio/RealtimeAnalyser.cpp:
(WebCore::RealtimeAnalyser::setFftSize):
(WebCore::RealtimeAnalyser::doFFTAnalysisIfNecessary):
* Source/WebCore/Modules/webaudio/RealtimeAnalyser.h:

Canonical link: <a href="https://commits.webkit.org/317954@main">https://commits.webkit.org/317954@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/560941ca1b48d3fc25fe3db67c116b094ff8f8e9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176740 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50677 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44469 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186342 "Build is in progress. Recent messages:Printed configuration; Checked out pull request; Compiled WebKit (warnings)") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/139976 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a0870aa3-5de6-473e-a6ee-60c4b2cbcdcd) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178603 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51970 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50363 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137683 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/139976 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/685a5c1d-94d1-4dd5-9a6c-d8bbee68ed9e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179696 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41188 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158473 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118157 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b43dfcdb-0476-4aab-ae52-61886a5f8607) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39842 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38211 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150254 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37971 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34810 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42421 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42427 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188766 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50344 "Built successfully") | | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146748 "Build is in progress. Recent messages:Printed configuration; Checked out pull request; Running run-layout-tests-in-stress-mode; 10 flakes 3 failures; Uploaded test results; 3 flakes; Passed layout tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39480 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51027 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34592 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146553 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41317 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123235 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117385 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49532 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12950 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48931 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49167 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48992 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->