### PR TITLE
Cancel the in-flight SpeculativeLoad when a stale-while-revalidate revalidation times out

### DIFF
--- a/Source/WebKit/NetworkProcess/cache/AsyncRevalidation.cpp
+++ b/Source/WebKit/NetworkProcess/cache/AsyncRevalidation.cpp
@@ -62,8 +62,13 @@ void AsyncRevalidation::cancel()
 
 void AsyncRevalidation::staleWhileRevalidateEnding()
 {
-    if (m_completionHandler)
-        m_completionHandler(Result::Timeout);
+    // Move the handler out before cancelling. m_load->cancel() would otherwise re-enter it via the
+    // load's own completion handler and report Result::Failure before we report Result::Timeout.
+    auto completionHandler = std::exchange(m_completionHandler, nullptr);
+    if (m_load)
+        m_load->cancel();
+    if (completionHandler)
+        completionHandler(Result::Timeout);
 }
 
 Ref<AsyncRevalidation> AsyncRevalidation::create(Cache& cache, const GlobalFrameID& frameID, const WebCore::ResourceRequest& request, std::unique_ptr<NetworkCache::Entry>&& entry, std::optional<NavigatingToAppBoundDomain> isNavigatingToAppBoundDomain, bool allowPrivacyProxy, OptionSet<WebCore::AdvancedPrivacyProtections> advancedPrivacyProtections, CompletionHandler<void(Result)>&& handler)


### PR DESCRIPTION
#### bff32498c2d9ad936c05a27899b5f794aacb2563
<pre>
Cancel the in-flight SpeculativeLoad when a stale-while-revalidate revalidation times out
<a href="https://bugs.webkit.org/show_bug.cgi?id=320350">https://bugs.webkit.org/show_bug.cgi?id=320350</a>

Reviewed by Youenn Fablet.

AsyncRevalidation::staleWhileRevalidateEnding() fires when the stale-while-revalidate
window elapses, which is precisely the case where the revalidation network load may still
be in flight. It only invoked the completion handler (reporting Result::Timeout), which
removes the AsyncRevalidation from Cache::m_pendingAsyncRevalidations and, once the timer&apos;s
protecting reference is released, destroys it along with its owned SpeculativeLoad.

Destroying a SpeculativeLoad whose load is still outstanding is not a clean teardown:
~SpeculativeLoad asserts that m_networkLoad is null, and its RevalidationCompletionHandler
is destroyed without ever being called (CompletionHandler asserts it must always be
called). In debug this is a pair of assertion failures; in release the in-flight
NetworkLoad is orphaned and the completion handler&apos;s captured state leaks.

Cancel the load on this path, matching AsyncRevalidation::cancel(). We move the completion
handler out before calling SpeculativeLoad::cancel() so that cancel()&apos;s own callback does
not re-enter our handler and report Result::Failure before we report Result::Timeout.

* Source/WebKit/NetworkProcess/cache/AsyncRevalidation.cpp:
(WebKit::NetworkCache::AsyncRevalidation::staleWhileRevalidateEnding):

Canonical link: <a href="https://commits.webkit.org/318056@main">https://commits.webkit.org/318056@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/58381850870d20dc603a95b424e66389b80a2979

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176908 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50845 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44637 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186511 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140144 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4b44ed7e-09e5-42e8-855c-eab3cfc01646) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52138 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50531 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137825 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140144 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179864 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41336 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158614 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118299 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fa57984d-e470-4d05-bfeb-fc4685ee7b60) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39990 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38359 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150402 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38113 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34979 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42591 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42574 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188934 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50512 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146901 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39545 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51195 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34738 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146702 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41464 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123403 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117651 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49700 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13097 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49099 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49335 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49160 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->