### PR TITLE
[PDF] Add an experimental, off-by-default, prototype implementation of an alternate PDF HUD View

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -9205,6 +9205,19 @@ UseAVCaptureDeviceRotationCoordinatorAPI:
       default: false
   sharedPreferenceForWebProcess: true
 
+UseAlternatePDFHUD:
+  type: bool
+  status: internal
+  category: html
+  humanReadableName: "Alternate PDF HUD"
+  humanReadableDescription: "Use the alternate PDF HUD"
+  webcoreBinding: none
+  exposed: [ WebKit ]
+  condition: ENABLE(PDF_HUD)
+  defaultValue:
+    WebKit:
+      default: false
+
 UseAppKitGestures:
   type: bool
   status: internal

--- a/Source/WebKit/Modules/Internal/module.modulemap
+++ b/Source/WebKit/Modules/Internal/module.modulemap
@@ -89,6 +89,18 @@ module WebKit_Internal [system] {
         export *
     }
 
+    module WKAlternatePDFHUDView {
+        requires objc
+        header "../../UIProcess/PDF/WKAlternatePDFHUDView.h"
+        export *
+    }
+
+    module WKDefaultPDFHUDView {
+        requires objc
+        header "../../UIProcess/PDF/WKDefaultPDFHUDView.h"
+        export *
+    }
+
     module WKTextSelectionRect {
         requires cplusplus20
         header "../../UIProcess/Cocoa/WKTextSelectionRect.h"

--- a/Source/WebKit/SourcesCocoa.txt
+++ b/Source/WebKit/SourcesCocoa.txt
@@ -667,7 +667,7 @@ UIProcess/Model/cocoa/ModelProcessProxyCocoa.mm @nonARC
 
 UIProcess/Network/CustomProtocols/LegacyCustomProtocolManagerProxy.cpp
 
-UIProcess/PDF/WKPDFHUDView.mm @nonARC
+UIProcess/PDF/WKDefaultPDFHUDView.mm @nonARC
 
 UIProcess/RemoteLayerTree/cocoa/RemoteLayerTreeLayers.mm @nonARC
 

--- a/Source/WebKit/UIProcess/PDF/WKAlternatePDFHUDView.h
+++ b/Source/WebKit/UIProcess/PDF/WKAlternatePDFHUDView.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2026 Apple Inc. All rights reserved.
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -29,6 +29,7 @@
 
 #if ENABLE(PDF_HUD)
 
+#import "WKPDFHUDView.h"
 #import <AppKit/AppKit.h>
 
 @class WKWebView;
@@ -36,11 +37,9 @@
 NS_HEADER_AUDIT_BEGIN(nullability, sendability)
 
 NS_SWIFT_UI_ACTOR
-@protocol WKPDFHUDView
+@interface WKAlternatePDFHUDView : NSView <WKPDFHUDView>
 
-@property (nonatomic, readonly) uint64_t frameIdentifier;
-
-- (void)show;
+- (instancetype)initWithFrame:(NSRect)frame frameIdentifier:(uint64_t)frameIdentifier NS_DESIGNATED_INITIALIZER;
 
 @end
 

--- a/Source/WebKit/UIProcess/PDF/WKAlternatePDFHUDView.swift
+++ b/Source/WebKit/UIProcess/PDF/WKAlternatePDFHUDView.swift
@@ -1,0 +1,114 @@
+// Copyright (C) 2026 Apple Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+
+#if ENABLE_PDF_HUD
+
+import AppKit
+public import Foundation
+internal import WebKit_Internal
+@_weakLinked import SwiftUI
+
+// FIXME: Add actions to the buttons.
+// FIXME: Add fade animations.
+// FIXME: Add localizable strings support.
+// FIXME: Implement `WKAlternatePDFHUDView.show`.
+// FIXME: Figure out the final design.
+
+private let barVerticalOffset: CGFloat = 40
+
+private enum ControlsAction {
+    case zoomIn
+    case zoomOut
+    case openInPreview
+    case savePDF
+}
+
+private struct Controls: View {
+    let action: (ControlsAction) -> Void
+
+    var body: some View {
+        ControlGroup {
+            Button("Zoom Out", systemImage: "minus.magnifyingglass") {
+                action(.zoomOut)
+            }
+
+            Button("Zoom In", systemImage: "plus.magnifyingglass") {
+                action(.zoomIn)
+            }
+
+            Button {
+                action(.openInPreview)
+            } label: {
+                Label {
+                    Text("Open in Preview")
+                } icon: {
+                    Image(_internalSystemName: "preview")
+                }
+            }
+
+            Button("Save PDF", systemImage: "arrow.down.circle") {
+                action(.savePDF)
+            }
+        }
+        .labelStyle(.iconOnly)
+        .controlSize(.extraLarge)
+        #if HAVE_LIQUID_GLASS
+        .glassEffect(.regular.interactive())
+        #endif
+    }
+}
+
+@objc
+@implementation
+extension WKAlternatePDFHUDView {
+    let frameIdentifier: UInt64
+
+    init(frame: NSRect, frameIdentifier: UInt64) {
+        self.frameIdentifier = frameIdentifier
+
+        super.init(frame: frame)
+
+        let controls = Controls { action in
+            print(action)
+        }
+
+        let hostingView = NSHostingView(rootView: controls)
+        hostingView.translatesAutoresizingMaskIntoConstraints = false
+
+        addSubview(hostingView)
+        hostingView.centerXAnchor.constraint(equalTo: centerXAnchor).isActive = true
+        hostingView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -barVerticalOffset).isActive = true
+    }
+
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
+    @objc
+    @available(*, unavailable)
+    public required dynamic init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func show() {
+    }
+}
+
+#endif // ENABLE_PDF_HUD

--- a/Source/WebKit/UIProcess/PDF/WKDefaultPDFHUDView.h
+++ b/Source/WebKit/UIProcess/PDF/WKDefaultPDFHUDView.h
@@ -29,6 +29,7 @@
 
 #if ENABLE(PDF_HUD)
 
+#import "WKPDFHUDView.h"
 #import <AppKit/AppKit.h>
 
 @class WKWebView;
@@ -36,11 +37,23 @@
 NS_HEADER_AUDIT_BEGIN(nullability, sendability)
 
 NS_SWIFT_UI_ACTOR
-@protocol WKPDFHUDView
+@interface WKDefaultPDFHUDView : NSView <WKPDFHUDView>
 
-@property (nonatomic, readonly) uint64_t frameIdentifier;
+@property (nonatomic, readonly) uint64_t pluginIdentifier;
+@property (nonatomic, readonly, weak, nullable) WKWebView *webView;
 
-- (void)show;
+- (instancetype)initWithFrame:(NSRect)frame pluginIdentifier:(uint64_t)pluginIdentifier frameIdentifier:(uint64_t)frameIdentifier webView:(nullable WKWebView *)webView NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithCoder:(NSCoder *)coder NS_UNAVAILABLE;
+- (instancetype)initWithFrame:(NSRect)frame NS_UNAVAILABLE;
+
+@end
+
+@interface WKDefaultPDFHUDView (Cpp)
+
+- (void)performPDFZoomIn;
+- (void)performPDFZoomOut;
+- (void)performPDFOpenWithPreview;
+- (void)performPDFSaveToPDF;
 
 @end
 

--- a/Source/WebKit/UIProcess/PDF/WKDefaultPDFHUDView.mm
+++ b/Source/WebKit/UIProcess/PDF/WKDefaultPDFHUDView.mm
@@ -24,7 +24,7 @@
  */
 
 #import "config.h"
-#import "WKPDFHUDView.h"
+#import "WKDefaultPDFHUDView.h"
 
 #if ENABLE(PDF_HUD)
 
@@ -32,7 +32,7 @@
 #import "WKWebViewMac.h"
 #import <WebCore/FrameIdentifier.h>
 
-@implementation WKPDFHUDView (Cpp)
+@implementation WKDefaultPDFHUDView (Cpp)
 
 - (void)performPDFZoomIn
 {

--- a/Source/WebKit/UIProcess/PDF/WKDefaultPDFHUDView.swift
+++ b/Source/WebKit/UIProcess/PDF/WKDefaultPDFHUDView.swift
@@ -23,7 +23,7 @@
 
 #if ENABLE_PDF_HUD
 
-public import AppKit
+import AppKit
 public import Foundation
 internal import WebKit_Internal
 private import pal.spi.mac.NSImageSPI
@@ -57,7 +57,7 @@ private func isInRecoveryOS() -> Bool {
 
 @objc
 @implementation
-extension WKPDFHUDView {
+extension WKDefaultPDFHUDView {
     var pluginIdentifier: UInt64
     var frameIdentifier: UInt64
     weak var webView: WKWebView?

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.h
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.h
@@ -119,7 +119,7 @@ OBJC_CLASS WebPlaybackControlsManager;
 OBJC_CLASS WKDigitalCredentialsPicker;
 #endif
 
-OBJC_CLASS WKPDFHUDView;
+OBJC_PROTOCOL(WKPDFHUDView);
 
 OBJC_CLASS VKCImageAnalysis;
 OBJC_CLASS VKCImageAnalysisOverlayView;
@@ -1064,7 +1064,7 @@ private:
     RetainPtr<WKFullScreenWindowController> m_fullScreenWindowController;
 #endif
 
-    HashMap<WebKit::PDFPluginIdentifier, RetainPtr<WKPDFHUDView>> _pdfHUDViews;
+    HashMap<WebKit::PDFPluginIdentifier, RetainPtr<NSView<WKPDFHUDView>>> _pdfHUDViews;
     // PDF HUDs awaiting their initial async coordinate conversion, mapped to the latest location update.
     HashMap<WebKit::PDFPluginIdentifier, WebCore::IntRect> m_pdfHUDsPendingCreation;
 

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -67,13 +67,14 @@
 #import "UIGamepadProvider.h"
 #import "UndoOrRedo.h"
 #import "ViewGestureController.h"
+#import "WKAlternatePDFHUDView.h"
 #import "WKAppKitGestureController.h"
+#import "WKDefaultPDFHUDView.h"
 #import "WKEditCommand.h"
 #import "WKErrorInternal.h"
 #import "WKFullScreenWindowController.h"
 #import "WKImmediateActionController.h"
 #import "WKNSURLExtras.h"
-#import "WKPDFHUDView.h"
 #import "WKPrintingView.h"
 #import "WKQuickLookPreviewController.h"
 #import "WKRevealItemPresenter.h"
@@ -1805,7 +1806,12 @@ void WebViewImpl::createPDFHUD(PDFPluginIdentifier identifier, WebCore::FrameIde
         if (!latestBoxInFrameRootView)
             return;
 
-        RetainPtr hud = adoptNS([[WKPDFHUDView alloc] initWithFrame:boundingBoxInWebView pluginIdentifier:identifier.toUInt64() frameIdentifier:frameID.toUInt64() webView:checkedThis->m_page->cocoaView()]);
+        RetainPtr<NSView<WKPDFHUDView>> hud;
+        if (protect(checkedThis->m_page->preferences())->useAlternatePDFHUD())
+            hud = adoptNS([[WKAlternatePDFHUDView alloc] initWithFrame:boundingBoxInWebView frameIdentifier:frameID.toUInt64()]);
+        else
+            hud = adoptNS([[WKDefaultPDFHUDView alloc] initWithFrame:boundingBoxInWebView pluginIdentifier:identifier.toUInt64() frameIdentifier:frameID.toUInt64() webView:checkedThis->m_page->cocoaView().get()]);
+
         [checkedThis->m_view.get() addSubview:hud];
         checkedThis->_pdfHUDViews.add(identifier, WTF::move(hud));
 
@@ -4529,7 +4535,7 @@ void WebViewImpl::setInspectorAttachmentView(NSView *newView)
         return;
 
     m_inspectorAttachmentView = newView;
-    
+
     if (RefPtr inspector = m_page->inspector())
         inspector->attachmentViewDidChange(oldView ? oldView.get() : m_view.get().get(), newView ? RetainPtr { newView }.get() : m_view.get().get());
 }

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -161,6 +161,13 @@
 		0735F3202D3761A10003D029 /* WKIntelligenceReplacementTextEffectCoordinator.h in Headers */ = {isa = PBXBuildFile; fileRef = 0735F31F2D3761A10003D029 /* WKIntelligenceReplacementTextEffectCoordinator.h */; };
 		0735F3222D38B09E0003D029 /* WKIntelligenceSmartReplyTextEffectCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0735F3212D38B09E0003D029 /* WKIntelligenceSmartReplyTextEffectCoordinator.swift */; };
 		0735F3242D38C7790003D029 /* WKIntelligenceSmartReplyTextEffectCoordinator.h in Headers */ = {isa = PBXBuildFile; fileRef = 0735F3232D38C7790003D029 /* WKIntelligenceSmartReplyTextEffectCoordinator.h */; };
+		0739EAF0301562080066ED1B /* WKPDFHUDView.h in Headers */ = {isa = PBXBuildFile; fileRef = 0739EAEA301561FE0066ED1B /* WKPDFHUDView.h */; };
+		0739EAF13015620C0066ED1B /* WKDefaultPDFHUDView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0739EAEC301561FE0066ED1B /* WKDefaultPDFHUDView.swift */; };
+		0739EAF2301562100066ED1B /* WKPDFPageNumberIndicator.h in Headers */ = {isa = PBXBuildFile; fileRef = 0739EAED301561FE0066ED1B /* WKPDFPageNumberIndicator.h */; };
+		0739EAF6301562A20066ED1B /* WKDefaultPDFHUDView.h in Headers */ = {isa = PBXBuildFile; fileRef = 0739EAF5301562A20066ED1B /* WKDefaultPDFHUDView.h */; };
+		0739EAF8301563080066ED1B /* WKAlternatePDFHUDView.h in Headers */ = {isa = PBXBuildFile; fileRef = 0739EAF7301563080066ED1B /* WKAlternatePDFHUDView.h */; };
+		0739EAFA301563480066ED1B /* WKAlternatePDFHUDView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0739EAF9301563480066ED1B /* WKAlternatePDFHUDView.swift */; };
+		0739F9AB301572270066ED1B /* WKPDFPageNumberIndicator.mm in Sources */ = {isa = PBXBuildFile; fileRef = 0739EAEE301561FE0066ED1B /* WKPDFPageNumberIndicator.mm */; };
 		073A63CC2DC33D8B0057A3F5 /* WKPreviewWindowController.h in Headers */ = {isa = PBXBuildFile; fileRef = B66F88C12B6D202600FB1734 /* WKPreviewWindowController.h */; };
 		073A63CD2DC33DA00057A3F5 /* WKStageMode.h in Headers */ = {isa = PBXBuildFile; fileRef = EE0D3CDD2D3709BE00072978 /* WKStageMode.h */; };
 		073A63CE2DC33DE30057A3F5 /* WKIntelligenceTextEffectCoordinator.h in Headers */ = {isa = PBXBuildFile; fileRef = 074F34802CC5F7D500CA5301 /* WKIntelligenceTextEffectCoordinator.h */; };
@@ -974,8 +981,6 @@
 		3309345B1315B9980097A7BC /* WKCookieManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 330934591315B9980097A7BC /* WKCookieManager.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		3311023B2B17B49E00B21C8C /* WebExtensionAPIDeclarativeNetRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = 3311023A2B17B49E00B21C8C /* WebExtensionAPIDeclarativeNetRequest.h */; };
 		331102412B17B99800B21C8C /* JSWebExtensionAPIDeclarativeNetRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = 3311023F2B17B99800B21C8C /* JSWebExtensionAPIDeclarativeNetRequest.h */; };
-		33266E3A2F60C374007310B8 /* WKPDFHUDView.h in Headers */ = {isa = PBXBuildFile; fileRef = DF84CEE3249AA21F009096F6 /* WKPDFHUDView.h */; };
-		33266E3C2F60C390007310B8 /* WKPDFHUDView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33266E3B2F60C390007310B8 /* WKPDFHUDView.swift */; };
 		3326F2662B06A1F4001A535F /* _WKWebExtensionDeclarativeNetRequestRule.h in Headers */ = {isa = PBXBuildFile; fileRef = 3326F2622B06A1F4001A535F /* _WKWebExtensionDeclarativeNetRequestRule.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		3326F2672B06A1F4001A535F /* _WKWebExtensionDeclarativeNetRequestTranslator.h in Headers */ = {isa = PBXBuildFile; fileRef = 3326F2632B06A1F4001A535F /* _WKWebExtensionDeclarativeNetRequestTranslator.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		3336763B130C99DC006C9DE2 /* WKResourceCacheManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 33367639130C99DC006C9DE2 /* WKResourceCacheManager.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -992,8 +997,6 @@
 		3399E1562B59F0F0008BFB60 /* WebExtensionAPIWebRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = 3399E1552B59F0E5008BFB60 /* WebExtensionAPIWebRequest.h */; };
 		33AE61252B20F13B00E1C215 /* PDFKitSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = 3178AF9720E2A7F80074DE94 /* PDFKitSPI.h */; };
 		33B5A80C2AFD298100A15D40 /* WebExtensionFrameParameters.h in Headers */ = {isa = PBXBuildFile; fileRef = 33B5A80B2AFD298100A15D40 /* WebExtensionFrameParameters.h */; };
-		33E743E82D66C0AC00AC715E /* WKPDFPageNumberIndicator.mm in Sources */ = {isa = PBXBuildFile; fileRef = 33E743E72D66C0AC00AC715E /* WKPDFPageNumberIndicator.mm */; };
-		33E743E92D66C0AC00AC715E /* WKPDFPageNumberIndicator.h in Headers */ = {isa = PBXBuildFile; fileRef = 33E743E62D66C0AC00AC715E /* WKPDFPageNumberIndicator.h */; };
 		33F6833E293FFA4B005C63C0 /* WebExtensionAPIWebNavigationEvent.h in Headers */ = {isa = PBXBuildFile; fileRef = 33F6833D293FFA4B005C63C0 /* WebExtensionAPIWebNavigationEvent.h */; };
 		370F34A31829BE1E009027C8 /* WKNavigationData.h in Headers */ = {isa = PBXBuildFile; fileRef = 370F34A11829BE1E009027C8 /* WKNavigationData.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		370F34A51829BEA3009027C8 /* WKNavigationDataInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 370F34A41829BEA3009027C8 /* WKNavigationDataInternal.h */; };
@@ -2432,7 +2435,6 @@
 		DF462E0F23F22F5500EFF35F /* WKHTTPCookieStorePrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = DF462E0E23F22F5300EFF35F /* WKHTTPCookieStorePrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		DF462E1223F338BE00EFF35F /* WKContentWorldPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = DF462E1123F338AD00EFF35F /* WKContentWorldPrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		DF7A231C291B088D00B98DF3 /* WKSnapshotConfigurationPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = DF7A231B291B088D00B98DF3 /* WKSnapshotConfigurationPrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		DF84CEE4249AA24D009096F6 /* WKPDFHUDView.mm in Sources */ = {isa = PBXBuildFile; fileRef = DF84CEE2249AA21F009096F6 /* WKPDFHUDView.mm */; };
 		DFEAFFC629664BB200038490 /* _WKContextMenuElementInfoInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = DFEAFFC529664BB200038490 /* _WKContextMenuElementInfoInternal.h */; };
 		E0E1E2E3E4E5E6E700000001 /* WriteWebArchiveToPasteBoardResult.h in Headers */ = {isa = PBXBuildFile; fileRef = E0E1E2E3E4E5E6E700000002 /* WriteWebArchiveToPasteBoardResult.h */; };
 		E105FE5418D7B9DE008F57A8 /* EditingRange.h in Headers */ = {isa = PBXBuildFile; fileRef = E105FE5318D7B9DE008F57A8 /* EditingRange.h */; };
@@ -3474,6 +3476,14 @@
 		0736B75C260D4A4E00E06994 /* RemoteMediaSessionCoordinatorProxy.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RemoteMediaSessionCoordinatorProxy.cpp; sourceTree = "<group>"; };
 		0736B75D260D4A4F00E06994 /* RemoteMediaSessionCoordinatorProxy.messages.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = RemoteMediaSessionCoordinatorProxy.messages.in; sourceTree = "<group>"; };
 		0736B75E260D4A5000E06994 /* RemoteMediaSessionCoordinatorProxy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemoteMediaSessionCoordinatorProxy.h; sourceTree = "<group>"; };
+		0739EAEA301561FE0066ED1B /* WKPDFHUDView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WKPDFHUDView.h; sourceTree = "<group>"; };
+		0739EAEB301561FE0066ED1B /* WKDefaultPDFHUDView.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WKDefaultPDFHUDView.mm; sourceTree = "<group>"; };
+		0739EAEC301561FE0066ED1B /* WKDefaultPDFHUDView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WKDefaultPDFHUDView.swift; sourceTree = "<group>"; };
+		0739EAED301561FE0066ED1B /* WKPDFPageNumberIndicator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WKPDFPageNumberIndicator.h; sourceTree = "<group>"; };
+		0739EAEE301561FE0066ED1B /* WKPDFPageNumberIndicator.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WKPDFPageNumberIndicator.mm; sourceTree = "<group>"; };
+		0739EAF5301562A20066ED1B /* WKDefaultPDFHUDView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WKDefaultPDFHUDView.h; sourceTree = "<group>"; };
+		0739EAF7301563080066ED1B /* WKAlternatePDFHUDView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WKAlternatePDFHUDView.h; sourceTree = "<group>"; };
+		0739EAF9301563480066ED1B /* WKAlternatePDFHUDView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WKAlternatePDFHUDView.swift; sourceTree = "<group>"; };
 		073A63D72DC344F40057A3F5 /* WKWebView+TextExtraction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WKWebView+TextExtraction.swift"; sourceTree = "<group>"; };
 		073B19992FEFB66B00BD5D69 /* WKAppKitGestureController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WKAppKitGestureController.swift; sourceTree = "<group>"; };
 		073EFBB72D0F448500FAE7CF /* Foundation+Extras.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Foundation+Extras.swift"; sourceTree = "<group>"; };
@@ -5386,7 +5396,6 @@
 		331102462B17CFE300B21C8C /* WebExtensionContextAPIDeclarativeNetRequestCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebExtensionContextAPIDeclarativeNetRequestCocoa.mm; sourceTree = "<group>"; };
 		33238F5D2B7EFD3B0014AE88 /* WKAccessibilityPDFDocumentObject.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = WKAccessibilityPDFDocumentObject.h; path = PDF/WKAccessibilityPDFDocumentObject.h; sourceTree = "<group>"; };
 		33238F5E2B7EFD6A0014AE88 /* WKAccessibilityPDFDocumentObject.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = WKAccessibilityPDFDocumentObject.mm; path = PDF/WKAccessibilityPDFDocumentObject.mm; sourceTree = "<group>"; };
-		33266E3B2F60C390007310B8 /* WKPDFHUDView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = WKPDFHUDView.swift; path = PDF/WKPDFHUDView.swift; sourceTree = "<group>"; };
 		3326F2612B06A1F4001A535F /* _WKWebExtensionDeclarativeNetRequestRule.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = _WKWebExtensionDeclarativeNetRequestRule.mm; sourceTree = "<group>"; };
 		3326F2622B06A1F4001A535F /* _WKWebExtensionDeclarativeNetRequestRule.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _WKWebExtensionDeclarativeNetRequestRule.h; sourceTree = "<group>"; };
 		3326F2632B06A1F4001A535F /* _WKWebExtensionDeclarativeNetRequestTranslator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _WKWebExtensionDeclarativeNetRequestTranslator.h; sourceTree = "<group>"; };
@@ -5427,8 +5436,6 @@
 		33DAECEE2B9AAE91005C596E /* PDFDataDetectorOverlayController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PDFDataDetectorOverlayController.h; sourceTree = "<group>"; };
 		33DAECEF2B9AAE92005C596E /* PDFDataDetectorOverlayController.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = PDFDataDetectorOverlayController.mm; sourceTree = "<group>"; };
 		33E5A6B32C6F8F8D00F2CD04 /* ImageOptions.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = ImageOptions.serialization.in; sourceTree = "<group>"; };
-		33E743E62D66C0AC00AC715E /* WKPDFPageNumberIndicator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = WKPDFPageNumberIndicator.h; path = PDF/WKPDFPageNumberIndicator.h; sourceTree = "<group>"; };
-		33E743E72D66C0AC00AC715E /* WKPDFPageNumberIndicator.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = WKPDFPageNumberIndicator.mm; path = PDF/WKPDFPageNumberIndicator.mm; sourceTree = "<group>"; };
 		33EBE2852C98366200549FB9 /* PDFAnnotationTypeHelpers.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.h; fileEncoding = 4; name = PDFAnnotationTypeHelpers.h; path = PDF/PDFAnnotationTypeHelpers.h; sourceTree = "<group>"; tabWidth = 8; };
 		33EBE2872C9838F900549FB9 /* PDFAnnotationTypeHelpers.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = PDFAnnotationTypeHelpers.mm; path = PDF/PDFAnnotationTypeHelpers.mm; sourceTree = "<group>"; };
 		33F1A0102FEFB66B00BD5D70 /* PositionInformationManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PositionInformationManager.h; sourceTree = "<group>"; };
@@ -8641,8 +8648,6 @@
 		DF74275C24F4955000F8ABE9 /* PDFPluginIdentifier.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PDFPluginIdentifier.h; sourceTree = "<group>"; };
 		DF7A231B291B088D00B98DF3 /* WKSnapshotConfigurationPrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKSnapshotConfigurationPrivate.h; sourceTree = "<group>"; };
 		DF7B8A232968A41000647721 /* APIContextMenuElementInfoMac.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = APIContextMenuElementInfoMac.h; sourceTree = "<group>"; };
-		DF84CEE2249AA21F009096F6 /* WKPDFHUDView.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = WKPDFHUDView.mm; path = PDF/WKPDFHUDView.mm; sourceTree = "<group>"; };
-		DF84CEE3249AA21F009096F6 /* WKPDFHUDView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WKPDFHUDView.h; path = PDF/WKPDFHUDView.h; sourceTree = "<group>"; };
 		DFEAFFC529664BB200038490 /* _WKContextMenuElementInfoInternal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _WKContextMenuElementInfoInternal.h; sourceTree = "<group>"; };
 		E0E1E2E3E4E5E6E700000002 /* WriteWebArchiveToPasteBoardResult.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WriteWebArchiveToPasteBoardResult.h; sourceTree = "<group>"; };
 		E0E1E2E3E4E5E6E700000003 /* WriteWebArchiveToPasteBoardResult.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = WriteWebArchiveToPasteBoardResult.serialization.in; sourceTree = "<group>"; };
@@ -9548,6 +9553,21 @@
 				0736B753260D039F00E06994 /* RemoteMediaSessionCoordinator.messages.in */,
 			);
 			path = MediaSession;
+			sourceTree = "<group>";
+		};
+		0739EAEF301561FE0066ED1B /* PDF */ = {
+			isa = PBXGroup;
+			children = (
+				0739EAF7301563080066ED1B /* WKAlternatePDFHUDView.h */,
+				0739EAF9301563480066ED1B /* WKAlternatePDFHUDView.swift */,
+				0739EAF5301562A20066ED1B /* WKDefaultPDFHUDView.h */,
+				0739EAEB301561FE0066ED1B /* WKDefaultPDFHUDView.mm */,
+				0739EAEC301561FE0066ED1B /* WKDefaultPDFHUDView.swift */,
+				0739EAEA301561FE0066ED1B /* WKPDFHUDView.h */,
+				0739EAED301561FE0066ED1B /* WKPDFPageNumberIndicator.h */,
+				0739EAEE301561FE0066ED1B /* WKPDFPageNumberIndicator.mm */,
+			);
+			path = PDF;
 			sourceTree = "<group>";
 		};
 		0744DA522CE05F5300AACC81 /* Internal */ = {
@@ -16054,7 +16074,7 @@
 				2DA8153428A4939700CF811C /* Model */,
 				510CC7E716138E7200D03ED3 /* Network */,
 				31A2EC401489973700810D71 /* Notifications */,
-				DF84CEE1249AA200009096F6 /* PDF */,
+				0739EAEF301561FE0066ED1B /* PDF */,
 				2D1551A91F5A9B420006E3FE /* RemoteLayerTree */,
 				1AAF089E192681AC00B6390C /* UserContent */,
 				57608294202BD84900116678 /* WebAuthentication */,
@@ -17537,18 +17557,6 @@
 				CEE4AE2A1A5DCF430002F49B /* UIKitSPI.h */,
 			);
 			path = ios;
-			sourceTree = "<group>";
-		};
-		DF84CEE1249AA200009096F6 /* PDF */ = {
-			isa = PBXGroup;
-			children = (
-				DF84CEE3249AA21F009096F6 /* WKPDFHUDView.h */,
-				DF84CEE2249AA21F009096F6 /* WKPDFHUDView.mm */,
-				33266E3B2F60C390007310B8 /* WKPDFHUDView.swift */,
-				33E743E62D66C0AC00AC715E /* WKPDFPageNumberIndicator.h */,
-				33E743E72D66C0AC00AC715E /* WKPDFPageNumberIndicator.mm */,
-			);
-			name = PDF;
 			sourceTree = "<group>";
 		};
 		E170876D16D6CA7200F99226 /* FileAPI */ = {
@@ -19285,6 +19293,7 @@
 				0FCB4E4818BBE044000FCFC9 /* WKActionSheet.h in Headers */,
 				0FCB4E4A18BBE044000FCFC9 /* WKActionSheetAssistant.h in Headers */,
 				C5FA1ED318E1062200B3F402 /* WKAirPlayRoutePicker.h in Headers */,
+				0739EAF8301563080066ED1B /* WKAlternatePDFHUDView.h in Headers */,
 				2D12DAB520662C73006F00FB /* WKAnimationDelegate.h in Headers */,
 				BCDDB32D124EC2E10048D13C /* WKAPICast.h in Headers */,
 				336E07482EBCC1E400B4D635 /* WKAppKitGestureController.h in Headers */,
@@ -19390,6 +19399,7 @@
 				2E94FC1620351A6D00974BA0 /* WKDatePickerViewController.h in Headers */,
 				C54256B518BEC18C00DE4179 /* WKDateTimeInputControl.h in Headers */,
 				377EAD4517E2C51A002D193D /* WKDeclarationSpecifiers.h in Headers */,
+				0739EAF6301562A20066ED1B /* WKDefaultPDFHUDView.h in Headers */,
 				F44815642387820000982657 /* WKDeferringGestureRecognizer.h in Headers */,
 				5C359C0D2154739F009E7948 /* WKDeprecated.h in Headers */,
 				8372DB2F1A677D4A00C697C5 /* WKDiagnosticLoggingResultType.h in Headers */,
@@ -19585,8 +19595,8 @@
 				A15EEDE61E301CEE000069B0 /* WKPasswordView.h in Headers */,
 				A1798B49222E531D000764BD /* WKPaymentAuthorizationDelegate.h in Headers */,
 				51D7E0AD2356555E00A67D3A /* WKPDFConfiguration.h in Headers */,
-				33266E3A2F60C374007310B8 /* WKPDFHUDView.h in Headers */,
-				33E743E92D66C0AC00AC715E /* WKPDFPageNumberIndicator.h in Headers */,
+				0739EAF0301562080066ED1B /* WKPDFHUDView.h in Headers */,
+				0739EAF2301562100066ED1B /* WKPDFPageNumberIndicator.h in Headers */,
 				7C135AA9173B0BCA00586AE2 /* WKPluginInformation.h in Headers */,
 				2DABA7741A817EE600EF0F1A /* WKPluginLoadPolicy.h in Headers */,
 				1AFDD3171891C94700153970 /* WKPreferences.h in Headers */,
@@ -22521,6 +22531,7 @@
 				9356F2DF2152B72300E6D5DF /* WebSWOriginStore.cpp in Sources */,
 				9356F2E12152B76600E6D5DF /* WebSWServerConnection.cpp in Sources */,
 				9356F2E02152B75200E6D5DF /* WebSWServerToContextConnection.cpp in Sources */,
+				0739EAFA301563480066ED1B /* WKAlternatePDFHUDView.swift in Sources */,
 				073B199A2FEFB66B00BD5D69 /* WKAppKitGestureController.swift in Sources */,
 				A190E9422F3DB703009615AD /* WKAVContentSource.mm in Sources */,
 				C6A4CA0C2252899800169289 /* WKBundlePageMac.mm in Sources */,
@@ -22528,6 +22539,7 @@
 				2D93116A212F61B500044BFE /* WKContentViewInteraction.mm in Sources */,
 				BE6818000000000000000001 /* WKContentWorld.swift in Sources */,
 				075C079A2D92125D00B3E900 /* WKContextMenuElementInfoAdapter.swift in Sources */,
+				0739EAF13015620C0066ED1B /* WKDefaultPDFHUDView.swift in Sources */,
 				079DD3032FAC583900592E03 /* WKDeferringGestureRecognizer.swift in Sources */,
 				07F0337E3B2E1A0044AABBCC /* WKDirectionalScrollLockTracker.swift in Sources */,
 				637281A321ADC744009E0DE6 /* WKDownloadProgress.mm in Sources */,
@@ -22536,9 +22548,7 @@
 				E502E4F82D4810EA00C3D56D /* WKMaterialHostingSupport.swift in Sources */,
 				07FEBC9A2E035A8B004A6D5D /* WKMouseDeviceObserver.swift in Sources */,
 				07CB79982CE943E400199C49 /* WKNavigationDelegateAdapter.swift in Sources */,
-				DF84CEE4249AA24D009096F6 /* WKPDFHUDView.mm in Sources */,
-				33266E3C2F60C390007310B8 /* WKPDFHUDView.swift in Sources */,
-				33E743E82D66C0AC00AC715E /* WKPDFPageNumberIndicator.mm in Sources */,
+				0739F9AB301572270066ED1B /* WKPDFPageNumberIndicator.mm in Sources */,
 				E31869C42B1A7C2400571519 /* WKProcessExtension.mm in Sources */,
 				07AF79E12D693DD7004E8D3A /* WKScrollGeometryAdapter.swift in Sources */,
 				B66A6BD92EF5581B00FC8EA5 /* WKSeparatedImageView+Analysis.swift in Sources */,


### PR DESCRIPTION
#### f1c90a305e8e3344fb79d4595e3931c3237ebcdb
<pre>
[PDF] Add an experimental, off-by-default, prototype implementation of an alternate PDF HUD View
<a href="https://bugs.webkit.org/show_bug.cgi?id=320292">https://bugs.webkit.org/show_bug.cgi?id=320292</a>
<a href="https://rdar.apple.com/183225101">rdar://183225101</a>

Reviewed by Abrar Rahman Protyasha.

This new implementation leverages SwiftUI to simplify the UI code of the PDF HUD view.

It is off-by-default as a runtime feature flag.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebKit/Modules/Internal/module.modulemap:
* Source/WebKit/SourcesCocoa.txt:
* Source/WebKit/UIProcess/PDF/WKAlternatePDFHUDView.h: Copied from Source/WebKit/UIProcess/PDF/WKPDFHUDView.h.
* Source/WebKit/UIProcess/PDF/WKAlternatePDFHUDView.swift: Added.
(Controls.body):
(WKAlternatePDFHUDView.show):
* Source/WebKit/UIProcess/PDF/WKDefaultPDFHUDView.h: Copied from Source/WebKit/UIProcess/PDF/WKPDFHUDView.h.
* Source/WebKit/UIProcess/PDF/WKDefaultPDFHUDView.mm: Renamed from Source/WebKit/UIProcess/PDF/WKPDFHUDView.mm.
(-[WKDefaultPDFHUDView performPDFZoomIn]):
(-[WKDefaultPDFHUDView performPDFZoomOut]):
(-[WKDefaultPDFHUDView performPDFOpenWithPreview]):
(-[WKDefaultPDFHUDView performPDFSaveToPDF]):
* Source/WebKit/UIProcess/PDF/WKDefaultPDFHUDView.swift: Renamed from Source/WebKit/UIProcess/PDF/WKPDFHUDView.swift.
(isInRecoveryOS):
(WKDefaultPDFHUDView.pluginIdentifier):
(WKDefaultPDFHUDView.frameIdentifier):
(WKDefaultPDFHUDView.webView):
(WKDefaultPDFHUDView.barView):
(WKDefaultPDFHUDView.stackView):
(WKDefaultPDFHUDView.zoomOutButton):
(WKDefaultPDFHUDView.zoomInButton):
(WKDefaultPDFHUDView.separatorView):
(WKDefaultPDFHUDView.openInPreviewButton):
(WKDefaultPDFHUDView.saveButton):
(WKDefaultPDFHUDView.isBarVisible):
(WKDefaultPDFHUDView.mouseMovedToHUD):
(WKDefaultPDFHUDView.initialHideTimerFired):
(WKDefaultPDFHUDView.hideTimerTask):
(WKDefaultPDFHUDView.show):
(WKDefaultPDFHUDView._performAction(forControl:)):
(WKDefaultPDFHUDView.layout):
(WKDefaultPDFHUDView.hitTest(_:)):
(WKDefaultPDFHUDView.mouseMoved(with:)):
(WKDefaultPDFHUDView.zoomOutAction):
(WKDefaultPDFHUDView.zoomInAction):
(WKDefaultPDFHUDView.openInPreviewAction):
(WKDefaultPDFHUDView.saveAction):
(WKDefaultPDFHUDView.setBarVisible(_:)):
(WKDefaultPDFHUDView.resetHideTimer):
(WKDefaultPDFHUDView.hideTimerFired):
(WKDefaultPDFHUDView.makeBarView):
(WKDefaultPDFHUDView.makeButton(_:accessibilityLabel:isPrivateSymbol:)):
(WKDefaultPDFHUDView.makeSeparator):
* Source/WebKit/UIProcess/PDF/WKPDFHUDView.h:
* Source/WebKit/UIProcess/mac/WebViewImpl.h:
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::createPDFHUD):
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/318196@main">https://commits.webkit.org/318196@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6f4e676e5696ef19009e755b24d43f067176141f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177609 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51547 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/45341 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187213 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140856 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c2133750-a00b-4a7a-a72d-ae741874f657) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52839 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51256 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/138431 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140856 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/54fc8b9a-d2c5-45ec-b4d0-24da7344f001) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180565 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/41943 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/159173 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118895 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/38e59b5a-120b-4277-af5c-22525f5657bb) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/40604 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/38967 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/251/builds/864 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/218/builds/7669 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/151011 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/38669 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35680 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/38880 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/43332 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/43202 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189642 "Built successfully") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/51214 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/158704 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/147529 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39622 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51896 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/35297 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147320 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42036 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124111 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118524 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50404 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/13646 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49800 "Built successfully") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/50040 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/49862 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->