### PR TITLE
Simplify remove-matching-entries loops by using WTF container removeIf()

### DIFF
--- a/Source/WebCore/PAL/pal/text/TextEncodingRegistry.cpp
+++ b/Source/WebCore/PAL/pal/text/TextEncodingRegistry.cpp
@@ -186,14 +186,9 @@ static void pruneBlocklistedCodecs() WTF_REQUIRES_LOCK(encodingRegistryLock)
         if (atomName.isNull())
             continue;
 
-        Vector<ASCIILiteral> names;
-        for (auto& entry : textEncodingNameMap) {
-            if (entry.value == atomName)
-                names.append(entry.key);
-        }
-
-        for (auto& name : names)
-            textEncodingNameMap.remove(name);
+        textEncodingNameMap.removeIf([&](auto& entry) {
+            return entry.value == atomName;
+        });
 
         textCodecMap.remove(atomName);
     }

--- a/Source/WebCore/platform/graphics/SystemFallbackFontCache.cpp
+++ b/Source/WebCore/platform/graphics/SystemFallbackFontCache.cpp
@@ -92,13 +92,9 @@ void SystemFallbackFontCache::remove(Font* font)
         return;
 
     for (auto& characterMap : m_characterFallbackMaps.values()) {
-        Vector<CharacterFallbackMapKey, 512> toRemove;
-        for (auto& entry : characterMap) {
-            if (entry.value == font)
-                toRemove.append(entry.key);
-        }
-        for (auto& key : toRemove)
-            characterMap.remove(key);
+        characterMap.removeIf([&](auto& entry) {
+            return entry.value == font;
+        });
     }
 }
 

--- a/Source/WebCore/platform/graphics/cg/CGSubimageCacheWithTimer.cpp
+++ b/Source/WebCore/platform/graphics/cg/CGSubimageCacheWithTimer.cpp
@@ -137,14 +137,9 @@ void CGSubimageCacheWithTimer::clearImageAndSubimages(CGImageRef image)
 {
     Locker locker { m_lock };
     if (m_imageCounts.contains(image)) {
-        Vector<CacheEntry> toBeRemoved;
-        for (const auto& entry : m_cache) {
-            if (entry.image.get() == image)
-                toBeRemoved.append(entry);
-        }
-
-        for (auto& entry : toBeRemoved)
-            m_cache.remove(entry);
+        m_cache.removeIf([&](auto& entry) {
+            return entry.image.get() == image;
+        });
 
         m_imageCounts.removeAll(image);
     }

--- a/Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp
@@ -746,13 +746,9 @@ std::unique_ptr<FontPlatformData> FontCache::createFontPlatformData(const FontDe
 
 void FontCache::platformPurgeInactiveFontData()
 {
-    Vector<CTFontRef> toRemove;
-    for (auto& font : m_fallbackFonts) {
-        if (CFGetRetainCount(font.get()) == 1)
-            toRemove.append(font.get());
-    }
-    for (auto& font : toRemove)
-        m_fallbackFonts.remove(font);
+    m_fallbackFonts.removeIf([](auto& font) {
+        return CFGetRetainCount(font.get()) == 1;
+    });
 
     m_databaseAllowingUserInstalledFonts.clear();
     m_databaseDisallowingUserInstalledFonts.clear();

--- a/Source/WebCore/platform/ios/LegacyTileGrid.mm
+++ b/Source/WebCore/platform/ios/LegacyTileGrid.mm
@@ -88,16 +88,10 @@ void LegacyTileGrid::dropTilesOutsideRect(const IntRect& keepRect)
 
 void LegacyTileGrid::dropTilesBetweenRects(const IntRect& dropRect, const IntRect& keepRect)
 {
-    Vector<TileIndex> toRemove;
-    for (const auto& tile : m_tiles) {
-        const TileIndex& index = tile.key;
+    m_tiles.removeIf([&](auto& tile) {
         IntRect tileRect = tile.value->rect();
-        if (tileRect.intersects(dropRect) && !tileRect.intersects(keepRect))
-            toRemove.append(index);
-    }
-    unsigned removeCount = toRemove.size();
-    for (unsigned n = 0; n < removeCount; ++n)
-        m_tiles.remove(toRemove[n]);
+        return tileRect.intersects(dropRect) && !tileRect.intersects(keepRect);
+    });
 }
 
 unsigned LegacyTileGrid::tileByteSize() const
@@ -319,17 +313,11 @@ void LegacyTileGrid::dropInvalidTiles()
 {
     IntRect bounds = this->bounds();
     IntRect dropBounds = intersection(m_validBounds, bounds);
-    Vector<TileIndex> toRemove;
-    for (const auto& tile : m_tiles) {
-        const TileIndex& index = tile.key;
+    m_tiles.removeIf([&](auto& tile) {
         const IntRect& tileRect = tile.value->rect();
-        IntRect expectedTileRect = tileRectForIndex(index);
-        if (expectedTileRect != tileRect || !dropBounds.contains(tileRect))
-            toRemove.append(index);
-    }
-    unsigned removeCount = toRemove.size();
-    for (unsigned n = 0; n < removeCount; ++n)
-        m_tiles.remove(toRemove[n]);
+        IntRect expectedTileRect = tileRectForIndex(tile.key);
+        return expectedTileRect != tileRect || !dropBounds.contains(tileRect);
+    });
 
     m_validBounds = bounds;
 }

--- a/Source/WebCore/platform/network/CredentialStorage.cpp
+++ b/Source/WebCore/platform/network/CredentialStorage.cpp
@@ -89,18 +89,14 @@ void CredentialStorage::remove(const String& partitionName, const ProtectionSpac
 
 void CredentialStorage::removeCredentialsWithOrigin(const SecurityOriginData& origin)
 {
-    Vector<std::pair<String, ProtectionSpace>> keysToRemove;
-    for (auto& keyValuePair : m_protectionSpaceToCredentialMap) {
+    m_protectionSpaceToCredentialMap.removeIf([&](auto& keyValuePair) {
         auto& protectionSpace = keyValuePair.key.second;
-        if (protectionSpace.host() == origin.host()
+        return protectionSpace.host() == origin.host()
             && ((origin.port() && protectionSpace.port() == *origin.port())
                 || (!origin.port() && protectionSpace.port() == 80))
             && ((protectionSpace.serverType() == ProtectionSpace::ServerType::HTTP && origin.protocol() == "http"_s)
-                || (protectionSpace.serverType() == ProtectionSpace::ServerType::HTTPS && origin.protocol() == "https"_s)))
-            keysToRemove.append(keyValuePair.key);
-    }
-    for (auto& key : keysToRemove)
-        remove(key.first, key.second);
+                || (protectionSpace.serverType() == ProtectionSpace::ServerType::HTTPS && origin.protocol() == "https"_s));
+    });
 }
 
 HashSet<SecurityOriginData> CredentialStorage::originsWithCredentials() const

--- a/Source/WebCore/rendering/TextAutoSizing.cpp
+++ b/Source/WebCore/rendering/TextAutoSizing.cpp
@@ -191,15 +191,10 @@ auto TextAutoSizingValue::adjustTextNodeSizes() -> StillHasNodes
 {
     // Remove stale nodes. Nodes may have had their renderers detached. We'll also need to remove the style from the documents m_textAutoSizedNodes
     // collection. Return true indicates we need to do that removal.
-    Vector<Text*> nodesForRemoval;
-    for (auto& textNode : m_autoSizedNodes) {
+    m_autoSizedNodes.removeIf([&](auto& textNode) {
         auto* renderer = textNode->renderer();
-        if (!renderer || !renderer->style().textSizeAdjust().isAuto() || !renderer->candidateComputedTextSize())
-            nodesForRemoval.append(textNode.ptr());
-    }
-
-    for (auto& node : nodesForRemoval)
-        m_autoSizedNodes.remove(node);
+        return !renderer || !renderer->style().textSizeAdjust().isAuto() || !renderer->candidateComputedTextSize();
+    });
 
     StillHasNodes stillHasNodes = m_autoSizedNodes.isEmpty() ? StillHasNodes::No : StillHasNodes::Yes;
 

--- a/Source/WebKit/UIProcess/API/glib/IconDatabase.cpp
+++ b/Source/WebKit/UIProcess/API/glib/IconDatabase.cpp
@@ -272,14 +272,9 @@ void IconDatabase::clearLoadedIconsTimerFired()
 
     Locker locker { m_loadedIconsLock };
     auto now = MonotonicTime::now();
-    Vector<String> iconsToRemove;
-    for (auto iter : m_loadedIcons) {
-        if (now - iter.value.second >= loadedIconExpirationTime)
-            iconsToRemove.append(iter.key);
-    }
-
-    for (auto& iconURL : iconsToRemove)
-        m_loadedIcons.remove(iconURL);
+    m_loadedIcons.removeIf([&](auto& iter) {
+        return now - iter.value.second >= loadedIconExpirationTime;
+    });
 
     if (!m_loadedIcons.isEmpty())
         startClearLoadedIconsTimer();

--- a/Source/WebKit/UIProcess/WebNavigationState.cpp
+++ b/Source/WebKit/UIProcess/WebNavigationState.cpp
@@ -114,13 +114,9 @@ void WebNavigationState::clearAllNavigations()
 
 void WebNavigationState::clearNavigationsFromProcess(WebCore::ProcessIdentifier processID)
 {
-    Vector<WebCore::NavigationIdentifier> navigationIDsToRemove;
-    for (auto& navigation : m_navigations.values()) {
-        if (navigation->processID() == processID)
-            navigationIDsToRemove.append(navigation->navigationID());
-    }
-    for (auto navigationID : navigationIDsToRemove)
-        m_navigations.remove(navigationID);
+    m_navigations.removeIf([&](auto& entry) {
+        return entry.value->processID() == processID;
+    });
 }
 
 void WebNavigationState::ref() const

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.mm
@@ -466,14 +466,9 @@ void AsyncPDFRenderer::willRemoveGrid(TiledBacking&, TileGridIdentifier gridIden
         return keyValuePair.key.gridIdentifier == gridIdentifier;
     });
 
-    Vector<TileForGrid> requestsToRemove;
-    for (auto& tileRequests : m_pendingTileRenderOrder) {
-        if (tileRequests.gridIdentifier == gridIdentifier)
-            requestsToRemove.append(tileRequests);
-    }
-
-    for (auto& tile : requestsToRemove)
-        m_pendingTileRenderOrder.remove(tile);
+    m_pendingTileRenderOrder.removeIf([gridIdentifier](auto& tileRequests) {
+        return tileRequests.gridIdentifier == gridIdentifier;
+    });
 
     m_tileGridToLayerIDMap.remove(gridIdentifier);
 }


### PR DESCRIPTION
#### 41655c489e18c93c2bf0614173c3ac942fbf35fe
<pre>
Simplify remove-matching-entries loops by using WTF container removeIf()
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=320290">https://bugs.webkit.org/show_bug.cgi?id=320290</a>&gt;
&lt;<a href="https://rdar.apple.com/183222655">rdar://183222655</a>&gt;

Reviewed by Abrar Rahman Protyasha.

Several call sites delete matching entries from a `HashMap`, `HashSet`,
or `ListHashSet` by first collecting the matching elements or keys into
a temporary `Vector`, then looping over that `Vector` to remove each one
from the container.  The temporary storage and the second traversal are
unnecessary: WTF containers provide `removeIf(predicate)`, which removes
every matching entry in a single pass.

Collapse each such loop into a `removeIf()` call.  In every converted
case the predicate depends only on the individual element, uses
loop-invariant captures, and does not mutate the container
mid-iteration, so the result is identical to the collect-then-remove
form.

No new tests since no change in behavior.

* Source/WebCore/PAL/pal/text/TextEncodingRegistry.cpp:
(PAL::pruneBlocklistedCodecs):
* Source/WebCore/platform/graphics/SystemFallbackFontCache.cpp:
(WebCore::SystemFallbackFontCache::remove):
* Source/WebCore/platform/graphics/cg/CGSubimageCacheWithTimer.cpp:
(WebCore::CGSubimageCacheWithTimer::clearImageAndSubimages):
* Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp:
(WebCore::FontCache::platformPurgeInactiveFontData):
* Source/WebCore/platform/ios/LegacyTileGrid.mm:
(WebCore::LegacyTileGrid::dropTilesBetweenRects):
(WebCore::LegacyTileGrid::dropInvalidTiles):
* Source/WebCore/platform/network/CredentialStorage.cpp:
(WebCore::CredentialStorage::removeCredentialsWithOrigin):
* Source/WebCore/rendering/TextAutoSizing.cpp:
(WebCore::TextAutoSizingValue::adjustTextNodeSizes):
* Source/WebKit/UIProcess/API/glib/IconDatabase.cpp:
(WebKit::IconDatabase::clearLoadedIconsTimerFired):
* Source/WebKit/UIProcess/WebNavigationState.cpp:
(WebKit::WebNavigationState::clearNavigationsFromProcess):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.mm:
(WebKit::AsyncPDFRenderer::willRemoveGrid):

Canonical link: <a href="https://commits.webkit.org/317934@main">https://commits.webkit.org/317934@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8bcff0e056cd56c496d22575014090035fab4820

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176801 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50738 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44530 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186403 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140037 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0f378af4-ba34-4757-bb5a-b6718b8966b1) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178664 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52031 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50424 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137730 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140037 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8d2a0dd4-ee4c-45bd-8720-dc783386c4b7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179757 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41234 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; Running run-layout-tests-in-stress-mode; Ignored 1 pre-existing failure based on results-db; Uploaded test results") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158515 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118204 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/73a90a4d-2342-46d5-879c-453609200dff) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39888 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38259 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; run-api-tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150300 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38014 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34871 "Build is in progress. Recent messages:Printed configuration; Checked out pull request; Compiled WebKit (warnings)") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42483 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42474 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188827 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50405 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146799 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51088 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34635 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146601 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26825 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41363 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123296 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117495 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49593 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12992 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48992 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49228 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49053 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->