### PR TITLE
[YARR] The dot-star-wrapped-expression optimization is wrong for sticky patterns

### DIFF
--- a/JSTests/stress/regexp-sticky-dot-star-wrapped-expression.js
+++ b/JSTests/stress/regexp-sticky-dot-star-wrapped-expression.js
@@ -1,0 +1,64 @@
+// optimizeDotStarWrappedExpressions() rewrites /^.*EXPR.*$/ into EXPR plus a DotStarEnclosure term
+// that stands in for the deleted `^` and the two `.*`. The enclosure reports the position of EXPR
+// rather than the position the leading `.*` starts at, which is fine for an ordinary search but not
+// for a sticky pattern: a sticky match must begin exactly at lastIndex, so /^.*a.*$/y on "xa" was
+// rejected instead of matching the whole string at index 0.
+//
+// This is a Yarr-level bug, so it reproduces in every tier including the interpreter; the loops here
+// only make sure the JIT tiers agree.
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error("bad value: " + actual + " expected: " + expected);
+}
+
+function check(re, lastIndex, string, expectedTest, expectedLastIndexAfterTest, expectedMatch) {
+    re.lastIndex = lastIndex;
+    shouldBe(re.test(string), expectedTest);
+    shouldBe(re.lastIndex, expectedLastIndexAfterTest);
+
+    re.lastIndex = lastIndex;
+    const result = re.exec(string);
+    if (expectedMatch === null) {
+        shouldBe(result, null);
+        return;
+    }
+    shouldBe(result[0], expectedMatch);
+    shouldBe(result.index, lastIndex);
+}
+
+const sticky = /^.*a.*$/y;
+const stickyGlobal = /^.*a.*$/gy;
+const stickyInverted = /^.*[^q].*$/y;
+const stickyNoEOL = /^.*a.*/y;
+
+function step() {
+    // The leading .* consumes "x", so the match begins at lastIndex 0 and covers the whole string.
+    check(sticky, 0, "xa", true, 2, "xa");
+    check(sticky, 0, "a", true, 1, "a");
+    check(sticky, 0, "zzza", true, 4, "zzza");
+    check(sticky, 0, "xb", false, 0, null);
+    check(sticky, 0, "", false, 0, null);
+
+    // A non-zero lastIndex still cannot match, because ^ only matches at index 0.
+    check(sticky, 1, "xa", false, 0, null);
+    check(sticky, 2, "xa", false, 0, null);
+
+    check(stickyGlobal, 0, "xa", true, 2, "xa");
+    check(stickyGlobal, 1, "xa", false, 0, null);
+
+    check(stickyInverted, 0, "qa", true, 2, "qa");
+    check(stickyInverted, 0, "qq", false, 0, null);
+
+    check(stickyNoEOL, 0, "xa", true, 2, "xa");
+    check(stickyNoEOL, 0, "xb", false, 0, null);
+
+    // Non-sticky spellings keep using the enclosure and must be unaffected.
+    shouldBe(/^.*a.*$/.test("xa"), true);
+    shouldBe(/^.*a.*$/.test("xb"), false);
+    shouldBe(/^.*a.*$/.exec("zzza")[0], "zzza");
+    shouldBe(/^.*a.*$/g.test("xa"), true);
+}
+
+for (var i = 0; i < testLoopCount; ++i)
+    step();

--- a/Source/JavaScriptCore/yarr/YarrPattern.cpp
+++ b/Source/JavaScriptCore/yarr/YarrPattern.cpp
@@ -2461,6 +2461,12 @@ public:
         if (alternatives.size() != 1)
             return;
 
+        // A sticky pattern must begin its match exactly at lastIndex, but the enclosure reports the
+        // position of the wrapped expression rather than of the leading `.*` it absorbs, so
+        // /^.*a.*$/y would fail on "xa" instead of matching the whole string at 0.
+        if (m_pattern.sticky())
+            return;
+
         CharacterClass* dotCharacterClass = dotAll() ? m_pattern.anyCharacterClass() : m_pattern.newlineCharacterClass();
         PatternAlternative* alternative = alternatives[0].get();
         Vector<PatternTerm>& terms = alternative->m_terms;


### PR DESCRIPTION
#### b128ddd863ab9e89a71288a461606b0aee6b3bca
<pre>
[YARR] The dot-star-wrapped-expression optimization is wrong for sticky patterns
<a href="https://bugs.webkit.org/show_bug.cgi?id=320348">https://bugs.webkit.org/show_bug.cgi?id=320348</a>
<a href="https://rdar.apple.com/183300106">rdar://183300106</a>

Reviewed by Yijia Huang.

optimizeDotStarWrappedExpressions() rewrites /^.*EXPR.*$/ into EXPR
followed by a DotStarEnclosure term standing in for the deleted `^`
and the two `.*`. The enclosure reports the position of EXPR rather than
the position the leading `.*` starts at. That is invisible for an
ordinary search, but a sticky pattern must begin its match exactly at
lastIndex, so /^.*a.*$/y rejected &quot;xa&quot; instead of matching the whole
string at index 0. This patch disables optimizeDotStarWrappedExpressions
when sticky bit is set.

Test: JSTests/stress/regexp-sticky-dot-star-wrapped-expression.js

* JSTests/stress/regexp-sticky-dot-star-wrapped-expression.js: Added.
(shouldBe):
(check):
(step):
* Source/JavaScriptCore/yarr/YarrPattern.cpp:
(JSC::Yarr::YarrPatternConstructor::optimizeDotStarWrappedExpressions):

Canonical link: <a href="https://commits.webkit.org/317983@main">https://commits.webkit.org/317983@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/056e6f49b88029489399c7b2b0cc1658cb5ddc24

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176898 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50835 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44627 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186501 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140134 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6f89ec5f-9104-4e86-a52a-c64c87ce3887) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52128 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50521 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137815 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140134 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/25813b2d-07ac-4fa8-9c2b-e32202294560) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179854 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41326 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; Skipped layout-tests; Ignored 1 pre-existing failure based on results-db; Uploaded test results") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158604 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118289 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/515a3674-0768-48c5-a621-16b1937696aa) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39980 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38348 "Passed tests") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/251/builds/258 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/7111 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150392 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38103 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34968 "Build is in progress. Recent messages:Printed configuration; Checked out pull request; Compiled WebKit (warnings)") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/38169 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42581 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42563 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188924 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50502 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146891 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51185 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34728 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146691 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26838 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41454 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123393 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117636 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49690 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13084 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49089 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49325 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49150 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->