### PR TITLE
[Site Isolation] REGRESSION(315872@main): Event coordinates are offset by the scroll position in isolated iframes

### DIFF
--- a/LayoutTests/http/tests/site-isolation/mouse-events/resources/scroll-and-message-mouse-down-client-coordinates.html
+++ b/LayoutTests/http/tests/site-isolation/mouse-events/resources/scroll-and-message-mouse-down-client-coordinates.html
@@ -1,0 +1,31 @@
+<style>
+body { margin: 0; }
+#content { width: 3000px; height: 5000px; }
+</style>
+<div id="content"></div>
+<script>
+const scrollX = 120;
+const scrollY = 300;
+
+addEventListener("mousedown", (event) => {
+    window.parent.postMessage({
+        clientX: event.clientX,
+        clientY: event.clientY,
+        pageX: event.pageX,
+        pageY: event.pageY,
+    }, "*");
+});
+
+addEventListener("load", () => {
+    window.scrollTo(scrollX, scrollY);
+
+    function checkScrollPosition() {
+        if (window.scrollX === scrollX && window.scrollY === scrollY)
+            window.parent.postMessage("scrolled", "*");
+        else
+            requestAnimationFrame(checkScrollPosition);
+    }
+
+    requestAnimationFrame(checkScrollPosition);
+});
+</script>

--- a/LayoutTests/http/tests/site-isolation/mouse-events/resources/scrolled-iframe-client-coordinates.js
+++ b/LayoutTests/http/tests/site-isolation/mouse-events/resources/scrolled-iframe-client-coordinates.js
@@ -1,0 +1,32 @@
+testRunner?.waitUntilDone();
+
+function addMarker(x, y, color)
+{
+    const marker = document.createElement("div");
+    marker.style.cssText = `position: fixed; left: ${x}px; top: ${y}px; width: 10px; height: 10px; background-color: ${color};`;
+    document.body.appendChild(marker);
+}
+
+addEventListener("message", async (event) => {
+    if (event.data == "scrolled") {
+        await eventSender.asyncMouseMoveTo(300, 240);
+        await eventSender.asyncMouseDown();
+        await eventSender.asyncMouseUp();
+        return;
+    }
+
+    addMarker(event.data.clientX, event.data.clientY, "green");
+    addMarker(event.data.pageX, event.data.pageY, "blue");
+
+    testRunner?.notifyDone();
+});
+
+function clickInScrolledSubframe(subframeOrigin)
+{
+    document.body.style.margin = "0";
+
+    const subframe = document.createElement("iframe");
+    subframe.style.cssText = "position: absolute; left: 50px; top: 40px; width: 600px; height: 500px; border: none;";
+    subframe.src = `${subframeOrigin}/site-isolation/mouse-events/resources/scroll-and-message-mouse-down-client-coordinates.html`;
+    document.body.appendChild(subframe);
+}

--- a/LayoutTests/http/tests/site-isolation/mouse-events/scrolled-iframe-client-coordinates-expected.html
+++ b/LayoutTests/http/tests/site-isolation/mouse-events/scrolled-iframe-client-coordinates-expected.html
@@ -1,0 +1,2 @@
+<script src="resources/scrolled-iframe-client-coordinates.js"></script>
+<body onload="clickInScrolledSubframe('http://127.0.0.1:8000')"></body>

--- a/LayoutTests/http/tests/site-isolation/mouse-events/scrolled-iframe-client-coordinates.html
+++ b/LayoutTests/http/tests/site-isolation/mouse-events/scrolled-iframe-client-coordinates.html
@@ -1,0 +1,3 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<script src="resources/scrolled-iframe-client-coordinates.js"></script>
+<body onload="clickInScrolledSubframe('http://localhost:8000')"></body>

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -1975,7 +1975,7 @@ std::optional<RemoteUserInputEventData> EventHandler::userInputEventDataForRemot
 
     return RemoteUserInputEventData {
         remoteFrame->frameID(),
-        remoteFrameView->rootViewToContents(frameView->contentsToRootView(pointInFrame))
+        remoteFrameView->convertFromRootView(frameView->contentsToRootView(pointInFrame))
     };
 }
 

--- a/Source/WebCore/page/RemoteFrameGeometryTransformer.cpp
+++ b/Source/WebCore/page/RemoteFrameGeometryTransformer.cpp
@@ -44,17 +44,17 @@ RemoteFrameGeometryTransformer& RemoteFrameGeometryTransformer::operator=(Remote
 
 IntPoint RemoteFrameGeometryTransformer::transformToRemoteFrameCoordinates(IntPoint pointInContents) const
 {
-    return Ref { m_remoteView }->rootViewToContents(Ref { m_localView }->contentsToRootView(pointInContents));
+    return Ref { m_remoteView }->convertFromRootView(Ref { m_localView }->contentsToRootView(pointInContents));
 }
 
 FloatPoint RemoteFrameGeometryTransformer::transformToRemoteFrameCoordinates(FloatPoint pointInContents) const
 {
-    return Ref { m_remoteView }->rootViewToContents(Ref { m_localView }->contentsToRootView(pointInContents));
+    return Ref { m_remoteView }->convertFromRootView(Ref { m_localView }->contentsToRootView(pointInContents));
 }
 
 DoublePoint RemoteFrameGeometryTransformer::transformToRemoteFrameCoordinates(DoublePoint pointInContents) const
 {
-    return Ref { m_remoteView }->rootViewToContents(Ref { m_localView }->contentsToRootView(pointInContents));
+    return Ref { m_remoteView }->convertFromRootView(Ref { m_localView }->contentsToRootView(pointInContents));
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/Widget.h
+++ b/Source/WebCore/platform/Widget.h
@@ -152,7 +152,7 @@ public:
     WEBCORE_EXPORT IntRect convertToRootView(const IntRect&) const;
     FloatRect convertToRootView(const FloatRect&) const;
 
-    IntPoint convertFromRootView(IntPoint) const;
+    WEBCORE_EXPORT IntPoint convertFromRootView(IntPoint) const;
     FloatPoint convertFromRootView(FloatPoint) const;
     DoublePoint convertFromRootView(DoublePoint) const;
     IntRect convertFromRootView(const IntRect&) const;

--- a/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
@@ -819,7 +819,7 @@ void WebPage::performImmediateActionHitTestAtLocation(WebCore::FrameIdentifier f
         if (RefPtr remoteFrameView = remoteFrame->view()) {
             immediateActionResult.remoteUserInputEventData = RemoteUserInputEventData {
                 remoteFrame->frameID(),
-                remoteFrameView->rootViewToContents(roundedIntPoint(locationInViewCoordinates))
+                remoteFrameView->convertFromRootView(roundedIntPoint(locationInViewCoordinates))
             };
         }
     }


### PR DESCRIPTION
#### 57ac0275ddfdd84d68ee272bbafff7c5c429e300
<pre>
[Site Isolation] REGRESSION(315872@main): Event coordinates are offset by the scroll position in isolated iframes
<a href="https://bugs.webkit.org/show_bug.cgi?id=320302">https://bugs.webkit.org/show_bug.cgi?id=320302</a>
<a href="https://rdar.apple.com/183236270">rdar://183236270</a>

Reviewed by Kiet Ho.

Since 315872@main began synchronizing a frame&apos;s scroll position to the RemoteFrameViews in other
processes, the parent-side RemoteFrameView now carries the child&apos;s scroll offset, so the target
process applied it a second time when converting the point with windowToContents(). Event
coordinates in scrolled iframes were therefore offset by the iframe&apos;s scroll position.

The transformed point is consumed as a root view point by the process hosting the remote frame, so
use convertFromRootView() instead. This leaves the parent process responsible only for geometry it
owns and the target process responsible for its own scroll offset.

Test: http/tests/site-isolation/mouse-events/scrolled-iframe-client-coordinates.html

* LayoutTests/http/tests/site-isolation/mouse-events/resources/scroll-and-message-mouse-down-client-coordinates.html: Added.
* LayoutTests/http/tests/site-isolation/mouse-events/resources/scrolled-iframe-client-coordinates.js: Added.
(addMarker):
(async event):
(clickInScrolledSubframe):
* LayoutTests/http/tests/site-isolation/mouse-events/scrolled-iframe-client-coordinates-expected.html: Added.
* LayoutTests/http/tests/site-isolation/mouse-events/scrolled-iframe-client-coordinates.html: Added.
* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::userInputEventDataForRemoteFrame):
* Source/WebCore/page/RemoteFrameGeometryTransformer.cpp:
(WebCore::RemoteFrameGeometryTransformer::transformToRemoteFrameCoordinates const):
* Source/WebCore/platform/Widget.h:
* Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm:
(WebKit::WebPage::performImmediateActionHitTestAtLocation):

Canonical link: <a href="https://commits.webkit.org/317940@main">https://commits.webkit.org/317940@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/99a9d926be7c5f449d79e4946246ae98a8145f56

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176795 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50732 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44524 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186397 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140031 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/06e05ce1-d375-4044-bb20-af04f4adfe76) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178658 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52025 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50418 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137726 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140031 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/37916c3f-7a64-4a2f-bdc8-765387124dc9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179751 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41231 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158512 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Checked out pull request; 1 api test failed or timed out; re-run-api-tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118200 "Build is in progress. Recent messages:Printed configuration; Checked out pull request; run-api-tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f010c01b-fd32-45fe-9881-62b9dfbc62ec) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39885 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38253 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150297 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38011 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34865 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42477 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42468 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188821 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50399 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/158055 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146790 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51082 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34632 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146595 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26829 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41359 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123290 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117478 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49587 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12989 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48986 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49222 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49047 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->