### PR TITLE
Make IRO faster

### DIFF
--- a/Source/JavaScriptCore/dfg/DFGIntegerRangeOptimizationPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGIntegerRangeOptimizationPhase.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2015-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2026 Igalia S.L.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -44,6 +45,7 @@ namespace DFGIntegerRangeOptimizationPhaseInternal {
 static constexpr bool verbose = false;
 }
 const unsigned giveUpThreshold = 50;
+constexpr size_t relationshipListInlineCapacity = 8;
 
 int64_t NODELETE clampedSumImpl() { return 0; }
 
@@ -1149,7 +1151,8 @@ public:
         bool changed = true;
         while (changed) {
             ++m_iterations;
-            if (m_iterations >= giveUpThreshold) {
+
+            if (outOfWorkBudget() || m_iterations >= giveUpThreshold) {
                 // This case is not necessarily wrong but it can be a sign that this phase
                 // does not converge. The value giveUpThreshold was chosen emperically based on
                 // current tests and real world JS.
@@ -1162,6 +1165,9 @@ public:
 
             changed = false;
             for (unsigned postOrderIndex = postOrder.size(); postOrderIndex--;) {
+                if (outOfWorkBudget()) [[unlikely]]
+                    return false;
+
                 BasicBlock* block = postOrder[postOrderIndex];
                 DFG_ASSERT(
                     m_graph, nullptr,
@@ -1268,19 +1274,16 @@ public:
 
                     if (relationshipForTrue.size() || relationshipForFalse.size()) {
                         RelationshipMap forTrue = m_relationships;
-                        RelationshipMap forFalse = m_relationships;
-
                         for (auto relationship : relationshipForTrue) {
                             dataLogLnIf(DFGIntegerRangeOptimizationPhaseInternal::verbose, "Dealing with true: ", relationship);
                             setRelationship(forTrue, relationship);
                         }
+                        changed |= mergeTo(forTrue, branchData->taken.block);
                         for (auto relationship : relationshipForFalse) {
                             dataLogLnIf(DFGIntegerRangeOptimizationPhaseInternal::verbose, "Dealing with false: ", relationship);
-                            setRelationship(forFalse, relationship);
+                            setRelationship(m_relationships, relationship);
                         }
-
-                        changed |= mergeTo(forTrue, branchData->taken.block);
-                        changed |= mergeTo(forFalse, branchData->notTaken.block);
+                        changed |= mergeTo(m_relationships, branchData->notTaken.block);
                         alreadyMerged = true;
                     }
                 }
@@ -1533,6 +1536,12 @@ public:
     }
 
 private:
+    bool outOfWorkBudget() const
+    {
+        unsigned budget = Options::maxIntegerRangeOptimizationWork();
+        return budget && m_work >= budget;
+    }
+
     void executeNode(Node* node)
     {
         switch (node->op()) {
@@ -1594,7 +1603,7 @@ private:
             
             auto iter = m_relationships.find(node->child1().node());
             if (iter != m_relationships.end()) {
-                Vector<Relationship> toAdd;
+                Vector<Relationship, relationshipListInlineCapacity> toAdd;
                 for (Relationship relationship : iter->value) {
                     // We have:
                     //     add: ArithAdd(@x, C)
@@ -1805,7 +1814,7 @@ private:
         
         auto iter = m_relationships.find(oldNode);
         if (iter != m_relationships.end()) {
-            Vector<Relationship> toAdd;
+            Vector<Relationship, relationshipListInlineCapacity> toAdd;
             for (Relationship relationship : iter->value) {
                 Relationship newRelationship = relationship;
                 // Avoid creating any kind of self-relationship.
@@ -1843,6 +1852,8 @@ private:
         auto result = relationshipMap.add(
             relationship.left(), Vector<Relationship>());
         Vector<Relationship>& relationships = result.iterator->value;
+
+        m_work += relationships.size();
 
         if (relationship.right()->isInt32Constant()) {
             // We want to do some work to refine relationships over constants. This is necessary because
@@ -1913,7 +1924,7 @@ private:
             }
         }
 
-        Vector<Relationship> toAdd;
+        Vector<Relationship, relationshipListInlineCapacity> toAdd;
         bool found = false;
         for (Relationship& otherRelationship : relationships) {
             if (otherRelationship.sameNodesAs(relationship)) {
@@ -1954,8 +1965,11 @@ private:
             }
         }
 
-        if (timeToLive && relationship.kind() != Relationship::Equal) {
-            for (Relationship& possibleEquality : relationshipMap.get(relationship.right())) {
+        auto possibleEqualities = timeToLive && relationship.kind() != Relationship::Equal
+            ? relationshipMap.find(relationship.right())
+            : relationshipMap.end();
+        if (possibleEqualities != relationshipMap.end()) {
+            for (Relationship& possibleEquality : possibleEqualities->value) {
                 if (possibleEquality.kind() != Relationship::Equal
                     || possibleEquality.offset() == std::numeric_limits<int>::min()
                     || possibleEquality.right() == relationship.left())
@@ -1978,7 +1992,8 @@ private:
             }
         }
 
-        if (!found)
+        unsigned maxRelationships = Options::maxIntegerRangeOptimizationRelationshipsPerNode();
+        if (!found && (!maxRelationships || relationships.size() < maxRelationships))
             relationships.append(relationship);
         
         for (Relationship anotherRelationship : toAdd) {
@@ -2019,7 +2034,7 @@ private:
                 }
                 
                 std::sort(values.begin(), values.end());
-                m_relationshipsAtHead[target].add(entry.key, values);
+                m_relationshipsAtHead[target].add(entry.key, WTF::move(values));
             }
             return true;
         }
@@ -2030,7 +2045,7 @@ private:
         // assigned would only happen if we have not processed the node's predecessor. We
         // shouldn't process blocks until we have processed the block's predecessor because we
         // are using reverse postorder.
-        Vector<NodeFlowProjection> toRemove;
+        Vector<NodeFlowProjection, relationshipListInlineCapacity> toRemove;
         bool changed = false;
         for (auto& entry : m_relationshipsAtHead[target]) {
             auto iter = relationshipMap.find(entry.key);
@@ -2040,13 +2055,14 @@ private:
                 continue;
             }
 
-            Vector<Relationship> constantRelationshipsAtHead;
+            Vector<Relationship, relationshipListInlineCapacity> constantRelationshipsAtHead;
             for (Relationship& relationshipAtHead : entry.value) {
                 if (relationshipAtHead.right()->isInt32Constant())
                     constantRelationshipsAtHead.append(relationshipAtHead);
             }
 
-            Vector<Relationship> mergedRelationships;
+            Vector<Relationship, relationshipListInlineCapacity> mergedRelationships;
+            m_work += static_cast<uint64_t>(entry.value.size()) * iter->value.size();
             for (Relationship targetRelationship : entry.value) {
                 for (Relationship sourceRelationship : iter->value) {
                     dataLogLnIf(DFGIntegerRangeOptimizationPhaseInternal::verbose, "  Merging ", targetRelationship, " and ", sourceRelationship, ":");
@@ -2145,6 +2161,8 @@ private:
     InsertionSet m_insertionSet;
 
     unsigned m_iterations { 0 };
+
+    uint64_t m_work { 0 };
 };
     
 } // anonymous namespace

--- a/Source/JavaScriptCore/dfg/DFGNodeFlowProjection.h
+++ b/Source/JavaScriptCore/dfg/DFGNodeFlowProjection.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2016-2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2026 Igalia S.L.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -28,6 +29,7 @@
 #if ENABLE(DFG_JIT)
 
 #include "DFGNode.h"
+#include <wtf/HashFunctions.h>
 #include <wtf/HashTable.h>
 
 namespace JSC { namespace DFG {
@@ -69,7 +71,7 @@ public:
     
     unsigned hash() const
     {
-        return m_word;
+        return WTF::IntHash<uintptr_t>::hash(m_word);
     }
     
     friend bool operator==(const NodeFlowProjection&, const NodeFlowProjection&) = default;
@@ -135,4 +137,3 @@ template<> struct HashTraits<JSC::DFG::NodeFlowProjection> : SimpleClassHashTrai
 } // namespace WTF
 
 #endif // ENABLE(DFG_JIT)
-

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -631,6 +631,8 @@ bool hasCapacityToUseLargeGigacage();
     v(Unsigned, maxPartialLoopUnrollingBodyNodeSize, 70, Normal, nullptr) \
     v(Unsigned, maxPartialLoopUnrollingIterationCount, 4, Normal, nullptr) \
     v(Unsigned, maxNumericHotLoopSize, 225, Normal, nullptr) \
+    v(Unsigned, maxIntegerRangeOptimizationRelationshipsPerNode, 24, Normal, "How many relationships IRO keeps about any one node, 0 for no cap."_s) \
+    v(Unsigned, maxIntegerRangeOptimizationWork, 50000000, Normal, "Give up threshold for IRO"_s) \
     v(Bool, printEachUnrolledLoop, false, Normal, nullptr) \
     v(Bool, verboseExecutablePoolAllocation, false, Normal, nullptr) \
     v(Bool, useHandlerICInFTL, false, Normal, nullptr) \


### PR DESCRIPTION
#### 68cde6ba2ad363f71e6c9faa71ae9ba7955b4506
<pre>
Make IRO faster
<a href="https://bugs.webkit.org/show_bug.cgi?id=320289">https://bugs.webkit.org/show_bug.cgi?id=320289</a>

Reviewed by Keith Miller.

IRO is pretty dumb sometimes, but it takes up a lot of compile time. Here
I have tuned it to not pessimise any existing benchmarks, but to stop
early in larger functions. When we get larger functions that benefit
from IRO in our benchmarks, we can reconsider this tuning (or perhaps
do something even more clever, such as an adjustable budget based on
trip count).

This saves ~20% of IRO execution time on IRO-heavy JS3 subtests, which is
~3% of FTL compile time.

* Source/JavaScriptCore/dfg/DFGIntegerRangeOptimizationPhase.cpp:
* Source/JavaScriptCore/dfg/DFGNodeFlowProjection.h:
(JSC::DFG::NodeFlowProjection::hash const):
* Source/JavaScriptCore/runtime/OptionsList.h:

Canonical link: <a href="https://commits.webkit.org/318321@main">https://commits.webkit.org/318321@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/36abe87c787a5117e471d1bfa1febb95b14b362b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177209 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51147 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44941 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186812 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140445 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52439 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50947 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138104 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140445 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180165 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41590 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158861 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118569 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40250 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38630 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/538 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/7361 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150659 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38359 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35280 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/38480 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42932 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42942 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189238 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50813 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147175 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39706 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51496 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34985 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146967 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41701 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123711 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118031 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50001 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13337 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49400 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49639 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49461 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->