### PR TITLE
Make ImageData work with non-Typed ArrayPixelBuffer

### DIFF
--- a/Source/WebCore/html/HTMLCanvasElement.cpp
+++ b/Source/WebCore/html/HTMLCanvasElement.cpp
@@ -761,7 +761,7 @@ RefPtr<ImageData> HTMLCanvasElement::getImageData()
         return nullptr;
 
     postProcessPixelBufferResults(*pixelBuffer);
-    return ImageData::create(pixelBuffer.releaseNonNull());
+    return ImageData::create(Ref<ArrayPixelBuffer>(pixelBuffer.releaseNonNull()));
 #else
     return nullptr;
 #endif

--- a/Source/WebCore/html/ImageData.cpp
+++ b/Source/WebCore/html/ImageData.cpp
@@ -54,37 +54,25 @@ static ImageDataPixelFormat NODELETE computePixelFormat(std::optional<ImageDataS
     return settings ? settings->pixelFormat : defaultPixelFormat;
 }
 
-Ref<ImageData> ImageData::create(Ref<ByteArrayPixelBuffer>&& pixelBuffer, std::optional<ImageDataPixelFormat> overridingPixelFormat)
+Ref<ImageData> ImageData::create(Ref<ArrayPixelBuffer>&& pixelBuffer, std::optional<ImageDataPixelFormat> overridingPixelFormat)
 {
-    auto colorSpace = toPredefinedColorSpace(pixelBuffer->format().colorSpace);
-    return adoptRef(*new ImageData(pixelBuffer->size(), WTF::move(pixelBuffer.get()).takeData(), *colorSpace, overridingPixelFormat));
-}
-
-#if ENABLE(PIXEL_FORMAT_RGBA16F)
-Ref<ImageData> ImageData::create(Ref<Float16ArrayPixelBuffer>&& pixelBuffer, std::optional<ImageDataPixelFormat> overridingPixelFormat)
-{
-    auto colorSpace = toPredefinedColorSpace(pixelBuffer->format().colorSpace);
     auto size = pixelBuffer->size();
-    return adoptRef(*new ImageData(size, WTF::move(pixelBuffer.get()).takeData(), *colorSpace, overridingPixelFormat));
-}
-#endif // ENABLE(PIXEL_FORMAT_RGBA16F)
-
-RefPtr<ImageData> ImageData::create(RefPtr<ByteArrayPixelBuffer>&& pixelBuffer, std::optional<ImageDataPixelFormat> overridingPixelFormat)
-{
-    if (!pixelBuffer)
-        return nullptr;
-    return create(pixelBuffer.releaseNonNull(), overridingPixelFormat);
+    auto colorSpace = toPredefinedColorSpace(pixelBuffer->format().colorSpace);
+    return adoptRef(*new ImageData(size, ImageDataArray(WTF::move(pixelBuffer.get()).takeData()), *colorSpace, overridingPixelFormat));
 }
 
 RefPtr<ImageData> ImageData::create(Ref<PixelBuffer>&& pixelBuffer, std::optional<ImageDataPixelFormat> overridingPixelFormat)
 {
-    if (is<ByteArrayPixelBuffer>(pixelBuffer))
-        return create(uncheckedDowncast<ByteArrayPixelBuffer>(WTF::move(pixelBuffer)), overridingPixelFormat);
-#if ENABLE(PIXEL_FORMAT_RGBA16F)
-    if (is<Float16ArrayPixelBuffer>(pixelBuffer))
-        return create(uncheckedDowncast<Float16ArrayPixelBuffer>(WTF::move(pixelBuffer)), overridingPixelFormat);
-#endif // ENABLE(PIXEL_FORMAT_RGBA16F)
+    if (is<ArrayPixelBuffer>(pixelBuffer))
+        return create(uncheckedDowncast<ArrayPixelBuffer>(WTF::move(pixelBuffer)), overridingPixelFormat);
     return nullptr;
+}
+
+RefPtr<ImageData> ImageData::create(RefPtr<ArrayPixelBuffer>&& pixelBuffer, std::optional<ImageDataPixelFormat> overridingPixelFormat)
+{
+    if (!pixelBuffer)
+        return nullptr;
+    return create(pixelBuffer.releaseNonNull(), overridingPixelFormat);
 }
 
 RefPtr<ImageData> ImageData::create(const IntSize& size, PredefinedColorSpace colorSpace, ImageDataPixelFormat imageDataPixelFormat)
@@ -133,8 +121,10 @@ ExceptionOr<Ref<ImageData>> ImageData::create(unsigned sw, unsigned sh, std::opt
     return create(sw, sh, PredefinedColorSpace::SRGB, settings);
 }
 
-ExceptionOr<Ref<ImageData>> ImageData::create(ImageDataArray&& array, unsigned sw, std::optional<unsigned> sh, std::optional<ImageDataSettings> settings)
+ExceptionOr<Ref<ImageData>> ImageData::create(Ref<JSC::ArrayBufferView>&& arrayBufferView, unsigned sw, std::optional<unsigned> sh, std::optional<ImageDataSettings> settings)
 {
+    auto array = ImageDataArray(WTF::move(arrayBufferView));
+
     auto length = array.length();
     if (!length || length % 4)
         return Exception { ExceptionCode::InvalidStateError, "Length is not a non-zero multiple of 4"_s };

--- a/Source/WebCore/html/ImageData.h
+++ b/Source/WebCore/html/ImageData.h
@@ -42,18 +42,15 @@ template<typename> class ExceptionOr;
 
 class ImageData : public RefCounted<ImageData> {
 public:
-    WEBCORE_EXPORT static Ref<ImageData> create(Ref<ByteArrayPixelBuffer>&&, std::optional<ImageDataPixelFormat> = { });
-#if ENABLE(PIXEL_FORMAT_RGBA16F)
-    WEBCORE_EXPORT static Ref<ImageData> create(Ref<Float16ArrayPixelBuffer>&&, std::optional<ImageDataPixelFormat> = { });
-#endif
+    WEBCORE_EXPORT static Ref<ImageData> create(Ref<ArrayPixelBuffer>&&, std::optional<ImageDataPixelFormat> = { });
     WEBCORE_EXPORT static RefPtr<ImageData> create(Ref<PixelBuffer>&&, std::optional<ImageDataPixelFormat> = { });
-    WEBCORE_EXPORT static RefPtr<ImageData> create(RefPtr<ByteArrayPixelBuffer>&&, std::optional<ImageDataPixelFormat> = { });
+    WEBCORE_EXPORT static RefPtr<ImageData> create(RefPtr<ArrayPixelBuffer>&&, std::optional<ImageDataPixelFormat> = { });
     WEBCORE_EXPORT static RefPtr<ImageData> create(const IntSize&, PredefinedColorSpace, ImageDataPixelFormat = ImageDataPixelFormat::RgbaUnorm8);
     WEBCORE_EXPORT static RefPtr<ImageData> create(const IntSize&, ImageDataArray&&, PredefinedColorSpace);
 
     WEBCORE_EXPORT static ExceptionOr<Ref<ImageData>> create(unsigned sw, unsigned sh, PredefinedColorSpace defaultColorSpace, std::optional<ImageDataSettings> = std::nullopt, std::span<const uint8_t> = { });
     WEBCORE_EXPORT static ExceptionOr<Ref<ImageData>> create(unsigned sw, unsigned sh, std::optional<ImageDataSettings>);
-    WEBCORE_EXPORT static ExceptionOr<Ref<ImageData>> create(ImageDataArray&&, unsigned sw, std::optional<unsigned> sh, std::optional<ImageDataSettings>);
+    WEBCORE_EXPORT static ExceptionOr<Ref<ImageData>> create(Ref<JSC::ArrayBufferView>&&, unsigned sw, std::optional<unsigned> sh, std::optional<ImageDataSettings>);
 
     WEBCORE_EXPORT ~ImageData();
 

--- a/Source/WebCore/html/ImageDataArray.cpp
+++ b/Source/WebCore/html/ImageDataArray.cpp
@@ -52,14 +52,6 @@ ImageDataArray::ImageDataArray(Ref<JSC::ArrayBufferView>&& arrayBufferView)
     ASSERT(isSupported(m_arrayBufferView.get()));
 }
 
-ImageDataArray::ImageDataArray(Ref<JSC::Uint8ClampedArray>&& data)
-    : ImageDataArray(Ref<JSC::ArrayBufferView>(WTF::move(data)))
-{ }
-
-ImageDataArray::ImageDataArray(Ref<JSC::Float16Array>&& data)
-    : ImageDataArray(Ref<JSC::ArrayBufferView>(WTF::move(data)))
-{ }
-
 ImageDataArray::ImageDataArray(ImageDataArray&& original, std::optional<ImageDataPixelFormat> overridingPixelFormat)
     : m_arrayBufferView(WTF::move(original).extractBufferViewWithPixelFormat(overridingPixelFormat))
 { }

--- a/Source/WebCore/html/ImageDataArray.h
+++ b/Source/WebCore/html/ImageDataArray.h
@@ -41,8 +41,7 @@ public:
     static constexpr bool isSupported(JSC::TypedArrayType type) { return !!toImageDataPixelFormat(type); }
     static bool NODELETE isSupported(const JSC::ArrayBufferView&);
 
-    ImageDataArray(Ref<JSC::Uint8ClampedArray>&&);
-    ImageDataArray(Ref<JSC::Float16Array>&&);
+    ImageDataArray(Ref<JSC::ArrayBufferView>&&);
     ImageDataArray(ImageDataArray&& original, std::optional<ImageDataPixelFormat> overridingPixelFormat);
 
     static std::optional<ImageDataArray> tryCreate(size_t, ImageDataPixelFormat, std::span<const uint8_t> = { });
@@ -60,8 +59,6 @@ public:
     Ref<JSON::Value> copyToJSONArray() const;
 
 private:
-    ImageDataArray(Ref<JSC::ArrayBufferView>&&);
-
     Ref<ArrayBufferView> extractBufferViewWithPixelFormat(std::optional<ImageDataPixelFormat>) &&;
 
     // Needed by `toJS<IDLUnion<IDLUint8ClampedArray, ...>, const ImageDataArray&>()`

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
@@ -2610,7 +2610,7 @@ RefPtr<ImageData> CanvasRenderingContext2DBase::makeImageDataIfContentsCached(co
         .rows = data->mutableSpan(),
     };
     convertImagePixels(source, destination, size);
-    return ImageData::create(size, WTF::move(data), m_settings.colorSpace);
+    return ImageData::create(size, Ref<JSC::ArrayBufferView>(WTF::move(data)), m_settings.colorSpace);
 }
 
 ExceptionOr<Ref<ImageData>> CanvasRenderingContext2DBase::getImageData(int sx, int sy, int sw, int sh, std::optional<ImageDataSettings> settings) const
@@ -2644,7 +2644,7 @@ ExceptionOr<Ref<ImageData>> CanvasRenderingContext2DBase::getImageData(int sx, i
             return Exception { ExceptionCode::InvalidStateError };
 
         auto format = PixelBufferFormat { AlphaPremultiplication::Unpremultiplied, outputPixelFormat, buffer->colorSpace() };
-        RefPtr pixelBuffer = dynamicDowncast<ByteArrayPixelBuffer>(buffer->getPixelBuffer(format, imageDataRect));
+        RefPtr pixelBuffer = dynamicDowncast<ArrayPixelBuffer>(buffer->getPixelBuffer(format, imageDataRect));
         if (!pixelBuffer)
             return Exception { ExceptionCode::InvalidStateError };
 


### PR DESCRIPTION
#### b005d0812158d04e151bbd671e718228adedbd40
<pre>
Make ImageData work with non-Typed ArrayPixelBuffer
<a href="https://bugs.webkit.org/show_bug.cgi?id=320622">https://bugs.webkit.org/show_bug.cgi?id=320622</a>
<a href="https://rdar.apple.com/183589141">rdar://183589141</a>

Reviewed by Mike Wyrzykowski.

Creating an `ImageData` from an `ArrayPixelBuffer` had to be done
through a concrete `TypedArrayPixelBuffer` (`Byte`- or `Float16`-),
which would become more cumbersome in the near future as HDR-capable
float16 buffers are added in more places, usually as generic non-`Typed`
`ArrayPixelBuffer` interface.

So this patch replaces groups of `Typed`-only `ImageData::create()`
functions with more generic `ArrayPixelBuffer` ones.
Under the covers, ImageDataArray was already referencing a generic
JSC::ArrayBufferView anyway, so this shouldn&apos;t introduce extra work.

A couple of callers had to explicitly convert their current
`Ref&lt;ByteArrayPixelBuffer&gt;` to a `Ref&lt;ArrayPixelBuffer&gt;` to avoid
ambiguous calls; but it&apos;s only temporary as eventually these users will
transition to float16-capable `ArrayPixelBuffer`s.

Covered by existing tests.

* Source/WebCore/html/HTMLCanvasElement.cpp:
(WebCore::HTMLCanvasElement::getImageData):
* Source/WebCore/html/ImageData.cpp:
(WebCore::ImageData::create):
* Source/WebCore/html/ImageData.h:
(WebCore::ImageData::create):
* Source/WebCore/html/ImageDataArray.cpp:
* Source/WebCore/html/ImageDataArray.h:
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
(WebCore::CanvasRenderingContext2DBase::makeImageDataIfContentsCached const):
(WebCore::CanvasRenderingContext2DBase::getImageData const):

Canonical link: <a href="https://commits.webkit.org/318348@main">https://commits.webkit.org/318348@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/add1ac489f2f7575a33655f45dce3e2b4aff955e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177696 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51634 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45428 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187301 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140943 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4ebc7bee-00c7-439f-8d36-24a1dcdf8273) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179559 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52926 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51343 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138503 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140943 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/63050904-dc62-4775-80ae-d8c989dff35e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180652 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42020 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159239 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118967 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/21aec20a-8370-4e2c-af6e-7e50ebf8fed1) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40681 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39045 "Passed tests") | | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/7735 "Build is in progress. Recent messages:") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151088 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38735 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35767 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/43419 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43280 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189732 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51301 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147614 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39725 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51983 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35363 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147402 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42113 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124198 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118611 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50491 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13712 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49887 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50127 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49949 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->