### PR TITLE
[PDF] Add fade animation support to alternate HUD view

### DIFF
--- a/Source/WebKit/UIProcess/PDF/WKAlternatePDFHUDView.swift
+++ b/Source/WebKit/UIProcess/PDF/WKAlternatePDFHUDView.swift
@@ -25,10 +25,9 @@
 
 import AppKit
 public import Foundation
-internal import WebKit_Internal
+import WebKit_Internal
 @_weakLinked @_spi(Private) import SwiftUI
 
-// FIXME: Add fade animations.
 // FIXME: Add localizable strings support.
 // FIXME: Implement `WKAlternatePDFHUDView.show`.
 // FIXME: Figure out the final design.
@@ -36,7 +35,19 @@ internal import WebKit_Internal
 private let barVerticalOffset: CGFloat = 40
 
 private struct Controls: View {
+    private static let autoHideDelay: Duration = .seconds(3)
+
     let action: (WKPDFHUDViewControlAction) -> Void
+
+    @State
+    private var initialHideTimerFired = false
+
+    @State
+    private var isHovered = false
+
+    private var isVisible: Bool {
+        !initialHideTimerFired || isHovered
+    }
 
     var body: some View {
         ControlGroup {
@@ -63,9 +74,19 @@ private struct Controls: View {
             }
         }
         .labelStyle(.iconOnly)
+        .opacity(isVisible ? 1 : 0)
+        .animation(.easeInOut, value: isVisible)
         #if USE_APPLE_INTERNAL_SDK && HAVE_NSGLASSEFFECTVIEW_EFFECT_IS_INTERACTIVE
         .controlGroupStyle(.toolbar)
         #endif
+        .onHover {
+            isHovered = $0
+        }
+        .task {
+            try? await Task.sleep(for: Self.autoHideDelay)
+            guard !Task.isCancelled else { return }
+            initialHideTimerFired = true
+        }
     }
 }
 


### PR DESCRIPTION
#### e02cba30b578dd75b0d12792795ad3a74441953e
<pre>
[PDF] Add fade animation support to alternate HUD view
<a href="https://bugs.webkit.org/show_bug.cgi?id=320311">https://bugs.webkit.org/show_bug.cgi?id=320311</a>
<a href="https://rdar.apple.com/183246201">rdar://183246201</a>

Reviewed by Abrar Rahman Protyasha.

Make the controls fade away when they&apos;re not being hovered.

* Source/WebKit/UIProcess/PDF/WKAlternatePDFHUDView.swift:
(Controls.isVisible):
(Controls.body):

Canonical link: <a href="https://commits.webkit.org/318227@main">https://commits.webkit.org/318227@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/23e5372252244592896c2d2b02fb52e824b239cb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177707 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51645 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45439 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187312 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140954 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/778a2184-a941-49ef-8c86-00df6ac0b4c5) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52937 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51354 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/138512 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140954 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/66e641b4-1a75-411c-a5d7-296e3ac19d31) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180663 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/42031 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/159251 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118976 "Build is in progress. Recent messages:Printed configuration; Checked out pull request; run-api-tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/500032ad-a2cb-4130-80aa-1952653d6f9f) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/40692 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/39055 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/151099 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38747 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35778 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/43430 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/43290 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189743 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51312 "Built successfully") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/147625 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39648 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51994 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/35375 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147411 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42123 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124209 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118631 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50502 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13724 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49898 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50138 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49960 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->