### PR TITLE
Digital Credentials:

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/concurrent-requests.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/concurrent-requests.https-expected.txt
@@ -1,3 +1,4 @@
 
 PASS A second get() call while another is pending should reject with NotAllowedError.
+PASS A concurrent get() rejection is queued on the DOM manipulation task source, not settled synchronously.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/concurrent-requests.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/concurrent-requests.https.html
@@ -1,5 +1,5 @@
-<!DOCTYPE html>
-<meta charset="utf-8">
+<!doctype html>
+<meta charset="utf-8" />
 <title>Digital Credential concurrent request rejection tests</title>
 <link rel="help" href="https://w3c-fedid.github.io/digital-credentials/" />
 <script src="/resources/testharness.js"></script>
@@ -37,7 +37,7 @@
       t,
       "NotAllowedError",
       secondRequest,
-      "Second concurrent request should be rejected with NotAllowedError"
+      "Second concurrent request should be rejected with NotAllowedError",
     );
 
     abortController.abort();
@@ -45,7 +45,42 @@
       t,
       "AbortError",
       firstRequest,
-      "First request should be aborted"
+      "First request should be aborted",
     );
   }, "A second get() call while another is pending should reject with NotAllowedError.");
+
+  promise_test(async (t) => {
+    // The concurrency rejection must be queued as a global task on the DOM
+    // manipulation task source (per "prepare credential requests"), not settled
+    // synchronously. A synchronous rejection would settle the promise within
+    // the get() call, scheduling its rejection reaction ahead of a microtask
+    // queued in the same tick; a task-queued rejection lets the microtask run
+    // first.
+    await test_driver.set_virtual_wallet_behavior("wait");
+    t.add_cleanup(() => test_driver.set_virtual_wallet_behavior("clear"));
+
+    const abortController = new AbortController();
+    await test_driver.bless("user activation for first request");
+    const firstRequest = navigator.credentials.get(
+      makeGetOptions({ signal: abortController.signal }),
+    );
+
+    const order = [];
+    let secondRequest;
+    await test_driver.bless("user activation for second request", () => {
+      secondRequest = navigator.credentials.get(makeGetOptions());
+      secondRequest.catch(() => order.push("rejection"));
+      Promise.resolve().then(() => order.push("microtask"));
+    });
+
+    await promise_rejects_dom(t, "NotAllowedError", secondRequest);
+    assert_array_equals(
+      order,
+      ["microtask", "rejection"],
+      "The concurrent-request rejection must be queued as a task, not settled synchronously.",
+    );
+
+    abortController.abort();
+    await promise_rejects_dom(t, "AbortError", firstRequest);
+  }, "A concurrent get() rejection is queued on the DOM manipulation task source, not settled synchronously.");
 </script>

--- a/Source/WebCore/Modules/identity/CredentialRequestCoordinator.cpp
+++ b/Source/WebCore/Modules/identity/CredentialRequestCoordinator.cpp
@@ -47,6 +47,7 @@
 #include "LocalFrame.h"
 #include "Page.h"
 #include "SecurityOriginData.h"
+#include "TaskSource.h"
 #include <JavaScriptCore/JSObject.h>
 #include <JavaScriptCore/StrongInlines.h>
 #include <Logging.h>
@@ -127,14 +128,32 @@ CredentialPromise* CredentialRequestCoordinator::currentPromise()
     return m_currentPromise.get();
 }
 
+template<typename SettleFunction>
+void CredentialRequestCoordinator::queuePromiseSettlement(SettleFunction settle)
+{
+    queueTaskKeepingObjectAlive(*this, TaskSource::DOMManipulation, [settle = WTF::move(settle)](auto& coordinator) mutable {
+        if (!coordinator.hasCurrentPromise())
+            return coordinator.setInteractionState(InteractionState::Idle);
+        coordinator.clearAbortAlgorithm();
+        auto promise = WTF::move(coordinator.m_currentPromise);
+        settle(coordinator, *promise);
+        coordinator.setInteractionState(InteractionState::Idle);
+    });
+}
+
 void CredentialRequestCoordinator::prepareCredentialRequests(const Document& document, CredentialPromise&& promise, Vector<UnvalidatedDigitalCredentialRequest>&& unvalidatedRequests, RefPtr<AbortSignal> signal)
 {
-    if (m_interactionState != InteractionState::Idle)
-        return promise.reject(ExceptionCode::NotAllowedError, "A credential request is already in progress."_s);
+    if (m_interactionState != InteractionState::Idle) {
+        queueTaskKeepingObjectAlive(*this, TaskSource::DOMManipulation, [promise = makeUnique<CredentialPromise>(WTF::move(promise))](auto&) mutable {
+            promise->reject(ExceptionCode::NotAllowedError, "A credential request is already in progress."_s);
+        });
+        return;
+    }
 
     ASSERT(!m_currentPromise);
     setInteractionState(InteractionState::Requesting);
     setCurrentPromise(WTF::move(promise));
+    observeContext(protect(document.scriptExecutionContext()).get());
 
     if (!m_page)
         return rejectTheCredentialRequestWith(Exception { ExceptionCode::AbortError, "Page was destroyed."_s });
@@ -178,8 +197,6 @@ void CredentialRequestCoordinator::initiateTheCredentialRequest(const Document& 
     if (requestDataAndRawRequests.hasException())
         return rejectTheCredentialRequestWith(requestDataAndRawRequests.releaseException());
 
-    observeContext(protect(document.scriptExecutionContext()).get());
-
     auto [requestData, rawRequests] = requestDataAndRawRequests.releaseReturnValue();
 
     std::optional<FrameIdentifier> requestingFrameID;
@@ -222,25 +239,25 @@ void CredentialRequestCoordinator::processCredentialChooserResponse(Expected<Dig
     guard.deactivate();
 
     if (!responseOrException)
-        return settleTheCredentialRequest(responseOrException.error().toException());
+        return rejectTheCredentialRequestWith(responseOrException.error().toException());
 
     auto& responseData = responseOrException.value();
 
     if (responseData.responseDataJSON.isEmpty())
-        return settleTheCredentialRequest(Exception { ExceptionCode::NotAllowedError, "The user cancelled the credential request."_s });
+        return rejectTheCredentialRequestWith(Exception { ExceptionCode::NotAllowedError, "The user cancelled the credential request."_s });
 
-    auto parsedObject = parseDigitalCredentialsResponseData(responseData.responseDataJSON);
-
-    if (parsedObject.hasException())
-        return settleTheCredentialRequest(parsedObject.releaseException());
-
-    if (!parsedObject.returnValue())
-        return settleTheCredentialRequest(Exception { ExceptionCode::TypeError, "No parsed object."_s });
-
-    auto returnValue = parsedObject.releaseReturnValue();
-    Ref credential = DigitalCredential::create({ returnValue->vm(), returnValue }, responseData.protocol);
-
-    settleTheCredentialRequest(credential.ptr());
+    queuePromiseSettlement([responseDataJSON = responseData.responseDataJSON, protocol = responseData.protocol](auto& coordinator, auto& promise) {
+        auto parsedObject = coordinator.parseDigitalCredentialsResponseData(responseDataJSON);
+        if (parsedObject.hasException())
+            promise.reject(parsedObject.releaseException());
+        else if (!parsedObject.returnValue())
+            promise.reject(Exception { ExceptionCode::TypeError, "Parsed JSON data is not an object."_s });
+        else {
+            auto returnValue = parsedObject.releaseReturnValue();
+            Ref credential = DigitalCredential::create({ returnValue->vm(), returnValue }, protocol);
+            promise.resolve(credential.ptr());
+        }
+    });
 }
 
 ExceptionOr<JSC::JSObject*> CredentialRequestCoordinator::parseDigitalCredentialsResponseData(const String& responseDataJSON) const
@@ -284,35 +301,8 @@ void CredentialRequestCoordinator::rejectTheCredentialRequestWith(Exception&& ex
 {
     ASSERT(m_interactionState != InteractionState::Idle);
     ASSERT(m_currentPromise);
-    clearAbortAlgorithm();
-    m_currentPromise->reject(WTF::move(exception));
-    m_currentPromise.reset();
-    setInteractionState(InteractionState::Idle);
-}
-
-void CredentialRequestCoordinator::settleTheCredentialRequest(ExceptionOr<RefPtr<BasicCredential>>&& result)
-{
-    clearAbortAlgorithm();
-
-    auto promise = WTF::move(m_currentPromise);
-    m_currentPromise.reset();
-
-    ASSERT(m_interactionState == InteractionState::Requesting || m_interactionState == InteractionState::Aborting);
-
-    m_client->dismissDigitalCredentialsChooser([weakThis = WeakPtr { *this }, promise = WTF::move(promise), result = WTF::move(result)](bool success) mutable {
-        if (!success)
-            LOG(DigitalCredentials, "Failed to dismiss the credential chooser.");
-
-        if (auto* rawThis = weakThis.get())
-            rawThis->setInteractionState(InteractionState::Idle);
-
-        if (!promise)
-            return;
-
-        if (result.hasException())
-            promise->reject(result.releaseException());
-        else
-            promise->resolve(result.releaseReturnValue().get());
+    queuePromiseSettlement([exception = WTF::move(exception)](auto&, auto& promise) mutable {
+        promise.reject(WTF::move(exception));
     });
 }
 
@@ -331,26 +321,18 @@ void CredentialRequestCoordinator::clearAbortAlgorithm()
 
 void CredentialRequestCoordinator::abortTheCredentialRequest(ExceptionOr<JSC::JSValue>&& reason)
 {
-    clearAbortAlgorithm();
-    if (m_interactionState == InteractionState::Idle) {
-        ASSERT(!m_currentPromise);
+    if (!m_currentPromise)
         return;
-    }
 
-    if (m_interactionState == InteractionState::Aborting) {
-        ASSERT(!m_currentPromise);
+    if (m_interactionState != InteractionState::Requesting)
         return;
-    }
-
-    if (m_interactionState != InteractionState::Requesting) {
-        LOG(DigitalCredentials, "Cannot abort the credential request when it is not presenting.");
-        return;
-    }
 
     setInteractionState(InteractionState::Aborting);
 
-    auto promise = WTF::move(m_currentPromise);
-    m_currentPromise.reset();
+    m_client->dismissDigitalCredentialsChooser([](bool success) {
+        if (!success)
+            LOG(DigitalCredentials, "Failed to dismiss the credential chooser.");
+    });
 
     std::optional<Exception> abortException;
     std::optional<JSC::Strong<JSC::Unknown>> protectedReason;
@@ -370,31 +352,21 @@ void CredentialRequestCoordinator::abortTheCredentialRequest(ExceptionOr<JSC::JS
         }
     }
 
-    m_client->dismissDigitalCredentialsChooser(
-        [weakThis = WeakPtr { *this }, promise = WTF::move(promise), abortException = WTF::move(abortException), protectedReason = WTF::move(protectedReason)](bool success) mutable {
-            if (!success)
-                LOG(DigitalCredentials, "Failed to dismiss the credential chooser.");
-
-            if (auto* rawThis = weakThis.get())
-                rawThis->setInteractionState(InteractionState::Idle);
-
-            if (!promise)
-                return;
-
-            if (abortException)
-                return promise->reject(WTF::move(*abortException));
-
-            if (protectedReason)
-                return promise->rejectType<IDLAny>(protectedReason->get());
-
-            promise->reject(ExceptionCode::AbortError);
-        });
+    queuePromiseSettlement([abortException = WTF::move(abortException), protectedReason = WTF::move(protectedReason)](auto&, auto& promise) mutable {
+        if (abortException)
+            promise.reject(WTF::move(*abortException));
+        else if (protectedReason)
+            promise.template rejectType<IDLAny>(protectedReason->get());
+        else
+            promise.reject(ExceptionCode::AbortError);
+    });
 }
 
 void CredentialRequestCoordinator::contextDestroyed()
 {
     LOG(DigitalCredentials, "The context we were observing got destroyed");
     abortTheCredentialRequest(Exception { ExceptionCode::AbortError, "script execution context was destroyed."_s });
+    ActiveDOMObject::contextDestroyed();
 };
 
 CredentialRequestCoordinator::~CredentialRequestCoordinator()

--- a/Source/WebCore/Modules/identity/CredentialRequestCoordinator.cpp
+++ b/Source/WebCore/Modules/identity/CredentialRequestCoordinator.cpp
@@ -59,6 +59,40 @@ namespace WebCore {
 WTF_MAKE_TZONE_ALLOCATED_IMPL(CredentialRequestCoordinator);
 WTF_MAKE_TZONE_ALLOCATED_IMPL(CredentialRequestCoordinatorClient);
 
+// The per-page coordinator registers as an ActiveDOMObject of the top document, so its own stop()
+// never fires for a subframe requester; this per-request observer supplies that signal from the
+// requesting document and aborts with an AbortError when it stops being fully active.
+class CredentialRequestActivityObserver final : public RefCounted<CredentialRequestActivityObserver>, public ActiveDOMObject {
+    WTF_MAKE_TZONE_ALLOCATED(CredentialRequestActivityObserver);
+public:
+    static Ref<CredentialRequestActivityObserver> create(ScriptExecutionContext& context, CredentialRequestCoordinator& coordinator)
+    {
+        Ref observer = adoptRef(*new CredentialRequestActivityObserver(context, coordinator));
+        observer->suspendIfNeeded();
+        return observer;
+    }
+
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
+private:
+    CredentialRequestActivityObserver(ScriptExecutionContext& context, CredentialRequestCoordinator& coordinator)
+        : ActiveDOMObject(&context)
+        , m_coordinator(coordinator)
+    {
+    }
+
+    void stop() final
+    {
+        if (RefPtr coordinator = m_coordinator.get())
+            coordinator->abortTheCredentialRequest(Exception { ExceptionCode::AbortError, "The document is no longer fully active."_s });
+    }
+
+    WeakPtr<CredentialRequestCoordinator> m_coordinator;
+};
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(CredentialRequestActivityObserver);
+
 Ref<CredentialRequestCoordinator> CredentialRequestCoordinator::create(Ref<CredentialRequestCoordinatorClient>&& client, Page& page)
 {
     return adoptRef(*new CredentialRequestCoordinator(WTF::move(client), page));
@@ -132,6 +166,7 @@ template<typename SettleFunction>
 void CredentialRequestCoordinator::queuePromiseSettlement(SettleFunction settle)
 {
     queueTaskKeepingObjectAlive(*this, TaskSource::DOMManipulation, [settle = WTF::move(settle)](auto& coordinator) mutable {
+        coordinator.m_activityObserver = nullptr;
         if (!coordinator.hasCurrentPromise())
             return coordinator.setInteractionState(InteractionState::Idle);
         coordinator.clearAbortAlgorithm();
@@ -202,6 +237,9 @@ void CredentialRequestCoordinator::initiateTheCredentialRequest(const Document& 
     std::optional<FrameIdentifier> requestingFrameID;
     if (RefPtr frame = document.frame())
         requestingFrameID = frame->frameID();
+
+    if (RefPtr scriptExecutionContext = document.scriptExecutionContext())
+        m_activityObserver = CredentialRequestActivityObserver::create(*scriptExecutionContext, *this);
 
     m_client->showDigitalCredentialsChooser(
         requestingFrameID,

--- a/Source/WebCore/Modules/identity/CredentialRequestCoordinator.h
+++ b/Source/WebCore/Modules/identity/CredentialRequestCoordinator.h
@@ -67,9 +67,9 @@ public:
     void contextDestroyed() final;
 
 private:
-    void settleTheCredentialRequest(ExceptionOr<RefPtr<BasicCredential>>&&);
     void rejectTheCredentialRequestWith(Exception&&);
     void clearAbortAlgorithm();
+    template<typename SettleFunction> void queuePromiseSettlement(SettleFunction);
 
     class InteractionStateGuard final {
     public:

--- a/Source/WebCore/Modules/identity/CredentialRequestCoordinator.h
+++ b/Source/WebCore/Modules/identity/CredentialRequestCoordinator.h
@@ -42,6 +42,7 @@
 namespace WebCore {
 class AbortSignal;
 class BasicCredential;
+class CredentialRequestActivityObserver;
 class CredentialRequestCoordinatorClient;
 class Document;
 class LocalFrame;
@@ -112,6 +113,7 @@ private:
     std::unique_ptr<CredentialPromise> m_currentPromise;
     std::optional<uint32_t> m_abortAlgorithmIdentifier;
     WeakPtr<Page> m_page;
+    RefPtr<CredentialRequestActivityObserver> m_activityObserver;
 };
 
 } // namespace WebCore

--- a/Source/WebKit/UIProcess/DigitalCredentials/WKDigitalCredentialsPicker.mm
+++ b/Source/WebKit/UIProcess/DigitalCredentials/WKDigitalCredentialsPicker.mm
@@ -428,6 +428,7 @@ static RetainPtr<NSArray<NSArray<WKIdentityDocumentPresentmentRequestAuthenticat
             WebCore::ExceptionData exceptionData = { ExceptionCode::TypeError, "Unknown protocol response from document."_s };
             [self completeWith:makeUnexpected(exceptionData)];
         }
+        return;
     }
 
     [self handleNSError:error];


### PR DESCRIPTION
#### badf1c8ea3cf4ae6e78a63b2f3f7c92d2bac0c63
<pre>
Digital Credentials: abort a pending request when the requesting document stops being fully active

<a href="https://bugs.webkit.org/show_bug.cgi?id=317884">https://bugs.webkit.org/show_bug.cgi?id=317884</a>
<a href="https://rdar.apple.com/180664061">rdar://180664061</a>

Reviewed by NOBODY (OOPS!).

A pending navigator.credentials.get() request was not aborted with an
AbortError when its requesting document stopped being fully active, for
example when a requesting subframe is removed. The CredentialRequestCoordinator
is a per-page ActiveDOMObject of the top document, so it never receives stop()
for a subframe requester, and the pending request settled with the wrong result.

Add a per-request CredentialRequestActivityObserver, an ActiveDOMObject created
on the requesting document, whose stop() aborts the request with an AbortError,
following the PaymentRequest pattern. It is created when the request is initiated
and reset when the request settles.
</pre>
----------------------------------------------------------------------
#### 3c958eaaffab9c8bd03d39d7fd0935a980c50c92
<pre>
Digital Credentials: reject and resolve paths must queue a global task per spec

<a href="https://bugs.webkit.org/show_bug.cgi?id=313736">https://bugs.webkit.org/show_bug.cgi?id=313736</a>
<a href="https://rdar.apple.com/182678875">rdar://182678875</a>

Reviewed by NOBODY (OOPS!).

Queue promise settlement on the DOM manipulation task source, matching the
&quot;prepare credential requests&quot;, &quot;reject the credential request with&quot;, and
&quot;initiate the credential request&quot; algorithms. Settlement previously ran
synchronously (the concurrent-request rejection) or inside the chooser
dismissal completion callback (success and abort); both now queue a global
task that guards on the active promise, clears the abort algorithm, settles,
and returns the coordinator to the idle state.

The chooser dismissal is dropped on the response outcome paths, since the
platform picker already dismisses itself when it delivers an outcome; the
explicit fire-and-forget dismissal is kept only in the abort path, where the
chooser is still presented.

Also stop WKDigitalCredentialsPicker from completing a valid response twice:
handlePresentmentCompletionWithResponse: fell through to handleNSError: after
handling a response, relying on the completion handler already being null.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/badf1c8ea3cf4ae6e78a63b2f3f7c92d2bac0c63

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176889 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50826 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44618 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186492 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/140125 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/048f4a33-31b3-4037-b99c-a15f3fc17269) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178752 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52119 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50512 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137808 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96277 "2 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e44919c6-1ca4-4135-8c6d-e93d32d3e546) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179845 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41319 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158598 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118282 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5528513e-c7ee-412c-97d2-a3e05a0380b0) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39973 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38341 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150385 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38097 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34959 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42572 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42556 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188915 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50493 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/158141 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Checked out pull request; Passed layout tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146882 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51176 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34721 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146683 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41447 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123384 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117620 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49681 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13078 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49080 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49316 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49141 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->