### PR TITLE
[WGSL] Fix uninitialized VisibilityValidator::m_stage member

### DIFF
--- a/Source/WebGPU/WGSL/VisibilityValidator.cpp
+++ b/Source/WebGPU/WGSL/VisibilityValidator.cpp
@@ -48,7 +48,7 @@ private:
     void error(const SourceSpan&, Arguments&&...);
 
     ShaderModule& m_shaderModule;
-    ShaderStage m_stage;
+    ShaderStage m_stage { ShaderStage::Vertex };
 };
 
 VisibilityValidator::VisibilityValidator(ShaderModule& shaderModule)


### PR DESCRIPTION
#### ced1eafb18fd6397a9cf57777148df375a0e0331
<pre>
[WGSL] Fix uninitialized VisibilityValidator::m_stage member
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=320319">https://bugs.webkit.org/show_bug.cgi?id=320319</a>&gt;
&lt;<a href="https://rdar.apple.com/183260812">rdar://183260812</a>&gt;

Reviewed by Dan Glastonbury.

The constructor initializes only `m_shaderModule`, leaving the
`m_stage` enum member with an indeterminate value.  `validate()`
assigns `m_stage` per entry point before visiting each one, but a
shader module with no entry points never enters that loop, so any
later read of `m_stage` would observe an indeterminate value.

Initialize `m_stage` to `ShaderStage::Vertex`, matching how the
sibling `IOValidator` and `GlobalVariableRewriter` passes default the
same member.  This silences the clang static analyzer&apos;s
`optin.cplusplus.UninitializedObject` finding.

* Source/WebGPU/WGSL/VisibilityValidator.cpp:
(WGSL::VisibilityValidator::VisibilityValidator):

Canonical link: <a href="https://commits.webkit.org/318025@main">https://commits.webkit.org/318025@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e65c4a977b554068fe0e6df2cfd0d41575f3ed63

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176828 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50765 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44557 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186430 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140064 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b2d910af-ddbe-4316-abc1-2503d6056631) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52058 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50451 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137755 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140064 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/cd4a8f50-36ed-4648-82a4-810e0f4c3116) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179784 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41263 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158542 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118229 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c13ecc76-f395-4707-b3e0-33199f821e15) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39917 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38284 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150329 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38041 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34898 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42510 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42499 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188854 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50432 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146826 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39522 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51115 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34663 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146628 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41391 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123323 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117537 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49620 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13020 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49019 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49255 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49080 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->