### PR TITLE
Web Inspector: Elements: Support toggling pseudo-class on multiple selected nodes

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/DOMTreeElement.js
+++ b/Source/WebInspectorUI/UserInterface/Views/DOMTreeElement.js
@@ -941,6 +941,23 @@ WI.DOMTreeElement = class DOMTreeElement extends WI.TreeElement
 
         if (this.treeOutline.editable) {
             if (this.selected && selectedTreeElements.length > 1) {
+                if (WI.cssManager.canForcePseudoClass()) {
+                    let attachedSelectedTreeElements = selectedTreeElements.filter((treeElement) => treeElement.representedObject.attached);
+                    if (attachedSelectedTreeElements.length) {
+                        let pseudoSubMenu = contextMenu.appendSubMenuItem(WI.UIString("Forced Pseudo-Classes", "A context menu item to force (override) a DOM node's pseudo-classes"));
+
+                        for (let pseudoClass of Object.values(WI.CSSManager.ForceablePseudoClass)) {
+                            if (!WI.cssManager.canForcePseudoClass(pseudoClass))
+                                continue;
+
+                            let allEnabled = attachedSelectedTreeElements.every((treeElement) => treeElement.representedObject.enabledPseudoClasses.includes(pseudoClass));
+                            pseudoSubMenu.appendCheckboxItem(WI.CSSManager.displayNameForForceablePseudoClass(pseudoClass), () => {
+                                this.treeOutline.toggleSelectedElementsPseudoClass(pseudoClass, !allEnabled);
+                            }, allEnabled);
+                        }
+                    }
+                }
+
                 let forceHidden = !selectedTreeElements.every((treeElement) => treeElement.isNodeHidden);
                 let label = forceHidden ? WI.UIString("Hide Elements") : WI.UIString("Show Elements");
                 contextMenu.appendItem(label, () => {

--- a/Source/WebInspectorUI/UserInterface/Views/DOMTreeOutline.js
+++ b/Source/WebInspectorUI/UserInterface/Views/DOMTreeOutline.js
@@ -245,6 +245,12 @@ WI.DOMTreeOutline = class DOMTreeOutline extends WI.TreeOutline
             treeElement.toggleElementVisibility(forceHidden);
     }
 
+    toggleSelectedElementsPseudoClass(pseudoClass, enabled)
+    {
+        for (let treeElement of this.selectedTreeElements)
+            treeElement.representedObject.setPseudoClassEnabled(pseudoClass, enabled);
+    }
+
     _selectedNodeChanged()
     {
         this.dispatchEventToListeners(WI.DOMTreeOutline.Event.SelectedNodeChanged);


### PR DESCRIPTION
#### bb38f2b405424f5ba74dae2a507be57816ec6286
<pre>
Web Inspector: Elements: Support toggling pseudo-class on multiple selected nodes
<a href="https://bugs.webkit.org/show_bug.cgi?id=307810">https://bugs.webkit.org/show_bug.cgi?id=307810</a>
<a href="https://rdar.apple.com/170325064">rdar://170325064</a>

Reviewed by NOBODY (OOPS!).

This follow-up from bug 307780 (<a href="https://commits.webkit.org/307485@main">307485@main</a>).

The &quot;Forced Pseudo-Classes&quot; submenu is built by
WI.appendContextMenuItemsForDOMNode, which DOMTreeOutline only invokes when
exactly one tree element is selected. As a result, forcing a pseudo-class
(:hover, :focus, etc.) was impossible when multiple DOM nodes were selected,
even though the underlying DOMNode.setPseudoClassEnabled already operates
per-node and needs no backend change.

Add the submenu to the multi-selection branch of the context menu, mirroring
the existing &quot;Hide Elements&quot; path. Each checkbox reflects whether every
attached selected node already has the pseudo-class forced, and toggles the
state across the whole selection via a new DOMTreeOutline helper that loops
over the selected tree elements (matching toggleSelectedElementsVisibility).

No new tests: this change lives entirely in the DOM tree View layer, which is
not part of the Web Inspector Test target (Test.html loads TreeOutline.js but
not DOMTreeOutline.js/DOMTreeElement.js), so it is not reachable from an
inspector LayoutTest. This matches the analogous &quot;Hide Elements&quot;
multi-selection path, which is likewise verified manually.

* Source/WebInspectorUI/UserInterface/Views/DOMTreeElement.js:
(WI.DOMTreeElement.prototype.populateDOMNodeContextMenu):
* Source/WebInspectorUI/UserInterface/Views/DOMTreeOutline.js:
(WI.DOMTreeOutline.prototype.toggleSelectedElementsPseudoClass):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bb38f2b405424f5ba74dae2a507be57816ec6286

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176888 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50825 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44617 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186491 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140124 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9b3dda6b-1d58-4b00-9117-54726e1a1999) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52118 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50511 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137807 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140124 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f0d09751-e607-4670-9dc9-97beb639d142) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179844 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41318 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158597 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118281 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7e5ac2df-d5c0-4048-904e-679d28bc8c82) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39972 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38340 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150384 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38096 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34958 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42571 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42555 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188914 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50492 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146881 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51175 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34720 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146682 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41446 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123383 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117619 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49680 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13085 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49079 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49315 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49140 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->