### PR TITLE
WebKitTestRunner: Fix out-of-bounds read in iOS PlatformWebView::keyWindow()

### DIFF
--- a/Tools/WebKitTestRunner/ios/PlatformWebViewIOS.mm
+++ b/Tools/WebKitTestRunner/ios/PlatformWebViewIOS.mm
@@ -259,9 +259,9 @@ PlatformWindow PlatformWebView::keyWindow()
 {
     size_t i = allWindows.size();
     while (i) {
+        --i;
         if ([allWindows[i] isKeyWindow])
             return allWindows[i];
-        --i;
     }
 
     return nil;


### PR DESCRIPTION
#### d6603cdc953449101221fc35928e66efa2f8601c
<pre>
WebKitTestRunner: Fix out-of-bounds read in iOS PlatformWebView::keyWindow()
<a href="https://bugs.webkit.org/show_bug.cgi?id=320352">https://bugs.webkit.org/show_bug.cgi?id=320352</a>

Reviewed by Abrar Rahman Protyasha.

keyWindow() initialized its index to allWindows.size() and only decremented
it after indexing, so the first loop iteration accessed allWindows[size()] —
one past the end of the Vector. WTF::Vector::operator[] bounds-checks via its
default CrashOnOverflow handler, so this hits CRASH() (in both debug and
release) whenever keyWindow() runs with a non-empty window list. The last
element (index 0) was also never examined.

Decrement the index before indexing so the loop walks the valid range
[size()-1 .. 0], matching the Mac implementation in
WebKitTestRunnerWindow::_WTR_keyWindow.

* Tools/WebKitTestRunner/ios/PlatformWebViewIOS.mm:
(WTR::PlatformWebView::keyWindow):

Canonical link: <a href="https://commits.webkit.org/318024@main">https://commits.webkit.org/318024@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/038c6b2c3cbd913d12dec4956dd00e4f9751be72

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176913 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50850 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44642 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186516 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140149 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/731ffe47-c26f-42c2-9699-b13da5d13267) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178776 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52143 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50536 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137830 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140149 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/10958446-deb8-434a-a56c-9911de684a5e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179869 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41339 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158620 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118304 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c87a385c-1b53-4072-a841-a324d9a1629e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39993 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38362 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150405 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38119 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34984 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42577 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188939 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50517 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146905 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39521 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51200 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34748 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146706 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41469 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117659 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49705 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13103 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49104 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49340 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49165 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->