### PR TITLE
OPFS FileSystemWritableFileStream quota accounting over-charges positioned writes

### DIFF
--- a/Source/WebKit/NetworkProcess/storage/FileSystemStorageHandle.cpp
+++ b/Source/WebKit/NetworkProcess/storage/FileSystemStorageHandle.cpp
@@ -370,12 +370,18 @@ std::optional<size_t> FileSystemStorageHandle::computeCommandSpace(WebCore::File
     if (type == WebCore::FileSystemWriteCommandType::Truncate)
         return *size > *fileSize ? *size - *fileSize : 0;
 
-    uint64_t finalSize;
-    auto currentOffset = activeWritableFile.handle.seek(position.value_or(0), FileSystem::FileSeekOrigin::Current);
-    if (!currentOffset)
-        return { };
+    uint64_t writeStart;
+    if (position)
+        writeStart = *position;
+    else {
+        auto currentOffset = activeWritableFile.handle.seek(0, FileSystem::FileSeekOrigin::Current);
+        if (!currentOffset)
+            return { };
+        writeStart = *currentOffset;
+    }
 
-    if (!WTF::safeAdd(*currentOffset, dataBytes.size(), finalSize))
+    uint64_t finalSize;
+    if (!WTF::safeAdd(writeStart, dataBytes.size(), finalSize))
         return { };
 
     return finalSize > *fileSize ? finalSize - *fileSize : 0;

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/FileSystemAccess.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/FileSystemAccess.mm
@@ -40,6 +40,7 @@
 #import <WebKit/WKWebsiteDataRecordPrivate.h>
 #import <WebKit/WKWebsiteDataStorePrivate.h>
 #import <WebKit/_WKWebsiteDataStoreConfiguration.h>
+#import <wtf/StdLibExtras.h>
 
 @interface FileSystemAccessMessageHandler : NSObject <WKScriptMessageHandler>
 @end
@@ -501,6 +502,64 @@ TEST(FileSystemAccess, FetchDataForThirdParty)
         done = true;
     }];
     TestWebKitAPI::Util::run(&done);
+}
+
+// A positioned write only consumes quota up to (position + dataLength), not
+// (currentFileOffset + position + dataLength). Overwriting data in place should
+// therefore not be charged more quota than the file's final size.
+static NSString *writableQuotaString = @"<script> \
+    async function test() \
+    { \
+        try { \
+            var rootHandle = await navigator.storage.getDirectory(); \
+            await rootHandle.removeEntry('writable-quota-accounting.txt').then(() => { }, () => { }); \
+            var fileHandle = await rootHandle.getFileHandle('writable-quota-accounting.txt', { 'create' : true }); \
+            var writable = await fileHandle.createWritable(); \
+            var chunkSize = 700 * 1024; \
+            await writable.write(new Uint8Array(chunkSize)); \
+            await writable.write({ type: 'write', position: 0, data: new Uint8Array(chunkSize) }); \
+            await writable.close(); \
+            window.webkit.messageHandlers.testHandler.postMessage('success'); \
+        } catch(err) { \
+            window.webkit.messageHandlers.testHandler.postMessage('error: ' + err.name + ' - ' + err.message); \
+        } \
+    } \
+    test(); \
+    </script>";
+
+TEST(FileSystemAccess, WritableQuotaAccountingForPositionedWrite)
+{
+    RetainPtr uuid = adoptNS([[NSUUID alloc] initWithUUIDString:@"68753a44-4d6f-1226-9c60-0050e4c00067"]);
+    RetainPtr websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initWithIdentifier:uuid.get()]);
+    [websiteDataStoreConfiguration setVolumeCapacityOverride:@(2 * MB)];
+    // Origin quota is 1 MB.
+    [websiteDataStoreConfiguration setOriginQuotaRatio:@(0.5)];
+    RetainPtr websiteDataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]);
+    done = false;
+    [websiteDataStore removeDataOfTypes:[WKWebsiteDataStore allWebsiteDataTypes] modifiedSince:[NSDate distantPast] completionHandler:^{
+        done = true;
+    }];
+    TestWebKitAPI::Util::run(&done);
+
+    RetainPtr handler = adoptNS([[FileSystemAccessMessageHandler alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    [[configuration userContentController] addScriptMessageHandler:handler.get() name:@"testHandler"];
+    [configuration setWebsiteDataStore:websiteDataStore.get()];
+    auto preferences = [configuration preferences];
+    preferences._fileSystemAccessEnabled = YES;
+    preferences._accessHandleEnabled = YES;
+    preferences._storageAPIEnabled = YES;
+
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
+    receivedScriptMessage = false;
+    [webView loadHTMLString:writableQuotaString baseURL:[NSURL URLWithString:@"https://webkit.org"]];
+    TestWebKitAPI::Util::run(&receivedScriptMessage);
+
+    // The two 700 KB writes both target the start of the file, so the file never
+    // exceeds 700 KB and stays well under the 1 MB quota. Before the fix, the
+    // positioned write was charged (currentOffset + position + length), i.e.
+    // 1400 KB, and was spuriously denied with QuotaExceededError.
+    EXPECT_WK_STREQ(@"success", [lastScriptMessage body]);
 }
 
 #endif // USE(APPLE_INTERNAL_SDK)


### PR DESCRIPTION
#### f280a9ac58cc5ee245d50ee11bec2069356f3804
<pre>
OPFS FileSystemWritableFileStream quota accounting over-charges positioned writes
<a href="https://bugs.webkit.org/show_bug.cgi?id=320355">https://bugs.webkit.org/show_bug.cgi?id=320355</a>

Reviewed by Sihui Liu.

FileSystemStorageHandle::computeCommandSpace() estimated the disk space a
write command would consume by seeking from FileSeekOrigin::Current, but the
write itself (executeCommandForWritableInternal) and the Seek command both
interpret the command&apos;s position as an absolute offset from the start of the
file (FileSeekOrigin::Beginning). Because the two used different seek origins,
the space estimate was wrong whenever the writable stream&apos;s file offset was
non-zero: computeCommandSpace() based finalSize on (currentOffset + position)
instead of just (position).

The estimate was always too large (the current offset is never negative), so
the code requested more quota than the write actually consumed. This could
spuriously deny an otherwise-valid write with QuotaError and inflate the
origin&apos;s tracked usage until the next usage re-measurement. It triggered even
for the common &quot;overwrite in place&quot; pattern (repeated writes at position 0),
because each write advances the file offset.

Fix computeCommandSpace() to compute the write&apos;s end offset the same way the
write does: use the command&apos;s position directly when present, otherwise query
the current file offset non-destructively via seek(0, Current). This also
removes the previous side effect of moving the file offset inside a helper
that is only meant to compute a size.

Add an API test that writes a chunk to advance the file offset and then
overwrites it in place at position 0 under a small origin quota. Before the
fix, the positioned write was charged (currentOffset + position + length) and
was spuriously denied with QuotaExceededError.

* Source/WebKit/NetworkProcess/storage/FileSystemStorageHandle.cpp:
(WebKit::FileSystemStorageHandle::computeCommandSpace):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/FileSystemAccess.mm:
(TEST(FileSystemAccess, WritableQuotaAccountingForPositionedWrite)):

Canonical link: <a href="https://commits.webkit.org/318130@main">https://commits.webkit.org/318130@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/60681be7071c574a76c667f941e0f164e9d80e38

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177161 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51098 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44893 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186764 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140397 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a36520b1-c21f-4989-8224-54fb3810b455) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179024 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52391 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50784 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138036 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140397 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ae6b3def-68c5-4328-9964-e7e44ed86c6b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180117 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41549 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158801 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118503 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/683be1a9-c8af-4649-84a4-b5a6dee10034) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40205 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38575 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150615 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38300 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35232 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42878 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42805 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189190 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50765 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147124 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39585 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51448 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34929 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146918 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41648 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123662 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117958 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49953 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13280 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49352 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49589 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49413 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->