### PR TITLE
Redundant shadowed fillToFrameTrunc computation in AudioParamTimeline::processLinearRamp()

### DIFF
--- a/Source/WebCore/Modules/webaudio/AudioParamTimeline.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioParamTimeline.cpp
@@ -519,6 +519,7 @@ void AudioParamTimeline::processLinearRamp(const AutomationState& currentState, 
     // is close enough to zero (less than float min), treat it as zero.
     float k = deltaTime.value() <= std::numeric_limits<float>::min() ? 0 : 1 / deltaTime.value();
 
+    // Truncate loop steps to multiple of 4.
     unsigned fillToFrameTrunc = writeIndex + ((currentState.fillToFrame - writeIndex) / 4) * 4;
     if (fillToFrameTrunc > writeIndex) {
         // Minimize in-loop operations. Calculate starting value and increment.
@@ -539,8 +540,6 @@ void AudioParamTimeline::processLinearRamp(const AutomationState& currentState, 
 
         float inc = 4 * currentState.samplingPeriod * k * valueDelta;
 
-        // Truncate loop steps to multiple of 4.
-        unsigned fillToFrameTrunc = writeIndex + ((currentState.fillToFrame - writeIndex) / 4) * 4;
         // Compute final frame.
         currentFrame += fillToFrameTrunc - writeIndex;
 


### PR DESCRIPTION
#### 92eed789f622c2c4954350f9d5f352bf554d69f9
<pre>
Redundant shadowed fillToFrameTrunc computation in AudioParamTimeline::processLinearRamp()
<a href="https://bugs.webkit.org/show_bug.cgi?id=320356">https://bugs.webkit.org/show_bug.cgi?id=320356</a>
<a href="https://rdar.apple.com/183308541">rdar://183308541</a>

Reviewed by Eric Carlson.

processLinearRamp() computed fillToFrameTrunc twice from a byte-identical
expression: an inner declaration shadowed the outer one that guards the
4-step unrolled fast path. The values are always equal, and both lines date
from 217453@main, which hoisted the computation to form the if-guard without
removing the original.

Remove the shadowing declaration, matching processSetTarget(), which computes
the same quantity once. No behavior change.

* Source/WebCore/Modules/webaudio/AudioParamTimeline.cpp:
(WebCore::AudioParamTimeline::processLinearRamp):

Canonical link: <a href="https://commits.webkit.org/317985@main">https://commits.webkit.org/317985@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/14aeb3d01123f39b8e267b2e16e933d84d0f1685

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176919 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50856 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44648 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186522 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140155 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/54e218df-3d95-4a32-9fb2-0a3aa87ccb43) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178782 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52149 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50542 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137837 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140155 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ee7579da-e8cd-4304-b797-319ee741eec2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179875 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41345 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158623 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118311 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a6b8b940-9d6d-4180-809c-0f7dcc54e3db) 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39999 "Build is in progress. Recent messages:OS: Tahoe (26.5.1), Xcode: 26.5; Checked out pull request; Skipped layout-tests; Ignored 4 pre-existing failure based on results-db; Uploaded test results") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38367 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150411 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38122 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34990 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42602 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42582 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188945 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50523 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146912 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39503 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51206 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34751 "Too many flaky failures: http/tests/contentextensions/two-distinguishable-css-display-none-rules-on-main-resource.html, http/tests/cookies/same-site/popup-same-site-post.html, http/tests/media/now-playing-info-private-browsing.html, http/tests/navigation/redirect-to-random-url-versus-memory-cache.html, http/tests/resourceLoadStatistics/only-accept-first-party-cookies-with-third-party-cookie-blocking.html, http/tests/security/contentSecurityPolicy/1.1/scriptnonce-allowed-by-enforced-policy-and-blocked-by-report-policy2.py, http/tests/security/contentSecurityPolicy/policy-does-not-affect-child.html, http/tests/security/mixedContent/redirect-http-to-https-script-in-iframe-UpgradeMixedContent.html, http/tests/storageAccess/deny-storage-access-under-opener-if-auto-dismiss-ephemeral.html, http/tests/webcodecs/vp9-hdr.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146713 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41473 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123414 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117668 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49711 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13106 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49110 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49346 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49171 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->