### PR TITLE
[ANGLE] Copy angle_end2end_tests_expectations.txt to build output folder

### DIFF
--- a/Source/ThirdParty/ANGLE/ANGLE.xcodeproj/project.pbxproj
+++ b/Source/ThirdParty/ANGLE/ANGLE.xcodeproj/project.pbxproj
@@ -637,6 +637,7 @@
 		445C4E2483088F91EA3BF4F5 /* es2sLongRunningTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF7F4BC68F2221441BBA47CC /* es2sLongRunningTests.cpp */; };
 		44EF4D53A634EA5A0968572B /* es3pStateChangeTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = D739486DA5E0126F0D0EF4BB /* es3pStateChangeTests.cpp */; };
 		4557460D814F5DF1D5787863 /* es3sLongRunningShaderTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7134402C9425888101366367 /* es3sLongRunningShaderTests.cpp */; };
+		457CC0343015771C001DE9FC /* angle_end2end_tests_expectations.txt in State Test Expectations */ = {isa = PBXBuildFile; fileRef = 7BD3D2E82FCDBB4E00C386DC /* angle_end2end_tests_expectations.txt */; };
 		45F4464AB2B8513CB3E3762B /* es3fNegativeStateApiTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2F264D619701179ECB7F6033 /* es3fNegativeStateApiTests.cpp */; };
 		46574F8EBAA668D2A75348A0 /* es3pShaderOperatorTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7F384DF192F867DA1896E9B2 /* es3pShaderOperatorTests.cpp */; };
 		46724657AF064907DE2EA506 /* deThreadTest.c in Sources */ = {isa = PBXBuildFile; fileRef = ADE748218E43074A54016343 /* deThreadTest.c */; };
@@ -2715,20 +2716,6 @@
 			remoteGlobalIDString = DA5446AEBAE5F6920A4C2227;
 			remoteInfo = ANGLEDeqpSupport;
 		};
-		EABF4011B5554627E06EB304 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = FB39D0701200ED9200088E69 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = DA5446AEBAE5F6920A4C2227;
-			remoteInfo = ANGLEDeqpSupport;
-		};
-		EFA74AB28E9728008475F897 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = FB39D0701200ED9200088E69 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = A3E045FAB988D2834BEDCF23;
-			remoteInfo = ANGLEDeqpGLES2Tests;
-		};
 		DDAD70172FF59CF40054DF83 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = FB39D0701200ED9200088E69 /* Project object */;
@@ -2764,6 +2751,20 @@
 			remoteGlobalIDString = DDAD70112FF59CB70054DF83;
 			remoteInfo = Setup;
 		};
+		EABF4011B5554627E06EB304 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = FB39D0701200ED9200088E69 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = DA5446AEBAE5F6920A4C2227;
+			remoteInfo = ANGLEDeqpSupport;
+		};
+		EFA74AB28E9728008475F897 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = FB39D0701200ED9200088E69 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = A3E045FAB988D2834BEDCF23;
+			remoteInfo = ANGLEDeqpGLES2Tests;
+		};
 		FF194FF52744331A006A97A3 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = FB39D0701200ED9200088E69 /* Project object */;
@@ -2793,6 +2794,17 @@
 				31CD00D12491979C00486F27 /* LICENSE in CopyFiles */,
 			);
 			runOnlyForDeploymentPostprocessing = 1;
+		};
+		457CC033301576C6001DE9FC /* State Test Expectations */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = src/tests;
+			dstSubfolderSpec = 16;
+			files = (
+				457CC0343015771C001DE9FC /* angle_end2end_tests_expectations.txt in State Test Expectations */,
+			);
+			name = "State Test Expectations";
+			runOnlyForDeploymentPostprocessing = 0;
 		};
 		7BD3D2D82FCDB8A300C386DC /* Copy Test Expectations */ = {
 			isa = PBXCopyFilesBuildPhase;
@@ -8336,6 +8348,7 @@
 			buildPhases = (
 				7BE4AA502DE4544900A16F7E /* Sources */,
 				7BE4AA512DE4544900A16F7E /* Frameworks */,
+				457CC033301576C6001DE9FC /* State Test Expectations */,
 			);
 			buildRules = (
 			);
@@ -8717,7 +8730,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "set -e\nD=\"$BUILT_PRODUCTS_DIR\"; S=\"$SRCROOT\"\nmkdir -p \"$D/vk_gl_cts_data/data\"\n/usr/bin/rsync -a --delete \"$S/third_party/VK-GL-CTS/src/data/gles2/\" \"$D/vk_gl_cts_data/data/gles2/\"\nmkdir -p \"$D/third_party/VK-GL-CTS/src/external/openglcts/data/gl_cts/data/mustpass/gles/aosp_mustpass/main\" \"$D/src/tests/deqp_support\"\n/bin/cp \"$S/third_party/VK-GL-CTS/src/external/openglcts/data/gl_cts/data/mustpass/gles/aosp_mustpass/main/gles2-main.txt\" \"$D/third_party/VK-GL-CTS/src/external/openglcts/data/gl_cts/data/mustpass/gles/aosp_mustpass/main/\"\n/bin/cp \"$S/src/tests/deqp_support/deqp_gles2_test_expectations.txt\" \"$D/src/tests/deqp_support/\"";
+			shellScript = "set -e\nD=\"$BUILT_PRODUCTS_DIR\"; S=\"$SRCROOT\"\nmkdir -p \"$D/vk_gl_cts_data/data\"\n/usr/bin/rsync -a --delete \"$S/third_party/VK-GL-CTS/src/data/gles2/\" \"$D/vk_gl_cts_data/data/gles2/\"\nmkdir -p \"$D/third_party/VK-GL-CTS/src/external/openglcts/data/gl_cts/data/mustpass/gles/aosp_mustpass/main\" \"$D/src/tests/deqp_support\"\n/bin/cp \"$S/third_party/VK-GL-CTS/src/external/openglcts/data/gl_cts/data/mustpass/gles/aosp_mustpass/main/gles2-main.txt\" \"$D/third_party/VK-GL-CTS/src/external/openglcts/data/gl_cts/data/mustpass/gles/aosp_mustpass/main/\"\n/bin/cp \"$S/src/tests/deqp_support/deqp_gles2_test_expectations.txt\" \"$D/src/tests/deqp_support/\"\n";
 			showEnvVarsInLog = 0;
 		};
 		1B104B2593111EC45EE1B461 /* Stage dEQP data */ = {
@@ -8796,21 +8809,6 @@
 			shellPath = /bin/sh;
 			shellScript = "[ -z \"${WK_DERIVED_SDK_HEADERS_DIR}\" -o -d \"${WK_DERIVED_SDK_HEADERS_DIR}\" ] && touch \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 		};
-		ED494454A21948BE9E42F8C8 /* Stage dEQP data */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Stage dEQP data";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "set -e\nD=\"$TARGET_BUILD_DIR/$UNLOCALIZED_RESOURCES_FOLDER_PATH\"; S=\"$SRCROOT\"\nmkdir -p \"$D/vk_gl_cts_data/data\"\n/usr/bin/rsync -a --delete \"$S/third_party/VK-GL-CTS/src/data/gles3/\" \"$D/vk_gl_cts_data/data/gles3/\"\nmkdir -p \"$D/third_party/VK-GL-CTS/src/external/openglcts/data/gl_cts/data/mustpass/gles/aosp_mustpass/main\" \"$D/src/tests/deqp_support\"\n/bin/cp \"$S/third_party/VK-GL-CTS/src/external/openglcts/data/gl_cts/data/mustpass/gles/aosp_mustpass/main/gles3-main.txt\" \"$D/third_party/VK-GL-CTS/src/external/openglcts/data/gl_cts/data/mustpass/gles/aosp_mustpass/main/\"\n/bin/cp \"$S/src/tests/deqp_support/deqp_gles3_test_expectations.txt\" \"$D/src/tests/deqp_support/\"";
-			showEnvVarsInLog = 0;
-		};
 		DDAD70162FF59CC60054DF83 /* Public SDK gate */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -8831,6 +8829,21 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "touch \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+		};
+		ED494454A21948BE9E42F8C8 /* Stage dEQP data */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Stage dEQP data";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "set -e\nD=\"$TARGET_BUILD_DIR/$UNLOCALIZED_RESOURCES_FOLDER_PATH\"; S=\"$SRCROOT\"\nmkdir -p \"$D/vk_gl_cts_data/data\"\n/usr/bin/rsync -a --delete \"$S/third_party/VK-GL-CTS/src/data/gles3/\" \"$D/vk_gl_cts_data/data/gles3/\"\nmkdir -p \"$D/third_party/VK-GL-CTS/src/external/openglcts/data/gl_cts/data/mustpass/gles/aosp_mustpass/main\" \"$D/src/tests/deqp_support\"\n/bin/cp \"$S/third_party/VK-GL-CTS/src/external/openglcts/data/gl_cts/data/mustpass/gles/aosp_mustpass/main/gles3-main.txt\" \"$D/third_party/VK-GL-CTS/src/external/openglcts/data/gl_cts/data/mustpass/gles/aosp_mustpass/main/\"\n/bin/cp \"$S/src/tests/deqp_support/deqp_gles3_test_expectations.txt\" \"$D/src/tests/deqp_support/\"";
+			showEnvVarsInLog = 0;
 		};
 		FFDA50D5269F895400AE11E2 /* Bake Metal Library to NSData */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -11105,21 +11118,6 @@
 			target = 7BB971FF2DE47B8A00455D13 /* ANGLE (static) */;
 			targetProxy = 1F9F42A696C9703F7B04B247 /* PBXContainerItemProxy */;
 		};
-		E26F4E349E4A9C3AAE23C8B4 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = DA5446AEBAE5F6920A4C2227 /* ANGLEDeqpSupport */;
-			targetProxy = EABF4011B5554627E06EB304 /* PBXContainerItemProxy */;
-		};
-		EAD24D89B44DD2F46EE9F6BB /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = 7BFAF76C2DE6EADC00327F7F /* utils */;
-			targetProxy = 375940D29363C30B195CB192 /* PBXContainerItemProxy */;
-		};
-		F0C041F2B6A7C6FAF9BC98EF /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = 9FDB44EAA70594111A0ED0EA /* ANGLEDeqpGLES3Tests */;
-			targetProxy = 31294C019492778D9D742220 /* PBXContainerItemProxy */;
-		};
 		DDAD70182FF59CF40054DF83 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = DDAD70112FF59CB70054DF83 /* Setup */;
@@ -11144,6 +11142,21 @@
 			isa = PBXTargetDependency;
 			target = DDAD70112FF59CB70054DF83 /* Setup */;
 			targetProxy = DDAD701F2FF59D000054DF83 /* PBXContainerItemProxy */;
+		};
+		E26F4E349E4A9C3AAE23C8B4 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = DA5446AEBAE5F6920A4C2227 /* ANGLEDeqpSupport */;
+			targetProxy = EABF4011B5554627E06EB304 /* PBXContainerItemProxy */;
+		};
+		EAD24D89B44DD2F46EE9F6BB /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 7BFAF76C2DE6EADC00327F7F /* utils */;
+			targetProxy = 375940D29363C30B195CB192 /* PBXContainerItemProxy */;
+		};
+		F0C041F2B6A7C6FAF9BC98EF /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 9FDB44EAA70594111A0ED0EA /* ANGLEDeqpGLES3Tests */;
+			targetProxy = 31294C019492778D9D742220 /* PBXContainerItemProxy */;
 		};
 		FF194FF62744331A006A97A3 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -11594,15 +11607,6 @@
 			};
 			name = Debug;
 		};
-		E7DE457FB500E964D8DADB05 /* Production */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 7CB5479A8D9BBB6D79F1A12F /* ANGLEDeqpGLES3TestsApp.xcconfig */;
-			buildSettings = {
-				SUPPORTED_PLATFORMS = "appletvos appletvsimulator iphoneos iphonesimulator watchos watchsimulator xros xrsimulator";
-				SUPPORTS_MACCATALYST = NO;
-			};
-			name = Production;
-		};
 		DDAD70122FF59CB70054DF83 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -11624,6 +11628,15 @@
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Production;
+		};
+		E7DE457FB500E964D8DADB05 /* Production */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 7CB5479A8D9BBB6D79F1A12F /* ANGLEDeqpGLES3TestsApp.xcconfig */;
+			buildSettings = {
+				SUPPORTED_PLATFORMS = "appletvos appletvsimulator iphoneos iphonesimulator watchos watchsimulator xros xrsimulator";
+				SUPPORTS_MACCATALYST = NO;
 			};
 			name = Production;
 		};
@@ -11854,6 +11867,16 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Production;
 		};
+		DDAD70152FF59CB70054DF83 /* Build configuration list for PBXAggregateTarget "Setup" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				DDAD70122FF59CB70054DF83 /* Debug */,
+				DDAD70132FF59CB70054DF83 /* Release */,
+				DDAD70142FF59CB70054DF83 /* Production */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Production;
+		};
 		F25C43B1A89B2A578F39A0DE /* Build configuration list for PBXNativeTarget "ANGLEDeqpGLES3TestsApp" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -11870,16 +11893,6 @@
 				3332450181D6667B032A60AA /* Debug */,
 				6FAC471F99BD174315920DDD /* Release */,
 				AF6640E096DC860854C31233 /* Production */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Production;
-		};
-		DDAD70152FF59CB70054DF83 /* Build configuration list for PBXAggregateTarget "Setup" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				DDAD70122FF59CB70054DF83 /* Debug */,
-				DDAD70132FF59CB70054DF83 /* Release */,
-				DDAD70142FF59CB70054DF83 /* Production */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Production;


### PR DESCRIPTION
#### b8b19de01e0ed105989ca7ef12df818c874100d4
<pre>
[ANGLE] Copy angle_end2end_tests_expectations.txt to build output folder
<a href="https://bugs.webkit.org/show_bug.cgi?id=320345">https://bugs.webkit.org/show_bug.cgi?id=320345</a>
<a href="https://rdar.apple.com/183297312">rdar://183297312</a>

Reviewed by Dan Glastonbury.

ANGLEEnd2EndTests fails at startup if it can&apos;t find src/tests/angle_end2end_tests_expectations.txt.
Currently it falls back to the copy in the WebKit checkout, found by walking up from the build directory
to a hardcoded relative path (i.e., Source/ThirdParty/ANGLE/src/tests/angle_end2end_tests_expectations.txt).
Without that checkout, the suite won&apos;t run.

Fix by copying the file to $BUILT_PRODUCTS_DIR/src/tests/, the first location searched.
Nothing else is needed, since the binary links ANGLE statically and has no other runtime data.
Also, both dEQP targets already stage their data this way. This is macOS only, as iOS-family uses
ANGLEEnd2EndTestsApp and is unaffected.

* Source/ThirdParty/ANGLE/ANGLE.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/318026@main">https://commits.webkit.org/318026@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/805f4e922dfac5802c5e3dd8526eb40426604aec

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176893 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50830 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44622 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186496 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140129 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/88d9d208-7800-4c1c-ac07-7553ba0890c1) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52123 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50516 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137812 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140129 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1b93cfca-ff02-4db8-a255-9e09d48752a2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179849 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41324 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158602 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118286 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/483d0f66-eb62-41e0-a524-a6619501e6ad) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39978 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38345 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150390 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38101 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34963 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42560 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188919 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50497 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146887 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51180 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34726 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146687 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26858 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41451 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117627 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49685 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13082 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49084 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49320 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49145 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->