### PR TITLE
[Site Isolation] A cross-site frame's FrameNetworkingContext is never valid, silently dropping in-process loads

### DIFF
--- a/LayoutTests/http/tests/site-isolation/provisional-frame-networking-context-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/provisional-frame-networking-context-expected.txt
@@ -1,0 +1,10 @@
+A cross-site iframe's FrameNetworkingContext should be valid. Under site isolation the iframe's FrameLoader is initialized while it is still provisional, so a context built from WebFrame::coreLocalFrame() would capture a null LocalFrame and stay permanently invalid, silently dropping any load that goes through ResourceHandle (QuickLook previews, PDFJS).
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS result.networkingContextIsValid is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/site-isolation/provisional-frame-networking-context.html
+++ b/LayoutTests/http/tests/site-isolation/provisional-frame-networking-context.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html><!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<html>
+<head>
+<script src="/js-test-resources/js-test.js"></script>
+</head>
+<body>
+<script>
+description("A cross-site iframe's FrameNetworkingContext should be valid. Under site isolation the iframe's FrameLoader is initialized while it is still provisional, so a context built from WebFrame::coreLocalFrame() would capture a null LocalFrame and stay permanently invalid, silently dropping any load that goes through ResourceHandle (QuickLook previews, PDFJS).");
+
+var jsTestIsAsync = true;
+var result = null;
+
+window.addEventListener("message", function(event) {
+    result = event.data;
+    shouldBeTrue("result.networkingContextIsValid");
+    finishJSTest();
+}, false);
+</script>
+<iframe src="http://localhost:8000/site-isolation/resources/report-networking-context-validity.html"></iframe>
+</body>
+</html>

--- a/LayoutTests/http/tests/site-isolation/resources/report-networking-context-validity.html
+++ b/LayoutTests/http/tests/site-isolation/resources/report-networking-context-validity.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script>
+let valid = "no internals";
+if (window.internals) {
+    try {
+        valid = internals.frameNetworkingContextIsValid();
+    } catch (e) {
+        valid = "threw " + e.name;
+    }
+}
+window.parent.postMessage({ networkingContextIsValid: valid }, "*");
+</script>
+</body>
+</html>

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -181,6 +181,7 @@
 #include "NavigatorBeacon.h"
 #include "NavigatorMediaDevices.h"
 #include "NetworkLoadInformation.h"
+#include "NetworkingContext.h"
 #include "Page.h"
 #include "PageInspectorController.h"
 #include "PageOverlay.h"
@@ -982,6 +983,19 @@ bool Internals::isLoadingFromMemoryCache(const String& url)
 {
     CachedResource* resource = resourceFromMemoryCache(url);
     return resource && resource->status() == CachedResource::Cached;
+}
+
+ExceptionOr<bool> Internals::frameNetworkingContextIsValid() const
+{
+    RefPtr document = contextDocument();
+    if (!document || !document->frame())
+        return Exception { ExceptionCode::InvalidAccessError };
+
+    RefPtr context = document->frame()->loader().networkingContext();
+    if (!context)
+        return Exception { ExceptionCode::InvalidAccessError };
+
+    return context->isValid();
 }
 
 CachedResource* Internals::resourceFromMemoryCache(const String& url)

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -244,6 +244,7 @@ public:
 
     bool isPreloaded(const String& url);
     bool isLoadingFromMemoryCache(const String& url);
+    ExceptionOr<bool> frameNetworkingContextIsValid() const;
     String fetchResponseSource(FetchResponse&);
     String xhrResponseSource(XMLHttpRequest&);
     bool NODELETE isSharingStyleSheetContents(HTMLLinkElement&, HTMLLinkElement&);

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -535,6 +535,7 @@ enum ContentsFormat {
     DOMString elementRenderTreeAsText(Element element);
     boolean isPreloaded(DOMString url);
     boolean isLoadingFromMemoryCache(DOMString url);
+    boolean frameNetworkingContextIsValid();
     DOMString fetchResponseSource(FetchResponse response);
     DOMString xhrResponseSource(XMLHttpRequest xhr);
     boolean isSharingStyleSheetContents(HTMLLinkElement a, HTMLLinkElement b);

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
@@ -2038,7 +2038,7 @@ bool WebLocalFrameLoaderClient::shouldForceUniversalAccessFromLocalURL(const URL
 Ref<FrameNetworkingContext> WebLocalFrameLoaderClient::createNetworkingContext()
 {
     ASSERT(!hasProcessPrivilege(ProcessPrivilege::CanAccessRawCookies));
-    return WebFrameNetworkingContext::create(m_frame.ptr());
+    return WebFrameNetworkingContext::create(protect(m_localFrame).ptr());
 }
 
 #if ENABLE(CONTENT_FILTERING)

--- a/Source/WebKit/WebProcess/WebCoreSupport/cocoa/WebFrameNetworkingContext.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/cocoa/WebFrameNetworkingContext.h
@@ -34,7 +34,7 @@ struct WebsiteDataStoreParameters;
 
 class WebFrameNetworkingContext : public WebCore::FrameNetworkingContext {
 public:
-    static Ref<WebFrameNetworkingContext> create(WebFrame* frame)
+    static Ref<WebFrameNetworkingContext> create(WebCore::LocalFrame* frame)
     {
         return adoptRef(*new WebFrameNetworkingContext(frame));
     }
@@ -45,8 +45,8 @@ public:
     WebLocalFrameLoaderClient* NODELETE webFrameLoaderClient() const;
 
 private:
-    WebFrameNetworkingContext(WebFrame* frame)
-        : WebCore::FrameNetworkingContext(frame->coreLocalFrame())
+    WebFrameNetworkingContext(WebCore::LocalFrame* frame)
+        : WebCore::FrameNetworkingContext(frame)
     {
     }
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/curl/WebFrameNetworkingContext.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/curl/WebFrameNetworkingContext.cpp
@@ -42,8 +42,8 @@ void WebFrameNetworkingContext::ensureWebsiteDataStoreSession(const WebsiteDataS
 {
 }
 
-WebFrameNetworkingContext::WebFrameNetworkingContext(WebFrame* frame)
-    : FrameNetworkingContext(frame->coreLocalFrame())
+WebFrameNetworkingContext::WebFrameNetworkingContext(WebCore::LocalFrame* frame)
+    : FrameNetworkingContext(frame)
 {
 }
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/curl/WebFrameNetworkingContext.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/curl/WebFrameNetworkingContext.h
@@ -36,7 +36,7 @@ struct WebsiteDataStoreParameters;
 
 class WebFrameNetworkingContext : public WebCore::FrameNetworkingContext {
 public:
-    static Ref<WebFrameNetworkingContext> create(WebFrame* frame)
+    static Ref<WebFrameNetworkingContext> create(WebCore::LocalFrame* frame)
     {
         return adoptRef(*new WebFrameNetworkingContext(frame));
     }
@@ -50,7 +50,7 @@ public:
 #endif
 
 private:
-    WebFrameNetworkingContext(WebFrame*);
+    WebFrameNetworkingContext(WebCore::LocalFrame*);
 
     WebCore::NetworkStorageSession* storageSession() const override { return nullptr; }
 };

--- a/Source/WebKit/WebProcess/WebCoreSupport/soup/WebFrameNetworkingContext.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/soup/WebFrameNetworkingContext.cpp
@@ -45,8 +45,8 @@ void WebFrameNetworkingContext::ensureWebsiteDataStoreSession(const WebsiteDataS
 {
 }
 
-WebFrameNetworkingContext::WebFrameNetworkingContext(WebFrame* frame)
-    : FrameNetworkingContext(frame->coreLocalFrame())
+WebFrameNetworkingContext::WebFrameNetworkingContext(WebCore::LocalFrame* frame)
+    : FrameNetworkingContext(frame)
 {
 }
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/soup/WebFrameNetworkingContext.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/soup/WebFrameNetworkingContext.h
@@ -37,7 +37,7 @@ struct WebsiteDataStoreParameters;
 
 class WebFrameNetworkingContext : public WebCore::FrameNetworkingContext {
 public:
-    static Ref<WebFrameNetworkingContext> create(WebFrame* frame)
+    static Ref<WebFrameNetworkingContext> create(WebCore::LocalFrame* frame)
     {
         return adoptRef(*new WebFrameNetworkingContext(frame));
     }
@@ -48,7 +48,7 @@ public:
     WebLocalFrameLoaderClient* webFrameLoaderClient() const;
 
 private:
-    WebFrameNetworkingContext(WebFrame*);
+    WebFrameNetworkingContext(WebCore::LocalFrame*);
 
     WebCore::NetworkStorageSession* storageSession() const override { return nullptr; }
 };


### PR DESCRIPTION
#### b644eadfe2244bdf01c08b31d4a5952cbb8c8fe0
<pre>
[Site Isolation] A cross-site frame&apos;s FrameNetworkingContext is never valid, silently dropping in-process loads
<a href="https://bugs.webkit.org/show_bug.cgi?id=320279">https://bugs.webkit.org/show_bug.cgi?id=320279</a>
<a href="https://rdar.apple.com/183196588">rdar://183196588</a>

Reviewed by Alex Christensen.

Use the LocalFrame that owns the client rather than WebFrame::coreLocalFrame(). During a
cross-site provisional load under site isolation, the WebFrame still points at the RemoteFrame
it will replace, so coreLocalFrame() is null and the context would never become valid.

Test: http/tests/site-isolation/provisional-frame-networking-context.html

* LayoutTests/http/tests/site-isolation/provisional-frame-networking-context-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/provisional-frame-networking-context.html: Added.
* LayoutTests/http/tests/site-isolation/resources/report-networking-context-validity.html: Added.
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::frameNetworkingContextIsValid const):
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:
* Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp:
(WebKit::WebLocalFrameLoaderClient::createNetworkingContext):
* Source/WebKit/WebProcess/WebCoreSupport/cocoa/WebFrameNetworkingContext.h:
(WebKit::WebFrameNetworkingContext::create):
(WebKit::WebFrameNetworkingContext::WebFrameNetworkingContext):
* Source/WebKit/WebProcess/WebCoreSupport/curl/WebFrameNetworkingContext.cpp:
(WebKit::WebFrameNetworkingContext::WebFrameNetworkingContext):
* Source/WebKit/WebProcess/WebCoreSupport/curl/WebFrameNetworkingContext.h:
(WebKit::WebFrameNetworkingContext::create):
* Source/WebKit/WebProcess/WebCoreSupport/soup/WebFrameNetworkingContext.cpp:
(WebKit::WebFrameNetworkingContext::WebFrameNetworkingContext):
* Source/WebKit/WebProcess/WebCoreSupport/soup/WebFrameNetworkingContext.h:
(WebKit::WebFrameNetworkingContext::create):

Canonical link: <a href="https://commits.webkit.org/318038@main">https://commits.webkit.org/318038@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d2ba11fd00feabe418efee4b908f82f270d5e159

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177112 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51049 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44844 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186715 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140348 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b5ed6951-558a-40e4-aae4-5d9f32c7f42f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178975 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52342 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50735 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137998 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140348 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b14983d2-892b-481d-a5db-0f8ef533a69e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180068 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41504 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158763 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118465 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/645b5c1a-f07c-4fab-a14e-33c1320e25a0) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40160 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38532 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150570 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38262 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35183 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/42825 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/42750 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189141 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50716 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/158302 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147081 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39528 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51399 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/34886 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146874 "Found 1 new API test failure: WebKitGTK/TestAutocleanups:/webkit/Autocleanups/ui-process-autocleanups (failure)") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41610 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123613 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117900 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49904 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13242 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49303 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49540 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49364 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->