### PR TITLE
REGRESSION(309541@main): Only one HUD responds to mouse clicks in web content with multiple embedded PDFs

### DIFF
--- a/Source/WebKit/UIProcess/PDF/WKPDFHUDView.swift
+++ b/Source/WebKit/UIProcess/PDF/WKPDFHUDView.swift
@@ -199,20 +199,20 @@ extension WKPDFHUDView {
     final override func hitTest(_ point: NSPoint) -> NSView? {
         let pointInSelf = convert(point, from: unsafe superview)
 
-        guard isBarVisible else { return webView }
+        guard bounds.contains(pointInSelf) else { return nil }
+
+        guard isBarVisible else { return nil }
 
         let pointInBar = barView.convert(pointInSelf, from: self)
-        if barView.bounds.contains(pointInBar) {
-            for button in [zoomOutButton, zoomInButton, openInPreviewButton, saveButton] {
-                let pointInButton = button.convert(pointInSelf, from: self)
-                if button.bounds.contains(pointInButton) && !button.isHidden {
-                    return button
-                }
-            }
-            return barView
-        }
+        guard barView.bounds.contains(pointInBar) else { return nil }
 
-        return webView
+        for button in [zoomOutButton, zoomInButton, openInPreviewButton, saveButton] {
+            let pointInButton = button.convert(pointInSelf, from: self)
+            if button.bounds.contains(pointInButton) && !button.isHidden {
+                return button
+            }
+        }
+        return barView
     }
 
     final override func mouseMoved(with event: NSEvent) {

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/UnifiedPDFTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/UnifiedPDFTests.mm
@@ -489,6 +489,58 @@ UNIFIED_PDF_TEST(SetPageZoomFactorDoesNotBailIncorrectly)
     EXPECT_EQ(scaleAfterResetting, 1.0);
 }
 
+UNIFIED_PDF_TEST(PDFHUDMultiplePluginsDoNotInterceptHitTesting)
+{
+    RetainPtr handler = adoptNS([TestURLSchemeHandler new]);
+    [handler setStartURLSchemeTaskHandler:^(WKWebView *, id<WKURLSchemeTask> task) {
+        if ([task.request.URL.path isEqualToString:@"/main.html"]) {
+            RetainPtr response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:@"text/html" expectedContentLength:0 textEncodingName:nil]);
+            const char* html = "<embed src='test.pdf' width='300' height='200'><embed src='test.pdf' width='300' height='200'>";
+            [task didReceiveResponse:response];
+            [task didReceiveData:[NSData dataWithBytes:html length:strlen(html)]];
+            [task didFinish];
+        } else {
+            EXPECT_WK_STREQ(task.request.URL.path, "/test.pdf");
+            RetainPtr data = testPDFData();
+            RetainPtr response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:@"application/pdf" expectedContentLength:[data length] textEncodingName:nil]);
+            [task didReceiveResponse:response];
+            [task didReceiveData:data];
+            [task didFinish];
+        }
+    }];
+
+    RetainPtr configuration = configurationForWebViewTestingUnifiedPDF(true);
+    [configuration setURLSchemeHandler:handler forURLScheme:@"test"];
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration]);
+    [webView _setWindowOcclusionDetectionEnabled:NO];
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"test:///main.html"]]];
+    [webView _test_waitForDidFinishNavigation];
+    [webView waitForNextPresentationUpdate];
+
+    // HUDs for <embed> plugins are created asynchronously after navigation, so wait for both to appear.
+    TestWebKitAPI::Util::waitFor([webView] {
+        return [webView _pdfHUDs].count >= 2;
+    });
+
+    RetainPtr huds = [[webView _pdfHUDs] allObjects];
+
+    for (NSView *hud in huds.get()) {
+        RetainPtr bar = [[hud subviews] firstObject];
+        NSRect barInSuperview = [bar convertRect:[bar bounds] toView:[hud superview]];
+        NSPoint barCenter = NSMakePoint(NSMidX(barInSuperview), NSMidY(barInSuperview));
+
+        // The HUD claims a point on its own bar.
+        EXPECT_NOT_NULL([hud hitTest:barCenter]);
+
+        // No other HUD intercepts it (the front-most HUD must not swallow siblings' bar clicks).
+        for (NSView *otherHUD in huds.get()) {
+            if (otherHUD == hud)
+                continue;
+            EXPECT_NULL([otherHUD hitTest:barCenter]);
+        }
+    }
+}
+
 static void checkFrame(NSRect frame, CGFloat x, CGFloat y, CGFloat width, CGFloat height, std::optional<CGFloat> frameOriginTolerance = { })
 {
     if (frameOriginTolerance) {


### PR DESCRIPTION
#### bb5b0c53252514e0bd1ed38e2f0f6ad2bebbb9c9
<pre>
REGRESSION(309541@main): Only one HUD responds to mouse clicks in web content with multiple embedded PDFs
<a href="https://bugs.webkit.org/show_bug.cgi?id=320295">https://bugs.webkit.org/show_bug.cgi?id=320295</a>
<a href="https://rdar.apple.com/183165576">rdar://183165576</a>

Reviewed by Richard Robinson.

Before 309541@main, mouse events were delivered to the HUD courtesy of a
polling loop in WebViewImpl&apos;s mouse responder methods. Since we moved to
AppKit-native dispatch in that method, the `-hitTest:` method became the
routing mechanism. Our `-hitTest:` implementation made one mistake,
which was to completely shortcircuit AppKit hit testing for off-the-bar
hits and return the underlying web view directly. We should have instead
delegated to AppKit&apos;s view hierarchy walk for said hit inquiries, which
we do so with this patch by returning `nil` instead of the web view.

Test: TestWebKitAPI.UnifiedPDF.PDFHUDMultiplePluginsDoNotInterceptHitTesting

* Source/WebKit/UIProcess/PDF/WKPDFHUDView.swift:
(WKPDFHUDView.hitTest(_:)):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/UnifiedPDFTests.mm:
(TestWebKitAPI::UNIFIED_PDF_TEST):

Canonical link: <a href="https://commits.webkit.org/317936@main">https://commits.webkit.org/317936@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7e652f817dd03b598afaa180a30726b64e88c9a3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176812 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50749 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44541 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186414 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140048 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f1cb2384-2f8b-4ae6-bd32-6fbde172e4e7) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178675 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52042 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50435 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137741 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140048 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/287c4b36-ea67-4cc0-8728-828f77d37f00) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179768 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41247 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158527 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118215 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5d961c62-67e7-4887-9b51-6f46a2cf1ce5) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/176135 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39901 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38269 "Passed tests") | | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/7034 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150313 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38026 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34882 "Built successfully") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/38083 "Build is in progress. Recent messages:OS: Tahoe (26.5.1), Xcode: 26.5; Checked out pull request; Compiled JSC; Passed JSC tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42494 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42484 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188838 "Built successfully") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/176215 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50416 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/158070 "") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146810 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51099 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34648 "Too many flaky failures: http/tests/contentextensions/video-element-resource-type.html, http/tests/media/now-playing-info-private-browsing.html, http/tests/navigation/redirect-to-random-url-versus-memory-cache.html, http/tests/resourceLoadStatistics/non-sandboxed-iframe-redirect-ip-to-localhost-to-ip.html, http/tests/security/canvas-remote-read-remote-video-allowed-anonymous.html, http/tests/security/contentSecurityPolicy/1.1/scriptnonce-allowed-by-enforced-policy-and-blocked-by-report-policy2.py, http/tests/security/contentSecurityPolicy/policy-does-not-affect-child.html, http/tests/site-isolation/iframe-process-termination-after-navigation-completed.html, http/tests/storageAccess/deny-storage-access-under-opener-ephemeral.html, http/tests/webgpu/webgpu/web_platform/copyToTexture/image_file.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146612 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26827 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41374 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123307 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117511 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49604 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13005 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49003 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49239 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49064 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->