### PR TITLE
[Cookie Store] Preserve cookie change subscription list order

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/cookiestore/cookieStore_subscribe_arguments.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookiestore/cookieStore_subscribe_arguments.https.any-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL cookieStore.subscribe without name or url in options assert_equals: expected (string) "cookie-name" but got (undefined) undefined
+PASS cookieStore.subscribe without name or url in options
 PASS cookieStore.subscribe with empty option
 PASS cookieStore.subscribe with invalid url path in option
 PASS cookieStore.subscribe is idempotent

--- a/LayoutTests/imported/w3c/web-platform-tests/cookiestore/cookieStore_subscribe_arguments.https.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookiestore/cookieStore_subscribe_arguments.https.any.serviceworker-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL cookieStore.subscribe without name or url in options assert_equals: expected (string) "cookie-name" but got (undefined) undefined
+PASS cookieStore.subscribe without name or url in options
 PASS cookieStore.subscribe with empty option
 PASS cookieStore.subscribe with invalid url path in option
 PASS cookieStore.subscribe is idempotent

--- a/Source/WebCore/workers/service/server/SWServerRegistration.cpp
+++ b/Source/WebCore/workers/service/server/SWServerRegistration.cpp
@@ -431,12 +431,14 @@ std::optional<ExceptionData> SWServerRegistration::setNavigationPreloadHeaderVal
 
 void SWServerRegistration::addCookieChangeSubscriptions(Vector<CookieChangeSubscription>&& subscriptions)
 {
-    m_cookieChangeSubscriptions.addAll(WTF::move(subscriptions));
+    for (auto& subscription : subscriptions)
+        m_cookieChangeSubscriptions.add(WTF::move(subscription));
 }
 
 void SWServerRegistration::removeCookieChangeSubscriptions(Vector<CookieChangeSubscription>&& subscriptions)
 {
-    m_cookieChangeSubscriptions.removeAll(subscriptions);
+    for (auto& subscription : subscriptions)
+        m_cookieChangeSubscriptions.remove(subscription);
 }
 
 Vector<CookieChangeSubscription> SWServerRegistration::cookieChangeSubscriptions() const

--- a/Source/WebCore/workers/service/server/SWServerRegistration.h
+++ b/Source/WebCore/workers/service/server/SWServerRegistration.h
@@ -36,6 +36,7 @@
 #include <wtf/HashCountedSet.h>
 #include <wtf/HashSet.h>
 #include <wtf/Identified.h>
+#include <wtf/ListHashSet.h>
 #include <wtf/MonotonicTime.h>
 #include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/TZoneMalloc.h>
@@ -142,7 +143,7 @@ private:
     RefPtr<SWServerWorker> m_waitingWorker;
     RefPtr<SWServerWorker> m_activeWorker;
 
-    HashSet<CookieChangeSubscription> m_cookieChangeSubscriptions;
+    ListHashSet<CookieChangeSubscription> m_cookieChangeSubscriptions;
 
     WallTime m_lastUpdateTime;
     


### PR DESCRIPTION
#### 3996020d9c9cde340f8c1607915dfa471d8658e4
<pre>
[Cookie Store] Preserve cookie change subscription list order
<a href="https://bugs.webkit.org/show_bug.cgi?id=320332">https://bugs.webkit.org/show_bug.cgi?id=320332</a>
<a href="https://rdar.apple.com/183271849">rdar://183271849</a>

Reviewed by Rupin Mittal.

The Cookie Store specification stores a service worker registration&apos;s cookie change subscriptions
in a list. subscribe() appends new subscriptions to that list, and getSubscriptions() iterates the
list in order.

Use ListHashSet to preserve the specified list order while avoiding duplicate subscriptions.

* LayoutTests/imported/w3c/web-platform-tests/cookiestore/cookieStore_subscribe_arguments.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookiestore/cookieStore_subscribe_arguments.https.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookiestore/httponly_cookies.https.window-expected.txt:
* Source/WebCore/workers/service/server/SWServerRegistration.cpp:
(WebCore::SWServerRegistration::addCookieChangeSubscriptions):
(WebCore::SWServerRegistration::removeCookieChangeSubscriptions):
* Source/WebCore/workers/service/server/SWServerRegistration.h:

Canonical link: <a href="https://commits.webkit.org/318087@main">https://commits.webkit.org/318087@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/07792f66ef2cd567f55c6efa4995670f6fa49596

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176994 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50931 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44726 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186597 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140230 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/15094dbc-a773-4b8d-bbfe-af05e1bf2764) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178857 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52224 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50617 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137909 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140230 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5eec7c92-dbe2-4394-be0a-2162270bcac9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179950 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41419 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158695 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118378 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/28d73917-e8d6-4e23-b968-abcc987e8b4a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40075 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38442 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150485 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38195 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35065 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42684 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42660 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189020 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50598 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146988 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51281 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34819 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146784 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26887 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41539 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123494 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117782 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49786 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13175 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49185 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49422 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49246 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->