### PR TITLE
AudioBufferSourceNode output channel count ignores actively-processing state

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiobuffersourcenode-interface/audiobuffersource-output-channel-count-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiobuffersourcenode-interface/audiobuffersource-output-channel-count-expected.txt
@@ -1,0 +1,9 @@
+
+PASS A source whose buffer was never set outputs one channel
+PASS A source with a stereo buffer that was never started outputs one channel
+PASS A playing source outputs the buffer channel count, then one channel at the end of the buffer
+PASS A source that is stopped outputs one channel after the stop time
+PASS A source outputs one channel after its duration has elapsed
+PASS A source whose buffer is set to null outputs one channel
+PASS A playing source whose buffer is null outputs one channel
+

--- a/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiobuffersourcenode-interface/audiobuffersource-output-channel-count.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiobuffersourcenode-interface/audiobuffersource-output-channel-count.html
@@ -1,0 +1,202 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>
+      AudioBufferSourceNode output channel count follows actively-processing state
+    </title>
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <script src="/webaudio/resources/audit-util.js"></script>
+  </head>
+  <body>
+    <script>
+      // Two spec rules together determine an AudioBufferSourceNode's output
+      // channel count.
+      //
+      // https://webaudio.github.io/web-audio-api/#AudioNode-actively-processing
+      //   "An AudioScheduledSourceNode is actively processing if and only if it
+      //    is playing for at least part of the current rendering quantum."
+      //   "AudioNodes that are not actively processing output a single channel
+      //    of silence."
+      //
+      // https://webaudio.github.io/web-audio-api/#AudioBufferSourceNode
+      //   "The number of channels of the output equals the number of channels
+      //    of the AudioBuffer assigned to the buffer attribute, or is one
+      //    channel of silence if buffer is null."
+      //
+      // So the output is one channel whenever the node is not playing, or is
+      // playing with a null buffer, and equals the buffer's channel count only
+      // while actually playing.
+      //
+      // MEASUREMENT
+      //
+      // Output channel count is not observable from JS, so it is measured
+      // indirectly. A mono ConstantSourceNode and the AudioBufferSourceNode
+      // under test both feed a GainNode with channelCountMode "max" and
+      // channelInterpretation "discrete". The gain node's channel count is the
+      // larger of its inputs' counts, and discrete up-mixing sums only the
+      // channels that exist rather than duplicating mono into both.
+      //
+      //   source contributes 1 channel -> gain is mono -> the destination
+      //       up-mixes that mono sum with "speakers", so channel 1 carries the
+      //       constant's value of 1.
+      //   source contributes 2 channels -> gain is stereo -> the mono constant
+      //       is summed discretely into channel 0 only, so channel 1 reads 0.
+      //
+      // The test buffer is stereo with a non-zero channel 0 and a silent
+      // channel 1. Channel 1 must stay silent so it does not pollute the
+      // reading; channel 0 must not, so that the node is never mistaken for a
+      // silent input by a channel-count optimization.
+
+      const sampleRate = 8000;
+      const renderQuantum = RENDER_QUANTUM_FRAMES;
+      const renderQuanta = 10;
+      const renderLength = renderQuanta * renderQuantum;
+
+      // Playback spans exactly three render quanta, so the collapse back to one
+      // channel is expected at quantum 3.
+      const bufferQuanta = 3;
+      const bufferFrames = bufferQuanta * renderQuantum;
+
+      function testBuffer(context) {
+        const buffer = new AudioBuffer({
+          numberOfChannels: 2,
+          length: bufferFrames,
+          sampleRate: context.sampleRate
+        });
+        buffer.getChannelData(0).fill(1);
+        // Channel 1 is deliberately left silent.
+        return buffer;
+      }
+
+      function renderWithSource(configureSource) {
+        const context = new OfflineAudioContext(2, renderLength, sampleRate);
+
+        const source = new AudioBufferSourceNode(context);
+        const constant = new ConstantSourceNode(context, {offset: 1});
+
+        const gain = new GainNode(context);
+        gain.channelCountMode = 'max';
+        gain.channelInterpretation = 'discrete';
+
+        source.connect(gain);
+        constant.connect(gain);
+        gain.connect(context.destination);
+
+        constant.start();
+        configureSource(context, source);
+
+        return context.startRendering();
+      }
+
+      // The number of channels the source contributed during each render
+      // quantum. Sampled mid-quantum, since the count can only change on a
+      // quantum boundary.
+      function channelCountPerQuantum(renderedBuffer) {
+        const channel1 = renderedBuffer.getChannelData(1);
+        const counts = [];
+        for (let q = 0; q < renderQuanta; ++q)
+          counts.push(channel1[q * renderQuantum + renderQuantum / 2] === 0 ? 2 : 1);
+        return counts;
+      }
+
+      // Asserts the source stayed at one channel for the whole render.
+      function assertAlwaysOneChannel(counts, description) {
+        assert_array_equals(counts, new Array(renderQuanta).fill(1), description);
+      }
+
+      // Asserts the source reported two channels for an initial run of quanta
+      // and one channel thereafter, and returns the quantum at which it
+      // collapsed. The expected boundary is given a one-quantum tolerance
+      // because the spec only requires the change to land at the beginning of a
+      // render quantum after the triggering condition.
+      function assertCollapsesAfter(counts, expectedQuantum, description) {
+        const collapseAt = counts.indexOf(1);
+        assert_not_equals(collapseAt, -1,
+            `${description}: should collapse to one channel before the render ends`);
+        assert_array_equals(
+            counts,
+            new Array(renderQuanta).fill(0).map((_, q) => q < collapseAt ? 2 : 1),
+            `${description}: should be two channels while playing, then one`);
+        assert_greater_than_equal(collapseAt, expectedQuantum,
+            `${description}: should not collapse before playback ends`);
+        assert_less_than_equal(collapseAt, expectedQuantum + 1,
+            `${description}: should collapse promptly once playback ends`);
+      }
+
+      // A node that was never given a buffer is never playing, so it is never
+      // actively processing.
+      promise_test(async () => {
+        const counts = channelCountPerQuantum(await renderWithSource(() => {}));
+        assertAlwaysOneChannel(counts, 'source with no buffer');
+      }, 'A source whose buffer was never set outputs one channel');
+
+      // Not started, so not playing, so not actively processing - the buffer's
+      // channel count must not reach the output.
+      promise_test(async () => {
+        const counts = channelCountPerQuantum(await renderWithSource(
+            (context, source) => {
+              source.buffer = testBuffer(context);
+            }));
+        assertAlwaysOneChannel(counts, 'unstarted source with a stereo buffer');
+      }, 'A source with a stereo buffer that was never started outputs one channel');
+
+      // Playing: the output takes the buffer's channel count, then drops back to
+      // one channel once the end of the buffer is reached.
+      promise_test(async () => {
+        const counts = channelCountPerQuantum(await renderWithSource(
+            (context, source) => {
+              source.buffer = testBuffer(context);
+              source.start();
+            }));
+        assertCollapsesAfter(counts, bufferQuanta, 'started source');
+      }, 'A playing source outputs the buffer channel count, then one channel at the end of the buffer');
+
+      // Same, but ended early by stop() rather than by reaching the end of the
+      // buffer. Stop lands on a quantum boundary.
+      promise_test(async () => {
+        const stopQuantum = 2;
+        const counts = channelCountPerQuantum(await renderWithSource(
+            (context, source) => {
+              source.buffer = testBuffer(context);
+              source.start();
+              source.stop(stopQuantum * renderQuantum / sampleRate);
+            }));
+        assertCollapsesAfter(counts, stopQuantum, 'stopped source');
+      }, 'A source that is stopped outputs one channel after the stop time');
+
+      // Same, but ended early by the start() duration argument.
+      promise_test(async () => {
+        const durationQuanta = 2;
+        const counts = channelCountPerQuantum(await renderWithSource(
+            (context, source) => {
+              source.buffer = testBuffer(context);
+              source.start(0, 0, durationQuanta * renderQuantum / sampleRate);
+            }));
+        assertCollapsesAfter(counts, durationQuanta, 'source with a duration');
+      }, 'A source outputs one channel after its duration has elapsed');
+
+      // Null buffer, not started: one channel for both reasons.
+      promise_test(async () => {
+        const counts = channelCountPerQuantum(await renderWithSource(
+            (context, source) => {
+              source.buffer = testBuffer(context);
+              source.buffer = null;
+            }));
+        assertAlwaysOneChannel(counts, 'unstarted source with a cleared buffer');
+      }, 'A source whose buffer is set to null outputs one channel');
+
+      // Null buffer while playing: actively processing, but the buffer is null,
+      // so the output is still a single channel of silence.
+      promise_test(async () => {
+        const counts = channelCountPerQuantum(await renderWithSource(
+            (context, source) => {
+              source.buffer = testBuffer(context);
+              source.buffer = null;
+              source.start();
+            }));
+        assertAlwaysOneChannel(counts, 'playing source with a cleared buffer');
+      }, 'A playing source whose buffer is null outputs one channel');
+    </script>
+  </body>
+</html>

--- a/Source/WebCore/Modules/webaudio/AudioBufferSourceNode.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioBufferSourceNode.cpp
@@ -458,7 +458,7 @@ ExceptionOr<void> AudioBufferSourceNode::setBufferForBindings(RefPtr<AudioBuffer
 
     if (buffer && m_wasBufferSet)
         return Exception { ExceptionCode::InvalidStateError, "The buffer was already set"_s };
-    
+
     if (buffer) {
         m_wasBufferSet = true;
 
@@ -466,17 +466,20 @@ ExceptionOr<void> AudioBufferSourceNode::setBufferForBindings(RefPtr<AudioBuffer
         unsigned numberOfChannels = buffer->numberOfChannels();
         ASSERT(numberOfChannels <= AudioContext::maxNumberOfChannels);
 
-        protect(output(0))->setNumberOfChannels(numberOfChannels);
-
         m_sourceChannels = FixedVector<std::span<const float>>(numberOfChannels);
         m_destinationChannels = FixedVector<std::span<float>>(numberOfChannels);
 
-        for (unsigned i = 0; i < numberOfChannels; ++i) 
+        for (unsigned i = 0; i < numberOfChannels; ++i)
             m_sourceChannels[i] = buffer->channelData(i)->typedSpan();
+    } else {
+        m_sourceChannels = { };
+        m_destinationChannels = { };
     }
 
     m_virtualReadIndex = 0;
     m_buffer = WTF::move(buffer);
+
+    updateOutputChannelCount();
 
     // In case the buffer gets set after playback has started, we need to clamp the grain parameters now.
     if (m_isGrain)
@@ -485,6 +488,25 @@ ExceptionOr<void> AudioBufferSourceNode::setBufferForBindings(RefPtr<AudioBuffer
     acquireBufferContent();
 
     return { };
+}
+
+// https://webaudio.github.io/web-audio-api/#AudioNode-actively-processing
+// https://webaudio.github.io/web-audio-api/#AudioBufferSourceNode
+void AudioBufferSourceNode::updateOutputChannelCount()
+{
+    ASSERT(isMainThread());
+    ASSERT(m_processLock.isHeld());
+    ASSERT(context().isGraphOwner());
+
+    unsigned numberOfChannels = 1;
+    if (m_buffer && isPlayingOrScheduled())
+        numberOfChannels = m_buffer->numberOfChannels();
+
+    ASSERT(numberOfChannels <= AudioContext::maxNumberOfChannels);
+    if (numberOfChannels == output(0)->numberOfChannels())
+        return;
+
+    protect(output(0))->setNumberOfChannels(numberOfChannels);
 }
 
 unsigned AudioBufferSourceNode::numberOfChannels()
@@ -537,8 +559,12 @@ ExceptionOr<void> AudioBufferSourceNode::startPlaying(double when, double grainO
 
     context().sourceNodeWillBeginPlayback(*this);
 
-    // This synchronizes with process().
+    // This synchronizes with process(), it is important to acquire the processLock before the
+    // graphLock to avoid a deadlock given that this is the order process() acquires the locks in.
     Locker locker { m_processLock };
+
+    // Changing the number of output channels below re-configures the graph.
+    Locker contextLocker { context().graphLock() };
 
     m_isGrain = true;
     m_grainOffset = grainOffset;
@@ -553,6 +579,9 @@ ExceptionOr<void> AudioBufferSourceNode::startPlaying(double when, double grainO
 
     acquireBufferContent();
     m_playbackState = SCHEDULED_STATE;
+
+    // The node is now playing, so the output takes the buffer's channel count.
+    updateOutputChannelCount();
 
     return { };
 }

--- a/Source/WebCore/Modules/webaudio/AudioBufferSourceNode.h
+++ b/Source/WebCore/Modules/webaudio/AudioBufferSourceNode.h
@@ -85,6 +85,7 @@ private:
     AudioBufferSourceNode(BaseAudioContext&);
 
     void acquireBufferContent() WTF_REQUIRES_LOCK(m_processLock);
+    void updateOutputChannelCount() WTF_REQUIRES_LOCK(m_processLock);
 
     double tailTime() const final { return 0; }
     double latencyTime() const final { return 0; }


### PR DESCRIPTION
#### d812eb91c045cbc32b619fecd38eac3b732a6d20
<pre>
AudioBufferSourceNode output channel count ignores actively-processing state
<a href="https://bugs.webkit.org/show_bug.cgi?id=320309">https://bugs.webkit.org/show_bug.cgi?id=320309</a>
<a href="https://rdar.apple.com/183245229">rdar://183245229</a>

Reviewed by Chris Dumez.

Per the Web Audio API, an AudioScheduledSourceNode is actively processing
&quot;if and only if it is playing for at least part of the current rendering
quantum&quot;, and &quot;AudioNodes that are not actively processing output a single
channel of silence&quot; [1]. The number of channels of an AudioBufferSourceNode&apos;s
output therefore equals the number of channels of its buffer only while the
node is playing, and &quot;is one channel of silence if buffer is null&quot; [2].

We instead latched the output channel count in the buffer setter, from the
buffer alone, so it was wrong in three cases:

- A node with a buffer that was never started kept the buffer&apos;s channel
  count, though it is not actively processing.
- Setting buffer back to null left the previous count in place.
- A playing node whose buffer is null kept the previous count.

The end-of-playback case already collapsed to a single channel, but only
incidentally: finish() drops the context&apos;s reference to the node, which
disables its outputs, which removes them from
AudioSummingJunction::maximumNumberOfChannels(). Nothing consulted playback
state, so the cases above were unaffected by that path.

Compute the count from both the buffer and the playback state instead, in a
new updateOutputChannelCount(), and call it from the buffer setter and from
startPlaying() once the node is scheduled. Setting the buffer to null now
also clears the stale source and destination channel spans.

startPlaying() now takes the graph lock, since changing the output channel
count reconfigures the graph. It is acquired after the process lock, matching
the order used by process() and setBufferForBindings() to avoid deadlock.

Firefox already behaves as specified in all of these cases; Chrome shares the
old behavior.

[1] <a href="https://webaudio.github.io/web-audio-api/#AudioNode-actively-processing">https://webaudio.github.io/web-audio-api/#AudioNode-actively-processing</a>
[2] <a href="https://webaudio.github.io/web-audio-api/#AudioBufferSourceNode">https://webaudio.github.io/web-audio-api/#AudioBufferSourceNode</a>

Test: imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiobuffersourcenode-interface/audiobuffersource-output-channel-count.html

* LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiobuffersourcenode-interface/audiobuffersource-output-channel-count-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiobuffersourcenode-interface/audiobuffersource-output-channel-count.html: Added.
* Source/WebCore/Modules/webaudio/AudioBufferSourceNode.cpp:
(WebCore::AudioBufferSourceNode::setBufferForBindings):
(WebCore::AudioBufferSourceNode::updateOutputChannelCount):
(WebCore::AudioBufferSourceNode::startPlaying):
* Source/WebCore/Modules/webaudio/AudioBufferSourceNode.h:

Canonical link: <a href="https://commits.webkit.org/317956@main">https://commits.webkit.org/317956@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/56cec961276a81680e9abce32b9cb761cf99ad75

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176810 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50747 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44539 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186412 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140046 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f4387cd4-d94b-438f-a3be-5611bf246f71) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178673 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52040 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50433 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137739 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140046 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2830e3dd-af17-4bee-834a-622d3d716958) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179766 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41245 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158525 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118213 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bb3144a1-e712-4b7d-9ec4-5edff28a1e1c) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/176133 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39899 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38267 "Passed tests") | | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/7032 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Checked out pull request; Passed JSC tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150311 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38024 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34880 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/38081 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42492 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42482 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188836 "Built successfully") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/176213 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50414 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/158068 "") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146808 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39482 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51097 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34646 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146610 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41373 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123305 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117508 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49602 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13003 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49001 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49237 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49062 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->