### PR TITLE
[Tools][CMake] build-webkit removes the CMake cache and reconfigures when only --makeargs changes

### DIFF
--- a/Tools/Scripts/webkitdirs.pm
+++ b/Tools/Scripts/webkitdirs.pm
@@ -2688,6 +2688,11 @@ sub shouldRemoveCMakeCache(@)
     my (@buildArgs) = grep(/^-/, sort(@_, @originalArgv));
     push @buildArgs, parse_line('\s+', 0, $ENV{'BUILD_WEBKIT_ARGS'}) if ($ENV{'BUILD_WEBKIT_ARGS'});
 
+    # Dashed options that select what gets built, rather than how CMake configures the build,
+    # must not trigger a reconfiguration either: --makeargs carries build target names
+    # (e.g. --makeargs="jsc testapi"), and --generate-project-only just stops before the build step.
+    @buildArgs = grep(!/^--makeargs(=|$)/ && $_ ne "--generate-project-only", @buildArgs);
+
     # We check this first, because we always want to create this file for a fresh build.
     my $productDir = productDir();
     my $optionsCache = File::Spec->catdir($productDir, "build-webkit-options.txt");


### PR DESCRIPTION
#### 407b315ed88930c693f88454ca1525d58b5bdb92
<pre>
[Tools][CMake] build-webkit removes the CMake cache and reconfigures when only --makeargs changes
<a href="https://bugs.webkit.org/show_bug.cgi?id=320285">https://bugs.webkit.org/show_bug.cgi?id=320285</a>

Reviewed by NOBODY (OOPS!).

shouldRemoveCMakeCache() decides whether to force a CMake reconfiguration by
comparing a fingerprint of the build arguments. It already tries to ignore the
targets to build, but it only skips arguments that don&apos;t start with a dash, so
--makeargs=&quot;jsc testapi&quot; was still taken into account and every change of the
target list caused a full reconfiguration. --generate-project-only had the same
problem.

Ignore both options when computing the fingerprint, since they only select what
gets built and not how CMake configures the build.

* Tools/Scripts/webkitdirs.pm:
(shouldRemoveCMakeCache):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/407b315ed88930c693f88454ca1525d58b5bdb92

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176754 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50691 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44483 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186356 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/139990 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178617 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51984 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50377 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137693 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96268 "3 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179710 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41199 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158483 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118167 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39853 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38221 "Passed tests") | [❌ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/132 "Found 2 new JSC stress test failures: wasm.yaml/wasm/stress/type-index-abstract-heap-types-globals-and-tables.js.wasm-aggressive-inline, wasm.yaml/wasm/stress/type-index-abstract-heap-types-nulls-and-casts.js.wasm-aggressive-inline (failure)") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/6990 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150265 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37981 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34824 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/38025 "Built successfully and passed tests") | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42437 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188780 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50358 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146758 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51041 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34602 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146563 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41328 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117418 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49546 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12960 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48945 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49181 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49006 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->