### PR TITLE
Web Inspector: associate WebAssembly module scripts with the resource that fetched it

### DIFF
--- a/LayoutTests/http/tests/inspector/debugger/wasm/resources/named-module.py
+++ b/LayoutTests/http/tests/inspector/debugger/wasm/resources/named-module.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+
+import base64
+import os
+import sys
+
+module = base64.b64decode(
+    'AGFzbQEAAAABBwFgAn9/AX8DAgEABQMBAAEHEAIDYWRkAAAGbWVtb3J5AgAKCQEHACAAIAFqCwAaBG5hbWUAExJlbWJlZGRlZC1uYW1lLndhc20='
+)
+
+headers = b'Content-Type: application/wasm\r\n'
+if os.environ.get('QUERY_STRING') == 'memory-cache':
+    headers += b'Cache-Control: max-age=3600\r\n'
+
+sys.stdout.buffer.write(headers + b'\r\n' + module)

--- a/LayoutTests/http/tests/inspector/debugger/wasm/resources/resource-worker.js
+++ b/LayoutTests/http/tests/inspector/debugger/wasm/resources/resource-worker.js
@@ -1,0 +1,11 @@
+let wasmInstances = [];
+
+addEventListener("message", async (event) => {
+    try {
+        let {instance} = await WebAssembly.instantiateStreaming(fetch(event.data));
+        wasmInstances.push(instance);
+        postMessage({result: "instantiated"});
+    } catch (error) {
+        postMessage({error: String(error)});
+    }
+});

--- a/LayoutTests/http/tests/inspector/debugger/wasm/script-url-expected.txt
+++ b/LayoutTests/http/tests/inspector/debugger/wasm/script-url-expected.txt
@@ -1,0 +1,75 @@
+Tests that WebAssembly modules preserve URLs supplied by streaming fetches and the module loader.
+
+
+== Running test suite: WI.Script.URL.WebAssembly
+-- Running test case: WI.Script.URL.WebAssembly.Streaming
+PASS: Should preserve the WebAssembly module's real URL.
+PASS: Should not expose the resource URL as a `sourceURL` directive.
+PASS: Should use the WebAssembly module's name section as the display name.
+PASS: Should associate the WebAssembly script with a Resource.
+PASS: Should associate the WebAssembly script with the resource for the module URL.
+PASS: The associated Resource should use the WebAssembly module's name section as its display name.
+PASS: The Resource should be associated with the WebAssembly script.
+PASS: The associated Resource should be treated as a script.
+PASS: The WebAssembly script should belong to the main frame.
+PASS: The associated Resource should belong to the main frame.
+PASS: The resource-backed WebAssembly script should not be an extra script.
+
+-- Running test case: WI.Script.URL.WebAssembly.StreamingResponseClone
+PASS: Should preserve the WebAssembly module's real URL.
+PASS: Should not expose the resource URL as a `sourceURL` directive.
+PASS: Should use the WebAssembly module's name section as the display name.
+PASS: Should associate the WebAssembly script with a Resource.
+PASS: Should associate the WebAssembly script with the resource for the module URL.
+PASS: The associated Resource should use the WebAssembly module's name section as its display name.
+PASS: The Resource should be associated with the WebAssembly script.
+PASS: The associated Resource should be treated as a script.
+PASS: The WebAssembly script should belong to the main frame.
+PASS: The associated Resource should belong to the main frame.
+PASS: The resource-backed WebAssembly script should not be an extra script.
+PASS: Only one WebAssembly script should associate with a cloned Response's Resource.
+PASS: The additional clone should remain visible as an extra script.
+
+-- Running test case: WI.Script.URL.WebAssembly.ModuleLoader
+PASS: Should preserve the WebAssembly module's real URL.
+PASS: Should not expose the resource URL as a `sourceURL` directive.
+PASS: Should use the WebAssembly module's name section as the display name.
+PASS: Should associate the WebAssembly script with a Resource.
+PASS: Should associate the WebAssembly script with the resource for the module URL.
+PASS: The associated Resource should use the WebAssembly module's name section as its display name.
+PASS: The Resource should be associated with the WebAssembly script.
+PASS: The associated Resource should be treated as a script.
+PASS: The WebAssembly script should belong to the main frame.
+PASS: The associated Resource should belong to the main frame.
+PASS: The resource-backed WebAssembly script should not be an extra script.
+
+-- Running test case: WI.Script.URL.WebAssembly.WorkerStreaming
+PASS: Should create a Worker target.
+PASS: The Worker's WebAssembly script should associate with a Resource.
+PASS: The associated Resource should belong to the Worker target.
+PASS: The Worker's associated Resource should not belong to a frame.
+PASS: The resource-backed WebAssembly script should not remain an extra script.
+
+-- Running test case: WI.Script.URL.WebAssembly.RepeatedStreamingURL
+PASS: Should associate the repeated WebAssembly script with a Resource.
+PASS: Should preserve the repeated WebAssembly module's final response URL.
+PASS: Repeated loads of the same URL should associate with distinct Resources.
+PASS: Repeated loads of the same URL should preserve distinct request identifiers.
+
+-- Running test case: WI.Script.URL.WebAssembly.MemoryCache
+PASS: Should associate the initial WebAssembly script with a Resource.
+PASS: Should associate the cached WebAssembly script with a Resource.
+PASS: The repeated load should use the memory cache.
+PASS: The cached WebAssembly script should use the newly-created Resource.
+PASS: The cached WebAssembly script should not remain an extra script.
+
+-- Running test case: WI.Script.URL.WebAssembly.FetchedBytes
+PASS: The fetched bytes should have a Resource.
+PASS: The module should not associate after its fetch provenance is lost.
+PASS: The resource-less module should remain visible as an extra script.
+
+-- Running test case: WI.Script.URL.WebAssembly.DirectBytes
+PASS: Should not associate the WebAssembly script with a Resource.
+PASS: The WebAssembly script should belong to the main frame.
+PASS: The resource-less WebAssembly script should be an extra script.
+

--- a/LayoutTests/http/tests/inspector/debugger/wasm/script-url.html
+++ b/LayoutTests/http/tests/inspector/debugger/wasm/script-url.html
@@ -1,0 +1,290 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/inspector-test.js"></script>
+<script>
+let wasmInstances = new Set;
+let wasmModuleNamespaces = new Set;
+let wasmResourceWorker = null;
+
+function instantiateWasmURL(url)
+{
+    return WebAssembly.instantiateStreaming(fetch(url)).then((result) => {
+        wasmInstances.add(result.instance);
+        return result;
+    });
+}
+
+async function instantiateWasmResponseClones(url)
+{
+    let response = await fetch(url);
+    let results = await Promise.all([
+        WebAssembly.instantiateStreaming(response.clone()),
+        WebAssembly.instantiateStreaming(response.clone()),
+    ]);
+    for (let result of results)
+        wasmInstances.add(result.instance);
+    return results;
+}
+
+async function instantiateWasmFetchedBytes(url)
+{
+    let response = await fetch(url);
+    let result = await WebAssembly.instantiate(await response.arrayBuffer());
+    wasmInstances.add(result.instance);
+    return result;
+}
+
+function importWasmURL(url)
+{
+    return import(url).then((namespace) => {
+        wasmModuleNamespaces.add(namespace);
+        return namespace;
+    });
+}
+
+function instantiateWasmBytes()
+{
+    let bytes = new Uint8Array([
+        0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
+        0x01, 0x05, 0x01, 0x60, 0x00, 0x01, 0x7f,
+        0x03, 0x02, 0x01, 0x00,
+        0x07, 0x07, 0x01, 0x03, 0x72, 0x75, 0x6e, 0x00, 0x00,
+        0x0a, 0x06, 0x01, 0x04, 0x00, 0x41, 0x2a, 0x0b,
+    ]);
+    let instance = new WebAssembly.Instance(new WebAssembly.Module(bytes));
+    wasmInstances.add(instance);
+    return instance;
+}
+
+function createWasmResourceWorker()
+{
+    wasmResourceWorker = new Worker("resources/resource-worker.js");
+}
+
+function instantiateWasmInWorker(url)
+{
+    return new Promise((resolve, reject) => {
+        function handleMessage(event)
+        {
+            if (event.data?.error) {
+                wasmResourceWorker.removeEventListener("message", handleMessage);
+                wasmResourceWorker.removeEventListener("error", handleError);
+                reject(new Error(event.data.error));
+                return;
+            }
+            if (event.data?.result !== "instantiated")
+                return;
+            wasmResourceWorker.removeEventListener("message", handleMessage);
+            wasmResourceWorker.removeEventListener("error", handleError);
+            resolve();
+        }
+
+        function handleError(event)
+        {
+            wasmResourceWorker.removeEventListener("message", handleMessage);
+            wasmResourceWorker.removeEventListener("error", handleError);
+            reject(event.error || new Error(event.message));
+        }
+
+        wasmResourceWorker.addEventListener("message", handleMessage);
+        wasmResourceWorker.addEventListener("error", handleError);
+        wasmResourceWorker.postMessage(url);
+    });
+}
+
+function test()
+{
+    async function evaluateAndAwaitPromise(expression)
+    {
+        let {result, wasThrown} = await WI.mainTarget.RuntimeAgent.evaluate.invoke({expression});
+        if (wasThrown)
+            throw new Error(result.description);
+        if (result.className === "Promise") {
+            let response = await WI.mainTarget.RuntimeAgent.awaitPromise.invoke({promiseObjectId: result.objectId});
+            if (response.wasThrown)
+                throw new Error(response.result.description);
+        }
+    }
+
+    function scriptsForTarget(target)
+    {
+        let scripts = [];
+        for (let candidate of target ? [target] : WI.targets) {
+            if (candidate.hasDomain("Debugger"))
+                scripts.pushAll(WI.debuggerManager.dataForTarget(candidate).scripts);
+        }
+        return scripts;
+    }
+
+    async function evaluateAndAwaitWebAssemblyScripts(expression, {target = null, count = 1} = {})
+    {
+        let knownScripts = new Set(scriptsForTarget(target));
+        await evaluateAndAwaitPromise(expression);
+        let scripts;
+        await retryUntil(() => {
+            scripts = scriptsForTarget(target).filter((script) => script.sourceType === WI.Script.SourceType.WebAssembly && !knownScripts.has(script));
+            return scripts.length >= count;
+        });
+        return scripts;
+    }
+
+    async function evaluateAndAwaitWebAssemblyScript(expression)
+    {
+        return (await evaluateAndAwaitWebAssemblyScripts(expression))[0];
+    }
+
+    async function awaitResourceAssociation(script)
+    {
+        await retryUntil(() => script.resource);
+    }
+
+    let suite = InspectorTest.createAsyncSuite("WI.Script.URL.WebAssembly");
+    let streamingScript = null;
+
+    [
+        {
+            name: "Streaming",
+            description: "A streamed WebAssembly module should preserve its final response URL.",
+            functionName: "instantiateWasmURL",
+            query: "streaming",
+            redirect: true,
+        },
+        {
+            name: "StreamingResponseClone",
+            description: "Cloned Responses should retain Resource provenance without assigning one Resource to multiple WebAssembly scripts.",
+            functionName: "instantiateWasmResponseClones",
+            query: "response-clone",
+            scriptCount: 2,
+        },
+        {
+            name: "ModuleLoader",
+            description: "A WebAssembly module imported by the module loader should preserve its module URL.",
+            functionName: "importWasmURL",
+            query: "module-loader",
+        },
+    ].forEach(function({name, description, functionName, query, redirect, scriptCount}) {
+        suite.addTestCase({
+            name: "WI.Script.URL.WebAssembly." + name,
+            description,
+            async test() {
+                let origin = await InspectorTest.evaluateInPage("location.origin");
+                let expectedURL = origin + "/inspector/debugger/wasm/resources/named-module.py/path-module.wasm?" + query;
+                let requestURL = redirect ? origin + "/resources/redirect.py?url=" + encodeURIComponent(expectedURL) : expectedURL;
+                let scripts = await evaluateAndAwaitWebAssemblyScripts(`${functionName}(${JSON.stringify(requestURL)})`, {count: scriptCount});
+                let script = scripts[0];
+                await awaitResourceAssociation(script);
+                InspectorTest.expectEqual(script.url, expectedURL, "Should preserve the WebAssembly module's real URL.");
+                InspectorTest.expectNull(script.sourceURL, "Should not expose the resource URL as a `sourceURL` directive.");
+                InspectorTest.expectEqual(script.displayName, "embedded-name.wasm", "Should use the WebAssembly module's name section as the display name.");
+                InspectorTest.expectTrue(script.resource instanceof WI.Resource, "Should associate the WebAssembly script with a Resource.");
+                InspectorTest.expectEqual(script.resource?.url, expectedURL, "Should associate the WebAssembly script with the resource for the module URL.");
+                InspectorTest.expectEqual(script.resource?.displayName, "embedded-name.wasm", "The associated Resource should use the WebAssembly module's name section as its display name.");
+                InspectorTest.expectTrue(script.resource?.scripts.includes(script), "The Resource should be associated with the WebAssembly script.");
+                InspectorTest.expectEqual(script.resource?.type, WI.Resource.Type.Script, "The associated Resource should be treated as a script.");
+                InspectorTest.expectEqual(script.parentFrame, WI.networkManager.mainFrame, "The WebAssembly script should belong to the main frame.");
+                InspectorTest.expectEqual(script.resource?.parentFrame, WI.networkManager.mainFrame, "The associated Resource should belong to the main frame.");
+                InspectorTest.expectFalse(WI.networkManager.mainFrame.extraScriptCollection.has(script), "The resource-backed WebAssembly script should not be an extra script.");
+
+                if (name === "StreamingResponseClone") {
+                    let additionalScript = scripts[1];
+                    InspectorTest.expectNull(additionalScript.resource, "Only one WebAssembly script should associate with a cloned Response's Resource.");
+                    InspectorTest.expectTrue(WI.networkManager.mainFrame.extraScriptCollection.has(additionalScript), "The additional clone should remain visible as an extra script.");
+                }
+
+                if (name === "Streaming")
+                    streamingScript = script;
+            },
+        });
+    });
+
+    suite.addTestCase({
+        name: "WI.Script.URL.WebAssembly.WorkerStreaming",
+        description: "A streamed WebAssembly script should associate with the Resource owned by its Worker target.",
+        async test() {
+            let targetAddedPromise = WI.targetManager.awaitEvent(WI.TargetManager.Event.TargetAdded);
+            await InspectorTest.evaluateInPage("createWasmResourceWorker()");
+            let {target: workerTarget} = (await targetAddedPromise).data;
+            InspectorTest.expectTrue(workerTarget instanceof WI.WorkerTarget, "Should create a Worker target.");
+
+            let origin = await InspectorTest.evaluateInPage("location.origin");
+            let requestURL = origin + "/inspector/debugger/wasm/resources/named-module.py/path-module.wasm?worker-streaming";
+            let scripts = await evaluateAndAwaitWebAssemblyScripts(`instantiateWasmInWorker(${JSON.stringify(requestURL)})`, {target: workerTarget});
+            let script = scripts[0];
+            await awaitResourceAssociation(script);
+            InspectorTest.expectTrue(script.resource instanceof WI.Resource, "The Worker's WebAssembly script should associate with a Resource.");
+            InspectorTest.expectEqual(script.resource?.target, workerTarget, "The associated Resource should belong to the Worker target.");
+            InspectorTest.expectNull(script.resource?.parentFrame, "The Worker's associated Resource should not belong to a frame.");
+            InspectorTest.expectFalse(workerTarget.extraScriptCollection.has(script), "The resource-backed WebAssembly script should not remain an extra script.");
+        },
+    });
+
+    suite.addTestCase({
+        name: "WI.Script.URL.WebAssembly.RepeatedStreamingURL",
+        description: "Repeated streaming loads should associate each WebAssembly script with the exact Resource for its request.",
+        async test() {
+            let origin = await InspectorTest.evaluateInPage("location.origin");
+            let expectedURL = origin + "/inspector/debugger/wasm/resources/named-module.py/path-module.wasm?streaming";
+            let requestURL = origin + "/resources/redirect.py?url=" + encodeURIComponent(expectedURL);
+            let script = await evaluateAndAwaitWebAssemblyScript(`instantiateWasmURL(${JSON.stringify(requestURL)})`);
+            await awaitResourceAssociation(script);
+            InspectorTest.expectTrue(script.resource instanceof WI.Resource, "Should associate the repeated WebAssembly script with a Resource.");
+            InspectorTest.expectEqual(script.resource?.url, expectedURL, "Should preserve the repeated WebAssembly module's final response URL.");
+            InspectorTest.expectNotEqual(script.resource, streamingScript.resource, "Repeated loads of the same URL should associate with distinct Resources.");
+            InspectorTest.expectNotEqual(script.resource?.requestIdentifier, streamingScript.resource?.requestIdentifier, "Repeated loads of the same URL should preserve distinct request identifiers.");
+        },
+    });
+
+    suite.addTestCase({
+        name: "WI.Script.URL.WebAssembly.MemoryCache",
+        description: "Repeated streaming loads from the memory cache should associate with the only unassociated Resource.",
+        async test() {
+            let origin = await InspectorTest.evaluateInPage("location.origin");
+            let requestURL = origin + "/inspector/debugger/wasm/resources/named-module.py/path-module.wasm?memory-cache";
+
+            let firstScript = await evaluateAndAwaitWebAssemblyScript(`instantiateWasmURL(${JSON.stringify(requestURL)})`);
+            await awaitResourceAssociation(firstScript);
+            InspectorTest.expectTrue(firstScript.resource instanceof WI.Resource, "Should associate the initial WebAssembly script with a Resource.");
+
+            let cachedScript = await evaluateAndAwaitWebAssemblyScript(`instantiateWasmURL(${JSON.stringify(requestURL)})`);
+            await awaitResourceAssociation(cachedScript);
+            InspectorTest.expectTrue(cachedScript.resource instanceof WI.Resource, "Should associate the cached WebAssembly script with a Resource.");
+            InspectorTest.expectTrue(cachedScript.resource?.cached, "The repeated load should use the memory cache.");
+            InspectorTest.expectNotEqual(cachedScript.resource, firstScript.resource, "The cached WebAssembly script should use the newly-created Resource.");
+            InspectorTest.expectFalse(WI.networkManager.mainFrame.extraScriptCollection.has(cachedScript), "The cached WebAssembly script should not remain an extra script.");
+        },
+    });
+
+    suite.addTestCase({
+        name: "WI.Script.URL.WebAssembly.FetchedBytes",
+        description: "A module compiled from a fetched ArrayBuffer should not guess that the fetch Resource is its owner.",
+        async test() {
+            let origin = await InspectorTest.evaluateInPage("location.origin");
+            let requestURL = origin + "/inspector/debugger/wasm/resources/named-module.py/path-module.wasm?fetched-bytes";
+            let script = await evaluateAndAwaitWebAssemblyScript(`instantiateWasmFetchedBytes(${JSON.stringify(requestURL)})`);
+            let resources = WI.networkManager.mainFrame.resourceCollection.resourcesForURL(requestURL);
+            InspectorTest.expectEqual(resources.size, 1, "The fetched bytes should have a Resource.");
+            InspectorTest.expectNull(script.resource, "The module should not associate after its fetch provenance is lost.");
+            InspectorTest.expectTrue(WI.networkManager.mainFrame.extraScriptCollection.has(script), "The resource-less module should remain visible as an extra script.");
+        },
+    });
+
+    suite.addTestCase({
+        name: "WI.Script.URL.WebAssembly.DirectBytes",
+        description: "A WebAssembly module created directly from bytes should remain resource-less.",
+        async test() {
+            let script = await evaluateAndAwaitWebAssemblyScript("instantiateWasmBytes()");
+            InspectorTest.expectNull(script.resource, "Should not associate the WebAssembly script with a Resource.");
+            InspectorTest.expectEqual(script.parentFrame, WI.networkManager.mainFrame, "The WebAssembly script should belong to the main frame.");
+            InspectorTest.expectTrue(WI.networkManager.mainFrame.extraScriptCollection.has(script), "The resource-less WebAssembly script should be an extra script.");
+        },
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+</head>
+<body onload="runTest()">
+<p>Tests that WebAssembly modules preserve URLs supplied by streaming fetches and the module loader.</p>
+</body>
+</html>

--- a/LayoutTests/http/tests/site-isolation/inspector/debugger/resources/wasm-frame.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/debugger/resources/wasm-frame.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<script>
+let wasmInstances = [];
+
+addEventListener("message", (event) => {
+    if (event.data === "instantiate-wasm") {
+        let bytes = Uint8Array.from(atob("AGFzbQEAAAABBwFgAn9/AX8DAgEABQMBAAEHEAIDYWRkAAAGbWVtb3J5AgAKCQEHACAAIAFqCw=="), (character) => character.charCodeAt(0));
+        wasmInstances.push(new WebAssembly.Instance(new WebAssembly.Module(bytes)));
+        return;
+    }
+
+    if (event.data === "instantiate-streaming") {
+        WebAssembly.instantiateStreaming(fetch("/inspector/debugger/wasm/resources/named-module.py/path-module.wasm?frame-target")).then(({instance}) => {
+            wasmInstances.push(instance);
+        });
+    }
+});
+</script>

--- a/LayoutTests/http/tests/site-isolation/inspector/debugger/wasm-frame-placement-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/inspector/debugger/wasm-frame-placement-expected.txt
@@ -1,0 +1,31 @@
+Tests WebAssembly source placement for a site-isolated frame.
+
+
+== Running test suite: WebAssembly.FrameTarget.Placement
+-- Running test case: WebAssembly.FrameTarget.Placement.CrossOriginFrame
+PASS: Should create the named child frame.
+PASS: The FrameTarget execution context should identify its frame.
+PASS: The WebAssembly script should belong to the cross-origin child frame.
+PASS: The main frame should not contain the child frame's WebAssembly script.
+PASS: The child frame should contain its WebAssembly script.
+
+-- Running test case: WebAssembly.FrameTarget.Placement.Resource
+PASS: The WebAssembly script should associate with a Resource.
+PASS: The WebAssembly script should belong to the cross-origin child frame.
+PASS: The associated Resource should belong to the cross-origin child frame.
+PASS: The Resource should be associated with the WebAssembly script.
+PASS: The Resource-backed WebAssembly script should not remain an extra script.
+PASS: Repeated loads of the same URL should associate with distinct Resources.
+PASS: Repeated loads of the same URL should preserve distinct request identifiers.
+PASS: The repeated Resource should use a site-isolation-qualified request identifier.
+
+-- Running test case: WebAssembly.FrameTarget.Placement.WorkerResource
+PASS: Should create a Worker target.
+PASS: The Worker's WebAssembly script should associate with a Resource.
+PASS: The Worker's associated Resource should use the final response URL.
+PASS: The associated Resource should belong to the Worker target.
+PASS: The Worker target should contain the associated Resource.
+PASS: The Worker's associated Resource should not belong to a frame.
+PASS: The associated Resource should use a site-isolation-qualified request identifier.
+PASS: The Resource-backed WebAssembly script should not remain an extra script.
+

--- a/LayoutTests/http/tests/site-isolation/inspector/debugger/wasm-frame-placement.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/debugger/wasm-frame-placement.html
@@ -1,0 +1,189 @@
+<!DOCTYPE html><!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<html>
+<head>
+<script src="../../../inspector/resources/inspector-test.js"></script>
+<script>
+let wasmFrameLoadedPromise;
+let wasmResourceWorker = null;
+
+function createCrossOriginFrame()
+{
+    let iframe = document.createElement("iframe");
+    iframe.name = "wasm-frame";
+    let crossOriginHost = location.hostname === "localhost" ? "127.0.0.1" : "localhost";
+    iframe.src = `http://${crossOriginHost}:8000/site-isolation/inspector/debugger/resources/wasm-frame.html`;
+    wasmFrameLoadedPromise = new Promise((resolve) => iframe.addEventListener("load", resolve, {once: true}));
+    document.body.appendChild(iframe);
+}
+
+function instantiateWasmInCrossOriginFrame(message)
+{
+    wasmFrameLoadedPromise.then(() => {
+        frames["wasm-frame"].postMessage(message, "*");
+    });
+}
+
+function createWasmResourceWorker()
+{
+    wasmResourceWorker = new Worker("/inspector/debugger/wasm/resources/resource-worker.js");
+}
+
+function instantiateWasmInWorker(url)
+{
+    return new Promise((resolve, reject) => {
+        function handleMessage(event)
+        {
+            if (event.data?.error) {
+                wasmResourceWorker.removeEventListener("message", handleMessage);
+                wasmResourceWorker.removeEventListener("error", handleError);
+                reject(new Error(event.data.error));
+                return;
+            }
+            if (event.data?.result !== "instantiated")
+                return;
+            wasmResourceWorker.removeEventListener("message", handleMessage);
+            wasmResourceWorker.removeEventListener("error", handleError);
+            resolve();
+        }
+
+        function handleError(event)
+        {
+            wasmResourceWorker.removeEventListener("message", handleMessage);
+            wasmResourceWorker.removeEventListener("error", handleError);
+            reject(event.error || new Error(event.message));
+        }
+
+        wasmResourceWorker.addEventListener("message", handleMessage);
+        wasmResourceWorker.addEventListener("error", handleError);
+        wasmResourceWorker.postMessage(url);
+    });
+}
+
+function test()
+{
+    let suite = InspectorTest.createAsyncSuite("WebAssembly.FrameTarget.Placement");
+
+    async function evaluateAndAwaitPromise(expression)
+    {
+        let {result, wasThrown} = await WI.mainTarget.RuntimeAgent.evaluate.invoke({expression});
+        if (wasThrown)
+            throw new Error(result.description);
+        if (result.className === "Promise") {
+            let response = await WI.mainTarget.RuntimeAgent.awaitPromise.invoke({promiseObjectId: result.objectId});
+            if (response.wasThrown)
+                throw new Error(response.result.description);
+        }
+    }
+
+    async function awaitFrameTargetForFrame(frame)
+    {
+        while (true) {
+            let target = WI.targets.find((candidate) => candidate instanceof WI.FrameTarget && candidate.executionContext?.frame === frame);
+            if (target)
+                return target;
+
+            let promises = [WI.targetManager.awaitEvent(WI.TargetManager.Event.TargetAdded)];
+            for (let frameTarget of WI.targets.filter((candidate) => candidate instanceof WI.FrameTarget))
+                promises.push(frameTarget.awaitEvent(WI.FrameTarget.Event.ExecutionContextAdded));
+            await Promise.race(promises);
+        }
+    }
+
+    async function instantiateAndAwaitWebAssemblyScript(target, message)
+    {
+        let knownScripts = new Set(WI.debuggerManager.dataForTarget(target).scripts);
+        await InspectorTest.evaluateInPage(`instantiateWasmInCrossOriginFrame(${JSON.stringify(message)})`);
+
+        let script;
+        await retryUntil(() => {
+            script = WI.debuggerManager.dataForTarget(target).scripts.find((candidate) => candidate.sourceType === WI.Script.SourceType.WebAssembly && !knownScripts.has(candidate));
+            return script;
+        });
+        return script;
+    }
+
+    let frame;
+    let target;
+
+    suite.addTestCase({
+        name: "WebAssembly.FrameTarget.Placement.CrossOriginFrame",
+        description: "A WebAssembly script should belong to the site-isolated frame that created it.",
+        async test() {
+            let frameAddedPromise = WI.networkManager.awaitEvent(WI.NetworkManager.Event.FrameWasAdded);
+            await InspectorTest.evaluateInPage("createCrossOriginFrame()");
+
+            let frameAddedEvent = await frameAddedPromise;
+            frame = frameAddedEvent.data.frame;
+            InspectorTest.expectEqual(frame.name, "wasm-frame", "Should create the named child frame.");
+
+            target = await awaitFrameTargetForFrame(frame);
+            InspectorTest.expectEqual(target.executionContext.frame, frame, "The FrameTarget execution context should identify its frame.");
+
+            let script = await instantiateAndAwaitWebAssemblyScript(target, "instantiate-wasm");
+
+            InspectorTest.expectEqual(script.parentFrame, frame, "The WebAssembly script should belong to the cross-origin child frame.");
+            InspectorTest.expectFalse(WI.networkManager.mainFrame.extraScriptCollection.has(script), "The main frame should not contain the child frame's WebAssembly script.");
+            InspectorTest.expectTrue(frame.extraScriptCollection.has(script), "The child frame should contain its WebAssembly script.");
+        }
+    });
+
+    suite.addTestCase({
+        name: "WebAssembly.FrameTarget.Placement.Resource",
+        description: "A streamed WebAssembly script should associate with the Resource owned by its site-isolated frame.",
+        async test() {
+            let script = await instantiateAndAwaitWebAssemblyScript(target, "instantiate-streaming");
+            await retryUntil(() => script.resource);
+            InspectorTest.expectTrue(script.resource instanceof WI.Resource, "The WebAssembly script should associate with a Resource.");
+            InspectorTest.expectEqual(script.parentFrame, frame, "The WebAssembly script should belong to the cross-origin child frame.");
+            InspectorTest.expectEqual(script.resource?.parentFrame, frame, "The associated Resource should belong to the cross-origin child frame.");
+            InspectorTest.expectTrue(script.resource?.scripts.includes(script), "The Resource should be associated with the WebAssembly script.");
+            InspectorTest.expectFalse(frame.extraScriptCollection.has(script), "The Resource-backed WebAssembly script should not remain an extra script.");
+
+            let repeatedScript = await instantiateAndAwaitWebAssemblyScript(target, "instantiate-streaming");
+            await retryUntil(() => repeatedScript.resource);
+            InspectorTest.expectNotEqual(repeatedScript.resource, script.resource, "Repeated loads of the same URL should associate with distinct Resources.");
+            InspectorTest.expectNotEqual(repeatedScript.resource?.requestIdentifier, script.resource?.requestIdentifier, "Repeated loads of the same URL should preserve distinct request identifiers.");
+            InspectorTest.expectTrue(repeatedScript.resource?.requestIdentifier?.startsWith("request-"), "The repeated Resource should use a site-isolation-qualified request identifier.");
+        }
+    });
+
+    suite.addTestCase({
+        name: "WebAssembly.FrameTarget.Placement.WorkerResource",
+        description: "A streamed WebAssembly script should associate with the Resource owned by its Worker under Site Isolation.",
+        async test() {
+            let targetAddedPromise = WI.targetManager.awaitEvent(WI.TargetManager.Event.TargetAdded);
+            await InspectorTest.evaluateInPage("createWasmResourceWorker()");
+            let {target: workerTarget} = (await targetAddedPromise).data;
+            InspectorTest.expectTrue(workerTarget instanceof WI.WorkerTarget, "Should create a Worker target.");
+
+            let origin = await InspectorTest.evaluateInPage("location.origin");
+            let expectedURL = origin + "/inspector/debugger/wasm/resources/named-module.py/path-module.wasm?site-isolation-worker";
+            let requestURL = origin + "/resources/redirect.py?url=" + encodeURIComponent(expectedURL);
+            let knownScripts = new Set(WI.debuggerManager.dataForTarget(workerTarget).scripts);
+            await evaluateAndAwaitPromise(`instantiateWasmInWorker(${JSON.stringify(requestURL)})`);
+
+            let script;
+            await retryUntil(() => {
+                script = WI.debuggerManager.dataForTarget(workerTarget).scripts.find((candidate) => candidate.sourceType === WI.Script.SourceType.WebAssembly && !knownScripts.has(candidate));
+                return script;
+            });
+            await retryUntil(() => script.resource);
+
+            InspectorTest.expectTrue(script.resource instanceof WI.Resource, "The Worker's WebAssembly script should associate with a Resource.");
+            InspectorTest.expectEqual(script.resource?.url, expectedURL, "The Worker's associated Resource should use the final response URL.");
+            InspectorTest.expectEqual(script.resource?.target, workerTarget, "The associated Resource should belong to the Worker target.");
+            InspectorTest.expectTrue(workerTarget.resourceCollection.has(script.resource), "The Worker target should contain the associated Resource.");
+            InspectorTest.expectNull(script.resource?.parentFrame, "The Worker's associated Resource should not belong to a frame.");
+            InspectorTest.expectTrue(script.resource?.requestIdentifier?.startsWith("request-"), "The associated Resource should use a site-isolation-qualified request identifier.");
+            InspectorTest.expectFalse(workerTarget.extraScriptCollection.has(script), "The Resource-backed WebAssembly script should not remain an extra script.");
+        }
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+</head>
+<body onload="runTest()">
+<p>Tests WebAssembly source placement for a site-isolated frame.</p>
+</body>
+</html>

--- a/LayoutTests/inspector/model/frame-extra-scripts-expected.txt
+++ b/LayoutTests/inspector/model/frame-extra-scripts-expected.txt
@@ -7,6 +7,10 @@ WI.Frame.extraScriptCollection.
 -- Running test case: FrameHasNoExtraScriptsYet
 PASS: Main frame should have no dynamic scripts.
 
+-- Running test case: HiddenConsoleEvaluationIsNotExtraScript
+PASS: Console evaluations should be hidden by default.
+PASS: The hidden console evaluation should not add an extra script.
+
 -- Running test case: AddExtraScript
 PASS: ExtraScriptAdded event fired.
 PASS: Script should identify as dynamic.

--- a/LayoutTests/inspector/model/frame-extra-scripts.html
+++ b/LayoutTests/inspector/model/frame-extra-scripts.html
@@ -95,6 +95,21 @@ function test()
     });
 
     suite.addTestCase({
+        name: "HiddenConsoleEvaluationIsNotExtraScript",
+        description: "A hidden console evaluation should not be added to the frame's extra script collection.",
+        async test() {
+            InspectorTest.expectFalse(WI.settings.debugShowConsoleEvaluations.value, "Console evaluations should be hidden by default.");
+
+            let initialExtraScriptCount = mainFrame.extraScriptCollection.size;
+            await new Promise((resolve) => {
+                WI.runtimeManager.evaluateInInspectedWindow("1 + 1", {objectGroup: "test"}, resolve);
+            });
+
+            InspectorTest.expectEqual(mainFrame.extraScriptCollection.size, initialExtraScriptCount, "The hidden console evaluation should not add an extra script.");
+        }
+    });
+
+    suite.addTestCase({
         name: "AddExtraScript",
         description: "Add extra script.",
         test(resolve, reject) {

--- a/LayoutTests/inspector/model/script-resource-relationship-expected.txt
+++ b/LayoutTests/inspector/model/script-resource-relationship-expected.txt
@@ -18,6 +18,12 @@ PASS: Resource should be related to the newly added script.
 PASS: Script should be related to the resource.
 PASS: Script should have a sourceURL.
 
+-- Running test case: RepeatedScriptsWithResources
+PASS: Should add two JavaScript scripts.
+PASS: Each JavaScript script should associate with a Resource.
+PASS: Each JavaScript script should associate with a distinct Resource.
+PASS: Each Resource should associate with its JavaScript script.
+
 -- Running test case: ScriptWithoutResource
 PASS: Script was added.
 PASS: Script should not be associated with a Resource.

--- a/LayoutTests/inspector/model/script-resource-relationship.html
+++ b/LayoutTests/inspector/model/script-resource-relationship.html
@@ -11,9 +11,22 @@
   </script>
 <script>
 function triggerResourceWithNormalScript() {
-    let script = document.createElement("script");
-    script.src = "resources/relationship-normal.js";
-    document.body.appendChild(script);
+    loadNormalScript();
+}
+
+function loadNormalScript() {
+    return new Promise((resolve, reject) => {
+        let script = document.createElement("script");
+        script.src = "resources/relationship-normal.js";
+        script.addEventListener("load", resolve, {once: true});
+        script.addEventListener("error", reject, {once: true});
+        document.body.appendChild(script);
+    });
+}
+
+async function triggerRepeatedResourcesWithNormalScripts() {
+    await loadNormalScript();
+    await loadNormalScript();
 }
 
 function triggerResourceWithNamedScript() {
@@ -121,6 +134,47 @@ function test()
     });
 
     suite.addTestCase({
+        name: "RepeatedScriptsWithResources",
+        description: "Repeated loads of the same JavaScript URL should each associate with the only unassociated Resource.",
+        async test() {
+            await NetworkAgent.setResourceCachingDisabled(true);
+
+            let scripts = [];
+            let resourceChangedPromises = [];
+
+            let scriptsAddedPromise = new Promise((resolve) => {
+                function handleScriptAdded(event) {
+                    let script = event.data.script;
+                    if (!script.url?.endsWith("/relationship-normal.js"))
+                        return;
+
+                    scripts.push(script);
+                    if (!script.resource)
+                        resourceChangedPromises.push(script.awaitEvent(WI.Script.Event.ResourceChanged));
+                    if (scripts.length !== 2)
+                        return;
+
+                    WI.debuggerManager.removeEventListener(WI.DebuggerManager.Event.ScriptAdded, handleScriptAdded);
+                    resolve();
+                }
+                WI.debuggerManager.addEventListener(WI.DebuggerManager.Event.ScriptAdded, handleScriptAdded);
+            });
+
+            InspectorTest.evaluateInPage("triggerRepeatedResourcesWithNormalScripts()");
+            await scriptsAddedPromise;
+            await Promise.all(resourceChangedPromises);
+
+            let resources = scripts.map((script) => script.resource);
+            InspectorTest.expectEqual(scripts.length, 2, "Should add two JavaScript scripts.");
+            InspectorTest.expectTrue(resources.every((resource) => resource instanceof WI.Resource), "Each JavaScript script should associate with a Resource.");
+            InspectorTest.expectEqual(new Set(resources).size, 2, "Each JavaScript script should associate with a distinct Resource.");
+            InspectorTest.expectTrue(resources.every((resource, index) => resource.scripts.includes(scripts[index])), "Each Resource should associate with its JavaScript script.");
+
+            await NetworkAgent.setResourceCachingDisabled(false);
+        }
+    });
+
+    suite.addTestCase({
         name: "ScriptWithoutResource",
         description: "A named eval does not have a resource.",
         test(resolve, reject) {
@@ -175,8 +229,11 @@ function test()
     suite.addTestCase({
         name: "DocumentWithInlineScripts",
         description: "A document resource may be associated with multiple inline scripts.",
-        test(resolve, reject) {
+        async test() {
             let mainResource = WI.networkManager.mainFrame.mainResource;
+            while (mainResource.scripts.length < 4)
+                await mainResource.awaitEvent(WI.Resource.Event.ScriptAssociated);
+
             let scripts = mainResource.scripts.slice().sort((a, b) => a.range.startLine - b.range.startLine);
 
             // Scripts are:
@@ -195,8 +252,6 @@ function test()
             InspectorTest.expectThat(scripts[1].range.startLine < 15, "Inline script 2 should have a low start line.");
             InspectorTest.expectThat(scripts[2].range.startLine < 15, "Inline script 3 should have a low start line.");
             InspectorTest.expectThat(scripts[3].range.startLine > 100, "Inline script 4 should have a high start line.");
-
-            resolve();
         }
     });
 

--- a/Source/JavaScriptCore/debugger/Debugger.cpp
+++ b/Source/JavaScriptCore/debugger/Debugger.cpp
@@ -454,9 +454,8 @@ void Debugger::sourceParsed(JSGlobalObject* globalObject, JSWebAssemblyModule* m
 
     Debugger::Script script;
     script.url = sourceProvider->sourceURL();
-    URL sourceURL { Wasm::makeString(info->sourceURL) };
-    if (info->sourceURL.isEmpty() || sourceURL.protocolIsBlob() || sourceURL.protocolIsData())
-        script.displayName = Wasm::makeString(info->nameSection().moduleName);
+    script.displayName = Wasm::makeString(info->nameSection().moduleName);
+    script.requestIdentifier = info->requestIdentifier;
     script.sourceProvider = WTF::move(sourceProvider);
     script.isContentScript = isContentScript(globalObject);
 

--- a/Source/JavaScriptCore/debugger/Debugger.h
+++ b/Source/JavaScriptCore/debugger/Debugger.h
@@ -200,6 +200,7 @@ public:
         String displayName;
         String sourceURL;
         String sourceMappingURL;
+        uint64_t requestIdentifier { 0 };
         RefPtr<SourceProvider> sourceProvider;
         int startLine { 0 };
         int startColumn { 0 };

--- a/Source/JavaScriptCore/inspector/agents/InspectorDebuggerAgent.cpp
+++ b/Source/JavaScriptCore/inspector/agents/InspectorDebuggerAgent.cpp
@@ -36,6 +36,7 @@
 #include "DeferGC.h"
 #include "ExecutableBaseInlines.h"
 #include "HeapIterationScope.h"
+#include "IdentifiersFactory.h"
 #include "InjectedScript.h"
 #include "InjectedScriptManager.h"
 #include "InternalFunction.h"
@@ -1602,6 +1603,14 @@ String InspectorDebuggerAgent::sourceMapURLForScript(const JSC::Debugger::Script
     return script.sourceMappingURL;
 }
 
+String InspectorDebuggerAgent::requestIdForScript(JSC::JSGlobalObject*, const JSC::Debugger::Script& script)
+{
+    if (!script.requestIdentifier)
+        return { };
+
+    return IdentifiersFactory::requestId(script.requestIdentifier);
+}
+
 Protocol::ErrorStringOr<void> InspectorDebuggerAgent::setPauseForInternalScripts(bool shouldPause)
 {
     if (shouldPause == m_pauseForInternalScripts)
@@ -1853,8 +1862,9 @@ void InspectorDebuggerAgent::didParseSource(JSC::JSGlobalObject* globalObject, J
     bool hasSourceURL = !script.sourceURL.isEmpty();
     String sourceURL = script.sourceURL;
     String sourceMappingURL = sourceMapURLForScript(script);
+    String requestId = requestIdForScript(globalObject, script);
 
-    m_frontendDispatcher->scriptParsed(scriptIDStr, script.url, script.startLine, script.startColumn, script.endLine, script.endColumn, injectedScriptManager().injectedScriptIdFor(globalObject), scriptTypeForScript(script), script.isContentScript, sourceURL, sourceMappingURL, script.displayName);
+    m_frontendDispatcher->scriptParsed(scriptIDStr, script.url, script.startLine, script.startColumn, script.endLine, script.endColumn, injectedScriptManager().injectedScriptIdFor(globalObject), scriptTypeForScript(script), script.isContentScript, sourceURL, sourceMappingURL, script.displayName, requestId);
 
     m_scripts.set(sourceID, script);
 

--- a/Source/JavaScriptCore/inspector/agents/InspectorDebuggerAgent.h
+++ b/Source/JavaScriptCore/inspector/agents/InspectorDebuggerAgent.h
@@ -181,6 +181,7 @@ protected:
     virtual void unmuteConsole() = 0;
 
     virtual String sourceMapURLForScript(const JSC::Debugger::Script&);
+    virtual String requestIdForScript(JSC::JSGlobalObject*, const JSC::Debugger::Script&);
 
     void didClearGlobalObject();
     virtual void didClearAsyncStackTraceData();

--- a/Source/JavaScriptCore/inspector/protocol/Debugger.json
+++ b/Source/JavaScriptCore/inspector/protocol/Debugger.json
@@ -387,7 +387,8 @@
                 { "name": "isContentScript", "type": "boolean", "optional": true, "description": "Determines whether this script is a user extension script." },
                 { "name": "sourceURL", "type": "string", "optional": true, "description": "sourceURL name of the script (if any)." },
                 { "name": "sourceMapURL", "type": "string", "optional": true, "description": "URL of source map associated with script (if any)." },
-                { "name": "displayName", "type": "string", "optional": true, "description": "Human-readable name of the script." }
+                { "name": "displayName", "type": "string", "optional": true, "description": "Human-readable name of the script." },
+                { "name": "requestId", "$ref": "Network.RequestId", "optional": true, "description": "Identifier of the network request associated with this script (if any)." }
             ]
         },
         {

--- a/Source/JavaScriptCore/wasm/WasmModuleInformation.h
+++ b/Source/JavaScriptCore/wasm/WasmModuleInformation.h
@@ -221,6 +221,7 @@ struct ModuleInformation final : public ThreadSafeRefCounted<ModuleInformation> 
     using ConstantExpressionAndSourceOffset = std::pair<Vector<uint8_t>, size_t>;
     Vector<ConstantExpressionAndSourceOffset> constantExpressions;
     Name sourceURL;
+    uint64_t requestIdentifier { 0 };
     Name sourceMappingURL;
 #if ENABLE(WEBASSEMBLY_DEBUGGER)
     std::unique_ptr<Wasm::ModuleDebugInfo> debugInfo;

--- a/Source/JavaScriptCore/wasm/WasmStreamingCompiler.cpp
+++ b/Source/JavaScriptCore/wasm/WasmStreamingCompiler.cpp
@@ -42,7 +42,7 @@
 
 namespace JSC { namespace Wasm {
 
-StreamingCompiler::StreamingCompiler(VM& vm, CompilerMode compilerMode, JSGlobalObject* globalObject, JSPromise* promise, JSObject* importObject, std::optional<WebAssemblyCompileOptions>&& compileOptions, const SourceCode& source, String wasmSourceURL)
+StreamingCompiler::StreamingCompiler(VM& vm, CompilerMode compilerMode, JSGlobalObject* globalObject, JSPromise* promise, JSObject* importObject, std::optional<WebAssemblyCompileOptions>&& compileOptions, const SourceCode& source, String wasmSourceURL, uint64_t requestIdentifier)
     : m_vm(vm)
     , m_compilerMode(compilerMode)
     , m_compileOptions(WTF::move(compileOptions))
@@ -51,6 +51,7 @@ StreamingCompiler::StreamingCompiler(VM& vm, CompilerMode compilerMode, JSGlobal
     , m_source(source)
 {
     m_info->sourceURL = Name(byteCast<char8_t>(wasmSourceURL.utf8().span()));
+    m_info->requestIdentifier = requestIdentifier;
     Vector<JSCell*> dependencies;
     dependencies.append(globalObject);
     if (importObject)
@@ -71,9 +72,9 @@ StreamingCompiler::~StreamingCompiler()
     m_ticket = nullptr;
 }
 
-Ref<StreamingCompiler> StreamingCompiler::create(VM& vm, CompilerMode compilerMode, JSGlobalObject* globalObject, JSPromise* promise, JSObject* importObject, std::optional<WebAssemblyCompileOptions>&& compileOptions, const SourceCode& source, String wasmSourceURL)
+Ref<StreamingCompiler> StreamingCompiler::create(VM& vm, CompilerMode compilerMode, JSGlobalObject* globalObject, JSPromise* promise, JSObject* importObject, std::optional<WebAssemblyCompileOptions>&& compileOptions, const SourceCode& source, String wasmSourceURL, uint64_t requestIdentifier)
 {
-    return adoptRef(*new StreamingCompiler(vm, compilerMode, globalObject, promise, importObject, WTF::move(compileOptions), source, WTF::move(wasmSourceURL)));
+    return adoptRef(*new StreamingCompiler(vm, compilerMode, globalObject, promise, importObject, WTF::move(compileOptions), source, WTF::move(wasmSourceURL), requestIdentifier));
 }
 
 bool StreamingCompiler::didReceiveFunctionData(FunctionCodeIndex functionIndex, const Wasm::FunctionData&)

--- a/Source/JavaScriptCore/wasm/WasmStreamingCompiler.h
+++ b/Source/JavaScriptCore/wasm/WasmStreamingCompiler.h
@@ -49,7 +49,7 @@ class StreamingPlan;
 
 class StreamingCompiler final : public StreamingParserClient, public ThreadSafeRefCounted<StreamingCompiler> {
 public:
-    JS_EXPORT_PRIVATE static Ref<StreamingCompiler> create(VM&, CompilerMode, JSGlobalObject*, JSPromise*, JSObject* importObject, std::optional<WebAssemblyCompileOptions>&&, const SourceCode&, String wasmSourceURL = { });
+    JS_EXPORT_PRIVATE static Ref<StreamingCompiler> create(VM&, CompilerMode, JSGlobalObject*, JSPromise*, JSObject* importObject, std::optional<WebAssemblyCompileOptions>&&, const SourceCode&, String wasmSourceURL = { }, uint64_t requestIdentifier = 0);
 
     JS_EXPORT_PRIVATE ~StreamingCompiler();
 
@@ -71,7 +71,7 @@ public:
     JS_EXPORT_PRIVATE JSGlobalObject* globalObjectIfActive();
 
 private:
-    JS_EXPORT_PRIVATE StreamingCompiler(VM&, CompilerMode, JSGlobalObject*, JSPromise*, JSObject* importObject, std::optional<WebAssemblyCompileOptions>&&, const SourceCode&, String wasmSourceURL);
+    JS_EXPORT_PRIVATE StreamingCompiler(VM&, CompilerMode, JSGlobalObject*, JSPromise*, JSObject* importObject, std::optional<WebAssemblyCompileOptions>&&, const SourceCode&, String wasmSourceURL, uint64_t requestIdentifier);
 
     bool didReceiveFunctionData(FunctionCodeIndex, const FunctionData&) final;
     void didFinishParsing() final;

--- a/Source/WebCore/Modules/fetch/FetchBodyOwner.cpp
+++ b/Source/WebCore/Modules/fetch/FetchBodyOwner.cpp
@@ -343,7 +343,7 @@ FetchBodyOwner::BlobLoader::BlobLoader(FetchBodyOwner& owner)
 
 FetchBodyOwner::BlobLoader::~BlobLoader() = default;
 
-void FetchBodyOwner::BlobLoader::didReceiveResponse(const ResourceResponse& response)
+void FetchBodyOwner::BlobLoader::didReceiveResponse(std::optional<ResourceLoaderIdentifier>, const ResourceResponse& response)
 {
     if (response.httpStatusCode() != httpStatus200OK)
         didFail({ });

--- a/Source/WebCore/Modules/fetch/FetchBodyOwner.h
+++ b/Source/WebCore/Modules/fetch/FetchBodyOwner.h
@@ -126,7 +126,7 @@ private:
         ~BlobLoader();
 
         // FetchLoaderClient API
-        void didReceiveResponse(const ResourceResponse&) final;
+        void didReceiveResponse(std::optional<ResourceLoaderIdentifier>, const ResourceResponse&) final;
         void didReceiveData(const SharedBuffer&) final;
         void didFail(const ResourceError&) final;
         void didSucceed(const NetworkLoadMetrics&) final;

--- a/Source/WebCore/Modules/fetch/FetchLoader.cpp
+++ b/Source/WebCore/Modules/fetch/FetchLoader.cpp
@@ -163,10 +163,10 @@ RefPtr<FragmentedSharedBuffer> FetchLoader::startStreaming()
     return firstChunk;
 }
 
-void FetchLoader::didReceiveResponse(ScriptExecutionContextIdentifier, std::optional<ResourceLoaderIdentifier>, const ResourceResponse& response)
+void FetchLoader::didReceiveResponse(ScriptExecutionContextIdentifier, std::optional<ResourceLoaderIdentifier> resourceLoaderIdentifier, const ResourceResponse& response)
 {
     if (RefPtr client = m_client.get())
-        client->didReceiveResponse(response);
+        client->didReceiveResponse(resourceLoaderIdentifier, response);
 }
 
 void FetchLoader::didReceiveData(const SharedBuffer& buffer)

--- a/Source/WebCore/Modules/fetch/FetchLoaderClient.h
+++ b/Source/WebCore/Modules/fetch/FetchLoaderClient.h
@@ -28,6 +28,8 @@
 
 #pragma once
 
+#include <WebCore/ResourceLoaderIdentifier.h>
+#include <optional>
 #include <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>
 #include <wtf/Forward.h>
 
@@ -41,7 +43,7 @@ class FetchLoaderClient : public AbstractRefCountedAndCanMakeWeakPtr<FetchLoader
 public:
     virtual ~FetchLoaderClient() = default;
 
-    virtual void didReceiveResponse(const ResourceResponse&) { }
+    virtual void didReceiveResponse(std::optional<ResourceLoaderIdentifier>, const ResourceResponse&) { }
 
     virtual void didReceiveData(const SharedBuffer&) { }
 

--- a/Source/WebCore/Modules/fetch/FetchResponse.cpp
+++ b/Source/WebCore/Modules/fetch/FetchResponse.cpp
@@ -221,6 +221,7 @@ ExceptionOr<Ref<FetchResponse>> FetchResponse::clone(JSDOMGlobalObject& globalOb
     clone->cloneBody(globalObject, *this);
     clone->m_opaqueLoadIdentifier = m_opaqueLoadIdentifier;
     clone->m_bodySizeWithPadding = m_bodySizeWithPadding;
+    clone->m_resourceLoaderIdentifier = m_resourceLoaderIdentifier;
     return clone;
 }
 
@@ -396,11 +397,15 @@ FetchResponse::Loader::Loader(FetchResponse& response, NotificationCallback&& re
 
 FetchResponse::Loader::~Loader() = default;
 
-void FetchResponse::Loader::didReceiveResponse(const ResourceResponse& resourceResponse)
+void FetchResponse::Loader::didReceiveResponse(std::optional<ResourceLoaderIdentifier> resourceLoaderIdentifier, const ResourceResponse& resourceResponse)
 {
     RefPtr response = m_response.get();
     if (!response)
         return;
+
+    if (resourceResponse.source() == ResourceResponse::Source::MemoryCache || resourceResponse.source() == ResourceResponse::Source::MemoryCacheAfterValidation)
+        resourceLoaderIdentifier = std::nullopt;
+    response->m_resourceLoaderIdentifier = resourceLoaderIdentifier;
 
     if (RefPtr document = dynamicDowncast<Document>(response->scriptExecutionContext()))
         document->quirks().clearLogoutSurvivingIdentityCookiesIfNeeded(resourceResponse.url(), resourceResponse.httpStatusCode());

--- a/Source/WebCore/Modules/fetch/FetchResponse.h
+++ b/Source/WebCore/Modules/fetch/FetchResponse.h
@@ -120,6 +120,7 @@ public:
 
     bool NODELETE isCORSSameOrigin() const;
     bool hasWasmMIMEType() const;
+    std::optional<ResourceLoaderIdentifier> resourceLoaderIdentifier() const { return m_resourceLoaderIdentifier; }
 
     const NetworkLoadMetrics& networkLoadMetrics() const LIFETIME_BOUND { return m_networkLoadMetrics; }
     void setReceivedInternalResponse(const ResourceResponse&, FetchOptions::Credentials);
@@ -177,7 +178,7 @@ private:
         // FetchLoaderClient API
         void didSucceed(const NetworkLoadMetrics&) final;
         void didFail(const ResourceError&) final;
-        void didReceiveResponse(const ResourceResponse&) final;
+        void didReceiveResponse(std::optional<ResourceLoaderIdentifier>, const ResourceResponse&) final;
         void didReceiveData(const SharedBuffer&) final;
 
         WeakPtr<FetchResponse> m_response;
@@ -197,6 +198,7 @@ private:
     RefPtr<Loader> m_loader;
     std::unique_ptr<FetchResponseBodyLoader> m_bodyLoader;
     mutable String m_responseURL;
+    std::optional<ResourceLoaderIdentifier> m_resourceLoaderIdentifier;
     // Opaque responses will padd their body size when used with Cache API.
     uint64_t m_bodySizeWithPadding { 0 };
     uint64_t m_opaqueLoadIdentifier { 0 };

--- a/Source/WebCore/bindings/js/JSDOMGlobalObject.cpp
+++ b/Source/WebCore/bindings/js/JSDOMGlobalObject.cpp
@@ -637,7 +637,9 @@ static void handleResponseOnStreamingAction(JSC::JSGlobalObject* globalObject, J
     }
 
     String wasmSourceURL = inputResponse->url();
-    auto compiler = JSC::Wasm::StreamingCompiler::create(vm, compilerMode, globalObject, promise, importObject, WTF::move(compileOptions), JSC::makeSource("handleResponseOnStreamingAction"_s, JSC::SourceOrigin(), JSC::SourceTaintedOrigin::Untainted), WTF::move(wasmSourceURL));
+    auto resourceLoaderIdentifier = inputResponse->resourceLoaderIdentifier();
+    uint64_t requestIdentifier = resourceLoaderIdentifier ? resourceLoaderIdentifier->toUInt64() : 0;
+    auto compiler = JSC::Wasm::StreamingCompiler::create(vm, compilerMode, globalObject, promise, importObject, WTF::move(compileOptions), JSC::makeSource("handleResponseOnStreamingAction"_s, JSC::SourceOrigin(), JSC::SourceTaintedOrigin::Untainted), WTF::move(wasmSourceURL), requestIdentifier);
 
     if (inputResponse->isBodyReceivedByChunk()) {
         inputResponse->consumeBodyReceivedByChunk([vmPtr = &vm, compiler = WTF::move(compiler)](auto&& result) mutable {

--- a/Source/WebCore/inspector/agents/WebDebuggerAgent.cpp
+++ b/Source/WebCore/inspector/agents/WebDebuggerAgent.cpp
@@ -26,9 +26,12 @@
 #include "config.h"
 #include "WebDebuggerAgent.h"
 
+#include "DocumentSettingsValues.h"
 #include "EventListener.h"
 #include "EventTarget.h"
+#include "InspectorIdentifierRegistry.h"
 #include "InstrumentingAgents.h"
+#include "JSDOMGlobalObject.h"
 #include "ScriptExecutionContext.h"
 #include "Timer.h"
 #include <wtf/TZoneMallocInlines.h>
@@ -50,6 +53,20 @@ WebDebuggerAgent::~WebDebuggerAgent() = default;
 bool WebDebuggerAgent::enabled() const
 {
     return Ref { m_instrumentingAgents.get() }->enabledWebDebuggerAgent() == this && InspectorDebuggerAgent::enabled();
+}
+
+String WebDebuggerAgent::requestIdForScript(JSC::JSGlobalObject* globalObject, const JSC::Debugger::Script& script)
+{
+    auto requestId = InspectorDebuggerAgent::requestIdForScript(globalObject, script);
+    if (requestId.isEmpty())
+        return requestId;
+
+    if (RefPtr context = uncheckedDowncast<JSDOMGlobalObject>(globalObject)->scriptExecutionContext()) {
+        if (context->settingsValues().siteIsolationEnabled && !context->isServiceWorkerGlobalScope())
+            return Inspector::IdentifierRegistry::protocolRequestId(context->identifier().processIdentifier(), ResourceLoaderIdentifier(script.requestIdentifier));
+    }
+
+    return requestId;
 }
 
 void WebDebuggerAgent::internalEnable()

--- a/Source/WebCore/inspector/agents/WebDebuggerAgent.h
+++ b/Source/WebCore/inspector/agents/WebDebuggerAgent.h
@@ -65,6 +65,8 @@ protected:
     void internalEnable() override;
     void internalDisable(bool isBeingDestroyed) override;
 
+    String requestIdForScript(JSC::JSGlobalObject*, const JSC::Debugger::Script&) override;
+
     void didClearAsyncStackTraceData() final;
 
     WeakRef<InstrumentingAgents> m_instrumentingAgents;

--- a/Source/WebCore/loader/WorkerThreadableLoader.cpp
+++ b/Source/WebCore/loader/WorkerThreadableLoader.cpp
@@ -256,9 +256,11 @@ void WorkerThreadableLoader::MainThreadBridge::didReceiveResponse(ScriptExecutio
     ScriptExecutionContext::postTaskForModeToWorkerOrWorklet(m_contextIdentifier, [workerClientWrapper = m_workerClientWrapper, workerRequestIdentifier = m_workerRequestIdentifier, mainContextIdentifier, identifier, responseData = response.crossThreadData()] (ScriptExecutionContext& context) mutable {
         ASSERT(context.isWorkerGlobalScope() || context.isWorkletGlobalScope());
         auto response = ResourceResponse::fromCrossThreadData(WTF::move(responseData));
-        workerClientWrapper->didReceiveResponse(mainContextIdentifier, identifier, response);
-        if (auto* serviceWorkerGlobalScope = dynamicDowncast<ServiceWorkerGlobalScope>(context))
+        if (auto* serviceWorkerGlobalScope = dynamicDowncast<ServiceWorkerGlobalScope>(context)) {
+            workerClientWrapper->didReceiveResponse(mainContextIdentifier, workerRequestIdentifier, response);
             InspectorInstrumentation::didReceiveResourceResponse(*serviceWorkerGlobalScope, workerRequestIdentifier, response);
+        } else
+            workerClientWrapper->didReceiveResponse(mainContextIdentifier, identifier, response);
     }, m_taskMode);
 }
 

--- a/Source/WebInspectorUI/UserInterface/Controllers/DebuggerManager.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/DebuggerManager.js
@@ -48,6 +48,7 @@ WI.DebuggerManager = class DebuggerManager extends WI.Object
         WI.auditManager.addEventListener(WI.AuditManager.Event.TestCompleted, this._handleAuditManagerTestCompleted, this);
 
         WI.targetManager.addEventListener(WI.TargetManager.Event.TargetRemoved, this._targetRemoved, this);
+        WI.networkManager.addEventListener(WI.NetworkManager.Event.FrameWasAdded, this._handleFrameWasAdded, this);
         WI.networkManager.addEventListener(WI.NetworkManager.Event.FrameWasRemoved, this._frameWasRemoved, this);
 
         WI.settings.blackboxBreakpointEvaluations.addEventListener(WI.Setting.Event.Changed, this._handleBlackboxBreakpointEvaluationsChange, this);
@@ -58,6 +59,10 @@ WI.DebuggerManager = class DebuggerManager extends WI.Object
         }
 
         WI.Frame.addEventListener(WI.Frame.Event.MainResourceDidChange, this._mainResourceDidChange, this);
+        WI.Frame.addEventListener(WI.Frame.Event.ResourceWasAdded, this._handleResourceAdded, this);
+        WI.Target.addEventListener(WI.Target.Event.ResourceAdded, this._handleResourceAdded, this);
+        WI.Resource.addEventListener(WI.Resource.Event.URLDidChange, this._handleResourceChanged, this);
+        WI.Resource.addEventListener(WI.Resource.Event.MIMETypeDidChange, this._handleResourceChanged, this);
 
         WI.SourceCode.addEventListener(WI.SourceCode.Event.SourceMapAdded, this._handleSourceCodeSourceMapAdded, this);
 
@@ -1106,7 +1111,7 @@ WI.DebuggerManager = class DebuggerManager extends WI.Object
         InspectorFrontendHost.beep();
     }
 
-    scriptDidParse(target, scriptIdentifier, url, startLine, startColumn, endLine, endColumn, executionContextId, scriptType, isContentScript, sourceURL, sourceMapURL, displayName)
+    scriptDidParse(target, scriptIdentifier, url, startLine, startColumn, endLine, endColumn, executionContextId, scriptType, isContentScript, sourceURL, sourceMapURL, displayName, requestId)
     {
         let targetData = this.dataForTarget(target);
 
@@ -1127,12 +1132,9 @@ WI.DebuggerManager = class DebuggerManager extends WI.Object
         let range = new WI.TextRange(startLine, startColumn, endLine, endColumn);
 
         let parentFrame = this._frameForExecutionContext(target, executionContextId);
-        let script = new WI.Script(target, scriptIdentifier, range, url, scriptType, isContentScript, sourceURL, sourceMapURL, parentFrame, displayName);
+        let script = new WI.Script(target, scriptIdentifier, range, url, scriptType, isContentScript, sourceURL, sourceMapURL, parentFrame, displayName, requestId);
 
         targetData.addScript(script);
-
-        if (!script.resource && script.sourceType === WI.Script.SourceType.WebAssembly)
-            script.parentFrame?.addExtraScript(script);
 
         // FIXME: <https://webkit.org/b/164427> Web Inspector: WorkerTarget's mainResource should be a Resource not a Script
         // We make the main resource of a WorkerTarget the Script instead of the Resource
@@ -1164,8 +1166,14 @@ WI.DebuggerManager = class DebuggerManager extends WI.Object
 
         this.dispatchEventToListeners(WI.DebuggerManager.Event.ScriptAdded, {script});
 
-        if ((target !== WI.mainTarget || WI.sharedApp.debuggableType === WI.DebuggableType.ServiceWorker) && !script.isMainResource() && !script.resource)
-            target.addScript(script);
+        if (!script.resource && !script.isMainResource()) {
+            // FIXME: Should we use `!script.dynamicallyAddedScriptElement` here instead?
+            if (script.sourceType === WI.Script.SourceType.WebAssembly)
+                script.parentFrame?.addExtraScript(script);
+
+            if (target !== WI.mainTarget || WI.sharedApp.debuggableType === WI.DebuggableType.ServiceWorker)
+                target.addScript(script);
+        }
     }
 
     scriptDidFail(target, url, scriptSource)
@@ -1509,6 +1517,32 @@ WI.DebuggerManager = class DebuggerManager extends WI.Object
             target.DebuggerAgent.setBlackboxBreakpointEvaluations(WI.settings.blackboxBreakpointEvaluations.value);
     }
 
+    _tryAssociateScripts(resource)
+    {
+        if (!(resource instanceof WI.Resource))
+            return;
+
+        for (let targetData of this._targetDebuggerDataMap.values()) {
+            for (let script of targetData.scripts) {
+                if (script.resource)
+                    continue;
+                if (script.url !== resource.url)
+                    continue;
+
+                let resourceCollection = script.parentFrame?.resourceCollection || script.target?.resourceCollection;
+                if (!resourceCollection?.has(resource) && !resource.isMainResource())
+                    continue;
+                if (!script.tryAssociateWithResource(resource))
+                    continue;
+
+                script.parentFrame?.extraScriptCollection.remove(script);
+                script.target?.extraScriptCollection.remove(script);
+
+                script.dispatchEventToListeners(WI.Script.Event.ResourceChanged);
+            }
+        }
+    }
+
     _breakpointDisplayLocationDidChange(event)
     {
         if (this._ignoreBreakpointDisplayLocationDidChangeEvent)
@@ -1712,6 +1746,11 @@ WI.DebuggerManager = class DebuggerManager extends WI.Object
             this.dispatchEventToListeners(WI.DebuggerManager.Event.Resumed);
     }
 
+    _handleFrameWasAdded(event)
+    {
+        this._tryAssociateScripts(event.data.frame.mainResource);
+    }
+
     _frameWasRemoved(event)
     {
         event.data.frame.extraScriptCollection.clear();
@@ -1738,10 +1777,22 @@ WI.DebuggerManager = class DebuggerManager extends WI.Object
 
     _mainResourceDidChange(event)
     {
+        this._tryAssociateScripts(event.target.mainResource);
+
         if (!event.target.isMainFrame())
             return;
 
         this._didResumeInternal(WI.mainTarget);
+    }
+
+    _handleResourceAdded(event)
+    {
+        this._tryAssociateScripts(event.data.resource);
+    }
+
+    _handleResourceChanged(event)
+    {
+        this._tryAssociateScripts(event.target);
     }
 
     _handleSourceCodeSourceMapAdded(event)

--- a/Source/WebInspectorUI/UserInterface/Controllers/NetworkManager.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/NetworkManager.js
@@ -750,9 +750,8 @@ WI.NetworkManager = class NetworkManager extends WI.Object
         let resource = this._resourceRequestIdentifierMap.get(requestIdentifier);
         if (resource) {
             // This is an existing request which is being redirected, update the resource.
-            console.assert(resource.parentFrame.id === frameIdentifier);
+            console.assert(resource.parentFrame?.id === frameIdentifier || resource.target?.identifier === targetId);
             console.assert(resource.loaderIdentifier === loaderIdentifier);
-            console.assert(!targetId);
             resource.updateForRedirectResponse(request, redirectResponse, elapsedTime, walltime);
             return;
         }

--- a/Source/WebInspectorUI/UserInterface/Models/Resource.js
+++ b/Source/WebInspectorUI/UserInterface/Models/Resource.js
@@ -391,7 +391,7 @@ WI.Resource = class Resource extends WI.SourceCode
 
     get displayName()
     {
-        return WI.displayNameForURL(this._url, this.urlComponents);
+        return this.scripts.find((script) => script.customName)?.customName || WI.displayNameForURL(this._url, this.urlComponents);
     }
 
     get displayURL()
@@ -1084,11 +1084,13 @@ WI.Resource = class Resource extends WI.SourceCode
 
         this._scripts.push(script);
 
-        if (this._type === WI.Resource.Type.Other || this._type === WI.Resource.Type.XHR) {
+        if (this._type === WI.Resource.Type.Other || this._type === WI.Resource.Type.XHR || this._type === WI.Resource.Type.Fetch) {
             let oldType = this._type;
             this._type = WI.Resource.Type.Script;
             this.dispatchEventToListeners(WI.Resource.Event.TypeDidChange, {oldType});
         }
+
+        this.dispatchEventToListeners(WI.Resource.Event.ScriptAssociated, {script});
     }
 
     saveIdentityToCookie(cookie)
@@ -1220,6 +1222,7 @@ WI.Resource.Event = {
     URLDidChange: "resource-url-did-change",
     MIMETypeDidChange: "resource-mime-type-did-change",
     TypeDidChange: "resource-type-did-change",
+    ScriptAssociated: "resource-script-associated",
     RequestHeadersDidChange: "resource-request-headers-did-change",
     RequestDataDidChange: "resource-request-data-did-change",
     ResponseReceived: "resource-response-received",

--- a/Source/WebInspectorUI/UserInterface/Models/Script.js
+++ b/Source/WebInspectorUI/UserInterface/Models/Script.js
@@ -25,7 +25,7 @@
 
 WI.Script = class Script extends WI.SourceCode
 {
-    constructor(target, id, range, url, sourceType, injected, sourceURL, sourceMapURL, parentFrame, displayName)
+    constructor(target, id, range, url, sourceType, injected, sourceURL, sourceMapURL, parentFrame, displayName, requestId)
     {
         super(url);
 
@@ -43,6 +43,7 @@ WI.Script = class Script extends WI.SourceCode
         this._displayName = displayName || null;
         this._dynamicallyAddedScriptElement = false;
         this._scriptSyntaxTree = null;
+        this._requestId = requestId || null;
 
         this._resource = this._resolveResource();
 
@@ -85,7 +86,7 @@ WI.Script = class Script extends WI.SourceCode
         if (sourceCode instanceof WI.Script)
             return sourceCode.sourceType === WI.Script.SourceType.WebAssembly;
 
-        return sourceCode instanceof WI.Resource && (sourceCode.mimeTypeComponents.type === "application/wasm" || sourceCode.scripts.some((script) => script.sourceType === WI.Script.SourceType.WebAssembly));
+        return sourceCode instanceof WI.Resource && (sourceCode.mimeTypeComponents.type === "application/wasm" || sourceCode.scripts.some((script) => WI.Script.isWebAssembly(script)));
     }
 
     // Public
@@ -98,6 +99,7 @@ WI.Script = class Script extends WI.SourceCode
     get sourceMappingURL() { return this._sourceMappingURL; }
     get injected() { return this._injected; }
     get parentFrame() { return this._parentFrame; }
+    get customName() { return this._displayName; }
 
     get contentIdentifier()
     {
@@ -209,6 +211,25 @@ WI.Script = class Script extends WI.SourceCode
     get resource()
     {
         return this._resource;
+    }
+
+    tryAssociateWithResource(resource)
+    {
+        console.assert(resource instanceof WI.Resource, resource);
+
+        if (this._resource)
+            return false;
+
+        if (this._resolveResource() !== resource)
+            return false;
+
+        this._resource = resource;
+        this._resource.associateWithScript(this);
+        for (let sourceMap of this.sourceMaps) {
+            if (!this._resource.sourceMaps.includes(sourceMap))
+                this._resource.addSourceMap(sourceMap);
+        }
+        return true;
     }
 
     get scriptSyntaxTree()
@@ -338,11 +359,6 @@ WI.Script = class Script extends WI.SourceCode
 
     _resolveResource()
     {
-        // FIXME: Associate WebAssembly scripts with a `WI.Resource` once the backend reports enough
-        // information to uniquely identify it.
-        if (this._sourceType === WI.Script.SourceType.WebAssembly)
-            return null;
-
         // FIXME: We should be able to associate a Script with a Resource through identifiers,
         // we shouldn't need to lookup by URL, which is not safe with frames, where there might
         // be multiple resources with the same URL.
@@ -350,6 +366,58 @@ WI.Script = class Script extends WI.SourceCode
 
         // No URL, no resource.
         if (!this._url)
+            return null;
+
+        let resourceCollection = this._parentFrame?.resourceCollection || this._target?.resourceCollection;
+        if (resourceCollection) {
+            let hasMatchingScript = (resource) => resource.scripts.some((script) => script.sourceType === this._sourceType);
+            let isMatchingResource = (resource) => resource.url === this._url && resource.mimeTypeComponents.type === this.syntheticMIMEType;
+
+            if (this._requestId) {
+                let resource = WI.networkManager.resourceForRequestIdentifier(this._requestId);
+                if (resource && resourceCollection.has(resource) && isMatchingResource(resource))
+                    return hasMatchingScript(resource) ? null : resource;
+
+                for (resource of resourceCollection) {
+                    if (resource.requestIdentifier === this._requestId && isMatchingResource(resource))
+                        return hasMatchingScript(resource) ? null : resource;
+                }
+
+                let matchingResource = null;
+                for (resource of resourceCollection.resourcesForURL(this._url)) {
+                    if (resource.requestIdentifier)
+                        continue;
+                    if (!isMatchingResource(resource))
+                        continue;
+                    if (hasMatchingScript(resource))
+                        continue;
+                    if (matchingResource)
+                        return null;
+                    matchingResource = resource;
+                }
+                return matchingResource;
+            }
+
+            let matchingResource = null;
+            let foundMatchingResource = false;
+            for (let resource of resourceCollection.resourcesForURL(this._url)) {
+                if (!isMatchingResource(resource))
+                    continue;
+
+                foundMatchingResource = true;
+
+                if (hasMatchingScript(resource))
+                    continue;
+
+                if (matchingResource)
+                    return null;
+                matchingResource = resource;
+            }
+            if (foundMatchingResource)
+                return matchingResource;
+        }
+
+        if (this._requestId)
             return null;
 
         let isOtherTarget = this._target && this._target !== WI.mainTarget;
@@ -413,6 +481,10 @@ WI.Script = class Script extends WI.SourceCode
 
         this._scriptSyntaxTree = new WI.ScriptSyntaxTree(sourceText, this);
     }
+};
+
+WI.Script.Event = {
+    ResourceChanged: "script-resource-changed",
 };
 
 WI.Script.SourceType = {

--- a/Source/WebInspectorUI/UserInterface/Protocol/DebuggerObserver.js
+++ b/Source/WebInspectorUI/UserInterface/Protocol/DebuggerObserver.js
@@ -39,7 +39,7 @@ WI.DebuggerObserver = class DebuggerObserver extends InspectorBackend.Dispatcher
         WI.debuggerManager.globalObjectCleared(this._target);
     }
 
-    scriptParsed(scriptId, url, startLine, startColumn, endLine, endColumn, executionContextId, scriptType, isContentScript, sourceURL, sourceMapURL, displayName)
+    scriptParsed(scriptId, url, startLine, startColumn, endLine, endColumn, executionContextId, scriptType, isContentScript, sourceURL, sourceMapURL, displayName, requestId)
     {
         if (this._legacyScriptParsed) {
             // COMPATIBILITY (macOS X.Y, iOS X.Y): Older backends report `module` instead of `scriptType`.
@@ -51,7 +51,7 @@ WI.DebuggerObserver = class DebuggerObserver extends InspectorBackend.Dispatcher
             scriptType = isModule ? InspectorBackend.Enum.Debugger.ScriptType.Module : InspectorBackend.Enum.Debugger.ScriptType.Program;
         }
 
-        WI.debuggerManager.scriptDidParse(this._target, scriptId, url, startLine, startColumn, endLine, endColumn, executionContextId, scriptType, isContentScript, sourceURL, sourceMapURL, displayName);
+        WI.debuggerManager.scriptDidParse(this._target, scriptId, url, startLine, startColumn, endLine, endColumn, executionContextId, scriptType, isContentScript, sourceURL, sourceMapURL, displayName, requestId);
     }
 
     scriptFailedToParse(url, scriptSource, startLine, errorLine, errorMessage)

--- a/Source/WebInspectorUI/UserInterface/Views/GenericResourceContentView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/GenericResourceContentView.js
@@ -29,4 +29,11 @@ WI.GenericResourceContentView = class GenericResourceContentView extends WI.Reso
     {
         super(resource, "generic");
     }
+
+    // Public
+
+    contentAvailable(content, base64Encoded)
+    {
+        this.showMessage(WI.UIString("Resource has binary content."));
+    }
 };

--- a/Source/WebInspectorUI/UserInterface/Views/OpenResourceDialog.js
+++ b/Source/WebInspectorUI/UserInterface/Views/OpenResourceDialog.js
@@ -161,6 +161,7 @@ WI.OpenResourceDialog = class OpenResourceDialog extends WI.Dialog
 
     didDismissDialog()
     {
+        WI.Script.removeEventListener(WI.Script.Event.ResourceChanged, this._handleScriptResourceChanged, this);
         WI.Frame.removeEventListener(WI.Frame.Event.MainResourceDidChange, this._mainResourceDidChange, this);
         WI.Frame.removeEventListener(WI.Frame.Event.ResourceWasAdded, this._resourceWasAdded, this);
         WI.Frame.removeEventListener(WI.Frame.Event.ResourceWasRemoved, this._resourceWasRemoved, this);
@@ -178,6 +179,7 @@ WI.OpenResourceDialog = class OpenResourceDialog extends WI.Dialog
 
     didPresentDialog()
     {
+        WI.Script.addEventListener(WI.Script.Event.ResourceChanged, this._handleScriptResourceChanged, this);
         WI.Frame.addEventListener(WI.Frame.Event.MainResourceDidChange, this._mainResourceDidChange, this);
         WI.Frame.addEventListener(WI.Frame.Event.ResourceWasAdded, this._resourceWasAdded, this);
         WI.Frame.addEventListener(WI.Frame.Event.ResourceWasRemoved, this._resourceWasRemoved, this);
@@ -429,6 +431,15 @@ WI.OpenResourceDialog = class OpenResourceDialog extends WI.Dialog
 
         for (let localResourceOverride of WI.networkManager.localResourceOverrides)
             this._addResource(localResourceOverride.localResource, suppressFilterUpdate);
+    }
+
+    _handleScriptResourceChanged(event)
+    {
+        let script = event.target;
+
+        const suppressFilterUpdate = true;
+        this._addResource(script.resource, suppressFilterUpdate);
+        this._removeResource(script);
     }
 
     _mainResourceDidChange(event)

--- a/Source/WebInspectorUI/UserInterface/Views/ResourceClusterContentView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/ResourceClusterContentView.js
@@ -31,6 +31,7 @@ WI.ResourceClusterContentView = class ResourceClusterContentView extends WI.Clus
 
         this._resource = resource;
         this._resource.addEventListener(WI.Resource.Event.TypeDidChange, this._resourceTypeDidChange, this);
+        this._resource.addEventListener(WI.Resource.Event.MIMETypeDidChange, this._resourceTypeDidChange, this);
         this._resource.addEventListener(WI.Resource.Event.LoadingDidFinish, this._resourceLoadingDidFinish, this);
         this._disableDropZone = disableDropZone || false;
 
@@ -249,6 +250,8 @@ WI.ResourceClusterContentView = class ResourceClusterContentView extends WI.Clus
         case WI.Resource.Type.Document:
         case WI.Resource.Type.Script:
         case WI.Resource.Type.StyleSheet:
+            if (!WI.shouldTreatMIMETypeAsText(this._resource.mimeType))
+                return null;
             return new WI.TextResourceContentView(this._resource);
 
         case WI.Resource.Type.Image:

--- a/Source/WebInspectorUI/UserInterface/Views/ResourceTreeElement.js
+++ b/Source/WebInspectorUI/UserInterface/Views/ResourceTreeElement.js
@@ -124,7 +124,7 @@ WI.ResourceTreeElement = class ResourceTreeElement extends WI.SourceCodeTreeElem
     get filterableData()
     {
         let urlComponents = this._resource.urlComponents;
-        return {text: [urlComponents.lastPathComponent, urlComponents.path, this._resource.url]};
+        return {text: [this._resource.displayName, urlComponents.lastPathComponent, urlComponents.path, this._resource.url]};
     }
 
     ondblclick()
@@ -152,6 +152,7 @@ WI.ResourceTreeElement = class ResourceTreeElement extends WI.SourceCodeTreeElem
             this._resource.removeEventListener(WI.Resource.Event.LoadingDidFinish, this.updateStatus, this);
             this._resource.removeEventListener(WI.Resource.Event.LoadingDidFail, this._loadingDidFail, this);
             this._resource.removeEventListener(WI.Resource.Event.ResponseReceived, this._responseReceived, this);
+            this._resource.removeEventListener(WI.Resource.Event.ScriptAssociated, this._handleScriptAssociated, this);
         }
 
         this._updateSourceCode(resource);
@@ -163,6 +164,7 @@ WI.ResourceTreeElement = class ResourceTreeElement extends WI.SourceCodeTreeElem
         resource.addEventListener(WI.Resource.Event.LoadingDidFinish, this.updateStatus, this);
         resource.addEventListener(WI.Resource.Event.LoadingDidFail, this._loadingDidFail, this);
         resource.addEventListener(WI.Resource.Event.ResponseReceived, this._responseReceived, this);
+        resource.addEventListener(WI.Resource.Event.ScriptAssociated, this._handleScriptAssociated, this);
 
         this._updateTitles();
         this.updateStatus();
@@ -175,7 +177,7 @@ WI.ResourceTreeElement = class ResourceTreeElement extends WI.SourceCodeTreeElem
     get mainTitleText()
     {
         // Overridden by subclasses if needed.
-        return WI.displayNameForURL(this._resource.url, this._resource.urlComponents, {
+        return this._resource.scripts.find((script) => script.customName)?.customName || WI.displayNameForURL(this._resource.url, this._resource.urlComponents, {
             allowDirectoryAsName: this._allowDirectoryAsName,
         });
     }
@@ -321,6 +323,12 @@ WI.ResourceTreeElement = class ResourceTreeElement extends WI.SourceCodeTreeElem
     _responseReceived(event)
     {
         this._updateIcon();
+    }
+
+    _handleScriptAssociated(event)
+    {
+        this._updateTitles();
+        this.updateStatus();
     }
 };
 

--- a/Source/WebInspectorUI/UserInterface/Views/ScriptContentView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/ScriptContentView.js
@@ -240,7 +240,7 @@ WI.ScriptContentView = class ScriptContentView extends WI.ContentView
 
     _contentDidPopulate(event)
     {
-        if (this._script.sourceType === WI.Script.SourceType.WebAssembly && !this._textEditor.string) {
+        if (!WI.shouldTreatMIMETypeAsText(this._script.mimeType) && !this._textEditor.string) {
             this.removeAllSubviews();
             this.element.appendChild(WI.createMessageTextView(WI.UIString("Resource has binary content.")));
             return;

--- a/Source/WebInspectorUI/UserInterface/Views/SearchSidebarPanel.js
+++ b/Source/WebInspectorUI/UserInterface/Views/SearchSidebarPanel.js
@@ -460,8 +460,7 @@ WI.SearchSidebarPanel = class SearchSidebarPanel extends WI.NavigationSidebarPan
         };
 
         if (treeElement instanceof WI.ResourceTreeElement || treeElement instanceof WI.ScriptTreeElement) {
-            const cookie = null;
-            WI.showRepresentedObject(treeElement.representedObject, cookie, options);
+            WI.showSourceCode(treeElement.representedObject, options);
             return;
         }
 

--- a/Source/WebInspectorUI/UserInterface/Views/SourcesNavigationSidebarPanel.js
+++ b/Source/WebInspectorUI/UserInterface/Views/SourcesNavigationSidebarPanel.js
@@ -321,6 +321,7 @@ WI.SourcesNavigationSidebarPanel = class SourcesNavigationSidebarPanel extends W
 
         WI.settings.resourceGroupingMode.addEventListener(WI.Setting.Event.Changed, this._handleResourceGroupingModeChanged, this);
 
+        WI.Script.addEventListener(WI.Script.Event.ResourceChanged, this._handleScriptResourceChanged, this);
         WI.Frame.addEventListener(WI.Frame.Event.MainResourceDidChange, this._handleFrameMainResourceDidChange, this);
         WI.Frame.addEventListener(WI.Frame.Event.ResourceWasAdded, this._handleResourceAdded, this);
         WI.Target.addEventListener(WI.Target.Event.ResourceAdded, this._handleResourceAdded, this);
@@ -491,6 +492,7 @@ WI.SourcesNavigationSidebarPanel = class SourcesNavigationSidebarPanel extends W
         if (WI.SourcesNavigationSidebarPanel.shouldPlaceResourcesAtTopLevel())
             WI.SourceCode.removeEventListener(WI.SourceCode.Event.SourceMapAdded, this._handleSourceCodeSourceMapAdded, this);
 
+        WI.Script.removeEventListener(WI.Script.Event.ResourceChanged, this._handleScriptResourceChanged, this);
         WI.Frame.removeEventListener(WI.Frame.Event.MainResourceDidChange, this._handleFrameMainResourceDidChange, this);
         WI.Frame.removeEventListener(WI.Frame.Event.ResourceWasAdded, this._handleResourceAdded, this);
         WI.Target.removeEventListener(WI.Target.Event.ResourceAdded, this._handleResourceAdded, this);
@@ -619,6 +621,12 @@ WI.SourcesNavigationSidebarPanel = class SourcesNavigationSidebarPanel extends W
                 resourceOrFrame = resourceOrFrame.sourceMap.originalSourceCode;
             }
 
+            if (resourceOrFrame instanceof WI.Script && resourceOrFrame.resource) {
+                if (resourceOrFrame.resource === ancestor)
+                    return true;
+                resourceOrFrame = resourceOrFrame.resource;
+            }
+
             let currentFrame = resourceOrFrame.parentFrame;
             while (currentFrame) {
                 if (currentFrame === ancestor)
@@ -632,6 +640,8 @@ WI.SourcesNavigationSidebarPanel = class SourcesNavigationSidebarPanel extends W
             // SourceMapResources are descendants of another SourceCode object.
             if (resourceOrFrame instanceof WI.SourceMapResource)
                 return resourceOrFrame.sourceMap.originalSourceCode;
+            if (resourceOrFrame instanceof WI.Script && resourceOrFrame.resource)
+                return resourceOrFrame.resource;
             return resourceOrFrame.parentFrame;
         }
 
@@ -1344,6 +1354,28 @@ WI.SourcesNavigationSidebarPanel = class SourcesNavigationSidebarPanel extends W
 
         this._addBreakpointsForSourceCode(script);
         this._addIssuesForSourceCode(script);
+    }
+
+    _removeScript(script)
+    {
+        if (script.parentFrame && WI.settings.resourceGroupingMode.value === WI.Resource.GroupingMode.Path) {
+            this._handleResourceGroupingModeChanged();
+            return;
+        }
+
+        let scriptTreeElement = this._resourcesTreeOutline.findTreeElement(script);
+        if (!scriptTreeElement)
+            return;
+
+        let parentTreeElement = scriptTreeElement.parent;
+        parentTreeElement.removeChild(scriptTreeElement);
+
+        if (parentTreeElement.representedObject instanceof WI.ScriptCollection) {
+            parentTreeElement.representedObject.remove(script);
+
+            if (!parentTreeElement.children.length)
+                parentTreeElement.parent.removeChild(parentTreeElement);
+        }
     }
 
     _addWorkerTargetWithMainResource(target)
@@ -2444,6 +2476,13 @@ WI.SourcesNavigationSidebarPanel = class SourcesNavigationSidebarPanel extends W
         }
     }
 
+    _handleScriptResourceChanged(event)
+    {
+        let script = event.target;
+        this._removeScript(script);
+        this._addScript(script);
+    }
+
     _handleFrameMainResourceDidChange(event)
     {
         let frame = event.target;
@@ -2527,20 +2566,7 @@ WI.SourcesNavigationSidebarPanel = class SourcesNavigationSidebarPanel extends W
 
     _handleDebuggerScriptRemoved(event)
     {
-        let script = event.data.script;
-        let scriptTreeElement = this._resourcesTreeOutline.findTreeElement(script);
-        if (!scriptTreeElement)
-            return;
-
-        let parentTreeElement = scriptTreeElement.parent;
-        parentTreeElement.removeChild(scriptTreeElement);
-
-        if (parentTreeElement.representedObject instanceof WI.ScriptCollection) {
-            parentTreeElement.representedObject.remove(script);
-
-            if (!parentTreeElement.children.length)
-                parentTreeElement.parent.removeChild(parentTreeElement);
-        }
+        this._removeScript(event.data.script);
     }
 
     _handleDebuggerScriptsCleared(event)

--- a/Source/WebInspectorUI/UserInterface/Views/WorkerTreeElement.js
+++ b/Source/WebInspectorUI/UserInterface/Views/WorkerTreeElement.js
@@ -68,6 +68,24 @@ WI.WorkerTreeElement = class WorkerTreeElement extends WI.ScriptTreeElement
 
     get target() { return this._target; }
 
+    descendantResourceTreeElementTypeDidChange(resourceTreeElement, oldType)
+    {
+        // Called by descendant ResourceTreeElements.
+
+        // Add the tree element again, which will move it to the new location
+        // based on sorting and possible folder changes.
+        this._addTreeElement(resourceTreeElement);
+    }
+
+    descendantResourceTreeElementMainTitleDidChange(resourceTreeElement, oldMainTitle)
+    {
+        // Called by descendant ResourceTreeElements.
+
+        // Add the tree element again, which will move it to the new location
+        // based on sorting and possible folder changes.
+        this._addTreeElement(resourceTreeElement);
+    }
+
     // Protected (TreeElement)
 
     onexpand()

--- a/Source/WebKit/WebProcess/Inspector/FrameNetworkAgentProxy.cpp
+++ b/Source/WebKit/WebProcess/Inspector/FrameNetworkAgentProxy.cpp
@@ -197,7 +197,7 @@ void FrameNetworkAgentProxy::willSendRequest(ResourceLoaderIdentifier resourceID
 
     protect(WebProcess::singleton().parentProcessConnection())->send(
         Messages::ProxyingNetworkAgent::RequestWillBeSent(
-            qualifyResourceID(resourceID), *frameID, loaderId, String(), documentURL, request,
+            qualifyResourceID(resourceID), *frameID, loaderId, request.initiatorIdentifier(), documentURL, request,
             WTF::move(optionalRedirectResponse), resourceType, timestamp, walltime),
         page->identifier());
 }
@@ -232,7 +232,7 @@ void FrameNetworkAgentProxy::willSendRequestOfType(ResourceLoaderIdentifier reso
 
     protect(WebProcess::singleton().parentProcessConnection())->send(
         Messages::ProxyingNetworkAgent::RequestWillBeSent(
-            qualifyResourceID(resourceID), *frameID, loaderId, String(), documentURL, request,
+            qualifyResourceID(resourceID), *frameID, loaderId, request.initiatorIdentifier(), documentURL, request,
             std::nullopt, ResourceType::Other, timestamp, walltime),
         page->identifier());
 }

--- a/Source/WebKit/WebProcess/Storage/WebServiceWorkerFetchTaskClient.h
+++ b/Source/WebKit/WebProcess/Storage/WebServiceWorkerFetchTaskClient.h
@@ -85,7 +85,7 @@ private:
         ~BlobLoader();
 
         // FetchLoaderClient API
-        void didReceiveResponse(const WebCore::ResourceResponse&) final { }
+        void didReceiveResponse(std::optional<WebCore::ResourceLoaderIdentifier>, const WebCore::ResourceResponse&) final { }
         void didReceiveData(const WebCore::SharedBuffer&) final;
         void didFail(const WebCore::ResourceError&) final;
         void didSucceed(const WebCore::NetworkLoadMetrics&) final;


### PR DESCRIPTION
#### 301d6b2b21f7a0d391ce46704ab7b2e83332c90e
<pre>
Web Inspector: associate WebAssembly module scripts with the resource that fetched it
<a href="https://bugs.webkit.org/show_bug.cgi?id=320249">https://bugs.webkit.org/show_bug.cgi?id=320249</a>

Reviewed by Yusuke Suzuki.

* Source/JavaScriptCore/wasm/WasmModuleInformation.h:
* Source/JavaScriptCore/wasm/WasmStreamingCompiler.h:
(JSC::Wasm::StreamingCompiler::create):
(JSC::Wasm::StreamingCompiler::StreamingCompiler):
* Source/JavaScriptCore/wasm/WasmStreamingCompiler.cpp:
(JSC::Wasm::StreamingCompiler::StreamingCompiler):
(JSC::Wasm::StreamingCompiler::create):
* Source/JavaScriptCore/debugger/Debugger.h:
* Source/JavaScriptCore/debugger/Debugger.cpp:
(JSC::Debugger::sourceParsed):
* Source/JavaScriptCore/inspector/protocol/Debugger.json:
* Source/JavaScriptCore/inspector/agents/InspectorDebuggerAgent.h:
* Source/JavaScriptCore/inspector/agents/InspectorDebuggerAgent.cpp:
(Inspector::InspectorDebuggerAgent::requestIdForScript): Added.
(Inspector::InspectorDebuggerAgent::didParseSource):
* Source/WebCore/inspector/agents/WebDebuggerAgent.h:
* Source/WebCore/inspector/agents/WebDebuggerAgent.cpp:
(WebCore::WebDebuggerAgent::requestIdForScript): Added.
* Source/WebInspectorUI/UserInterface/Protocol/DebuggerObserver.js:
(WI.DebuggerObserver.prototype.scriptParsed):
Keep the final response URL and request identifier in `ModuleInformation`, and format the protocol `requestId` in Inspector so that it can be process-qualified when site isolation is enabled.

* Source/WebInspectorUI/UserInterface/Controllers/NetworkManager.js:
(WI.NetworkManager.prototype.resourceRequestWillBeSent):
Update assertions for redirects of resources associated with a `WI.Target`.

* Source/WebInspectorUI/UserInterface/Controllers/DebuggerManager.js:
(WI.DebuggerManager):
(WI.DebuggerManager.prototype.scriptDidParse):
(WI.DebuggerManager.prototype._tryAssociateScripts): Added.
(WI.DebuggerManager.prototype._handleResourceAdded): Added.
(WI.DebuggerManager.prototype._handleResourceChanged): Added.
* Source/WebInspectorUI/UserInterface/Models/Resource.js:
(WI.Resource.prototype.get displayName):
(WI.Resource.prototype.associateWithScript):
(WI.Resource.Event.ScriptAssociated): Added.
* Source/WebInspectorUI/UserInterface/Models/Script.js:
(WI.Script):
(WI.Script.isWebAssembly):
(WI.Script.prototype.get customName): Added.
(WI.Script.prototype.tryAssociateWithResource): Added.
(WI.Script.prototype._resolveResource):
(WI.Script.prototype._resolveResource.hasMatchingScript): Added.
(WI.Script.prototype._resolveResource.isMatchingResource): Added.
(WI.Script.Event.ResourceChanged): Added.
Expand how `WI.Script` are associated with a `WI.Resource`.

* Source/WebInspectorUI/UserInterface/Views/ResourceTreeElement.js:
(WI.ResourceTreeElement.prototype.get filterableData):
(WI.ResourceTreeElement.prototype._updateResource):
(WI.ResourceTreeElement.prototype.get mainTitleText):
(WI.ResourceTreeElement.prototype._handleScriptAssociated): Added.
* Source/WebInspectorUI/UserInterface/Views/OpenResourceDialog.js:
(WI.OpenResourceDialog.prototype.didDismissDialog):
(WI.OpenResourceDialog.prototype.didPresentDialog):
(WI.OpenResourceDialog.prototype._handleScriptResourceChanged): Added.
* Source/WebInspectorUI/UserInterface/Views/SearchSidebarPanel.js:
(WI.SearchSidebarPanel.prototype._handleTreeSelectionDidChange):
* Source/WebInspectorUI/UserInterface/Views/SourcesNavigationSidebarPanel.js:
(WI.SourcesNavigationSidebarPanel):
(WI.SourcesNavigationSidebarPanel.prototype.closed):
(WI.SourcesNavigationSidebarPanel.prototype.treeElementForRepresentedObject):
(WI.SourcesNavigationSidebarPanel.prototype.treeElementForRepresentedObject.isAncestor):
(WI.SourcesNavigationSidebarPanel.prototype.treeElementForRepresentedObject.getParent):
(WI.SourcesNavigationSidebarPanel.prototype._removeScript): Added.
(WI.SourcesNavigationSidebarPanel.prototype._handleScriptResourceChanged): Added.
(WI.SourcesNavigationSidebarPanel.prototype._handleDebuggerScriptRemoved):
* Source/WebInspectorUI/UserInterface/Views/WorkerTreeElement.js:
(WI.WorkerTreeElement.prototype.descendantResourceTreeElementTypeDidChange): Added.
(WI.WorkerTreeElement.prototype.descendantResourceTreeElementMainTitleDidChange): Added.
Replace `WI.Script` with its associated `WI.Resource` wherever possible.

* Source/WebInspectorUI/UserInterface/Views/GenericResourceContentView.js:
(WI.GenericResourceContentView.prototype.contentAvailable): Added.
* Source/WebInspectorUI/UserInterface/Views/ResourceClusterContentView.js:
(WI.ResourceClusterContentView):
(WI.ResourceClusterContentView.prototype._contentViewForResourceType):
* Source/WebInspectorUI/UserInterface/Views/ScriptContentView.js:
(WI.ScriptContentView.prototype._contentDidPopulate):
Show a binary-content message for non-text resources that do not have a more specific preview.

* Source/WebCore/Modules/fetch/FetchLoaderClient.h:
(WebCore::FetchLoaderClient::didReceiveResponse):
* Source/WebCore/Modules/fetch/FetchLoader.cpp:
(WebCore::FetchLoader::didReceiveResponse):
* Source/WebCore/Modules/fetch/FetchBodyOwner.h:
(WebCore::FetchBodyOwner::BlobLoader::didReceiveResponse):
* Source/WebCore/Modules/fetch/FetchBodyOwner.cpp:
(WebCore::FetchBodyOwner::BlobLoader::didReceiveResponse):
* Source/WebCore/Modules/fetch/FetchResponse.h:
(WebCore::FetchResponse::resourceLoaderIdentifier const): Added.
(WebCore::FetchResponse::Loader::didReceiveResponse):
* Source/WebCore/Modules/fetch/FetchResponse.cpp:
(WebCore::FetchResponse::clone):
(WebCore::FetchResponse::Loader::didReceiveResponse):
* Source/WebCore/loader/WorkerThreadableLoader.cpp:
(WebCore::WorkerThreadableLoader::MainThreadBridge::didReceiveResponse):
* Source/WebKit/WebProcess/Storage/WebServiceWorkerFetchTaskClient.h:
(WebKit::WebServiceWorkerFetchTaskClient::BlobLoader::didReceiveResponse):
* Source/WebKit/WebProcess/Inspector/FrameNetworkAgentProxy.cpp:
(WebKit::FrameNetworkAgentProxy::willSendRequest):
(WebKit::FrameNetworkAgentProxy::willSendRequestOfType):
* Source/WebCore/bindings/js/JSDOMGlobalObject.cpp:
(WebCore::handleResponseOnStreamingAction):
Propagate the request identifier through cloning, `Worker`, `ServiceWorker`, etc..

* LayoutTests/http/tests/inspector/debugger/wasm/resources/named-module.py: Added.
* LayoutTests/http/tests/inspector/debugger/wasm/resources/resource-worker.js: Added.
* LayoutTests/http/tests/inspector/debugger/wasm/script-url.html: Added.
* LayoutTests/http/tests/inspector/debugger/wasm/script-url-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/inspector/debugger/resources/wasm-frame.html: Added.
* LayoutTests/http/tests/site-isolation/inspector/debugger/wasm-frame-placement.html: Added.
* LayoutTests/http/tests/site-isolation/inspector/debugger/wasm-frame-placement-expected.txt: Added.
* LayoutTests/inspector/model/frame-extra-scripts.html:
* LayoutTests/inspector/model/frame-extra-scripts-expected.txt:
* LayoutTests/inspector/model/script-resource-relationship.html:
* LayoutTests/inspector/model/script-resource-relationship-expected.txt:

Canonical link: <a href="https://commits.webkit.org/318207@main">https://commits.webkit.org/318207@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e5fa568d761431fab8f36fa2f1addc129b38c525

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176849 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50786 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44578 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186451 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140085 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178712 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52079 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50472 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137770 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140085 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179805 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41280 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158559 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118244 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39934 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38301 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/232 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/7066 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150346 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38058 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34919 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/38120 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42531 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42516 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188875 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50453 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/158102 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146843 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39633 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51136 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34680 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146645 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41407 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123344 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117563 "Built successfully") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49641 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13041 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49040 "Built successfully") | | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49276 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; Compiled WebKit (warnings)") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49101 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->