### PR TITLE
IPC Message refactoring

### DIFF
--- a/Source/WebCore/platform/graphics/BifurcatedGraphicsContext.cpp
+++ b/Source/WebCore/platform/graphics/BifurcatedGraphicsContext.cpp
@@ -457,46 +457,6 @@ void BifurcatedGraphicsContext::drawVideoFrame(const VideoFrame& videoFrame, con
 }
 #endif // ENABLE(VIDEO)
 
-void BifurcatedGraphicsContext::scale(const FloatSize& scale)
-{
-    m_primaryContext.scale(scale);
-    m_secondaryContext.scale(scale);
-
-    VERIFY_STATE_SYNCHRONIZATION();
-}
-
-void BifurcatedGraphicsContext::rotate(float angleInRadians)
-{
-    m_primaryContext.rotate(angleInRadians);
-    m_secondaryContext.rotate(angleInRadians);
-
-    VERIFY_STATE_SYNCHRONIZATION();
-}
-
-void BifurcatedGraphicsContext::translate(float x, float y)
-{
-    m_primaryContext.translate(x, y);
-    m_secondaryContext.translate(x, y);
-
-    VERIFY_STATE_SYNCHRONIZATION();
-}
-
-void BifurcatedGraphicsContext::concatCTM(const AffineTransform& transform)
-{
-    m_primaryContext.concatCTM(transform);
-    m_secondaryContext.concatCTM(transform);
-
-    VERIFY_STATE_SYNCHRONIZATION();
-}
-
-void BifurcatedGraphicsContext::setCTM(const AffineTransform& transform)
-{
-    m_primaryContext.setCTM(transform);
-    m_secondaryContext.setCTM(transform);
-
-    VERIFY_STATE_SYNCHRONIZATION();
-}
-
 AffineTransform BifurcatedGraphicsContext::getCTM(IncludeDeviceScale includeDeviceScale) const
 {
     return m_primaryContext.getCTM(includeDeviceScale);

--- a/Source/WebCore/platform/graphics/BifurcatedGraphicsContext.h
+++ b/Source/WebCore/platform/graphics/BifurcatedGraphicsContext.h
@@ -118,14 +118,6 @@ public:
     void drawVideoFrame(const VideoFrame&, const FloatRect& destination, WebCore::ImageOrientation, bool shouldDiscardAlpha) final;
 #endif
 
-    using GraphicsContext::scale;
-    void scale(const FloatSize&) final;
-    void rotate(float angleInRadians) final;
-    void translate(float x, float y) final;
-
-    void concatCTM(const AffineTransform&) final;
-    void setCTM(const AffineTransform&) final;
-
     AffineTransform getCTM(IncludeDeviceScale = PossiblyIncludeDeviceScale) const final;
 
     void drawFocusRing(const Path&, float outlineWidth, const Color&, float zoomFactor) final;

--- a/Source/WebCore/platform/graphics/FontCascade.cpp
+++ b/Source/WebCore/platform/graphics/FontCascade.cpp
@@ -247,8 +247,10 @@ RefPtr<const DisplayList::DisplayList> FontCascade::displayListForGlyphBuffer(Gr
     constexpr auto drawGlyphsMode = DisplayList::Recorder::DrawGlyphsMode::Deconstruct;
 #endif
 
-    DisplayList::RecorderImpl recordingContext(context.state().clone(GraphicsContextState::Purpose::Initial), { },
-        context.getCTM(GraphicsContext::DefinitelyIncludeDeviceScale), context.colorSpace(), drawGlyphsMode);
+    auto initialState = context.state().clone(GraphicsContextState::Purpose::Initial);
+    // Seed the CTM without marking the change flag.
+    initialState.ctm() = context.getCTM(GraphicsContext::DefinitelyIncludeDeviceScale);
+    DisplayList::RecorderImpl recordingContext(initialState, { }, context.colorSpace(), drawGlyphsMode);
 
     FloatPoint startPoint = toFloatPoint(WebCore::size(glyphBuffer.initialAdvance()));
     drawGlyphBuffer(recordingContext, glyphBuffer, startPoint, customFontNotReadyAction);

--- a/Source/WebCore/platform/graphics/GraphicsContext.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsContext.cpp
@@ -48,7 +48,7 @@ namespace WebCore {
 WTF_MAKE_TZONE_ALLOCATED_IMPL(GraphicsContext);
 
 GraphicsContext::GraphicsContext(IsDeferred isDeferred, const GraphicsContextState::ChangeFlags& changeFlags, InterpolationQuality imageInterpolationQuality)
-    : m_state(changeFlags, imageInterpolationQuality)
+    : m_state({ }, changeFlags, imageInterpolationQuality)
     , m_isDeferred(isDeferred)
 {
 }

--- a/Source/WebCore/platform/graphics/GraphicsContext.h
+++ b/Source/WebCore/platform/graphics/GraphicsContext.h
@@ -171,6 +171,11 @@ public:
     virtual void didUpdateState(GraphicsContextState&) = 0;
     virtual void didUpdateSingleState(GraphicsContextState& state, GraphicsContextState::ChangeIndex) { didUpdateState(state); }
 
+    // Called *before* the CTM changes. Subclasses that buffer draws whose interpretation
+    // depends on the CTM being stable (e.g. batched line strokes) must flush them here,
+    // since such draws are not otherwise revisited when the CTM changes.
+    virtual void willChangeCTM() { }
+
     WEBCORE_EXPORT virtual void save(GraphicsContextState::Purpose = GraphicsContextState::Purpose::SaveRestore);
     WEBCORE_EXPORT virtual void restore(GraphicsContextState::Purpose = GraphicsContextState::Purpose::SaveRestore);
 
@@ -331,15 +336,44 @@ public:
 
     // Transforms
 
+    const AffineTransform& ctm() const { return m_state.ctm(); }
+    void setCTM(const AffineTransform& matrix)
+    {
+        willChangeCTM();
+        m_state.setCTM(matrix);
+        didUpdateSingleState(m_state, GraphicsContextState::toIndex(GraphicsContextState::Change::TransformationMatrix));
+    }
+
+    void concatCTM(const AffineTransform& matrix)
+    {
+        willChangeCTM();
+        m_state.concatCTM(matrix);
+        didUpdateSingleState(m_state, GraphicsContextState::toIndex(GraphicsContextState::Change::TransformationMatrix));
+    }
+
+    void scale(const FloatSize& size)
+    {
+        willChangeCTM();
+        m_state.scale(size);
+        didUpdateSingleState(m_state, GraphicsContextState::toIndex(GraphicsContextState::Change::TransformationMatrix));
+    }
     void scale(float s) { scale({ s, s }); }
-    virtual void scale(const FloatSize&) = 0;
-    virtual void rotate(float angleInRadians) = 0;
+
+    void rotate(float angleInRadians)
+    {
+        willChangeCTM();
+        m_state.rotate(angleInRadians);
+        didUpdateSingleState(m_state, GraphicsContextState::toIndex(GraphicsContextState::Change::TransformationMatrix));
+    }
+
+    void translate(float x, float y)
+    {
+        willChangeCTM();
+        m_state.translate(x, y);
+        didUpdateSingleState(m_state, GraphicsContextState::toIndex(GraphicsContextState::Change::TransformationMatrix));
+    }
     void translate(const FloatSize& size) { translate(size.width(), size.height()); }
     void translate(const FloatPoint& p) { translate(p.x(), p.y()); }
-    virtual void translate(float x, float y) = 0;
-
-    virtual void concatCTM(const AffineTransform&) = 0;
-    virtual void setCTM(const AffineTransform&) = 0;
 
     enum IncludeDeviceScale { DefinitelyIncludeDeviceScale, PossiblyIncludeDeviceScale };
     virtual AffineTransform getCTM(IncludeDeviceScale = PossiblyIncludeDeviceScale) const = 0;

--- a/Source/WebCore/platform/graphics/GraphicsContextState.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsContextState.cpp
@@ -31,8 +31,9 @@
 
 namespace WebCore {
 
-GraphicsContextState::GraphicsContextState(const ChangeFlags& changeFlags, InterpolationQuality imageInterpolationQuality)
-    : m_changeFlags(changeFlags)
+GraphicsContextState::GraphicsContextState(const AffineTransform& ctm, const ChangeFlags& changeFlags, InterpolationQuality imageInterpolationQuality)
+    : m_transformationMatrix { ctm }
+    , m_changeFlags(changeFlags)
     , m_imageInterpolationQuality(imageInterpolationQuality)
 {
 }
@@ -130,6 +131,10 @@ void GraphicsContextState::mergeSingleChange(const GraphicsContextState& state, 
     case toIndex(Change::DrawLuminanceMask).value:
         mergeChange(&GraphicsContextState::m_drawLuminanceMask);
         break;
+
+    case toIndex(Change::TransformationMatrix).value:
+        mergeChange(&GraphicsContextState::m_transformationMatrix);
+        break;
     default:
         RELEASE_ASSERT_NOT_REACHED();
     }
@@ -216,6 +221,9 @@ static ASCIILiteral stateChangeName(GraphicsContextState::Change change)
 
     case GraphicsContextState::Change::DrawLuminanceMask:
         return "draw-luminance-mask"_s;
+
+    case GraphicsContextState::Change::TransformationMatrix:
+        return "transformation-matrix"_s;
     }
 
     RELEASE_ASSERT_NOT_REACHED();
@@ -250,6 +258,8 @@ TextStream& GraphicsContextState::dump(TextStream& ts) const
     dump(Change::ShouldSubpixelQuantizeFonts,   &GraphicsContextState::m_shouldSubpixelQuantizeFonts);
     dump(Change::ShadowsIgnoreTransforms,       &GraphicsContextState::m_shadowsIgnoreTransforms);
     dump(Change::DrawLuminanceMask,             &GraphicsContextState::m_drawLuminanceMask);
+
+    dump(Change::TransformationMatrix,          &GraphicsContextState::m_transformationMatrix);
     return ts;
 }
 

--- a/Source/WebCore/platform/graphics/GraphicsContextState.h
+++ b/Source/WebCore/platform/graphics/GraphicsContextState.h
@@ -58,6 +58,8 @@ public:
         ShouldSubpixelQuantizeFonts = 1 << 13,
         ShadowsIgnoreTransforms     = 1 << 14,
         DrawLuminanceMask           = 1 << 15,
+
+        TransformationMatrix        = 1 << 16,
     };
     using ChangeFlags = OptionSet<Change>;
 
@@ -77,13 +79,47 @@ public:
         TransparencyLayer
     };
 
-    WEBCORE_EXPORT GraphicsContextState(const ChangeFlags& = { }, InterpolationQuality = InterpolationQuality::Default);
+    WEBCORE_EXPORT GraphicsContextState(const AffineTransform& ctm = { }, const ChangeFlags& = { }, InterpolationQuality = InterpolationQuality::Default);
 
     void repurpose(Purpose);
     GraphicsContextState clone(Purpose) const;
 
     ChangeFlags changes() const { return m_changeFlags; }
     void didApplyChanges() { m_changeFlags = { }; }
+    void didApplyChanges(ChangeFlags applied) { m_changeFlags.remove(applied); }
+
+    AffineTransform& ctm() LIFETIME_BOUND { return m_transformationMatrix; }
+    const AffineTransform& ctm() const LIFETIME_BOUND { return m_transformationMatrix; }
+    void setCTM(const AffineTransform& ctm) { setProperty(Change::TransformationMatrix, &GraphicsContextState::m_transformationMatrix, ctm); }
+
+    void concatCTM(const AffineTransform& matrix)
+    {
+        auto ctm = m_transformationMatrix;
+        ctm *= matrix;
+        setCTM(ctm);
+    }
+
+    void scale(const FloatSize& size)
+    {
+        auto ctm = m_transformationMatrix;
+        ctm.scale(size);
+        setCTM(ctm);
+    }
+
+    void rotate(float angleInRadians)
+    {
+        double angleInDegrees = rad2deg(static_cast<double>(angleInRadians));
+        auto ctm = m_transformationMatrix;
+        ctm.rotate(angleInDegrees);
+        setCTM(ctm);
+    }
+
+    void translate(float x, float y)
+    {
+        auto ctm = m_transformationMatrix;
+        ctm.translate(x, y);
+        setCTM(ctm);
+    }
 
     SourceBrush& fillBrush() LIFETIME_BOUND { return m_fillBrush; }
     const SourceBrush& fillBrush() const LIFETIME_BOUND { return m_fillBrush; }
@@ -173,6 +209,8 @@ private:
         this->*property = std::forward<T>(value);
         m_changeFlags.add(change);
     }
+
+    AffineTransform m_transformationMatrix { };
 
     SourceBrush m_fillBrush { Color::black };
     SourceBrush m_strokeBrush { Color::black };

--- a/Source/WebCore/platform/graphics/NullGraphicsContext.h
+++ b/Source/WebCore/platform/graphics/NullGraphicsContext.h
@@ -93,11 +93,6 @@ private:
     void setLineJoin(LineJoin) final { }
     void setMiterLimit(float) final { }
     void clipOut(const Path&) final { }
-    void scale(const FloatSize&) final { }
-    void rotate(float) final { }
-    void translate(float, float) final { }
-    void concatCTM(const AffineTransform&) final { }
-    void setCTM(const AffineTransform&) final { }
     AffineTransform getCTM(IncludeDeviceScale = PossiblyIncludeDeviceScale) const final { return { }; }
     void clearRect(const FloatRect&) final { }
     void resetClip() final { }

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
@@ -2056,7 +2056,7 @@ void GraphicsLayerCA::recursiveCommitChanges(CommitState& commitState, const Tra
         TraceScope tracingScope(DisplayListRecordStart, DisplayListRecordEnd);
         m_displayList = nullptr;
         FloatRect initialClip(boundsOrigin(), size());
-        DisplayList::RecorderImpl context(GraphicsContextState(), initialClip, AffineTransform());
+        DisplayList::RecorderImpl context(GraphicsContextState(), initialClip);
         paintGraphicsLayerContents(context, FloatRect(FloatPoint(), size()));
         m_displayList = context.takeDisplayList();
     }

--- a/Source/WebCore/platform/graphics/cairo/CairoOperationRecorder.cpp
+++ b/Source/WebCore/platform/graphics/cairo/CairoOperationRecorder.cpp
@@ -84,6 +84,30 @@ OperationRecorder::OperationRecorder(PaintingOperations& commandList)
 
 void OperationRecorder::didUpdateState(GraphicsContextState& state)
 {
+    if (state.changes().contains(GraphicsContextState::Change::TransformationMatrix)) {
+        struct SetCTM final : PaintingOperation, OperationData<AffineTransform> {
+            virtual ~SetCTM() = default;
+
+            void execute(WebCore::GraphicsContextCairo& context) override
+            {
+                Cairo::State::setCTM(context, arg<0>());
+            }
+
+            void dump(TextStream& ts) override
+            {
+                ts << indent << "SetCTM<>\n"_s;
+            }
+        };
+
+        if (auto inverse = state.ctm().inverse()) {
+            append(createCommand<SetCTM>(state.ctm()));
+
+            auto& recorderState = m_stateStack.last();
+            recorderState.ctm = state.ctm();
+            recorderState.ctmInverse = inverse.value();
+        }
+    }
+
     if (state.changes().contains(GraphicsContextState::Change::StrokeThickness)) {
         struct StrokeThicknessChange final : PaintingOperation, OperationData<float> {
             virtual ~StrokeThicknessChange() = default;
@@ -862,144 +886,6 @@ void OperationRecorder::restore(GraphicsContextState::Purpose purpose)
     m_stateStack.removeLast();
     if (m_stateStack.isEmpty())
         m_stateStack.clear();
-}
-
-void OperationRecorder::translate(float x, float y)
-{
-    struct Translate final : PaintingOperation, OperationData<float, float> {
-        virtual ~Translate() = default;
-
-        void execute(WebCore::GraphicsContextCairo& context) override
-        {
-            Cairo::translate(context, arg<0>(), arg<1>());
-        }
-
-        void dump(TextStream& ts) override
-        {
-            ts << indent << "Translate<>\n"_s;
-        }
-    };
-
-    append(createCommand<Translate>(x, y));
-
-    {
-        auto& state = m_stateStack.last();
-        state.ctm.translate(x, y);
-
-        AffineTransform t;
-        t.translate(-x, -y);
-        state.ctmInverse = t * state.ctmInverse;
-    }
-}
-
-void OperationRecorder::rotate(float angleInRadians)
-{
-    struct Rotate final : PaintingOperation, OperationData<float> {
-        virtual ~Rotate() = default;
-
-        void execute(WebCore::GraphicsContextCairo& context) override
-        {
-            Cairo::rotate(context, arg<0>());
-        }
-
-        void dump(TextStream& ts) override
-        {
-            ts << indent << "Rotate<>\n"_s;
-        }
-    };
-
-    append(createCommand<Rotate>(angleInRadians));
-
-    {
-        auto& state = m_stateStack.last();
-        state.ctm.rotate(angleInRadians);
-
-        AffineTransform t;
-        t.rotate(angleInRadians);
-        state.ctmInverse = t * state.ctmInverse;
-    }
-}
-
-void OperationRecorder::scale(const FloatSize& size)
-{
-    struct Scale final : PaintingOperation, OperationData<FloatSize> {
-        virtual ~Scale() = default;
-
-        void execute(WebCore::GraphicsContextCairo& context) override
-        {
-            Cairo::scale(context, arg<0>());
-        }
-
-        void dump(TextStream& ts) override
-        {
-            ts << indent << "Scale<>\n"_s;
-        }
-    };
-
-    append(createCommand<Scale>(size));
-
-    {
-        auto& state = m_stateStack.last();
-        state.ctm.scale(size.width(), size.height());
-
-        AffineTransform t;
-        t.scale(1 / size.width(), 1 / size.height());
-        state.ctmInverse = t * state.ctmInverse;
-    }
-}
-
-void OperationRecorder::concatCTM(const AffineTransform& transform)
-{
-    struct ConcatCTM final : PaintingOperation, OperationData<AffineTransform> {
-        virtual ~ConcatCTM() = default;
-
-        void execute(WebCore::GraphicsContextCairo& context) override
-        {
-            Cairo::concatCTM(context, arg<0>());
-        }
-
-        void dump(TextStream& ts) override
-        {
-            ts << indent << "ConcatCTM<>\n"_s;
-        }
-    };
-
-    auto inverse = transform.inverse();
-    if (!inverse)
-        return;
-
-    append(createCommand<ConcatCTM>(transform));
-
-    auto& state = m_stateStack.last();
-    state.ctm *= transform;
-    state.ctmInverse = inverse.value() * state.ctmInverse;
-}
-
-void OperationRecorder::setCTM(const AffineTransform& transform)
-{
-    struct SetCTM final : PaintingOperation, OperationData<AffineTransform> {
-        virtual ~SetCTM() = default;
-
-        void execute(WebCore::GraphicsContextCairo& context) override
-        {
-            Cairo::State::setCTM(context, arg<0>());
-        }
-
-        void dump(TextStream& ts) override
-        {
-            ts << indent << "SetCTM<>\n"_s;
-        }
-    };
-
-    auto inverse = transform.inverse();
-    if (!inverse)
-        return;
-
-    append(createCommand<SetCTM>(transform));
-
-    auto& state = m_stateStack.last();
-    state.ctm = transform;
-    state.ctmInverse = inverse.value();
 }
 
 AffineTransform OperationRecorder::getCTM(GraphicsContext::IncludeDeviceScale) const

--- a/Source/WebCore/platform/graphics/cairo/CairoOperationRecorder.h
+++ b/Source/WebCore/platform/graphics/cairo/CairoOperationRecorder.h
@@ -85,11 +85,6 @@ private:
     void save(WebCore::GraphicsContextState::Purpose = WebCore::GraphicsContextState::Purpose::SaveRestore) override;
     void restore(WebCore::GraphicsContextState::Purpose = WebCore::GraphicsContextState::Purpose::SaveRestore) override;
 
-    void translate(float, float) override;
-    void rotate(float angleInRadians) override;
-    void scale(const WebCore::FloatSize&) override;
-    void concatCTM(const WebCore::AffineTransform&) override;
-    void setCTM(const WebCore::AffineTransform&) override;
     WebCore::AffineTransform getCTM(WebCore::GraphicsContext::IncludeDeviceScale) const override;
 
     void beginTransparencyLayer(float) override;

--- a/Source/WebCore/platform/graphics/cairo/GraphicsContextCairo.cpp
+++ b/Source/WebCore/platform/graphics/cairo/GraphicsContextCairo.cpp
@@ -258,13 +258,11 @@ void GraphicsContextCairo::drawDotsForDocumentMarker(const FloatRect& rect, Docu
     Cairo::drawDotsForDocumentMarker(*this, rect, style);
 }
 
-void GraphicsContextCairo::translate(float x, float y)
-{
-    Cairo::translate(*this, x, y);
-}
-
 void GraphicsContextCairo::didUpdateState(GraphicsContextState& state)
 {
+    if (state.changes().contains(GraphicsContextState::Change::TransformationMatrix))
+        Cairo::State::setCTM(*this, state.ctm());
+
     if (state.changes().contains(GraphicsContextState::Change::StrokeThickness))
         Cairo::State::setStrokeThickness(*this, state.strokeThickness());
 
@@ -278,16 +276,6 @@ void GraphicsContextCairo::didUpdateState(GraphicsContextState& state)
         Cairo::State::setShouldAntialias(*this, state.shouldAntialias());
 
     state.didApplyChanges();
-}
-
-void GraphicsContextCairo::concatCTM(const AffineTransform& transform)
-{
-    Cairo::concatCTM(*this, transform);
-}
-
-void GraphicsContextCairo::setCTM(const AffineTransform& transform)
-{
-    Cairo::State::setCTM(*this, transform);
 }
 
 void GraphicsContextCairo::beginTransparencyLayer(float opacity)
@@ -336,16 +324,6 @@ void GraphicsContextCairo::setMiterLimit(float miter)
 void GraphicsContextCairo::clipOut(const Path& path)
 {
     Cairo::clipOut(*this, path);
-}
-
-void GraphicsContextCairo::rotate(float radians)
-{
-    Cairo::rotate(*this, radians);
-}
-
-void GraphicsContextCairo::scale(const FloatSize& size)
-{
-    Cairo::scale(*this, size);
 }
 
 void GraphicsContextCairo::clipOut(const FloatRect& rect)

--- a/Source/WebCore/platform/graphics/cairo/GraphicsContextCairo.h
+++ b/Source/WebCore/platform/graphics/cairo/GraphicsContextCairo.h
@@ -83,13 +83,6 @@ public:
 
     void save(GraphicsContextState::Purpose = GraphicsContextState::Purpose::SaveRestore) final;
     void restore(GraphicsContextState::Purpose = GraphicsContextState::Purpose::SaveRestore) final;
-
-    void translate(float, float) final;
-    void rotate(float) final;
-    using GraphicsContext::scale;
-    void scale(const FloatSize&) final;
-    void concatCTM(const AffineTransform&) final;
-    void setCTM(const AffineTransform&) final;
     AffineTransform getCTM(GraphicsContext::IncludeDeviceScale) const final;
 
     void beginTransparencyLayer(float) final;

--- a/Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp
@@ -1252,6 +1252,10 @@ void GraphicsContextCG::didUpdateState(GraphicsContextState& state)
             CGContextSetShouldSmoothFonts(context, state.shouldSmoothFonts());
             break;
 
+        case GraphicsContextState::Change::TransformationMatrix:
+            CGContextSetCTM(context, state.ctm());
+            m_userToDeviceTransformKnownToBeIdentity = false;
+            break;
         default:
             break;
         }
@@ -1409,36 +1413,6 @@ void GraphicsContextCG::setLineJoin(LineJoin join)
     }
 }
 
-void GraphicsContextCG::scale(const FloatSize& size)
-{
-    CGContextScaleCTM(platformContext(), size.width(), size.height());
-    m_userToDeviceTransformKnownToBeIdentity = false;
-}
-
-void GraphicsContextCG::rotate(float angle)
-{
-    CGContextRotateCTM(platformContext(), angle);
-    m_userToDeviceTransformKnownToBeIdentity = false;
-}
-
-void GraphicsContextCG::translate(float x, float y)
-{
-    CGContextTranslateCTM(platformContext(), x, y);
-    m_userToDeviceTransformKnownToBeIdentity = false;
-}
-
-void GraphicsContextCG::concatCTM(const AffineTransform& transform)
-{
-    CGContextConcatCTM(platformContext(), transform);
-    m_userToDeviceTransformKnownToBeIdentity = false;
-}
-
-void GraphicsContextCG::setCTM(const AffineTransform& transform)
-{
-    CGContextSetCTM(platformContext(), transform);
-    m_userToDeviceTransformKnownToBeIdentity = false;
-}
-
 AffineTransform GraphicsContextCG::getCTM(IncludeDeviceScale includeScale) const
 {
     // The CTM usually includes the deviceScaleFactor except in WebKit 1 when the
@@ -1563,6 +1537,11 @@ void GraphicsContextCG::beginPage(const FloatRect& pageRect)
     auto pageInfo = adoptCF(CFDictionaryCreate(kCFAllocatorDefault, &key, &value, 1, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
 
     CGPDFContextBeginPage(context, pageInfo.get());
+
+    // CGPDFContextBeginPage resets the platform CTM to identity for the new page.
+    // Reset the cached CTM to match, without marking it as a pending change --
+    // it's already correct on the platform context, nothing needs to be pushed.
+    m_state.ctm() = { };
 }
 
 void GraphicsContextCG::endPage()

--- a/Source/WebCore/platform/graphics/cg/GraphicsContextCG.h
+++ b/Source/WebCore/platform/graphics/cg/GraphicsContextCG.h
@@ -109,14 +109,6 @@ public:
 
     void drawPattern(const NativeImage&, const FloatRect& destRect, const FloatRect& tileRect, const AffineTransform& patternTransform, const FloatPoint& phase, const FloatSize& spacing, ImagePaintingOptions = { }) final;
 
-    using GraphicsContext::scale;
-    void scale(const FloatSize&) final;
-    void rotate(float angleInRadians) final;
-    void translate(float x, float y) final;
-
-    void concatCTM(const AffineTransform&) final;
-    void setCTM(const AffineTransform&) override;
-
     AffineTransform getCTM(IncludeDeviceScale = PossiblyIncludeDeviceScale) const override;
 
     void drawFocusRing(const Path&, float outlineWidth, const Color&, float zoomFactor) final;

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp
@@ -45,17 +45,17 @@ namespace DisplayList {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(Recorder);
 
-Recorder::Recorder(IsDeferred isDeferred, const GraphicsContextState& state, const FloatRect& initialClip, const AffineTransform& initialCTM, const DestinationColorSpace& colorSpace, DrawGlyphsMode drawGlyphsMode)
+Recorder::Recorder(IsDeferred isDeferred, const GraphicsContextState& state, const FloatRect& initialClip, const DestinationColorSpace& colorSpace, DrawGlyphsMode drawGlyphsMode)
     : GraphicsContext(isDeferred, state)
     , m_colorSpace(colorSpace)
-    , m_initialClip(initialCTM.mapRect(initialClip))
+    , m_initialClip(state.ctm().mapRect(initialClip))
     , m_drawGlyphsMode(drawGlyphsMode)
 #if USE(CORE_TEXT)
-    , m_initialScale(initialCTM.xScale())
+    , m_initialScale(state.ctm().xScale())
 #endif
 {
     ASSERT(!state.changes());
-    m_stateStack.append({ state, initialCTM, initialCTM.mapRect(initialClip) });
+    m_stateStack.append({ state, m_initialClip });
 }
 
 Recorder::~Recorder()
@@ -175,7 +175,7 @@ void Recorder::updateStateForSetCTM(const AffineTransform& transform)
 
 AffineTransform Recorder::getCTM(GraphicsContext::IncludeDeviceScale) const
 {
-    return currentState().ctm;
+    return currentState().ctm();
 }
 
 void Recorder::updateStateForBeginTransparencyLayer(float opacity)
@@ -221,13 +221,13 @@ FloatRect Recorder::initialClip() const
 void Recorder::updateStateForClip(const FloatRect& rect)
 {
     appendStateChangeItemIfNecessary(); // Conservative: we do not know if the clip application might use state such as antialiasing.
-    currentState().clipBounds.intersect(currentState().ctm.mapRect(rect));
+    currentState().clipBounds.intersect(currentState().ctm().mapRect(rect));
 }
 
 void Recorder::updateStateForClipRoundedRect(const FloatRoundedRect& rect)
 {
     appendStateChangeItemIfNecessary(); // Conservative: we do not know if the clip application might use state such as antialiasing.
-    currentState().clipBounds.intersect(currentState().ctm.mapRect(rect.rect()));
+    currentState().clipBounds.intersect(currentState().ctm().mapRect(rect.rect()));
 }
 
 void Recorder::updateStateForClipOut(const FloatRect&)
@@ -251,18 +251,18 @@ void Recorder::updateStateForClipOut(const Path&)
 void Recorder::updateStateForClipPath(const Path& path)
 {
     appendStateChangeItemIfNecessary(); // Conservative: we do not know if the clip application might use state such as antialiasing.
-    currentState().clipBounds.intersect(currentState().ctm.mapRect(path.fastBoundingRect()));
+    currentState().clipBounds.intersect(currentState().ctm().mapRect(path.fastBoundingRect()));
 }
 
 void Recorder::updateStateForClipToImageBuffer(const FloatRect& rect)
 {
     appendStateChangeItemIfNecessary(); // Conservative: we do not know if the clip application might use state such as antialiasing.
-    currentState().clipBounds.intersect(currentState().ctm.mapRect(rect));
+    currentState().clipBounds.intersect(currentState().ctm().mapRect(rect));
 }
 
 IntRect Recorder::clipBounds() const
 {
-    if (auto inverse = currentState().ctm.inverse())
+    if (auto inverse = currentState().ctm().inverse())
         return enclosingIntRect(inverse->mapRect(currentState().clipBounds));
 
     // If the CTM is not invertible, return the original rect.
@@ -280,38 +280,36 @@ void Recorder::updateStateForApplyDeviceScaleFactor(float deviceScaleFactor)
     // Assert that it's only called early on?
 }
 
+/*
 const AffineTransform& Recorder::ctm() const
 {
-    return currentState().ctm;
+    return currentState().ctm();
 }
+*/
 
 void Recorder::ContextState::translate(float x, float y)
 {
-    ctm.translate(x, y);
+    state.translate(x, y);
 }
 
 void Recorder::ContextState::rotate(float angleInRadians)
 {
-    double angleInDegrees = rad2deg(static_cast<double>(angleInRadians));
-    ctm.rotate(angleInDegrees);
-
-    AffineTransform rotation;
-    rotation.rotate(angleInDegrees);
+    state.rotate(angleInRadians);
 }
 
 void Recorder::ContextState::scale(const FloatSize& size)
 {
-    ctm.scale(size);
+    state.scale(size);
 }
 
 void Recorder::ContextState::setCTM(const AffineTransform& matrix)
 {
-    ctm = matrix;
+    state.setCTM(matrix);
 }
 
 void Recorder::ContextState::concatCTM(const AffineTransform& matrix)
 {
-    ctm *= matrix;
+    state.concatCTM(matrix);
 }
 
 } // namespace DisplayList

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.h
@@ -66,8 +66,8 @@ public:
 #endif
     };
 
-    Recorder(const GraphicsContextState& state, const FloatRect& initialClip, const AffineTransform& transform, const DestinationColorSpace& colorSpace, DrawGlyphsMode drawGlyphsMode = DrawGlyphsMode::Normal)
-        : Recorder(IsDeferred::Yes, state, initialClip, transform, colorSpace, drawGlyphsMode)
+    Recorder(const GraphicsContextState& state, const FloatRect& initialClip, const DestinationColorSpace& colorSpace, DrawGlyphsMode drawGlyphsMode = DrawGlyphsMode::Normal)
+        : Recorder(IsDeferred::Yes, state, initialClip, colorSpace, drawGlyphsMode)
     {
     }
     WEBCORE_EXPORT virtual ~Recorder();
@@ -75,13 +75,16 @@ public:
     WEBCORE_EXPORT void appendDisplayList(const DisplayList&);
 
 protected:
-    WEBCORE_EXPORT Recorder(IsDeferred, const GraphicsContextState&, const FloatRect& initialClip, const AffineTransform&, const DestinationColorSpace&, DrawGlyphsMode);
+    WEBCORE_EXPORT Recorder(IsDeferred, const GraphicsContextState&, const FloatRect& initialClip, const DestinationColorSpace&, DrawGlyphsMode);
 
     struct ContextState {
         GraphicsContextState state;
-        AffineTransform ctm;
         FloatRect clipBounds;
         std::optional<GraphicsContextState> lastDrawingState { std::nullopt };
+        // The CTM as of the last DisplayList item emitted for this state (see RecorderImpl::
+        // appendStateChangeItemIfNecessary). Used to record CTM changes as a relative
+        // ConcatenateCTM delta, which replays correctly against any base transform.
+        AffineTransform lastRecordedCTM { state.ctm() };
 
         ContextState cloneForTransparencyLayer() const
         {
@@ -89,14 +92,16 @@ protected:
             std::optional<GraphicsContextState> lastDrawingStateClone;
             if (lastDrawingStateClone)
                 lastDrawingStateClone = lastDrawingState->clone(GraphicsContextState::Purpose::TransparencyLayer);
-            return ContextState { WTF::move(stateClone), ctm, clipBounds, WTF::move(lastDrawingStateClone) };
+            return ContextState { WTF::move(stateClone), clipBounds, WTF::move(lastDrawingStateClone), lastRecordedCTM };
         }
 
-        void NODELETE translate(float x, float y);
+        const AffineTransform& ctm() const { return state.ctm(); }
+
+        void translate(float x, float y);
         void rotate(float angleInRadians);
         void scale(const FloatSize&);
-        void NODELETE concatCTM(const AffineTransform&);
-        void NODELETE setCTM(const AffineTransform&);
+        void concatCTM(const AffineTransform&);
+        void setCTM(const AffineTransform&);
     };
 
     const Vector<ContextState, 4>& stateStack() const LIFETIME_BOUND { return m_stateStack; }
@@ -107,11 +112,11 @@ protected:
 protected:
     WEBCORE_EXPORT void updateStateForSave(GraphicsContextState::Purpose);
     [[nodiscard]] WEBCORE_EXPORT bool updateStateForRestore(GraphicsContextState::Purpose);
-    [[nodiscard]] WEBCORE_EXPORT bool NODELETE updateStateForTranslate(float x, float y);
+    [[nodiscard]] WEBCORE_EXPORT bool updateStateForTranslate(float x, float y);
     [[nodiscard]] WEBCORE_EXPORT bool updateStateForRotate(float angleInRadians);
     [[nodiscard]] WEBCORE_EXPORT bool updateStateForScale(const FloatSize&);
-    [[nodiscard]] WEBCORE_EXPORT bool NODELETE updateStateForConcatCTM(const AffineTransform&);
-    WEBCORE_EXPORT void NODELETE updateStateForSetCTM(const AffineTransform&);
+    [[nodiscard]] WEBCORE_EXPORT bool updateStateForConcatCTM(const AffineTransform&);
+    WEBCORE_EXPORT void updateStateForSetCTM(const AffineTransform&);
     WEBCORE_EXPORT void updateStateForBeginTransparencyLayer(float opacity);
     WEBCORE_EXPORT void updateStateForBeginTransparencyLayer(CompositeOperator, BlendMode);
     [[nodiscard]] WEBCORE_EXPORT bool updateStateForEndTransparencyLayer();
@@ -150,7 +155,7 @@ private:
 
     virtual void appendStateChangeItemIfNecessary() = 0;
 
-    const AffineTransform& NODELETE ctm() const;
+    //const AffineTransform& NODELETE ctm() const;
 
     Vector<ContextState, 4> m_stateStack;
     DestinationColorSpace m_colorSpace;

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.cpp
@@ -45,8 +45,8 @@ namespace DisplayList {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(RecorderImpl);
 
-RecorderImpl::RecorderImpl(const GraphicsContextState& state, const FloatRect& initialClip, const AffineTransform& initialCTM, const DestinationColorSpace& colorSpace, DrawGlyphsMode drawGlyphsMode)
-    : Recorder(state, initialClip, initialCTM, colorSpace, drawGlyphsMode)
+RecorderImpl::RecorderImpl(const GraphicsContextState& state, const FloatRect& initialClip, const DestinationColorSpace& colorSpace, DrawGlyphsMode drawGlyphsMode)
+    : Recorder(state, initialClip, colorSpace, drawGlyphsMode)
 {
     LOG_WITH_STREAM(DisplayLists, stream << "\nRecording with clip " << initialClip);
 }
@@ -132,40 +132,6 @@ void RecorderImpl::restore(GraphicsContextState::Purpose purpose)
     if (!updateStateForRestore(purpose))
         return;
     m_items.append(Restore());
-}
-
-void RecorderImpl::translate(float x, float y)
-{
-    if (!updateStateForTranslate(x, y))
-        return;
-    m_items.append(Translate(x, y));
-}
-
-void RecorderImpl::rotate(float angle)
-{
-    if (!updateStateForRotate(angle))
-        return;
-    m_items.append(Rotate(angle));
-}
-
-void RecorderImpl::scale(const FloatSize& scale)
-{
-    if (!updateStateForScale(scale))
-        return;
-    m_items.append(Scale(scale));
-}
-
-void RecorderImpl::setCTM(const AffineTransform& transform)
-{
-    updateStateForSetCTM(transform);
-    m_items.append(SetCTM(transform));
-}
-
-void RecorderImpl::concatCTM(const AffineTransform& transform)
-{
-    if (!updateStateForConcatCTM(transform))
-        return;
-    m_items.append(ConcatenateCTM(transform));
 }
 
 void RecorderImpl::setLineCap(LineCap lineCap)
@@ -510,6 +476,28 @@ void RecorderImpl::appendStateChangeItemIfNecessary()
         state.didApplyChanges();
         currentState().lastDrawingState = state;
     };
+
+    // The CTM is relocatable state: a recorded DisplayList can be replayed against a
+    // different base transform than the one in effect when it was recorded (e.g. a cached
+    // glyph display list drawn at a new text origin). SetState bakes in an absolute CTM,
+    // which would stomp the replay-time base transform instead of composing with it. Record
+    // the CTM delta since the last emitted item as a ConcatenateCTM instead, which composes
+    // correctly no matter where the display list is replayed.
+    if (changes.contains(GraphicsContextState::Change::TransformationMatrix)) {
+        auto& lastCTM = currentState().lastRecordedCTM;
+        if (auto inverse = lastCTM.inverse())
+            m_items.append(ConcatenateCTM(*inverse * state.ctm()));
+        lastCTM = state.ctm();
+        // Clear the bit on `state` itself (not just the local `changes` copy) so that if
+        // execution falls through to recordFullItem() below, the SetState it captures does
+        // not also carry the absolute CTM as a pending change.
+        state.didApplyChanges({ GraphicsContextState::Change::TransformationMatrix });
+        changes.remove(GraphicsContextState::Change::TransformationMatrix);
+        if (!changes) {
+            currentState().lastDrawingState = state;
+            return;
+        }
+    }
 
     if (!changes.containsOnly({ GraphicsContextState::Change::FillBrush, GraphicsContextState::Change::StrokeBrush, GraphicsContextState::Change::StrokeThickness })) {
         recordFullItem();

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.h
@@ -36,9 +36,9 @@ class RecorderImpl : public Recorder {
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(RecorderImpl, WEBCORE_EXPORT);
     WTF_MAKE_NONCOPYABLE(RecorderImpl);
 public:
-    WEBCORE_EXPORT RecorderImpl(const GraphicsContextState&, const FloatRect& initialClip, const AffineTransform&, const DestinationColorSpace& = DestinationColorSpace::SRGB(), DrawGlyphsMode = DrawGlyphsMode::Normal);
+    WEBCORE_EXPORT RecorderImpl(const GraphicsContextState&, const FloatRect& initialClip, const DestinationColorSpace& = DestinationColorSpace::SRGB(), DrawGlyphsMode = DrawGlyphsMode::Normal);
     RecorderImpl(FloatSize initialClipSize)
-        : RecorderImpl({ }, { { }, initialClipSize }, { }, DestinationColorSpace::SRGB(), DrawGlyphsMode::Normal)
+        : RecorderImpl({ }, { { }, initialClipSize }, DestinationColorSpace::SRGB(), DrawGlyphsMode::Normal)
     {
     }
     WEBCORE_EXPORT virtual ~RecorderImpl();
@@ -53,11 +53,6 @@ public:
 
     void save(GraphicsContextState::Purpose) final;
     void restore(GraphicsContextState::Purpose) final;
-    void translate(float x, float y) final;
-    void rotate(float angle) final;
-    void scale(const FloatSize&) final;
-    void setCTM(const AffineTransform&) final;
-    void concatCTM(const AffineTransform&) final;
     void setLineCap(LineCap) final;
     void setLineDash(const DashArray&, float dashOffset) final;
     void setLineJoin(LineJoin) final;

--- a/Source/WebCore/platform/graphics/skia/GraphicsContextSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/GraphicsContextSkia.cpp
@@ -816,27 +816,10 @@ void GraphicsContextSkia::drawDotsForDocumentMarker(const FloatRect& boundaries,
     m_canvas.drawPath(createErrorUnderlinePath(boundaries), paint);
 }
 
-void GraphicsContextSkia::translate(float x, float y)
+void GraphicsContextSkia::didUpdateState(GraphicsContextState& state)
 {
-    m_canvas.translate(SkFloatToScalar(x), SkFloatToScalar(y));
-}
-
-void GraphicsContextSkia::didUpdateState(GraphicsContextState&)
-{
-}
-
-void GraphicsContextSkia::didUpdateSingleState(GraphicsContextState&, GraphicsContextState::ChangeIndex)
-{
-}
-
-void GraphicsContextSkia::concatCTM(const AffineTransform& ctm)
-{
-    m_canvas.concat(ctm);
-}
-
-void GraphicsContextSkia::setCTM(const AffineTransform& ctm)
-{
-    m_canvas.setMatrix(ctm);
+    if (state.changes().contains(GraphicsContextState::Change::TransformationMatrix))
+        m_canvas.setMatrix(state.ctm());
 }
 
 void GraphicsContextSkia::saveLayer(float opacity, CompositeMode compositeMode)
@@ -1009,16 +992,6 @@ void GraphicsContextSkia::clipOut(const Path& path)
 
     m_canvas.clipPath(skiaPath, true);
     skiaPath.toggleInverseFillType();
-}
-
-void GraphicsContextSkia::rotate(float radians)
-{
-    m_canvas.rotate(SkFloatToScalar(rad2deg(radians)));
-}
-
-void GraphicsContextSkia::scale(const FloatSize& scale)
-{
-    m_canvas.scale(SkFloatToScalar(scale.width()), SkFloatToScalar(scale.height()));
 }
 
 void GraphicsContextSkia::clipOut(const FloatRect& rect)

--- a/Source/WebCore/platform/graphics/skia/GraphicsContextSkia.h
+++ b/Source/WebCore/platform/graphics/skia/GraphicsContextSkia.h
@@ -65,7 +65,6 @@ public:
     void replayStateOnCanvas(SkCanvas&) const;
 
     void didUpdateState(GraphicsContextState&) final;
-    void didUpdateSingleState(GraphicsContextState&, GraphicsContextState::ChangeIndex) final;
 
     void setLineCap(LineCap) final;
     void setLineDash(const DashArray&, float) final;
@@ -97,12 +96,6 @@ public:
     void save(GraphicsContextState::Purpose = GraphicsContextState::Purpose::SaveRestore) final;
     void restore(GraphicsContextState::Purpose = GraphicsContextState::Purpose::SaveRestore) final;
 
-    void translate(float, float) final;
-    void rotate(float) final;
-    using GraphicsContext::scale;
-    void scale(const FloatSize&) final;
-    void concatCTM(const AffineTransform&) final;
-    void setCTM(const AffineTransform&) final;
     AffineTransform getCTM(GraphicsContext::IncludeDeviceScale) const final;
 
     void beginTransparencyLayer(float) final;

--- a/Source/WebCore/rendering/updating/RenderTreeBuilder.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilder.cpp
@@ -968,7 +968,17 @@ void RenderTreeBuilder::destroyAndCleanUpAnonymousWrappers(RenderObject& rendere
         return;
 
     auto anonymousDestroyRoot = SetForScope { m_anonymousDestroyRoot, destroyRootParent };
-    removeAnonymousWrappersForInlineChildrenIfNeeded(*destroyRootParent);
+
+    // Removing an out-of-flow positioned or floating child cannot change
+    // whether the parent's in-flow children need their anonymous block wrappers
+    // (out-of-flow/floating boxes don't participate in the inline/block
+    // determination that creates those wrappers).
+    bool destroyRootParticipatesInInlineLayout = true;
+    if (CheckedPtr box = dynamicDowncast<RenderBox>(destroyRoot.get()))
+        destroyRootParticipatesInInlineLayout = !box->isFloatingOrOutOfFlowPositioned();
+
+    if (destroyRootParticipatesInInlineLayout)
+        removeAnonymousWrappersForInlineChildrenIfNeeded(*destroyRootParent);
 
     // Anonymous parent might have become empty, try to delete it too.
     if (isAnonymousAndSafeToDelete(*destroyRootParent) && !destroyRootParent->firstChild())

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContext.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContext.cpp
@@ -431,10 +431,12 @@ void RemoteGraphicsContext::drawDisplayList(RemoteDisplayListIdentifier identifi
     context().drawDisplayList(*displayList, controlFactory());
 }
 
-void RemoteGraphicsContext::drawNativeImage(RenderingResourceIdentifier imageIdentifier, const FloatRect& destRect, const FloatRect& srcRect, ImagePaintingOptions options)
+void RemoteGraphicsContext::drawNativeImage(RenderingResourceIdentifier imageIdentifier, const FloatRect& destRect, const FloatRect& srcRect, ImagePaintingOptions options, const AffineTransform& ctm, float alpha)
 {
     RefPtr image = resourceCache().cachedNativeImage(imageIdentifier);
     MESSAGE_CHECK(image);
+    context().setCTM(ctm);
+    context().setAlpha(alpha);
     context().drawNativeImage(*image, destRect, srcRect, options);
 }
 

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContext.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContext.h
@@ -102,7 +102,7 @@ public:
     void drawDisplayList(RemoteDisplayListIdentifier);
     void drawFilteredImageBuffer(std::optional<WebCore::RenderingResourceIdentifier> sourceImageIdentifier, const WebCore::FloatRect& sourceImageRect, Ref<WebCore::Filter>&&);
     virtual void drawImageBuffer(WebCore::RenderingResourceIdentifier imageBufferIdentifier, const WebCore::FloatRect& destinationRect, const WebCore::FloatRect& srcRect, WebCore::ImagePaintingOptions);
-    void drawNativeImage(WebCore::RenderingResourceIdentifier imageIdentifier, const WebCore::FloatRect& destRect, const WebCore::FloatRect& srcRect, WebCore::ImagePaintingOptions);
+    void drawNativeImage(WebCore::RenderingResourceIdentifier imageIdentifier, const WebCore::FloatRect& destRect, const WebCore::FloatRect& srcRect, WebCore::ImagePaintingOptions, const WebCore::AffineTransform&, float);
     void drawSystemImage(Ref<WebCore::SystemImage>&&, const WebCore::FloatRect&);
 #if PLATFORM(COCOA) && ENABLE(VIDEO)
     void drawVideoFrame(SharedVideoFrame&&, const WebCore::FloatRect& destination, WebCore::ImageOrientation, bool shouldDiscardAlpha);

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContext.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContext.messages.in
@@ -30,11 +30,7 @@
 messages -> RemoteGraphicsContext Stream {
     Save() StreamBatched
     Restore() StreamBatched
-    Translate(float x, float y) StreamBatched
-    Rotate(float angle) StreamBatched
-    Scale(WebCore::FloatSize scale) StreamBatched
     SetCTM(WebCore::AffineTransform ctm) StreamBatched
-    ConcatCTM(WebCore::AffineTransform ctm) StreamBatched
     SetFillPackedColor(struct WebCore::PackedColor::RGBA color) StreamBatched
     SetFillColor(WebCore::Color color) StreamBatched
     SetFillCachedGradient(WebKit::RemoteGradientIdentifier identifier, WebCore::AffineTransform spaceTransform) StreamBatched
@@ -79,7 +75,7 @@ messages -> RemoteGraphicsContext Stream {
     DrawDisplayList(WebKit::RemoteDisplayListIdentifier identifier) StreamBatched
     DrawFilteredImageBuffer(std::optional<WebCore::RenderingResourceIdentifier> sourceImageIdentifier, WebCore::FloatRect sourceImageRect, Ref<WebCore::Filter> filter) StreamBatched
     DrawImageBuffer(WebCore::RenderingResourceIdentifier imageBufferIdentifier, WebCore::FloatRect destinationRect, WebCore::FloatRect srcRect, struct WebCore::ImagePaintingOptions options) StreamBatched
-    DrawNativeImage(WebCore::RenderingResourceIdentifier imageIdentifier, WebCore::FloatRect destRect, WebCore::FloatRect srcRect, struct WebCore::ImagePaintingOptions options) StreamBatched
+    DrawNativeImage(WebCore::RenderingResourceIdentifier imageIdentifier, WebCore::FloatRect destRect, WebCore::FloatRect srcRect, struct WebCore::ImagePaintingOptions options, WebCore::AffineTransform ctm, float alpha) StreamBatched
     DrawSystemImage(Ref<WebCore::SystemImage> systemImage, WebCore::FloatRect destinationRect) StreamBatched
     DrawPatternNativeImage(WebCore::RenderingResourceIdentifier imageIdentifier, WebCore::FloatRect destRect, WebCore::FloatRect tileRect, WebCore::AffineTransform transform, WebCore::FloatPoint phase, WebCore::FloatSize spacing, struct WebCore::ImagePaintingOptions options) StreamBatched
     DrawPatternImageBuffer(WebCore::RenderingResourceIdentifier imageIdentifier, WebCore::FloatRect destRect, WebCore::FloatRect tileRect, WebCore::AffineTransform transform, WebCore::FloatPoint phase, WebCore::FloatSize spacing, struct WebCore::ImagePaintingOptions options) StreamBatched

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextProxy.cpp
@@ -70,7 +70,7 @@ RemoteGraphicsContextProxy::RemoteGraphicsContextProxy(const DestinationColorSpa
 }
 
 RemoteGraphicsContextProxy::RemoteGraphicsContextProxy(const DestinationColorSpace& colorSpace, std::optional<ContentsFormat> contentsFormat, RenderingMode renderingMode, const FloatRect& initialClip, const AffineTransform& initialCTM, DrawGlyphsMode drawGlyphsMode, RemoteGraphicsContextIdentifier identifier, RemoteRenderingBackendProxy& renderingBackend)
-    : DisplayList::Recorder(IsDeferred::No, { }, initialClip, initialCTM, colorSpace, drawGlyphsMode)
+    : DisplayList::Recorder(IsDeferred::No, { initialCTM }, initialClip, colorSpace, drawGlyphsMode)
     , m_renderingMode(renderingMode)
     , m_identifier(identifier)
     , m_renderingBackend(renderingBackend)
@@ -145,45 +145,6 @@ void RemoteGraphicsContextProxy::restore(GraphicsContextState::Purpose purpose)
     if (!updateStateForRestore(purpose))
         return;
     send(Messages::RemoteGraphicsContext::Restore());
-}
-
-void RemoteGraphicsContextProxy::translate(float x, float y)
-{
-    sendPendingDrawsIfNecessary();
-    if (!updateStateForTranslate(x, y))
-        return;
-    send(Messages::RemoteGraphicsContext::Translate(x, y));
-}
-
-void RemoteGraphicsContextProxy::rotate(float angle)
-{
-    sendPendingDrawsIfNecessary();
-    if (!updateStateForRotate(angle))
-        return;
-    send(Messages::RemoteGraphicsContext::Rotate(angle));
-}
-
-void RemoteGraphicsContextProxy::scale(const FloatSize& scale)
-{
-    sendPendingDrawsIfNecessary();
-    if (!updateStateForScale(scale))
-        return;
-    send(Messages::RemoteGraphicsContext::Scale(scale));
-}
-
-void RemoteGraphicsContextProxy::setCTM(const AffineTransform& transform)
-{
-    sendPendingDrawsIfNecessary();
-    updateStateForSetCTM(transform);
-    send(Messages::RemoteGraphicsContext::SetCTM(transform));
-}
-
-void RemoteGraphicsContextProxy::concatCTM(const AffineTransform& transform)
-{
-    sendPendingDrawsIfNecessary();
-    if (!updateStateForConcatCTM(transform))
-        return;
-    send(Messages::RemoteGraphicsContext::ConcatCTM(transform));
 }
 
 void RemoteGraphicsContextProxy::setLineCap(LineCap lineCap)
@@ -357,16 +318,14 @@ void RemoteGraphicsContextProxy::drawNativeImage(const NativeImage& image, const
     m_maxPaintedEDRHeadroom = std::max(m_maxPaintedEDRHeadroom, headroom.headroom);
     m_maxRequestedEDRHeadroom = std::max(m_maxRequestedEDRHeadroom, image.headroom().headroom);
     ImagePaintingOptions clampedOptions(options, headroom);
+#else
+    ImagePaintingOptions clampedOptions = options;
 #endif
     sendPendingDrawsIfNecessary();
-    appendStateChangeItemIfNecessary();
+    appendStateChangeItemIfNecessaryExcluding({ GraphicsContextState::Change::Alpha, GraphicsContextState::Change::TransformationMatrix });
     if (!recordResourceUse(const_cast<NativeImage&>(image)))
         return;
-#if HAVE(SUPPORT_HDR_DISPLAY_APIS)
-    send(Messages::RemoteGraphicsContext::DrawNativeImage(image.renderingResourceIdentifier(), destRect, srcRect, clampedOptions));
-#else
-    send(Messages::RemoteGraphicsContext::DrawNativeImage(image.renderingResourceIdentifier(), destRect, srcRect, options));
-#endif
+    send(Messages::RemoteGraphicsContext::DrawNativeImage(image.renderingResourceIdentifier(), destRect, srcRect, clampedOptions, ctm(), alpha()));
 }
 
 void RemoteGraphicsContextProxy::drawSystemImage(SystemImage& systemImage, const FloatRect& destinationRect)
@@ -882,10 +841,10 @@ RefPtr<ImageBuffer> RemoteGraphicsContextProxy::createAlignedImageBuffer(const F
     return GraphicsContext::createScaledImageBuffer(rect, scaleFactor(), colorSpace, renderingMode, renderingMethod);
 }
 
-void RemoteGraphicsContextProxy::appendStateChangeItemIfNecessary()
+void RemoteGraphicsContextProxy::appendStateChangeItemIfNecessaryExcluding(GraphicsContextState::ChangeFlags excluded)
 {
     auto& state = currentState().state;
-    auto changes = state.changes();
+    auto changes = state.changes() - excluded;
     if (!changes)
         return;
     if (changes.contains(GraphicsContextState::Change::FillBrush)) {
@@ -932,6 +891,8 @@ void RemoteGraphicsContextProxy::appendStateChangeItemIfNecessary()
         } else
             send(Messages::RemoteGraphicsContext::SetStrokeColor(strokeBrush.color()));
     }
+    if (changes.contains(GraphicsContextState::Change::TransformationMatrix))
+        send(Messages::RemoteGraphicsContext::SetCTM(state.ctm()));
     if (changes.contains(GraphicsContextState::Change::FillRule))
         send(Messages::RemoteGraphicsContext::SetFillRule(state.fillRule()));
     if (changes.contains(GraphicsContextState::Change::StrokeThickness))

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextProxy.h
@@ -97,11 +97,7 @@ private:
 
     void save(WebCore::GraphicsContextState::Purpose) final;
     void restore(WebCore::GraphicsContextState::Purpose) final;
-    void translate(float x, float y) final;
-    void rotate(float angle) final;
-    void scale(const WebCore::FloatSize&) final;
-    void setCTM(const WebCore::AffineTransform&) final;
-    void concatCTM(const WebCore::AffineTransform&) final;
+    void willChangeCTM() final { sendPendingDrawsIfNecessary(); }
     void setLineCap(WebCore::LineCap) final;
     void setLineDash(const WebCore::DashArray&, float dashOffset) final;
     void setLineJoin(WebCore::LineJoin) final;
@@ -172,7 +168,8 @@ private:
 
     // Synchronizes draw state.
 protected:
-    void appendStateChangeItemIfNecessary() final;
+    void appendStateChangeItemIfNecessaryExcluding(WebCore::GraphicsContextState::ChangeFlags);
+    void appendStateChangeItemIfNecessary() final { appendStateChangeItemIfNecessaryExcluding({}); }
 
 private:
     struct InlineStrokeData {

--- a/Tools/TestWebKitAPI/Tests/WebCore/DisplayListRecorderTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/DisplayListRecorderTests.cpp
@@ -268,9 +268,8 @@ struct ResetClipRect {
     static String description()
     {
         return R"DL(
-(translate
-  (x 10.00)
-  (y 10.00))
+(concatenate-ctm
+  (ctm {m=((1.00,0.00)(0.00,1.00)) t=(10.00,10.00)}))
 (save)
 (reset-clip)
 (clip
@@ -382,12 +381,8 @@ struct TrivialTranslate {
     static String description()
     {
         return R"DL(
-(translate
-  (x 1.00)
-  (y 0.00))
-(translate
-  (x 0.00)
-  (y 2.00))
+(concatenate-ctm
+  (ctm {m=((1.00,0.00)(0.00,1.00)) t=(1.00,2.00)}))
 (draw-rect
   (rect at (0,0) size 1x1)
   (border-thickness 1.00)))DL"_s;
@@ -405,10 +400,8 @@ struct TrivialScale {
     static String description()
     {
         return R"DL(
-(scale
-  (size width=1.10 height=1.20))
-(scale
-  (size width=0.10 height=0.70))
+(concatenate-ctm
+  (ctm {m=((0.11,0.00)(0.00,0.84)) t=(0.00,0.00)}))
 (draw-rect
   (rect at (0,0) size 1x1)
   (border-thickness 1.00)))DL"_s;
@@ -429,12 +422,8 @@ struct TrivialRotate {
     static String description()
     {
         return R"DL(
-(rotate
-  (angle 1.00))
-(rotate
-  (angle 2.00))
-(rotate
-  (angle 43.98))
+(concatenate-ctm
+  (ctm {m=((-0.99,0.14)(-0.14,-0.99)) t=(0.00,0.00)}))
 (draw-rect
   (rect at (0,0) size 1x1)
   (border-thickness 1.00)))DL"_s;
@@ -484,6 +473,30 @@ TYPED_TEST_P(DisplayListRecorderResultStateTest, StateThroughDisplayListIsPreser
 }
 
 REGISTER_TYPED_TEST_SUITE_P(DisplayListRecorderResultStateTest, StateThroughDisplayListIsPreserved);
+
+TEST(DisplayListRecorderTest, RecordedCTMChangeIsRelativeToReplayTimeBaseCTM)
+{
+    WebCore::DisplayList::RecorderImpl recorderImpl { { testContextWidth, testContextHeight } };
+    WebCore::GraphicsContext& recorder = recorderImpl;
+    recorder.translate(3, 4);
+    recorder.scale(WebCore::FloatSize { 2, 2 });
+    recorder.drawRect({ 0, 0, 1, 1 });
+    Ref displayList = recorderImpl.takeDisplayList();
+
+    // Replay into a target whose CTM already differs from the one live when the list was
+    // recorded (analogous to drawing a cached glyph run at a different text origin).
+    auto replayTarget = createReferenceTarget();
+    auto& replayContext = replayTarget->context();
+    replayContext.translate(10, 20);
+
+    auto expectedCTM = replayContext.getCTM();
+    expectedCTM.translate(3, 4);
+    expectedCTM.scale(WebCore::FloatSize { 2, 2 });
+
+    replayContext.drawDisplayList(displayList);
+
+    EXPECT_EQ(expectedCTM, replayContext.getCTM());
+}
 
 INSTANTIATE_TYPED_TEST_SUITE_P(DisplayListRecorderTest, DisplayListRecorderResultStateTest, AllOperations);
 

--- a/Tools/TestWebKitAPI/Tests/WebCore/cocoa/BifurcatedGraphicsContextTestsCG.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/cocoa/BifurcatedGraphicsContextTestsCG.cpp
@@ -53,7 +53,7 @@ TEST(BifurcatedGraphicsContextTests, Basic)
     RetainPtr primaryCGContext = adoptCF(CGBitmapContextCreate(nullptr, contextWidth, contextHeight, 8, 4 * contextWidth, colorSpace.platformColorSpace(), kCGImageAlphaPremultipliedLast));
 
     GraphicsContextCG primaryContext(primaryCGContext.get());
-    RecorderImpl secondaryContext({ }, FloatRect(0, 0, contextWidth, contextHeight), { });
+    RecorderImpl secondaryContext({ }, FloatRect(0, 0, contextWidth, contextHeight));
 
     BifurcatedGraphicsContext ctx(primaryContext, secondaryContext);
 
@@ -83,8 +83,8 @@ TEST(BifurcatedGraphicsContextTests, Basic)
 
 TEST(BifurcatedGraphicsContextTests, Text)
 {
-    RecorderImpl primaryContext({ }, FloatRect(0, 0, contextWidth, contextHeight), { });
-    RecorderImpl secondaryContext({ }, FloatRect(0, 0, contextWidth, contextHeight), { });
+    RecorderImpl primaryContext({ }, FloatRect(0, 0, contextWidth, contextHeight));
+    RecorderImpl secondaryContext({ }, FloatRect(0, 0, contextWidth, contextHeight));
 
     BifurcatedGraphicsContext ctx(primaryContext, secondaryContext);
 
@@ -184,7 +184,7 @@ TEST(BifurcatedGraphicsContextTests, Borders)
     RetainPtr primaryCGContext = adoptCF(CGBitmapContextCreate(nullptr, contextWidth, contextHeight, 8, 4 * contextWidth, colorSpace.platformColorSpace(), kCGImageAlphaPremultipliedLast));
 
     GraphicsContextCG primaryContext(primaryCGContext.get());
-    RecorderImpl secondaryContext({ }, FloatRect(0, 0, contextWidth, contextHeight), { });
+    RecorderImpl secondaryContext({ }, FloatRect(0, 0, contextWidth, contextHeight));
 
     BifurcatedGraphicsContext ctx(primaryContext, secondaryContext);
 
@@ -210,7 +210,7 @@ TEST(BifurcatedGraphicsContextTests, TransformedClip)
     GraphicsContextCG primaryContextCG(primaryCGContext.get());
     GraphicsContext& primaryContext = primaryContextCG;
 
-    RecorderImpl secondaryContextDL({ }, FloatRect(0, 0, 100, 100), { });
+    RecorderImpl secondaryContextDL({ }, FloatRect(0, 0, 100, 100));
     GraphicsContext& secondaryContext = secondaryContextDL;
 
     BifurcatedGraphicsContext ctx(primaryContext, secondaryContext);
@@ -268,7 +268,7 @@ TEST(BifurcatedGraphicsContextTests, ApplyDeviceScaleFactor)
     GraphicsContextCG primaryContextCG(primaryCGContext.get());
     GraphicsContext& primaryContext = primaryContextCG;
 
-    RecorderImpl secondaryContextDL({ }, FloatRect(0, 0, 100, 100), { });
+    RecorderImpl secondaryContextDL({ }, FloatRect(0, 0, 100, 100));
     GraphicsContext& secondaryContext = secondaryContextDL;
 
     BifurcatedGraphicsContext ctx(primaryContext, secondaryContext);
@@ -287,8 +287,8 @@ TEST(BifurcatedGraphicsContextTests, ApplyDeviceScaleFactor)
 
 TEST(BifurcatedGraphicsContextTests, ClipToImageBuffer)
 {
-    RecorderImpl primaryContext({ }, FloatRect(0, 0, contextWidth, contextHeight), { });
-    RecorderImpl secondaryContext({ }, FloatRect(0, 0, contextWidth, contextHeight), { });
+    RecorderImpl primaryContext({ }, FloatRect(0, 0, contextWidth, contextHeight));
+    RecorderImpl secondaryContext({ }, FloatRect(0, 0, contextWidth, contextHeight));
 
     BifurcatedGraphicsContext ctx(primaryContext, secondaryContext);
 


### PR DESCRIPTION
Need a short description (OOPS!).
Need the bug URL (OOPS!).
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

Test: Tools/TestWebKitAPI/Tests/WebCore/cocoa/BifurcatedGraphicsContextTestsCG.cpp

<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4e2da3304447832c7bbc762be6f9d88fd543f08f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177693 "19 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51631 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45425 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187298 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/140940 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/adc55c7a-15d3-47a9-a0c2-4aa49e3c441c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179556 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52923 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51340 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138501 "Found 5 new test failures: imported/w3c/web-platform-tests/css/css-color/t32-opacity-offscreen-b.xht imported/w3c/web-platform-tests/html/canvas/element/layers/2d.layer.global-states.no-cxt-filter.rotation.html imported/w3c/web-platform-tests/svg/painting/marker-009.svg svg/clip-path/clip-opacity.html svg/custom/marker-zero-length-linecaps.svg (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96340 "1 flakes 3 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/26e1cfda-94b5-4ea8-aa76-2f5340a8d4a2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180649 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42021 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159244 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118965 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/449a84c8-6dca-4768-aa55-363d83a03ddf) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40682 "Found 4 new test failures: imported/w3c/web-platform-tests/css/css-view-transitions/massive-element-below-and-on-top-of-viewport-partially-onscreen-old.html imported/w3c/web-platform-tests/css/css-view-transitions/massive-element-below-viewport-offscreen-old.html imported/w3c/web-platform-tests/css/css-view-transitions/massive-element-below-viewport-partially-onscreen-old.html imported/w3c/web-platform-tests/css/css-view-transitions/massive-element-on-top-of-viewport-offscreen-old.html (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39044 "Passed tests") | | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151089 "Found 3 new API test failures: TestWebKitAPI.WKWebView.SnapshotNodeIncludingOffscreen, TestWebKitAPI.WKWebView.SnapshotNodeByJSHandle, TestWebKitAPI.WKWebView.SnapshotNodeWithTransform (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38740 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-highlight-api/painting/custom-highlight-dynamic-font-metrics-001.html (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35764 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/43416 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43279 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189729 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51298 "Built successfully") | | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147615 "") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51980 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35368 "Found unexpected failure with change (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147403 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42114 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124195 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118608 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50488 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13717 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49884 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50124 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49946 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->