### PR TITLE
[WKCI][ews-build.webkit.org][WPE] The WPE-JSC queue should use build-webkit instead build-jsc to build without change.

### DIFF
--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -3320,6 +3320,11 @@ def customBuildFlag(platform, fullPlatform):
     return ['--' + platform]
 
 
+def shouldBuildJSCOnly(group_name, platform):
+    # GTK and WPE use build-webkit rather than build-jsc, so the whole build process (build flags, etc.) matches what post-commit bots do.
+    return group_name == 'jsc' and platform not in ('gtk', 'wpe')
+
+
 class BuildLogLineObserver(ParseByLineLogObserver):
     def __init__(self, errorReceived, searchString='rror:', includeRelatedLines=True, thresholdExceedCallBack=None):
         self.errorReceived = errorReceived
@@ -3467,7 +3472,7 @@ class CompileWebKit(shell.Compile, AddToLogMixin, ShellMixin):
                 steps_to_add.append(InstallWpeDependencies())
             elif platform == 'gtk':
                 steps_to_add.append(InstallGtkDependencies())
-            if self.getProperty('group') == 'jsc':
+            if shouldBuildJSCOnly(self.getProperty('group'), platform):
                 steps_to_add.append(CompileJSCWithoutChange())
             else:
                 steps_to_add.append(CompileWebKitWithoutChange())
@@ -3565,7 +3570,7 @@ class AnalyzeCompileWebKitResults(buildstep.BuildStep, BugzillaMixin, GitHubMixi
     def run(self):
         self.error_logs = {}
         self.compile_webkit_step = CompileWebKit.name
-        if self.getProperty('group') == 'jsc':
+        if shouldBuildJSCOnly(self.getProperty('group'), self.getProperty('platform')):
             self.compile_webkit_step = CompileJSC.name
         yield self.getResults(self.compile_webkit_step)
         rc = yield self.analyzeResults()
@@ -3574,7 +3579,7 @@ class AnalyzeCompileWebKitResults(buildstep.BuildStep, BugzillaMixin, GitHubMixi
     @defer.inlineCallbacks
     def analyzeResults(self):
         compile_without_patch_step = CompileWebKitWithoutChange.name
-        if self.getProperty('group') == 'jsc':
+        if shouldBuildJSCOnly(self.getProperty('group'), self.getProperty('platform')):
             compile_without_patch_step = CompileJSCWithoutChange.name
         compile_without_patch_result = self.getStepResult(compile_without_patch_step)
 
@@ -3870,6 +3875,7 @@ class RunJavaScriptCoreTests(shell.Test, AddToLogMixin, ShellMixin):
             self.setProperty('results-db_jsc_pre_existing', sorted(self.preexisting_failures_in_results_db))
 
     def evaluateCommand(self, cmd):
+        platform = self.getProperty('platform')
         rc = super().evaluateCommand(cmd)
         steps_to_add = []
         if SHOULD_FILTER_LOGS is True:
@@ -3904,10 +3910,17 @@ class RunJavaScriptCoreTests(shell.Test, AddToLogMixin, ShellMixin):
                 RevertAppliedChanges(),
                 CleanWorkingDirectory(),
                 ValidateChange(verifyBugClosed=False, addURLs=False),
-                SetO3OptimizationLevel()
             ]
+            if platform == 'wpe':
+                steps_to_add.append(InstallWpeDependencies())
+            elif platform == 'gtk':
+                steps_to_add.append(InstallGtkDependencies())
+            else:
+                steps_to_add.append(SetO3OptimizationLevel())
             if self.getProperty('rebuild_without_change_on_builder', False):
                 steps_to_add.extend([DownloadBuiltProduct(suffix=SUFFIX_WITHOUT_CHANGE), ExtractBuiltProduct()])
+            if platform in ('gtk', 'wpe'):
+                steps_to_add.extend([CompileWebKitWithoutChange()])
             else:
                 steps_to_add.extend([CompileJSCWithoutChange()])
             steps_to_add += [


### PR DESCRIPTION
#### faf76febcd287b3d3a959104f60587ba7a9ce80b
<pre>
[WKCI][ews-build.webkit.org][WPE] The WPE-JSC queue should use build-webkit instead build-jsc to build without change.
<a href="https://bugs.webkit.org/show_bug.cgi?id=320284">https://bugs.webkit.org/show_bug.cgi?id=320284</a>

Reviewed by Nikolas Zimmermann.

The new WPE-JSC queue added in 317773@main is not working well because
when there are failures it tries to use script build-jsc instead of
build-webkit to rebuild WPE without change.

And it fails because script build-jsc does not currently implement the
auto enter mechanism into the SDK.

Fixing build-jsc is in theory possible, but this changes the EWS logic
to use script build-webkit for GTK and WPE ports in this case because:

 - The build product it receives it was generated with build-webkit
   (not with build-jsc)
 - build-jsc has different quirks than build-webkit and doesn&apos;t enable
   the same CMake switches by default.
 - Thanks to the shared ccache building webkit is very fast if the caches
   are hot and for a &quot;build without change&quot; step the caches should be hot,
   so I don&apos; think is worth optimizing the time this step takes.
 - The post-commit bots that run JSC test with WPE also use build-webkit
   script to build.
 - In the case of WPE there isn&apos;t a split of libjsc and libwebkit, so to
   link the jsc binary is needed to build all of libwebkit in any case.

So I think is better to standarize on build-webkit rather than trying
to maintain build-jsc to have the same quirks/default_flags than
build-webkit.

* Tools/CISupport/ews-build/steps.py:
(shouldBuildJSCOnly):
(CompileWebKit.evaluateCommand):
(AnalyzeCompileWebKitResults.run):
(AnalyzeCompileWebKitResults.analyzeResults):
(RunJavaScriptCoreTests.evaluateCommand):

Canonical link: <a href="https://commits.webkit.org/317938@main">https://commits.webkit.org/317938@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4b6ddc3d395bddfe0e1ab8709e5b096772f1bd74

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176753 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50690 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44482 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186355 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/139989 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178616 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51983 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50376 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137692 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/139989 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179709 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41198 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158481 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118166 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39852 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38220 "Passed tests") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150264 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; run-api-tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37979 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34823 "Built successfully") | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42436 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188779 "Built successfully") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/176156 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50357 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146757 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51040 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34600 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146562 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26828 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41326 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117408 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49545 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12958 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Checked out pull request; Uploaded test results") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48944 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49180 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49005 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->