### PR TITLE
Web Inspector: guard against null activeCallFrame in SourcesNavigationSidebarPanel._updatePauseReason()

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/SourcesNavigationSidebarPanel.js
+++ b/Source/WebInspectorUI/UserInterface/Views/SourcesNavigationSidebarPanel.js
@@ -1735,7 +1735,10 @@ WI.SourcesNavigationSidebarPanel = class SourcesNavigationSidebarPanel extends W
 
         this._updatePauseReasonGotoArrow();
 
-        let target = WI.debuggerManager.activeCallFrame.target;
+        let target = WI.debuggerManager.activeCallFrame?.target;
+        if (!target)
+            return false;
+
         let targetData = WI.debuggerManager.dataForTarget(target);
         return this._updatePauseReasonSection(target, targetData.pauseReason, targetData.pauseData);
     }


### PR DESCRIPTION
#### 0ad125d05d0a239587d663e65f8e4f52638ad947
<pre>
Web Inspector: guard against null activeCallFrame in SourcesNavigationSidebarPanel._updatePauseReason()
<a href="https://bugs.webkit.org/show_bug.cgi?id=320310">https://bugs.webkit.org/show_bug.cgi?id=320310</a>
<a href="https://rdar.apple.com/183245713">rdar://183245713</a>

Reviewed by NOBODY (OOPS!).

WI.debuggerManager.paused returns true if any target is paused, but
activeCallFrame is a single value that is nulled out when the specific
target that owns it resumes, even while other targets (additional
Workers, or cross-origin frames under Site Isolation) remain paused.
_updatePauseReason() dereferenced activeCallFrame.target without a
null check, so constructing or re-entering the panel in this state
would crash. This is defensive fix and test cannot be created due to
current test infrastructure limitations.

* Source/WebInspectorUI/UserInterface/Views/SourcesNavigationSidebarPanel.js:
(WI.SourcesNavigationSidebarPanel.prototype._updatePauseReason):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0ad125d05d0a239587d663e65f8e4f52638ad947

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176811 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50748 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44540 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186413 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/140047 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/409edd97-46fd-45fb-a39f-30c729407353) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52041 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50434 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137740 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96272 "1 flakes 5 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/56547f45-b2ca-4d50-81bf-5deef1bc2e26) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179767 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41246 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158526 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118214 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9793e675-5d84-4936-8cd6-fc2b7d21c217) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39900 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38268 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150312 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38025 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34881 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42493 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42483 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188837 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50415 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146809 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51098 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34647 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146611 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41375 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123306 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117510 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49603 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13004 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49002 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49238 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49063 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->