### PR TITLE
[EWS] MapBranchAlias resolves the base of a fresh new branch to 'main'

### DIFF
--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -7230,21 +7230,24 @@ class ValidateRemote(shell.ShellCommand):
 # changing branch.
 class MapBranchAlias(shell.ShellCommand):
     name = 'map-branch-alias'
-    haltOnFailure = False
+    # A failed query means an unresolvable base ref, so halt rather than land on a stale one.
+    haltOnFailure = True
     flunkOnFailure = True
-    DEV_BRANCHES = re.compile(r'.*[(eng)(dev)(bug)]/.+')
+    DEV_BRANCHES = re.compile(r'^(.+/)?(eng|dev|bug)/.+')
     PROD_BRANCHES = re.compile(r'\S+-[\d+\.]+-branch')
 
     def __init__(self, **kwargs):
         self.summary = ''
+        self._requested_base_ref = None
         super().__init__(logEnviron=False, timeout=60, **kwargs)
 
     @defer.inlineCallbacks
     def run(self, BufferLogObserverClass=logobserver.BufferLogObserver):
         branch = self.getProperty('github.base.ref', DEFAULT_BRANCH)
+        self._requested_base_ref = branch
         remote = self.getProperty('remote', DEFAULT_REMOTE)
 
-        self.command = ['git', 'branch', '-a', '--contains', f'remotes/{remote}/{branch}']
+        self.command = ['git', 'branch', '-a', '--points-at', f'remotes/{remote}/{branch}']
 
         self.log_observer = BufferLogObserverClass(wantStderr=True)
         self.addLogObserver('stdio', self.log_observer)
@@ -7261,7 +7264,9 @@ class MapBranchAlias(shell.ShellCommand):
         log_text = self.log_observer.getStdout()
         for line in log_text.splitlines():
             line = line.lstrip().rstrip()
-            if not line.startswith(f'remotes/{remote}'):
+            if '->' in line:  # Symbolic refs (e.g. HEAD -> origin/main)
+                continue
+            if not line.startswith(f'remotes/{remote}/'):
                 continue
             candidate = line.split('/', 2)[-1]
             if self.DEV_BRANCHES.match(candidate):
@@ -7271,9 +7276,9 @@ class MapBranchAlias(shell.ShellCommand):
         if DEFAULT_BRANCH in aliases:
             branch = DEFAULT_BRANCH
         if branch != DEFAULT_BRANCH and self.DEV_BRANCHES.match(branch) and aliases:
-            branch = next(iter(aliases))
+            branch = next(iter(sorted(aliases)))
         if branch != DEFAULT_BRANCH and not self.PROD_BRANCHES.match(branch):
-            for alias in aliases:
+            for alias in sorted(aliases):
                 if self.PROD_BRANCHES.match(alias):
                     branch = alias
                     break
@@ -7290,7 +7295,11 @@ class MapBranchAlias(shell.ShellCommand):
     def doStepIf(self, step):
         if not self.getProperty('github.number'):
             return False
-        return self.getProperty('github.base.ref', DEFAULT_BRANCH) != DEFAULT_BRANCH
+        # run() overwrites github.base.ref, so hideStepIf can't read it back directly.
+        branch = self._requested_base_ref
+        if branch is None:
+            branch = self.getProperty('github.base.ref', DEFAULT_BRANCH)
+        return branch != DEFAULT_BRANCH
 
     def hideStepIf(self, results, step):
         return not self.doStepIf(step)

--- a/Tools/CISupport/ews-build/steps_unittest.py
+++ b/Tools/CISupport/ews-build/steps_unittest.py
@@ -8924,7 +8924,7 @@ class TestMapBranchAlias(BuildStepMixinAdditions, unittest.TestCase):
                 workdir='wkdir',
                 log_environ=False,
                 timeout=60,
-                command=['git', 'branch', '-a', '--contains', 'remotes/origin/safari-000-branch'],
+                command=['git', 'branch', '-a', '--points-at', 'remotes/origin/safari-000-branch'],
             ).exit(0)
             .log('stdio', stdout='  safari-000-branch\n  remotes/origin/safari-000-branch\n  remotes/origin/safari-alias\n  remotes/origin/eng/pr-branch\n'),
         )
@@ -8943,7 +8943,7 @@ class TestMapBranchAlias(BuildStepMixinAdditions, unittest.TestCase):
                 workdir='wkdir',
                 log_environ=False,
                 timeout=60,
-                command=['git', 'branch', '-a', '--contains', 'remotes/origin/safari-000-branch'],
+                command=['git', 'branch', '-a', '--points-at', 'remotes/origin/safari-000-branch'],
             ).exit(0)
             .log('stdio', stdout='  safari-000-branch\n  remotes/origin/safari-000-branch\n  remotes/origin/safari-alias\n  remotes/origin/eng/pr-branch\n  remotes/origin/main\n'),
         )
@@ -8962,7 +8962,7 @@ class TestMapBranchAlias(BuildStepMixinAdditions, unittest.TestCase):
                 workdir='wkdir',
                 log_environ=False,
                 timeout=60,
-                command=['git', 'branch', '-a', '--contains', 'remotes/origin/safari-alias'],
+                command=['git', 'branch', '-a', '--points-at', 'remotes/origin/safari-alias'],
             ).exit(0)
             .log('stdio', stdout='  safari-alias\n  remotes/origin/safari-000-branch\n  remotes/origin/safari-alias\n  remotes/origin/eng/pr-branch\n'),
         )
@@ -8981,7 +8981,7 @@ class TestMapBranchAlias(BuildStepMixinAdditions, unittest.TestCase):
                 workdir='wkdir',
                 log_environ=False,
                 timeout=60,
-                command=['git', 'branch', '-a', '--contains', 'remotes/security/safari-000-branch'],
+                command=['git', 'branch', '-a', '--points-at', 'remotes/security/safari-000-branch'],
             ).exit(0)
             .log('stdio', stdout='  safari-000-branch\n  remotes/security/safari-000-branch\n  remotes/security/safari-alias\n  remotes/security/eng/pr-branch\n  remotes/origin/main\n'),
         )
@@ -9000,7 +9000,7 @@ class TestMapBranchAlias(BuildStepMixinAdditions, unittest.TestCase):
                 workdir='wkdir',
                 log_environ=False,
                 timeout=60,
-                command=['git', 'branch', '-a', '--contains', 'remotes/security/safari-alias'],
+                command=['git', 'branch', '-a', '--points-at', 'remotes/security/safari-alias'],
             ).exit(0)
             .log('stdio', stdout='  safari-alias\n  remotes/security/safari-000-branch\n  remotes/security/safari-alias\n  remotes/security/eng/pr-branch\n  remotes/origin/main\n'),
         )
@@ -9009,7 +9009,8 @@ class TestMapBranchAlias(BuildStepMixinAdditions, unittest.TestCase):
         self.expect_property('github.base.ref', 'safari-000-branch')
         return rc
 
-    def test_failure(self):
+    def test_unresolvable_ref_fails_and_halts(self):
+        # A missing base ref makes the query error out; fail, leave the base ref untouched, and halt.
         self.setup_step(MapBranchAlias())
         self.setProperty('remote', 'origin')
         self.setProperty('github.base.ref', 'safari-000-branch')
@@ -9019,12 +9020,104 @@ class TestMapBranchAlias(BuildStepMixinAdditions, unittest.TestCase):
                 workdir='wkdir',
                 log_environ=False,
                 timeout=60,
-                command=['git', 'branch', '-a', '--contains', 'remotes/origin/safari-000-branch'],
+                command=['git', 'branch', '-a', '--points-at', 'remotes/origin/safari-000-branch'],
             ).exit(129)
-            .log('stdio', stdout='error: malformed object name remotes/origin/safari-000-branch\n'),
+            .log('stdio', stdout="error: malformed object name 'remotes/origin/safari-000-branch'\n"),
         )
         self.expect_outcome(result=FAILURE, state_string="Failed to query checkout for aliases of 'safari-000-branch'")
-        return self.run_step()
+        rc = self.run_step()
+        self.expect_property('github.base.ref', 'safari-000-branch')
+
+        def check_halting(result):
+            self.assertTrue(self.get_nth_step(0).haltOnFailure, 'unresolvable base ref must halt the queue')
+            return result
+        rc.addCallback(check_halting)
+        return rc
+
+    def test_freshly_cut_release_branch(self):
+        # Regression (build 26800): under --points-at, a freshly-cut branch resolves to itself, not main.
+        self.setup_step(MapBranchAlias())
+        self.setProperty('remote', 'origin')
+        self.setProperty('github.base.ref', 'webkitglib/2.54')
+        self.setProperty('github.number', '1234')
+        self.expectRemoteCommands(
+            ExpectShell(
+                workdir='wkdir',
+                log_environ=False,
+                timeout=60,
+                command=['git', 'branch', '-a', '--points-at', 'remotes/origin/webkitglib/2.54'],
+            ).exit(0)
+            .log('stdio', stdout='* webkitglib/2.54\n  remotes/origin/webkitglib/2.54\n'),
+        )
+        self.expect_outcome(result=SUCCESS, state_string="'webkitglib/2.54' is the prevailing alias")
+        rc = self.run_step()
+        self.expect_property('github.base.ref', 'webkitglib/2.54')
+        return rc
+
+    def test_diverged_release_branch(self):
+        # No-op guard: a diverged release branch lists only itself and resolves to itself.
+        self.setup_step(MapBranchAlias())
+        self.setProperty('remote', 'origin')
+        self.setProperty('github.base.ref', 'webkitglib/2.52')
+        self.setProperty('github.number', '1234')
+        self.expectRemoteCommands(
+            ExpectShell(
+                workdir='wkdir',
+                log_environ=False,
+                timeout=60,
+                command=['git', 'branch', '-a', '--points-at', 'remotes/origin/webkitglib/2.52'],
+            ).exit(0)
+            .log('stdio', stdout='* webkitglib/2.52\n  remotes/origin/webkitglib/2.52\n'),
+        )
+        self.expect_outcome(result=SUCCESS, state_string="'webkitglib/2.52' is the prevailing alias")
+        rc = self.run_step()
+        self.expect_property('github.base.ref', 'webkitglib/2.52')
+        return rc
+
+    def test_dev_branch_base_is_found_and_resolves(self):
+        # A dev-branch base resolves to its co-pointing production alias.
+        self.setup_step(MapBranchAlias())
+        self.setProperty('remote', 'origin')
+        self.setProperty('github.base.ref', 'eng/pr-branch')
+        self.setProperty('github.number', '1234')
+        self.expectRemoteCommands(
+            ExpectShell(
+                workdir='wkdir',
+                log_environ=False,
+                timeout=60,
+                command=['git', 'branch', '-a', '--points-at', 'remotes/origin/eng/pr-branch'],
+            ).exit(0)
+            .log('stdio', stdout='* eng/pr-branch\n  remotes/origin/eng/pr-branch\n  remotes/origin/safari-000-branch\n'),
+        )
+        self.expect_outcome(result=SUCCESS, state_string="'safari-000-branch' is the prevailing alias")
+        rc = self.run_step()
+        self.expect_property('github.base.ref', 'safari-000-branch')
+        return rc
+
+    def test_step_visible_after_remap_to_main(self):
+        # A step that remaps to main did real work and must stay visible (hideStepIf uses the original base ref).
+        self.setup_step(MapBranchAlias())
+        self.setProperty('remote', 'origin')
+        self.setProperty('github.base.ref', 'safari-000-branch')
+        self.setProperty('github.number', '1234')
+        self.expectRemoteCommands(
+            ExpectShell(
+                workdir='wkdir',
+                log_environ=False,
+                timeout=60,
+                command=['git', 'branch', '-a', '--points-at', 'remotes/origin/safari-000-branch'],
+            ).exit(0)
+            .log('stdio', stdout='  safari-000-branch\n  remotes/origin/safari-000-branch\n  remotes/origin/main\n'),
+        )
+        self.expect_outcome(result=SUCCESS, state_string="'main' is the prevailing alias")
+        rc = self.run_step()
+
+        def check_visible(result):
+            step = self.get_nth_step(0)
+            self.assertFalse(step.hideStepIf(SUCCESS, step), 'step remapped to main must stay visible')
+            return result
+        rc.addCallback(check_visible)
+        return rc
 
 
 DIFF_NO_MARKERS = (


### PR DESCRIPTION
#### c08865ddc5b6b45492e2e5653b90563d58630d14
<pre>
[EWS] MapBranchAlias resolves the base of a fresh new branch to &apos;main&apos;
<a href="https://bugs.webkit.org/show_bug.cgi?id=320244">https://bugs.webkit.org/show_bug.cgi?id=320244</a>

Reviewed by NOBODY (OOPS!).

Recently, a PR to the webkitglib/2.54 branch, which had not yet
diverged from main, failed with this base branch being silently replaced
by main itself.

This commit includes a number of related changes to harden
MapBranchAlias, avoiding these accidental and silent aliases. These
include:

- Fix the regex used for dev branches, to ensure they start with &quot;eng/&quot;,
  &quot;dev/&quot;, or &quot;bug/&quot;. Previously, &quot;webkitglib/...&quot; would match as a dev
  branch and be skipped as a potential alias.
- Use &quot;git branch -a --points-at&quot; instead of &quot;--contains&quot;, so we check
  proper aliases pointing to the same commit instead of ancestors.
- Bail out, error, and halt the queue if we can&apos;t find a proper base
  ref.
- Decide whether to hide the step from the requested base ref, not the
  value run() resolved to.
- Sort the aliases for iteration, as iterating over a plain set has no
  guaranteed order.

New tests for improved coverage:

- test_freshly_cut_release_branch: Mirrors the scenario that triggered
  this patch, before the base branch diverged from main.
- test_diverged_release_branch: Typical case, where the target branch
  already has its own history.
- test_unresolvable_ref_fails_and_halts: Ensure the step fails and halts
  if it can&apos;t find the ref.
- test_dev_branch_base_is_found_and_resolves: Ensure aliasing works for
  dev branches.
- test_step_visible_after_remap_to_main: Ensure the step does not hide
  itself if aliasing the base branch.

Co-authored with Claude.

* Tools/CISupport/ews-build/steps.py:
(MapBranchAlias):
(MapBranchAlias.__init__):
(MapBranchAlias.run):
(MapBranchAlias.doStepIf):
* Tools/CISupport/ews-build/steps_unittest.py:
</pre>