### PR TITLE
[JSC] `Iterator.zip` should use null-prototype objects for `GetOptionsObject` and the synthetic underlying iterator

### DIFF
--- a/JSTests/stress/iterator-zip-object-prototype-pollution.js
+++ b/JSTests/stress/iterator-zip-object-prototype-pollution.js
@@ -1,0 +1,70 @@
+//@ requireOptions("--useJointIteration=1")
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`bad value: ${actual}, expected ${expected}`);
+}
+
+function makeIterator(values, log) {
+    var index = 0;
+    return {
+        next() {
+            if (index < values.length)
+                return { value: values[index++], done: false };
+            return { value: undefined, done: true };
+        },
+        return() {
+            log.push("return");
+            return { value: undefined, done: true };
+        },
+        [Symbol.iterator]() { return this; }
+    };
+}
+
+// GetOptionsObject must produce a null-prototype object when options is undefined,
+// so "mode" and "padding" lookups do not read through Object.prototype.
+{
+    Object.defineProperty(Object.prototype, "mode", { value: "strict", configurable: true });
+    Object.defineProperty(Object.prototype, "padding", { value: null, configurable: true });
+    try {
+        shouldBe(JSON.stringify(Array.from(Iterator.zip([[1, 2, 3], [4, 5]]))), "[[1,4],[2,5]]");
+        shouldBe(JSON.stringify(Array.from(Iterator.zipKeyed({ a: [1, 2, 3], b: [4, 5] }))), `[{"a":1,"b":4},{"a":2,"b":5}]`);
+    } finally {
+        delete Object.prototype.mode;
+        delete Object.prototype.padding;
+    }
+}
+
+// The synthetic underlying iterator's return() must be installed on a null-prototype object.
+// A non-writable Object.prototype.return must not make zip creation throw.
+{
+    Object.defineProperty(Object.prototype, "return", { value: 42, writable: false, configurable: true });
+    try {
+        var log = [];
+        shouldBe(JSON.stringify(Array.from(Iterator.zip([makeIterator([1], log), makeIterator([2], log)]))), "[[1,2]]");
+        shouldBe(JSON.stringify(Array.from(Iterator.zipKeyed({ a: makeIterator([1], log), b: makeIterator([2], log) }))), `[{"a":1,"b":2}]`);
+    } finally {
+        delete Object.prototype.return;
+    }
+}
+
+// An Object.prototype.return accessor must not swallow the closure: closing the zip result
+// closes the underlying iterators.
+{
+    Object.defineProperty(Object.prototype, "return", { get() { return undefined; }, set(v) { }, configurable: true });
+    try {
+        var log = [];
+        var zipped = Iterator.zip([makeIterator([1, 2, 3], log), makeIterator([4, 5, 6], log)]);
+        zipped.next();
+        zipped.return();
+        shouldBe(log.length, 2);
+
+        log = [];
+        var zippedKeyed = Iterator.zipKeyed({ a: makeIterator([1, 2, 3], log), b: makeIterator([4, 5, 6], log) });
+        zippedKeyed.next();
+        zippedKeyed.return();
+        shouldBe(log.length, 2);
+    } finally {
+        delete Object.prototype.return;
+    }
+}

--- a/Source/JavaScriptCore/builtins/JSIteratorConstructor.js
+++ b/Source/JavaScriptCore/builtins/JSIteratorConstructor.js
@@ -160,7 +160,7 @@ function iteratorZip(iters, nextMethods, mode, padding, finishResults)
     // return() before the first next(), when the closure body has never run) then
     // closes all of them. This is invoked with a return completion, so a failing
     // return() propagates.
-    var underlyingIterators = { };
+    var underlyingIterators = @Object.@create(null);
     underlyingIterators.return = function () {
         @iteratorCloseAllNormal(openIters);
         return { done: true, value: @undefined };
@@ -306,7 +306,7 @@ function getOptionsObject(options)
     // 1. If options is undefined, then
     if (options === @undefined) {
         // 1.a. Return OrdinaryObjectCreate(null).
-        return {};
+        return @Object.@create(null);
     }
 
     // 2. If options is an Object, then


### PR DESCRIPTION
#### 0731b27c1b605241c9e23cceddae5af7717716ea
<pre>
[JSC] `Iterator.zip` should use null-prototype objects for `GetOptionsObject` and the synthetic underlying iterator
<a href="https://bugs.webkit.org/show_bug.cgi?id=320312">https://bugs.webkit.org/show_bug.cgi?id=320312</a>

Reviewed by Yusuke Suzuki.

Two places in the Joint Iteration builtins created ordinary objects backed by
Object.prototype, so polluting the prototype changed observable behavior:

1. getOptionsObject() returned `{}` instead of OrdinaryObjectCreate(null), so with
   options omitted, Get(options, &quot;mode&quot;) / Get(options, &quot;padding&quot;) read through
   Object.prototype:

       Object.defineProperty(Object.prototype, &quot;mode&quot;, { value: &quot;strict&quot; });
       Array.from(Iterator.zip([[1, 2, 3], [4, 5]]));   // throws instead of [[1, 4], [2, 5]]

2. iteratorZip() installed the synthetic underlying iterator&apos;s return() with an
   ordinary [[Set]] on `{}`. A non-writable Object.prototype.return made every
   Iterator.zip() call throw at creation, and an accessor silently swallowed the
   assignment so IteratorCloseAll never ran.

Use @Object.@create(null) for both. This covers zip and zipKeyed since both go
through @iteratorZip.

Test: JSTests/stress/iterator-zip-object-prototype-pollution.js

* JSTests/stress/iterator-zip-object-prototype-pollution.js: Added.
(shouldBe):
(try.shouldBe.JSON.stringify.Array.from.Iterator.zipKeyed):
(try.b.makeIterator):
(set configurable):
* Source/JavaScriptCore/builtins/JSIteratorConstructor.js:
(linkTimeConstant.getOptionsObject):

Canonical link: <a href="https://commits.webkit.org/318061@main">https://commits.webkit.org/318061@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1b7c7b5a50e932cdd7214f9fb77ddbedcd64730e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176814 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50751 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44543 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186416 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140050 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178677 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52044 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50437 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137743 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140050 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179770 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41250 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158528 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118217 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/176137 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39904 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38270 "Passed tests") | [❌ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/182 "Found 3 new JSC stress test failures: wasm.yaml/wasm/stress/type-index-abstract-heap-types-concrete-vs-abstract.js.wasm-aggressive-inline, wasm.yaml/wasm/stress/type-index-abstract-heap-types-concrete-vs-abstract.js.wasm-eager, wasm.yaml/wasm/stress/type-index-abstract-heap-types-nulls-and-casts.js.wasm-aggressive-inline (failure)") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/7035 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150316 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38027 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34884 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/38085 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42496 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42485 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188840 "Built successfully") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/176217 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50418 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/158071 "") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146812 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39550 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51101 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34649 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146614 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41377 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123309 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117516 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49606 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13006 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49005 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49241 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49066 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->