### PR TITLE
Do not navigate newly opened windows to about:blank

### DIFF
--- a/LayoutTests/fast/dom/location-new-window-no-crash-expected.txt
+++ b/LayoutTests/fast/dom/location-new-window-no-crash-expected.txt
@@ -14,24 +14,24 @@ PASS testWindow.location.search is ''
 PASS testWindow.location.hash is ''
 PASS testWindow.location.href = 'data:text/plain,b' is 'data:text/plain,b'
 PASS testWindow.location.protocol = 'data' is 'data'
-PASS testWindow.location.host = 'c' threw exception SyntaxError: Invalid URL.
-PASS testWindow.location.hostname = 'd' threw exception SyntaxError: Invalid URL.
-PASS testWindow.location.port = 'e' threw exception SyntaxError: Invalid URL.
-PASS testWindow.location.pathname = 'f' threw exception SyntaxError: Invalid URL.
-PASS testWindow.location.search = 'g' threw exception SyntaxError: Invalid URL.
+PASS testWindow.location.host = 'c' is 'c'
+PASS testWindow.location.hostname = 'd' is 'd'
+PASS testWindow.location.port = 'e' is 'e'
+PASS testWindow.location.pathname = 'f' is 'f'
+PASS testWindow.location.search = 'g' is 'g'
 PASS testWindow.location.hash = 'h' is 'h'
 PASS testWindow.location.assign('data:text/plain,i') is undefined
 PASS testWindow.location.replace('data:text/plain,j') is undefined
 PASS testWindow.location.reload() is undefined
-PASS testWindow.location.toString() is 'about:blank'
-PASS testWindow.location.href is 'about:blank'
+PASS testWindow.location.toString() is 'about:blank#h'
+PASS testWindow.location.href is 'about:blank#h'
 PASS testWindow.location.protocol is 'about:'
 PASS testWindow.location.host is ''
 PASS testWindow.location.hostname is ''
 PASS testWindow.location.port is ''
 PASS testWindow.location.pathname is 'blank'
 PASS testWindow.location.search is ''
-PASS testWindow.location.hash is ''
+PASS testWindow.location.hash is '#h'
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/dom/location-new-window-no-crash.html
+++ b/LayoutTests/fast/dom/location-new-window-no-crash.html
@@ -27,26 +27,26 @@ shouldBe("testWindow.location.hash", "''");
 
 shouldBe("testWindow.location.href = 'data:text/plain,b'", "'data:text/plain,b'");
 shouldBe("testWindow.location.protocol = 'data'", "'data'"); // Firefox throws an exception
-shouldThrow("testWindow.location.host = 'c'");
-shouldThrow("testWindow.location.hostname = 'd'");
-shouldThrow("testWindow.location.port = 'e'");
-shouldThrow("testWindow.location.pathname = 'f'");
-shouldThrow("testWindow.location.search = 'g'");
+shouldBe("testWindow.location.host = 'c'", "'c'");
+shouldBe("testWindow.location.hostname = 'd'", "'d'");
+shouldBe("testWindow.location.port = 'e'", "'e'");
+shouldBe("testWindow.location.pathname = 'f'", "'f'");
+shouldBe("testWindow.location.search = 'g'", "'g'");
 shouldBe("testWindow.location.hash = 'h'", "'h'");
 
 shouldBe("testWindow.location.assign('data:text/plain,i')", "undefined");
 shouldBe("testWindow.location.replace('data:text/plain,j')", "undefined");
 shouldBe("testWindow.location.reload()", "undefined");
 
-shouldBe("testWindow.location.toString()", "'about:blank'");
-shouldBe("testWindow.location.href", "'about:blank'");
+shouldBe("testWindow.location.toString()", "'about:blank#h'");
+shouldBe("testWindow.location.href", "'about:blank#h'");
 shouldBe("testWindow.location.protocol", "'about:'");
 shouldBe("testWindow.location.host", "''"); // Firefox throws an exception
 shouldBe("testWindow.location.hostname", "''"); // Firefox throws an exception
 shouldBe("testWindow.location.port", "''");
 shouldBe("testWindow.location.pathname", "'blank'"); // Firefox returns the empty string
 shouldBe("testWindow.location.search", "''");
-shouldBe("testWindow.location.hash", "''");
+shouldBe("testWindow.location.hash", "'#h'");
 
 setTimeout(function () {
     testWindow.close();

--- a/LayoutTests/http/tests/security/cross-origin-opener-policy/popup-from-initial-about-blank-expected.txt
+++ b/LayoutTests/http/tests/security/cross-origin-opener-policy/popup-from-initial-about-blank-expected.txt
@@ -1,0 +1,7 @@
+
+PASS window.open() preserves the initial popup relationship
+PASS window.open('') preserves the initial popup relationship
+PASS window.open('about:blank') preserves the initial popup relationship
+PASS window.open('about:blank#foo') preserves the initial popup relationship
+PASS window.open('about:blank?foo') preserves the initial popup relationship
+

--- a/LayoutTests/http/tests/security/cross-origin-opener-policy/popup-from-initial-about-blank.py
+++ b/LayoutTests/http/tests/security/cross-origin-opener-policy/popup-from-initial-about-blank.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+
+import sys
+
+sys.stdout.write(
+    'Cross-Origin-Opener-Policy: same-origin-allow-popups\r\n'
+    'Content-Type: text/html\r\n\r\n'
+)
+
+print('''<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Navigation from a popup's initial about:blank document</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+const variants = [
+    { expression: "window.open()", open: () => window.open() },
+    { expression: "window.open('')", open: () => window.open("") },
+    { expression: "window.open('about:blank')", open: () => window.open("about:blank") },
+    { expression: "window.open('about:blank#foo')", open: () => window.open("about:blank#foo") },
+    { expression: "window.open('about:blank?foo')", open: () => window.open("about:blank?foo") },
+];
+
+const resourcePath = "/security/cross-origin-opener-policy/resources/popup-from-initial-about-blank.py";
+
+for (const variant of variants) {
+    promise_test(async t => {
+        const channelName = "popup-from-initial-about-blank-" + Math.random();
+        const channel = new BroadcastChannel(channelName);
+        const popup = variant.open();
+        assert_not_equals(popup, null, `${variant.expression} returned a popup`);
+
+        t.add_cleanup(() => {
+            channel.postMessage("close");
+            channel.close();
+        });
+
+        const destinationState = new Promise((resolve, reject) => {
+            const timeout = t.step_timeout(() => reject(new Error("Timed out waiting for the popup destination")), 5000);
+            channel.onmessage = event => {
+                clearTimeout(timeout);
+                resolve(event.data);
+            };
+        });
+
+        popup.location = `${resourcePath}?channel=${encodeURIComponent(channelName)}`;
+
+        const state = await destinationState;
+        assert_true(state.hasOpener, "destination retained its opener");
+        assert_false(popup.closed, "returned WindowProxy is not closed");
+    }, `${variant.expression} preserves the initial popup relationship`);
+}
+</script>
+''')

--- a/LayoutTests/http/tests/security/cross-origin-opener-policy/resources/popup-from-initial-about-blank.py
+++ b/LayoutTests/http/tests/security/cross-origin-opener-policy/resources/popup-from-initial-about-blank.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+
+import sys
+
+sys.stdout.write(
+    'Cross-Origin-Opener-Policy: unsafe-none\r\n'
+    'Content-Type: text/html\r\n\r\n'
+)
+
+print('''<!DOCTYPE html>
+<meta charset="utf-8">
+<script>
+const channelName = new URL(location).searchParams.get("channel");
+const channel = new BroadcastChannel(channelName);
+
+channel.onmessage = event => {
+    if (event.data === "close") {
+        channel.close();
+        window.close();
+    }
+};
+
+channel.postMessage({
+    hasOpener: window.opener !== null,
+});
+</script>''')

--- a/LayoutTests/http/tests/security/navigate-when-restoring-cached-page.html
+++ b/LayoutTests/http/tests/security/navigate-when-restoring-cached-page.html
@@ -49,39 +49,47 @@ function runTest()
           testRunner.notifyDone();
         }
       }
-      w.history.pushState('', '');
-      
-      cached_doc = w.document;
-      setTimeout(() => {
-        w.location = 'about:blank';
-        interval_id = setInterval(() => {
-          if (cached_doc == w.document)
-            return;
-          
-          clearInterval(interval_id);
+      initial_doc = w.document;
+      w.location = 'about:blank';
+      interval_id = setInterval(() => {
+        if (initial_doc == w.document)
+          return;
 
-          if (w.internals)
-            w.internals.preventDocumentFromEnteringBackForwardCache();
+        clearInterval(interval_id);
+        w.history.pushState('', '');
 
-          child_frame = w.document.body.appendChild(document.createElement('iframe'));
-          child_frame.contentWindow.onunload = () => {
-            child_frame.contentWindow.onunload = null;
-            
-            a = w.document.createElement('a');
-            a.href = '${victim_url}';
-            a.click();
+        cached_doc = w.document;
+        setTimeout(() => {
+          w.location = 'about:blank';
+          interval_id = setInterval(() => {
+            if (cached_doc == w.document)
+              return;
 
-            showModalDialog(createURL('<script>timeout = 100; setInterval(() => { if (!--timeout || opener.child_loaded) { close(); if (window.testRunner) testRunner.abortModal(); } }, 1)</sc' + 'ript>'));
+            clearInterval(interval_id);
 
-            if (!window.child_loaded && window.testRunner) {
-              testRunner.abortModal();
-              testRunner.notifyDone();
+            if (w.internals)
+              w.internals.preventDocumentFromEnteringBackForwardCache();
+
+            child_frame = w.document.body.appendChild(document.createElement('iframe'));
+            child_frame.contentWindow.onunload = () => {
+              child_frame.contentWindow.onunload = null;
+
+              a = w.document.createElement('a');
+              a.href = '${victim_url}';
+              a.click();
+
+              showModalDialog(createURL('<script>timeout = 100; setInterval(() => { if (!--timeout || opener.child_loaded) { close(); if (window.testRunner) testRunner.abortModal(); } }, 1)</sc' + 'ript>'));
+
+              if (!window.child_loaded && window.testRunner) {
+                testRunner.abortModal();
+                testRunner.notifyDone();
+              }
             }
-          }
-          
-          w.history.back();
+
+            w.history.back();
+          }, 0);
         }, 0);
-      }, 0); 
+      }, 0);
     </scr` + `ipt>`));
 }
 

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/inheritance/history-iframe.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/inheritance/history-iframe.sub-expected.txt
@@ -1,7 +1,7 @@
 
 
 PASS History navigation in iframe: "about:blank" document is navigated back from history same-origin.
-FAIL History navigation in iframe: "about:blank" document is navigated back from history cross-origin. step_wait_func: Wait for the iframe to navigate. Timed out waiting on condition
+PASS History navigation in iframe: "about:blank" document is navigated back from history cross-origin.
 PASS History navigation in iframe: blob URL document is navigated back from history same-origin.
 PASS History navigation in iframe: blob URL document is navigated back from history cross-origin.
 PASS History navigation in iframe: data URL document is navigated back from history same-origin.

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/initial-empty-document/iframe-src-204-fragment-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/initial-empty-document/iframe-src-204-fragment-expected.txt
@@ -1,7 +1,7 @@
 
-FAIL src assert_equals: history.length must not change after normal navigation from initial empty document expected 2 but got 3
-FAIL location.href assert_equals: history.length must not change after normal navigation from initial empty document expected 3 but got 4
-FAIL location.assign assert_equals: history.length must not change after normal navigation from initial empty document expected 4 but got 5
-FAIL window.open assert_equals: history.length must not change after normal navigation from initial empty document expected 5 but got 6
-FAIL link click assert_equals: history.length must not change after fragment navigation on initial empty document expected 6 but got 7
+PASS src
+PASS location.href
+PASS location.assign
+PASS window.open
+FAIL link click assert_equals: history.length must not change after fragment navigation on initial empty document expected 2 but got 3
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/initial-empty-document/window-open-204-pushState-replaceState-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/initial-empty-document/window-open-204-pushState-replaceState-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL history.pushState promise_test: Unhandled rejection with value: object "SecurityError: Blocked attempt to use history.pushState() to change session history URL from  to about:blank#foo. Protocols, domains, ports, usernames, and passwords must match."
-FAIL history.replaceState promise_test: Unhandled rejection with value: object "SecurityError: Blocked attempt to use history.replaceState() to change session history URL from  to about:blank#foo. Protocols, domains, ports, usernames, and passwords must match."
+FAIL history.pushState assert_equals: history.length must not change after history.pushState() on the initial empty document expected 1 but got 2
+FAIL history.replaceState assert_equals: history.length must not change after history.replaceState() on the initial empty document expected 1 but got 2
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/window-reuse.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/window-reuse.tentative-expected.txt
@@ -1,4 +1,4 @@
 
 PASS Initially navigating window to non-about:blank page should reuse synchonously available window
-PASS synchronously navigating window away from initial about:blank should not reuse window
+FAIL synchronously navigating window away from initial about:blank should not reuse window assert_equals: did reuse window expected (undefined) undefined but got (string) "bar"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/urls/base-url/initial-about-blank-baseURI.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/urls/base-url/initial-about-blank-baseURI.window-expected.txt
@@ -2,7 +2,7 @@
 PASS Initial iframe about:blank gets base url from creator
 PASS Transient iframe about:blank gets base url from creator
 PASS Initial top-level about:blank gets base url from creator = opener
-FAIL Transient top-level about:blank gets base url from creator = opener assert_equals: about:blank has creator's base URI expected "http://web-platform.test:8800/html/infrastructure/urls/base-url/initial-about-blank-baseURI.window.html" but got "about:blank"
-FAIL Initial top-level about:blank gets base url from creator != opener assert_equals: about:blank has creator's base URI expected "http://www1.web-platform.test:8800/" but got "http://web-platform.test:8800/html/infrastructure/urls/base-url/initial-about-blank-baseURI.window.html"
-FAIL Transient top-level about:blank gets base url from creator != opener assert_equals: about:blank has creator's base URI expected "http://www1.web-platform.test:8800/" but got "about:blank"
+PASS Transient top-level about:blank gets base url from creator = opener
+PASS Initial top-level about:blank gets base url from creator != opener
+PASS Transient top-level about:blank gets base url from creator != opener
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/urls/base-url/initial-about-blank-baseURI.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/urls/base-url/initial-about-blank-baseURI.window-expected.txt
@@ -3,6 +3,6 @@ PASS Initial iframe about:blank gets base url from creator
 PASS Transient iframe about:blank gets base url from creator
 PASS Initial top-level about:blank gets base url from creator = opener
 PASS Transient top-level about:blank gets base url from creator = opener
-PASS Initial top-level about:blank gets base url from creator != opener
-PASS Transient top-level about:blank gets base url from creator != opener
+FAIL Initial top-level about:blank gets base url from creator != opener assert_equals: about:blank has creator's base URI expected "http://www1.web-platform.test:8800/" but got "http://web-platform.test:8800/html/infrastructure/urls/base-url/initial-about-blank-baseURI.window.html"
+FAIL Transient top-level about:blank gets base url from creator != opener assert_equals: about:blank has creator's base URI expected "http://www1.web-platform.test:8800/" but got "http://web-platform.test:8800/html/infrastructure/urls/base-url/initial-about-blank-baseURI.window.html"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/sandbox-inherit-to-blank-document-unsandboxed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/sandbox-inherit-to-blank-document-unsandboxed-expected.txt
@@ -1,6 +1,6 @@
 
 PASS Document is sandboxed via its CSP.
-PASS The initial empty document inherit sandbox via CSP.
-PASS The synchronous re-navigation to about:blank inherits sandbox via CSP
+FAIL The initial empty document inherit sandbox via CSP. assert_throws_dom: Access before timeout throws function "() => { w.origin }" did not throw
+FAIL The synchronous re-navigation to about:blank inherits sandbox via CSP assert_throws_dom: Access before timeout throws function "() => { w.origin }" did not throw
 PASS Popup do not inherit sandbox, because of 'allow-popups-to-escape-sandbox' the document doesn't inherit CSP. The document isn't sandboxed
 

--- a/LayoutTests/js/dom/modules/import-from-javascript-url-new-window-expected.txt
+++ b/LayoutTests/js/dom/modules/import-from-javascript-url-new-window-expected.txt
@@ -1,2 +1,2 @@
-This test passes if import() in the null-URL initial document of a new top-level window rejects with a TypeError instead of crashing the WebContent process.
+This test passes if import() in the initial about:blank document of a new top-level window rejects with a TypeError instead of crashing the WebContent process.
 PASS

--- a/LayoutTests/js/dom/modules/import-from-javascript-url-new-window.html
+++ b/LayoutTests/js/dom/modules/import-from-javascript-url-new-window.html
@@ -15,7 +15,7 @@ function test() {
 
 // Called from the opened window once import() settles.
 function concludeTest(result, isTypeError) {
-    var pass = isTypeError && result === "TypeError: Cannot import a module from a document with no base URL.";
+    var pass = isTypeError && result === "TypeError: Module name, 'x' does not resolve to a valid URL.";
     document.getElementById("console").textContent = pass ? "PASS" : ("FAIL: " + result);
 
     if (w)
@@ -33,7 +33,7 @@ function concludeTest(result, isTypeError) {
     }
 }
 </script>
-This test passes if import() in the null-URL initial document of a new top-level window rejects with a TypeError instead of crashing the WebContent process.
+This test passes if import() in the initial about:blank document of a new top-level window rejects with a TypeError instead of crashing the WebContent process.
 <div id="console">FAIL, test did not run</div>
 </body>
 </html>

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -4795,12 +4795,15 @@ URL Document::fallbackBaseURL() const
         [](const URL& url) { return url; }
     );
 
-    if (documentURL.isAboutSrcDoc()) {
-        if (auto* parent = parentDocument())
-            return parent->baseURL();
+    if (isSrcdocDocument()) {
+        ASSERT(!m_aboutBaseURL.isNull());
+        return m_aboutBaseURL;
     }
 
     if (documentURL.isAboutBlank()) {
+        if (!m_aboutBaseURL.isNull())
+            return m_aboutBaseURL;
+
         auto* creator = parentDocument();
         if (!creator && frame()) {
             if (auto* localOpener = dynamicDowncast<LocalFrame>(frame()->opener()))
@@ -4943,6 +4946,12 @@ void Document::processSpeculationRules()
 SpeculationRules& Document::speculationRules() const
 {
     return m_speculationRules;
+}
+
+void Document::setAboutBaseURL(const URL& url)
+{
+    m_aboutBaseURL = url;
+    updateBaseURL();
 }
 
 void Document::setBaseURLOverride(const URL& url)
@@ -5776,7 +5785,7 @@ ClonedDocumentType Document::clonedDocumentType() const
 
 Ref<Node> Document::cloneNodeInternal(Document&, CloningOperation type, CustomElementRegistry* registry) const
 {
-    Ref clone = createCloned(clonedDocumentType(), settings(), url(), baseURL(), baseURLOverride(), m_documentURI, m_compatibilityMode, protect(contextDocument()), securityOriginPolicy(), contentType(), protect(decoder()).get());
+    Ref clone = createCloned(clonedDocumentType(), settings(), url(), baseURL(), m_aboutBaseURL, baseURLOverride(), m_documentURI, m_compatibilityMode, protect(contextDocument()), securityOriginPolicy(), contentType(), protect(decoder()).get());
     switch (type) {
     case CloningOperation::SelfOnly:
     case CloningOperation::SelfWithTemplateContent:
@@ -5804,6 +5813,7 @@ SerializedNode Document::serializeNode(CloningOperation type) const
             clonedDocumentType(),
             url(),
             m_baseURL,
+            m_aboutBaseURL,
             m_baseURLOverride,
             m_documentURI,
             contentType(),
@@ -5811,7 +5821,7 @@ SerializedNode Document::serializeNode(CloningOperation type) const
     };
 }
 
-Ref<Document> Document::createCloned(ClonedDocumentType clonedDocumentType, const Settings& settings, const URL& url, const URL& baseURL, const URL& baseURLOverride, const Variant<String, URL>& documentURI, DocumentCompatibilityMode compatibilityMode, Document& contextDocument, SecurityOriginPolicy* securityOriginPolicy, const String& contentType, TextResourceDecoder* decoder)
+Ref<Document> Document::createCloned(ClonedDocumentType clonedDocumentType, const Settings& settings, const URL& url, const URL& baseURL, const URL& aboutBaseURL, const URL& baseURLOverride, const Variant<String, URL>& documentURI, DocumentCompatibilityMode compatibilityMode, Document& contextDocument, SecurityOriginPolicy* securityOriginPolicy, const String& contentType, TextResourceDecoder* decoder)
 {
     Ref clone = [&] -> Ref<Document> {
         switch (clonedDocumentType) {
@@ -5831,6 +5841,7 @@ Ref<Document> Document::createCloned(ClonedDocumentType clonedDocumentType, cons
 
     ASSERT(clone->m_url == url);
     clone->m_baseURL = baseURL;
+    clone->m_aboutBaseURL = aboutBaseURL;
     clone->m_baseURLOverride = baseURLOverride;
     clone->m_documentURI = documentURI;
     clone->setCompatibilityMode(compatibilityMode);
@@ -8429,7 +8440,7 @@ void Document::initSecurityContext()
     RefPtr parentDocument = ownerElement() ? &ownerElement()->document() : nullptr;
     if (parentDocument && m_frame->loader().shouldTreatURLAsSrcdocDocument(url())) {
         m_isSrcdocDocument = true;
-        setBaseURLOverride(parentDocument->baseURL());
+        setAboutBaseURL(parentDocument->baseURL());
     }
 
     if (!SecurityPolicy::shouldInheritSecurityOriginFromOwner(m_url))

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -8439,53 +8439,67 @@ void Document::initSecurityContext()
     if (!SecurityPolicy::shouldInheritSecurityOriginFromOwner(m_url))
         return;
 
-    // If we do not obtain a meaningful origin from the URL, then we try to
-    // find one via the frame hierarchy.
+    RefPtr initialDocumentCreator = m_frame->loader().initialDocumentCreator();
+    if (initialDocumentCreator)
+        setAboutBaseURL(initialDocumentCreator->baseURL());
+
+    // If we do not obtain a meaningful origin from the URL, then we use the
+    // initial document's explicit creator or try to find an owner via the frame hierarchy.
     RefPtr parentFrame = m_frame->tree().parent();
     RefPtr openerFrame = dynamicDowncast<LocalFrame>(m_frame->opener());
 
-    RefPtr ownerFrame = dynamicDowncast<LocalFrame>(parentFrame.get());
-    if (!ownerFrame)
-        ownerFrame = openerFrame;
+    RefPtr ownerDocument = initialDocumentCreator;
+    if (!ownerDocument) {
+        RefPtr ownerFrame = dynamicDowncast<LocalFrame>(parentFrame.get());
+        if (!ownerFrame)
+            ownerFrame = openerFrame;
+        if (ownerFrame)
+            ownerDocument = ownerFrame->document();
+    }
 
-    if (!ownerFrame) {
+    if (!ownerDocument) {
         didFailToInitializeSecurityOrigin();
         return;
     }
 
+    if (initialDocumentCreator)
+        inheritPolicyContainerFrom(initialDocumentCreator->policyContainer());
     CheckedPtr contentSecurityPolicy = this->contentSecurityPolicy();
-    contentSecurityPolicy->copyStateFrom(protect(protect(ownerFrame->document())->contentSecurityPolicy()).get());
-    contentSecurityPolicy->updateSourceSelf(protect(ownerFrame->document()->securityOrigin()));
+    if (!initialDocumentCreator)
+        contentSecurityPolicy->copyStateFrom(protect(ownerDocument->contentSecurityPolicy()).get());
+    contentSecurityPolicy->updateSourceSelf(protect(ownerDocument->securityOrigin()));
 
-    setCrossOriginEmbedderPolicy(ownerFrame->document()->crossOriginEmbedderPolicy());
-    setIsOriginKeyed(ownerFrame->document()->isOriginKeyed());
+    setCrossOriginEmbedderPolicy(ownerDocument->crossOriginEmbedderPolicy());
+    setIsOriginKeyed(ownerDocument->isOriginKeyed());
 
     // https://html.spec.whatwg.org/multipage/browsers.html#creating-a-new-browsing-context (Step 12)
     // If creator is non-null and creator's origin is same origin with creator's relevant settings object's top-level origin, then set coop
     // to creator's browsing context's top-level browsing context's active document's cross-origin opener policy.
-    if (m_frame->isMainFrame() && openerFrame && openerFrame->document() && openerFrame->document()->isSameOriginAsTopDocument())
-        setCrossOriginOpenerPolicy(openerFrame->document()->crossOriginOpenerPolicy());
+    if (m_frame->isMainFrame() && ownerDocument->isSameOriginAsTopDocument()) {
+        if (RefPtr topDocument = ownerDocument->mainFrameDocument())
+            setCrossOriginOpenerPolicy(topDocument->crossOriginOpenerPolicy());
+    }
 
     // Per <http://www.w3.org/TR/upgrade-insecure-requests/>, new browsing contexts must inherit from an
     // ongoing set of upgraded requests. When opening a new browsing context, we need to capture its
     // existing upgrade request. Nested browsing contexts are handled during DocumentWriter::begin.
-    if (RefPtr openerDocument = openerFrame ? openerFrame->document() : nullptr)
-        contentSecurityPolicy->inheritInsecureNavigationRequestsToUpgradeFromOpener(*protect(openerDocument->contentSecurityPolicy()));
+    if (m_frame->isMainFrame())
+        contentSecurityPolicy->inheritInsecureNavigationRequestsToUpgradeFromOpener(*protect(ownerDocument->contentSecurityPolicy()));
 
     if (isSandboxed(SandboxFlag::Origin)) {
         // If we're supposed to inherit our security origin from our owner,
         // but we're also sandboxed, the only thing we inherit is the ability
         // to load local resources. This lets about:blank iframes in file://
         // URL documents load images and other resources from the file system.
-        if (ownerFrame->document()->securityOrigin().canLoadLocalResources())
+        if (ownerDocument->securityOrigin().canLoadLocalResources())
             securityOrigin().grantLoadLocalResources();
         return;
     }
 
-    setCookieURL(ownerFrame->document()->cookieURL());
+    setCookieURL(ownerDocument->cookieURL());
     // We alias the SecurityOrigins to match Firefox, see Bug 15313
     // https://bugs.webkit.org/show_bug.cgi?id=15313
-    setSecurityOriginPolicy(ownerFrame->document()->securityOriginPolicy());
+    setSecurityOriginPolicy(ownerDocument->securityOriginPolicy());
 }
 
 void Document::initContentSecurityPolicy()

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -8462,8 +8462,12 @@ void Document::initSecurityContext()
         return;
     }
 
-    if (initialDocumentCreator)
+    if (initialDocumentCreator) {
         inheritPolicyContainerFrom(initialDocumentCreator->policyContainer());
+        // Unlike WebCore's PolicyContainer, an HTML policy container does not include the opener policy.
+        // The initial document's opener policy is initialized separately below.
+        setCrossOriginOpenerPolicy({ });
+    }
     CheckedPtr contentSecurityPolicy = this->contentSecurityPolicy();
     if (!initialDocumentCreator)
         contentSecurityPolicy->copyStateFrom(protect(ownerDocument->contentSecurityPolicy()).get());

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -722,13 +722,7 @@ Document::Document(LocalFrame* frame, const Settings& settings, const URL& url, 
     setEventTargetFlag(EventTargetFlag::IsConnected);
     addToDocumentsMap();
 
-    // We depend on the url getting immediately set in subframes, but we
-    // also depend on the url NOT getting immediately set in opened windows.
-    // See fast/dom/early-frame-url.html
-    // and fast/dom/location-new-window-no-crash.html, respectively.
-    // FIXME: Can/should we unify this behavior?
-    if ((frame && frame->ownerElement()) || !url.isEmpty())
-        setURL(URL { url });
+    setURL(URL { url });
 
     if (!frame)
         setUsesNullCustomElementRegistry();
@@ -2050,8 +2044,7 @@ void Document::setReadyState(ReadyState readyState)
             if (auto* eventTiming = documentEventTimingFromNavigationTiming())
                 eventTiming->domLoading = now;
             // We do this here instead of in the Document constructor because monotonicTimestamp() is 0 when the Document constructor is running.
-            if (!url().isEmpty())
-                WTFBeginSignpostWithTimeDelta(this, NavigationAndPaintTiming, -Seconds(monotonicTimestamp()), "Loading %" PRIVATE_LOG_STRING " | isMainFrame: %d", url().string().utf8().data(), frame() && frame()->isMainFrame());
+            WTFBeginSignpostWithTimeDelta(this, NavigationAndPaintTiming, -Seconds(monotonicTimestamp()), "Loading %" PRIVATE_LOG_STRING " | isMainFrame: %d", url().string().utf8().data(), frame() && frame()->isMainFrame());
             WTFEmitSignpost(this, NavigationAndPaintTiming, "domLoading");
         }
         break;
@@ -4705,7 +4698,7 @@ void Document::setURL(URL&& url)
 const URL& Document::urlForBindings()
 {
     auto shouldAdjustURL = [this] {
-        if (m_url.url().isEmpty() || !loader() || !isTopDocument() || !frame())
+        if (!loader() || !isTopDocument() || !frame())
             return false;
 
         Ref protectedThis { *this };
@@ -4776,7 +4769,7 @@ const URL& Document::urlForBindings()
     if (shouldAdjustURL)
         return m_adjustedURL;
 
-    return m_url.url().isEmpty() ? aboutBlankURL() : m_url.url();
+    return m_url.url();
 }
 
 URL Document::adjustedURL() const
@@ -5839,7 +5832,7 @@ Ref<Document> Document::createCloned(ClonedDocumentType clonedDocumentType, cons
         RELEASE_ASSERT_NOT_REACHED();
     } ();
 
-    ASSERT(clone->m_url == url);
+    ASSERT(clone->m_url == (url.isEmpty() ? aboutBlankURL() : url));
     clone->m_baseURL = baseURL;
     clone->m_aboutBaseURL = aboutBaseURL;
     clone->m_baseURLOverride = baseURLOverride;

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -470,7 +470,7 @@ public:
     inline static Ref<Document> create(const Settings&, const URL&);
     static Ref<Document> createNonRenderedPlaceholder(LocalFrame&, const URL&);
     static Ref<Document> create(Document&);
-    static Ref<Document> createCloned(ClonedDocumentType, const Settings&, const URL&, const URL& baseURL, const URL& baseURLOverride, const Variant<String, URL>& documentURI, DocumentCompatibilityMode, Document& contextDocument, SecurityOriginPolicy*, const String& contentType, TextResourceDecoder*);
+    static Ref<Document> createCloned(ClonedDocumentType, const Settings&, const URL&, const URL& baseURL, const URL& aboutBaseURL, const URL& baseURLOverride, const Variant<String, URL>& documentURI, DocumentCompatibilityMode, Document& contextDocument, SecurityOriginPolicy*, const String& contentType, TextResourceDecoder*);
 
     virtual ~Document();
 
@@ -898,6 +898,7 @@ public:
     // To understand how these concepts relate to one another, please see the
     // comments surrounding their declaration.
     const URL& baseURL() const LIFETIME_BOUND { return m_baseURL; }
+    void setAboutBaseURL(const URL&);
     void setBaseURLOverride(const URL&);
     const URL& baseURLOverride() const LIFETIME_BOUND { return m_baseURLOverride; }
     const URL& baseElementURL() const LIFETIME_BOUND { return m_baseElementURL; }
@@ -2326,6 +2327,7 @@ private:
     URLKeepingBlobAlive m_url; // Document.URL: The URL from which this document was retrieved.
     URL m_creationURL; // https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-creation-url.
     URL m_baseURL; // Node.baseURI: The URL to use when resolving relative URLs.
+    URL m_aboutBaseURL; // The creator document's base URL, used by about:-schemed documents.
     URL m_baseURLOverride; // An alternative base URL that takes precedence over m_baseURL (but not m_baseElementURL).
     URL m_baseElementURL; // The URL set by the <base> element.
     URL m_cookieURL; // The URL to use for cookie access.

--- a/Source/WebCore/dom/SerializedNode.cpp
+++ b/Source/WebCore/dom/SerializedNode.cpp
@@ -103,6 +103,7 @@ Ref<Node> SerializedNode::deserialize(SerializedNode&& serializedNode, WebCore::
             document.settings(),
             serializedDocument.url,
             serializedDocument.baseURL,
+            serializedDocument.aboutBaseURL,
             serializedDocument.baseURLOverride,
             serializedDocument.documentURI,
             document.compatibilityMode(),

--- a/Source/WebCore/dom/SerializedNode.h
+++ b/Source/WebCore/dom/SerializedNode.h
@@ -69,6 +69,7 @@ struct SerializedNode {
         ClonedDocumentType type;
         URL url;
         URL baseURL;
+        URL aboutBaseURL;
         URL baseURLOverride;
         Variant<String, URL> documentURI;
         String contentType;

--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -1337,8 +1337,10 @@ void DocumentLoader::commitData(const SharedBuffer& data)
             document->securityOrigin().grantLoadLocalResources();
         }
 
-        if (frameLoader()->stateMachine().creatingInitialEmptyDocument())
+        if (frameLoader()->stateMachine().creatingInitialEmptyDocument()) {
+            m_writer.setEncoding(response().textEncodingName(), DocumentWriter::IsEncodingUserChosen::No);
             return;
+        }
 
 #if ENABLE(WEB_ARCHIVE) || ENABLE(MHTML)
         if (RefPtr archive = m_archive; archive && archive->shouldOverrideBaseURL())

--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -1650,7 +1650,7 @@ void DocumentLoader::loadApplicationManifest(CompletionHandler<void(const std::o
     if (!document->isTopDocument())
         return;
 
-    if (document->url().isEmpty() || document->url().protocolIsAbout())
+    if (document->url().protocolIsAbout())
         return;
 
     RefPtr head = document->head();
@@ -2485,7 +2485,7 @@ void DocumentLoader::startIconLoading()
     if (!m_frame->isMainFrame())
         return;
 
-    if (document->url().isEmpty() || document->url().protocolIsAbout())
+    if (document->url().protocolIsAbout())
         return;
 
     m_linkIcons = LinkIconCollector { *document }.iconsOfTypes({ LinkIconType::Favicon, LinkIconType::TouchIcon, LinkIconType::TouchPrecomposedIcon });

--- a/Source/WebCore/loader/EmptyClients.cpp
+++ b/Source/WebCore/loader/EmptyClients.cpp
@@ -616,7 +616,7 @@ class EmptyVisitedLinkStore final : public VisitedLinkStore {
     void NODELETE addVisitedLink(Page&, SharedStringHash) final { }
 };
 
-RefPtr<Page> EmptyChromeClient::createWindow(LocalFrame&, const String&, const WindowFeatures&, const NavigationAction&)
+RefPtr<Page> EmptyChromeClient::createWindow(LocalFrame&, Document*, const String&, const WindowFeatures&, const NavigationAction&)
 {
     return nullptr;
 }
@@ -1303,7 +1303,8 @@ PageConfiguration pageConfigurationWithEmptyClients(std::optional<PageIdentifier
                 return makeUniqueRefWithoutRefCountedCheck<EmptyFrameLoaderClient>(frameLoader);
             } },
             SandboxFlags::all(),
-            ReferrerPolicy::EmptyString
+            ReferrerPolicy::EmptyString,
+            nullptr
         },
         generateFrameIdentifier(),
         nullptr,

--- a/Source/WebCore/loader/EmptyClients.h
+++ b/Source/WebCore/loader/EmptyClients.h
@@ -77,7 +77,7 @@ class EmptyChromeClient : public ChromeClient {
     void focusedElementChanged(Element*, LocalFrame*, FocusOptions, BroadcastFocusedElement) final { }
     void focusedFrameChanged(Frame*) final { }
 
-    RefPtr<Page> createWindow(LocalFrame&, const String&, const WindowFeatures&, const NavigationAction&) final;
+    RefPtr<Page> createWindow(LocalFrame&, Document*, const String&, const WindowFeatures&, const NavigationAction&) final;
     void show() final { }
 
     bool canRunModal() const final { return false; }

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -379,7 +379,7 @@ private:
     bool m_inProgress { false };
 };
 
-FrameLoader::FrameLoader(LocalFrame& frame, CompletionHandler<UniqueRef<LocalFrameLoaderClient>(LocalFrame&, FrameLoader&)>&& clientCreator)
+FrameLoader::FrameLoader(LocalFrame& frame, CompletionHandler<UniqueRef<LocalFrameLoaderClient>(LocalFrame&, FrameLoader&)>&& clientCreator, RefPtr<Document>&& initialDocumentCreator)
     : m_frame(frame)
     , m_client(clientCreator(frame, *this))
     , m_policyChecker(makeUniqueRef<PolicyChecker>(frame))
@@ -390,6 +390,7 @@ FrameLoader::FrameLoader(LocalFrame& frame, CompletionHandler<UniqueRef<LocalFra
     , m_loadType(FrameLoadType::Standard)
     , m_checkTimer(*this, &FrameLoader::checkTimerFired)
     , m_crossOriginParentSyntheticSameDocLoadEventTimer(*this, &FrameLoader::crossOriginParentSyntheticSameDocLoadEventTimerFired)
+    , m_initialDocumentCreator(WTF::move(initialDocumentCreator))
     , m_documentPrefetcher(DocumentPrefetcher::create(frame))
 {
 }
@@ -425,6 +426,7 @@ void FrameLoader::init()
     setPolicyDocumentLoader(m_client->createDocumentLoader(ResourceRequest(URL({ }, emptyString())), SubstituteData()));
     setProvisionalDocumentLoader(m_policyDocumentLoader.copyRef());
     protect(m_provisionalDocumentLoader)->startLoadingMainResource();
+    m_initialDocumentCreator = nullptr;
     setPolicyDocumentLoader(nullptr);
 
     Ref frame = m_frame.get();
@@ -5075,7 +5077,7 @@ std::pair<RefPtr<Frame>, CreatedNewPage> createWindow(LocalFrame& openerFrame, F
     NavigationAction action { request, NavigationType::Other };
     action.setShouldOpenExternalURLsPolicy(shouldOpenExternalURLsPolicy);
     action.setNewFrameOpenerPolicy(features.wantsNoOpener() ? NewFrameOpenerPolicy::Suppress : NewFrameOpenerPolicy::Allow);
-    RefPtr page = oldPage->chrome().createWindow(openerFrame, openedMainFrameName, features, action);
+    RefPtr page = oldPage->chrome().createWindow(openerFrame, features.wantsNoOpener() ? nullptr : &request.requester(), openedMainFrameName, features, action);
     if (!page)
         return { nullptr, CreatedNewPage::No };
 

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -3185,9 +3185,13 @@ void FrameLoader::setOriginalURLForDownloadRequest(ResourceRequest& request)
     URL originalURL;
     RefPtr initiator = m_frame->document();
     if (initiator) {
-        originalURL = initiator->firstPartyForCookies();
-        // If there is no main document URL, it means that this document is newly opened and just for download purpose.
-        // In this case, we need to set the originalURL to this document's opener's main document URL.
+        // Initial top-level documents used to have an empty URL. Preserve the empty original URL used for direct
+        // downloads now that such documents have an explicit about:blank URL.
+        if (!m_frame->isMainFrame() || !m_stateMachine.isDisplayingInitialEmptyDocument())
+            originalURL = initiator->firstPartyForCookies();
+
+        // If there is no main document URL, this document was newly opened just for the download.
+        // In this case, use the opener's main document URL when an opener is available.
         if (originalURL.isEmpty()) {
             if (RefPtr localOpener = dynamicDowncast<LocalFrame>(m_frame->opener()); localOpener && localOpener->document()) {
                 originalURL = localOpener->document()->firstPartyForCookies();

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -423,7 +423,10 @@ LocalFrame& FrameLoader::frame() const
 void FrameLoader::init()
 {
     // This somewhat odd set of steps gives the frame an initial empty document.
-    setPolicyDocumentLoader(m_client->createDocumentLoader(ResourceRequest(URL({ }, emptyString())), SubstituteData()));
+    ResourceRequest initialRequest { URL({ }, emptyString()) };
+    initialRequest.setIsSameSite(true);
+    initialRequest.setIsTopSite(m_frame->isMainFrame());
+    setPolicyDocumentLoader(m_client->createDocumentLoader(WTF::move(initialRequest), SubstituteData()));
     setProvisionalDocumentLoader(m_policyDocumentLoader.copyRef());
     protect(m_provisionalDocumentLoader)->startLoadingMainResource();
     m_initialDocumentCreator = nullptr;

--- a/Source/WebCore/loader/FrameLoader.h
+++ b/Source/WebCore/loader/FrameLoader.h
@@ -112,7 +112,7 @@ class FrameLoader final : public CanMakeWeakPtr<FrameLoader> {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(FrameLoader, Loader);
     friend class PolicyChecker;
 public:
-    FrameLoader(LocalFrame&, CompletionHandler<UniqueRef<LocalFrameLoaderClient>(LocalFrame&, FrameLoader&)>&& clientCreator);
+    FrameLoader(LocalFrame&, CompletionHandler<UniqueRef<LocalFrameLoaderClient>(LocalFrame&, FrameLoader&)>&& clientCreator, RefPtr<Document>&& initialDocumentCreator);
     ~FrameLoader();
 
     WEBCORE_EXPORT void NODELETE ref() const;
@@ -122,6 +122,7 @@ public:
     void initForSynthesizedDocument(const URL&);
 
     WEBCORE_EXPORT LocalFrame& NODELETE frame() const;
+    Document* initialDocumentCreator() const { return m_initialDocumentCreator.get(); }
 
     PolicyChecker& policyChecker() const { return m_policyChecker; }
 
@@ -564,6 +565,7 @@ private:
 
     URL m_previousURL;
     RefPtr<HistoryItem> m_requestedHistoryItem;
+    RefPtr<Document> m_initialDocumentCreator;
 
     enum class AsyncBackForwardNavigationState : uint8_t { None, Pending, Cancelled };
     AsyncBackForwardNavigationState m_asyncBackForwardNavigationState { AsyncBackForwardNavigationState::None };

--- a/Source/WebCore/loader/HistoryController.cpp
+++ b/Source/WebCore/loader/HistoryController.cpp
@@ -597,7 +597,7 @@ void HistoryController::updateForStandardLoad(HistoryUpdateType updateType)
         if (RefPtr page = m_frame->page())
             addVisitedLink(*page, historyURL);
 
-        if (!documentLoader->didCreateGlobalHistoryEntry() && documentLoader->unreachableURL().isEmpty() && !protect(m_frame->document())->url().isEmpty())
+        if (!documentLoader->didCreateGlobalHistoryEntry() && documentLoader->unreachableURL().isEmpty())
             protect(frameLoader->client())->updateGlobalHistoryRedirectLinks();
     }
 }
@@ -757,9 +757,6 @@ void HistoryController::recursiveUpdateForCommit()
 void HistoryController::updateForSameDocumentNavigation()
 {
     Ref frame = m_frame.get();
-    if (protect(frame->document())->url().isEmpty())
-        return;
-
     RefPtr page = frame->page();
     if (!page)
         return;
@@ -828,7 +825,7 @@ bool HistoryController::currentItemShouldBeReplaced() const
     //   and that was the about:blank Document created when the browsing context
     //   was created, then the navigation must be done with replacement enabled."
     RefPtr currentItem = m_currentItem;
-    return currentItem && !m_previousItem && equalIgnoringASCIICase(currentItem->urlString(), aboutBlankURL().string());
+    return currentItem && !m_previousItem && currentItem->isInitialAboutBlank() == IsInitialAboutBlank::Yes;
 }
 
 void HistoryController::clearPreviousItem()

--- a/Source/WebCore/loader/cache/CachedResourceLoader.cpp
+++ b/Source/WebCore/loader/cache/CachedResourceLoader.cpp
@@ -773,7 +773,8 @@ static bool shouldPerformHTTPSUpgrade(const URL& originalURL, const URL& newURL,
     if (!frame.isMainFrame() || type != CachedResource::Type::MainResource)
         return false;
 
-    bool isSameSiteNavigation = (originalURL.isEmpty() || RegistrableDomain(newURL) == RegistrableDomain(originalURL));
+    bool isSameSiteNavigation = frame.loader().stateMachine().isDisplayingInitialEmptyDocument()
+        || RegistrableDomain(newURL) == RegistrableDomain(originalURL);
     const bool isSameSiteBypassEnabled =
         isSameSiteNavigation
         && (advancedPrivacyProtections.contains(AdvancedPrivacyProtections::HTTPSOnlyExplicitlyBypassedForDomain) || frame.loader().shouldNavigateWithHTTP(isSameSiteNavigation) || originalURL.protocolIs("http"_s));

--- a/Source/WebCore/page/Chrome.cpp
+++ b/Source/WebCore/page/Chrome.cpp
@@ -224,9 +224,9 @@ void Chrome::focusedFrameChanged(Frame* frame)
     m_client->focusedFrameChanged(frame);
 }
 
-RefPtr<Page> Chrome::createWindow(LocalFrame& frame, const String& openedMainFrameName, const WindowFeatures& features, const NavigationAction& action)
+RefPtr<Page> Chrome::createWindow(LocalFrame& frame, Document* creator, const String& openedMainFrameName, const WindowFeatures& features, const NavigationAction& action)
 {
-    RefPtr newPage = m_client->createWindow(frame, openedMainFrameName, features, action);
+    RefPtr newPage = m_client->createWindow(frame, creator, openedMainFrameName, features, action);
     if (!newPage)
         return nullptr;
 

--- a/Source/WebCore/page/Chrome.h
+++ b/Source/WebCore/page/Chrome.h
@@ -67,6 +67,7 @@ class DataListSuggestionPicker;
 class DataListSuggestionsClient;
 class DateTimeChooser;
 class DateTimeChooserClient;
+class Document;
 class FileChooser;
 class FileIconLoader;
 class FloatRect;
@@ -172,7 +173,7 @@ public:
     void focusedElementChanged(Element*, LocalFrame*, FocusOptions, BroadcastFocusedElement);
     void focusedFrameChanged(Frame*);
 
-    WEBCORE_EXPORT RefPtr<Page> createWindow(LocalFrame&, const String& openedMainFrameName, const WindowFeatures&, const NavigationAction&);
+    WEBCORE_EXPORT RefPtr<Page> createWindow(LocalFrame&, Document* creator, const String& openedMainFrameName, const WindowFeatures&, const NavigationAction&);
     WEBCORE_EXPORT void show();
 
     bool canRunModal() const;

--- a/Source/WebCore/page/ChromeClient.h
+++ b/Source/WebCore/page/ChromeClient.h
@@ -99,6 +99,7 @@ class DataListSuggestionsClient;
 class DateTimeChooser;
 class DateTimeChooserClient;
 class DisplayRefreshMonitorFactory;
+class Document;
 class Element;
 class FileChooser;
 class FileIconLoader;
@@ -249,7 +250,7 @@ public:
     // should not be shown to the user until the ChromeClient of the newly
     // created Page has its show method called.
     // The ChromeClient should not load the request.
-    virtual RefPtr<Page> createWindow(LocalFrame&, const String& openedMainFrameName, const WindowFeatures&, const NavigationAction&) = 0;
+    virtual RefPtr<Page> createWindow(LocalFrame&, Document* creator, const String& openedMainFrameName, const WindowFeatures&, const NavigationAction&) = 0;
     virtual void show() = 0;
 
     virtual bool canRunModal() const = 0;

--- a/Source/WebCore/page/ContextMenuController.cpp
+++ b/Source/WebCore/page/ContextMenuController.cpp
@@ -280,7 +280,7 @@ static void openNewWindow(const URL& urlToLoad, LocalFrame& frame, Event* event,
     frameLoadRequest.setShouldOpenExternalURLsPolicy(shouldOpenExternalURLsPolicy);
     frameLoadRequest.setNewFrameOpenerPolicy(NewFrameOpenerPolicy::Suppress);
 
-    RefPtr newPage = oldPage->chrome().createWindow(frame, { }, { }, { *protect(frame.document()), frameLoadRequest.resourceRequest(), frameLoadRequest.initiatedByMainFrame(), frameLoadRequest.isRequestFromClientOrUserInput() });
+    RefPtr newPage = oldPage->chrome().createWindow(frame, nullptr, { }, { }, { *protect(frame.document()), frameLoadRequest.resourceRequest(), frameLoadRequest.initiatedByMainFrame(), frameLoadRequest.isRequestFromClientOrUserInput() });
     if (!newPage)
         return;
     newPage->chrome().show();

--- a/Source/WebCore/page/LocalDOMWindow.cpp
+++ b/Source/WebCore/page/LocalDOMWindow.cpp
@@ -2938,7 +2938,10 @@ ExceptionOr<RefPtr<Frame>> LocalDOMWindow::createWindow(const String& urlString,
     if (prepareDialogFunction && localNewFrame)
         prepareDialogFunction(*protect(localNewFrame->document()->window()));
 
-    if (created == CreatedNewPage::Yes) {
+    if (created == CreatedNewPage::Yes && localNewFrame && (completedURL.isEmpty() || completedURL.isAboutBlank())) {
+        if (!completedURL.isEmpty() && completedURL != aboutBlankURL())
+            localNewFrame->loader().updateURLAndHistory(completedURL, nullptr);
+    } else if (created == CreatedNewPage::Yes) {
         ResourceRequest resourceRequest { WTF::move(completedURL), referrer, ResourceRequestCachePolicy::UseProtocolCachePolicy };
         FrameLoader::addSameSiteInfoToRequestIfNeeded(resourceRequest, openerDocument.get());
         FrameLoadRequest frameLoadRequest { protect(activeWindow.document()).releaseNonNull(), protect(protect(activeWindow.document())->securityOrigin()), WTF::move(resourceRequest), selfTargetFrameName(), initiatedByMainFrame };

--- a/Source/WebCore/page/LocalDOMWindow.cpp
+++ b/Source/WebCore/page/LocalDOMWindow.cpp
@@ -2912,8 +2912,6 @@ ExceptionOr<RefPtr<Frame>> LocalDOMWindow::createWindow(const String& urlString,
         return RefPtr<Frame> { nullptr };
 
     RefPtr localNewFrame = dynamicDowncast<LocalFrame>(newFrame);
-    if (created == CreatedNewPage::Yes && localNewFrame && !noopener)
-        protect(localNewFrame->document())->setAboutBaseURL(activeDocument->baseURL());
 
     // https://html.spec.whatwg.org/#the-rules-for-choosing-a-navigable
     // Consume user activation when a new browsing context is created.

--- a/Source/WebCore/page/LocalDOMWindow.cpp
+++ b/Source/WebCore/page/LocalDOMWindow.cpp
@@ -2911,6 +2911,10 @@ ExceptionOr<RefPtr<Frame>> LocalDOMWindow::createWindow(const String& urlString,
     if (!newFrame)
         return RefPtr<Frame> { nullptr };
 
+    RefPtr localNewFrame = dynamicDowncast<LocalFrame>(newFrame);
+    if (created == CreatedNewPage::Yes && localNewFrame && !noopener)
+        protect(localNewFrame->document())->setAboutBaseURL(activeDocument->baseURL());
+
     // https://html.spec.whatwg.org/#the-rules-for-choosing-a-navigable
     // Consume user activation when a new browsing context is created.
     if (created == CreatedNewPage::Yes)
@@ -2934,7 +2938,6 @@ ExceptionOr<RefPtr<Frame>> LocalDOMWindow::createWindow(const String& urlString,
     if (window && window->isInsecureScriptAccess(activeWindow, completedURL))
         return noopener ? RefPtr<Frame> { nullptr } : newFrame;
 
-    RefPtr localNewFrame = dynamicDowncast<LocalFrame>(newFrame);
     if (prepareDialogFunction && localNewFrame)
         prepareDialogFunction(*protect(localNewFrame->document()->window()));
 

--- a/Source/WebCore/page/LocalFrame.cpp
+++ b/Source/WebCore/page/LocalFrame.cpp
@@ -190,9 +190,9 @@ static const LocalFrame& NODELETE rootFrame(const LocalFrame& frame, Frame* pare
     return frame;
 }
 
-LocalFrame::LocalFrame(Page& page, ClientCreator&& clientCreator, FrameIdentifier identifier, SandboxFlags sandboxFlags, ReferrerPolicy referrerPolicy, std::optional<ScrollbarMode> scrollingMode, HTMLFrameOwnerElement* ownerElement, Frame* parent, Frame* opener, Ref<FrameTreeSyncData>&& frameTreeSyncData, AddToFrameTree addToFrameTree)
+LocalFrame::LocalFrame(Page& page, ClientCreator&& clientCreator, FrameIdentifier identifier, SandboxFlags sandboxFlags, ReferrerPolicy referrerPolicy, std::optional<ScrollbarMode> scrollingMode, HTMLFrameOwnerElement* ownerElement, Frame* parent, Frame* opener, RefPtr<Document>&& initialDocumentCreator, Ref<FrameTreeSyncData>&& frameTreeSyncData, AddToFrameTree addToFrameTree)
     : Frame(page, identifier, FrameType::Local, ownerElement, parent, opener, WTF::move(frameTreeSyncData), addToFrameTree)
-    , m_loader(makeUniqueRefWithoutRefCountedCheck<FrameLoader>(*this, WTF::move(clientCreator)))
+    , m_loader(makeUniqueRefWithoutRefCountedCheck<FrameLoader>(*this, WTF::move(clientCreator), WTF::move(initialDocumentCreator)))
     , m_script(makeUniqueRef<ScriptController>(*this))
 #if PLATFORM(IOS_FAMILY)
     , m_viewportArguments(makeUniqueRef<ViewportArguments>())
@@ -232,19 +232,19 @@ void LocalFrame::init()
     loader().init();
 }
 
-Ref<LocalFrame> LocalFrame::createMainFrame(Page& page, ClientCreator&& clientCreator, FrameIdentifier identifier, SandboxFlags effectiveSandboxFlags, ReferrerPolicy effectiveReferrerPolicy, Frame* opener, Ref<FrameTreeSyncData>&& frameTreeSyncData)
+Ref<LocalFrame> LocalFrame::createMainFrame(Page& page, ClientCreator&& clientCreator, FrameIdentifier identifier, SandboxFlags effectiveSandboxFlags, ReferrerPolicy effectiveReferrerPolicy, Frame* opener, RefPtr<Document>&& initialDocumentCreator, Ref<FrameTreeSyncData>&& frameTreeSyncData)
 {
-    return adoptRef(*new LocalFrame(page, WTF::move(clientCreator), identifier, effectiveSandboxFlags, effectiveReferrerPolicy, ScrollbarMode::Auto, nullptr, nullptr, opener, WTF::move(frameTreeSyncData)));
+    return adoptRef(*new LocalFrame(page, WTF::move(clientCreator), identifier, effectiveSandboxFlags, effectiveReferrerPolicy, ScrollbarMode::Auto, nullptr, nullptr, opener, WTF::move(initialDocumentCreator), WTF::move(frameTreeSyncData)));
 }
 
 Ref<LocalFrame> LocalFrame::createSubframe(Page& page, ClientCreator&& clientCreator, FrameIdentifier identifier, SandboxFlags effectiveSandboxFlags, ReferrerPolicy effectiveReferrerPolicy, HTMLFrameOwnerElement& ownerElement, Ref<FrameTreeSyncData>&& frameTreeSyncData)
 {
-    return adoptRef(*new LocalFrame(page, WTF::move(clientCreator), identifier, effectiveSandboxFlags, effectiveReferrerPolicy, std::nullopt, &ownerElement, ownerElement.document().frame(), nullptr, WTF::move(frameTreeSyncData)));
+    return adoptRef(*new LocalFrame(page, WTF::move(clientCreator), identifier, effectiveSandboxFlags, effectiveReferrerPolicy, std::nullopt, &ownerElement, ownerElement.document().frame(), nullptr, nullptr, WTF::move(frameTreeSyncData)));
 }
 
 Ref<LocalFrame> LocalFrame::createProvisionalSubframe(Page& page, ClientCreator&& clientCreator, FrameIdentifier identifier, SandboxFlags effectiveSandboxFlags, ReferrerPolicy effectiveReferrerPolicy, ScrollbarMode scrollingMode, Frame& parent, Ref<FrameTreeSyncData>&& frameTreeSyncData)
 {
-    return adoptRef(*new LocalFrame(page, WTF::move(clientCreator), identifier, effectiveSandboxFlags, effectiveReferrerPolicy, scrollingMode, nullptr, &parent, nullptr, WTF::move(frameTreeSyncData), AddToFrameTree::No));
+    return adoptRef(*new LocalFrame(page, WTF::move(clientCreator), identifier, effectiveSandboxFlags, effectiveReferrerPolicy, scrollingMode, nullptr, &parent, nullptr, nullptr, WTF::move(frameTreeSyncData), AddToFrameTree::No));
 }
 
 LocalFrame::~LocalFrame()

--- a/Source/WebCore/page/LocalFrame.h
+++ b/Source/WebCore/page/LocalFrame.h
@@ -134,7 +134,7 @@ using NodeQualifier = Function<RefPtr<Node> (const HitTestResult&, Node* termina
 class LocalFrame final : public Frame {
 public:
     using ClientCreator = CompletionHandler<UniqueRef<LocalFrameLoaderClient>(LocalFrame&, FrameLoader&)>;
-    WEBCORE_EXPORT static Ref<LocalFrame> createMainFrame(Page&, ClientCreator&&, FrameIdentifier, SandboxFlags, ReferrerPolicy, Frame* opener, Ref<FrameTreeSyncData>&&);
+    WEBCORE_EXPORT static Ref<LocalFrame> createMainFrame(Page&, ClientCreator&&, FrameIdentifier, SandboxFlags, ReferrerPolicy, Frame* opener, RefPtr<Document>&& initialDocumentCreator, Ref<FrameTreeSyncData>&&);
     WEBCORE_EXPORT static Ref<LocalFrame> createSubframe(Page&, ClientCreator&&, FrameIdentifier, SandboxFlags, ReferrerPolicy, HTMLFrameOwnerElement&, Ref<FrameTreeSyncData>&&);
     WEBCORE_EXPORT static Ref<LocalFrame> createProvisionalSubframe(Page&, ClientCreator&&, FrameIdentifier, SandboxFlags, ReferrerPolicy, ScrollbarMode, Frame& parent, Ref<FrameTreeSyncData>&&);
 
@@ -374,7 +374,7 @@ protected:
 private:
     friend class NavigationDisabler;
 
-    LocalFrame(Page&, ClientCreator&&, FrameIdentifier, SandboxFlags, ReferrerPolicy, std::optional<ScrollbarMode>, HTMLFrameOwnerElement*, Frame* parent, Frame* opener, Ref<FrameTreeSyncData>&&, AddToFrameTree = AddToFrameTree::Yes);
+    LocalFrame(Page&, ClientCreator&&, FrameIdentifier, SandboxFlags, ReferrerPolicy, std::optional<ScrollbarMode>, HTMLFrameOwnerElement*, Frame* parent, Frame* opener, RefPtr<Document>&& initialDocumentCreator, Ref<FrameTreeSyncData>&&, AddToFrameTree = AddToFrameTree::Yes);
 
     void dropChildren();
 

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -5707,7 +5707,7 @@ void LocalFrameView::updateControlTints()
     // to define when controls get the tint and to call this function when that changes.
     
     // Optimize the common case where we bring a window to the front while it's still empty.
-    if (protect(m_frame->document())->url().isEmpty())
+    if (m_frame->loader().stateMachine().isDisplayingInitialEmptyDocument())
         return;
 
     // As noted above, this is a "fake" paint, so we should pause counting relevant repainted objects.

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -366,7 +366,7 @@ GCC_MAYBE_NO_INLINE static Ref<Frame> createMainFrame(Page& page, PageConfigurat
 {
     page.relaxAdoptionRequirement();
     return switchOn(WTF::move(clientCreator), [&] (PageConfiguration::LocalMainFrameCreationParameters&& creationParameters) -> Ref<Frame> {
-        return LocalFrame::createMainFrame(page, WTF::move(creationParameters.clientCreator), identifier, creationParameters.effectiveSandboxFlags, creationParameters.effectiveReferrerPolicy, mainFrameOpener.get(), WTF::move(frameTreeSyncData));
+        return LocalFrame::createMainFrame(page, WTF::move(creationParameters.clientCreator), identifier, creationParameters.effectiveSandboxFlags, creationParameters.effectiveReferrerPolicy, mainFrameOpener.get(), WTF::move(creationParameters.initialDocumentCreator), WTF::move(frameTreeSyncData));
     }, [&] (CompletionHandler<UniqueRef<RemoteFrameClient>(RemoteFrame&)>&& remoteFrameClientCreator) -> Ref<Frame> {
         return RemoteFrame::createMainFrame(page, WTF::move(remoteFrameClientCreator), identifier, mainFrameOpener.get(), WTF::move(frameTreeSyncData));
     });

--- a/Source/WebCore/page/PageConfiguration.cpp
+++ b/Source/WebCore/page/PageConfiguration.cpp
@@ -38,6 +38,7 @@
 #include "CryptoClient.h"
 #include "DatabaseProvider.h"
 #include "DiagnosticLoggingClient.h"
+#include "Document.h"
 #include "DocumentSyncClient.h"
 #include "DragClient.h"
 #include "EditorClient.h"

--- a/Source/WebCore/page/PageConfiguration.h
+++ b/Source/WebCore/page/PageConfiguration.h
@@ -75,6 +75,7 @@ class CredentialRequestCoordinatorClient;
 class CryptoClient;
 class DatabaseProvider;
 class DiagnosticLoggingClient;
+class Document;
 class DragClient;
 class EditorClient;
 class Frame;
@@ -116,6 +117,7 @@ public:
         CompletionHandler<UniqueRef<LocalFrameLoaderClient>(LocalFrame&, FrameLoader&)> clientCreator;
         SandboxFlags effectiveSandboxFlags;
         ReferrerPolicy effectiveReferrerPolicy { ReferrerPolicy::EmptyString };
+        RefPtr<Document> initialDocumentCreator;
     };
     using MainFrameCreationParameters = Variant<LocalMainFrameCreationParameters, CompletionHandler<UniqueRef<RemoteFrameClient>(RemoteFrame&)>>;
 

--- a/Source/WebKit/Shared/SerializedNode.serialization.in
+++ b/Source/WebKit/Shared/SerializedNode.serialization.in
@@ -39,6 +39,7 @@
     WebCore::ClonedDocumentType type;
     URL url;
     URL baseURL;
+    URL aboutBaseURL;
     URL baseURLOverride;
     Variant<String, URL> documentURI;
     String contentType;

--- a/Source/WebKit/Shared/WebPageCreationParameters.h
+++ b/Source/WebKit/Shared/WebPageCreationParameters.h
@@ -114,6 +114,7 @@ struct WebPageCreationParameters {
     WebCore::IntSize viewSize { };
 
     OptionSet<WebCore::ActivityState> activityState { };
+    uint64_t activityStateChangeSequence { };
     
     WebPreferencesStore store { };
 #if ENABLE(TILED_CA_DRAWING_AREA)

--- a/Source/WebKit/Shared/WebPageCreationParameters.serialization.in
+++ b/Source/WebKit/Shared/WebPageCreationParameters.serialization.in
@@ -28,6 +28,7 @@ enum class WebCore::UserInterfaceLayoutDirection : bool;
     WebCore::IntSize viewSize;
 
     OptionSet<WebCore::ActivityState> activityState;
+    uint64_t activityStateChangeSequence;
 
     WebKit::WebPreferencesStore store;
 #if ENABLE(TILED_CA_DRAWING_AREA)

--- a/Source/WebKit/UIProcess/PageLoadState.cpp
+++ b/Source/WebKit/UIProcess/PageLoadState.cpp
@@ -350,7 +350,8 @@ void PageLoadState::didFailLoad(const Transaction::Token& token)
 void PageLoadState::didSameDocumentNavigation(const Transaction::Token& token, const URL& url)
 {
     ASSERT_UNUSED(token, &token.m_pageLoadState == this);
-    ASSERT(!m_uncommittedState.url.isEmpty());
+    // The initial empty document does not commit a load in the UI process, but its URL can be updated in place.
+    ASSERT(!m_uncommittedState.url.isEmpty() || url.isAboutBlank());
 
     m_uncommittedState.url = url;
 }

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -3664,12 +3664,13 @@ void WebPageProxy::dispatchActivityStateChange()
     auto activityStateChangeID = m_activityStateChangeWantsSynchronousReply ? takeNextActivityStateChangeID() : static_cast<ActivityStateChangeID>(ActivityStateChangeAsynchronous);
 
     if (changed || activityStateChangeID != ActivityStateChangeAsynchronous || !m_nextActivityStateChangeCallbacks.isEmpty()) {
+        auto activityStateChangeSequence = ++internals().activityStateChangeSequence;
         auto callbackAggregator = CallbackAggregator::create([callbacks = std::exchange(m_nextActivityStateChangeCallbacks, { })] () mutable {
             for (auto& callback : callbacks)
                 callback();
         });
         forEachWebContentProcess([&](auto& webProcess, auto pageID) {
-            webProcess.sendWithAsyncReply(Messages::WebPage::SetActivityState(internals().activityState, activityStateChangeID), [callbackAggregator] { }, pageID);
+            webProcess.sendWithAsyncReply(Messages::WebPage::SetActivityState(internals().activityState, activityStateChangeID, activityStateChangeSequence), [callbackAggregator] { }, pageID);
         });
     }
 
@@ -14112,6 +14113,7 @@ WebPageCreationParameters WebPageProxy::creationParameters(WebProcessProxy& proc
     parameters.windowFeatures = m_configuration->windowFeatures();
     parameters.viewSize = pageClient ? pageClient->viewSize() : WebCore::IntSize { };
     parameters.activityState = internals().activityState;
+    parameters.activityStateChangeSequence = internals().activityStateChangeSequence;
 #if ENABLE(TILED_CA_DRAWING_AREA)
     parameters.drawingAreaType = drawingArea.type();
 #endif

--- a/Source/WebKit/UIProcess/WebPageProxyInternals.h
+++ b/Source/WebKit/UIProcess/WebPageProxyInternals.h
@@ -221,6 +221,7 @@ public:
 
     WeakRef<WebPageProxy> page;
     OptionSet<WebCore::ActivityState> activityState;
+    uint64_t activityStateChangeSequence { };
     RunLoop::Timer audibleActivityTimer;
     std::optional<WebCore::Color> backgroundColor;
     WebCore::LayoutSize baseLayoutViewportSize;

--- a/Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.cpp
+++ b/Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.cpp
@@ -183,7 +183,8 @@ void WebSWContextManagerConnection::installServiceWorker(ServiceWorkerContextDat
                     client->setServiceWorkerPageIdentifier(*serviceWorkerPageIdentifier);
                 return client;
             } }, SandboxFlags { },
-            ReferrerPolicy::EmptyString
+            ReferrerPolicy::EmptyString,
+            nullptr
         };
 
         [[maybe_unused]] auto serviceWorkerIdentifier = contextData.serviceWorkerIdentifier;

--- a/Source/WebKit/WebProcess/Storage/WebSharedWorkerContextManagerConnection.cpp
+++ b/Source/WebKit/WebProcess/Storage/WebSharedWorkerContextManagerConnection.cpp
@@ -45,6 +45,7 @@
 #include "WebStorageProvider.h"
 #include "WebUserContentController.h"
 #include "WebWorkerClient.h"
+#include <WebCore/Document.h>
 #include <WebCore/EmptyClients.h>
 #include <WebCore/Page.h>
 #include <WebCore/PageConfiguration.h>

--- a/Source/WebKit/WebProcess/Storage/WebSharedWorkerContextManagerConnection.cpp
+++ b/Source/WebKit/WebProcess/Storage/WebSharedWorkerContextManagerConnection.cpp
@@ -120,7 +120,7 @@ void WebSharedWorkerContextManagerConnection::launchSharedWorker(WebCore::Client
 
     pageConfiguration.mainFrameCreationParameters = WebCore::PageConfiguration::LocalMainFrameCreationParameters { CompletionHandler<UniqueRef<WebCore::LocalFrameLoaderClient>(WebCore::LocalFrame&, WebCore::FrameLoader&)> { [webPageProxyID = m_webPageProxyID, pageID = m_pageID, userAgent = m_userAgent] (auto&, auto& frameLoader) mutable {
         return makeUniqueRefWithoutRefCountedCheck<RemoteWorkerFrameLoaderClient>(frameLoader, webPageProxyID, pageID, userAgent);
-    } }, WebCore::SandboxFlags { }, WebCore::ReferrerPolicy::EmptyString };
+    } }, WebCore::SandboxFlags { }, WebCore::ReferrerPolicy::EmptyString, nullptr };
 
     Ref page = WebCore::Page::create(WTF::move(pageConfiguration));
     if (m_preferencesStore) {

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -378,7 +378,7 @@ void WebChromeClient::focusedFrameChanged(Frame* frame)
     protect(WebProcess::singleton().parentProcessConnection())->send(Messages::WebPageProxy::FocusedFrameChanged(webFrame ? std::make_optional(webFrame->frameID()) : std::nullopt), m_page->identifier());
 }
 
-RefPtr<Page> WebChromeClient::createWindow(LocalFrame& frame, const String& openedMainFrameName, const WindowFeatures& windowFeatures, const NavigationAction& navigationAction)
+RefPtr<Page> WebChromeClient::createWindow(LocalFrame& frame, Document* creator, const String& openedMainFrameName, const WindowFeatures& windowFeatures, const NavigationAction& navigationAction)
 {
 #if ENABLE(FULLSCREEN_API)
     if (RefPtr document = frame.document())
@@ -452,7 +452,7 @@ RefPtr<Page> WebChromeClient::createWindow(LocalFrame& frame, const String& open
     parameters->oldPageID = page->identifier();
     parameters->isPopup = windowFeatures.wantsPopup();
 
-    webProcess.createWebPage(*newPageID, WTF::move(*parameters));
+    webProcess.createWebPageWithInitialDocumentCreator(*newPageID, WTF::move(*parameters), creator);
     return webProcess.webPage(*newPageID)->corePage();
 }
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
@@ -91,7 +91,7 @@ private:
     // Frame wants to create the new Page.  Also, the newly created window
     // should not be shown to the user until the ChromeClient of the newly
     // created Page has its show method called.
-    RefPtr<WebCore::Page> createWindow(WebCore::LocalFrame&, const String& openedMainFrameName, const WebCore::WindowFeatures&, const WebCore::NavigationAction&) final;
+    RefPtr<WebCore::Page> createWindow(WebCore::LocalFrame&, WebCore::Document* creator, const String& openedMainFrameName, const WebCore::WindowFeatures&, const WebCore::NavigationAction&) final;
     void show() final;
     
     bool canRunModal() const final;

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
@@ -952,7 +952,8 @@ LocalFrame* WebLocalFrameLoaderClient::dispatchCreatePage(const NavigationAction
     WindowFeatures windowFeatures;
     windowFeatures.noopener = newFrameOpenerPolicy == NewFrameOpenerPolicy::Suppress;
 
-    RefPtr newPage = webPage->corePage()->chrome().createWindow(protect(m_localFrame), openedMainFrameName, windowFeatures, navigationAction);
+    RefPtr creator = newFrameOpenerPolicy == NewFrameOpenerPolicy::Suppress ? nullptr : m_localFrame->document();
+    RefPtr newPage = webPage->corePage()->chrome().createWindow(protect(m_localFrame), creator.get(), openedMainFrameName, windowFeatures, navigationAction);
     if (!newPage)
         return nullptr;
     

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -306,6 +306,9 @@ FrameInfoData WebFrame::info(WithCertificateInfo withCertificateInfo) const
     RefPtr document = coreLocalFrame ? coreLocalFrame->document() : nullptr;
     RefPtr page = m_page.get();
     RefPtr loadingFrame = m_provisionalFrame ? m_provisionalFrame : coreLocalFrame;
+    URL frameURL = url();
+    if (frameURL.isEmpty() && document)
+        frameURL = document->url();
 
     WebFrameMetrics metrics;
     FrameType frameType = FrameType::Local;
@@ -325,7 +328,7 @@ FrameInfoData WebFrame::info(WithCertificateInfo withCertificateInfo) const
         isMainFrame(),
         frameType,
         // FIXME: This should use the full request.
-        ResourceRequest(url()),
+        ResourceRequest(WTF::move(frameURL)),
         coreFrame ? SecurityOriginData::fromFrame(*coreFrame) : SecurityOriginData { },
         coreFrame ? coreFrame->topOrigin().data() : SecurityOriginData { },
         coreFrame ? coreFrame->tree().specifiedName().string() : String(),

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -482,7 +482,7 @@ void WebFrame::createProvisionalFrame(ProvisionalFrameCreationParameters&& param
     auto clientCreator = [this, protectedThis = Ref { *this }] (auto& localFrame, auto& frameLoader) mutable {
         return makeUniqueRefWithoutRefCountedCheck<WebLocalFrameLoaderClient>(localFrame, frameLoader, WTF::move(protectedThis), makeInvalidator());
     };
-    auto localFrame = parent ? LocalFrame::createProvisionalSubframe(*corePage, WTF::move(clientCreator), m_frameID, parameters.effectiveSandboxFlags, parameters.effectiveReferrerPolicy, parameters.scrollingMode, *parent, Ref { remoteFrame->frameTreeSyncData() }) : LocalFrame::createMainFrame(*corePage, WTF::move(clientCreator), m_frameID, parameters.effectiveSandboxFlags, parameters.effectiveReferrerPolicy, nullptr, Ref { remoteFrame->frameTreeSyncData() });
+    auto localFrame = parent ? LocalFrame::createProvisionalSubframe(*corePage, WTF::move(clientCreator), m_frameID, parameters.effectiveSandboxFlags, parameters.effectiveReferrerPolicy, parameters.scrollingMode, *parent, Ref { remoteFrame->frameTreeSyncData() }) : LocalFrame::createMainFrame(*corePage, WTF::move(clientCreator), m_frameID, parameters.effectiveSandboxFlags, parameters.effectiveReferrerPolicy, nullptr, nullptr, Ref { remoteFrame->frameTreeSyncData() });
     ASSERT(!m_provisionalFrame);
     m_provisionalFrame = localFrame.ptr();
     m_frameIDBeforeProvisionalNavigation = parameters.frameIDBeforeProvisionalNavigation;

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -719,6 +719,7 @@ WebPage::WebPage(PageIdentifier pageID, WebPageCreationParameters&& parameters, 
 #endif
     , m_layerVolatilityTimer(*this, &WebPage::layerVolatilityTimerFired)
     , m_activityState(parameters.activityState)
+    , m_activityStateChangeSequence(parameters.activityStateChangeSequence)
     , m_userInterfaceLayoutDirection(parameters.userInterfaceLayoutDirection)
     , m_overrideContentSecurityPolicy { WTF::move(parameters.overrideContentSecurityPolicy) }
     , m_cpuLimit(parameters.cpuLimit)
@@ -1692,7 +1693,9 @@ void WebPage::reinitializeWebPage(WebPageCreationParameters&& parameters)
     setSizeToContentAutoSizeMaximumSize(parameters.sizeToContentAutoSizeMaximumSize);
 
     if (m_activityState != parameters.activityState)
-        setActivityState(parameters.activityState, ActivityStateChangeAsynchronous, [] { });
+        setActivityState(parameters.activityState, ActivityStateChangeAsynchronous, parameters.activityStateChangeSequence, [] { });
+    else
+        m_activityStateChangeSequence = std::max(m_activityStateChangeSequence, parameters.activityStateChangeSequence);
 
 #if HAVE(APP_ACCENT_COLORS)
     setAccentColor(parameters.accentColor);
@@ -4746,9 +4749,15 @@ void WebPage::windowActivityDidChange()
 #endif
 }
 
-void WebPage::setActivityState(OptionSet<ActivityState> activityState, ActivityStateChangeID activityStateChangeID, CompletionHandler<void()>&& callback)
+void WebPage::setActivityState(OptionSet<ActivityState> activityState, ActivityStateChangeID activityStateChangeID, uint64_t activityStateChangeSequence, CompletionHandler<void()>&& callback)
 {
     LOG_WITH_STREAM(ActivityState, stream << "WebPage " << identifier().toUInt64() << " setActivityState to " << activityState);
+
+    if (activityStateChangeSequence < m_activityStateChangeSequence) {
+        protect(drawingArea())->activityStateDidChange({ }, activityStateChangeID, WTF::move(callback));
+        return;
+    }
+    m_activityStateChangeSequence = activityStateChangeSequence;
 
     auto changed = m_activityState ^ activityState;
     m_activityState = activityState;

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -8547,7 +8547,12 @@ void WebPage::loadAndDecodeImage(WebCore::ResourceRequest&& request, std::option
     if (!page)
         return completionHandler(makeUnexpected(decodeError(url)));
 
-    request.setFirstPartyForCookies(page->mainFrameURL());
+    RefPtr localMainFrame = page->localMainFrame();
+    RefPtr mainFrameDocument = localMainFrame ? localMainFrame->document() : nullptr;
+    if (mainFrameDocument)
+        request.setFirstPartyForCookies(mainFrameDocument->firstPartyForCookies());
+    else
+        request.setFirstPartyForCookies(page->mainFrameURL());
     WebProcess::singleton().ensureNetworkProcessConnection().connection().sendWithAsyncReply(Messages::NetworkConnectionToWebProcess::LoadImageForDecoding(WTF::move(request), m_webPageProxyIdentifier, maximumBytesFromNetwork), [completionHandler = WTF::move(completionHandler), sizeConstraint, url] (Expected<Ref<WebCore::FragmentedSharedBuffer>, WebCore::ResourceError>&& result) mutable {
         if (!result)
             return completionHandler(makeUnexpected(WTF::move(result.error())));

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -546,11 +546,11 @@ public:
     }
 };
 
-Ref<WebPage> WebPage::create(PageIdentifier pageID, WebPageCreationParameters&& parameters)
+Ref<WebPage> WebPage::create(PageIdentifier pageID, WebPageCreationParameters&& parameters, RefPtr<Document> initialDocumentCreator)
 {
     auto mainFrameOpenerIdentifier = parameters.mainFrameOpenerIdentifier;
     String openedMainFrameName = parameters.openedMainFrameName;
-    auto page = adoptRef(*new WebPage(pageID, WTF::move(parameters)));
+    Ref page = adoptRef(*new WebPage(pageID, WTF::move(parameters), WTF::move(initialDocumentCreator)));
 
     if (RefPtr injectedBundle = WebProcess::singleton().injectedBundle())
         injectedBundle->didCreatePage(page);
@@ -602,7 +602,7 @@ static Vector<UserContentURLPattern> parseAndAllowAccessToCORSDisablingPatterns(
     });
 }
 
-static PageConfiguration::MainFrameCreationParameters mainFrameCreationParameters(Ref<WebFrame>&& mainFrame, auto frameType, auto initialSandboxFlags, auto initialReferrerPolicy)
+static PageConfiguration::MainFrameCreationParameters mainFrameCreationParameters(Ref<WebFrame>&& mainFrame, auto frameType, auto initialSandboxFlags, auto initialReferrerPolicy, RefPtr<Document>&& initialDocumentCreator)
 {
     auto invalidator = mainFrame->makeInvalidator();
     switch (frameType) {
@@ -612,7 +612,8 @@ static PageConfiguration::MainFrameCreationParameters mainFrameCreationParameter
                 return makeUniqueRefWithoutRefCountedCheck<WebLocalFrameLoaderClient>(localFrame, frameLoader, WTF::move(mainFrame), WTF::move(invalidator));
             } },
             initialSandboxFlags,
-            initialReferrerPolicy
+            initialReferrerPolicy,
+            WTF::move(initialDocumentCreator)
         };
     case Frame::FrameType::Remote:
         return CompletionHandler<UniqueRef<RemoteFrameClient>(RemoteFrame&)> { [mainFrame = WTF::move(mainFrame), invalidator = WTF::move(invalidator)] (auto&) mutable {
@@ -632,7 +633,7 @@ static RefPtr<Frame> frameFromIdentifier(std::optional<FrameIdentifier> identifi
     return webFrame->coreFrame();
 }
 
-WebPage::WebPage(PageIdentifier pageID, WebPageCreationParameters&& parameters)
+WebPage::WebPage(PageIdentifier pageID, WebPageCreationParameters&& parameters, RefPtr<Document>&& initialDocumentCreator)
     : m_internals(makeUniqueRef<Internals>())
     , m_identifier(pageID)
     , m_viewSize(parameters.viewSize)
@@ -811,7 +812,7 @@ WebPage::WebPage(PageIdentifier pageID, WebPageCreationParameters&& parameters)
         WebBackForwardListProxy::create(*this),
         WebProcess::singleton().cookieJar(),
         makeUniqueRef<WebProgressTrackerClient>(*this),
-        mainFrameCreationParameters(m_mainFrame.copyRef(), frameType, parameters.initialSandboxFlags, parameters.initialReferrerPolicy),
+        mainFrameCreationParameters(m_mainFrame.copyRef(), frameType, parameters.initialSandboxFlags, parameters.initialReferrerPolicy, WTF::move(initialDocumentCreator)),
         m_mainFrame->frameID(),
         frameFromIdentifier(parameters.mainFrameOpenerIdentifier),
         makeUniqueRef<WebSpeechRecognitionProvider>(pageID),

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -4754,10 +4754,13 @@ void WebPage::setActivityState(OptionSet<ActivityState> activityState, ActivityS
     LOG_WITH_STREAM(ActivityState, stream << "WebPage " << identifier().toUInt64() << " setActivityState to " << activityState);
 
     if (activityStateChangeSequence < m_activityStateChangeSequence) {
-        protect(drawingArea())->activityStateDidChange({ }, activityStateChangeID, WTF::move(callback));
-        return;
-    }
-    m_activityStateChangeSequence = activityStateChangeSequence;
+        // Synchronous page creation can overtake previously sent asynchronous activity state messages. Replaying
+        // their visibility state would temporarily hide the new page, but other changes can represent observable
+        // transitions, such as focus events, and still need to be applied.
+        static constexpr OptionSet visibilityState { ActivityState::IsVisible, ActivityState::IsVisibleOrOccluded, ActivityState::IsVisuallyIdle };
+        activityState = (activityState - visibilityState) | (m_activityState & visibilityState);
+    } else
+        m_activityStateChangeSequence = activityStateChangeSequence;
 
     auto changed = m_activityState ^ activityState;
     m_activityState = activityState;

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -2370,7 +2370,7 @@ private:
     void updateIsInWindow(bool isInitialState = false);
     void visibilityDidChange();
     void windowActivityDidChange();
-    void setActivityState(OptionSet<WebCore::ActivityState>, ActivityStateChangeID, CompletionHandler<void()>&&);
+    void setActivityState(OptionSet<WebCore::ActivityState>, ActivityStateChangeID, uint64_t activityStateChangeSequence, CompletionHandler<void()>&&);
     void validateCommand(const String&, CompletionHandler<void(bool, int32_t)>&&);
     void executeEditCommand(const String&, const String&);
     void setEditable(bool);
@@ -3259,6 +3259,7 @@ private:
     bool m_useAsyncScrolling { false };
 
     OptionSet<WebCore::ActivityState> m_activityState;
+    uint64_t m_activityStateChangeSequence { };
 
     bool m_isAppNapEnabled { true };
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -177,6 +177,7 @@ namespace WebCore {
 class AXIsolatedTree;
 class CachedPage;
 class CaptureDevice;
+class Document;
 class DocumentLoader;
 class DocumentSyncData;
 class DragData;
@@ -618,7 +619,7 @@ String plainTextForDisplay(const std::optional<WebCore::SimpleRange>&);
 
 class WebPage final : public API::ObjectImpl<API::Object::Type::BundlePage>, public IPC::MessageReceiver, public IPC::MessageSender {
 public:
-    static Ref<WebPage> create(WebCore::PageIdentifier, WebPageCreationParameters&&);
+    static Ref<WebPage> create(WebCore::PageIdentifier, WebPageCreationParameters&&, RefPtr<WebCore::Document> initialDocumentCreator = nullptr);
 
     virtual ~WebPage();
 
@@ -2236,7 +2237,7 @@ public:
     void updateRemoteIntersectionObservers();
 
 private:
-    WebPage(WebCore::PageIdentifier, WebPageCreationParameters&&);
+    WebPage(WebCore::PageIdentifier, WebPageCreationParameters&&, RefPtr<WebCore::Document>&&);
 
     void constructFrameTree(WebFrame& parent, const FrameTreeCreationParameters&);
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -27,7 +27,7 @@
 ]
 messages -> WebPage WantsAsyncDispatchMessage {
     SetInitialFocus(bool forward, bool isKeyboardEventValid, std::optional<WebKit::WebKeyboardEvent> event) -> ()
-    SetActivityState(OptionSet<WebCore::ActivityState> activityState, WebKit::ActivityStateChangeID activityStateChangeID) -> ()
+    SetActivityState(OptionSet<WebCore::ActivityState> activityState, WebKit::ActivityStateChangeID activityStateChangeID, uint64_t activityStateChangeSequence) -> ()
 
     SetBackgroundColor(std::optional<WebCore::Color> color)
 

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -1050,10 +1050,15 @@ WebPage* WebProcess::webPage(PageIdentifier pageID) const
 
 void WebProcess::createWebPage(PageIdentifier pageID, WebPageCreationParameters&& parameters)
 {
+    createWebPageWithInitialDocumentCreator(pageID, WTF::move(parameters), nullptr);
+}
+
+void WebProcess::createWebPageWithInitialDocumentCreator(PageIdentifier pageID, WebPageCreationParameters&& parameters, RefPtr<Document> initialDocumentCreator)
+{
     m_hasEverHadAnyWebPages = true;
 
     auto addResult = m_pageMap.ensure(pageID, [&] {
-        return WebPage::create(pageID, WTF::move(parameters));
+        return WebPage::create(pageID, WTF::move(parameters), WTF::move(initialDocumentCreator));
     });
     Ref page { addResult.iterator->value };
 

--- a/Source/WebKit/WebProcess/WebProcess.h
+++ b/Source/WebKit/WebProcess/WebProcess.h
@@ -104,6 +104,7 @@ enum class UserInterfaceIdiom : uint8_t;
 
 namespace WebCore {
 class CPUMonitor;
+class Document;
 class Frame;
 class PageGroup;
 class SecurityOriginData;
@@ -239,6 +240,7 @@ public:
 
     WebPage* webPage(WebCore::PageIdentifier) const;
     void createWebPage(WebCore::PageIdentifier, WebPageCreationParameters&&);
+    void createWebPageWithInitialDocumentCreator(WebCore::PageIdentifier, WebPageCreationParameters&&, RefPtr<WebCore::Document>);
     Awaitable<unsigned> countWebPagesForTesting();
     void removeWebPage(WebCore::PageIdentifier);
     WebPage* NODELETE focusedWebPage() const;

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebChromeClient.h
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebChromeClient.h
@@ -70,7 +70,7 @@ private:
     void focusedElementChanged(WebCore::Element*, WebCore::LocalFrame*, WebCore::FocusOptions, WebCore::BroadcastFocusedElement) override;
     void focusedFrameChanged(WebCore::Frame*) final;
 
-    RefPtr<WebCore::Page> createWindow(WebCore::LocalFrame&, const String& openedMainFrameName, const WebCore::WindowFeatures&, const WebCore::NavigationAction&) final;
+    RefPtr<WebCore::Page> createWindow(WebCore::LocalFrame&, WebCore::Document* creator, const String& openedMainFrameName, const WebCore::WindowFeatures&, const WebCore::NavigationAction&) final;
     void show() final;
 
     bool canRunModal() const final;

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebChromeClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebChromeClient.mm
@@ -265,7 +265,7 @@ void WebChromeClient::focusedFrameChanged(WebCore::Frame*)
 {
 }
 
-RefPtr<WebCore::Page> WebChromeClient::createWindow(WebCore::LocalFrame& frame, const String& openedMainFrameName, const WebCore::WindowFeatures& features, const WebCore::NavigationAction&)
+RefPtr<WebCore::Page> WebChromeClient::createWindow(WebCore::LocalFrame& frame, WebCore::Document*, const String& openedMainFrameName, const WebCore::WindowFeatures& features, const WebCore::NavigationAction&)
 {
     RetainPtr<id> delegate = [m_webView UIDelegate];
     RetainPtr<WebView> newWebView;

--- a/Source/WebKitLegacy/mac/WebView/WebView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebView.mm
@@ -1496,7 +1496,8 @@ static void WebKitInitializeGamepadProviderIfNecessary()
                 return makeUniqueRefWithoutRefCountedCheck<WebFrameLoaderClient>(frameLoader);
             } },
             WebCore::SandboxFlags { }, // Set by updateSandboxFlags after instantiation.
-            WebCore::ReferrerPolicy::EmptyString
+            WebCore::ReferrerPolicy::EmptyString,
+            nullptr
         },
         WebCore::generateFrameIdentifier(),
         nullptr, // Opener may be set by setOpenerForWebKitLegacy after instantiation.
@@ -1762,7 +1763,8 @@ static void WebKitInitializeGamepadProviderIfNecessary()
                 return makeUniqueRefWithoutRefCountedCheck<WebFrameLoaderClient>(frameLoader);
             } },
             WebCore::SandboxFlags { }, // Set by updateSandboxFlags after instantiation.
-            WebCore::ReferrerPolicy::EmptyString
+            WebCore::ReferrerPolicy::EmptyString,
+            nullptr
         },
         WebCore::generateFrameIdentifier(),
         nullptr, // Opener may be set by setOpenerForWebKitLegacy after instantiation.

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKPage/ModalAlertsSPI.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKPage/ModalAlertsSPI.cpp
@@ -48,8 +48,7 @@ static void analyzeDialogArguments(WKPageRef page, WKFrameRef frame, WKSecurityO
     EXPECT_EQ(page, WKFrameGetPage(frame));
 
     WKRetainPtr<WKURLRef> url = adoptWK(WKFrameCopyURL(frame));
-    WKRetainPtr<WKStringRef> urlString = adoptWK(WKURLCopyString(url.get()));
-    EXPECT_WK_STREQ("about:blank", urlString.get());
+    EXPECT_NULL(url.get());
 
     if (securityOrigin) {
         WKRetainPtr<WKStringRef> protocol = adoptWK(WKSecurityOriginCopyProtocol(securityOrigin));

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
@@ -10636,21 +10636,18 @@ TEST(SiteIsolation, OpenAboutBlankFromAboutBlank)
     [navigationDelegate waitForDidFinishNavigation];
     RetainPtr uiDelegate = adoptNS([TestUIDelegate new]);
     RetainPtr<WKWebView> opened;
-    __block bool openedFinishedLoading { false };
-    RetainPtr openedNavigationDelegate = adoptNS([TestNavigationDelegate new]);
-    openedNavigationDelegate.get().didFinishNavigation = ^(WKWebView *, WKNavigation *navigation) {
-        openedFinishedLoading = true;
-    };
+    bool openedWebViewCreated { false };
     uiDelegate.get().createWebViewWithConfiguration = [&](WKWebViewConfiguration *configuration, WKNavigationAction *action, WKWindowFeatures *windowFeatures) {
         opened = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration]);
-        opened.get().navigationDelegate = openedNavigationDelegate.get();
         opened.get().UIDelegate = uiDelegate.get();
+        openedWebViewCreated = true;
         return opened.get();
     };
     [webView setUIDelegate:uiDelegate.get()];
 
     [webView evaluateJavaScript:@"window.open()" completionHandler:nil];
-    Util::run(&openedFinishedLoading);
+    Util::run(&openedWebViewCreated);
+    EXPECT_WK_STREQ("about:blank", [opened stringByEvaluatingJavaScript:@"document.URL"]);
 }
 
 TEST(SiteIsolation, OpenNonEmptySiteFromAboutBlank)
@@ -10695,22 +10692,18 @@ TEST(SiteIsolation, OpenEmptySiteFromProcessWithNonEmptySite)
     [navigationDelegate waitForDidFinishNavigation];
     RetainPtr uiDelegate = adoptNS([TestUIDelegate new]);
     RetainPtr<WKWebView> opened;
-    __block bool openedFinishedLoading { false };
-    RetainPtr openedNavigationDelegate = adoptNS([TestNavigationDelegate new]);
-    [openedNavigationDelegate allowAnyTLSCertificate];
-    openedNavigationDelegate.get().didFinishNavigation = ^(WKWebView *, WKNavigation *navigation) {
-        openedFinishedLoading = true;
-    };
+    bool openedWebViewCreated { false };
     uiDelegate.get().createWebViewWithConfiguration = [&](WKWebViewConfiguration *configuration, WKNavigationAction *action, WKWindowFeatures *windowFeatures) {
         opened = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration]);
-        opened.get().navigationDelegate = openedNavigationDelegate.get();
         opened.get().UIDelegate = uiDelegate.get();
+        openedWebViewCreated = true;
         return opened.get();
     };
     [webView setUIDelegate:uiDelegate.get()];
 
     [webView evaluateJavaScript:@"window.open()" completionHandler:nil];
-    Util::run(&openedFinishedLoading);
+    Util::run(&openedWebViewCreated);
+    EXPECT_WK_STREQ("about:blank", [opened stringByEvaluatingJavaScript:@"document.URL"]);
 }
 
 TEST(SiteIsolation, MultiProcessBFCacheIframeProcessSurvival)


### PR DESCRIPTION
#### 6464cd358431d6ac919b3be23ab3921637de0800
<pre>
Do not navigate newly opened windows to about:blank
<a href="https://bugs.webkit.org/show_bug.cgi?id=320281">https://bugs.webkit.org/show_bug.cgi?id=320281</a>

Reviewed by NOBODY (OOPS!).

Step 15.4 of the HTML Standard&apos;s window open steps requires a URL that
matches about:blank to update the active document&apos;s URL and history
instead of initiating a navigation:
<a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window-open-steps">https://html.spec.whatwg.org/multipage/nav-history-apis.html#window-open-steps</a>

A newly created window already has an initial about:blank document, but
LocalDOMWindow::createWindow() unnecessarily scheduled another navigation
for an empty or about:blank URL. This replaced the initial document and
advanced the frame out of its initial empty-document state.

Follow the specification by avoiding that navigation for newly created
pages. For about:blank URLs containing a query or fragment, update the
initial document&apos;s URL and history in place.

Keeping the frame in its initial empty-document state also ensures that its
first real navigation uses the popup-specific Cross-Origin-Opener-Policy
comparison and does not incorrectly disconnect the opener&apos;s WindowProxy.

Test: http/tests/security/cross-origin-opener-policy/popup-from-initial-about-blank.py

* LayoutTests/http/tests/security/cross-origin-opener-policy/popup-from-initial-about-blank-expected.txt: Added.
* LayoutTests/http/tests/security/cross-origin-opener-policy/popup-from-initial-about-blank.py: Added.
* LayoutTests/http/tests/security/cross-origin-opener-policy/resources/popup-from-initial-about-blank.py: Added.
* Source/WebCore/page/LocalDOMWindow.cpp:
(WebCore::LocalDOMWindow::createWindow): Keep the initial empty document
for empty and about:blank URLs, updating its URL and history when needed.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/888f74847f1620784e563c5bcfac16c1dbf641cb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179656 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53595 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47393 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189488 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/143965 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181519 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54889 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53306 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140116 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96942 "3 flakes 8 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182613 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43728 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160859 "Found 9 new API test failures: TestWebKitAPI.EnhancedSecurityPolicies.HttpsOnlyExplicitlyBypassedWithHttpRedirect, TestWebKitAPI.WebKit.LoadAndDecodeImage, TestWebKitAPI.WKNavigation.PreferredHTTPSPolicyAutomaticHTTPFallbackAfterTerminateProcess, TestWebKitAPI.WKNavigation.HTTPSOnlyWithHTTPRedirect, TestWebKitAPI.WKNavigation.FramesWithLoadingError, TestWebKitAPI.URLSchemeHandler.Frame, TestWebKitAPI.WKNavigation.FramesWithHTTPSNavigation, TestWebKitAPI.WebKit.LoadAndDecodeImageBeforeAnyNavigation, TestWebKitAPI.WKNavigation.Frames (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120568 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42398 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40719 "Found 9 new API test failures: TestWebKitAPI.EnhancedSecurityPolicies.HttpsOnlyExplicitlyBypassedWithHttpRedirect, TestWebKitAPI.WebKit.LoadAndDecodeImage, TestWebKitAPI.WKNavigation.PreferredHTTPSPolicyAutomaticHTTPFallbackAfterTerminateProcess, TestWebKitAPI.WKNavigation.HTTPSOnlyWithHTTPRedirect, TestWebKitAPI.WKNavigation.FramesWithLoadingError, TestWebKitAPI.URLSchemeHandler.Frame, TestWebKitAPI.WKNavigation.FramesWithHTTPSNavigation, TestWebKitAPI.WebKit.LoadAndDecodeImageBeforeAnyNavigation, TestWebKitAPI.WKNavigation.Frames (failure)") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/2537 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/9344 "Passed tests") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152799 "Found 8 new API test failures: TestWebKitAPI.WebKit.LoadAndDecodeImage, TestWebKitAPI.WKNavigation.PreferredHTTPSPolicyAutomaticHTTPFallbackAfterTerminateProcess, TestWebKitAPI.WKNavigation.HTTPSOnlyWithHTTPRedirect, TestWebKitAPI.WKNavigation.FramesWithLoadingError, TestWebKitAPI.URLSchemeHandler.Frame, TestWebKitAPI.WKNavigation.FramesWithHTTPSNavigation, TestWebKitAPI.WebKit.LoadAndDecodeImageBeforeAnyNavigation, TestWebKitAPI.WKNavigation.Frames (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40372 "Found 1 new test failure: imported/w3c/web-platform-tests/wasm/webapi/esm-integration/execute-start.tentative.html (failure)") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/942 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/40931 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46201 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44967 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191710 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53265 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/160376 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149383 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53946 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36997 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149127 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43787 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126218 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/121216 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52463 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15364 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51848 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52089 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51909 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->