### PR TITLE
REGRESSION (317357@main): imported/w3c/web-platform-tests/navigation-api/navigation-methods/traverseTo-with-cross-origin-in-history.html fails on Site Isolation bots

### DIFF
--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -4142,11 +4142,9 @@ bool Document::isFullyActive() const
     if (!frame || frame->document() != this)
         return false;
 
-    // Walk the ancestor chain: the document is fully active only if it reaches the main
-    // frame. A RemoteFrame ancestor lives in another process, but if it became parentless
-    // without being the main frame, its iframe was removed in the parent process and the
-    // chain was severed. (The local chain may briefly lag that removal until this process
-    // receives the IPC; we treat it as up to date.)
+    // The document is fully active only if the ancestor chain reaches the main frame. A
+    // RemoteFrame ancestor lives in another process, but if it became parentless without
+    // being the main frame, its iframe was removed there and the chain was severed.
     for (RefPtr ancestor = frame->tree().parent(); ancestor; ancestor = ancestor->tree().parent()) {
         if (RefPtr localAncestor = dynamicDowncast<LocalFrame>(ancestor.get())) {
             if (!localAncestor->document() || localAncestor->document()->frame() != localAncestor)
@@ -4156,7 +4154,10 @@ bool Document::isFullyActive() const
         if (!ancestor->tree().parent())
             return ancestor->isMainFrame();
     }
-    return frame->isMainFrame();
+
+    // A provisional frame for a cross-process navigation is parentless by construction until its
+    // load commits, so parentlessness alone does not mean the chain was severed.
+    return frame->isMainFrame() || frame->loader().client().isProvisionalFrame();
 }
 
 // https://html.spec.whatwg.org/multipage/interaction.html#fully-active-descendant-of-a-top-level-traversable-with-user-attention

--- a/Source/WebCore/loader/LocalFrameLoaderClient.cpp
+++ b/Source/WebCore/loader/LocalFrameLoaderClient.cpp
@@ -81,6 +81,11 @@ RefPtr<Frame> LocalFrameLoaderClient::provisionalParentFrame() const
     return nullptr;
 }
 
+bool LocalFrameLoaderClient::isProvisionalFrame() const
+{
+    return false;
+}
+
 void LocalFrameLoaderClient::dispatchBackForwardItemLoading(const URL& url, const String& referer, LocalFrame& childFrame)
 {
     Ref loader = m_loader;

--- a/Source/WebCore/loader/LocalFrameLoaderClient.h
+++ b/Source/WebCore/loader/LocalFrameLoaderClient.h
@@ -366,6 +366,10 @@ public:
 
     virtual RefPtr<Frame> provisionalParentFrame() const;
 
+    // True while this frame is a provisional frame for a cross-process navigation that has not
+    // committed yet, and so is not in the frame tree even though it has a parent to be attached to.
+    virtual bool isProvisionalFrame() const;
+
     virtual AllowsContentJavaScript allowsContentJavaScriptFromMostRecentNavigation() const { return AllowsContentJavaScript::Yes; }
 
 #if ENABLE(APP_BOUND_DOMAINS)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
@@ -2175,6 +2175,11 @@ RefPtr<WebCore::Frame> WebLocalFrameLoaderClient::provisionalParentFrame() const
     return nullptr;
 }
 
+bool WebLocalFrameLoaderClient::isProvisionalFrame() const
+{
+    return webFrame().provisionalFrame() == m_localFrame.ptr();
+}
+
 #if ENABLE(CONTENT_EXTENSIONS)
 
 void WebLocalFrameLoaderClient::didExceedNetworkUsageThreshold()

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.h
@@ -335,6 +335,7 @@ private:
     RefPtr<WebCore::HistoryItem> createHistoryItemTree(bool clipAtTarget, WebCore::BackForwardItemIdentifier) const final;
 
     RefPtr<WebCore::Frame> provisionalParentFrame() const final;
+    bool isProvisionalFrame() const final;
 };
 
 } // namespace WebKit


### PR DESCRIPTION
#### f9c7e1033362aa474ed608e994dfec49297b3347
<pre>
REGRESSION (317357@main): imported/w3c/web-platform-tests/navigation-api/navigation-methods/traverseTo-with-cross-origin-in-history.html fails on Site Isolation bots
<a href="https://bugs.webkit.org/show_bug.cgi?id=320325">https://bugs.webkit.org/show_bug.cgi?id=320325</a>
<a href="https://rdar.apple.com/183266525">rdar://183266525</a>

Reviewed by Alex Christensen.

317357@main taught isFullyActive to treat a parentless frame that is not the
page&apos;s main frame as severed from the frame tree. That signal is correct for a
frame whose owner iframe was removed in another process, but it also matches a
provisional frame mid-cross-process-navigation, which is parentless purely by
construction: createProvisionalSubframe passes AddToFrameTree::No with a
non-null parent, so tree().parent() is null while m_mainFrame points at the
remote main frame.

The mismatch is not transient. Navigation::initializeForNewWindow runs from
didBeginDocument inside DocumentLoader::commitData, before receivedFirstData()
commits the provisional frame into the tree, and it returns early on
hasEntriesAndEventsDisabled() without populating m_entries. An ASSERT that
m_entries is empty prevents it from ever running again, so navigation.entries()
stayed permanently empty for a subframe that had navigated across processes.

Distinguish the two cases explicitly rather than inferring severance from
parentlessness. isFullyActive now asks the LocalFrameLoaderClient whether this
frame is a provisional frame whose load has not committed, in the same shape as
the existing provisionalParentFrame() query. That needs no new state: WebFrame
already tracks the answer in m_provisionalFrame, set by createProvisionalFrame
and cleared by commitProvisionalFrame and destroyProvisionalFrame. Only a
LocalFrame can be provisional, so nothing is added to Frame or RemoteFrame. The
client is consulted only in the no-ancestor case, leaving the severance behavior
317357@main added unchanged.

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::isFullyActive const):
* Source/WebCore/loader/LocalFrameLoaderClient.cpp:
(WebCore::LocalFrameLoaderClient::isProvisionalFrame const):
* Source/WebCore/loader/LocalFrameLoaderClient.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp:
(WebKit::WebLocalFrameLoaderClient::isProvisionalFrame const):
* Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.h:

Canonical link: <a href="https://commits.webkit.org/318191@main">https://commits.webkit.org/318191@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cdf282aef5897ebd1a889a5e0726cf6fa4e079ea

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177341 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51279 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45073 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186944 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140588 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179204 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52571 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50988 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138195 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140588 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180297 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41701 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158956 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118660 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40362 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38739 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150770 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38453 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35412 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/43064 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42973 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189373 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50945 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147293 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39620 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51628 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35080 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147085 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41803 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123843 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118181 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50136 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13431 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49532 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49772 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49594 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->