### PR TITLE
[WKCI][ews-build.webkit.org][WPE] The WPE-JSC queue should use build-webkit instead build-jsc to build without change (follow-up fix)

### DIFF
--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -3320,9 +3320,13 @@ def customBuildFlag(platform, fullPlatform):
     return ['--' + platform]
 
 
-def shouldBuildJSCOnly(group_name, platform):
+def usesBuildWebKitForJSC(platform):
     # GTK and WPE use build-webkit rather than build-jsc, so the whole build process (build flags, etc.) matches what post-commit bots do.
-    return group_name == 'jsc' and platform not in ('gtk', 'wpe')
+    return platform in ('gtk', 'wpe')
+
+
+def shouldBuildJSCOnly(group_name, platform):
+    return group_name == 'jsc' and not usesBuildWebKitForJSC(platform)
 
 
 class BuildLogLineObserver(ParseByLineLogObserver):
@@ -3916,13 +3920,12 @@ class RunJavaScriptCoreTests(shell.Test, AddToLogMixin, ShellMixin):
             elif platform == 'gtk':
                 steps_to_add.append(InstallGtkDependencies())
             else:
+                # SetO3OptimizationLevel is only needed by the macOS JSC O3 debug queue (see 305715@main).
                 steps_to_add.append(SetO3OptimizationLevel())
             if self.getProperty('rebuild_without_change_on_builder', False):
                 steps_to_add.extend([DownloadBuiltProduct(suffix=SUFFIX_WITHOUT_CHANGE), ExtractBuiltProduct()])
-            if platform in ('gtk', 'wpe'):
-                steps_to_add.extend([CompileWebKitWithoutChange()])
             else:
-                steps_to_add.extend([CompileJSCWithoutChange()])
+                steps_to_add.append(CompileWebKitWithoutChange() if usesBuildWebKitForJSC(platform) else CompileJSCWithoutChange())
             steps_to_add += [
                 ValidateChange(verifyBugClosed=False, addURLs=False),
                 KillOldProcesses(),


### PR DESCRIPTION
#### 1e8fcb431bbb04288310c5b7e6955cb246e54163
<pre>
[WKCI][ews-build.webkit.org][WPE] The WPE-JSC queue should use build-webkit instead build-jsc to build without change (follow-up fix)
<a href="https://bugs.webkit.org/show_bug.cgi?id=320284">https://bugs.webkit.org/show_bug.cgi?id=320284</a>

Unreviewed follow-up patch.

In the previous commit at 317938@main I broke the check on the JSC queues to see if
the bot should rebuild or download the built product without change from the builder.

The rebuild should only happen when the property rebuild_without_change_on_builder
is False.

* Tools/CISupport/ews-build/steps.py:
(usesBuildWebKitForJSC):
(shouldBuildJSCOnly):
(RunJavaScriptCoreTests.evaluateCommand):

Canonical link: <a href="https://commits.webkit.org/317943@main">https://commits.webkit.org/317943@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0aae85470019c9b02e4773a529d98cb4d7d0828d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176858 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50795 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44587 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186460 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140094 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178721 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52088 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50481 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/137777 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140094 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179814 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41287 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/158565 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118251 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/39941 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38309 "Passed tests") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/150353 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38064 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34928 "Built successfully") | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42524 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188884 "Built successfully") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/176261 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50462 "Built successfully") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/146851 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51145 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34687 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146653 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26830 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41415 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117575 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49650 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13045 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49049 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49285 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49110 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->