### PR TITLE
Add "track" Media Fragments URI dimension (#track=) for <audio>/<video>

### DIFF
--- a/LayoutTests/media/media-fragments/track-dimension-double-track-expected.txt
+++ b/LayoutTests/media/media-fragments/track-dimension-double-track-expected.txt
@@ -1,0 +1,10 @@
+When a "track=" fragment is repeated, every occurrence is considered (unlike "t="), and the last id that matches an audio track is the one that gets selected.
+
+
+EVENT(canplaythrough)
+EXPECTED (video.audioTracks.length == '2') OK
+EVENT(canplaythrough)
+EXPECTED (video.audioTracks[0].enabled == 'false') OK
+EXPECTED (video.audioTracks[1].enabled == 'true') OK
+END OF TEST
+

--- a/LayoutTests/media/media-fragments/track-dimension-double-track.html
+++ b/LayoutTests/media/media-fragments/track-dimension-double-track.html
@@ -1,0 +1,39 @@
+<!DOCTYPE HTML>
+<html>
+    <head>
+        <script src="../video-test.js"></script>
+        <script>
+            var firstAudioId;
+            var secondAudioId;
+
+            function canplaythrough2()
+            {
+                testExpected('video.audioTracks[0].enabled', false);
+                testExpected('video.audioTracks[1].enabled', true);
+                endTest();
+            }
+
+            function canplaythrough1()
+            {
+                testExpected('video.audioTracks.length', 2);
+                firstAudioId = video.audioTracks[0].id;
+                secondAudioId = video.audioTracks[1].id;
+
+                video.src = '../content/vp9-opus-good-3tracks.webm#track=' + encodeURIComponent(firstAudioId) + '&track=' + encodeURIComponent(secondAudioId);
+                waitForEventOnce('canplaythrough', canplaythrough2);
+            }
+
+            function setup()
+            {
+                findMediaElement();
+                video.src = '../content/vp9-opus-good-3tracks.webm';
+                waitForEventOnce('canplaythrough', canplaythrough1);
+            }
+        </script>
+    </head>
+
+    <body onload="setup()">
+        <p>When a "track=" fragment is repeated, every occurrence is considered (unlike "t="), and the last id that matches an audio track is the one that gets selected.</p>
+        <video controls></video>
+    </body>
+</html>

--- a/LayoutTests/media/media-fragments/track-dimension-invalid-track-expected.txt
+++ b/LayoutTests/media/media-fragments/track-dimension-invalid-track-expected.txt
@@ -1,0 +1,10 @@
+A "track=" fragment that does not match any track id is ignored, leaving the default audio track selection unchanged.
+
+
+EVENT(canplaythrough)
+EXPECTED (video.audioTracks.length == '2') OK
+EVENT(canplaythrough)
+EXPECTED (video.audioTracks[0].enabled == 'true') OK
+EXPECTED (video.audioTracks[1].enabled == 'false') OK
+END OF TEST
+

--- a/LayoutTests/media/media-fragments/track-dimension-invalid-track.html
+++ b/LayoutTests/media/media-fragments/track-dimension-invalid-track.html
@@ -1,0 +1,34 @@
+<!DOCTYPE HTML>
+<html>
+    <head>
+        <script src="../video-test.js"></script>
+        <script>
+            function canplaythrough2()
+            {
+                testExpected('video.audioTracks[0].enabled', true);
+                testExpected('video.audioTracks[1].enabled', false);
+                endTest();
+            }
+
+            function canplaythrough1()
+            {
+                testExpected('video.audioTracks.length', 2);
+
+                video.src = '../content/vp9-opus-good-3tracks.webm#track=blahblah';
+                waitForEventOnce('canplaythrough', canplaythrough2);
+            }
+
+            function setup()
+            {
+                findMediaElement();
+                video.src = '../content/vp9-opus-good-3tracks.webm';
+                waitForEventOnce('canplaythrough', canplaythrough1);
+            }
+        </script>
+    </head>
+
+    <body onload="setup()">
+        <p>A "track=" fragment that does not match any track id is ignored, leaving the default audio track selection unchanged.</p>
+        <video controls></video>
+    </body>
+</html>

--- a/LayoutTests/media/media-fragments/track-dimension-selects-audio-track-expected.txt
+++ b/LayoutTests/media/media-fragments/track-dimension-selects-audio-track-expected.txt
@@ -1,0 +1,12 @@
+A "track=" fragment naming a non-default audio track selects that track and deselects the previously-selected default.
+
+
+EVENT(canplaythrough)
+EXPECTED (video.audioTracks.length == '2') OK
+EXPECTED (video.audioTracks[0].enabled == 'true') OK
+EXPECTED (video.audioTracks[1].enabled == 'false') OK
+EVENT(canplaythrough)
+EXPECTED (video.audioTracks[0].enabled == 'false') OK
+EXPECTED (video.audioTracks[1].enabled == 'true') OK
+END OF TEST
+

--- a/LayoutTests/media/media-fragments/track-dimension-selects-audio-track.html
+++ b/LayoutTests/media/media-fragments/track-dimension-selects-audio-track.html
@@ -1,0 +1,40 @@
+<!DOCTYPE HTML>
+<html>
+    <head>
+        <script src="../video-test.js"></script>
+        <script>
+            var secondAudioId;
+
+            function canplaythrough2()
+            {
+                testExpected('video.audioTracks[0].enabled', false);
+                testExpected('video.audioTracks[1].enabled', true);
+                endTest();
+            }
+
+            function canplaythrough1()
+            {
+                // Discover the real id of the non-default track (avoid hardcoding a guessed id).
+                testExpected('video.audioTracks.length', 2);
+                testExpected('video.audioTracks[0].enabled', true);
+                testExpected('video.audioTracks[1].enabled', false);
+                secondAudioId = video.audioTracks[1].id;
+
+                video.src = '../content/vp9-opus-good-3tracks.webm#track=' + encodeURIComponent(secondAudioId);
+                waitForEventOnce('canplaythrough', canplaythrough2);
+            }
+
+            function setup()
+            {
+                findMediaElement();
+                video.src = '../content/vp9-opus-good-3tracks.webm';
+                waitForEventOnce('canplaythrough', canplaythrough1);
+            }
+        </script>
+    </head>
+
+    <body onload="setup()">
+        <p>A "track=" fragment naming a non-default audio track selects that track and deselects the previously-selected default.</p>
+        <video controls></video>
+    </body>
+</html>

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -5335,6 +5335,7 @@ void HTMLMediaElement::mediaPlayerDidAddAudioTrack(AudioTrackPrivate& track)
     }
 
     addAudioTrack(AudioTrack::create(protect(scriptExecutionContext()).get(), track));
+    selectTracksForFragment();
 }
 
 void HTMLMediaElement::mediaPlayerDidAddTextTrack(InbandTextTrackPrivate& track)
@@ -5372,6 +5373,7 @@ void HTMLMediaElement::mediaPlayerDidAddTextTrack(InbandTextTrackPrivate& track)
 void HTMLMediaElement::mediaPlayerDidAddVideoTrack(VideoTrackPrivate& track)
 {
     addVideoTrack(VideoTrack::create(protect(scriptExecutionContext()).get(), track));
+    selectTracksForFragment();
 }
 
 void HTMLMediaElement::mediaPlayerDidRemoveAudioTrack(AudioTrackPrivate& track)
@@ -8637,6 +8639,9 @@ void HTMLMediaElement::prepareMediaFragmentURI()
 
     if (m_fragmentStartTime.isValid() && m_readyState < HAVE_FUTURE_DATA)
         prepareToPlay();
+
+    m_fragmentTrackIdentifiers = fragmentParser.trackIdentifiers();
+    selectTracksForFragment();
 }
 
 void HTMLMediaElement::applyMediaFragmentURI()
@@ -8645,6 +8650,34 @@ void HTMLMediaElement::applyMediaFragmentURI()
         m_sentEndEvent = false;
         seek(m_fragmentStartTime);
     }
+}
+
+void HTMLMediaElement::selectTracksForFragment()
+{
+    if (m_fragmentTrackIdentifiers.isEmpty())
+        return;
+
+    RefPtr<AudioTrack> matchedAudioTrack;
+    RefPtr<VideoTrack> matchedVideoTrack;
+    for (auto& identifier : m_fragmentTrackIdentifiers) {
+        AtomString trackId { identifier };
+        if (RefPtr track = m_audioTracks ? m_audioTracks->getTrackById(trackId) : nullptr)
+            matchedAudioTrack = WTF::move(track);
+        if (RefPtr track = m_videoTracks ? m_videoTracks->getTrackById(trackId) : nullptr)
+            matchedVideoTrack = WTF::move(track);
+    }
+
+    // The "track" dimension selects a single track per kind, so disable every
+    // other track of that kind: unlike the temporal dimension, WebKit otherwise
+    // allows multiple audio tracks to be enabled simultaneously.
+    if (matchedAudioTrack) {
+        for (unsigned i = 0; i < m_audioTracks->length(); ++i) {
+            Ref track = m_audioTracks->item(i);
+            track->setEnabled(track.ptr() == matchedAudioTrack.get());
+        }
+    }
+    if (matchedVideoTrack)
+        matchedVideoTrack->setSelected(true);
 }
 
 void HTMLMediaElement::updateSleepDisabling()

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -1048,6 +1048,7 @@ private:
 
     void prepareMediaFragmentURI();
     void applyMediaFragmentURI();
+    void selectTracksForFragment();
 
     void changeNetworkStateFromLoadingToIdle();
 
@@ -1309,6 +1310,7 @@ private:
 
     MediaTime m_fragmentStartTime;
     MediaTime m_fragmentEndTime;
+    Vector<String> m_fragmentTrackIdentifiers;
 
     using PendingActionFlags = unsigned;
     PendingActionFlags m_pendingActionFlags { 0 };

--- a/Source/WebCore/html/MediaFragmentURIParser.cpp
+++ b/Source/WebCore/html/MediaFragmentURIParser.cpp
@@ -93,6 +93,15 @@ MediaTime MediaFragmentURIParser::endTime()
     return m_endTime;
 }
 
+Vector<String> MediaFragmentURIParser::trackIdentifiers()
+{
+    if (!m_url.isValid())
+        return { };
+    if (m_timeFormat == None)
+        parseTimeFragment();
+    return m_trackIdentifiers;
+}
+
 void MediaFragmentURIParser::parseFragments()
 {
     auto fragmentString = m_url.fragmentIdentifier();
@@ -160,8 +169,17 @@ void MediaFragmentURIParser::parseTimeFragment()
         ASSERT(fragment.first.is8Bit());
         ASSERT(fragment.second.is8Bit());
 
+        // http://www.w3.org/2008/WebVideo/Fragments/WD-media-fragments-spec/#naming-track
+        // Track selection is denoted by the name track. Multiple track dimensions are allowed,
+        // so every occurrence is kept (unlike the "last occurrence wins" rule that applies to
+        // the temporal dimension below).
+        if (fragment.first == "track"_s) {
+            m_trackIdentifiers.append(fragment.second);
+            continue;
+        }
+
         // http://www.w3.org/2008/WebVideo/Fragments/WD-media-fragments-spec/#naming-time
-        // Temporal clipping is denoted by the name t, and specified as an interval with a begin 
+        // Temporal clipping is denoted by the name t, and specified as an interval with a begin
         // time and an end time
         if (fragment.first != "t"_s)
             continue;

--- a/Source/WebCore/html/MediaFragmentURIParser.h
+++ b/Source/WebCore/html/MediaFragmentURIParser.h
@@ -40,6 +40,7 @@ public:
 
     MediaTime startTime();
     MediaTime endTime();
+    Vector<String> trackIdentifiers();
 
 private:
 
@@ -54,6 +55,7 @@ private:
     TimeFormat m_timeFormat;
     MediaTime m_startTime;
     MediaTime m_endTime;
+    Vector<String> m_trackIdentifiers;
     Vector<std::pair<String, String>> m_fragments;
 };
 


### PR DESCRIPTION
#### 98ff5ead9890f03ba261bc3405d6bf3fa19721c6
<pre>
Add &quot;track&quot; Media Fragments URI dimension (#track=) for &lt;audio&gt;/&lt;video&gt;
<a href="https://bugs.webkit.org/show_bug.cgi?id=320349">https://bugs.webkit.org/show_bug.cgi?id=320349</a>
<a href="https://rdar.apple.com/183304887">rdar://183304887</a>

Reviewed by Eric Carlson.

WebKit&apos;s MediaFragmentURIParser only implemented the temporal (&quot;t=&quot;)
dimension of the Media Fragments URI spec. This adds the track
dimension [1]: a &quot;#track=name&quot; fragment selects the named audio or
video track by id. Unlike &quot;t=&quot;, &quot;track=&quot; may be repeated and is not
last-occurrence-wins at the parser level; when more than one
occurrence matches a track of the same kind, the last match is the
one selected.

MediaFragmentURIParser now collects every &quot;track=&quot; value it sees
into m_trackIdentifiers, exposed via a new trackIdentifiers()
accessor, using the same parseTimeFragment() pass that already walks
the fragment list (a second pass would find the list already
cleared).

HTMLMediaElement::prepareMediaFragmentURI() stores the parsed ids and
calls a new selectTracksForFragment(), which looks up each id against
m_audioTracks/m_videoTracks by id, exclusively enables the matched
audio track (disabling every other audio track, since WebKit -
unlike video - otherwise allows multiple audio tracks enabled at
once), and selects the matched video track.

Track lists are not guaranteed to be populated yet at HAVE_METADATA
(AVFoundation and GStreamer both report tracks asynchronously), so
selectTracksForFragment() is also called from
mediaPlayerDidAddAudioTrack()/mediaPlayerDidAddVideoTrack(), making
it safe to invoke repeatedly as tracks trickle in.

[1] <a href="https://www.w3.org/2008/WebVideo/Fragments/WD-media-fragments-spec/#naming-track">https://www.w3.org/2008/WebVideo/Fragments/WD-media-fragments-spec/#naming-track</a>

Tests: media/media-fragments/track-dimension-double-track.html
       media/media-fragments/track-dimension-invalid-track.html
       media/media-fragments/track-dimension-selects-audio-track.html

* LayoutTests/media/media-fragments/track-dimension-double-track-expected.txt: Added.
* LayoutTests/media/media-fragments/track-dimension-double-track.html: Added.
* LayoutTests/media/media-fragments/track-dimension-invalid-track-expected.txt: Added.
* LayoutTests/media/media-fragments/track-dimension-invalid-track.html: Added.
* LayoutTests/media/media-fragments/track-dimension-selects-audio-track-expected.txt: Added.
* LayoutTests/media/media-fragments/track-dimension-selects-audio-track.html: Added.
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::mediaPlayerDidAddAudioTrack):
(WebCore::HTMLMediaElement::mediaPlayerDidAddVideoTrack):
(WebCore::HTMLMediaElement::prepareMediaFragmentURI):
(WebCore::HTMLMediaElement::selectTracksForFragment):
* Source/WebCore/html/HTMLMediaElement.h:
* Source/WebCore/html/MediaFragmentURIParser.cpp:
(WebCore::MediaFragmentURIParser::trackIdentifiers):
(WebCore::MediaFragmentURIParser::parseTimeFragment):
* Source/WebCore/html/MediaFragmentURIParser.h:

Canonical link: <a href="https://commits.webkit.org/321279@main">https://commits.webkit.org/321279@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8428e7119b1bcf604fa1cef32d141884baac8759

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/187330 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/61160 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/54896 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/197552 "Built successfully") | [⏳ 🛠 win](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f931aac9-034a-4694-ac94-8b375d9327f8) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/189192 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/62569 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/60895 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/146302 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0a9f24cb-918a-444a-8de9-3010c8158cb2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/190285 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/50019 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/166771 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/126790 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/efde6773-af5d-49f1-bb12-f77634d24a87) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/48745 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/46616 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/159062 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/46385 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/8644 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/53582 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/51153 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/199579 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/60793 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/166317 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/155956 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41822 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/61505 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/42908 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/155610 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/49938 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/133659 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/131178 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/59900 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/21374 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/59327 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/59510 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/59439 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->