### PR TITLE
[JSC] Add fast flag for ToPrimitive(Object) calls in runtime

### DIFF
--- a/JSTests/stress/object-toprimitive-fastpath-deopt.js
+++ b/JSTests/stress/object-toprimitive-fastpath-deopt.js
@@ -1,0 +1,95 @@
+function shouldBe(a, b) { if (a !== b) throw new Error("bad: " + a + " !== " + b); }
+
+// Scenario 1: overriding Object.prototype.toString must deopt all plain objects, then re-engage.
+(function () {
+    function O() {}
+    var a = new O();
+    for (var i = 0; i < testLoopCount; ++i)
+        shouldBe(`${a}`, "[object Object]");
+    a < 1;
+
+    var originalToString = Object.prototype.toString;
+    // Delete first: a plain reassignment leaves the memoized mode unable to return to Fast.
+    delete Object.prototype.toString;
+    Object.prototype.toString = function () { return "custom"; };
+    try {
+        shouldBe(`${a}`, "custom");
+        shouldBe(a + "", "custom");
+        shouldBe(String(a), "custom");
+
+        var b = new O();
+        shouldBe(`${b}`, "custom");
+    } finally {
+        // Restore as non-enumerable; a plain assignment would leave toString enumerable.
+        delete Object.prototype.toString;
+        Object.defineProperty(Object.prototype, "toString", {
+            value: originalToString,
+            writable: true,
+            enumerable: false,
+            configurable: true,
+        });
+    }
+
+    for (var i = 0; i < testLoopCount; ++i)
+        shouldBe(`${a}`, "[object Object]");
+    a < 1;
+})();
+
+// Scenario 2: an own Symbol.toPrimitive added after warmup must be honored, then removable.
+(function () {
+    function O() {}
+    var a = new O();
+    for (var i = 0; i < testLoopCount; ++i) {
+        shouldBe(`${a}`, "[object Object]");
+        shouldBe(a < 100, false);
+    }
+
+    a[Symbol.toPrimitive] = function (hint) {
+        if (hint === "number")
+            return 42;
+        if (hint === "string")
+            return "forty-two";
+        return "default-forty-two";
+    };
+
+    shouldBe(a < 100, true);
+    shouldBe(100 < a, false);
+    shouldBe(a + 1, "default-forty-two1");
+    shouldBe(`${a}`, "forty-two");
+    shouldBe(String(a), "forty-two");
+    shouldBe(Number(a), 42);
+
+    delete a[Symbol.toPrimitive];
+    for (var i = 0; i < testLoopCount; ++i) {
+        shouldBe(`${a}`, "[object Object]");
+        shouldBe(a < 100, false);
+    }
+})();
+
+// Scenario 3: a prototype Symbol.toStringTag added after warmup must be honored, then removable.
+(function () {
+    function Tagged() {}
+    var obj = new Tagged();
+    for (var i = 0; i < testLoopCount; ++i) {
+        shouldBe(Object.prototype.toString.call(obj), "[object Object]");
+        shouldBe(`${obj}`, "[object Object]");
+    }
+    obj < 1;
+
+    Tagged.prototype[Symbol.toStringTag] = "Tag";
+
+    shouldBe(Object.prototype.toString.call(obj), "[object Tag]");
+    shouldBe(`${obj}`, "[object Tag]");
+    shouldBe(obj + "", "[object Tag]");
+    shouldBe(String(obj), "[object Tag]");
+
+    function Plain() {}
+    var plain = new Plain();
+    shouldBe(`${plain}`, "[object Object]");
+
+    delete Tagged.prototype[Symbol.toStringTag];
+    for (var i = 0; i < testLoopCount; ++i) {
+        shouldBe(`${obj}`, "[object Object]");
+        obj < 1;
+    }
+})();

--- a/JSTests/stress/object-toprimitive-fastpath-overrides.js
+++ b/JSTests/stress/object-toprimitive-fastpath-overrides.js
@@ -1,0 +1,127 @@
+function shouldBe(a, b) { if (a !== b) throw new Error("bad: " + a + " !== " + b); }
+
+// Objects with an own or exotic override must always take the full, spec-compliant slow path.
+
+// own valueOf returning a number.
+(function () {
+    var v = { valueOf() { return 5; } };
+    shouldBe(v < 10, true);
+    shouldBe(v + 1, 6);
+})();
+
+// own toString.
+(function () {
+    var s = { toString() { return "z"; } };
+    shouldBe(`${s}`, "z");
+})();
+
+// own Symbol.toPrimitive.
+(function () {
+    var tp = { [Symbol.toPrimitive](hint) { return hint; } };
+    shouldBe(`${tp}`, "string");
+    shouldBe(Number.isNaN(+tp), true);
+    shouldBe(tp + "", "default");
+})();
+
+// own Symbol.toStringTag.
+(function () {
+    var tag = { [Symbol.toStringTag]: "X" };
+    shouldBe(`${tag}`, "[object X]");
+})();
+
+// Mixed-operand relational compares against a plain object.
+(function () {
+    var o = {};
+    shouldBe(o < 5, false);
+    shouldBe(1 < o, false);
+    shouldBe("a" < o, false);
+    shouldBe(o < "b", true);
+    shouldBe(o <= 5, false);
+    shouldBe(5 <= o, false);
+    shouldBe(o > 5, false);
+    shouldBe(o >= 5, false);
+})();
+
+// Arrays use their own fast path, not the plain-object one.
+(function () {
+    shouldBe([1, 2] < [1, 3], true);
+})();
+
+// Object.create(null) has no toString/valueOf/toPrimitive, so ToPrimitive throws.
+(function () {
+    var n = Object.create(null);
+    var threw = false;
+    try {
+        `${n}`;
+    } catch (e) {
+        threw = e instanceof TypeError;
+    }
+    shouldBe(threw, true);
+
+    threw = false;
+    try {
+        n + 1;
+    } catch (e) {
+        threw = e instanceof TypeError;
+    }
+    shouldBe(threw, true);
+
+    threw = false;
+    try {
+        n < 5;
+    } catch (e) {
+        threw = e instanceof TypeError;
+    }
+    shouldBe(threw, true);
+})();
+
+// Object identity (a == b) is unaffected, same-realm and cross-realm.
+(function () {
+    var a = {}, b = {};
+    shouldBe(a == b, false);
+    shouldBe(a == a, true);
+
+    var other = createGlobalObject();
+    var otherObjectCtor = other.Object;
+    var crossA = new otherObjectCtor();
+    var crossB = new otherObjectCtor();
+    shouldBe(crossA == crossB, false);
+    shouldBe(crossA == crossA, true);
+})();
+
+// Cross-realm: the verdict must be computed against the object's own realm, so an override on
+// the other realm's Object.prototype.toString is honored when coercing from the main realm.
+(function () {
+    var other = createGlobalObject();
+    var o = new other.Object();
+
+    var p = new other.Object();
+    for (var i = 0; i < testLoopCount; ++i) {
+        o < p;
+        o <= p;
+        `${o}`;
+    }
+
+    shouldBe(`${o}`, "[object Object]");
+    shouldBe(o + "", "[object Object]");
+    shouldBe(String(o), "[object Object]");
+    shouldBe(o < o, false);
+    shouldBe(o <= o, true);
+    shouldBe(o > o, false);
+    shouldBe(o >= o, true);
+
+    other.Object.prototype.toString = function () { return "custom-other-realm"; };
+    shouldBe(`${o}`, "custom-other-realm");
+    shouldBe(o + "", "custom-other-realm");
+    shouldBe(String(o), "custom-other-realm");
+})();
+
+// The default fast path coexists with all the overridden cases above without cross-contamination.
+(function () {
+    function Plain() {}
+    var p = new Plain();
+    for (var i = 0; i < testLoopCount; ++i) {
+        shouldBe(`${p}`, "[object Object]");
+        shouldBe(p < 5, false);
+    }
+})();

--- a/JSTests/stress/object-toprimitive-fastpath-prototype.js
+++ b/JSTests/stress/object-toprimitive-fastpath-prototype.js
@@ -1,0 +1,83 @@
+function shouldBe(a, b) { if (a !== b) throw new Error("bad: " + a + " !== " + b); }
+
+// A special property on the [[Prototype]] (not own) must still be honored: the fast path only
+// checks own properties for memoization, but the eligibility itself resolves valueOf / toString /
+// @@toPrimitive up the whole prototype chain, so it must never fold such objects to "[object Object]".
+
+// Prototype has valueOf: number/default hints use it; string hint falls to the primordial toString.
+(function () {
+    function O() {}
+    O.prototype = { valueOf() { return 111; } };
+    var o = new O();
+    for (var i = 0; i < testLoopCount; ++i) { o < 1; o + ""; `${o}`; }
+    shouldBe(o < 200, true);
+    shouldBe(200 < o, false);
+    shouldBe(o + 1, 112);
+    shouldBe(`${o}`, "[object Object]");
+})();
+
+// Prototype has toString.
+(function () {
+    function O() {}
+    O.prototype = { toString() { return "PROTO"; } };
+    var o = new O();
+    for (var i = 0; i < testLoopCount; ++i) { `${o}`; o < 1; o + ""; }
+    shouldBe(`${o}`, "PROTO");
+    shouldBe(o + "", "PROTO");
+    shouldBe(String(o), "PROTO");
+})();
+
+// Prototype has Symbol.toPrimitive.
+(function () {
+    function O() {}
+    O.prototype = { [Symbol.toPrimitive](hint) { return hint === "string" ? "S" : 7; } };
+    var o = new O();
+    for (var i = 0; i < testLoopCount; ++i) { o < 1; `${o}`; o + ""; }
+    shouldBe(`${o}`, "S");
+    shouldBe(o < 10, true);
+    shouldBe(o + 1, 8);
+})();
+
+// Prototype has a string Symbol.toStringTag: coercion reflects it.
+(function () {
+    function O() {}
+    O.prototype = {};
+    O.prototype[Symbol.toStringTag] = "PT";
+    var o = new O();
+    for (var i = 0; i < testLoopCount; ++i) { `${o}`; o < 1; }
+    shouldBe(`${o}`, "[object PT]");
+    shouldBe(Object.prototype.toString.call(o), "[object PT]");
+})();
+
+// Reach the fast path as a plain object, then insert a prototype with valueOf: must deopt.
+(function () {
+    var o = {};
+    for (var i = 0; i < testLoopCount; ++i) { o < 1; `${o}`; o + ""; }
+    shouldBe(o + 1, "[object Object]1");
+
+    Object.setPrototypeOf(o, { valueOf() { return 5; } });
+    shouldBe(o < 10, true);
+    shouldBe(o + 1, 6);
+    shouldBe(`${o}`, "[object Object]");
+})();
+
+// Reach the fast path, then insert a prototype with valueOf into the middle of the chain.
+(function () {
+    function O() {}
+    var o = new O();
+    for (var i = 0; i < testLoopCount; ++i) { o < 1; `${o}`; o + ""; }
+    shouldBe(o + 1, "[object Object]1");
+
+    Object.setPrototypeOf(O.prototype, { valueOf() { return 9; } });
+    shouldBe(o < 10, true);
+    shouldBe(o + 1, 10);
+})();
+
+// Reach the fast path, then add an own valueOf directly.
+(function () {
+    var o = {};
+    for (var i = 0; i < testLoopCount; ++i) { o < 1; `${o}`; o + ""; }
+    o.valueOf = function () { return 3; };
+    shouldBe(o < 10, true);
+    shouldBe(o + 1, 4);
+})();

--- a/JSTests/stress/object-toprimitive-fastpath.js
+++ b/JSTests/stress/object-toprimitive-fastpath.js
@@ -1,0 +1,14 @@
+function shouldBe(a, b) { if (a !== b) throw new Error("bad: " + JSON.stringify(a) + " !== " + JSON.stringify(b)); }
+function O() {}
+var a = new O(), b = new O();
+for (var i = 0; i < testLoopCount; ++i) {
+    shouldBe(a < b, false);
+    shouldBe(a <= b, true);
+    shouldBe(a > b, false);
+    shouldBe(a >= b, true);
+    shouldBe(`${a}`, "[object Object]");
+    shouldBe(a + "", "[object Object]");
+    shouldBe(String(a), "[object Object]");
+}
+shouldBe(a == b, false);
+shouldBe(a == a, true);

--- a/Source/JavaScriptCore/runtime/JSObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSObject.cpp
@@ -2610,6 +2610,11 @@ JSValue JSObject::toPrimitive(JSGlobalObject* globalObject, PreferredPrimitiveTy
             RELEASE_AND_RETURN(scope, array->fastToString(globalObject));
     }
 
+    // For a plain default object ordinaryToPrimitive collapses to the cached ToStringTag string
+    // for both hints (primordial valueOf is skipped), so returning it here matches the slow path.
+    if (auto* tag = structure()->defaultToPrimitiveFastAndNonObservable(vm))
+        return tag;
+
     JSValue value = callToPrimitiveFunction<CachedSpecialPropertyKey::ToPrimitive>(globalObject, this, vm.propertyNames->toPrimitiveSymbol, preferredType);
     RETURN_IF_EXCEPTION(scope, { });
     if (value)

--- a/Source/JavaScriptCore/runtime/Structure.h
+++ b/Source/JavaScriptCore/runtime/Structure.h
@@ -635,6 +635,8 @@ public:
     inline JSValue cachedSpecialProperty(CachedSpecialPropertyKey key); // Defined in StructureInlines.h
     void cacheSpecialProperty(JSGlobalObject*, VM&, JSValue, CachedSpecialPropertyKey, const PropertySlot&);
 
+    inline JSString* defaultToPrimitiveFastAndNonObservable(VM&);
+
     static constexpr ptrdiff_t prototypeOffset()
     {
         return OBJECT_OFFSETOF(Structure, m_prototype);

--- a/Source/JavaScriptCore/runtime/StructureInlines.h
+++ b/Source/JavaScriptCore/runtime/StructureInlines.h
@@ -696,6 +696,64 @@ inline JSValue Structure::cachedSpecialProperty(CachedSpecialPropertyKey key)
     return rareData()->cachedSpecialProperty(key);
 }
 
+inline JSString* Structure::defaultToPrimitiveFastAndNonObservable(VM& vm)
+{
+    if (typeInfo().type() != FinalObjectType)
+        return nullptr;
+
+    if (!hasRareData())
+        return nullptr;
+
+    // Use the object's own realm: the cached special properties below were resolved against this
+    // structure's prototype chain, so they must be compared against that realm's primordials.
+    JSGlobalObject* globalObject = this->realm();
+    if (!globalObject) [[unlikely]]
+        return nullptr;
+
+    if (!globalObject->objectPrototypeChainIsSaneWatchpointSet().isStillValid()) [[unlikely]]
+        return nullptr;
+
+    StructureRareData* rareData = this->rareData();
+    switch (rareData->cachedHasDefaultToPrimitiveFastAndNonObservable()) {
+    case TriState::True:
+        return asString(rareData->cachedSpecialProperty(CachedSpecialPropertyKey::ToStringTag));
+    case TriState::False:
+        return nullptr;
+    case TriState::Indeterminate:
+        break;
+    }
+
+    JSValue toPrimitive = rareData->cachedSpecialProperty(CachedSpecialPropertyKey::ToPrimitive);
+    JSValue valueOf = rareData->cachedSpecialProperty(CachedSpecialPropertyKey::ValueOf);
+    JSValue toString = rareData->cachedSpecialProperty(CachedSpecialPropertyKey::ToString);
+    JSValue toStringTag = rareData->cachedSpecialProperty(CachedSpecialPropertyKey::ToStringTag);
+
+    bool definitelySlow = (toPrimitive && !toPrimitive.isUndefined())
+        || (valueOf && valueOf != globalObject->objectProtoValueOfFunction())
+        || (toString && toString != globalObject->objectProtoToStringFunction())
+        || (toStringTag && !toStringTag.isString());
+
+    if (definitelySlow)
+        rareData->setCachedHasDefaultToPrimitiveFastAndNonObservable(TriState::False);
+    else {
+        if (toPrimitive && valueOf && toString && toStringTag) {
+            rareData->setCachedHasDefaultToPrimitiveFastAndNonObservable(TriState::True);
+            return asString(toStringTag);
+        }
+
+        // Memoize Slow only when the verdict is stable. An empty cache with no own special property is
+        // merely not-yet-probed, so leave it Unknown and let a later call reach Fast once it populates.
+        bool hasOwnSpecialProperty = isValidOffset(get(vm, vm.propertyNames->valueOf))
+            || isValidOffset(get(vm, vm.propertyNames->toString))
+            || isValidOffset(get(vm, vm.propertyNames->toPrimitiveSymbol))
+            || isValidOffset(get(vm, vm.propertyNames->toStringTagSymbol));
+        if (hasOwnSpecialProperty)
+            rareData->setCachedHasDefaultToPrimitiveFastAndNonObservable(TriState::False);
+    }
+
+    return nullptr;
+}
+
 inline void Structure::clearCachedPrototypeChain()
 {
     m_cachedPrototypeChain.clear();

--- a/Source/JavaScriptCore/runtime/StructureRareData.cpp
+++ b/Source/JavaScriptCore/runtime/StructureRareData.cpp
@@ -122,6 +122,8 @@ SpecialPropertyCache& StructureRareData::ensureSpecialPropertyCacheSlow()
 
 inline void StructureRareData::giveUpOnSpecialPropertyCache(CachedSpecialPropertyKey key)
 {
+    // Invalidate the memoized fast-path verdict along with the cache it is derived from.
+    m_cachedHasDefaultToPrimitiveFastAndNonObservable = TriState::Indeterminate;
     ensureSpecialPropertyCache().m_cache[static_cast<unsigned>(key)].m_value.setWithoutWriteBarrier(JSCell::seenMultipleCalleeObjects());
 }
 
@@ -220,6 +222,11 @@ void StructureRareData::cacheSpecialPropertySlow(JSGlobalObject* globalObject, V
 
 void StructureRareData::clearCachedSpecialProperty(CachedSpecialPropertyKey key)
 {
+    // The fast-path verdict is derived from every special property except ToJSON, so invalidate it
+    // whenever one of those caches is cleared.
+    if (key != CachedSpecialPropertyKey::ToJSON)
+        m_cachedHasDefaultToPrimitiveFastAndNonObservable = TriState::Indeterminate;
+
     auto* objectToStringCache = m_specialPropertyCache.get();
     if (!objectToStringCache)
         return;

--- a/Source/JavaScriptCore/runtime/StructureRareData.h
+++ b/Source/JavaScriptCore/runtime/StructureRareData.h
@@ -87,6 +87,9 @@ public:
     JSValue cachedSpecialProperty(CachedSpecialPropertyKey) const;
     void cacheSpecialProperty(JSGlobalObject*, VM&, Structure* baseStructure, JSValue, CachedSpecialPropertyKey, const PropertySlot&);
 
+    TriState cachedHasDefaultToPrimitiveFastAndNonObservable() const { return m_cachedHasDefaultToPrimitiveFastAndNonObservable; }
+    void setCachedHasDefaultToPrimitiveFastAndNonObservable(TriState mode) { m_cachedHasDefaultToPrimitiveFastAndNonObservable = mode; }
+
     JSPropertyNameEnumerator* cachedPropertyNameEnumerator() const;
     uintptr_t cachedPropertyNameEnumeratorAndFlag() const;
     void setCachedPropertyNameEnumerator(VM&, Structure*, JSPropertyNameEnumerator*, StructureChain*);
@@ -178,6 +181,7 @@ private:
     PropertyOffset m_maxOffset;
     PropertyOffset m_transitionOffset;
     unsigned m_activeReplacementWatchpointSet { 0 };
+    TriState m_cachedHasDefaultToPrimitiveFastAndNonObservable : 2 { TriState::Indeterminate };
 };
 
 } // namespace JSC


### PR DESCRIPTION
#### cd91e7f128dd09f6f9bb8f19e8bc66c6d7e94dfa
<pre>
[JSC] Add fast flag for ToPrimitive(Object) calls in runtime
<a href="https://bugs.webkit.org/show_bug.cgi?id=320343">https://bugs.webkit.org/show_bug.cgi?id=320343</a>
<a href="https://rdar.apple.com/183289080">rdar://183289080</a>

Reviewed by Sosuke Suzuki.

Make ToPrimitive(object) faster by caching a flag in StructureRareData.
m_cachedHasDefaultToPrimitiveFastAndNonObservable says that we can use
toStringTag cached value.

Tests: JSTests/stress/object-toprimitive-fastpath-deopt.js
       JSTests/stress/object-toprimitive-fastpath-overrides.js
       JSTests/stress/object-toprimitive-fastpath-prototype.js
       JSTests/stress/object-toprimitive-fastpath.js

* JSTests/stress/object-toprimitive-fastpath-deopt.js: Added.
(shouldBe):
(O):
(Object.prototype.toString):
(a.Symbol.toPrimitive):
(Tagged):
(Plain):
* JSTests/stress/object-toprimitive-fastpath-overrides.js: Added.
(shouldBe):
(v.valueOf):
(s.toString):
(tp.Symbol.toPrimitive):
(catch):
(other.Object.prototype.toString):
(Plain):
* JSTests/stress/object-toprimitive-fastpath-prototype.js: Added.
(shouldBe):
(O):
(O.prototype.valueOf):
(O.prototype.toString):
(O.prototype.Symbol.toPrimitive):
(valueOf):
(o.valueOf):
* JSTests/stress/object-toprimitive-fastpath.js: Added.
(shouldBe):
(O):
* Source/JavaScriptCore/runtime/JSObject.cpp:
(JSC::JSObject::toPrimitive const):
* Source/JavaScriptCore/runtime/Structure.h:
* Source/JavaScriptCore/runtime/StructureInlines.h:
(JSC::Structure::defaultToPrimitiveFastAndNonObservable):
* Source/JavaScriptCore/runtime/StructureRareData.cpp:
(JSC::StructureRareData::giveUpOnSpecialPropertyCache):
(JSC::StructureRareData::clearCachedSpecialProperty):
* Source/JavaScriptCore/runtime/StructureRareData.h:

Canonical link: <a href="https://commits.webkit.org/317978@main">https://commits.webkit.org/317978@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dcb74f433469946cbfaedf1b42222469454c28b8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176879 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50816 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44608 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186482 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140115 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/da5ba745-3e81-449c-aeb3-65bd259ced3c) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52109 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50502 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137803 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140115 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d627b10e-d298-42f8-b3ef-d44359c420de) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179835 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41312 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158591 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118277 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d19e3f94-c64e-4031-ba12-b4ca266d69bd) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39966 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38333 "Passed tests") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/251/builds/246 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/7098 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150378 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38090 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34949 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/38150 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42562 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42548 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188905 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50483 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146873 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51166 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34714 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146674 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26835 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41440 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123374 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117607 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49671 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13071 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49070 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49306 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49131 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->