### PR TITLE
[GStreamer][MSE] Fix mainthread deadlock during encrypted playback with seeking

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.cpp
@@ -172,7 +172,8 @@ struct Stream : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<Stream> {
         Condition padLinkedOrFlushedCondition;
         Condition queueChangedOrFlushedCondition;
         bool isFlushing { false };
-
+        bool isActive { false }; // Controls whether the streaming thread should be active. Set false when deactivating the pad.
+        bool isSeekingFlush { false }; // Indicates if the current flush is due to a seek operation.
         // Flushes before any buffer has been popped from the queue and sent downstream can be avoided just
         // by clearing the queue.
         bool hasPoppedFirstObject { false };
@@ -405,20 +406,21 @@ static gboolean webKitMediaSrcActivateMode(GstPad* pad, [[maybe_unused]] GstObje
         return false;
     }
 
-    if (active)
-        gst_pad_start_task(pad, webKitMediaSrcLoop, gst_object_ref(pad), gst_object_unref);
-    else {
-        RefPtr<Stream> stream(WEBKIT_MEDIA_SRC_PAD(pad)->priv->stream.get());
-        if (!stream)
-            return false;
-
-        // Unblock the streaming thread.
-        {
-            DataMutexLocker streamingMembers { stream->streamingMembersDataMutex };
+    RefPtr<Stream> stream(WEBKIT_MEDIA_SRC_PAD(pad)->priv->stream.get());
+    if (!stream)
+        return false;
+    {
+        DataMutexLocker streamingMembers { stream->streamingMembersDataMutex };
+        streamingMembers->isActive = active;
+        if (!active) {
             streamingMembers->isFlushing = true;
             streamingMembers->padLinkedOrFlushedCondition.notifyOne();
             streamingMembers->queueChangedOrFlushedCondition.notifyOne();
         }
+    }
+    if (active)
+        gst_pad_start_task(pad, webKitMediaSrcLoop, gst_object_ref(pad), gst_object_unref);
+    else {
         // Following gstbasesrc implementation, this code is not flushing downstream.
         // If there is any possibility of the streaming thread being blocked downstream the caller MUST flush before.
         // Otherwise a deadlock would occur as the next function tries to join the thread.
@@ -459,7 +461,45 @@ static void webKitMediaSrcWaitForPadLinkedOrFlush(GstPad* pad, DataMutexLocker<S
     GST_DEBUG_OBJECT(pad, "Finished waiting for the pad to be linked.");
 }
 
+static void webKitMediaSrcSendFlushEvent(Stream* stream, DataMutexLocker<Stream::StreamingMembers>& streamingMembers)
+{
+    bool isSeekingFlush = streamingMembers->isSeekingFlush;
+    streamingMembers.unlockEarly();
+    GST_DEBUG_OBJECT(stream->pad.get(), "Sending FLUSH_START downstream.");
+    dumpPipeline("flush-before"_s, stream);
+    gst_pad_push_event(stream->pad.get(), gst_event_new_flush_start());
+    GST_DEBUG_OBJECT(stream->pad.get(), "FLUSH_START sent, now sending FLUSH_STOP downstream (resetTime = %s).", boolForPrinting(isSeekingFlush));
+    gst_pad_push_event(stream->pad.get(), gst_event_new_flush_stop(isSeekingFlush));
+    GST_DEBUG_OBJECT(stream->pad.get(), "FLUSH_STOP sent.");
+    dumpPipeline("flush-after"_s, stream);
+    {
+        DataMutexLocker streamingMembers { stream->streamingMembersDataMutex };
+        // Resets the flush state flags after flush events have been sent.
+        // This must be called from within the streaming thread while holding the streamingMembers mutex.
+        streamingMembers->hasPoppedFirstObject = false;
+        streamingMembers->isSeekingFlush = false;
+        streamingMembers->isFlushing = false;
+        streamingMembers->doesNeedSegmentEvent = true;
+        if (!gst_check_version(1, 22, 0)) {
+            // In older GST versions STREAM_COLLECTION event is delivered to decodebin3
+            // from parsebin src pad probe. On the way, this event is cached inside
+            // parser element (GstBaseParse) and pushed downstream with first frame.
+            // Flushing before first frame is handled by the parser,
+            // the event is dropped from GstBaseParse and never reaches decodebin3.
+            // GST 1.21.3 added STREAM_COLLECTION event handling on decodebin3 sink pad directly
+            // so this workaround is not needed anymore.
+            GST_DEBUG_OBJECT(stream->pad.get(), "Reset hasPushedStreamCollectionEvent");
+            streamingMembers->hasPushedStreamCollectionEvent = false;
+        }
+    }
+}
+
 // Called with STREAM_LOCK.
+// StreamingMembers state machine (both flags controlled from mainthread and streaming thread):
+// - isActive = true  → streaming thread runs normally, processing buffers and events
+// - isActive = false → streaming thread pauses and exits the loop
+// - isFlushing = true  → instead of processing buffers, streaming thread sends FLUSH_START/FLUSH_STOP events
+// - isFlushing = false → normal buffer processing
 static void webKitMediaSrcLoop(void* userData)
 {
     GstPad* pad = GST_PAD(userData);
@@ -468,16 +508,25 @@ static void webKitMediaSrcLoop(void* userData)
         return;
 
     DataMutexLocker streamingMembers { stream->streamingMembersDataMutex };
-    if (streamingMembers->isFlushing) {
+    if (!streamingMembers->isActive) {
         gst_pad_pause_task(pad);
         return;
     }
 
     // Since the pad can and will be added when the element is in PLAYING state, this task can start running
     // before the pad is linked. Wait for the pad to be linked to avoid buffers being lost to not-linked errors.
-    webKitMediaSrcWaitForPadLinkedOrFlush(pad, streamingMembers);
-    if (streamingMembers->isFlushing) {
+    if (!streamingMembers->isFlushing)
+        webKitMediaSrcWaitForPadLinkedOrFlush(pad, streamingMembers);
+    if (!streamingMembers->isActive) {
         gst_pad_pause_task(pad);
+        return;
+    }
+    if (streamingMembers->isFlushing) {
+        // Send flush events from the streaming thread (not the mainthread) to avoid deadlock scenarios where
+        // the mainthread would block waiting for the streaming thread while trying to flush.
+        // See: [GStreamer][MSE] Fix mainthread deadlock during encrypted playback with seeking.
+        if (gst_pad_is_linked(pad))
+            webKitMediaSrcSendFlushEvent(stream, streamingMembers);
         return;
     }
     ASSERT(gst_pad_is_linked(pad));
@@ -554,8 +603,13 @@ static void webKitMediaSrcLoop(void* userData)
         DataMutexLocker queue { stream->track->queueDataMutex() };
         queue->resetNotEmptyHandler();
     }
-    if (streamingMembers->isFlushing) {
+    if (!streamingMembers->isActive) {
         gst_pad_pause_task(pad);
+        return;
+    }
+
+    if (streamingMembers->isFlushing) {
+        webKitMediaSrcSendFlushEvent(stream, streamingMembers);
         return;
     }
 
@@ -589,8 +643,12 @@ static void webKitMediaSrcLoop(void* userData)
                 if (!result && !GST_PAD_IS_FLUSHING(pad))
                     GST_WARNING_OBJECT(pad, "CAPS event was not handled downstream");
             });
-            if (streamingMembers->isFlushing) {
+            if (!streamingMembers->isActive) {
                 gst_pad_pause_task(pad);
+                return;
+            }
+            if (streamingMembers->isFlushing) {
+                webKitMediaSrcSendFlushEvent(stream, streamingMembers);
                 return;
             }
         }
@@ -655,6 +713,19 @@ static void webKitMediaSrcStreamFlush(Stream* stream, bool isSeekingFlush)
 
     {
         DataMutexLocker streamingMembers { stream->streamingMembersDataMutex };
+        if (streamingMembers->isFlushing) {
+            if (isSeekingFlush) {
+                // In the case of seeking flush we reset the timeline.
+                WebKitMediaSrcPrivate* priv = stream->source->priv;
+                streamingMembers->segment.base = 0;
+                streamingMembers->segment.rate = priv->rate;
+                streamingMembers->segment.start = streamingMembers->segment.time = priv->startTime;
+                streamingMembers->isSeekingFlush = true;
+            }
+            DataMutexLocker queue { stream->track->queueDataMutex() };
+            queue->clear();
+            return;
+        }
 
         if (!streamingMembers->hasPoppedFirstObject) {
             GST_DEBUG_OBJECT(stream->source, "Flush request for stream '%" PRIu64 "' occurred before hasPoppedFirstObject, just clearing the queue and readjusting the segment.", stream->track->id());
@@ -665,31 +736,6 @@ static void webKitMediaSrcStreamFlush(Stream* stream, bool isSeekingFlush)
             queue->clear();
             skipFlush = true;
         }
-    }
-
-    if (!skipFlush) {
-        // Signal the loop() function to stop waiting for any condition variable, pause the task and return,
-        // which will keeping the streaming thread idle.
-        GST_DEBUG_OBJECT(stream->pad.get(), "Taking the StreamingMembers mutex and setting isFlushing = true.");
-        {
-            DataMutexLocker streamingMembers { stream->streamingMembersDataMutex };
-            DataMutexLocker queue { stream->track->queueDataMutex() };
-
-            streamingMembers->isFlushing = true;
-            queue->flush(); // Clear the queue and cancel any waiting callback.
-
-            streamingMembers->queueChangedOrFlushedCondition.notifyAll();
-            streamingMembers->padLinkedOrFlushedCondition.notifyAll();
-        }
-
-        // Flush downstream. This will stop processing in downstream elements and if the streaming thread was in a
-        // downstream chain() function, it will quickly return to the loop() function, which thanks to the
-        // previous section will also quickly end.
-        GST_DEBUG_OBJECT(stream->pad.get(), "Sending FLUSH_START downstream.");
-        dumpPipeline("flush-start-before"_s, stream);
-        gst_pad_push_event(stream->pad.get(), gst_event_new_flush_start());
-        GST_DEBUG_OBJECT(stream->pad.get(), "FLUSH_START sent.");
-        dumpPipeline("flush-start-after"_s, stream);
     }
 
     // Adjust segment. This is different for seeks and non-seeking flushes.
@@ -723,43 +769,18 @@ static void webKitMediaSrcStreamFlush(Stream* stream, bool isSeekingFlush)
     }
 
     if (!skipFlush) {
-        // By taking the stream lock we are waiting for the streaming thread task to stop if it hadn't yet.
-        GST_DEBUG_OBJECT(stream->pad.get(), "Taking the STREAM_LOCK.");
-        auto streamLock = GstPadStreamLocker(stream->pad.get());
-        {
-            GST_DEBUG_OBJECT(stream->pad.get(), "Taking the StreamingMembers mutex again.");
-            DataMutexLocker streamingMembers { stream->streamingMembersDataMutex };
-            GST_DEBUG_OBJECT(stream->pad.get(), "StreamingMembers mutex taken, using it to set isFlushing = false.");
-            streamingMembers->isFlushing = false;
-            streamingMembers->doesNeedSegmentEvent = true;
-
-            if (!gst_check_version(1, 22, 0)) {
-                // In older GST versions STREAM_COLLECTION event is delivered to decodebin3
-                // from parsebin src pad probe. On the way, this event is cached inside
-                // parser element (GstBaseParse) and pushed downstream with first frame.
-                // Flushing before first frame is handled by the parser,
-                // the event is dropped from GstBaseParse and never reaches decodebin3.
-                // GST 1.21.3 added STREAM_COLLECTION event handling on decodebin3 sink pad directly
-                // so this workaround is not needed anymore.
-                GST_DEBUG_OBJECT(stream->pad.get(), "Reset hasPushedStreamCollectionEvent");
-                streamingMembers->hasPushedStreamCollectionEvent = false;
-            }
-        }
-
-        GST_DEBUG_OBJECT(stream->pad.get(), "Sending FLUSH_STOP downstream (resetTime = %s).", boolForPrinting(isSeekingFlush));
-        dumpPipeline("flush-stop-before"_s, stream);
-        // Since FLUSH_STOP is a synchronized event, we send it while we still hold the stream lock of the pad.
-        gst_pad_push_event(stream->pad.get(), gst_event_new_flush_stop(isSeekingFlush));
-        GST_DEBUG_OBJECT(stream->pad.get(), "FLUSH_STOP sent.");
-        dumpPipeline("flush-stop-after"_s, stream);
-
         {
             DataMutexLocker streamingMembers { stream->streamingMembersDataMutex };
-            streamingMembers->hasPoppedFirstObject = false;
-        }
+            DataMutexLocker queue { stream->track->queueDataMutex() };
 
-        GST_DEBUG_OBJECT(stream->pad.get(), "Starting webKitMediaSrcLoop task and releasing the STREAM_LOCK.");
-        gst_pad_start_task(stream->pad.get(), webKitMediaSrcLoop, stream->pad.ref(), gst_object_unref);
+            streamingMembers->isFlushing = true;
+            streamingMembers->isSeekingFlush = isSeekingFlush;
+            queue->flush(); // Clear the queue and cancel any waiting callback.
+
+            // Signal the loop() function to stop waiting for any condition variable and return.
+            streamingMembers->queueChangedOrFlushedCondition.notifyAll();
+            streamingMembers->padLinkedOrFlushedCondition.notifyAll();
+        }
     }
 
     GST_DEBUG_OBJECT(stream->source, "Flush request for stream '%" PRIu64 "' (isSeekingFlush = %s) satisfied.",


### PR DESCRIPTION
#### 25a97385a9a42539e00041af7f8ed2a31bd7a8fc
<pre>
[GStreamer][MSE] Fix mainthread deadlock during encrypted playback with seeking
<a href="https://bugs.webkit.org/show_bug.cgi?id=320336.">https://bugs.webkit.org/show_bug.cgi?id=320336.</a>

Reviewed by NOBODY (OOPS!).

Deadlock scenario:
1. Playback starts with encrypted video and cleared audio
2. Before the GStreamer pipeline is fully built, a seek operation triggers a flush
3. The audio track is blocked in playsink waiting for the video track
4. The video track is blocked in WebKitMediaCommonEncryptionDecrypt waiting for the DRM license
5. The mainthread attempts to send flush events but blocks in multiqueue because
   the audio track is already blocked in playsink
6. The DRM license response arrives but cannot be handled because the mainthread
   is blocked trying to flush the audio track

Solution:
Instead of sending flush events from the mainthread (which can block on downstream
operations), defer flush event sending to the streaming threads (audio/video). This
allows the mainthread to remain unblocked and available to handle DRM license
responses and other critical operations.

This change introduces two new state flags to manage the flush operation:
- isActive: controls whether the streaming thread should be running
- isSeekingFlush: indicates if the current flush is a seek operation

Flush handling is now performed directly by the streaming thread in webKitMediaSrcLoop()
instead of from webKitMediaSrcStreamFlush(), eliminating the deadlock condition.

* Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.cpp:
(webKitMediaSrcActivateMode):
(webKitMediaSrcSendFlushEvent):
(webKitMediaSrcLoop):
(webKitMediaSrcStreamFlush):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/25a97385a9a42539e00041af7f8ed2a31bd7a8fc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177211 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51149 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44943 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186814 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/140447 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179074 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52441 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50957 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138082 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96296 "1 flakes 3 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180167 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41586 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158848 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118547 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40246 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38624 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150655 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38346 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35282 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42934 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42947 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189240 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50815 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147173 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51498 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34972 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146965 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41691 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123713 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/118034 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50003 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13324 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49402 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49641 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49463 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->