### PR TITLE
Add removeIf() to WeakHashSet and WeakListHashSet and adopt it to simplify more remove-matching-entries loops

### DIFF
--- a/Source/WTF/wtf/WeakHashSet.h
+++ b/Source/WTF/wtf/WeakHashSet.h
@@ -142,6 +142,17 @@ public:
         return removed;
     }
 
+    template<typename Functor>
+    bool removeIf(NOESCAPE Functor&& functor)
+    {
+        bool result = m_set.removeIf([&](const KeyType& item) {
+            auto* pointer = item.get();
+            return !pointer || functor(*pointer);
+        });
+        cleanupHappened();
+        return result;
+    }
+
     void clear()
     {
         m_set.clear();

--- a/Source/WTF/wtf/WeakListHashSet.h
+++ b/Source/WTF/wtf/WeakListHashSet.h
@@ -289,6 +289,17 @@ public:
         return result;
     }
 
+    template<typename Functor>
+    bool removeIf(NOESCAPE Functor&& functor)
+    {
+        bool result = m_set.removeIf([&](const KeyType& item) {
+            auto* pointer = item.get();
+            return !pointer || functor(*pointer);
+        });
+        cleanupHappened();
+        return result;
+    }
+
     void clear()
     {
         m_set.clear();

--- a/Source/WebCore/Modules/gamepad/GamepadManager.cpp
+++ b/Source/WebCore/Modules/gamepad/GamepadManager.cpp
@@ -275,34 +275,24 @@ void GamepadManager::updateQuarantineStatus()
     if (m_gamepadQuarantinedNavigators.isEmptyIgnoringNullReferences() && m_gamepadQuarantinedDOMWindows.isEmptyIgnoringNullReferences())
         return;
 
-    WeakHashSet<Navigator> navigators;
-    WeakHashSet<LocalDOMWindow, WeakPtrImplWithEventTargetData> windows;
-    for (auto& navigator : m_gamepadQuarantinedNavigators) {
+    m_gamepadQuarantinedNavigators.removeIf([&](auto& navigator) {
         RefPtr page = navigator.page();
         if (page && page->gamepadAccessGranted()) {
             LOG(Gamepad, "(%u) GamepadManager found navigator %p to release from quarantine", (unsigned)getpid(), &navigator);
-            navigators.add(navigator);
+            m_gamepadBlindNavigators.add(navigator);
+            return true;
         }
-    }
-    for (auto& window : m_gamepadQuarantinedDOMWindows) {
+        return false;
+    });
+    m_gamepadQuarantinedDOMWindows.removeIf([&](auto& window) {
         RefPtr page = window.page();
         if (page && page->gamepadAccessGranted()) {
             LOG(Gamepad, "(%u) GamepadManager found window %p to release from quarantine", (unsigned)getpid(), &window);
-            windows.add(window);
+            m_gamepadBlindDOMWindows.add(window);
+            return true;
         }
-    }
-
-    if (navigators.isEmptyIgnoringNullReferences() && windows.isEmptyIgnoringNullReferences())
-        return;
-
-    for (auto& navigator : navigators) {
-        m_gamepadBlindNavigators.add(navigator);
-        m_gamepadQuarantinedNavigators.remove(navigator);
-    }
-    for (auto& window : windows) {
-        m_gamepadBlindDOMWindows.add(window);
-        m_gamepadQuarantinedDOMWindows.remove(window);
-    }
+        return false;
+    });
 }
 #endif // PLATFORM(VISION)
 

--- a/Source/WebCore/Modules/indexeddb/IDBObjectStore.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBObjectStore.cpp
@@ -701,21 +701,18 @@ void IDBObjectStore::rollbackForVersionChangeAbort()
 
     Locker locker { m_referencedIndexLock };
 
-    Vector<IDBIndexIdentifier> identifiersToRemove;
     Vector<std::unique_ptr<IDBIndex>> indexesToDelete;
-    for (auto& iterator : m_deletedIndexes) {
-        if (m_info.hasIndex(iterator.key)) {
-            auto name = iterator.value->info().name();
-            auto result = m_referencedIndexes.add(name, nullptr);
-            if (!result.isNewEntry)
-                indexesToDelete.append(std::exchange(result.iterator->value, nullptr));
-            result.iterator->value = std::exchange(iterator.value, nullptr);
-            identifiersToRemove.append(iterator.key);
-        }
-    }
-
-    for (auto identifier : identifiersToRemove)
-        m_deletedIndexes.remove(identifier);
+    m_deletedIndexes.removeIf([&](auto& iterator) {
+        assertIsHeld(m_referencedIndexLock);
+        if (!m_info.hasIndex(iterator.key))
+            return false;
+        auto name = iterator.value->info().name();
+        auto result = m_referencedIndexes.add(name, nullptr);
+        if (!result.isNewEntry)
+            indexesToDelete.append(std::exchange(result.iterator->value, nullptr));
+        result.iterator->value = std::exchange(iterator.value, nullptr);
+        return true;
+    });
 
     for (auto& index : m_referencedIndexes.values())
         index->rollbackInfoForVersionChangeAbort();

--- a/Source/WebCore/Modules/indexeddb/IDBTransaction.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBTransaction.cpp
@@ -231,21 +231,18 @@ void IDBTransaction::abortInternal()
         Locker locker { m_objectStoresLock };
 
         auto& info = m_database->info();
-        Vector<IDBObjectStoreIdentifier> identifiersToRemove;
         Vector<std::unique_ptr<IDBObjectStore>> objectStoresToDelete;
-        for (auto& iterator : m_deletedObjectStores) {
-            if (info.infoForExistingObjectStore(iterator.key)) {
-                auto name = iterator.value->info().name();
-                auto result = m_referencedObjectStores.add(name, nullptr);
-                if (!result.isNewEntry)
-                    objectStoresToDelete.append(std::exchange(result.iterator->value, nullptr));
-                result.iterator->value = std::exchange(iterator.value, nullptr);
-                identifiersToRemove.append(iterator.key);
-            }
-        }
-
-        for (auto identifier : identifiersToRemove)
-            m_deletedObjectStores.remove(identifier);
+        m_deletedObjectStores.removeIf([&](auto& iterator) {
+            assertIsHeld(m_objectStoresLock);
+            if (!info.infoForExistingObjectStore(iterator.key))
+                return false;
+            auto name = iterator.value->info().name();
+            auto result = m_referencedObjectStores.add(name, nullptr);
+            if (!result.isNewEntry)
+                objectStoresToDelete.append(std::exchange(result.iterator->value, nullptr));
+            result.iterator->value = std::exchange(iterator.value, nullptr);
+            return true;
+        });
 
         for (auto& objectStore : m_referencedObjectStores.values())
             objectStore->rollbackForVersionChangeAbort();

--- a/Source/WebCore/Modules/indexeddb/server/IndexValueStore.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/IndexValueStore.cpp
@@ -142,20 +142,14 @@ void IndexValueStore::removeRecord(const IDBKeyData& indexKey)
 
 void IndexValueStore::removeEntriesWithValueKey(MemoryIndex& index, const IDBKeyData& valueKey)
 {
-    Vector<IDBKeyData> entryKeysToRemove;
-    entryKeysToRemove.reserveInitialCapacity(m_records.size());
-
-    for (auto& entry : m_records) {
+    m_records.removeIf([&](auto& entry) {
         if (entry.value->removeKey(valueKey))
             index.notifyCursorsOfValueChange(entry.key, valueKey);
-        if (!entry.value->getCount())
-            entryKeysToRemove.append(entry.key);
-    }
-
-    for (auto& entry : entryKeysToRemove) {
-        m_orderedKeys.erase(entry);
-        m_records.remove(entry);
-    }
+        if (entry.value->getCount())
+            return false;
+        m_orderedKeys.erase(entry.key);
+        return true;
+    });
 }
 
 Vector<IDBKeyData> IndexValueStore::findKeysWithValueKey(const IDBKeyData& valueKey)

--- a/Source/WebCore/animation/StyleOriginatedTimelinesController.cpp
+++ b/Source/WebCore/animation/StyleOriginatedTimelinesController.cpp
@@ -475,9 +475,7 @@ void StyleOriginatedTimelinesController::unregisterNamedTimelinesAssociatedWithE
 {
     LOG_WITH_STREAM(Animations, stream << "StyleOriginatedTimelinesController::unregisterNamedTimelinesAssociatedWithElement element: " << styleable);
 
-    HashSet<AtomString> namesToClear;
-
-    for (auto& entry : m_nameToTimelineMap) {
+    m_nameToTimelineMap.removeIf([&](auto& entry) {
         auto& timelines = entry.value;
         for (size_t i = 0; i < timelines.size(); ++i) {
             auto& timeline = timelines[i];
@@ -486,12 +484,8 @@ void StyleOriginatedTimelinesController::unregisterNamedTimelinesAssociatedWithE
                 timelines.removeAt(i--);
             }
         }
-        if (timelines.isEmpty())
-            namesToClear.add(entry.key);
-    }
-
-    for (auto& name : namesToClear)
-        m_nameToTimelineMap.remove(name);
+        return timelines.isEmpty();
+    });
 }
 
 void StyleOriginatedTimelinesController::styleableWasRemoved(const Styleable& styleable)

--- a/Source/WebCore/loader/cache/CachedResourceLoader.cpp
+++ b/Source/WebCore/loader/cache/CachedResourceLoader.cpp
@@ -1773,25 +1773,22 @@ void CachedResourceLoader::loadDone(LoadCompletionType type, bool shouldPerformP
 // remove it from the map.
 void CachedResourceLoader::garbageCollectDocumentResources()
 {
-    typedef Vector<String, 10> StringVector;
-    StringVector resourcesToDelete;
+    [[maybe_unused]] auto documentResourceCountBefore = m_documentResources.size();
 
-    for (auto& resourceEntry : m_documentResources) {
+    m_documentResources.removeIf([&](auto& resourceEntry) {
         Ref resource = *resourceEntry.value;
 
         // A refcount of 2 is guaranteed by the m_documentResources ref and `resource` variable ref.
         // If the resource is in the memory cache then the cache is also holding a ref, making the ref-count 3.
         bool resourceHasExternalUsers = resource->refCount() > (resource->inCache() ? 3u : 2u);
         if (!resourceHasExternalUsers && !resource->loader() && !resource->isPreloaded()) {
-            resourcesToDelete.append(resourceEntry.key);
             m_resourceTimingInfo.removeResourceTiming(resource);
+            return true;
         }
-    }
+        return false;
+    });
 
-    LOG_WITH_STREAM(ResourceLoading, stream << "CachedResourceLoader " << this << " garbageCollectDocumentResources - deleting " << resourcesToDelete.size() << " resources");
-
-    for (auto& resource : resourcesToDelete)
-        m_documentResources.remove(resource);
+    LOG_WITH_STREAM(ResourceLoading, stream << "CachedResourceLoader " << this << " garbageCollectDocumentResources - deleting " << (documentResourceCountBefore - m_documentResources.size()) << " resources");
 }
 
 void CachedResourceLoader::performPostLoadActions()

--- a/Source/WebCore/platform/graphics/cg/CGSubimageCacheWithTimer.cpp
+++ b/Source/WebCore/platform/graphics/cg/CGSubimageCacheWithTimer.cpp
@@ -99,17 +99,14 @@ void CGSubimageCacheWithTimer::prune()
 {
     auto now = MonotonicTime::now();
 
-    Vector<CacheEntry> toBeRemoved;
-
-    for (const auto& entry : m_cache) {
-        if ((now - entry.lastAccessTime) > CGSubimageCacheWithTimer::cacheEntryLifetime)
-            toBeRemoved.append(entry);
-    }
-
-    for (auto& entry : toBeRemoved) {
-        m_imageCounts.remove(entry.image.get());
-        m_cache.remove(entry);
-    }
+    m_cache.removeIf([&](auto& entry) {
+        assertIsHeld(m_lock);
+        if ((now - entry.lastAccessTime) > CGSubimageCacheWithTimer::cacheEntryLifetime) {
+            m_imageCounts.remove(entry.image.get());
+            return true;
+        }
+        return false;
+    });
 }
 
 RetainPtr<CGImageRef> CGSubimageCacheWithTimer::subimage(CGImageRef image, const FloatRect& rect)

--- a/Source/WebCore/rendering/RenderView.cpp
+++ b/Source/WebCore/rendering/RenderView.cpp
@@ -1009,13 +1009,9 @@ void RenderView::resumePausedImageAnimationsIfNeeded(const IntRect& visibleRect)
     for (auto& pair : toRemove)
         removeRendererWithPausedImageAnimations(*pair.first, protect(*pair.second));
 
-    Vector<Ref<SVGSVGElement>> svgSvgElementsToRemove;
-    m_SVGSVGElementsWithPausedImageAnimation.forEach([&] (WeakPtr<SVGSVGElement, WeakPtrImplWithEventTargetData> svgSvgElement) {
-        if (svgSvgElement && svgSvgElement->resumePausedAnimationsIfNeeded(visibleRect))
-            svgSvgElementsToRemove.append(*svgSvgElement);
+    m_SVGSVGElementsWithPausedImageAnimation.removeIf([&](auto& svgSvgElement) {
+        return svgSvgElement.resumePausedAnimationsIfNeeded(visibleRect);
     });
-    for (auto& svgSvgElement : svgSvgElementsToRemove)
-        m_SVGSVGElementsWithPausedImageAnimation.remove(svgSvgElement.get());
 }
 
 #if ENABLE(ACCESSIBILITY_ANIMATION_CONTROL)

--- a/Source/WebKit/NetworkProcess/NetworkBroadcastChannelRegistry.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkBroadcastChannelRegistry.cpp
@@ -118,21 +118,13 @@ void NetworkBroadcastChannelRegistry::postMessage(IPC::Connection& connection, c
 
 void NetworkBroadcastChannelRegistry::removeConnection(IPC::Connection& connection)
 {
-    Vector<WebCore::ClientOrigin> originsToRemove;
-    for (auto& entry : m_broadcastChannels) {
-        Vector<String> namesToRemove;
-        for (auto& innerEntry : entry.value) {
+    m_broadcastChannels.removeIf([&](auto& entry) {
+        entry.value.removeIf([&](auto& innerEntry) {
             innerEntry.value.removeFirst(connection.uniqueID());
-            if (innerEntry.value.isEmpty())
-                namesToRemove.append(innerEntry.key);
-        }
-        for (auto& nameToRemove : namesToRemove)
-            entry.value.remove(nameToRemove);
-        if (entry.value.isEmpty())
-            originsToRemove.append(entry.key);
-    }
-    for (auto& originToRemove : originsToRemove)
-        m_broadcastChannels.remove(originToRemove);
+            return innerEntry.value.isEmpty();
+        });
+        return entry.value.isEmpty();
+    });
 }
 
 std::optional<SharedPreferencesForWebProcess> NetworkBroadcastChannelRegistry::sharedPreferencesForWebProcess(const IPC::Connection& connection) const

--- a/Source/WebKit/NetworkProcess/storage/CacheStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageManager.cpp
@@ -475,19 +475,17 @@ void CacheStorageManager::connectionClosed(IPC::Connection::UniqueID connection)
 {
     m_activeConnections.remove(connection);
 
-    HashSet<WebCore::DOMCacheIdentifier> unusedCacheIdentifiers;
-    for (auto& [identifier, refConnections] : m_cacheRefConnections) {
+    m_cacheRefConnections.removeIf([&](auto& entry) {
+        auto& [identifier, refConnections] = entry;
         refConnections.removeAllMatching([&](auto refConnection) {
             return refConnection == connection;
         });
         if (refConnections.isEmpty()) {
             removeUnusedCache(identifier);
-            unusedCacheIdentifiers.add(identifier);
+            return true;
         }
-    }
-
-    for (auto& identifier : unusedCacheIdentifiers)
-        m_cacheRefConnections.remove(identifier);
+        return false;
+    });
 }
 
 void CacheStorageManager::removeUnusedCache(WebCore::DOMCacheIdentifier cacheIdentifier)

--- a/Source/WebKit/UIProcess/WebBackForwardCache.cpp
+++ b/Source/WebKit/UIProcess/WebBackForwardCache.cpp
@@ -224,6 +224,8 @@ void WebBackForwardCache::removeEntriesMatching(NOESCAPE const Function<bool(Web
             itemsWithEntriesToClear.append(WTF::move(item));
     }
     for (Ref item : itemsWithEntriesToClear) {
+        // Clearing the BackForwardCache entry can destroy its SuspendedPageProxy, whose teardown
+        // can re-enter WebBackForwardCache and mutate m_itemsWithCachedPage, so remove before clearing.
         m_itemsWithCachedPage.remove(item.get());
         item->setBackForwardCacheEntry(nullptr);
     }

--- a/Source/WebKit/UIProcess/WebProcessCache.cpp
+++ b/Source/WebKit/UIProcess/WebProcessCache.cpp
@@ -371,38 +371,32 @@ void WebProcessCache::clear()
 
 void WebProcessCache::clearAllProcessesForSession(PAL::SessionID sessionID)
 {
-    Vector<std::tuple<WebCore::Site, WebCore::Site>> keysToRemove;
-    for (auto& pair : m_processesPerSite) {
+    m_processesPerSite.removeIf([&](auto& pair) {
         RefPtr dataStore = pair.value->process().websiteDataStore();
         if (!dataStore || dataStore->sessionID() == sessionID) {
             WEBPROCESSCACHE_RELEASE_LOG("clearAllProcessesForSession: Evicting process because its session was destroyed", pair.value->process().processID());
-            keysToRemove.append(pair.key);
+            return true;
         }
-    }
-    for (auto& key : keysToRemove)
-        m_processesPerSite.remove(key);
+        return false;
+    });
 
-    HashMap<WebCore::Site, Ref<CachedProcess>> sharedProcessesPerSite;
-    for (auto& pair : m_sharedProcessesPerSite) {
+    m_sharedProcessesPerSite.removeIf([&](auto& pair) {
         RefPtr dataStore = pair.value->process().websiteDataStore();
         if (!dataStore || dataStore->sessionID() == sessionID) {
             WEBPROCESSCACHE_RELEASE_LOG("clearAllProcessesForSession: Evicting shared process because its session was destroyed", pair.value->process().processID());
-            continue;
+            return true;
         }
-        sharedProcessesPerSite.add(pair.key, pair.value);
-    }
-    m_sharedProcessesPerSite = std::exchange(sharedProcessesPerSite, { });
+        return false;
+    });
 
-    Vector<uint64_t> pendingRequestsToRemove;
-    for (auto& pair : m_pendingAddRequests) {
+    m_pendingAddRequests.removeIf([&](auto& pair) {
         RefPtr dataStore = pair.value->process().websiteDataStore();
         if (!dataStore || dataStore->sessionID() == sessionID) {
             WEBPROCESSCACHE_RELEASE_LOG("clearAllProcessesForSession: Evicting process because its session was destroyed", pair.value->process().processID());
-            pendingRequestsToRemove.append(pair.key);
+            return true;
         }
-    }
-    for (auto& key : pendingRequestsToRemove)
-        m_pendingAddRequests.remove(key);
+        return false;
+    });
 }
 
 void WebProcessCache::setApplicationIsActive(bool isActive)

--- a/Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.cpp
@@ -279,16 +279,12 @@ void WebFoundTextRangeController::decorateTextRangeWithStyle(const WebFoundTextR
                 flashTextIndicatorAndUpdateSelectionWithRange(*simpleRange);
 
             if (ancestorsRevealed) {
-                HashSet<WebFoundTextRange> rangesToRemove;
-                for (auto unhighlightedRange : m_unhighlightedFoundRanges) {
-                    if (auto unhighlightedSimpleRange = simpleRangeFromFoundTextRange(unhighlightedRange)) {
-                        auto addedMarker = protect(protect(unhighlightedSimpleRange->start.document())->markers())->addMarker(*unhighlightedSimpleRange, WebCore::DocumentMarkerType::TextMatch);
-                        if (addedMarker)
-                            rangesToRemove.add(unhighlightedRange);
-                    }
-                }
-                for (auto rangeToRemove : rangesToRemove)
-                    m_unhighlightedFoundRanges.remove(rangeToRemove);
+                m_unhighlightedFoundRanges.removeIf([&](auto& unhighlightedRange) {
+                    auto unhighlightedSimpleRange = simpleRangeFromFoundTextRange(unhighlightedRange);
+                    if (!unhighlightedSimpleRange)
+                        return false;
+                    return protect(protect(unhighlightedSimpleRange->start.document())->markers())->addMarker(*unhighlightedSimpleRange, WebCore::DocumentMarkerType::TextMatch);
+                });
             }
             break;
         }

--- a/Tools/TestWebKitAPI/Tests/WTF/WeakPtr.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/WeakPtr.cpp
@@ -623,6 +623,62 @@ TEST(WTF_WeakPtr, WeakHashSetBasic)
     EXPECT_EQ(s_baseWeakReferences, 0u);
 }
 
+TEST(WTF_WeakPtr, WeakHashSetRemoveIf)
+{
+    {
+        WeakHashSet<Base> weakHashSet;
+        Base object1;
+        Base object2;
+        Base object3;
+        weakHashSet.add(object1);
+        weakHashSet.add(object2);
+        weakHashSet.add(object3);
+        EXPECT_EQ(computeSizeOfWeakHashSet(weakHashSet), 3u);
+
+        bool removedAny = weakHashSet.removeIf([&](Base& item) {
+            return &item == &object2;
+        });
+        EXPECT_TRUE(removedAny);
+        EXPECT_TRUE(weakHashSet.contains(object1));
+        EXPECT_FALSE(weakHashSet.contains(object2));
+        EXPECT_TRUE(weakHashSet.contains(object3));
+        EXPECT_EQ(computeSizeOfWeakHashSet(weakHashSet), 2u);
+
+        bool removedNone = weakHashSet.removeIf([](Base&) {
+            return false;
+        });
+        EXPECT_FALSE(removedNone);
+        EXPECT_EQ(computeSizeOfWeakHashSet(weakHashSet), 2u);
+        weakHashSet.checkConsistency();
+    }
+    EXPECT_EQ(s_baseWeakReferences, 0u);
+
+    {
+        // removeIf() drops dead (null) weak references as it iterates and reports them
+        // as removed, but never invokes the predicate for them.
+        WeakHashSet<Base> weakHashSet;
+        auto object1 = makeUnique<Base>();
+        Base object2;
+        weakHashSet.add(*object1);
+        weakHashSet.add(object2);
+        EXPECT_EQ(s_baseWeakReferences, 2u);
+        object1 = nullptr;
+
+        unsigned predicateCalls = 0;
+        bool removedAny = weakHashSet.removeIf([&](Base& item) {
+            ++predicateCalls;
+            EXPECT_EQ(&item, &object2);
+            return false;
+        });
+        EXPECT_TRUE(removedAny);
+        EXPECT_EQ(predicateCalls, 1u);
+        EXPECT_TRUE(weakHashSet.contains(object2));
+        EXPECT_EQ(computeSizeOfWeakHashSet(weakHashSet), 1u);
+        weakHashSet.checkConsistency();
+    }
+    EXPECT_EQ(s_baseWeakReferences, 0u);
+}
+
 TEST(WTF_WeakPtr, WeakHashSetConstObjects)
 {
     {
@@ -2150,6 +2206,62 @@ TEST(WTF_WeakPtr, WeakListHashMapConstObjects)
         EXPECT_EQ(computeSizeOfWeakListHashSet(weakListHashSet), 0u);
         EXPECT_FALSE(weakListHashSet.contains(object));
     }
+}
+
+TEST(WTF_WeakPtr, WeakListHashSetRemoveIf)
+{
+    {
+        WeakListHashSet<Base> weakListHashSet;
+        Base object1;
+        Base object2;
+        Base object3;
+        Base object4;
+        weakListHashSet.add(object1);
+        weakListHashSet.add(object2);
+        weakListHashSet.add(object3);
+        weakListHashSet.add(object4);
+        EXPECT_EQ(computeSizeOfWeakListHashSet(weakListHashSet), 4u);
+
+        // Remove object2 and object3; object1 and object4 must remain in insertion order.
+        bool removedAny = weakListHashSet.removeIf([&](Base& item) {
+            return &item == &object2 || &item == &object3;
+        });
+        EXPECT_TRUE(removedAny);
+        EXPECT_EQ(computeSizeOfWeakListHashSet(weakListHashSet), 2u);
+
+        Vector<Base*> objectsInIterationOrder;
+        for (auto& object : weakListHashSet)
+            objectsInIterationOrder.append(&object);
+        EXPECT_EQ(objectsInIterationOrder.size(), 2u);
+        EXPECT_EQ(objectsInIterationOrder[0], &object1);
+        EXPECT_EQ(objectsInIterationOrder[1], &object4);
+        weakListHashSet.checkConsistency();
+    }
+    EXPECT_EQ(s_baseWeakReferences, 0u);
+
+    {
+        // removeIf() drops dead (null) weak references without invoking the predicate.
+        WeakListHashSet<Base> weakListHashSet;
+        auto object1 = makeUnique<Base>();
+        Base object2;
+        weakListHashSet.add(*object1);
+        weakListHashSet.add(object2);
+        EXPECT_EQ(s_baseWeakReferences, 2u);
+        object1 = nullptr;
+
+        unsigned predicateCalls = 0;
+        bool removedAny = weakListHashSet.removeIf([&](Base& item) {
+            ++predicateCalls;
+            EXPECT_EQ(&item, &object2);
+            return false;
+        });
+        EXPECT_TRUE(removedAny);
+        EXPECT_EQ(predicateCalls, 1u);
+        EXPECT_TRUE(weakListHashSet.contains(object2));
+        EXPECT_EQ(computeSizeOfWeakListHashSet(weakListHashSet), 1u);
+        weakListHashSet.checkConsistency();
+    }
+    EXPECT_EQ(s_baseWeakReferences, 0u);
 }
 
 TEST(WTF_WeakPtr, WeakListHashSetRemoveIterator)


### PR DESCRIPTION
#### f7a9d16e1531496bbe9d20952252b0d28aa56061
<pre>
Add removeIf() to WeakHashSet and WeakListHashSet and adopt it to simplify more remove-matching-entries loops
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=320324">https://bugs.webkit.org/show_bug.cgi?id=320324</a>&gt;
&lt;<a href="https://rdar.apple.com/183264359">rdar://183264359</a>&gt;

Reviewed by Darin Adler, Abrar Rahman Protyasha, and Zak Ridouh.

Follow-up to 317934@main, which implemented the same optimization
at sites whose predicate was a pure function of the element.  The
sites converted here additionally perform a per-element side effect (a
release log, a secondary-container update, or `std::exchange`
bookkeeping).  Because `removeIf()` visits each live entry exactly once,
the side effect moves into the lambda unchanged, eliminating the
temporary storage and the second traversal.

One candidate, `WebBackForwardCache::removeEntriesMatching()`, is
intentionally left as a two-pass loop: its side effect can destroy a
`SuspendedPageProxy` whose teardown re-enters the cache and mutates the
container, which a single-pass `removeIf()` would do mid-iteration.

Add `removeIf()` to `WeakHashSet` and `WeakListHashSet` so that call
sites backed by those weak containers can use the same single-pass
algorithm.  `HashMap`, `HashSet`, `ListHashSet`, and `WeakHashMap`
already provide it; the two additions delegate to the underlying
container&apos;s `removeIf()`, drop dead (null) weak references without
invoking the predicate, and then run the amortized cleanup, matching
`WeakHashMap::removeIf()`.

Where the predicate reads a member guarded by a lock, the lambda calls
`assertIsHeld()` because the Clang thread-safety analyzer does not carry
the caller&apos;s lock state into a lambda body.

Tests: WTF_WeakPtr.WeakHashSetRemoveIf
       WTF_WeakPtr.WeakListHashSetRemoveIf

* Source/WTF/wtf/WeakHashSet.h:
(WTF::WeakHashSet::removeIf): Add.
* Source/WTF/wtf/WeakListHashSet.h:
(WTF::WeakListHashSet::removeIf): Add.
* Source/WebCore/Modules/gamepad/GamepadManager.cpp:
(WebCore::GamepadManager::updateQuarantineStatus):
* Source/WebCore/Modules/indexeddb/IDBObjectStore.cpp:
(WebCore::IDBObjectStore::rollbackForVersionChangeAbort):
* Source/WebCore/Modules/indexeddb/IDBTransaction.cpp:
(WebCore::IDBTransaction::abortInternal):
* Source/WebCore/Modules/indexeddb/server/IndexValueStore.cpp:
(WebCore::IDBServer::IndexValueStore::removeEntriesWithValueKey):
* Source/WebCore/animation/StyleOriginatedTimelinesController.cpp:
(WebCore::StyleOriginatedTimelinesController::unregisterNamedTimelinesAssociatedWithElement):
* Source/WebCore/loader/cache/CachedResourceLoader.cpp:
(WebCore::CachedResourceLoader::garbageCollectDocumentResources):
* Source/WebCore/platform/graphics/cg/CGSubimageCacheWithTimer.cpp:
(WebCore::CGSubimageCacheWithTimer::prune):
* Source/WebCore/rendering/RenderView.cpp:
(WebCore::RenderView::resumePausedImageAnimationsIfNeeded):
* Source/WebKit/NetworkProcess/NetworkBroadcastChannelRegistry.cpp:
(WebKit::NetworkBroadcastChannelRegistry::removeConnection):
* Source/WebKit/NetworkProcess/storage/CacheStorageManager.cpp:
(WebKit::CacheStorageManager::connectionClosed):
* Source/WebKit/UIProcess/WebBackForwardCache.cpp:
(WebKit::WebBackForwardCache::removeEntriesMatching):
- Document why removeIf() can&apos;t be used.
* Source/WebKit/UIProcess/WebProcessCache.cpp:
(WebKit::WebProcessCache::clearAllProcessesForSession):
* Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.cpp:
(WebKit::WebFoundTextRangeController::decorateTextRangeWithStyle):
* Tools/TestWebKitAPI/Tests/WTF/WeakPtr.cpp:
(TestWebKitAPI::TEST(WTF_WeakPtr, WeakHashSetRemoveIf)): Add.
(TestWebKitAPI::TEST(WTF_WeakPtr, WeakListHashSetRemoveIf)): Add.

Canonical link: <a href="https://commits.webkit.org/318341@main">https://commits.webkit.org/318341@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c4ac689fe1ae5b8de8d383206f8bc3b32b31ad58

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177661 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51599 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45393 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187265 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140908 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0dd4f44d-104e-4989-9dda-592bfefb74e1) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179524 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52891 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51308 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138507 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140908 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1411b473-9ece-4a19-9335-0e8992fd5388) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180617 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41986 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159216 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118971 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7a39b1b4-1870-4518-b52d-15c46a2598a3) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40647 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39015 "Passed tests") | [❌ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/940 "") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/7712 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151054 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38712 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35732 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/38932 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/43384 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43250 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189696 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51266 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147581 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51948 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35340 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147371 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26999 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42084 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124163 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118576 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50456 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13689 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49852 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50092 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49914 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->