### PR TITLE
[regression] Storage::traverse(const String& type, const String& partition, ...) is broken

### DIFF
--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.cpp
@@ -363,27 +363,33 @@ RefPtr<Storage> Storage::open(const String& baseCachePath, Mode mode, size_t cap
 }
 
 using RecordFileTraverseFunction = Function<void (const String& fileName, const String& hashString, const String& type, bool isBlob, const String& recordDirectoryPath)>;
+
+static void traversePartitionFiles(const String& partitionPath, const String& expectedType, NOESCAPE const RecordFileTraverseFunction& function)
+{
+    traverseDirectory(partitionPath, [&](const String& actualType, DirectoryEntryType entryType) {
+        if (entryType != DirectoryEntryType::Directory)
+            return;
+        if (!expectedType.isEmpty() && expectedType != actualType)
+            return;
+        String recordDirectoryPath = FileSystem::pathByAppendingComponent(partitionPath, actualType);
+        traverseDirectory(recordDirectoryPath, [&function, &recordDirectoryPath, &actualType](const String& fileName, DirectoryEntryType entryType) {
+            if (entryType != DirectoryEntryType::File || fileName.length() < Key::hashStringLength())
+                return;
+
+            String hashString = fileName.left(Key::hashStringLength());
+            auto isBlob = fileName.length() > Key::hashStringLength() && fileName.endsWith(blobSuffix);
+            function(fileName, hashString, actualType, isBlob, recordDirectoryPath);
+        });
+    });
+}
+
 static void traverseRecordsFiles(const String& recordsPath, const String& expectedType, NOESCAPE const RecordFileTraverseFunction& function)
 {
     traverseDirectory(recordsPath, [&](const String& partitionName, DirectoryEntryType entryType) {
         if (entryType != DirectoryEntryType::Directory)
             return;
         String partitionPath = FileSystem::pathByAppendingComponent(recordsPath, partitionName);
-        traverseDirectory(partitionPath, [&](const String& actualType, DirectoryEntryType entryType) {
-            if (entryType != DirectoryEntryType::Directory)
-                return;
-            if (!expectedType.isEmpty() && expectedType != actualType)
-                return;
-            String recordDirectoryPath = FileSystem::pathByAppendingComponent(partitionPath, actualType);
-            traverseDirectory(recordDirectoryPath, [&function, &recordDirectoryPath, &actualType](const String& fileName, DirectoryEntryType entryType) {
-                if (entryType != DirectoryEntryType::File || fileName.length() < Key::hashStringLength())
-                    return;
-
-                String hashString = fileName.left(Key::hashStringLength());
-                auto isBlob = fileName.length() > Key::hashStringLength() && fileName.endsWith(blobSuffix);
-                function(fileName, hashString, actualType, isBlob, recordDirectoryPath);
-            });
-        });
+        traversePartitionFiles(partitionPath, expectedType, function);
     });
 }
 
@@ -1131,14 +1137,14 @@ void Storage::store(const Record& record, MappedBodyHandler&& mappedBodyHandler,
     m_writeOperationDispatchTimer.startOneShot(m_initialWriteDelay);
 }
 
-void Storage::traverseWithinRootPath(const String& rootPath, const String& type, OptionSet<TraverseFlag> flags, TraverseHandler&& traverseHandler)
+void Storage::traverseInternal(const String& partitionName, const String& type, OptionSet<TraverseFlag> flags, TraverseHandler&& traverseHandler)
 {
     ASSERT(RunLoop::isMain());
     ASSERT(traverseHandler);
 
     auto traverseOperation = TraverseOperation::create(WTF::move(traverseHandler));
-    ioQueue().dispatch([this, protectedThis = Ref { *this }, traverseOperation = WTF::move(traverseOperation), flags, rootPath = crossThreadCopy(rootPath), type = crossThreadCopy(type)]() mutable {
-        traverseRecordsFiles(rootPath, type, [this, protectedThis, expectedType = type, flags, traverseOperation](const String& fileName, const String& hashString, const String& type, bool isBlob, const String& recordDirectoryPath) {
+    ioQueue().dispatch([this, protectedThis = Ref { *this }, traverseOperation = WTF::move(traverseOperation), flags, partitionName = crossThreadCopy(partitionName), type = crossThreadCopy(type)]() mutable {
+        RecordFileTraverseFunction traverseFunction = [this, protectedThis, expectedType = type, flags, traverseOperation](const String& fileName, const String& hashString, const String& type, bool isBlob, const String& recordDirectoryPath) {
             ASSERT(type == expectedType || expectedType.isEmpty());
             if (isBlob)
                 return;
@@ -1190,7 +1196,12 @@ void Storage::traverseWithinRootPath(const String& rootPath, const String& type,
                 }
                 traverseOperation->decrementActivityCount();
             });
-        });
+        };
+        if (!partitionName.isEmpty()) {
+            String partitionPath = FileSystem::pathByAppendingComponent(recordsPathIsolatedCopy(), partitionName);
+            traversePartitionFiles(partitionPath, type, traverseFunction);
+        } else
+            traverseRecordsFiles(recordsPathIsolatedCopy(), type, traverseFunction);
 
         if (flags & TraverseFlag::LastAccessedRecordPerPartition) {
             for (auto& [directoryPath, entry] : traverseOperation->ensurePartitionMap()) {
@@ -1219,14 +1230,14 @@ void Storage::traverseWithinRootPath(const String& rootPath, const String& type,
 
 void Storage::traverse(const String& type, OptionSet<TraverseFlag> flags, TraverseHandler&& traverseHandler)
 {
-    traverseWithinRootPath(recordsPathIsolatedCopy(), type, flags, WTF::move(traverseHandler));
+    String anyPartition;
+    traverseInternal(anyPartition, type, flags, WTF::move(traverseHandler));
 }
 
 void Storage::traverse(const String& type, const String& partition, OptionSet<TraverseFlag> flags, TraverseHandler&& traverseHandler)
 {
     auto partitionHashAsString = Key::partitionToPartitionHashAsString(partition, salt());
-    auto rootPath = FileSystem::pathByAppendingComponent(recordsPathIsolatedCopy(), partitionHashAsString);
-    traverseWithinRootPath(rootPath, type, flags, WTF::move(traverseHandler));
+    traverseInternal(partitionHashAsString, type, flags, WTF::move(traverseHandler));
 }
 
 void Storage::setCapacity(size_t capacity)

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.h
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.h
@@ -150,7 +150,7 @@ private:
     String recordPathForKey(const Key&) const;
     String blobPathForKey(const Key&) const;
 
-    void traverseWithinRootPath(const String& rootPath, const String& type, OptionSet<TraverseFlag>, TraverseHandler&&);
+    void traverseInternal(const String& partitionName, const String& type, OptionSet<TraverseFlag>, TraverseHandler&&);
 
     void synchronize();
     void deleteOldVersions();


### PR DESCRIPTION
#### 8bc8f4ca4c47be01c6b6e166763ef55f57c8a800
<pre>
[regression] Storage::traverse(const String&amp; type, const String&amp; partition, ...) is broken
<a href="https://bugs.webkit.org/show_bug.cgi?id=315416">https://bugs.webkit.org/show_bug.cgi?id=315416</a>
<a href="https://rdar.apple.com/183308318">rdar://183308318</a>

Reviewed by Chris Dumez.

<a href="https://github.com/WebKit/WebKit/pull/9665">https://github.com/WebKit/WebKit/pull/9665</a> introduced a new version of
Storage::traverse that accepts a cache partition argument to traverse
only the cache entries corresponding to that partition. This is done by
passing the subdirectory corresponding to that partition on the disk
as a rootPath argument to Storage::traverseWithinRootPath and that
ends up using that subdirectory as a recordsPath argument for
Storage::traverseRecordsFiles. However, that latter function actually
expects recordsPath to be the root of Records files, since it
traverses all the subdirectories as if they were cache partitions.

Currently, this code is only hit by the version of Cache::traverse that
acccepts a partition argument, which is itself only used by
NetworkProcess::deleteWebsiteDataForOrigin and finally
by NetworkResourceLoader::processClearSiteDataHeader. So that regression
from 2023 only affects Clear-Site-Data: &quot;cache&quot;.

This bug can be manually tested with some simple steps from the command
line: <a href="https://bugs.webkit.org/show_bug.cgi?id=315416#c1.">https://bugs.webkit.org/show_bug.cgi?id=315416#c1.</a> This method to
traverse cache entries per-partition is also critically used to
implement Compression Dictionary Transport and is covered by many WPT
tests from fetch/compression-dictionary. However, we don&apos;t implement
this yet, see bug 295249.

No new tests, verified manually and covered by WPT tests.

* Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.cpp:
(WebKit::NetworkCache::traversePartitionFiles): New traverse function that accepts a partition path as an argument.
(WebKit::NetworkCache::traverseRecordsFiles): New function that accepts the root of Records as an argument and calls traversePartitionFiles on all subdirectories.
(WebKit::NetworkCache::Storage::traverseWithinRootPath): Deleted.
(WebKit::NetworkCache::Storage::traverseInternal): Replace traverseWithinRootPath, using a partition name instead, and call either traverseRecordsFiles (if partition name is empty) or traversePartitionFiles on the specific partition folder.
(WebKit::NetworkCache::Storage::traverse): Calls traverseWithinRootPath with a partion name (empty or not depending on the version).
* Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.h: Replace traverseWithinRootPath with traverseInternal.

Canonical link: <a href="https://commits.webkit.org/318124@main">https://commits.webkit.org/318124@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a72ae9c85abe22d11b03f6bd7e1a87c4178c1297

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177224 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51162 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44956 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186827 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140460 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52454 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50848 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138094 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140460 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180180 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41601 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158863 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118559 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40261 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38638 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150670 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38361 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35295 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42947 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42852 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189254 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50828 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147185 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39581 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51511 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34987 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146977 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41706 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123726 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118051 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50016 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13339 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49415 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49654 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49476 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->