### PR TITLE
[Site Isolation] [iOS] Tapping sometimes doesn't work when shared process is enabled

### DIFF
--- a/LayoutTests/http/tests/site-isolation/touch-events/resources/nested-ad-reports-click.html
+++ b/LayoutTests/http/tests/site-isolation/touch-events/resources/nested-ad-reports-click.html
@@ -1,0 +1,6 @@
+<body style="margin: 0; width: 100vw; height: 100vh;">
+<a href="#" style="display: block; width: 100vw; height: 100vh;" onclick="window.top.postMessage('clicked', '*'); return false;">ad</a>
+<script>
+window.top.postMessage("ready", "*");
+</script>
+</body>

--- a/LayoutTests/http/tests/site-isolation/touch-events/resources/samesite-offset-container.html
+++ b/LayoutTests/http/tests/site-isolation/touch-events/resources/samesite-offset-container.html
@@ -1,0 +1,3 @@
+<body style="margin: 0;">
+<iframe style="width: 100%; height: 100%; border: none;" src="http://localhost:8000/site-isolation/touch-events/resources/nested-ad-reports-click.html"></iframe>
+</body>

--- a/LayoutTests/http/tests/site-isolation/touch-events/tap-nested-cross-origin-frame-in-offset-subframe-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/touch-events/tap-nested-cross-origin-frame-in-offset-subframe-expected.txt
@@ -1,0 +1,10 @@
+Tapping a cross-origin iframe that is nested inside an offset same-site subframe must reach the iframe. Regression test: potentialTapAtPosition transformed the tap using the nested owner frame's view with a top-level-frame position, double-counting the container's offset so the tap landed outside the cross-origin frame.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS The nested cross-origin iframe received the tap.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/site-isolation/touch-events/tap-nested-cross-origin-frame-in-offset-subframe.html
+++ b/LayoutTests/http/tests/site-isolation/touch-events/tap-nested-cross-origin-frame-in-offset-subframe.html
@@ -1,0 +1,30 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<script src="/js-test-resources/js-test.js"></script>
+<script src="/js-test-resources/ui-helper.js"></script>
+<script>
+description("Tapping a cross-origin iframe that is nested inside an offset same-site subframe must reach the iframe. Regression test: potentialTapAtPosition transformed the tap using the nested owner frame's view with a top-level-frame position, double-counting the container's offset so the tap landed outside the cross-origin frame.");
+jsTestIsAsync = true;
+
+let done = false;
+addEventListener("message", (event) => {
+    if (event.data === "ready") {
+        // The same-site container iframe is at (350, 300) sized 300x250, and the cross-origin ad
+        // fills it. Tap the ad's center at the top-level point (500, 425), which is (150, 125)
+        // inside the ad. With the bug the container's (350, 300) offset is double-counted, so the
+        // ad receives the tap at (500, 425) -- outside its 300x250 box -- and nothing happens.
+        UIHelper.tapAt(500, 425);
+        setTimeout(() => {
+            if (done)
+                return;
+            done = true;
+            testFailed("The nested cross-origin iframe did not receive the tap.");
+            finishJSTest();
+        }, 3000);
+    } else if (event.data === "clicked" && !done) {
+        done = true;
+        testPassed("The nested cross-origin iframe received the tap.");
+        finishJSTest();
+    }
+});
+</script>
+<iframe style="position: absolute; left: 350px; top: 300px; width: 300px; height: 250px; border: none;" src="http://127.0.0.1:8000/site-isolation/touch-events/resources/samesite-offset-container.html"></iframe>

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -3106,20 +3106,19 @@ Awaitable<std::optional<WebCore::RemoteUserInputEventData>> WebPage::potentialTa
 
     RefPtr localMainFrame = protect(*m_page)->localMainFrame();
 
-    if (RefPtr localRootFrame = this->localRootFrame(frameID))
+    RefPtr localRootFrame = this->localRootFrame(frameID);
+    if (localRootFrame)
         m_potentialTapNode = localRootFrame->nodeRespondingToClickEvents(position, m_potentialTapLocation, m_potentialTapSecurityOrigin.get());
 
     RefPtr frameOwner = dynamicDowncast<HTMLFrameOwnerElement>(m_potentialTapNode.get());
     if (RefPtr remoteFrame = frameOwner ? dynamicDowncast<RemoteFrame>(frameOwner->contentFrame()) : nullptr) {
-        RefPtr localFrame = frameOwner->document().frame();
-        if (RefPtr frameView = localFrame ? localFrame->view() : nullptr) {
-            if (RefPtr remoteFrameView = remoteFrame->view()) {
-                RemoteFrameGeometryTransformer transformer(remoteFrameView.releaseNonNull(), frameView.releaseNonNull(), remoteFrame->frameID());
-                co_return WebCore::RemoteUserInputEventData {
-                    remoteFrame->frameID(),
-                    transformer.transformToRemoteFrameCoordinates(position)
-                };
-            }
+        RefPtr localRootView = localRootFrame ? localRootFrame->view() : nullptr;
+        if (RefPtr remoteFrameView = remoteFrame->view(); remoteFrameView && localRootView) {
+            RemoteFrameGeometryTransformer transformer(remoteFrameView.releaseNonNull(), localRootView.releaseNonNull(), remoteFrame->frameID());
+            co_return WebCore::RemoteUserInputEventData {
+                remoteFrame->frameID(),
+                transformer.transformToRemoteFrameCoordinates(position)
+            };
         }
     }
 


### PR DESCRIPTION
#### 0825ca6fee879a88c69897d806a5d1db09b77f70
<pre>
[Site Isolation] [iOS] Tapping sometimes doesn&apos;t work when shared process is enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=320288">https://bugs.webkit.org/show_bug.cgi?id=320288</a>
<a href="https://rdar.apple.com/179511074">rdar://179511074</a>

Reviewed by Sihui Liu and Wenson Hsieh.

The bug was caused by a coordinate-transform bug in the iOS two-phase tap path.

When user taps on a page and the main frame&apos;s process first does hit testing. When it lands
on a cross-origin (remote) iframe it transforms the tap into that frame&apos;s coordinate space
and re-dispatches it to the frame&apos;s process. The transform was:

remoteFrameView-&gt;rootViewToContents( ownerFrameView-&gt;contentsToRootView(position) )

where ownerFrameView was frameOwner-&gt;document().frame()-&gt;view() - the view of the frame that
contains the tapped iframe element. The position is now expressed in the hit-tested (root)
frame&apos;s coordinates, but when the cross-origin iframe is nested inside an offset same-site
subframe, frameOwner-&gt;document().frame() is that nested subframe - not the root frame.

Feeding a root-frame point through the nested frame&apos;s contentsToRootView double-counts the
container&apos;s offset; rootViewToContents then subtracts it back, so the transform nets to
identity and the tap lands outside the target frame. The remote frame&apos;s process finds no
node there so the click is never synthesized and nothing happens.

This PR fixes the bug by in potentialTapAtPosition, transforming the point starting from
localRootFrame&apos;s view (the frame the hit-test was performed in, whose coordinates position
is actually in) instead of the tapped iframe owner&apos;s frame view.
RemoteFrameView::rootViewToContents already walks the full ancestor chain, so composing it
with the root frame&apos;s contentsToRootView yields the correct point regardless of nesting depth.
Direct-child taps are unchanged (there localRootFrame == the owner&apos;s frame).

Test: http/tests/site-isolation/touch-events/tap-nested-cross-origin-frame-in-offset-subframe.html

* LayoutTests/http/tests/site-isolation/touch-events/resources/nested-ad-reports-click.html: Added.
* LayoutTests/http/tests/site-isolation/touch-events/resources/samesite-offset-container.html: Added.
* LayoutTests/http/tests/site-isolation/touch-events/tap-nested-cross-origin-frame-in-offset-subframe-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/touch-events/tap-nested-cross-origin-frame-in-offset-subframe.html: Added.
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::potentialTapAtPosition):

Canonical link: <a href="https://commits.webkit.org/317994@main">https://commits.webkit.org/317994@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b3f6232a1d6370d771a647ddb421a0d16b8252dc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176761 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50698 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44490 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186363 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/139997 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b412a9f5-955e-4b0c-b815-fa6f4ad6dd12) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51991 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50384 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137697 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/139997 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e3cd10ab-f213-4181-9d03-0c5955218856) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179717 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41203 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158487 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118171 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/60d793c1-f540-4b47-bde7-4598ae06f27d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39857 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38225 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150269 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37985 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34831 "Build is in progress. Recent messages:Printed configuration; Checked out pull request; Compiled WebKit (warnings)") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42442 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42441 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188787 "Built successfully") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50365 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/158030 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146762 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51048 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34606 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146567 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26843 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41331 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123256 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117428 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49553 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12964 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48952 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49188 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49013 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->