### PR TITLE
Out-of-bounds read in CtapHidDriver when a CTAPHID_INIT response is too short

### DIFF
--- a/LayoutTests/http/wpt/webauthn/ctap-hid-failure.https-expected.txt
+++ b/LayoutTests/http/wpt/webauthn/ctap-hid-failure.https-expected.txt
@@ -3,6 +3,7 @@ PASS CTAP HID with init sub stage data not sent error in a mock hid authenticato
 PASS CTAP HID with init sub stage empty report error in a mock hid authenticator.
 PASS CTAP HID with init sub stage wrong channel id error in a mock hid authenticator.
 PASS CTAP HID with init sub stage wrong nonce error in a mock hid authenticator.
+PASS CTAP HID with init sub stage short init response in a mock hid authenticator.
 PASS CTAP HID with msg sub stage data not sent error in a mock hid authenticator.
 PASS CTAP HID with msg sub stage empty report error in a mock hid authenticator.
 PASS CTAP HID with msg sub stage wrong channel id error in a mock hid authenticator.

--- a/LayoutTests/http/wpt/webauthn/ctap-hid-failure.https.html
+++ b/LayoutTests/http/wpt/webauthn/ctap-hid-failure.https.html
@@ -45,6 +45,15 @@
     }, "CTAP HID with init sub stage wrong nonce error in a mock hid authenticator.");
 
     promise_test(function(t) {
+        // The authenticator returns a CTAPHID_INIT response whose payload matches the nonce but is
+        // too short to contain the channel ID. This must be rejected without an out-of-bounds read
+        // in CtapHidDriver::continueAfterChannelAllocated(); the transaction is restarted and times out.
+        if (window.internals)
+            internals.setMockWebAuthenticationConfiguration({ hid: { stage: "info", subStage: "init", error: "short-init-response" } });
+        return promiseRejects(t, "NotAllowedError", navigator.credentials.create(defaultOptions), "Operation timed out.");
+    }, "CTAP HID with init sub stage short init response in a mock hid authenticator.");
+
+    promise_test(function(t) {
         if (window.internals)
             internals.setMockWebAuthenticationConfiguration({ hid: { stage: "info", subStage: "msg", error: "data-not-sent" } });
         return promiseRejects(t, "NotAllowedError", navigator.credentials.create(defaultOptions), "Operation timed out.");

--- a/Source/WebCore/testing/MockWebAuthenticationConfiguration.h
+++ b/Source/WebCore/testing/MockWebAuthenticationConfiguration.h
@@ -50,7 +50,8 @@ struct MockWebAuthenticationConfiguration {
         WrongChannelId,
         MaliciousPayload,
         UnsupportedOptions,
-        WrongNonce
+        WrongNonce,
+        ShortInitResponse
     };
 
     enum class NfcError : uint8_t {

--- a/Source/WebCore/testing/MockWebAuthenticationConfiguration.idl
+++ b/Source/WebCore/testing/MockWebAuthenticationConfiguration.idl
@@ -46,7 +46,8 @@
     "wrong-channel-id",
     "malicious-payload",
     "unsupported-options",
-    "wrong-nonce"
+    "wrong-nonce",
+    "short-init-response"
 };
 
 [

--- a/Source/WebKit/Shared/WebCoreArgumentCodersAuth.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCodersAuth.serialization.in
@@ -219,7 +219,8 @@ enum class WebCore::AuthenticatorAttachment : uint8_t {
     WrongChannelId,
     MaliciousPayload,
     UnsupportedOptions,
-    WrongNonce
+    WrongNonce,
+    ShortInitResponse
 };
 
 [Nested] struct WebCore::MockWebAuthenticationConfiguration::HidConfiguration {

--- a/Source/WebKit/UIProcess/WebAuthentication/Mock/MockHidConnection.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/Mock/MockHidConnection.cpp
@@ -209,6 +209,15 @@ void MockHidConnection::feedReports()
         size_t writePosition = payload.size();
         if (stagesMatch() && m_configuration.hid->error == Mock::HidError::WrongNonce)
             payload[0]--;
+        if (stagesMatch() && m_configuration.hid->error == Mock::HidError::ShortInitResponse) {
+            // Emit an INIT response whose payload matches the requested nonce but is too short
+            // to contain the subsequent 4-byte channel ID, to exercise the bounds check in
+            // CtapHidDriver::continueAfterChannelAllocated().
+            FidoHidInitPacket shortPacket(kHidBroadcastChannel, FidoHidDeviceCommand::kInit, WTF::move(payload), kHidInitNonceLength);
+            receiveReport(shortPacket.getSerializedData());
+            shouldContinueFeedReports();
+            return;
+        }
         payload.grow(kHidInitResponseSize);
         cryptographicallyRandomValues(payload.mutableSpan().subspan(writePosition, kCtapChannelIdSize));
         auto channel = kHidBroadcastChannel;

--- a/Source/WebKit/UIProcess/WebAuthentication/fido/CtapHidDriver.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/fido/CtapHidDriver.cpp
@@ -216,9 +216,7 @@ void CtapHidDriver::continueAfterChannelAllocated(std::optional<FidoHidMessage>&
     ASSERT(message->channelId() == m_channelId);
 
     auto payload = message->getMessagePayload();
-    ASSERT(payload.size() == kHidInitResponseSize);
-    // Restart the transaction in the next run loop when nonce mismatches.
-    if (!spanHasPrefix(payload.span(), m_nonce.span())) {
+    if (payload.size() < kHidInitResponseSize || !spanHasPrefix(payload.span(), m_nonce.span())) {
         m_state = State::Idle;
         RunLoop::mainSingleton().dispatch([weakThis = WeakPtr { *this }, data = WTF::move(m_requestData), callback = WTF::move(m_responseCallback)]() mutable {
             if (!weakThis)


### PR DESCRIPTION
#### 808e77190fcf15156e06761c31e79230b166c8d0
<pre>
Out-of-bounds read in CtapHidDriver when a CTAPHID_INIT response is too short
<a href="https://bugs.webkit.org/show_bug.cgi?id=320344">https://bugs.webkit.org/show_bug.cgi?id=320344</a>
<a href="https://rdar.apple.com/problem/183363731">rdar://problem/183363731</a>

Reviewed by Pascoe.

CtapHidDriver::continueAfterChannelAllocated() reads the 4-byte channel ID from
payload[8..11] of the CTAPHID_INIT response after only checking that the payload
begins with the requested nonce. spanHasPrefix() merely requires the payload to
be at least as long as the 8-byte nonce, and the size assumption was otherwise
only enforced by a debug-only ASSERT(payload.size() == kHidInitResponseSize). A
malicious or buggy authenticator can therefore return an INIT response whose
payload matches the nonce prefix but is shorter than kHidInitResponseSize (as
few as 8 bytes), causing an out-of-bounds Vector access when reading the channel
ID. Under WebKit&apos;s bounds-checked Vector this crashes the UI process.

Treat a too-short response the same as a nonce mismatch: replace the debug
assertion with a runtime `payload.size() &lt; kHidInitResponseSize` check folded
into the existing restart condition, so the transaction is restarted (and
eventually times out) instead of reading past the buffer.

To make the vulnerable path testable, add a &quot;short-init-response&quot; mock HID
error. MockHidConnection previously always produced a well-formed
kHidInitResponseSize-byte INIT response; it now emits a payload consisting of
just the nonce when this error is configured.

No new tests, updated http/wpt/webauthn/ctap-hid-failure.https.html.

* LayoutTests/http/wpt/webauthn/ctap-hid-failure.https-expected.txt:
* LayoutTests/http/wpt/webauthn/ctap-hid-failure.https.html:
* Source/WebCore/testing/MockWebAuthenticationConfiguration.h:
* Source/WebCore/testing/MockWebAuthenticationConfiguration.idl:
* Source/WebKit/Shared/WebCoreArgumentCodersAuth.serialization.in:
* Source/WebKit/UIProcess/WebAuthentication/Mock/MockHidConnection.cpp:
(WebKit::MockHidConnection::feedReports):
* Source/WebKit/UIProcess/WebAuthentication/fido/CtapHidDriver.cpp:
(WebKit::CtapHidDriver::continueAfterChannelAllocated):

Canonical link: <a href="https://commits.webkit.org/318015@main">https://commits.webkit.org/318015@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f247a9a709b35b412a16be68c0c07d314d664c6e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177069 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51006 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/44801 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186672 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140305 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178932 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52299 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50692 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/137964 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140305 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fceff05e-427e-4d2a-a81b-e0bb057c55b6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180025 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41468 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/158741 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118433 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/253b954a-bd71-40c5-9b44-eec5a5fe972b) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/40124 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/38496 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/150534 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/38240 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35140 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/42780 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/42714 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189098 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50673 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/158280 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/147049 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39516 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51356 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/34864 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146840 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41584 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123570 "Build is in progress. Recent messages:") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117857 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49861 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/13220 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49260 "Built successfully") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/49497 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49321 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->