### PR TITLE
WebKitTestRunner: Fix corrupted pixel hash on big-endian byte-order contexts

### DIFF
--- a/Tools/WebKitTestRunner/cocoa/TestInvocationCocoa.mm
+++ b/Tools/WebKitTestRunner/cocoa/TestInvocationCocoa.mm
@@ -78,10 +78,10 @@ static std::optional<std::string> computeSHA1HashStringForContext(CGContextRef b
 #if PLATFORM(COCOA)
     if ((CGBitmapContextGetBitmapInfo(bitmapContext) & kCGBitmapByteOrderMask) == kCGBitmapByteOrder32Big) {
         for (unsigned row = 0; row < pixelsHigh; row++) {
-            Vector<uint8_t> buffer(4 * pixelsWide);
+            Vector<uint32_t> buffer(pixelsWide);
             for (unsigned column = 0; column < pixelsWide; column++)
                 buffer[column] = OSReadLittleInt32(bitmapData, 4 * column);
-            sha1.addBytes(buffer);
+            sha1.addBytes(asBytes(buffer.span()));
             bitmapData += bytesPerRow;
         }
     } else


### PR DESCRIPTION
#### 6e308ae07c58e7517c33cce7078d3bd8ed6a258e
<pre>
WebKitTestRunner: Fix corrupted pixel hash on big-endian byte-order contexts
<a href="https://bugs.webkit.org/show_bug.cgi?id=320353">https://bugs.webkit.org/show_bug.cgi?id=320353</a>

Reviewed by Mike Wyrzykowski.

computeSHA1HashStringForContext()&apos;s big-endian branch declared its scratch
buffer as Vector&lt;uint8_t&gt; buffer(4 * pixelsWide) but then assigned a 32-bit
value (OSReadLittleInt32) into buffer[column], truncating each pixel to its
low byte and leaving 3/4 of the buffer uninitialized. It then hashed the
entire 4 * pixelsWide-byte span, so the resulting SHA-1 was derived partly
from uninitialized memory and varied run-to-run, making the actual-vs-expected
hash comparison meaningless on any kCGBitmapByteOrder32Big context.

Store the byte-swapped pixels in a Vector&lt;uint32_t&gt; of pixelsWide elements and
hash asBytes(buffer.span()), so every element is written and exactly the bytes
we populated are hashed. This matches the little-endian branch and the
DumpRenderTree implementation in PixelDumpSupportCG.cpp, producing a
deterministic, endianness-independent hash.

* Tools/WebKitTestRunner/cocoa/TestInvocationCocoa.mm:
(WTR::computeSHA1HashStringForContext):

Canonical link: <a href="https://commits.webkit.org/318129@main">https://commits.webkit.org/318129@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/864781b3257670231e0592c05de82e293bf0d776

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176915 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50852 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44644 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186518 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140151 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/91da2d3b-7737-40a4-afdb-c87c6740d3fa) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178778 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52145 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50538 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137832 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140151 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e44b2377-9a22-40e8-842d-111827cc0ba1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179871 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41340 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158621 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118306 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/29d5e61b-ffc2-47d8-aa6c-17c9809d4850) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39994 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38364 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150406 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38120 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34986 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42579 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188941 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50519 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146907 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39583 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51202 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34749 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146708 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41468 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117662 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49707 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13104 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49106 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49342 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49167 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->