### PR TITLE
Add removeIf() to WTF::RobinHoodHashTable and adopt it to simplify remove-matching-entries loops

### DIFF
--- a/Source/WTF/wtf/RobinHoodHashTable.h
+++ b/Source/WTF/wtf/RobinHoodHashTable.h
@@ -200,6 +200,7 @@ public:
     void remove(iterator);
     void removeWithoutEntryConsistencyCheck(iterator);
     void removeWithoutEntryConsistencyCheck(const_iterator);
+    bool removeIf(NOESCAPE const Invocable<bool(ValueType&)> auto&);
     void clear();
 
     static bool isEmptyBucket(const ValueType& value) { return isHashTraitsEmptyValue<KeyTraits>(Extractor::extract(value)); }
@@ -242,6 +243,7 @@ private:
     void removeAndInvalidateWithoutEntryConsistencyCheck(ValueType*);
     void removeAndInvalidate(ValueType*);
     void remove(ValueType*);
+    void shiftDeleteWithoutShrink(ValueType*);
 
     static unsigned computeTableHash(ValueType* table) { return DefaultHash<ValueType*>::hash(table); }
 
@@ -615,12 +617,14 @@ void RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits,
 }
 
 template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits, typename SizePolicy, typename Malloc>
-void RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, SizePolicy, Malloc>::remove(ValueType* pos)
+void RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, SizePolicy, Malloc>::shiftDeleteWithoutShrink(ValueType* pos)
 {
     // This is removal via "backward-shift-deletion". This basically shift existing entries to removed empty entry place so that we make
     // the table as if no removal happened so far. This decreases distance-to-initial-bucket (DIB) of the subsequent entries by 1. This maintains
     // DIB of the table low and relatively constant even if we have many removals, compared to using tombstones.
     // https://codecapsule.com/2013/11/17/robin-hood-hashing-backward-shift-deletion/
+    // Unlike remove(), this does NOT shrink the table afterwards, so a caller removing many entries (removeIf) can defer a single
+    // shrink to the end instead of rehashing repeatedly mid-removal.
     deleteBucket(*pos);
     initializeBucket(*pos);
     m_keyCount -= 1;
@@ -650,11 +654,57 @@ void RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits,
         indexPrevious = index;
         index = (index + 1) & sizeMask;
     }
+}
+
+template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits, typename SizePolicy, typename Malloc>
+void RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, SizePolicy, Malloc>::remove(ValueType* pos)
+{
+    shiftDeleteWithoutShrink(pos);
 
     if (shouldShrink())
         shrink();
 
     internalCheckTableConsistency();
+}
+
+template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits, typename SizePolicy, typename Malloc>
+inline bool RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, SizePolicy, Malloc>::removeIf(NOESCAPE const Invocable<bool(ValueType&)> auto& functor)
+{
+    if (!m_table)
+        return false;
+
+    invalidateIterators(this);
+    internalCheckTableConsistency();
+
+    // Sweep the table forward, backward-shift-deleting every matching live entry. Because shiftDeleteWithoutShrink() shifts the
+    // following in-cluster entries down into the just-emptied slot, a not-yet-examined entry can move into the current slot, so we
+    // re-examine the same index after a removal rather than advancing. Backward-shift can only move an entry into an already-swept
+    // slot from an equal-or-lower (already-swept, hence known non-matching) slot, so no match is ever skipped. Deferring shrink()
+    // keeps m_table and tableSize() stable for the whole sweep (a mid-sweep rehash would relocate every entry and invalidate the
+    // index-based iteration); we do a single shrinkToBestSize() at the end, mirroring HashTable::removeIf().
+    //
+    // The per-entry removal work is the same backward shift as the second-loop remove() this replaces (minus its re-find() and
+    // per-removal shrink()), so this is never slower than collect-into-a-Vector-then-remove. A caller deleting a long *contiguous*
+    // run within one probe cluster re-shifts that cluster's tail once per removal, which a "collect doomed slots up front, then
+    // rebuild survivors in one pass" variant would avoid; that is not implemented here because it shares no code with remove() and
+    // RobinHood's low, bounded probe distances (expansion is forced past probeDistanceThreshold) keep clusters short by design.
+    unsigned removedCount = 0;
+    unsigned size = tableSize();
+    for (unsigned index = 0; index < size;) {
+        ValueType* entry = m_table + index;
+        if (isEmptyBucket(*entry) || !functor(*entry)) {
+            ++index;
+            continue;
+        }
+        shiftDeleteWithoutShrink(entry);
+        ++removedCount;
+    }
+
+    if (removedCount && shouldShrink())
+        shrinkToBestSize();
+
+    internalCheckTableConsistency();
+    return removedCount;
 }
 
 template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits, typename SizePolicy, typename Malloc>

--- a/Source/WebCore/Modules/web-locks/WebLockRegistry.cpp
+++ b/Source/WebCore/Modules/web-locks/WebLockRegistry.cpp
@@ -282,28 +282,21 @@ void LocalWebLockRegistry::PerOriginRegistry::clientsAreGoingAway(NOESCAPE const
     // FIXME: This is inefficient. We could optimize this by keeping track of which locks map to which clients.
     HashSet<String> namesOfQueuesToProcess;
 
-    Vector<String> namesWithoutRequests;
-    for (auto& pair : m_lockRequestQueueMap) {
+    m_lockRequestQueueMap.removeIf([&](auto& pair) {
         if (!pair.value.removeAllMatching(matchClient))
-            continue;
+            return false;
         if (pair.value.isEmpty())
-            namesWithoutRequests.append(pair.key);
-        else
-            namesOfQueuesToProcess.add(pair.key);
-    }
-    for (auto& name : namesWithoutRequests)
-        m_lockRequestQueueMap.remove(name);
-
-    Vector<String> namesWithoutLocks;
-    for (auto& pair : m_heldLocks) {
-        if (!pair.value.removeAllMatching(matchClient))
-            continue;
-        if (pair.value.isEmpty())
-            namesWithoutLocks.append(pair.key);
+            return true;
         namesOfQueuesToProcess.add(pair.key);
-    }
-    for (auto& name : namesWithoutLocks)
-        m_heldLocks.remove(name);
+        return false;
+    });
+
+    m_heldLocks.removeIf([&](auto& pair) {
+        if (!pair.value.removeAllMatching(matchClient))
+            return false;
+        namesOfQueuesToProcess.add(pair.key);
+        return pair.value.isEmpty();
+    });
 
     for (auto& name : namesOfQueuesToProcess) {
         auto queueIterator = m_lockRequestQueueMap.find(name);

--- a/Source/WebCore/dom/TreeScope.cpp
+++ b/Source/WebCore/dom/TreeScope.cpp
@@ -765,17 +765,11 @@ void TreeScope::removeElementFromPendingSVGResources(SVGElement& element)
     }
 
     if (!svgResourcesMap().pendingResourcesForRemoval.isEmpty()) {
-        Vector<AtomString> toBeRemoved;
-        for (auto& resource : svgResourcesMap().pendingResourcesForRemoval) {
-            auto& elements = resource.value;
-            elements.remove(element);
-            if (elements.isEmptyIgnoringNullReferences())
-                toBeRemoved.append(resource.key);
-        }
-
-        // We use m_pendingResourcesForRemoval here because it deals with set lifetime correctly.
-        for (auto& resource : toBeRemoved)
-            svgResourcesMap().pendingResourcesForRemoval.remove(resource);
+        // We remove from m_pendingResourcesForRemoval directly here because it deals with set lifetime correctly.
+        svgResourcesMap().pendingResourcesForRemoval.removeIf([&](auto& resource) {
+            resource.value.remove(element);
+            return resource.value.isEmptyIgnoringNullReferences();
+        });
     }
 }
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
@@ -2988,23 +2988,18 @@ void MediaPlayerPrivateAVFoundationObjC::keyAdded()
     if (!player)
         return;
 
-    Vector<String> fulfilledKeyIds;
-
     ALWAYS_LOG(LOGIDENTIFIER);
-    for (auto& pair : m_keyURIToRequestMap) {
+    m_keyURIToRequestMap.removeIf([&](auto& pair) {
         const String& keyId = pair.key;
         const RetainPtr<AVAssetResourceLoadingRequest>& request = pair.value;
 
         auto keyData = player->cachedKeyForKeyId(keyId);
         if (!keyData)
-            continue;
+            return false;
 
         fulfillRequestWithKeyData(request.get(), keyData.get());
-        fulfilledKeyIds.append(keyId);
-    }
-
-    for (auto& keyId : fulfilledKeyIds)
-        m_keyURIToRequestMap.remove(keyId);
+        return true;
+    });
 }
 
 RefPtr<LegacyCDMSession> MediaPlayerPrivateAVFoundationObjC::createSession(const String& keySystem, LegacyCDMSessionClient& client)

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.mm
@@ -928,15 +928,15 @@ void updateTracksOfKind(MemoryCompactRobinHoodHashMap<String, RefT>& trackMap, T
             addedPrivateTracks.append(track);
     }
 
-    for (const auto& track : trackMap.values()) {
+    trackMap.removeIf([&](auto& keyValue) {
+        auto& track = keyValue.value;
         Ref streamTrack = track->streamTrack();
         if (currentTracks.containsIf([&streamTrack](auto& track) { return track.ptr() == streamTrack.ptr(); }))
-            continue;
+            return false;
 
         removedTracks.append(track);
-    }
-    for (auto& track : removedTracks)
-        trackMap.remove(track->streamTrack().id());
+        return true;
+    });
 
     for (auto& track : addedPrivateTracks) {
         RefT newTrack = itemFactory(track.get());

--- a/Tools/TestWebKitAPI/Tests/WTF/RobinHoodHashMap.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/RobinHoodHashMap.cpp
@@ -1273,4 +1273,72 @@ TEST(WTF_RobinHoodHashMap, LargeRemoval)
     EXPECT_EQ(map.capacity(), 8u);
 }
 
+TEST(WTF_RobinHoodHashMap, RemoveIf)
+{
+    MemoryCompactLookupOnlyRobinHoodHashMap<unsigned, unsigned, RobinHoodHash<unsigned>> map;
+
+    // Removing from an empty map removes nothing and returns false.
+    EXPECT_FALSE(map.removeIf([](auto&) {
+        return true;
+    }));
+    EXPECT_TRUE(map.isEmpty());
+
+    for (unsigned i = 1; i <= 100; ++i)
+        map.add(i, i * 10);
+
+    // A predicate that never matches removes nothing and returns false.
+    EXPECT_FALSE(map.removeIf([](auto&) {
+        return false;
+    }));
+    EXPECT_EQ(100u, map.size());
+
+    // The predicate receives the key/value pair (not just the mapped value),
+    // and may carry a side effect before returning true.
+    unsigned removedCount = 0;
+    bool removed = map.removeIf([&](auto& entry) {
+        if (entry.key % 3)
+            return false;
+        EXPECT_EQ(entry.key * 10, entry.value);
+        ++removedCount;
+        return true;
+    });
+    EXPECT_TRUE(removed);
+    EXPECT_EQ(33u, removedCount); // 3, 6, ..., 99
+    EXPECT_EQ(100u - 33u, map.size());
+    for (unsigned i = 1; i <= 100; ++i) {
+        if (i % 3)
+            EXPECT_EQ(i * 10, map.get(i)) << i;
+        else
+            EXPECT_FALSE(map.contains(i)) << i;
+    }
+}
+
+TEST(WTF_RobinHoodHashMap, RemoveIfLarge)
+{
+    MemoryCompactRobinHoodHashMap<unsigned, unsigned, RobinHoodHash<unsigned>> map;
+    for (unsigned i = 1; i <= 10000; ++i)
+        map.add(i, i);
+    EXPECT_EQ(10000u, map.size());
+
+    // Remove every odd key. This drives heavy backward-shift deletion across
+    // many probe clusters (including clusters that wrap past the end of the
+    // table), with a single deferred shrink rather than a shrink per removal.
+    EXPECT_TRUE(map.removeIf([](auto& entry) {
+        return entry.key & 0x1u;
+    }));
+    EXPECT_EQ(5000u, map.size());
+
+    // The RobinHood probe-distance invariant must survive the sweep: every
+    // surviving key remains findable, and every removed key is gone.
+    for (unsigned i = 1; i <= 10000; ++i)
+        EXPECT_EQ(!(i & 0x1u), map.contains(i)) << i;
+
+    // Removing the remainder empties the map and shrinks it to the minimum.
+    EXPECT_TRUE(map.removeIf([](auto&) {
+        return true;
+    }));
+    EXPECT_TRUE(map.isEmpty());
+    EXPECT_EQ(8u, map.capacity());
+}
+
 } // namespace TestWebKitAPI

--- a/Tools/TestWebKitAPI/Tests/WTF/RobinHoodHashSet.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/RobinHoodHashSet.cpp
@@ -596,4 +596,70 @@ TEST(WTF_RobinHoodHashSet, LargeRemoval)
     EXPECT_EQ(set.capacity(), 8u);
 }
 
+TEST(WTF_RobinHoodHashSet, RemoveIf)
+{
+    MemoryCompactLookupOnlyRobinHoodHashSet<unsigned, RobinHoodHash<unsigned>> set;
+
+    // Removing from an empty set removes nothing and returns false.
+    EXPECT_FALSE(set.removeIf([](auto&) {
+        return true;
+    }));
+    EXPECT_TRUE(set.isEmpty());
+
+    for (unsigned i = 1; i <= 100; ++i)
+        set.add(i);
+
+    // A predicate that never matches removes nothing and returns false.
+    EXPECT_FALSE(set.removeIf([](auto&) {
+        return false;
+    }));
+    EXPECT_EQ(100u, set.size());
+
+    // A predicate with a side effect runs exactly once per surviving-or-removed
+    // live entry; the side effect belongs before the returned true.
+    unsigned removedCount = 0;
+    unsigned removedSum = 0;
+    bool removed = set.removeIf([&](auto& value) {
+        if (value % 3)
+            return false;
+        ++removedCount;
+        removedSum += value;
+        return true;
+    });
+    EXPECT_TRUE(removed);
+    EXPECT_EQ(33u, removedCount); // 3, 6, ..., 99
+    EXPECT_EQ(1683u, removedSum); // 3 * (1 + ... + 33)
+    EXPECT_EQ(100u - 33u, set.size());
+    for (unsigned i = 1; i <= 100; ++i)
+        EXPECT_EQ(static_cast<bool>(i % 3), set.contains(i)) << i;
+}
+
+TEST(WTF_RobinHoodHashSet, RemoveIfLarge)
+{
+    MemoryCompactLookupOnlyRobinHoodHashSet<unsigned, RobinHoodHash<unsigned>> set;
+    for (unsigned i = 1; i <= 10000; ++i)
+        set.add(i);
+    EXPECT_EQ(10000u, set.size());
+
+    // Remove every odd key. This drives heavy backward-shift deletion across
+    // many probe clusters (including clusters that wrap past the end of the
+    // table), with a single deferred shrink rather than a shrink per removal.
+    EXPECT_TRUE(set.removeIf([](auto& value) {
+        return value & 0x1u;
+    }));
+    EXPECT_EQ(5000u, set.size());
+
+    // The RobinHood probe-distance invariant must survive the sweep: every
+    // surviving key remains findable, and every removed key is gone.
+    for (unsigned i = 1; i <= 10000; ++i)
+        EXPECT_EQ(!(i & 0x1u), set.contains(i)) << i;
+
+    // Removing the remainder empties the set and shrinks it to the minimum.
+    EXPECT_TRUE(set.removeIf([](auto&) {
+        return true;
+    }));
+    EXPECT_TRUE(set.isEmpty());
+    EXPECT_EQ(8u, set.capacity());
+}
+
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### e1fc460b8f1d82f50a1165573faca85fb9636352
<pre>
Add removeIf() to WTF::RobinHoodHashTable and adopt it to simplify remove-matching-entries loops
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=320337">https://bugs.webkit.org/show_bug.cgi?id=320337</a>&gt;
&lt;<a href="https://rdar.apple.com/183275236">rdar://183275236</a>&gt;

Reviewed by Yusuke Suzuki.

`WTF::HashTable` and its `Weak*` wrappers provide `removeIf()`, but
`WTF::RobinHoodHashTable` did not, so the RobinHood-backed
`HashMap`/`HashSet` variants failed to compile any `removeIf()` call.
Several WebCore sites backed by RobinHood maps therefore collected
matching entries into a temporary `Vector` and then removed them in a
second loop.

`RobinHoodHashTable` uses backward-shift deletion rather than tombstones,
so it cannot reuse `HashTable::removeIf()`: deleting a match shifts a
following entry into the current slot, so the sweep must re-examine that
slot, and it must defer `shrink()` (which rehashes) to a single
`shrinkToBestSize()` at the end.  Factor the backward-shift core of
`remove()` into `shiftDeleteWithoutShrink()` for `removeIf()` to reuse.

Tests: TestWTF.WTF_RobinHoodHashSet.RemoveIf
       TestWTF.WTF_RobinHoodHashSet.RemoveIfLarge
       TestWTF.WTF_RobinHoodHashMap.RemoveIf
       TestWTF.WTF_RobinHoodHashMap.RemoveIfLarge

* Source/WTF/wtf/RobinHoodHashTable.h:
(WTF::RobinHoodHashTable::shiftDeleteWithoutShrink): Add.
(WTF::RobinHoodHashTable::remove):
(WTF::RobinHoodHashTable::removeIf): Add.
* Source/WebCore/Modules/web-locks/WebLockRegistry.cpp:
(WebCore::LocalWebLockRegistry::PerOriginRegistry::clientsAreGoingAway):
* Source/WebCore/dom/TreeScope.cpp:
(WebCore::TreeScope::removeElementFromPendingSVGResources):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm:
(WebCore::MediaPlayerPrivateAVFoundationObjC::keyAdded):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.mm:
(WebCore::updateTracksOfKind):
* Tools/TestWebKitAPI/Tests/WTF/RobinHoodHashMap.cpp:
(TestWebKitAPI::TEST(WTF_RobinHoodHashMap, RemoveIf)): Add.
(TestWebKitAPI::TEST(WTF_RobinHoodHashMap, RemoveIfLarge)): Add.
* Tools/TestWebKitAPI/Tests/WTF/RobinHoodHashSet.cpp:
(TestWebKitAPI::TEST(WTF_RobinHoodHashSet, RemoveIf)): Add.
(TestWebKitAPI::TEST(WTF_RobinHoodHashSet, RemoveIfLarge)): Add.

Canonical link: <a href="https://commits.webkit.org/318010@main">https://commits.webkit.org/318010@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dbe9d5648774dd78adfa9dba1036599bb090cf79

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176856 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50793 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44585 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186458 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140092 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4efcc1de-3ce9-48f5-ad2d-8e4e37f5548e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178719 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52086 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50479 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137781 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140092 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7e1051ed-6887-48a2-a210-81a1efe18125) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179812 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41289 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158567 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118255 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e53dfa95-a760-4844-a47c-68cac377ed68) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39943 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38310 "Passed tests") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/251/builds/220 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/7074 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150355 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38066 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34926 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/38127 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42538 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42525 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188882 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50460 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146852 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51143 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34747 "Too many flaky failures: http/tests/contentextensions/video-element-resource-type.html, http/tests/media/now-playing-info-default-artwork-favicon.html, http/tests/misc/resource-timing-navigation-in-restored-iframe-2.html, http/tests/navigation/redirect-to-random-url-versus-memory-cache.html, http/tests/resourceLoadStatistics/only-partitioned-cookies-after-redirect.html, http/tests/security/canvas-remote-read-remote-video-allowed-anonymous.html, http/tests/security/contentSecurityPolicy/1.1/scriptnonce-allowed-by-enforced-policy-and-blocked-by-report-policy2.py, http/tests/security/contentSecurityPolicy/redirect-does-not-match-paths.html, http/tests/security/mixedContent/secure-redirect-to-insecure-redirect-to-basic-auth-secure-image-UpgradeMixedContent.https.html, http/tests/storageAccess/deny-storage-access-under-opener-if-auto-dismiss.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146654 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26850 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41416 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123351 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117573 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49648 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13047 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49047 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49283 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49108 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->