### PR TITLE
[site-isolation] media/audio-session-category-at-most-recent-playback.html is a permanent failure

### DIFF
--- a/LayoutTests/platform/ios-site-isolation/TestExpectations
+++ b/LayoutTests/platform/ios-site-isolation/TestExpectations
@@ -390,7 +390,6 @@ imported/w3c/web-platform-tests/webrtc/RTCRtpReceiver-getSynchronizationSources.
 imported/w3c/web-platform-tests/webrtc/RTCRtpSender-getStats.https.html [ Failure ]
 media/audio-play-with-video-element.html [ Failure ]
 media/audio-playback-restriction-play.html [ Failure ]
-media/audio-session-category-at-most-recent-playback.html [ Failure ]
 media/audio-session-category-play-unmute-pause.html [ Failure ]
 media/audio-session-category.html [ Failure ]
 media/audioSession/audioSessionType.html [ Failure ]

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -5134,6 +5134,15 @@ void HTMLMediaElement::routingContextUIDDidChange(const AudioSession& session)
     });
 }
 
+void HTMLMediaElement::categoryDidChange(const AudioSession& session)
+{
+    if (paused())
+        return;
+
+    m_categoryAtMostRecentPlayback = session.category();
+    m_modeAtMostRecentPlayback = session.mode();
+}
+
 #endif // USE(AUDIO_SESSION)
 
 void HTMLMediaElement::togglePlayState()

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -1097,6 +1097,7 @@ private:
     void hardwareMutedStateDidChange(const AudioSession&) final;
 #endif
     void routingContextUIDDidChange(const AudioSession&) final;
+    void categoryDidChange(const AudioSession&) final;
 #endif
 
     bool NODELETE hasMediaSource() const;

--- a/Source/WebCore/platform/audio/AudioSession.h
+++ b/Source/WebCore/platform/audio/AudioSession.h
@@ -93,6 +93,7 @@ public:
     virtual void bufferSizeDidChange(const AudioSession&) { }
     virtual void sampleRateDidChange(const AudioSession&) { }
     virtual void routingContextUIDDidChange(const AudioSession&) { }
+    virtual void categoryDidChange(const AudioSession&) { }
 };
 
 class WEBCORE_EXPORT AudioSession : public AbstractThreadSafeRefCountedAndCanMakeWeakPtr {

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioSession.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioSession.cpp
@@ -105,12 +105,19 @@ void RemoteAudioSession::setCategory(CategoryType type, Mode mode, RouteSharingP
     if (type == m_category && mode == m_mode && policy == m_routeSharingPolicy && !m_isPlayingToBluetoothOverrideChanged)
         return;
 
+    bool categoryOrModeChanged = type != m_category || mode != m_mode;
     m_category = type;
     m_mode = mode;
     m_routeSharingPolicy = policy;
     m_isPlayingToBluetoothOverrideChanged = false;
 
     protect(ensureConnection())->send(Messages::RemoteAudioSessionProxy::SetCategory(type, mode, policy), { });
+
+    if (categoryOrModeChanged) {
+        m_configurationChangeObservers.forEach([this](auto& observer) {
+            observer.categoryDidChange(*this);
+        });
+    }
 #else
     UNUSED_PARAM(type);
     UNUSED_PARAM(policy);


### PR DESCRIPTION
#### bb1d958caa857d4d81bc1b829acbaa86f0d12dad
<pre>
[site-isolation] media/audio-session-category-at-most-recent-playback.html is a permanent failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=320304">https://bugs.webkit.org/show_bug.cgi?id=320304</a>
<a href="https://rdar.apple.com/183238244">rdar://183238244</a>

Reviewed by Eric Carlson.

HTMLMediaElement::playPlayer() took a one-shot synchronous snapshot of
m_categoryAtMostRecentPlayback and m_modeAtMostRecentPlayback; it was never read
again.
With site isolation, updating the category occurs asynchronously and the UIP
sends an IPC message with the new category. However, any changes wasn&apos;t
broadcast to clients.

We add a categoryDidChange() API to the AudioSessionConfigurationChangeObserver
and notify the HTMLMediaElement client of the category change.

Covered by existing test

* LayoutTests/platform/ios-site-isolation/TestExpectations:
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::categoryDidChange):
* Source/WebCore/html/HTMLMediaElement.h:
* Source/WebCore/platform/audio/AudioSession.h:
(WebCore::AudioSessionConfigurationChangeObserver::categoryDidChange):
* Source/WebKit/WebProcess/GPU/media/RemoteAudioSession.cpp:
(WebKit::RemoteAudioSession::setCategory):

Canonical link: <a href="https://commits.webkit.org/317945@main">https://commits.webkit.org/317945@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/09d49daffb2e1ad9c38f5bdbffa758ed97836116

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176800 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50737 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44529 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186402 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140036 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a03fad07-3bdf-4b90-999f-72bee21a5fc5) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178663 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52030 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50423 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137729 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140036 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fa45dd7f-bb56-448b-921c-577c4bb8b99d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179756 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41236 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158516 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118203 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e2307147-a61d-4203-b8e0-a77cbd57f6fc) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39890 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38258 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150302 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38015 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34870 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42482 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42473 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188826 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50404 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146795 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39468 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51087 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34636 "Found 1 new test failure: scrollingcoordinator/mac/latching/horizontal-overflow-back-swipe.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146600 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41362 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123295 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117494 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49592 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12993 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48991 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49227 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49052 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->