### PR TITLE
Add foundation for Accessibility Custom Color Mode

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -113,6 +113,21 @@ AVFoundationEnabled:
       "PLATFORM(WATCHOS)": false
       default: true
 
+AXCustomColorModeEnabled:
+  type: bool
+  status: embedder
+  getter: axCustomColorModeEnabled
+  webcoreName: axCustomColorModeEnabled
+  webcoreOnChange: setNeedsRecalcStyleInAllFrames
+  condition: ENABLE(AX_CUSTOM_COLOR_MODE)
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 AcceleratedCompositingEnabled:
   type: bool
   status: embedder

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -508,6 +508,10 @@ public:
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(Document::PendingScrollEventTargetList);
 
+#if USE(APPLE_INTERNAL_SDK)
+#include <WebKitAdditions/DocumentAdditions.cpp>
+#endif
+
 static const Seconds intersectionObserversInitialUpdateDelay { 2000_ms };
 
 static void CallbackForContainIntrinsicSize(const Vector<Ref<ResizeObserverEntry>>& entries, ResizeObserver& observer)
@@ -10106,6 +10110,12 @@ bool Document::useElevatedUserInterfaceLevel() const
     return false;
 }
 
+#if !ENABLE(AX_CUSTOM_COLOR_MODE)
+void Document::adjustStyleColorOptionsIfNeeded(OptionSet<StyleColorOptions>&) const
+{
+}
+#endif
+
 OptionSet<StyleColorOptions> Document::styleColorOptions(const Style::ComputedStyle* style) const
 {
     OptionSet<StyleColorOptions> options;
@@ -10115,6 +10125,8 @@ OptionSet<StyleColorOptions> Document::styleColorOptions(const Style::ComputedSt
         options.add(StyleColorOptions::UseDarkAppearance);
     if (useElevatedUserInterfaceLevel())
         options.add(StyleColorOptions::UseElevatedUserInterfaceLevel);
+
+    adjustStyleColorOptionsIfNeeded(options);
     return options;
 }
 

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -1646,6 +1646,14 @@ public:
     Ref<DocumentFragment> documentFragmentForInnerOuterHTML();
 
     void didAssociateFormControl(Element&);
+
+#if ENABLE(AX_CUSTOM_COLOR_MODE)
+    bool addAXCustomColorModeAdjustedElement(Element&);
+    bool isAXCustomColorModeAdjustedElement(const Element&) const;
+#endif
+
+    void adjustStyleColorOptionsIfNeeded(OptionSet<StyleColorOptions>&) const;
+
     bool hasDisabledFieldsetElement() const { return m_disabledFieldsetElementsCount; }
     void addDisabledFieldsetElement() { m_disabledFieldsetElementsCount++; }
     void removeDisabledFieldsetElement() { ASSERT(m_disabledFieldsetElementsCount); m_disabledFieldsetElementsCount--; }
@@ -2604,6 +2612,9 @@ private:
     Markable<WallTime> m_overrideLastModified;
 
     WeakHashSet<Element, WeakPtrImplWithEventTargetData> m_associatedFormControls;
+#if ENABLE(AX_CUSTOM_COLOR_MODE)
+    WeakHashSet<Element, WeakPtrImplWithEventTargetData> m_axCustomColorModeAdjustedElements;
+#endif
 
     const std::unique_ptr<OrientationNotifier> m_orientationNotifier;
     mutable RefPtr<Logger> m_logger;

--- a/Source/WebCore/loader/cache/CachedImage.cpp
+++ b/Source/WebCore/loader/cache/CachedImage.cpp
@@ -39,6 +39,7 @@
 #include "LocalFrameView.h"
 #include "MIMETypeRegistry.h"
 #include "MemoryCache.h"
+#include "NativeImage.h"
 #include "RenderElement.h"
 #include "RenderImage.h"
 #include "SVGElementTypeHelpers.h"
@@ -509,7 +510,28 @@ inline void CachedImage::clearImage()
     m_lastUpdateImageDataTime = { };
     m_updateImageDataCount = 0;
     m_allowsOrientationOverride = true;
+
+#if ENABLE(AX_CUSTOM_COLOR_MODE)
+    m_axCustomColorModeShouldAdjust = std::nullopt;
+    m_axCustomColorModeAdjustedTile = nullptr;
+    m_axCustomColorModeAdjustedTileSize = { };
+#endif
 }
+
+#if ENABLE(AX_CUSTOM_COLOR_MODE)
+NativeImage* CachedImage::axCustomColorModeAdjustedTile(const FloatSize& forSize) const
+{
+    if (!m_axCustomColorModeAdjustedTile || m_axCustomColorModeAdjustedTileSize != forSize)
+        return nullptr;
+    return m_axCustomColorModeAdjustedTile.get();
+}
+
+void CachedImage::setAXCustomColorModeAdjustedTile(RefPtr<NativeImage>&& tile, const FloatSize& size)
+{
+    m_axCustomColorModeAdjustedTile = WTF::move(tile);
+    m_axCustomColorModeAdjustedTileSize = size;
+}
+#endif
 
 void CachedImage::updateBufferInternal(const FragmentedSharedBuffer& data)
 {

--- a/Source/WebCore/loader/cache/CachedImage.h
+++ b/Source/WebCore/loader/cache/CachedImage.h
@@ -23,6 +23,7 @@
 #pragma once
 
 #include <WebCore/CachedResource.h>
+#include <WebCore/FloatSize.h>
 #include <WebCore/Image.h>
 #include <WebCore/ImageObserver.h>
 #include <WebCore/IntRect.h>
@@ -36,8 +37,8 @@ namespace WebCore {
 class CachedImageClient;
 class CachedResourceLoader;
 class WeakPtrImplWithEventTargetData;
-class FloatSize;
 class MemoryCache;
+class NativeImage;
 class RenderElement;
 class RenderObject;
 class SecurityOrigin;
@@ -104,6 +105,13 @@ public:
 
     bool isVisibleInViewport(const Document&) const;
     bool allowsAnimation(const Image&) const;
+
+#if ENABLE(AX_CUSTOM_COLOR_MODE)
+    std::optional<bool> axCustomColorModeShouldAdjust() const { return m_axCustomColorModeShouldAdjust; }
+    void setAXCustomColorModeShouldAdjust(bool value) { m_axCustomColorModeShouldAdjust = value; }
+    NativeImage* axCustomColorModeAdjustedTile(const FloatSize& forSize) const;
+    void setAXCustomColorModeAdjustedTile(RefPtr<NativeImage>&&, const FloatSize&);
+#endif
 
 private:
     FloatSize internalImageSizeForRenderer(const RenderElement*, float multiplier, SizeType, float density) const;
@@ -198,6 +206,12 @@ private:
     RefPtr<CachedImageObserver> m_imageObserver;
     RefPtr<Image> m_image;
     std::unique_ptr<SVGImageCache> m_svgImageCache;
+
+#if ENABLE(AX_CUSTOM_COLOR_MODE)
+    std::optional<bool> m_axCustomColorModeShouldAdjust;
+    RefPtr<NativeImage> m_axCustomColorModeAdjustedTile;
+    FloatSize m_axCustomColorModeAdjustedTileSize;
+#endif
 
     MonotonicTime m_lastUpdateImageDataTime;
 

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -4854,6 +4854,11 @@ void LocalFrameView::performPostLayoutTasks()
     LOG(Layout, "LocalFrameView %p performPostLayoutTasks", this);
     updateHasReachedSignificantRenderedTextThreshold();
 
+#if ENABLE(AX_CUSTOM_COLOR_MODE)
+    if (CheckedPtr renderView = this->renderView())
+        renderView->adjustAXCustomColorModeAfterLayout();
+#endif
+
     if (!layoutContext().isLayoutNested() && m_frame->document()->documentElement())
         fireLayoutRelatedMilestonesIfNeeded();
 

--- a/Source/WebCore/rendering/BackgroundPainter.cpp
+++ b/Source/WebCore/rendering/BackgroundPainter.cpp
@@ -50,6 +50,10 @@
 #include "StylePrimitiveNumericTypes+Evaluation.h"
 #include "TextBoxPainter.h"
 
+#if ENABLE(AX_CUSTOM_COLOR_MODE)
+#include <WebKitAdditions/BackgroundPainterAdditions.cpp>
+#endif
+
 namespace WebCore {
 
 BackgroundImageGeometry::BackgroundImageGeometry(const LayoutRect& destinationRect, const LayoutSize& tileSizeWithoutPixelSnapping, const LayoutSize& tileSize, const LayoutSize& phase, const LayoutSize& spaceSize, bool fixedAttachment)
@@ -193,7 +197,11 @@ static void applyBoxShadowForBackground(GraphicsContext& context, const Style::C
                 shadow.location.y().resolveZoom(zoomFactor),
             },
             shadow.blur.resolveZoom(zoomFactor),
+#if ENABLE(AX_CUSTOM_COLOR_MODE)
+            axCustomColorModeShadowColor(colorResolver, style, shadow.color),
+#else
             colorResolver.colorResolvingCurrentColorApplyingColorFilter(shadow.color),
+#endif
             shadow.isWebkitBoxShadow ? ShadowRadiusMode::Legacy : ShadowRadiusMode::Default
         });
         break;
@@ -544,6 +552,14 @@ template<typename Layer> void BackgroundPainter::paintFillLayerImpl(const Color&
                     return m_renderer.imageOrientation();
             }();
 
+            RefPtr imageToDraw = image;
+#if ENABLE(AX_CUSTOM_COLOR_MODE)
+            if constexpr (std::same_as<Layer, Style::BackgroundLayer>) {
+                if (RefPtr adjusted = axCustomColorModeAdjustedBackgroundImage(context, document(), bgImage->cachedImage(), *image, geometry.tileSize, orientation))
+                    imageToDraw = WTF::move(adjusted);
+            }
+#endif
+
             ImagePaintingOptions options = {
                 op == CompositeOperator::SourceOver ? layer.layer.compositeForPainting(layer.isLast) : op,
                 layerBlendMode,
@@ -557,7 +573,7 @@ template<typename Layer> void BackgroundPainter::paintFillLayerImpl(const Color&
                 style.dynamicRangeLimit().toPlatformDynamicRangeLimit()
             };
 
-            auto drawResult = context.drawTiledImage(*image, geometry.destinationRect, toLayoutPoint(geometry.relativePhase()), geometry.tileSize, geometry.spaceSize, options);
+            auto drawResult = context.drawTiledImage(*imageToDraw, geometry.destinationRect, toLayoutPoint(geometry.relativePhase()), geometry.tileSize, geometry.spaceSize, options);
             if (drawResult == ImageDrawResult::DidRequestDecoding) {
                 ASSERT(bgImage->hasCachedImage());
                 protect(bgImage->cachedImage())->addClientWaitingForAsyncDecoding(protect(m_renderer)->cachedImageClient());
@@ -900,7 +916,11 @@ void BackgroundPainter::paintBoxShadow(const LayoutRect& paintRect, const Style:
             continue;
 
         Style::ColorResolver colorResolver { style };
+#if ENABLE(AX_CUSTOM_COLOR_MODE)
+        auto shadowColor = axCustomColorModeShadowColor(colorResolver, style, shadow.color);
+#else
         auto shadowColor = colorResolver.colorResolvingCurrentColorApplyingColorFilter(shadow.color);
+#endif
 
         auto shouldInflateBorderRect = [&]() {
             if (!hasOpaqueBackground)

--- a/Source/WebCore/rendering/RenderImage.cpp
+++ b/Source/WebCore/rendering/RenderImage.cpp
@@ -88,6 +88,10 @@
 #include "SpatialImageControls.h"
 #endif
 
+#if ENABLE(AX_CUSTOM_COLOR_MODE)
+#include <WebKitAdditions/RenderImageAdditions.cpp>
+#endif
+
 namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(RenderImage);
@@ -308,6 +312,12 @@ void RenderImage::imageChanged(WrappedImagePtr newImage, const IntRect* rect)
 {
     if (renderTreeBeingDestroyed())
         return;
+
+#if ENABLE(AX_CUSTOM_COLOR_MODE)
+    m_axCustomColorModeShouldAdjustImage = std::nullopt;
+    m_axCustomColorModeAdjustedBuffer = nullptr;
+    m_axCustomColorModeAdjustedBufferSize = { };
+#endif
 
     if (hasVisibleBoxDecorations() || hasMask() || hasShapeOutside())
         RenderReplaced::imageChanged(newImage, rect);
@@ -803,6 +813,12 @@ ImageDrawResult RenderImage::paintIntoRect(PaintInfo& paintInfo, const FloatRect
     };
 
     auto drawResult = ImageDrawResult::DidNothing;
+
+#if ENABLE(AX_CUSTOM_COLOR_MODE)
+    if (axCustomColorModePaintImage(paintInfo, *img, rect))
+        return ImageDrawResult::DidDraw;
+#endif
+
 #if ENABLE(MULTI_REPRESENTATION_HEIC)
     if (isMultiRepresentationHEIC())
         drawResult = paintInfo.context().drawMultiRepresentationHEIC(*img, style().fontCascade().primaryFont(), rect, options);

--- a/Source/WebCore/rendering/RenderImage.h
+++ b/Source/WebCore/rendering/RenderImage.h
@@ -32,6 +32,8 @@ namespace WebCore {
 
 class HTMLAreaElement;
 class HTMLMapElement;
+class GraphicsContext;
+class ImageBuffer;
 
 enum ImageSizeChangeType {
     ImageSizeChangeNone,
@@ -143,6 +145,12 @@ private:
 
     bool shouldCollapseToEmpty() const;
 
+#if ENABLE(AX_CUSTOM_COLOR_MODE)
+    bool axCustomColorModeShouldAdjustImage(Image&);
+    RefPtr<ImageBuffer> axCustomColorModeAdjustedImageBuffer(GraphicsContext&, Image&, const FloatRect&);
+    bool axCustomColorModePaintImage(PaintInfo&, Image&, const FloatRect&);
+#endif
+
     // Text to display as long as the image isn't available.
     String m_altText;
     std::unique_ptr<RenderImageResource> m_imageResource;
@@ -151,6 +159,11 @@ private:
     bool m_hasShadowControls { false };
     bool m_hasImageOverlay { false };
     float m_imageDevicePixelRatio { 1 };
+#if ENABLE(AX_CUSTOM_COLOR_MODE)
+    std::optional<bool> m_axCustomColorModeShouldAdjustImage;
+    RefPtr<ImageBuffer> m_axCustomColorModeAdjustedBuffer;
+    FloatSize m_axCustomColorModeAdjustedBufferSize;
+#endif
 
     friend class RenderImageScaleObserver;
 };

--- a/Source/WebCore/rendering/RenderView.cpp
+++ b/Source/WebCore/rendering/RenderView.cpp
@@ -77,6 +77,10 @@
 #include <wtf/StackStats.h>
 #include <wtf/TZoneMallocInlines.h>
 
+#if ENABLE(AX_CUSTOM_COLOR_MODE)
+#include <WebKitAdditions/RenderViewAdditions.cpp>
+#endif
+
 namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(RenderView);

--- a/Source/WebCore/rendering/RenderView.h
+++ b/Source/WebCore/rendering/RenderView.h
@@ -101,6 +101,12 @@ public:
     void repaintViewRectangle(const LayoutRect&);
     void repaintViewAndCompositedLayers();
 
+#if ENABLE(AX_CUSTOM_COLOR_MODE)
+    // Some color-filter decisions depend on how boxes actually end up positioned relative to the content
+    // behind them, which is only known once layout has run.
+    void adjustAXCustomColorModeAfterLayout();
+#endif
+
     void paint(PaintInfo&, const LayoutPoint&) override;
     void paintBoxDecorations(PaintInfo&, const LayoutPoint&) override;
     // Return the renderer whose background style is used to paint the root background.

--- a/Source/WebCore/style/StyleAdjuster.cpp
+++ b/Source/WebCore/style/StyleAdjuster.cpp
@@ -95,6 +95,10 @@
 #include "DocumentFullscreen.h"
 #endif
 
+#if ENABLE(AX_CUSTOM_COLOR_MODE)
+#include <WebKitAdditions/StyleAdjusterAdditions.cpp>
+#endif
+
 namespace WebCore {
 namespace Style {
 
@@ -801,6 +805,10 @@ void Adjuster::adjust(Style::ComputedStyle& style) const
         style.setContainIntrinsicWidth(style.containIntrinsicWidth().addingAuto());
         style.setContainIntrinsicHeight(style.containIntrinsicHeight().addingAuto());
     }
+
+#if ENABLE(AX_CUSTOM_COLOR_MODE)
+    adjustForAXCustomColorMode(style);
+#endif
 
     adjustForSiteSpecificQuirks(style);
 }

--- a/Source/WebCore/style/StyleAdjuster.h
+++ b/Source/WebCore/style/StyleAdjuster.h
@@ -79,6 +79,10 @@ private:
     void NODELETE adjustDisplayContentsStyle(Style::ComputedStyle&) const;
     void adjustForSiteSpecificQuirks(Style::ComputedStyle&) const;
 
+#if ENABLE(AX_CUSTOM_COLOR_MODE)
+    void adjustForAXCustomColorMode(Style::ComputedStyle&) const;
+#endif
+
     void adjustThemeStyle(Style::ComputedStyle&, const Style::ComputedStyle& parentStyle) const;
 
     static void adjustAnimations(Style::ComputedStyle&);

--- a/Source/WebCore/style/values/color/StyleColorOptions.cpp
+++ b/Source/WebCore/style/values/color/StyleColorOptions.cpp
@@ -37,6 +37,7 @@ TextStream& operator<<(TextStream& ts, StyleColorOptions colorOptions)
     case StyleColorOptions::UseSystemAppearance: ts << "UseSystemAppearance"_s; break;
     case StyleColorOptions::UseDarkAppearance: ts << "UseDarkAppearance"_s; break;
     case StyleColorOptions::UseElevatedUserInterfaceLevel: ts << "UseElevatedUserInterfaceLevel"_s; break;
+    case StyleColorOptions::UseAXCustomColorMode: ts << "UseAXCustomColorMode"_s; break;
     }
     return ts;
 }

--- a/Source/WebCore/style/values/color/StyleColorOptions.h
+++ b/Source/WebCore/style/values/color/StyleColorOptions.h
@@ -33,7 +33,8 @@ enum class StyleColorOptions : uint8_t {
     ForVisitedLink                  = 1 << 0,
     UseSystemAppearance             = 1 << 1,
     UseDarkAppearance               = 1 << 2,
-    UseElevatedUserInterfaceLevel   = 1 << 3
+    UseElevatedUserInterfaceLevel   = 1 << 3,
+    UseAXCustomColorMode            = 1 << 4
 };
 
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, StyleColorOptions);

--- a/Source/WebCore/style/values/images/kinds/StyleGradientImage.h
+++ b/Source/WebCore/style/values/images/kinds/StyleGradientImage.h
@@ -46,6 +46,8 @@ public:
 
     static constexpr bool isFixedSize = false;
 
+    const Gradient& gradient() const LIFETIME_BOUND { return m_gradient; }
+
 private:
     explicit GradientImage(Gradient&&);
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKPreferences.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKPreferences.mm
@@ -885,6 +885,27 @@ static WebCore::EditableLinkBehavior NODELETE toEditableLinkBehavior(_WKEditable
     return protect(*_preferences)->colorFilterEnabled();
 }
 
+#if ENABLE(AX_CUSTOM_COLOR_MODE)
+- (void)_setAXCustomColorModeEnabled:(BOOL)enabled
+{
+    protect(*_preferences)->setAXCustomColorModeEnabled(enabled);
+}
+
+- (BOOL)_axCustomColorModeEnabled
+{
+    return protect(*_preferences)->axCustomColorModeEnabled();
+}
+#else
+- (void)_setAXCustomColorModeEnabled:(BOOL)enabled
+{
+}
+
+- (BOOL)_axCustomColorModeEnabled
+{
+    return NO;
+}
+#endif
+
 - (void)_setPunchOutWhiteBackgroundsInDarkMode:(BOOL)punches
 {
     protect(*_preferences)->setPunchOutWhiteBackgroundsInDarkMode(punches);

--- a/Source/WebKit/UIProcess/API/Cocoa/WKPreferencesPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKPreferencesPrivate.h
@@ -165,6 +165,7 @@ typedef NS_ENUM(NSInteger, _WKNavigatorWebDriverActivePolicy) {
 @property (nonatomic, getter=_isSafeBrowsingEnabled, setter=_setSafeBrowsingEnabled:) BOOL _safeBrowsingEnabled WK_API_AVAILABLE(macos(10.14.4), ios(12.2));
 
 @property (nonatomic, setter=_setColorFilterEnabled:) BOOL _colorFilterEnabled WK_API_AVAILABLE(macos(10.14), ios(12.0));
+@property (nonatomic, setter=_setAXCustomColorModeEnabled:) BOOL _axCustomColorModeEnabled WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
 @property (nonatomic, setter=_setPunchOutWhiteBackgroundsInDarkMode:) BOOL _punchOutWhiteBackgroundsInDarkMode WK_API_AVAILABLE(macos(10.14), ios(12.0));
 @property (nonatomic, setter=_setLowPowerVideoAudioBufferSizeEnabled:) BOOL _lowPowerVideoAudioBufferSizeEnabled WK_API_AVAILABLE(macos(10.14.4), ios(12.2));
 @property (nonatomic, setter=_setShouldIgnoreMetaViewport:) BOOL _shouldIgnoreMetaViewport WK_API_AVAILABLE(macos(10.14.4), ios(12.2));


### PR DESCRIPTION
#### 2c2a4add5574c8388732a753dd1841715ed15fc4
<pre>
Add foundation for Accessibility Custom Color Mode
<a href="https://webkit.org/b/320261">https://webkit.org/b/320261</a>
<a href="https://rdar.apple.com/183153900">rdar://183153900</a>

Reviewed by Tim Nguyen.

Add foundation for Accessibility Custom Color Mode.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::adjustStyleColorOptionsIfNeeded const):
(WebCore::Document::styleColorOptions const):
* Source/WebCore/dom/Document.h:
* Source/WebCore/loader/cache/CachedImage.cpp:
(WebCore::CachedImage::clearImage):
(WebCore::CachedImage::axCustomColorModeAdjustedTile const):
(WebCore::CachedImage::setAXCustomColorModeAdjustedTile):
* Source/WebCore/loader/cache/CachedImage.h:
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::performPostLayoutTasks):
* Source/WebCore/rendering/BackgroundPainter.cpp:
(WebCore::applyBoxShadowForBackground):
(WebCore::BackgroundPainter::paintFillLayerImpl const):
(WebCore::BackgroundPainter::paintBoxShadow const):
* Source/WebCore/rendering/RenderImage.cpp:
(WebCore::RenderImage::imageChanged):
(WebCore::RenderImage::paintIntoRect):
* Source/WebCore/rendering/RenderImage.h:
* Source/WebCore/rendering/RenderView.cpp:
* Source/WebCore/rendering/RenderView.h:
* Source/WebCore/style/StyleAdjuster.cpp:
(WebCore::Style::Adjuster::adjust const):
* Source/WebCore/style/StyleAdjuster.h:
* Source/WebCore/style/values/color/StyleColorOptions.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/style/values/color/StyleColorOptions.h:
* Source/WebCore/style/values/images/kinds/StyleGradientImage.h:
* Source/WebKit/UIProcess/API/Cocoa/WKPreferences.mm:
(-[WKPreferences _setAXCustomColorModeEnabled:]):
(-[WKPreferences _axCustomColorModeEnabled]):
* Source/WebKit/UIProcess/API/Cocoa/WKPreferencesPrivate.h:

Canonical link: <a href="https://commits.webkit.org/318119@main">https://commits.webkit.org/318119@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/58157a1180a3251871e3aa8a80dfe96d33ad9536

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177396 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51334 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/45128 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187000 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140643 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/13a21c91-7878-49cb-a333-1a06ed1949dc) 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179259 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; Passed bindings tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52626 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51043 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/138249 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140643 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/66b886f4-0463-4ae6-a51e-4b7ff259ef3c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180352 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/41749 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/45128 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/118714 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8c09ac4a-edb4-4c9e-bb64-fef5d9a204c0) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/40411 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/38785 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/251/builds/683 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/45128 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/150818 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/45128 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35467 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/38667 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/43119 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/43019 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189428 "Built successfully") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/51001 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/45128 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/147341 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51683 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/45128 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/147133 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26899 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/41853 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/123898 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/118236 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50191 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/45128 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49587 "Built successfully") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/49827 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/49649 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->