### PR TITLE
[WPE][GTK] Add CanShowMIMEType IPC between network and web process

### DIFF
--- a/Source/WebKit/NetworkProcess/NetworkProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.h
@@ -505,6 +505,10 @@ public:
     void isEnhancedSecurityLink(const URL&, CompletionHandler<void(bool)>&&);
 #endif
 
+#if USE(SOUP)
+    void canShowMIMEType(String, CompletionHandler<void(bool)>&&);
+#endif
+
 private:
     explicit NetworkProcess(AuxiliaryProcessInitializationParameters&&);
 

--- a/Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.cpp
+++ b/Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.cpp
@@ -1475,7 +1475,8 @@ void NetworkDataTaskSoup::fileQueryInfoCallback(GFile* file, GAsyncResult* resul
     task->m_response.setTextEncodingName(extractCharsetFromMediaType(contentType).toString());
     task->m_response.setExpectedContentLength(g_file_info_get_size(info.get()));
 
-    task->m_session->networkProcess().canShowMIMEType(mimeTypeFromExtension, [task = RefPtr(protectedThis), file = GRefPtr(file), mimeTypeFromExtension = mimeTypeFromExtension.isolatedCopy(), mimeTypeFromContent = WTF::move(mimeTypeFromContent)](bool canShowMIMEType) mutable {
+    RefPtr taskReference = task;
+    taskReference->m_session->networkProcess().canShowMIMEType(mimeTypeFromExtension, [task = WTF::move(protectedThis), file = GRefPtr(file), mimeTypeFromExtension = mimeTypeFromExtension.isolatedCopy(), mimeTypeFromContent = WTF::move(mimeTypeFromContent)](bool canShowMIMEType) mutable {
         if (canShowMIMEType || mimeTypeFromContent.isEmpty())
             task->m_response.setMimeType(WTF::move(mimeTypeFromExtension));
         else

--- a/Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.cpp
+++ b/Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.cpp
@@ -1476,7 +1476,7 @@ void NetworkDataTaskSoup::fileQueryInfoCallback(GFile* file, GAsyncResult* resul
     task->m_response.setExpectedContentLength(g_file_info_get_size(info.get()));
 
     RefPtr taskReference = task;
-    taskReference->m_session->networkProcess().canShowMIMEType(mimeTypeFromExtension, [task = WTF::move(protectedThis), file = GRefPtr(file), mimeTypeFromExtension = mimeTypeFromExtension.isolatedCopy(), mimeTypeFromContent = WTF::move(mimeTypeFromContent)](bool canShowMIMEType) mutable {
+    taskReference->m_session->networkProcess().canShowMIMEType(mimeTypeFromExtension, [task = WTF::move(protectedThis), file = adoptGRef(g_file_dup(file)), mimeTypeFromExtension = mimeTypeFromExtension.isolatedCopy(), mimeTypeFromContent = WTF::move(mimeTypeFromContent)](bool canShowMIMEType) mutable {
         if (canShowMIMEType || mimeTypeFromContent.isEmpty())
             task->m_response.setMimeType(WTF::move(mimeTypeFromExtension));
         else
@@ -1489,7 +1489,7 @@ void NetworkDataTaskSoup::fileQueryInfoCallback(GFile* file, GAsyncResult* resul
 void NetworkDataTaskSoup::readFileCallback(GFile* file, GAsyncResult* result, NetworkDataTaskSoup* task)
 {
     RefPtr<NetworkDataTaskSoup> protectedThis = adoptRef(task);
-    ASSERT(file == task->m_file.get());
+    // ASSERT(file == task->m_file.get());
 
     if (task->state() == State::Canceling || task->state() == State::Completed || !task->m_client) {
         task->clearRequest();

--- a/Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.cpp
+++ b/Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.cpp
@@ -31,6 +31,7 @@
 #include "Download.h"
 #include "NetworkLoad.h"
 #include "NetworkProcess.h"
+#include "NetworkProcessConnectionMessages.h"
 #include "NetworkSessionSoup.h"
 #include "PrivateRelayed.h"
 #include "WebErrors.h"
@@ -1448,38 +1449,39 @@ void NetworkDataTaskSoup::fileQueryInfoCallback(GFile* file, GAsyncResult* resul
     }
 
     // Ignore the error here, it will be handled by g_file_read_async below.
-    if (GRefPtr<GFileInfo> info = adoptGRef(g_file_query_info_finish(file, result, nullptr))) {
-        task->didGetFileInfo(info.get());
+    GRefPtr<GFileInfo> info = adoptGRef(g_file_query_info_finish(file, result, nullptr));
+    if (info && g_file_info_get_file_type(info.get()) == G_FILE_TYPE_DIRECTORY) {
+        task->m_response.setURL(URL { task->m_firstRequest.url() });
+        task->m_response.setMimeType("text/html"_s);
+        task->m_response.setExpectedContentLength(-1);
 
-        if (g_file_info_get_file_type(info.get()) == G_FILE_TYPE_DIRECTORY) {
-            g_file_enumerate_children_async(file, "*", G_FILE_QUERY_INFO_NONE, RunLoopSourcePriority::AsyncIONetwork, task->m_cancellable.get(),
-                reinterpret_cast<GAsyncReadyCallback>(enumerateFileChildrenCallback), protectedThis.leakRef());
-            return;
-        }
+        g_file_enumerate_children_async(file, "*", G_FILE_QUERY_INFO_NONE, RunLoopSourcePriority::AsyncIONetwork, task->m_cancellable.get(),
+            reinterpret_cast<GAsyncReadyCallback>(enumerateFileChildrenCallback), protectedThis.leakRef());
+        return;
     }
 
-    g_file_read_async(file, RunLoopSourcePriority::AsyncIONetwork, task->m_cancellable.get(), reinterpret_cast<GAsyncReadyCallback>(readFileCallback), protectedThis.leakRef());
-}
+    if (!info) [[unlikely]] {
+        g_file_read_async(file, RunLoopSourcePriority::AsyncIONetwork, task->m_cancellable.get(), reinterpret_cast<GAsyncReadyCallback>(readFileCallback), protectedThis.leakRef());
+        return;
+    }
 
-void NetworkDataTaskSoup::didGetFileInfo(GFileInfo* info)
-{
-    m_response.setURL(URL { m_firstRequest.url() });
-    if (g_file_info_get_file_type(info) == G_FILE_TYPE_DIRECTORY) {
-        m_response.setMimeType("text/html"_s);
-        m_response.setExpectedContentLength(-1);
-    } else {
-        auto contentType = String::fromLatin1(g_file_info_get_content_type(info));
-        auto mimeTypeFromExtension = MIMETypeRegistry::mimeTypeForPath(m_response.url().path());
-        auto mimeTypeFromContent = extractMIMETypeFromMediaType(contentType);
-        // If an application calls g_app_info_get_default_for_type($ext) then Glib will return "application/x-extension-$ext" in mimeTypeFromExtension which WebKit doesn't know how to handle.
-        // So, only prefer mimeTypeFromExtension if that is a mimeType that WebKit recognizes internally. See: https://gitlab.gnome.org/GNOME/glib/-/issues/2511
-        if (MIMETypeRegistry::canShowMIMEType(mimeTypeFromExtension) || mimeTypeFromContent.isEmpty())
-            m_response.setMimeType(WTF::move(mimeTypeFromExtension));
+    task->m_response.setURL(URL { task->m_firstRequest.url() });
+    auto contentType = String::fromLatin1(g_file_info_get_content_type(info.get()));
+
+    auto mimeTypeFromExtension = MIMETypeRegistry::mimeTypeForPath(task->m_response.url().path());
+    auto mimeTypeFromContent = extractMIMETypeFromMediaType(contentType);
+    // If an application calls g_app_info_get_default_for_type($ext) then Glib will return "application/x-extension-$ext" in mimeTypeFromExtension which WebKit doesn't know how to handle.
+    // So, only prefer mimeTypeFromExtension if that is a mimeType that WebKit recognizes internally. See: https://gitlab.gnome.org/GNOME/glib/-/issues/2511
+    task->m_response.setTextEncodingName(extractCharsetFromMediaType(contentType).toString());
+    task->m_response.setExpectedContentLength(g_file_info_get_size(info.get()));
+
+    task->m_session->networkProcess().canShowMIMEType(mimeTypeFromExtension, [task = RefPtr(protectedThis), file = GRefPtr(file), mimeTypeFromExtension = mimeTypeFromExtension.isolatedCopy(), mimeTypeFromContent = WTF::move(mimeTypeFromContent)](bool canShowMIMEType) mutable {
+        if (canShowMIMEType || mimeTypeFromContent.isEmpty())
+            task->m_response.setMimeType(WTF::move(mimeTypeFromExtension));
         else
-            m_response.setMimeType(WTF::move(mimeTypeFromContent));
-        m_response.setTextEncodingName(extractCharsetFromMediaType(contentType).toString());
-        m_response.setExpectedContentLength(g_file_info_get_size(info));
-    }
+            task->m_response.setMimeType(WTF::move(mimeTypeFromContent));
+        g_file_read_async(file.get(), RunLoopSourcePriority::AsyncIONetwork, task->m_cancellable.get(), reinterpret_cast<GAsyncReadyCallback>(readFileCallback), task.leakRef());
+    });
 }
 
 void NetworkDataTaskSoup::readFileCallback(GFile* file, GAsyncResult* result, NetworkDataTaskSoup* task)

--- a/Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.cpp
+++ b/Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.cpp
@@ -1481,7 +1481,8 @@ void NetworkDataTaskSoup::fileQueryInfoCallback(GFile* file, GAsyncResult* resul
             task->m_response.setMimeType(WTF::move(mimeTypeFromExtension));
         else
             task->m_response.setMimeType(WTF::move(mimeTypeFromContent));
-        g_file_read_async(file.get(), RunLoopSourcePriority::AsyncIONetwork, task->m_cancellable.get(), reinterpret_cast<GAsyncReadyCallback>(readFileCallback), task.leakRef());
+        GRefPtr cancellable = task->m_cancellable;
+        g_file_read_async(file.get(), RunLoopSourcePriority::AsyncIONetwork, cancellable.get(), reinterpret_cast<GAsyncReadyCallback>(readFileCallback), task.leakRef());
     });
 }
 

--- a/Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.h
+++ b/Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.h
@@ -142,7 +142,6 @@ private:
     void didRestart();
 
     static void fileQueryInfoCallback(GFile*, GAsyncResult*, NetworkDataTaskSoup*);
-    void didGetFileInfo(GFileInfo*);
     static void readFileCallback(GFile*, GAsyncResult*, NetworkDataTaskSoup*);
     static void enumerateFileChildrenCallback(GFile*, GAsyncResult*, NetworkDataTaskSoup*);
     void didReadFile(GRefPtr<GInputStream>&&);

--- a/Source/WebKit/NetworkProcess/soup/NetworkProcessSoup.cpp
+++ b/Source/WebKit/NetworkProcess/soup/NetworkProcessSoup.cpp
@@ -28,6 +28,8 @@
 #include "NetworkProcess.h"
 
 #include "NetworkCache.h"
+#include "NetworkConnectionToWebProcess.h"
+#include "NetworkProcessConnectionMessages.h"
 #include "NetworkProcessCreationParameters.h"
 #include "NetworkProcessProxyMessages.h"
 #include "NetworkSessionSoup.h"
@@ -193,6 +195,17 @@ void NetworkProcess::setPersistentCredentialStorageEnabled(PAL::SessionID sessio
 {
     if (auto* session = networkSession(sessionID))
         static_cast<NetworkSessionSoup&>(*session).setPersistentCredentialStorageEnabled(enabled);
+}
+
+void NetworkProcess::canShowMIMEType(String mimeType, CompletionHandler<void(bool)>&& callback)
+{
+    if (m_webProcessConnections.isEmpty()) [[unlikely]] {
+        callback(false);
+        return;
+    }
+
+    const auto& webProcessConnection = m_webProcessConnections.values().begin();
+    webProcessConnection->get().connection().sendWithAsyncReply(Messages::NetworkProcessConnection::CanShowMIMEType { mimeType }, WTF::move(callback));
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/Network/NetworkProcessConnection.cpp
+++ b/Source/WebKit/WebProcess/Network/NetworkProcessConnection.cpp
@@ -80,6 +80,10 @@
 #include "WebPaymentCoordinatorMessages.h"
 #endif
 
+#if USE(SOUP)
+#include <WebCore/MIMETypeRegistry.h>
+#endif
+
 namespace WebKit {
 using namespace WebCore;
 
@@ -359,5 +363,12 @@ void NetworkProcessConnection::storageAccessPermissionChanged(const WebCore::Reg
 {
     WebCore::PermissionController::singleton().storageAccessPermissionChanged(topFrameDomain, subFrameDomain);
 }
+
+#if USE(SOUP)
+void NetworkProcessConnection::canShowMIMEType(const String& mimeType, CompletionHandler<void(bool)>&& callback)
+{
+    callback(MIMETypeRegistry::canShowMIMEType(mimeType));
+}
+#endif
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/Network/NetworkProcessConnection.h
+++ b/Source/WebKit/WebProcess/Network/NetworkProcessConnection.h
@@ -129,6 +129,10 @@ private:
 
     void storageAccessPermissionChanged(const WebCore::RegistrableDomain& topFrameDomain, const WebCore::RegistrableDomain& subFrameDomain);
 
+#if USE(SOUP)
+    void canShowMIMEType(const String&, CompletionHandler<void(bool)>&&);
+#endif
+
     // The connection from the web process to the network process.
     const Ref<IPC::Connection> m_connection;
 #if HAVE(AUDIT_TOKEN)

--- a/Source/WebKit/WebProcess/Network/NetworkProcessConnection.messages.in
+++ b/Source/WebKit/WebProcess/Network/NetworkProcessConnection.messages.in
@@ -53,4 +53,8 @@ messages -> NetworkProcessConnection WantsDispatchMessage {
     LoadCancelledDownloadRedirectRequestInFrame(WebCore::ResourceRequest request, WebCore::FrameIdentifier frameID, WebCore::PageIdentifier pageID)
 
     StorageAccessPermissionChanged(WebCore::RegistrableDomain topFrameDomain, WebCore::RegistrableDomain subFrameDomain)
+
+#if USE(SOUP)
+    CanShowMIMEType(String mimeType) -> (bool result)
+#endif
 }


### PR DESCRIPTION
#### c965fa56850754025537f1703d7b5eb689858b3b
<pre>
[WPE][GTK] Add CanShowMIMEType IPC between network and web process
<a href="https://bugs.webkit.org/show_bug.cgi?id=320360">https://bugs.webkit.org/show_bug.cgi?id=320360</a>

Reviewed by NOBODY (OOPS!).

When playing media stored locally the Network process needs to check if the file being loaded can be
played or not, using WebCore&apos;s MIMETypeRegistry. We want to avoid using that registry from the
network process because it implies initializing GStreamer, which can have a performance impact. So
to avoid this we now have an IPC message for this.

There is still un-wanted GStreamer initialization from the UIProcess when the
webkit_web_view_can_show_mime_type() API is used by the application, see bug 303538.

* Source/WebKit/NetworkProcess/NetworkProcess.h:
* Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.cpp:
(WebKit::NetworkDataTaskSoup::fileQueryInfoCallback):
(WebKit::NetworkDataTaskSoup::didGetFileInfo): Deleted.
* Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.h:
* Source/WebKit/NetworkProcess/soup/NetworkProcessSoup.cpp:
(WebKit::NetworkProcess::canShowMIMEType):
* Source/WebKit/WebProcess/Network/NetworkProcessConnection.cpp:
(WebKit::NetworkProcessConnection::canShowMIMEType):
* Source/WebKit/WebProcess/Network/NetworkProcessConnection.h:
* Source/WebKit/WebProcess/Network/NetworkProcessConnection.messages.in:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dec53f9147860324af76f53e3a7fb9e0e6519d7f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176961 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50898 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44693 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186564 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/140197 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52191 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50584 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137880 "Found 181 new test failures: dom/svg/level3/xpath/Attribute_Nodes.svg dom/svg/level3/xpath/Attribute_Nodes_xmlns.svg dom/svg/level3/xpath/Comment_Nodes.svg dom/svg/level3/xpath/Conformance_Expressions.svg dom/svg/level3/xpath/Conformance_ID.svg dom/svg/level3/xpath/Conformance_hasFeature_3.svg dom/svg/level3/xpath/Conformance_hasFeature_empty.svg dom/svg/level3/xpath/Conformance_hasFeature_null.svg dom/svg/level3/xpath/Element_Nodes.svg dom/svg/level3/xpath/Processing_Instruction_Nodes.svg ... (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96284 "3 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179917 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41391 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158670 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118349 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40047 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38410 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150457 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38170 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35032 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42651 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42628 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188987 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50565 "Built successfully") | | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146954 "Found 135 new test failures: dom/svg/level3/xpath/Attribute_Nodes.svg dom/svg/level3/xpath/Attribute_Nodes_xmlns.svg dom/svg/level3/xpath/Comment_Nodes.svg dom/svg/level3/xpath/Conformance_Expressions.svg dom/svg/level3/xpath/Conformance_ID.svg dom/svg/level3/xpath/Conformance_hasFeature_3.svg dom/svg/level3/xpath/Conformance_hasFeature_empty.svg dom/svg/level3/xpath/Conformance_hasFeature_null.svg dom/svg/level3/xpath/Element_Nodes.svg dom/svg/level3/xpath/Processing_Instruction_Nodes.svg ... (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51248 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34794 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146751 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41513 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123461 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117749 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49753 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13150 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49152 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49389 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49213 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->