### PR TITLE
[JSC] Add missing `U_FAILURE(status)` for `actualLunisolarMonthLength`

### DIFF
--- a/Source/JavaScriptCore/runtime/temporal/core/CalendarICUBridge.cpp
+++ b/Source/JavaScriptCore/runtime/temporal/core/CalendarICUBridge.cpp
@@ -462,12 +462,15 @@ static std::optional<int32_t> stableLunisolarYear(UCalendar* cal, CalendarID cal
     return relatedYear.hasOverflowed() ? std::nullopt : std::optional<int32_t> { relatedYear.value() };
 }
 
-static std::optional<int32_t> actualLunisolarMonthLength(UCalendar* cal, CalendarID calendarId, UErrorCode& status)
+static std::optional<int32_t> actualLunisolarMonthLength(UCalendar* cal, CalendarID calendarId)
 {
-    if (calendarId != chineseCalendarID() && calendarId != dangiCalendarID())
-        return ucal_getLimit(cal, UCAL_DAY_OF_MONTH, UCAL_ACTUAL_MAXIMUM, &status);
-    if (U_FAILURE(status)) [[unlikely]]
-        return std::nullopt;
+    UErrorCode status = U_ZERO_ERROR;
+    if (calendarId != chineseCalendarID() && calendarId != dangiCalendarID()) {
+        int32_t limit = ucal_getLimit(cal, UCAL_DAY_OF_MONTH, UCAL_ACTUAL_MAXIMUM, &status);
+        if (U_FAILURE(status)) [[unlikely]]
+            return std::nullopt;
+        return limit;
+    }
     double savedMs = ucal_getMillis(cal, &status);
     if (U_FAILURE(status)) [[unlikely]]
         return std::nullopt;
@@ -994,7 +997,7 @@ TemporalResult<int32_t> calendarDaysInMonth(CalendarID calendarId, const ISO8601
             return makeUnexpected(rangeError(icuSetCalendarFailed));
         UErrorCode status = U_ZERO_ERROR;
         if (calendarId == chineseCalendarID() || calendarId == dangiCalendarID()) {
-            auto result = actualLunisolarMonthLength(cal, calendarId, status);
+            auto result = actualLunisolarMonthLength(cal, calendarId);
             if (!result) [[unlikely]]
                 return makeUnexpected(rangeError(icuReadCalendarFailed));
             return *result;
@@ -2272,7 +2275,7 @@ TemporalResult<ISO8601::PlainDate> calendarDateFromFields(CalendarID calendarId,
                 }
                 if (!found && overflow == TemporalOverflow::Reject) [[unlikely]]
                     return makeUnexpected(rangeError("monthCode does not exist in this calendar year"_s)); // Clamp day via ucal_add.
-                auto maxDayOrError = actualLunisolarMonthLength(cal, calendarId, status);
+                auto maxDayOrError = actualLunisolarMonthLength(cal, calendarId);
                 if (!maxDayOrError) [[unlikely]]
                     return makeUnexpected(rangeError(icuReadCalendarFailed));
                 int32_t maxDay = *maxDayOrError;
@@ -2362,7 +2365,7 @@ TemporalResult<ISO8601::PlainDate> calendarDateFromFields(CalendarID calendarId,
             }
 
             // Clamp day to daysInMonth if constrain.
-            auto maxDayOrError = actualLunisolarMonthLength(cal, calendarId, status);
+            auto maxDayOrError = actualLunisolarMonthLength(cal, calendarId);
             if (!maxDayOrError) [[unlikely]]
                 return makeUnexpected(rangeError(icuReadCalendarFailed));
             int32_t maxDay = *maxDayOrError;


### PR DESCRIPTION
#### 09917ef55b0f95601817be0ad3100e4ff5044a69
<pre>
[JSC] Add missing `U_FAILURE(status)` for `actualLunisolarMonthLength`
<a href="https://bugs.webkit.org/show_bug.cgi?id=320313">https://bugs.webkit.org/show_bug.cgi?id=320313</a>

Reviewed by Yusuke Suzuki.

The U_FAILURE(status) check sat after the early return for non-Chinese/Dangi
calendars (i.e. Hebrew), so it never guarded the ucal_getLimit call: on ICU
failure the function returned an engaged optional { 0 } and the callers
clamped the day to 0 under overflow: &quot;constrain&quot; instead of throwing a
RangeError. Check the status right after ucal_getLimit.

* Source/JavaScriptCore/runtime/temporal/core/CalendarICUBridge.cpp:
(JSC::TemporalCore::actualLunisolarMonthLength):

Canonical link: <a href="https://commits.webkit.org/318062@main">https://commits.webkit.org/318062@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/beede65fcaf991a4b8476f1e30042c2113f2da63

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176872 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50809 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44601 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186475 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140108 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52102 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50495 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137792 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140108 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179828 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41302 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158581 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118266 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39956 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38324 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/235 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/7088 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150368 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38080 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34942 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/38143 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42554 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42539 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188898 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50476 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146866 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39551 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51159 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34704 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146667 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41430 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123367 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117596 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49664 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13061 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49063 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49299 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49124 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->