### PR TITLE
Service worker fetch event request body cancellation should be propagated to the original ReadableStream

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/fetch-request-body-cancel-worker.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/fetch-request-body-cancel-worker.js
@@ -1,0 +1,14 @@
+async function cancelBodyTest(event)
+{
+    await new Promise(resolve => setTimeout(resolve, 100));
+    event.request.body.cancel("service worker cancelled body");
+    await new Promise(resolve => setTimeout(resolve, 100));
+    return new Response("PASS");
+}
+
+self.addEventListener("fetch", (event) => {
+    if (!event.request.url.includes("cancel-body-test"))
+        return;
+
+    event.respondWith(cancelBodyTest(event));
+});

--- a/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/fetch-request-body-cancel.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/fetch-request-body-cancel.https-expected.txt
@@ -1,0 +1,4 @@
+
+PASS Setup worker
+PASS Service worker cancelling event.request.body should cancel the page's upload stream
+

--- a/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/fetch-request-body-cancel.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/fetch-request-body-cancel.https.html
@@ -1,0 +1,56 @@
+<html>
+<head>
+<title>Service Worker cancelling a fetch upload stream body</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/service-workers/service-worker/resources/test-helpers.sub.js"></script>
+</head>
+<body>
+<script>
+var scope = "resources";
+var activeWorker;
+
+promise_test(async (test) => {
+    var registration = await navigator.serviceWorker.register("fetch-request-body-cancel-worker.js", { scope : scope });
+    activeWorker = registration.active;
+    if (activeWorker)
+        return;
+    activeWorker = registration.installing;
+    return new Promise(resolve => {
+        activeWorker.addEventListener('statechange', () => {
+            if (activeWorker.state === "activated")
+                resolve();
+        });
+    });
+}, "Setup worker");
+
+promise_test(async (test) => {
+    const iframe = await with_iframe("resources/empty.html");
+
+    const cancelPromise = new Promise((resolve, reject) => {
+        test.step_timeout(() => reject("cancel timed out"), 3000);
+        var stream = new ReadableStream({
+            start: controller => {
+                controller.enqueue(new Uint8Array([1, 2, 3]));
+            },
+            cancel: reason => {
+                resolve(reason);
+            }
+        });
+
+        var options = { method: "POST", body: stream, duplex: "half" };
+        test.fetchPromise = iframe.contentWindow.fetch("cancel-body-test", options);
+    });
+    const response = await test.fetchPromise;
+    assert_true(response.ok, "fetch should succeed even though the request stream was cancelled");
+    const text = await response.text();
+    assert_equals(text, "PASS");
+
+    iframe.remove();
+
+    // FIXME: We should be able to validate cancelPromise value.
+    await cancelPromise;
+}, "Service worker cancelling event.request.body should cancel the page's upload stream");
+</script>
+</body>
+</html>

--- a/Source/WebCore/Modules/fetch/FetchBody.cpp
+++ b/Source/WebCore/Modules/fetch/FetchBody.cpp
@@ -294,7 +294,7 @@ RefPtr<FormData> FetchBody::bodyAsFormData() const
     return nullptr;
 }
 
-Ref<ReadableStreamToSharedBufferSink> FetchBody::startPendingStreamUpload()
+Ref<ReadableStreamToSharedBufferSink> FetchBody::startPendingStreamUpload(ScriptExecutionContext& context)
 {
     ASSERT(isReadableStream());
     ASSERT(!m_pendingStreamState);
@@ -302,7 +302,7 @@ Ref<ReadableStreamToSharedBufferSink> FetchBody::startPendingStreamUpload()
     Ref state = PendingStreamState::create();
     m_pendingStreamState = state.copyRef();
 
-    Ref sink = ReadableStreamToSharedBufferSink::create([state = WTF::move(state)](auto&& result) mutable {
+    Ref sink = ReadableStreamToSharedBufferSink::create([state](auto&& result) mutable {
         WTF::switchOn(result,
             [&](std::nullptr_t) { state->endStream(); },
             [&](std::span<const uint8_t> chunk) { state->appendData(SharedBuffer::create(chunk)); },
@@ -310,9 +310,28 @@ Ref<ReadableStreamToSharedBufferSink> FetchBody::startPendingStreamUpload()
             [&](Exception&) { state->errorStream(-1); }
         );
     });
+    state->setCancelCallback([weakSink = WeakPtr { sink }, contextIdentifier = context.identifier()] {
+        ScriptExecutionContext::postTaskTo(contextIdentifier, [weakSink](auto& context) {
+            auto* globalObject = downcast<JSDOMGlobalObject>(context.globalObject());
+            if (!globalObject)
+                return;
+
+            if (RefPtr sink = weakSink) {
+                JSC::JSLockHolder lock(globalObject->vm());
+                // FIXME: Provide a meaningful reason.
+                sink->cancel(*globalObject, JSC::jsUndefined());
+            }
+        });
+    });
 
     sink->pipeFrom(protect(readableStreamBody()));
     return sink;
+}
+
+void FetchBody::cancelReadableStream()
+{
+    if (m_consumer)
+        protect(m_consumer)->cancelReadableStream();
 }
 
 void FetchBody::convertReadableStreamToArrayBuffer(FetchBodyOwner& owner, CompletionHandler<void(std::optional<Exception>&&)>&& completionHandler)

--- a/Source/WebCore/Modules/fetch/FetchBody.h
+++ b/Source/WebCore/Modules/fetch/FetchBody.h
@@ -107,8 +107,9 @@ public:
 
     void convertReadableStreamToArrayBuffer(FetchBodyOwner&, CompletionHandler<void(std::optional<Exception>&&)>&&);
 
-    Ref<ReadableStreamToSharedBufferSink> startPendingStreamUpload();
+    Ref<ReadableStreamToSharedBufferSink> startPendingStreamUpload(ScriptExecutionContext&);
     PendingStreamState* pendingStreamState() const { return m_pendingStreamState.get(); }
+    void cancelReadableStream();
 
     bool isBlob() const { return std::holds_alternative<Ref<Blob>>(m_data); }
     bool isFormData() const { return std::holds_alternative<Ref<FormData>>(m_data); }

--- a/Source/WebCore/Modules/fetch/FetchBodyConsumer.cpp
+++ b/Source/WebCore/Modules/fetch/FetchBodyConsumer.cpp
@@ -287,6 +287,12 @@ void FetchBodyConsumer::clean()
     }
 }
 
+void FetchBodyConsumer::cancelReadableStream()
+{
+    if (RefPtr formDataConsumer = m_formDataConsumer)
+        formDataConsumer->cancel();
+}
+
 void FetchBodyConsumer::resolveWithData(Ref<DeferredPromise>&& promise, const String& contentType, std::span<const uint8_t> data)
 {
     resolveWithTypeAndData(WTF::move(promise), m_type, contentType, data);

--- a/Source/WebCore/Modules/fetch/FetchBodyConsumer.h
+++ b/Source/WebCore/Modules/fetch/FetchBodyConsumer.h
@@ -86,6 +86,7 @@ public:
 
     void setConsumePromise(Ref<DeferredPromise>&&);
     void setSource(Ref<FetchBodySource>&&);
+    void cancelReadableStream();
 
     void setAsLoading() { m_isLoading = true; }
 

--- a/Source/WebCore/Modules/fetch/FetchRequest.cpp
+++ b/Source/WebCore/Modules/fetch/FetchRequest.cpp
@@ -416,6 +416,12 @@ void FetchRequest::stop()
     FetchBodyOwner::stop();
 }
 
+void FetchRequest::cancel()
+{
+    if (!isBodyNull())
+        body().cancelReadableStream();
+}
+
 WebCoreOpaqueRoot root(FetchRequest* request)
 {
     return WebCoreOpaqueRoot { request };

--- a/Source/WebCore/Modules/fetch/FetchRequest.h
+++ b/Source/WebCore/Modules/fetch/FetchRequest.h
@@ -106,6 +106,7 @@ private:
     ExceptionOr<void> setBody(FetchRequest&);
 
     void stop() final;
+    void cancel() final;
 
     ResourceRequest m_request;
     URLKeepingBlobAlive m_requestURL;

--- a/Source/WebCore/Modules/fetch/FetchResponse.cpp
+++ b/Source/WebCore/Modules/fetch/FetchResponse.cpp
@@ -285,7 +285,7 @@ void FetchResponse::fetch(ScriptExecutionContext& context, FetchRequest& request
             responseCallback(Exception { ExceptionCode::NotSupportedError, "ReadableStream uploading is not supported"_s });
             return;
         }
-        uploadSink = request.body().startPendingStreamUpload();
+        uploadSink = request.body().startPendingStreamUpload(context);
     } else if (request.hasReadableStreamBody()) {
         request.body().convertReadableStreamToArrayBuffer(request, [context = Ref { context }, weakRequest = WeakPtr { request }, responseCallback = WTF::move(responseCallback), initiator](auto&& exception) mutable {
             if (!!exception) {

--- a/Source/WebCore/platform/network/PendingStreamState.cpp
+++ b/Source/WebCore/platform/network/PendingStreamState.cpp
@@ -33,9 +33,9 @@
 
 namespace WebCore {
 
-class PendingStreamState::DataAvailableHandler : public ThreadSafeRefCounted<DataAvailableHandler> {
+class PendingStreamState::CallbackHandler : public ThreadSafeRefCounted<CallbackHandler> {
 public:
-    static Ref<DataAvailableHandler> create(Function<void()>&& function) { return adoptRef(*new DataAvailableHandler(WTF::move(function))); }
+    static Ref<CallbackHandler> create(Function<void()>&& function) { return adoptRef(*new CallbackHandler(WTF::move(function))); }
 
     void invoke()
     {
@@ -44,7 +44,7 @@ public:
     }
 
 private:
-    explicit DataAvailableHandler(Function<void()>&& function)
+    explicit CallbackHandler(Function<void()>&& function)
         : m_function(WTF::move(function))
     {
     }
@@ -68,7 +68,7 @@ void PendingStreamState::setHTTPVersionProbe(HTTPVersionProbe&& probe)
     m_httpVersionProbe = WTF::move(probe);
 }
 
-void PendingStreamState::invokeHandlerIfNeeded(NOESCAPE const std::function<RefPtr<DataAvailableHandler>()>& function)
+void PendingStreamState::invokeHandlerIfNeeded(NOESCAPE const std::function<RefPtr<CallbackHandler>()>& function)
 {
     if (RefPtr handler = function())
         handler->invoke();
@@ -76,7 +76,7 @@ void PendingStreamState::invokeHandlerIfNeeded(NOESCAPE const std::function<RefP
 
 void PendingStreamState::appendData(Ref<SharedBuffer>&& buffer)
 {
-    invokeHandlerIfNeeded([&] -> RefPtr<DataAvailableHandler> {
+    invokeHandlerIfNeeded([&] -> RefPtr<CallbackHandler> {
         Locker locker { m_lock };
         if (m_ended || m_errorCode)
             return nullptr;
@@ -87,7 +87,7 @@ void PendingStreamState::appendData(Ref<SharedBuffer>&& buffer)
 
 void PendingStreamState::endStream()
 {
-    invokeHandlerIfNeeded([&] -> RefPtr<DataAvailableHandler> {
+    invokeHandlerIfNeeded([&] -> RefPtr<CallbackHandler> {
         Locker locker { m_lock };
         if (m_ended || m_errorCode)
             return nullptr;
@@ -98,7 +98,7 @@ void PendingStreamState::endStream()
 
 void PendingStreamState::errorStream(int errorCode)
 {
-    invokeHandlerIfNeeded([&] -> RefPtr<DataAvailableHandler> {
+    invokeHandlerIfNeeded([&] -> RefPtr<CallbackHandler> {
         Locker locker { m_lock };
         if (m_ended || m_errorCode)
             return nullptr;
@@ -115,11 +115,11 @@ void PendingStreamState::setDataAvailableHandler(Function<void()>&& handler)
         return;
     }
 
-    invokeHandlerIfNeeded([&] -> RefPtr<DataAvailableHandler> {
+    invokeHandlerIfNeeded([&] -> RefPtr<CallbackHandler> {
         Locker locker { m_lock };
         ASSERT(!m_dataAvailableHandler);
         RELEASE_LOG_ERROR_IF(m_dataAvailableHandler, Network, "Trying to get upload stream data twice");
-        m_dataAvailableHandler = DataAvailableHandler::create(WTF::move(handler));
+        m_dataAvailableHandler = CallbackHandler::create(WTF::move(handler));
         if (!m_chunks.isEmpty() || m_ended || m_errorCode)
             return m_dataAvailableHandler;
         return nullptr;
@@ -202,5 +202,37 @@ bool PendingStreamState::hasReadyData()
     Locker locker { m_lock };
     return !m_chunks.isEmpty() || m_ended || m_errorCode;
 }
+
+void PendingStreamState::setCancelCallback(Function<void()>&& handler)
+{
+    if (!handler) {
+        Locker locker { m_lock };
+        m_cancelHandler = nullptr;
+        return;
+    }
+    {
+        Locker locker { m_lock };
+        if (m_ended || m_errorCode)
+            return;
+        m_cancelHandler = CallbackHandler::create(WTF::move(handler));
+    }
+}
+
+void PendingStreamState::cancel()
+{
+    RefPtr<CallbackHandler> cancelHandler;
+    {
+        Locker locker { m_lock };
+        if (m_ended || m_errorCode)
+            return;
+
+        m_errorCode = -1;
+        cancelHandler = m_cancelHandler;
+    }
+
+    if (cancelHandler)
+        cancelHandler->invoke();
+}
+
 
 } // namespace WebCore

--- a/Source/WebCore/platform/network/PendingStreamState.h
+++ b/Source/WebCore/platform/network/PendingStreamState.h
@@ -52,37 +52,40 @@ public:
     WEBCORE_EXPORT static Ref<PendingStreamState> create();
     WEBCORE_EXPORT ~PendingStreamState();
 
+    // Data provider API
     WEBCORE_EXPORT void appendData(Ref<SharedBuffer>&&);
     WEBCORE_EXPORT void endStream();
     // FIXME: Provide meaningful PendingStreamState errors.
     WEBCORE_EXPORT void errorStream(int errorCode);
+    WEBCORE_EXPORT void setCancelCallback(Function<void()>&&);
+
+    // Data consumer API
+    WEBCORE_EXPORT void setDataAvailableHandler(Function<void()>&&);
+    WEBCORE_EXPORT void clearDataAvailableHandler();
+    size_t read(std::span<uint8_t> outBuffer, bool& atEOF, int& errorCode);
+    WEBCORE_EXPORT RefPtr<SharedBuffer> takeNextChunk(bool& atEOF, int& errorCode);
+    bool hasReadyData();
+    WEBCORE_EXPORT void cancel();
 
     WEBCORE_EXPORT void setHTTPVersionProbe(HTTPVersionProbe&&);
+    HTTPVersion currentHTTPVersion();
 
     void setServiceWorkerFetchIdentifier(FetchIdentifier fetchIdentifier) { m_serviceWorkerFetchIdentifier = fetchIdentifier; }
     Markable<FetchIdentifier> serviceWorkerFetchIdentifier() const { return m_serviceWorkerFetchIdentifier; }
 
-    WEBCORE_EXPORT void setDataAvailableHandler(Function<void()>&&);
-    WEBCORE_EXPORT void clearDataAvailableHandler();
-
-    HTTPVersion currentHTTPVersion();
-
-    size_t read(std::span<uint8_t> outBuffer, bool& atEOF, int& errorCode);
-    WEBCORE_EXPORT RefPtr<SharedBuffer> takeNextChunk(bool& atEOF, int& errorCode);
-    bool hasReadyData();
-
 private:
-    class DataAvailableHandler;
+    class CallbackHandler;
     PendingStreamState();
 
-    static void invokeHandlerIfNeeded(NOESCAPE const std::function<RefPtr<DataAvailableHandler>()>&);
+    static void invokeHandlerIfNeeded(NOESCAPE const std::function<RefPtr<CallbackHandler>()>&);
 
     Lock m_lock;
     Deque<Ref<SharedBuffer>> m_chunks WTF_GUARDED_BY_LOCK(m_lock);
     size_t m_frontChunkOffset WTF_GUARDED_BY_LOCK(m_lock) { 0 };
     bool m_ended WTF_GUARDED_BY_LOCK(m_lock) { false };
     int m_errorCode WTF_GUARDED_BY_LOCK(m_lock) { 0 };
-    RefPtr<DataAvailableHandler> m_dataAvailableHandler WTF_GUARDED_BY_LOCK(m_lock);
+    RefPtr<CallbackHandler> m_dataAvailableHandler WTF_GUARDED_BY_LOCK(m_lock);
+    RefPtr<CallbackHandler> m_cancelHandler WTF_GUARDED_BY_LOCK(m_lock);
     HTTPVersionProbe m_httpVersionProbe WTF_GUARDED_BY_LOCK(m_lock);
     Markable<FetchIdentifier> m_serviceWorkerFetchIdentifier;
 };

--- a/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.cpp
@@ -471,6 +471,11 @@ void ServiceWorkerFetchTask::continueDidReceiveFetchResponse()
         connection->send(Messages::WebSWContextManagerConnection::ContinueDidReceiveFetchResponse { *m_serverConnectionIdentifier, *m_serviceWorkerIdentifier, m_fetchIdentifier }, 0);
 }
 
+void ServiceWorkerFetchTask::cancelPendingStreamUpload()
+{
+    sendToClient(Messages::WebResourceLoader::CancelPendingStreamUpload { });
+}
+
 void ServiceWorkerFetchTask::continueFetchTaskWith(ResourceRequest&& request)
 {
     SWFETCH_RELEASE_LOG("continueFetchTaskWith: (hasServiceWorkerConnection=%d)", !!m_serviceWorkerConnection);

--- a/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.h
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.h
@@ -83,6 +83,7 @@ public:
 
     void continueDidReceiveFetchResponse();
     void continueFetchTaskWith(WebCore::ResourceRequest&&);
+    void cancelPendingStreamUpload();
 
     WebCore::FetchIdentifier fetchIdentifier() const { return m_fetchIdentifier; }
     std::optional<WebCore::ServiceWorkerIdentifier> serviceWorkerIdentifier() const { return m_serviceWorkerIdentifier; }

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.cpp
@@ -460,9 +460,11 @@ void WebSWServerToContextConnection::pendingStreamDataAvailable(WebCore::FetchId
 
 void WebSWServerToContextConnection::cancelPendingStreamUploadForwarding(WebCore::FetchIdentifier fetchIdentifier)
 {
-    // FIXME: We might want to let know the source stream we no longer care about getting any data.
     if (RefPtr state = m_requestPendingStreamStates.take(fetchIdentifier))
         state->clearDataAvailableHandler();
+
+    if (RefPtr fetch = m_ongoingFetches.get(fetchIdentifier))
+        fetch->cancelPendingStreamUpload();
 }
 
 void WebSWServerToContextConnection::didReceiveFetchTaskMessage(IPC::Connection& connection, IPC::Decoder& decoder)

--- a/Source/WebKit/WebProcess/Network/WebResourceLoader.cpp
+++ b/Source/WebKit/WebProcess/Network/WebResourceLoader.cpp
@@ -406,6 +406,12 @@ void WebResourceLoader::updateResultingClientIdentifier(WTF::UUID currentIdentif
         loader->setNewResultingClientId({ newIdentifier, Process::identifier() });
 }
 
+void WebResourceLoader::cancelPendingStreamUpload()
+{
+    if (RefPtr state = m_pendingStreamState)
+        state->cancel();
+}
+
 void WebResourceLoader::didFailResourceLoad(const ResourceError& error)
 {
     RefPtr coreLoader = m_coreLoader;

--- a/Source/WebKit/WebProcess/Network/WebResourceLoader.h
+++ b/Source/WebKit/WebProcess/Network/WebResourceLoader.h
@@ -97,6 +97,7 @@ private:
     void didFailServiceWorkerLoad(const WebCore::ResourceError&);
     void serviceWorkerDidNotHandle();
     void updateResultingClientIdentifier(WTF::UUID currentIdentifier, WTF::UUID newIdentifier);
+    void cancelPendingStreamUpload();
 
     void didBlockAuthenticationChallenge();
     void setServiceWorkerTimingInfo(ServiceWorkerTimingInfo&& info) { m_serviceWorkerTimingInfo = WTF::move(info); }

--- a/Source/WebKit/WebProcess/Network/WebResourceLoader.messages.in
+++ b/Source/WebKit/WebProcess/Network/WebResourceLoader.messages.in
@@ -35,6 +35,7 @@ messages -> WebResourceLoader {
     DidFailServiceWorkerLoad(WebCore::ResourceError error)
     ServiceWorkerDidNotHandle()
     UpdateResultingClientIdentifier(WTF::UUID currentIdentifier, WTF::UUID newIdentifier);
+    CancelPendingStreamUpload()
     DidBlockAuthenticationChallenge()
 
     StopLoadingAfterXFrameOptionsOrContentSecurityPolicyDenied(WebCore::ResourceResponse response)


### PR DESCRIPTION
#### b0957d9ae341ce80fcb9818848aff2635b457f00
<pre>
Service worker fetch event request body cancellation should be propagated to the original ReadableStream
<a href="https://rdar.apple.com/183317580">rdar://183317580</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=320359">https://bugs.webkit.org/show_bug.cgi?id=320359</a>

Reviewed by Alex Christensen.

When a service worker is cancelling a fetch event request body, we propagate it as follows:
1. FetchRequest will cancel its FetchBody which will cancel its FetchBodyConsumer which will cancel its FormDataConsumer
2. FormDataConsumer will ask its sw connection to cancel the upload forwarding to network process via IPC.
3. network process stops the forwarding and notifies the related WebResourceLoader in web process.
4. WebResourceLoader tells the PendingStreamState it has been cancelled.

When starting the upstream, the PendingStreamState is created and the it is registered a cancel callback from the FetchRequest.
This cancel callback is now cancelling the original ReadableStream.
To implement this we rename DataAvailableHandler to CallbackHandler and add a specific cancel callback like there is a data available callback.

Test: LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/fetch-request-body-cancel.https.html

* Source/WebCore/Modules/fetch/FetchBody.cpp:
(WebCore::FetchBody::startPendingStreamUpload):
(WebCore::FetchBody::cancelReadableStream):
* Source/WebCore/Modules/fetch/FetchBody.h:
* Source/WebCore/Modules/fetch/FetchBodyConsumer.cpp:
(WebCore::FetchBodyConsumer::cancelReadableStream):
* Source/WebCore/Modules/fetch/FetchBodyConsumer.h:
* Source/WebCore/Modules/fetch/FetchRequest.cpp:
(WebCore::FetchRequest::cancel):
* Source/WebCore/Modules/fetch/FetchRequest.h:
* Source/WebCore/Modules/fetch/FetchResponse.cpp:
(WebCore::FetchResponse::fetch):
* Source/WebCore/platform/network/PendingStreamState.cpp:
(WebCore::PendingStreamState::CallbackHandler::create):
(WebCore::PendingStreamState::CallbackHandler::CallbackHandler):
(WebCore::PendingStreamState::invokeHandlerIfNeeded):
(WebCore::PendingStreamState::appendData):
(WebCore::PendingStreamState::endStream):
(WebCore::PendingStreamState::errorStream):
(WebCore::PendingStreamState::setDataAvailableHandler):
(WebCore::PendingStreamState::setCancelCallback):
(WebCore::PendingStreamState::cancel):
(WebCore::PendingStreamState::DataAvailableHandler::create): Deleted.
(WebCore::PendingStreamState::DataAvailableHandler::invoke): Deleted.
(WebCore::PendingStreamState::DataAvailableHandler::DataAvailableHandler): Deleted.
* Source/WebCore/platform/network/PendingStreamState.h:
(WebCore::PendingStreamState::setServiceWorkerFetchIdentifier):
(WebCore::PendingStreamState::serviceWorkerFetchIdentifier const):
* Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.cpp:
(WebKit::ServiceWorkerFetchTask::cancelPendingStreamUpload):
* Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.h:
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.cpp:
(WebKit::WebSWServerToContextConnection::cancelPendingStreamUploadForwarding):
* Source/WebKit/WebProcess/Network/WebResourceLoader.cpp:
(WebKit::WebResourceLoader::cancelPendingStreamUpload):
* Source/WebKit/WebProcess/Network/WebResourceLoader.h:
* Source/WebKit/WebProcess/Network/WebResourceLoader.messages.in:
* LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/fetch-request-body-cancel-worker.js: Added.
(async cancelBodyTest):
* LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/fetch-request-body-cancel.https-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/fetch-request-body-cancel.https.html: Added.

Canonical link: <a href="https://commits.webkit.org/318043@main">https://commits.webkit.org/318043@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8878b829bab80f4ca0b1d16d691baab84d22b259

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176948 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50885 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44680 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186551 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140184 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9eb85173-1143-476c-a37b-2355ddaeb105) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178811 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52178 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50571 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137870 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140184 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/050741da-9e8f-40a2-92d9-d1a3b7da19cd) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179904 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41378 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158658 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118339 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/582c8d49-c6b1-4cc4-ae75-672a08d7ef0e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40034 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38399 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150444 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38158 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35019 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42636 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42617 "Found 1 new test failure: imported/w3c/web-platform-tests/wasm/core/float_exprs.wast.js.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188974 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50552 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/158198 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146943 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39534 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51235 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34782 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146740 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41501 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123448 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117732 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49740 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13138 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49139 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49376 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49200 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->