### PR TITLE
Limit URL size at the IPC boundary to match Chrome/Blink

### DIFF
--- a/Source/WTF/wtf/URL.h
+++ b/Source/WTF/wtf/URL.h
@@ -51,6 +51,10 @@ protected:
     virtual ~URLTextEncoding() = default;
 };
 
+// Maximum length (in code units) of a URL that may be passed across an IPC boundary.
+// Matches Chromium's url::kMaxURLChars; URLs longer than this are rejected when decoded.
+constexpr unsigned maxURLLength = 2 * 1024 * 1024;
+
 class URL {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED(URL);
 public:

--- a/Source/WebKit/Shared/WTFArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WTFArgumentCoders.serialization.in
@@ -23,7 +23,12 @@
 webkit_platform_headers: "StreamConnectionEncoder.h"
 
 [WebKitPlatform, AdditionalEncoder=StreamConnectionEncoder] class WTF::URL {
+#if PLATFORM(COCOA)
+    [Validator='(*string).length() <= WTF::maxURLLength'] String string()
+#endif
+#if !PLATFORM(COCOA)
     String string()
+#endif
 }
 
 header: <wtf/text/CString.h>

--- a/Tools/TestWebKitAPI/Tests/IPC/ArgumentCoderTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/IPC/ArgumentCoderTests.cpp
@@ -36,6 +36,8 @@
 #include <WebCore/ShareableResource.h>
 #include <limits>
 #include <wtf/StdLibExtras.h>
+#include <wtf/URL.h>
+#include <wtf/text/StringBuilder.h>
 
 namespace TestWebKitAPI {
 
@@ -776,5 +778,62 @@ TEST(ArgumentCoderShareableResourceHandle, OverflowingOffsetAndSizeIsRejectedNot
     EXPECT_FALSE(result.has_value());
 }
 #endif // ENABLE(SHAREABLE_RESOURCE)
+
+// Builds a valid "https://webkit.org/aaa...a" URL string of exactly the requested length.
+static String makeURLStringOfLength(size_t length)
+{
+    ASSERT(length >= 19);
+    StringBuilder builder;
+    builder.append("https://webkit.org/"_s);
+    while (builder.length() < length)
+        builder.append('a');
+    return builder.toString();
+}
+
+// Round-trips a URL wire payload (a String) through an Encoder/Decoder and decodes it as a URL,
+// exercising the decode-side length validator.
+static std::optional<URL> decodeURLFromWireString(const String& wireString)
+{
+    IPC::Encoder encoder(IPC::MessageName::IPCTester_EmptyMessage, 0);
+    encoder << wireString;
+    auto decoder = IPC::Decoder::create(encoder.span(), encoder.releaseAttachments());
+    if (!decoder)
+        return std::nullopt;
+    return decoder->decode<URL>();
+}
+
+TEST(ArgumentCoderURL, RoundTripsNormalURL)
+{
+    auto url = decodeURLFromWireString("https://webkit.org/path?q=1"_str);
+    ASSERT_TRUE(url.has_value());
+    EXPECT_TRUE(url->isValid());
+    EXPECT_EQ(url->string(), "https://webkit.org/path?q=1"_str);
+}
+
+TEST(ArgumentCoderURL, URLAtLengthLimitIsPreserved)
+{
+    auto urlString = makeURLStringOfLength(WTF::maxURLLength);
+    ASSERT_EQ(urlString.length(), WTF::maxURLLength);
+
+    auto url = decodeURLFromWireString(urlString);
+    ASSERT_TRUE(url.has_value());
+    EXPECT_TRUE(url->isValid());
+    EXPECT_EQ(url->string().length(), WTF::maxURLLength);
+}
+
+// The over-limit rejection is enforced by the WTF::URL IPC validator, which is
+// currently Cocoa-only (see WTFArgumentCoders.serialization.in).
+#if PLATFORM(COCOA)
+TEST(ArgumentCoderURL, OversizedURLIsRejectedOnDecode)
+{
+    auto urlString = makeURLStringOfLength(WTF::maxURLLength + 1);
+    ASSERT_EQ(urlString.length(), WTF::maxURLLength + 1);
+
+    // An over-limit URL on the wire fails to decode (the message is rejected) and is
+    // never parsed, matching Chromium's GURL/KURL mojo traits.
+    auto url = decodeURLFromWireString(urlString);
+    EXPECT_FALSE(url.has_value());
+}
+#endif // PLATFORM(COCOA)
 
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### 04e3d47960f3135b16aff2382ac0d1b712e0d884
<pre>
Limit URL size at the IPC boundary to match Chrome/Blink
<a href="https://bugs.webkit.org/show_bug.cgi?id=320340">https://bugs.webkit.org/show_bug.cgi?id=320340</a>
<a href="https://rdar.apple.com/183139377">rdar://183139377</a>

Reviewed by Abrar Rahman Protyasha.

Spindumps of watchdog-terminated MobileSafari showed the UIProcess main
thread spinning while decoding a DecidePolicyForNavigationAction message:
the ResourceRequest it carries holds a pathologically large URL, and
decoding it re-parses that URL on the main thread, which can burn seconds
of CPU and trip the process watchdog.

Reject over-sized URLs when decoding them for IPC, matching Chromium. Chromium
caps every URL crossing a process boundary at url::kMaxURLChars (2MB) in its
GURL and KURL mojo traits, whose Read() returns false past that length; the
URL is never parsed. Do the same via a Validator on the WTF::URL IPC decoder:
the validator runs on the raw string before the URL is constructed, so an
over-sized URL is rejected (the message is treated as invalid) without being
parsed. The limit is WTF::maxURLLength, matching kMaxURLChars.

For now the validator is enabled on Cocoa only. A failed decode is treated as
an invalid message and terminates the sender, so the limit is only safe where
a legitimately-large URL never crosses this boundary. On Cocoa, data: URLs are
loaded in-process (WebLoaderStrategy::startLocalLoad), so they do not cross it.
On the other ports (GTK/WPE/Win/PlayStation) data: URLs are loaded by the
NetworkProcess (NetworkDataTaskDataURL, routed via NetworkDataTask::create), so
a large-but-legitimate data: URL does cross this boundary and rejecting it would
terminate the process (e.g. large canvas.toDataURL() images). Enabling
the limit on the other ports requires either loading data: URLs in-process there
too, or capping navigation URLs specifically rather than every URL on the wire.

Test: TestWebKitAPI ArgumentCoderURL.*

* Source/WTF/wtf/URL.h:
Add WTF::maxURLLength (2MB, matching url::kMaxURLChars).
* Source/WebKit/Shared/WTFArgumentCoders.serialization.in:
Reject URLs longer than WTF::maxURLLength when decoding WTF::URL, on Cocoa.
* Tools/TestWebKitAPI/Tests/IPC/ArgumentCoderTests.cpp:
(TestWebKitAPI::makeURLStringOfLength): Added.
(TestWebKitAPI::decodeURLFromWireString): Added.
Add ArgumentCoderURL tests for round-trip, the at-limit boundary, and (on
Cocoa) decode rejection over the limit.

Canonical link: <a href="https://commits.webkit.org/318045@main">https://commits.webkit.org/318045@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/05685f74bdc3f3b5fe7069da6ef847fcc49b4dee

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177085 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51022 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44817 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186688 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140321 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/50c0bd0c-50ac-4d9b-950c-1f545ca239e1) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178948 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52315 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50708 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137984 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140321 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b45b3bf6-c880-4482-8d56-093dd29c1789) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180041 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41488 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; Running run-layout-tests-in-stress-mode; Ignored 1 pre-existing failure based on results-db; Uploaded test results") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158751 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118452 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c80e27c8-b4d9-49fe-acf1-856939cb2727) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40144 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38512 "Passed tests") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/251/builds/421 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/7255 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150554 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38250 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35156 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/38356 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42855 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42730 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189114 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50689 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147068 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39535 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51372 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34874 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146892 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41596 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123586 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117873 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49877 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13230 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49276 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49513 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49337 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->