### PR TITLE
run-webkit-tests and run-api-tests should apply sanitizer suppressions and options consistently

### DIFF
--- a/Tools/Scripts/webkitpy/port/base.py
+++ b/Tools/Scripts/webkitpy/port/base.py
@@ -353,7 +353,9 @@ class Port(object):
         return True
 
     def environment_for_api_tests(self):
-        return self.setup_environ_for_server()
+        environment = self.setup_environ_for_server()
+        self._append_sanitizer_options(environment)
+        return environment
 
     def _check_driver(self):
         driver_path = self._path_to_driver()
@@ -835,6 +837,34 @@ class Port(object):
             env[name] = env[name] + os.pathsep + value
         else:
             env[name] = value
+
+    @staticmethod
+    def _append_sanitizer_option(environment, variable, option):
+        # Sanitizer options are always ':'-separated, unlike a path list (os.pathsep is ';' on Windows).
+        # Keep an existing setting for the same key, so --additional-env-var wins.
+        if not environment.get(variable):
+            environment[variable] = option
+            return
+        key = option.split('=', 1)[0]
+        options = [each for each in environment[variable].split(':') if each]
+        if any(each.split('=', 1)[0] == key for each in options):
+            return
+        environment[variable] = ':'.join(options + [option])
+
+    def _append_asan_options(self, environment):
+        self._append_sanitizer_option(environment, 'ASAN_OPTIONS', 'allocator_may_return_null=1')
+        environment['__XPC_ASAN_OPTIONS'] = environment['ASAN_OPTIONS']
+
+    def _append_tsan_options(self, environment):
+        if not self._config.tsan:
+            return
+        self._append_sanitizer_option(environment, 'TSAN_OPTIONS', 'second_deadlock_stack=1')
+        self._append_sanitizer_option(environment, 'TSAN_OPTIONS', 'suppressions=' + self.path_from_webkit_base('Tools', 'Scripts', 'tsan_suppressions.txt'))
+        environment['__XPC_TSAN_OPTIONS'] = environment['TSAN_OPTIONS']
+
+    def _append_sanitizer_options(self, environment):
+        self._append_asan_options(environment)
+        self._append_tsan_options(environment)
 
     def show_results_html_file(self, results_filename):
         """This routine should display the HTML file pointed at by

--- a/Tools/Scripts/webkitpy/port/base_unittest.py
+++ b/Tools/Scripts/webkitpy/port/base_unittest.py
@@ -223,6 +223,99 @@ class PortTest(unittest.TestCase):
         self.assertEqual(environment['FOO'], 'BAR')
         self.assertEqual(environment['BAR'], 'FOO')
 
+    def test__append_sanitizer_option(self):
+        port = self.make_port()
+        variable = 'TSAN_OPTIONS'
+
+        # Unset: the option becomes the whole value.
+        environment = {}
+        port._append_sanitizer_option(environment, variable, 'suppressions=/a.txt')
+        self.assertEqual('suppressions=/a.txt', environment[variable])
+
+        # Different key present: append with a ':' separator, never os.pathsep.
+        environment[variable] = 'halt_on_error=0'
+        port._append_sanitizer_option(environment, variable, 'suppressions=/a.txt')
+        self.assertEqual('halt_on_error=0:suppressions=/a.txt', environment[variable])
+
+        # Same key already present: keep the existing value.
+        environment[variable] = 'suppressions=/mine.txt'
+        port._append_sanitizer_option(environment, variable, 'suppressions=/a.txt')
+        self.assertEqual('suppressions=/mine.txt', environment[variable])
+
+        # Same key present among others: still keep it, and do not reorder.
+        environment[variable] = 'halt_on_error=0:suppressions=/mine.txt:log_path=/tmp/t'
+        port._append_sanitizer_option(environment, variable, 'suppressions=/a.txt')
+        self.assertEqual('halt_on_error=0:suppressions=/mine.txt:log_path=/tmp/t', environment[variable])
+
+        # A key that merely ENDS WITH ours is a different key: append.
+        environment[variable] = 'foo_suppressions=/other.txt'
+        port._append_sanitizer_option(environment, variable, 'suppressions=/a.txt')
+        self.assertEqual('foo_suppressions=/other.txt:suppressions=/a.txt', environment[variable])
+
+        # Applying twice is idempotent.
+        port._append_sanitizer_option(environment, variable, 'suppressions=/a.txt')
+        self.assertEqual('foo_suppressions=/other.txt:suppressions=/a.txt', environment[variable])
+
+    def make_tsan_api_test_port(self, additional_env_var=None):
+        # A TSan build is identified by the marker file build-webkit --tsan writes.
+        port = self.make_port(options=optparse.Values({'additional_env_var': additional_env_var or []}))
+        port._config.build_directory = lambda configuration: '/mock-build'
+        port.host.filesystem.write_text_file('/mock-build/TSan', 'YES\n')
+        return port
+
+    def test_environment_for_api_tests_asan_options(self):
+        # ASan options apply to every build, TSan or not.
+        port = self.make_port(options=optparse.Values({'additional_env_var': []}))
+        port._config.build_directory = lambda configuration: '/mock-build'
+        environment = port.environment_for_api_tests()
+        self.assertEqual('allocator_may_return_null=1', environment['ASAN_OPTIONS'])
+        self.assertEqual(environment['ASAN_OPTIONS'], environment['__XPC_ASAN_OPTIONS'])
+
+    def test_environment_for_api_tests_asan_options_additive(self):
+        # ASAN_OPTIONS set with a different key: keep theirs, append ours.
+        port = self.make_port(options=optparse.Values({'additional_env_var': ['ASAN_OPTIONS=detect_leaks=1']}))
+        port._config.build_directory = lambda configuration: '/mock-build'
+        environment = port.environment_for_api_tests()
+        self.assertEqual('detect_leaks=1:allocator_may_return_null=1', environment['ASAN_OPTIONS'])
+
+    def test_environment_for_api_tests_asan_options_not_clobbered(self):
+        # ASAN_OPTIONS already sets our key: leave it alone.
+        port = self.make_port(options=optparse.Values({'additional_env_var': ['ASAN_OPTIONS=allocator_may_return_null=0']}))
+        port._config.build_directory = lambda configuration: '/mock-build'
+        environment = port.environment_for_api_tests()
+        self.assertEqual('allocator_may_return_null=0', environment['ASAN_OPTIONS'])
+
+    def test_environment_for_api_tests_non_tsan_build(self):
+        # Not a TSan build: leave TSAN_OPTIONS alone entirely.
+        port = self.make_port(options=optparse.Values({'additional_env_var': []}))
+        port._config.build_directory = lambda configuration: '/mock-build'
+        environment = port.environment_for_api_tests()
+        self.assertNotIn('TSAN_OPTIONS', environment)
+        self.assertNotIn('__XPC_TSAN_OPTIONS', environment)
+
+    def test_environment_for_api_tests_tsan_options_unset(self):
+        # TSan build, no TSAN_OPTIONS: set the in-tree suppressions file.
+        port = self.make_tsan_api_test_port()
+        environment = port.environment_for_api_tests()
+        self.assertEqual('second_deadlock_stack=1:suppressions=' + port.path_from_webkit_base('Tools', 'Scripts', 'tsan_suppressions.txt'), environment['TSAN_OPTIONS'])
+        # XPC-spawned children only inherit the __XPC_-prefixed twin.
+        self.assertEqual(environment['TSAN_OPTIONS'], environment['__XPC_TSAN_OPTIONS'])
+
+    def test_environment_for_api_tests_tsan_options_without_suppressions(self):
+        # TSAN_OPTIONS set without suppressions=: append ours, keep theirs.
+        # The separator is always ':', even on Windows where os.pathsep is ';'
+        # (TSan fails flag parsing and aborts on ';').
+        port = self.make_tsan_api_test_port(additional_env_var=['TSAN_OPTIONS=log_path=/tmp/tsan'])
+        environment = port.environment_for_api_tests()
+        self.assertEqual('log_path=/tmp/tsan:second_deadlock_stack=1:suppressions=' + port.path_from_webkit_base('Tools', 'Scripts', 'tsan_suppressions.txt'), environment['TSAN_OPTIONS'])
+        self.assertNotIn(';', environment['TSAN_OPTIONS'])
+
+    def test_environment_for_api_tests_tsan_options_with_suppressions(self):
+        # TSAN_OPTIONS already names a suppressions file: leave it alone.
+        port = self.make_tsan_api_test_port(additional_env_var=['TSAN_OPTIONS=suppressions=/tmp/mine.txt'])
+        environment = port.environment_for_api_tests()
+        self.assertEqual('suppressions=/tmp/mine.txt:second_deadlock_stack=1', environment['TSAN_OPTIONS'])
+
     def test_uses_test_expectations_file(self):
         port = self.make_port(port_name='foo')
         port.port_name = 'foo'

--- a/Tools/Scripts/webkitpy/port/config.py
+++ b/Tools/Scripts/webkitpy/port/config.py
@@ -143,7 +143,7 @@ class Config(object):
             configuration_path = self._filesystem.join(self.build_directory(None), "Configuration")
             if not self._filesystem.exists(configuration_path):
                 return None
-        except:
+        except Exception:
             return None
 
         return self._filesystem.read_text_file(configuration_path).rstrip()
@@ -156,5 +156,14 @@ class Config(object):
             return True
         try:
             return self._filesystem.exists(self._filesystem.join(self.build_directory(None), "ASan"))
-        except:
+        except Exception:
+            return False
+
+    @property
+    @memoized
+    def tsan(self):
+        # There is no --tsan option, so the marker file written by build-webkit --tsan is the only signal.
+        try:
+            return self._filesystem.exists(self._filesystem.join(self.build_directory(None), "TSan"))
+        except Exception:
             return False

--- a/Tools/Scripts/webkitpy/port/config_unittest.py
+++ b/Tools/Scripts/webkitpy/port/config_unittest.py
@@ -156,6 +156,16 @@ class ConfigTest(unittest.TestCase):
         self.assertNotIn('--asan', seen[-1])
         self.assertNotIn('--cmake', seen[-1])
 
+    def test_tsan_marker(self):
+        # There is no --tsan option, so the marker file is the only signal.
+        def mock_run_command(arg_list):
+            return 'foo\nfoo/Release'
+
+        self.assertTrue(self.make_config(run_command_fn=mock_run_command, files={'foo/TSan': 'YES'}).tsan)
+        self.assertFalse(self.make_config(run_command_fn=mock_run_command).tsan)
+        # An ASan build is not a TSan build.
+        self.assertFalse(self.make_config(run_command_fn=mock_run_command, files={'foo/ASan': 'YES'}).tsan)
+
     def test_build_directory_passes_xcode_flag(self):
         seen = []
 

--- a/Tools/Scripts/webkitpy/port/driver.py
+++ b/Tools/Scripts/webkitpy/port/driver.py
@@ -482,8 +482,7 @@ class Driver(object):
         else:
             environment['DUMPRENDERTREE_TEMP'] = str(self._driver_tempdir)
         environment['LOCAL_RESOURCE_ROOT'] = str(self._port.layout_tests_dir())
-        environment['ASAN_OPTIONS'] = "allocator_may_return_null=1"
-        environment['__XPC_ASAN_OPTIONS'] = environment['ASAN_OPTIONS']
+        self._port._append_sanitizer_options(environment)
 
         # Disable vnode-guard related simulated crashes for WKTR / DRT (rdar://problem/40674034).
         environment['SQLITE_EXEMPT_PATH_FROM_VNODE_GUARDS'] = '/'

--- a/Tools/Scripts/webkitpy/port/driver_unittest.py
+++ b/Tools/Scripts/webkitpy/port/driver_unittest.py
@@ -358,6 +358,75 @@ class DriverTest(unittest.TestCase):
             self.assertIn('WEBKIT_OUTPUTDIR', environment_driver_test)
             self.assertEqual(environment_user['WEBKIT_OUTPUTDIR'], environment_driver_test['WEBKIT_OUTPUTDIR'])
 
+    def test_setup_environ_for_test_asan_options(self):
+        # No ASAN_OPTIONS: set our default.
+        with patch('os.environ', {}):
+            port = self.make_port()
+            driver = Driver(port, None, pixel_tests=False)
+            environment = driver._setup_environ_for_test()
+            self.assertEqual('allocator_may_return_null=1', environment['ASAN_OPTIONS'])
+            self.assertEqual(environment['ASAN_OPTIONS'], environment['__XPC_ASAN_OPTIONS'])
+
+    def test_setup_environ_for_test_asan_options_additive(self):
+        # ASAN_OPTIONS set with a different key: keep theirs, append ours.
+        with patch('os.environ', {}):
+            port = self.make_port(options=MockOptions(additional_env_var=['ASAN_OPTIONS=detect_leaks=1']))
+            driver = Driver(port, None, pixel_tests=False)
+            environment = driver._setup_environ_for_test()
+            self.assertEqual('detect_leaks=1:allocator_may_return_null=1', environment['ASAN_OPTIONS'])
+
+    def test_setup_environ_for_test_asan_options_not_clobbered(self):
+        # ASAN_OPTIONS already sets our key: leave it alone.
+        with patch('os.environ', {}):
+            port = self.make_port(options=MockOptions(additional_env_var=['ASAN_OPTIONS=allocator_may_return_null=0']))
+            driver = Driver(port, None, pixel_tests=False)
+            environment = driver._setup_environ_for_test()
+            self.assertEqual('allocator_may_return_null=0', environment['ASAN_OPTIONS'])
+
+    def make_tsan_port(self, additional_env_var=None):
+        # A TSan build is identified by the marker file build-webkit --tsan writes.
+        port = self.make_port(options=MockOptions(additional_env_var=additional_env_var or []))
+        port.host.filesystem.write_text_file(port.host.filesystem.join(port._config.build_directory(None), 'TSan'), 'YES\n')
+        return port
+
+    def test_setup_environ_for_test_tsan_options_non_tsan_build(self):
+        # Not a TSan build: leave TSAN_OPTIONS alone entirely.
+        with patch('os.environ', {}):
+            port = self.make_port()
+            driver = Driver(port, None, pixel_tests=False)
+            environment = driver._setup_environ_for_test()
+            self.assertNotIn('TSAN_OPTIONS', environment)
+            self.assertNotIn('__XPC_TSAN_OPTIONS', environment)
+
+    def test_setup_environ_for_test_tsan_options_unset(self):
+        # TSan build, no TSAN_OPTIONS: set the in-tree suppressions file.
+        with patch('os.environ', {}):
+            port = self.make_tsan_port()
+            driver = Driver(port, None, pixel_tests=False)
+            environment = driver._setup_environ_for_test()
+            self.assertEqual('second_deadlock_stack=1:suppressions=' + port.path_from_webkit_base('Tools', 'Scripts', 'tsan_suppressions.txt'), environment['TSAN_OPTIONS'])
+            # XPC-spawned children only inherit the __XPC_-prefixed twin.
+            self.assertEqual(environment['TSAN_OPTIONS'], environment['__XPC_TSAN_OPTIONS'])
+
+    def test_setup_environ_for_test_tsan_options_without_suppressions(self):
+        # TSAN_OPTIONS set without suppressions=: append ours, keep theirs.
+        # The separator is always ':', even on Windows where os.pathsep is ';'
+        # (TSan fails flag parsing and aborts on ';').
+        with patch('os.environ', {}):
+            port = self.make_tsan_port(additional_env_var=['TSAN_OPTIONS=log_path=/tmp/tsan'])
+            driver = Driver(port, None, pixel_tests=False)
+            environment = driver._setup_environ_for_test()
+            self.assertEqual('log_path=/tmp/tsan:second_deadlock_stack=1:suppressions=' + port.path_from_webkit_base('Tools', 'Scripts', 'tsan_suppressions.txt'), environment['TSAN_OPTIONS'])
+            self.assertNotIn(';', environment['TSAN_OPTIONS'])
+
+    def test_setup_environ_for_test_tsan_options_with_suppressions(self):
+        # TSAN_OPTIONS already names a suppressions file: leave it alone.
+        with patch('os.environ', {}):
+            port = self.make_tsan_port(additional_env_var=['TSAN_OPTIONS=suppressions=/tmp/mine.txt'])
+            driver = Driver(port, None, pixel_tests=False)
+            environment = driver._setup_environ_for_test()
+            self.assertEqual('suppressions=/tmp/mine.txt:second_deadlock_stack=1', environment['TSAN_OPTIONS'])
+
     def test_setup_environ_for_test_webkit_prefix(self):
         environment_user = {}
         environment_user['WEBKIT2_PAUSE_WEB_PROCESS_ON_LAUNCH'] = '1'


### PR DESCRIPTION
#### 63cd1fe348a9e14b19b9187b1bb392c6e7097dcd
<pre>
run-webkit-tests and run-api-tests should apply sanitizer suppressions and options consistently
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=320338">https://bugs.webkit.org/show_bug.cgi?id=320338</a>&gt;
&lt;<a href="https://rdar.apple.com/183283578">rdar://183283578</a>&gt;

Reviewed by NOBODY (OOPS!).

TSan reads a suppressions file only when `TSAN_OPTIONS` names one, but the
entries in `Tools/Scripts/tsan_suppressions.txt` currently only apply to
Xcode schemes created by `generate-cmake-xcode-project`.  A sanitizer
sweep re-reports every race the file already covers, which is most of
what a sweep finds, leaving untriaged reports buried.

`run-webkit-tests` and `run-api-tests` also set up their sanitizer
environments independently: the `run-webkit-tests` driver set
`ASAN_OPTIONS`, while the `run-api-tests` path set neither `ASAN_OPTIONS`
nor `TSAN_OPTIONS`.  So the suppressions file and the
`allocator_may_return_null=1` default reached only one of the two
runners.

Fix this by moving the sanitizer setup onto the shared `Port` object so
both runners apply the same options: `allocator_may_return_null=1` for
ASan, and `second_deadlock_stack=1` plus the in-tree suppressions file
for TSan builds.  Make the options additive so that
`--additional-env-var` will now override (and merge with) the default
values set by the script.

Tests:
  webkitpy.port.base_unittest.PortTest.test__append_sanitizer_option
  webkitpy.port.base_unittest.PortTest.test_environment_for_api_tests_asan_options
  webkitpy.port.base_unittest.PortTest.test_environment_for_api_tests_asan_options_additive
  webkitpy.port.base_unittest.PortTest.test_environment_for_api_tests_asan_options_not_clobbered
  webkitpy.port.base_unittest.PortTest.test_environment_for_api_tests_non_tsan_build
  webkitpy.port.base_unittest.PortTest.test_environment_for_api_tests_tsan_options_unset
  webkitpy.port.base_unittest.PortTest.test_environment_for_api_tests_tsan_options_with_suppressions
  webkitpy.port.base_unittest.PortTest.test_environment_for_api_tests_tsan_options_without_suppressions
  webkitpy.port.config_unittest.ConfigTest.test_tsan_marker
  webkitpy.port.driver_unittest.DriverTest.test_setup_environ_for_test_asan_options
  webkitpy.port.driver_unittest.DriverTest.test_setup_environ_for_test_asan_options_additive
  webkitpy.port.driver_unittest.DriverTest.test_setup_environ_for_test_asan_options_not_clobbered
  webkitpy.port.driver_unittest.DriverTest.test_setup_environ_for_test_tsan_options_non_tsan_build
  webkitpy.port.driver_unittest.DriverTest.test_setup_environ_for_test_tsan_options_unset
  webkitpy.port.driver_unittest.DriverTest.test_setup_environ_for_test_tsan_options_with_suppressions
  webkitpy.port.driver_unittest.DriverTest.test_setup_environ_for_test_tsan_options_without_suppressions

* Tools/Scripts/webkitpy/port/base.py:
(Port.environment_for_api_tests): Apply the sanitizer options so
run-api-tests matches run-webkit-tests.
(Port._append_sanitizer_option): Add.
(Port._append_asan_options): Add.
(Port._append_tsan_options): Add.
(Port._append_sanitizer_options): Add.
* Tools/Scripts/webkitpy/port/base_unittest.py:
(PortTest.test__append_sanitizer_option): Add.
(PortTest.make_tsan_api_test_port): Add.
(PortTest.test_environment_for_api_tests_asan_options): Add.
(PortTest.test_environment_for_api_tests_asan_options_additive): Add.
(PortTest.test_environment_for_api_tests_asan_options_not_clobbered): Add.
(PortTest.test_environment_for_api_tests_non_tsan_build): Add.
(PortTest.test_environment_for_api_tests_tsan_options_unset): Add.
(PortTest.test_environment_for_api_tests_tsan_options_with_suppressions): Add.
(PortTest.test_environment_for_api_tests_tsan_options_without_suppressions): Add.
* Tools/Scripts/webkitpy/port/config.py:
(Config.asan):
(Config.tsan): Add.
* Tools/Scripts/webkitpy/port/config_unittest.py:
(ConfigTest.test_tsan_marker): Add.
* Tools/Scripts/webkitpy/port/driver.py:
(Driver._setup_environ_for_driver): Use the shared Port sanitizer setup.
* Tools/Scripts/webkitpy/port/driver_unittest.py:
(DriverTest.test_setup_environ_for_test_asan_options): Add.
(DriverTest.test_setup_environ_for_test_asan_options_additive): Add.
(DriverTest.test_setup_environ_for_test_asan_options_not_clobbered): Add.
(DriverTest.make_tsan_port): Add.
(DriverTest.test_setup_environ_for_test_tsan_options_non_tsan_build): Add.
(DriverTest.test_setup_environ_for_test_tsan_options_unset): Add.
(DriverTest.test_setup_environ_for_test_tsan_options_without_suppressions): Add.
(DriverTest.test_setup_environ_for_test_tsan_options_with_suppressions): Add.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/63cd1fe348a9e14b19b9187b1bb392c6e7097dcd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176890 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50827 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44619 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186493 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/140126 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/01c252c8-8504-42bf-802b-01888484634b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178753 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52120 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50513 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137809 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96278 "3 failures") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5c4fbb61-98ab-4fef-8824-c7768d610156) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179846 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41320 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158599 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118283 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/543f25bd-28eb-4191-90dd-c9c0edcaa7c3) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/176213 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39974 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38342 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150386 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38098 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34960 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42557 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188916 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50494 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146884 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51177 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34722 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146684 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41448 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117621 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49682 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13079 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49081 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49317 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49142 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->