### PR TITLE
IPC::MessageLog::add() has a data race on the ring buffer element store

### DIFF
--- a/Source/WebKit/Platform/IPC/MessageLog.cpp
+++ b/Source/WebKit/Platform/IPC/MessageLog.cpp
@@ -32,9 +32,9 @@ constinit MessageLog<messageLogCapacity> gMessageLog;
 
 const MessageLogMetadata gMessageLogMetadata = {
     .version = 0,
-    .capacity = std::tuple_size_v<std::remove_reference_t<decltype(gMessageLog.bufferForTesting())>>,
-    .elementSize = sizeof(std::remove_reference_t<decltype(gMessageLog.bufferForTesting())>::value_type),
-    .size = sizeof(std::remove_reference_t<decltype(gMessageLog.bufferForTesting())>),
+    .capacity = gMessageLog.capacity(),
+    .elementSize = gMessageLog.elementSize(),
+    .size = gMessageLog.bufferSize(),
     .initialValue = MessageName::Invalid
 };
 

--- a/Source/WebKit/Platform/IPC/MessageLog.h
+++ b/Source/WebKit/Platform/IPC/MessageLog.h
@@ -29,6 +29,7 @@
 #include <WebKit/WKDeclarationSpecifiers.h>
 #include <array>
 #include <atomic>
+#include <utility>
 #include <wtf/ExportMacros.h>
 #include <wtf/MathExtras.h>
 #include <wtf/Noncopyable.h>
@@ -43,22 +44,33 @@ class MessageLog {
     static_assert(hasOneBitSet(Capacity), "Capacity must be a power of two to handle size_t overflow correctly");
 public:
     constexpr MessageLog()
+        : MessageLog(std::make_index_sequence<Capacity> { })
     {
-        m_buffer.fill(MessageName::Invalid);
     }
 
     void add(MessageName messageName)
     {
         size_t index = m_index.fetch_add(1, std::memory_order_relaxed);
-        m_buffer[index % Capacity] = messageName;
+        m_buffer[index % Capacity].store(messageName, std::memory_order_relaxed);
     }
 
+    constexpr size_t bufferSize() const { return sizeof(m_buffer); }
+    constexpr size_t capacity() const { return bufferSize() / elementSize(); }
+    constexpr size_t elementSize() const { return sizeof(m_buffer[0]); }
+
+    MessageName atForTesting(size_t index) const { return m_buffer[index % Capacity].load(std::memory_order_relaxed); }
     size_t indexForTesting() const { return m_index.load(std::memory_order_relaxed); }
-    const std::array<MessageName, Capacity>& bufferForTesting() const LIFETIME_BOUND { return m_buffer; }
 
 private:
+    // std::atomic is not constexpr-assignable, so expand the initializer over an index sequence.
+    template<size_t... Indices>
+    constexpr MessageLog(std::index_sequence<Indices...>)
+        : m_buffer { (static_cast<void>(Indices), MessageName::Invalid)... }
+    {
+    }
+
     std::atomic<size_t> m_index { 0 };
-    std::array<MessageName, Capacity> m_buffer;
+    std::array<std::atomic<MessageName>, Capacity> m_buffer;
 };
 
 // Exported information to help a debugger read the data

--- a/Tools/TestWebKitAPI/Tests/IPC/MessageLogEndToEndTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/IPC/MessageLogEndToEndTests.cpp
@@ -97,13 +97,11 @@ protected:
 
     bool messageLogContains(IPC::MessageName messageName, size_t startIndex = 0) const
     {
-        const auto& buffer = IPC::messageLog().bufferForTesting();
         size_t currentIndex = IPC::messageLog().indexForTesting();
-        size_t capacity = buffer.size();
 
         // Search from startIndex to currentIndex
         for (size_t i = startIndex; i < currentIndex; ++i) {
-            if (buffer[i % capacity] == messageName)
+            if (IPC::messageLog().atForTesting(i) == messageName)
                 return true;
         }
         return false;
@@ -111,13 +109,12 @@ protected:
 
     size_t countMessagesInLog(IPC::MessageName messageName) const
     {
-        const auto& buffer = IPC::messageLog().bufferForTesting();
-        size_t capacity = buffer.size();
+        size_t capacity = IPC::messageLog().capacity();
         size_t count = 0;
 
         // Count in the entire buffer (for wrap-around tests)
         for (size_t i = 0; i < capacity; ++i) {
-            if (buffer[i] == messageName)
+            if (IPC::messageLog().atForTesting(i) == messageName)
                 count++;
         }
         return count;
@@ -572,11 +569,9 @@ protected:
 
     bool messageLogContains(IPC::MessageName messageName) const
     {
-        const auto& buffer = IPC::messageLog().bufferForTesting();
         size_t currentIndex = IPC::messageLog().indexForTesting();
-        size_t capacity = buffer.size();
         for (size_t i = m_initialLogIndex; i < currentIndex; ++i) {
-            if (buffer[i % capacity] == messageName)
+            if (IPC::messageLog().atForTesting(i) == messageName)
                 return true;
         }
         return false;

--- a/Tools/TestWebKitAPI/Tests/IPC/MessageLogTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/IPC/MessageLogTests.cpp
@@ -39,7 +39,7 @@ TEST(MessageLogTests, InitialState)
     // Verify buffer is initialized with Invalid message names
     EXPECT_EQ(buffer.indexForTesting(), 0u);
     for (size_t i = 0; i < 8; ++i)
-        EXPECT_EQ(buffer.bufferForTesting()[i], IPC::MessageName::Invalid);
+        EXPECT_EQ(buffer.atForTesting(i), IPC::MessageName::Invalid);
 }
 
 TEST(MessageLogTests, AddSingleMessage)
@@ -49,11 +49,11 @@ TEST(MessageLogTests, AddSingleMessage)
     buffer.add(IPC::MessageName::IPCTester_EmptyMessage);
 
     EXPECT_EQ(buffer.indexForTesting(), 1u);
-    EXPECT_EQ(buffer.bufferForTesting()[0], IPC::MessageName::IPCTester_EmptyMessage);
+    EXPECT_EQ(buffer.atForTesting(0), IPC::MessageName::IPCTester_EmptyMessage);
 
     // Rest should still be Invalid
     for (size_t i = 1; i < 8; ++i)
-        EXPECT_EQ(buffer.bufferForTesting()[i], IPC::MessageName::Invalid);
+        EXPECT_EQ(buffer.atForTesting(i), IPC::MessageName::Invalid);
 }
 
 TEST(MessageLogTests, AddMultipleMessages)
@@ -65,9 +65,9 @@ TEST(MessageLogTests, AddMultipleMessages)
     buffer.add(IPC::MessageName::IPCTester_AsyncPing);
 
     EXPECT_EQ(buffer.indexForTesting(), 3u);
-    EXPECT_EQ(buffer.bufferForTesting()[0], IPC::MessageName::IPCTester_EmptyMessage);
-    EXPECT_EQ(buffer.bufferForTesting()[1], IPC::MessageName::IPCStreamTester_AsyncPing);
-    EXPECT_EQ(buffer.bufferForTesting()[2], IPC::MessageName::IPCTester_AsyncPing);
+    EXPECT_EQ(buffer.atForTesting(0), IPC::MessageName::IPCTester_EmptyMessage);
+    EXPECT_EQ(buffer.atForTesting(1), IPC::MessageName::IPCStreamTester_AsyncPing);
+    EXPECT_EQ(buffer.atForTesting(2), IPC::MessageName::IPCTester_AsyncPing);
 }
 
 TEST(MessageLogTests, WrapAroundAtCapacity)
@@ -81,17 +81,17 @@ TEST(MessageLogTests, WrapAroundAtCapacity)
     buffer.add(IPC::MessageName::IPCStreamTester_EmptyMessage);
 
     EXPECT_EQ(buffer.indexForTesting(), 4u); // Free-running index
-    EXPECT_EQ(buffer.bufferForTesting()[0], IPC::MessageName::IPCTester_EmptyMessage);
-    EXPECT_EQ(buffer.bufferForTesting()[1], IPC::MessageName::IPCStreamTester_AsyncPing);
-    EXPECT_EQ(buffer.bufferForTesting()[2], IPC::MessageName::IPCTester_AsyncPing);
-    EXPECT_EQ(buffer.bufferForTesting()[3], IPC::MessageName::IPCStreamTester_EmptyMessage);
+    EXPECT_EQ(buffer.atForTesting(0), IPC::MessageName::IPCTester_EmptyMessage);
+    EXPECT_EQ(buffer.atForTesting(1), IPC::MessageName::IPCStreamTester_AsyncPing);
+    EXPECT_EQ(buffer.atForTesting(2), IPC::MessageName::IPCTester_AsyncPing);
+    EXPECT_EQ(buffer.atForTesting(3), IPC::MessageName::IPCStreamTester_EmptyMessage);
 
     // Add one more, should overwrite index 0
     buffer.add(IPC::MessageName::IPCTester_CreateStreamTester);
 
     EXPECT_EQ(buffer.indexForTesting(), 5u); // Free-running index
-    EXPECT_EQ(buffer.bufferForTesting()[0], IPC::MessageName::IPCTester_CreateStreamTester);
-    EXPECT_EQ(buffer.bufferForTesting()[1], IPC::MessageName::IPCStreamTester_AsyncPing);
+    EXPECT_EQ(buffer.atForTesting(0), IPC::MessageName::IPCTester_CreateStreamTester);
+    EXPECT_EQ(buffer.atForTesting(1), IPC::MessageName::IPCStreamTester_AsyncPing);
 }
 
 TEST(MessageLogTests, MultipleWraps)
@@ -107,7 +107,7 @@ TEST(MessageLogTests, MultipleWraps)
 
     // All entries should have the test message
     for (size_t i = 0; i < 4; ++i)
-        EXPECT_EQ(buffer.bufferForTesting()[i], IPC::MessageName::IPCTester_EmptyMessage);
+        EXPECT_EQ(buffer.atForTesting(i), IPC::MessageName::IPCTester_EmptyMessage);
 }
 
 TEST(MessageLogTests, ConcurrentAddFromTwoThreads)
@@ -143,9 +143,9 @@ TEST(MessageLogTests, ConcurrentAddFromTwoThreads)
     size_t thread2Count = 0;
 
     for (size_t i = 0; i < bufferSize; ++i) {
-        if (buffer.bufferForTesting()[i] == thread1Message)
+        if (buffer.atForTesting(i) == thread1Message)
             thread1Count++;
-        else if (buffer.bufferForTesting()[i] == thread2Message)
+        else if (buffer.atForTesting(i) == thread2Message)
             thread2Count++;
         else
             FAIL() << "Unexpected message name at index " << i << ": expected either thread1 or thread2 message";
@@ -200,7 +200,7 @@ TEST(MessageLogTests, ConcurrentAddFromMultipleThreads)
     for (size_t i = 0; i < bufferSize; ++i) {
         bool found = false;
         for (size_t t = 0; t < numThreads; ++t) {
-            if (buffer.bufferForTesting()[i] == messageNames[t]) {
+            if (buffer.atForTesting(i) == messageNames[t]) {
                 messageCounts[t]++;
                 found = true;
                 break;
@@ -249,7 +249,7 @@ TEST(MessageLogTests, ConcurrentAddWithWrapping)
     for (size_t i = 0; i < bufferSize; ++i) {
         bool found = false;
         for (size_t t = 0; t < numThreads; ++t) {
-            if (buffer.bufferForTesting()[i] == messageNames[t]) {
+            if (buffer.atForTesting(i) == messageNames[t]) {
                 found = true;
                 break;
             }


### PR DESCRIPTION
#### 152f921e9acfac813163cc430abb7409280d9f91
<pre>
IPC::MessageLog::add() has a data race on the ring buffer element store
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=320321">https://bugs.webkit.org/show_bug.cgi?id=320321</a>&gt;
&lt;<a href="https://rdar.apple.com/183262390">rdar://183262390</a>&gt;

Reviewed by Kimmo Kinnunen.

Store message names into the ring buffer atomically.  Threads that
dispatch IPC never synchronize with one another, and the relaxed
increment of `m_index` orders only the index, so successive writers of
a slot are unordered once the buffer wraps.  A relaxed store compiles
to the same instruction as the plain assignment.  `std::atomic` is not
constexpr-assignable, so expand the constructor&apos;s initializer over an
index sequence to keep `gMessageLog` constant-initialized.

Covered by existing tests.  With the element store reverted to a plain
assignment, ThreadSanitizer reports the race in
MessageLogTests.ConcurrentAddWithWrapping.

* Source/WebKit/Platform/IPC/MessageLog.cpp:
* Source/WebKit/Platform/IPC/MessageLog.h:
(IPC::MessageLog::MessageLog):
(IPC::MessageLog::add):
(IPC::MessageLog::atForTesting const): Add.
(IPC::MessageLog::bufferForTesting const): Remove.
(IPC::MessageLog::bufferSize const): Add.
(IPC::MessageLog::capacity const): Add.
(IPC::MessageLog::elementSize const): Add.
* Tools/TestWebKitAPI/Tests/IPC/MessageLogEndToEndTests.cpp:
(TestWebKitAPI::MessageLogEndToEndTest::messageLogContains const):
(TestWebKitAPI::MessageLogEndToEndTest::countMessagesInLog const):
(TestWebKitAPI::MessageLogStreamTest::messageLogContains const):
* Tools/TestWebKitAPI/Tests/IPC/MessageLogTests.cpp:
(TestWebKitAPI::TEST(MessageLogTests, InitialState)):
(TestWebKitAPI::TEST(MessageLogTests, AddSingleMessage)):
(TestWebKitAPI::TEST(MessageLogTests, AddMultipleMessages)):
(TestWebKitAPI::TEST(MessageLogTests, WrapAroundAtCapacity)):
(TestWebKitAPI::TEST(MessageLogTests, MultipleWraps)):
(TestWebKitAPI::TEST(MessageLogTests, ConcurrentAddFromTwoThreads)):
(TestWebKitAPI::TEST(MessageLogTests, ConcurrentAddFromMultipleThreads)):
(TestWebKitAPI::TEST(MessageLogTests, ConcurrentAddWithWrapping)):

Canonical link: <a href="https://commits.webkit.org/318465@main">https://commits.webkit.org/318465@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/258cc2aca2ff98e1f9c2b286536fdafd14ca3039

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176850 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50787 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44579 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186452 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/140086 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/728a5ef6-1005-4ce7-a1cd-9438d9341547) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178713 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52080 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50473 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137771 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96279 "2 failures") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4b7581a6-3e8c-4926-b579-5c0fc77df2dd) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179806 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41281 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158560 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118245 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/467714db-f9b8-4357-aa26-8c3da75899c0) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39935 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38302 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150347 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38059 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34920 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42532 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42517 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188876 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50454 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146844 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51137 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34723 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146646 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27057 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41409 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123345 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117565 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49642 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13039 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49041 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49277 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49102 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->