### PR TITLE
[YARR] A ^ inside a parenthesis that can match empty does not anchor the pattern

### DIFF
--- a/JSTests/stress/regexp-bol-inside-parentheses-is-not-anchored.js
+++ b/JSTests/stress/regexp-bol-inside-parentheses-is-not-anchored.js
@@ -1,0 +1,74 @@
+// A `^` inside a parenthesis only anchors the pattern when that parenthesis has to be matched. Getting
+// this wrong made optimizeBOL() treat the alternative as once-through, only ever tried at index 0.
+// See recomputeStartsWithBOL() in YarrPattern.cpp. The bug is in Yarr's pattern analysis, so it
+// reproduces in every tier; the loop only makes sure the JIT tiers agree.
+
+function shouldBe(actual, expected, context) {
+    if (actual !== expected)
+        throw new Error("bad value: " + actual + " expected: " + expected + " for " + context);
+}
+
+function check(re, string, expectedTest, expectedMatch, expectedIndex) {
+    const context = re + " against " + JSON.stringify(string);
+    shouldBe(re.test(string), expectedTest, context);
+    const result = re.exec(string);
+    if (expectedMatch === null) {
+        shouldBe(result, null, context);
+        return;
+    }
+    shouldBe(result[0], expectedMatch, context);
+    shouldBe(result.index, expectedIndex, context);
+}
+
+function step() {
+    // A leading parenthesis that can match empty leaves the pattern unanchored.
+    check(/(?:^a)?b/, "zzb", true, "b", 2);
+    check(/(?:^a)*b/, "zzb", true, "b", 2);
+    check(/(?:^a){0,1}b/, "zzb", true, "b", 2);
+    check(/(?:(?:^a)?)b/, "zzb", true, "b", 2);
+    check(/(?:^a)?[bc]/, "zzc", true, "c", 2);
+    check(/(?:^[^\x00-\xfe])?b/, "zzb", true, "b", 2);
+    check(/(?:^a)?b|q/, "zzb", true, "b", 2);
+    check(/((?:^a)?)b/, "zzb", true, "b", 2);
+    check(/(?:^a|^c)?b/, "zzb", true, "b", 2);
+
+    // The anchored spelling must still match at 0, and an unmatchable subject must still be a no-match.
+    check(/(?:^a)?b/, "ab", true, "ab", 0);
+    check(/(?:^a)?b/, "zzz", false, null);
+
+    // The parenthesis need not be the leading term.
+    check(/x(?:^a)?b/, "zxb", true, "xb", 1);
+    // ... nor at the top level: the once-through/loop split filters at every nesting depth.
+    check(/x(?:(?:(?:^a)?q|b)c)y/, "zxqcy", true, "xqcy", 1);
+    check(/x(?:(?:(?:^a)?q|b)c)y/, "zxbcy", true, "xbcy", 1);
+    check(/x(?:^a)?b/, "xb", true, "xb", 0);
+
+    // A parenthesis that must be matched and can only match at 0 makes the whole alternative
+    // impossible elsewhere, so the loop alternative has to be dropped, not just the parenthesis.
+    check(/x(?:^a)b/, "xb", false, null);
+    check(/x(?:^a)b/, "xab", false, null);
+    check(/x(?:^a)b/, "zxab", false, null);
+    check(/x(?=^a)b/, "xb", false, null);
+    check(/x(?=^a)ab/, "xab", false, null);
+
+    // A negative assertion whose content can only match at 0 succeeds everywhere else, so its term
+    // can be dropped from the loop alternative.
+    check(/(?!^a)b/, "zzb", true, "b", 2);
+    check(/(?!^a)b/, "ab", true, "b", 1);
+    check(/(?!^a)a/, "ab", false, null);
+
+    // Genuinely anchored patterns must keep matching only at 0.
+    check(/(?:^a)b/, "ab", true, "ab", 0);
+    check(/(?:^a)b/, "zab", false, null);
+    check(/^ab/, "ab", true, "ab", 0);
+    check(/^ab/, "zab", false, null);
+    check(/(?:^a|^b)c/, "bc", true, "bc", 0);
+    check(/(?:^a|^b)c/, "zbc", false, null);
+
+    // With the m flag optimizeBOL() bails out entirely; that must not regress either.
+    check(/(?:^a)?b/m, "zzb", true, "b", 2);
+    check(/(?:^a)?b/m, "z\nab", true, "ab", 2);
+}
+
+for (var i = 0; i < testLoopCount; ++i)
+    step();

--- a/Source/JavaScriptCore/yarr/YarrPattern.cpp
+++ b/Source/JavaScriptCore/yarr/YarrPattern.cpp
@@ -1572,7 +1572,8 @@ public:
 
         if (numBOLAnchoredAlts) {
             m_alternative->m_containsBOL = true;
-            // If all the alternatives in parens start with BOL, then so does this one
+            // If all the alternatives in parens start with BOL, then so does this one. Optimistic:
+            // recomputeStartsWithBOL() redoes this once the terms are final.
             if (numBOLAnchoredAlts == numParenAlternatives)
                 m_alternative->m_startsWithBOL = true;
         }
@@ -1683,9 +1684,9 @@ public:
             m_forwardReferencesInLookbehind.append(UnresolvedForwardReference(m_alternative, m_alternative->lastTermIndex(), subpatternName));
         }
     }
-    
+
     // deep copy the argument disjunction.  If filterStartsWithBOL is true,
-    // skip alternatives with m_startsWithBOL set true.
+    // skip alternatives with m_startsWithBOL set true, and those left impossible by that filtering.
     PatternDisjunction* copyDisjunction(PatternDisjunction* disjunction, bool filterStartsWithBOL)
     {
         if (!isSafeToRecurse()) [[unlikely]] {
@@ -1696,21 +1697,22 @@ public:
         std::unique_ptr<PatternDisjunction> newDisjunction;
         for (unsigned alt = 0; alt < disjunction->m_alternatives.size(); ++alt) {
             PatternAlternative* alternative = disjunction->m_alternatives[alt].get();
-            if (!filterStartsWithBOL || !alternative->m_startsWithBOL || alternative->m_direction == Backward) {
-                if (!newDisjunction) {
-                    newDisjunction = makeUnique<PatternDisjunction>();
-                    newDisjunction->m_parent = disjunction->m_parent;
-                }
-                PatternAlternative* newAlternative = newDisjunction->addNewAlternative(alternative->m_firstSubpatternId, alternative->matchDirection());
-                newAlternative->m_lastSubpatternId = alternative->m_lastSubpatternId;
-                newAlternative->m_terms.reserveCapacity(alternative->m_terms.size());
-                for (auto& term : alternative->m_terms) {
-                    if (auto copied = copyTerm(term, filterStartsWithBOL))
-                        newAlternative->m_terms.append(WTF::move(*copied));
-                }
+            if (filterStartsWithBOL && alternative->m_startsWithBOL && alternative->matchDirection() != Backward)
+                continue;
+
+            auto copiedTerms = copyTerms(alternative, filterStartsWithBOL);
+            if (!copiedTerms)
+                continue;
+
+            if (!newDisjunction) {
+                newDisjunction = makeUnique<PatternDisjunction>();
+                newDisjunction->m_parent = disjunction->m_parent;
             }
+            PatternAlternative* newAlternative = newDisjunction->addNewAlternative(alternative->m_firstSubpatternId, alternative->matchDirection());
+            newAlternative->m_lastSubpatternId = alternative->m_lastSubpatternId;
+            newAlternative->m_terms = WTF::move(*copiedTerms);
         }
-        
+
         if (hasError(error())) {
             newDisjunction = nullptr;
             return nullptr;
@@ -1724,6 +1726,33 @@ public:
         return copiedDisjunction;
     }
     
+    // True when this parenthesis has to participate in every match of its alternative. An optional
+    // one can be skipped, and a negative assertion succeeds when its content cannot match.
+    static bool parenthesesMustMatch(const PatternTerm& term)
+    {
+        ASSERT(term.type == PatternTerm::Type::ParenthesesSubpattern || term.type == PatternTerm::Type::ParentheticalAssertion);
+        return term.quantityMinCount && !term.invert();
+    }
+
+    // Copy the terms of `alternative`, dropping the parentheses copyTerm() filtered out. Returns
+    // std::nullopt when one of those has to be matched, i.e. this alternative cannot match at all.
+    std::optional<Vector<PatternTerm>> copyTerms(PatternAlternative* alternative, bool filterStartsWithBOL)
+    {
+        Vector<PatternTerm> copiedTerms;
+        copiedTerms.reserveInitialCapacity(alternative->m_terms.size());
+        for (auto& term : alternative->m_terms) {
+            if (auto copied = copyTerm(term, filterStartsWithBOL)) {
+                copiedTerms.append(WTF::move(*copied));
+                continue;
+            }
+            // Every alternative inside this parenthesis was filtered out, so it can only match at
+            // the start of the input.
+            if (parenthesesMustMatch(term))
+                return std::nullopt;
+        }
+        return copiedTerms;
+    }
+
     std::optional<PatternTerm> copyTerm(PatternTerm& term, bool filterStartsWithBOL)
     {
         if (!isSafeToRecurse()) [[unlikely]] {
@@ -2311,12 +2340,66 @@ public:
         }
     }
 
+    // m_startsWithBOL means "every match of this alternative begins at the start of the input", which
+    // is what optimizeBOL() turns into onceThrough. This pass is the authoritative source of the flag,
+    // so it runs before any consumer of it. Returns true when every alternative of `disjunction` must
+    // begin at the start of the input.
+    bool recomputeStartsWithBOL(PatternDisjunction* disjunction)
+    {
+        if (!isSafeToRecurse()) [[unlikely]] {
+            m_error = ErrorCode::PatternTooLarge;
+            return false;
+        }
+
+        bool allAlternativesStartWithBOL = true;
+        for (auto& alternativeRef : disjunction->m_alternatives) {
+            PatternAlternative* alternative = alternativeRef.get();
+            bool startsWithBOL = false;
+            for (unsigned index = 0; index < alternative->m_terms.size(); ++index) {
+                PatternTerm& term = alternative->m_terms[index];
+                bool termStartsWithBOL = false;
+                switch (term.type) {
+                case PatternTerm::Type::AssertionBOL:
+                    termStartsWithBOL = term.matchDirection() == Forward;
+                    break;
+                case PatternTerm::Type::ParenthesesSubpattern:
+                case PatternTerm::Type::ParentheticalAssertion:
+                    // Recurse even for a non-leading term, whose result goes unused: nested
+                    // alternatives carry their own flag and copyTerms() filters on it at every
+                    // nesting depth, so all of them have to be recomputed. Only bubble the flag out
+                    // of a parenthesis that copyTerms() would let kill its alternative.
+                    termStartsWithBOL = recomputeStartsWithBOL(term.parentheses.disjunction)
+                        && term.matchDirection() == Forward
+                        && parenthesesMustMatch(term);
+                    break;
+                default:
+                    break;
+                }
+                // Only the leading term can anchor the alternative. Conservative for cases like
+                // /\b^a/, matching what the parser already did.
+                if (!index)
+                    startsWithBOL = termStartsWithBOL;
+            }
+            alternative->m_startsWithBOL = startsWithBOL;
+            if (!startsWithBOL)
+                allAlternativesStartWithBOL = false;
+        }
+        return allAlternativesStartWithBOL;
+    }
+
+    void recomputeStartsWithBOL()
+    {
+        // No leading `^` anywhere means the parser never set the flag.
+        if (m_pattern.m_containsBOL)
+            recomputeStartsWithBOL(m_pattern.m_body);
+    }
+
     void optimizeBOL()
     {
         // Look for expressions containing beginning of line (^) anchoring and unroll them.
         // e.g. /^a|^b|c/ becomes /^a|^b|c/ which is executed once followed by /c/ which loops
-        // This code relies on the parsing code tagging alternatives with m_containsBOL and
-        // m_startsWithBOL and rolling those up to containing alternatives.
+        // This code relies on recomputeStartsWithBOL() having tagged the alternatives with
+        // m_startsWithBOL, and on m_containsBOL from the parsing code.
         // At this point, this is only valid for non-multiline expressions.
         PatternDisjunction* disjunction = m_pattern.m_body;
         
@@ -2427,7 +2510,9 @@ public:
                     terms.removeAt(termIndex - 1);
 
                 terms.append(PatternTerm(startsWithBOL, endsWithEOL, m_flags));
-                
+
+                // The enclosure now carries the anchoring, so the alternative no longer starts with ^.
+                alternative->m_startsWithBOL = false;
                 m_pattern.m_containsBOL = false;
             }
         }
@@ -2927,6 +3012,7 @@ ErrorCode YarrPattern::compile(StringView patternString)
             return error;
     }
 
+    constructor.recomputeStartsWithBOL();
     constructor.checkForTerminalParentheses();
     constructor.optimizeDotStarWrappedExpressions();
     constructor.optimizeBOL();


### PR DESCRIPTION
#### 98d0367d2247df6cfc363a38eadc33fa2ce1723e
<pre>
[YARR] A ^ inside a parenthesis that can match empty does not anchor the pattern
<a href="https://bugs.webkit.org/show_bug.cgi?id=320347">https://bugs.webkit.org/show_bug.cgi?id=320347</a>
<a href="https://rdar.apple.com/183300022">rdar://183300022</a>

Reviewed by Yijia Huang.

/(?:^a)?b/ is incorrectly working since it is marked as m_startsWithBOL.
But we need to ensure that ^ parentheses does not pass with empty input.
This patch correctly recomputes m_startsWithBOL flag by scanning
alternatives.

We also fixes copyDisjunction too. The current one is incorrectly
dropping ^ pattern in the middle, so /x(?:^a)b/ becomes /xb/, but this
is not correct. We should use only when all copies succeed.

Test: JSTests/stress/regexp-bol-inside-parentheses-is-not-anchored.js

* JSTests/stress/regexp-bol-inside-parentheses-is-not-anchored.js: Added.
(shouldBe):
(check):
(step):
* Source/JavaScriptCore/yarr/YarrPattern.cpp:
(JSC::Yarr::YarrPatternConstructor::atomParenthesesEnd):
(JSC::Yarr::YarrPatternConstructor::copyDisjunction):
(JSC::Yarr::YarrPatternConstructor::parenthesesMustMatch):
(JSC::Yarr::YarrPatternConstructor::copyTerms):
(JSC::Yarr::YarrPatternConstructor::recomputeStartsWithBOL):
(JSC::Yarr::YarrPatternConstructor::optimizeBOL):
(JSC::Yarr::YarrPatternConstructor::optimizeDotStarWrappedExpressions):
(JSC::Yarr::YarrPattern::compile):

Canonical link: <a href="https://commits.webkit.org/317981@main">https://commits.webkit.org/317981@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5c72495dac276c5edc7762857adf0a4bcf441bc5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176895 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50832 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44624 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186498 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140131 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6b445e43-f243-4e07-8062-5282f2c13cfa) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52125 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50518 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137814 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140131 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3a7172aa-f393-475f-9bfd-1761aa69f2d7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179851 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41325 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158605 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118288 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/66695a76-5f71-4681-ab79-ab7c20dfdada) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39979 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38347 "Passed tests") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/251/builds/257 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/7112 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150391 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38104 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34965 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/38166 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42578 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42562 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188921 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50499 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146889 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51182 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34729 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146689 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26836 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41453 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123390 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117631 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49687 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13086 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49086 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49322 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49147 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->