### PR TITLE
Improve ability to get all chunks of PendingStreamState at once

### DIFF
--- a/Source/WebCore/Modules/fetch/FormDataConsumer.cpp
+++ b/Source/WebCore/Modules/fetch/FormDataConsumer.cpp
@@ -173,39 +173,30 @@ void FormDataConsumer::drainPendingStream()
     if (!state)
         return;
 
-    while (m_callback) {
-        bool atEOF = false;
-        int errorCode = 0;
-        RefPtr chunk = state->takeNextChunk(atEOF, errorCode);
+    auto result = state->takeAvailableChunks();
 
-        if (errorCode) {
-            didFail(Exception { ExceptionCode::NetworkError, "Stream upload failed"_s });
-            return;
-        }
+    if (!result) {
+        didFail(Exception { ExceptionCode::NetworkError, "Stream upload failed"_s });
+        return;
+    }
 
-        if (chunk) {
+    for (auto chunk : result->first) {
+        if (m_callback) {
             if (!m_callback(chunk->span())) {
                 cancel();
                 return;
             }
-            if (!m_callback)
-                return;
-        }
-
-        if (atEOF) {
-            state->clearDataAvailableHandler();
-            m_pendingStreamState = nullptr;
-
-            auto callback = std::exchange(m_callback, nullptr);
-            callback(std::span<const uint8_t> { });
-            return;
-        }
-
-        if (!chunk) {
-            // No chunk and not at EOF — wait for the data-available handler to run.
-            return;
         }
     }
+
+    if (!result->second)
+        return;
+
+    state->clearDataAvailableHandler();
+    m_pendingStreamState = nullptr;
+
+    if (auto callback = std::exchange(m_callback, nullptr))
+        callback(std::span<const uint8_t> { });
 }
 
 void FormDataConsumer::consume(std::span<const uint8_t> content)

--- a/Source/WebCore/platform/network/PendingStreamState.cpp
+++ b/Source/WebCore/platform/network/PendingStreamState.cpp
@@ -140,14 +140,12 @@ PendingStreamState::HTTPVersion PendingStreamState::currentHTTPVersion()
     return m_httpVersionProbe();
 }
 
-size_t PendingStreamState::read(std::span<uint8_t> outBuffer, bool& atEOF, int& errorCode)
+Expected<std::pair<size_t, bool>, int> PendingStreamState::readInto(std::span<uint8_t> outBuffer)
 {
     Locker locker { m_lock };
-    errorCode = m_errorCode;
-    atEOF = false;
 
-    if (errorCode)
-        return 0;
+    if (m_errorCode)
+        return makeUnexpected(m_errorCode);
 
     size_t written = 0;
     while (written < outBuffer.size() && !m_chunks.isEmpty()) {
@@ -164,37 +162,17 @@ size_t PendingStreamState::read(std::span<uint8_t> outBuffer, bool& atEOF, int& 
         }
     }
 
-    if (m_chunks.isEmpty() && m_ended)
-        atEOF = true;
-
-    return written;
+    return std::make_pair(written, m_chunks.isEmpty() && m_ended);
 }
 
-RefPtr<SharedBuffer> PendingStreamState::takeNextChunk(bool& atEOF, int& errorCode)
+Expected<std::pair<Deque<Ref<SharedBuffer>>, bool>, int> PendingStreamState::takeAvailableChunks()
 {
     Locker locker { m_lock };
-    errorCode = m_errorCode;
-    atEOF = false;
+    ASSERT(!m_frontChunkOffset);
+    if (m_errorCode)
+        return makeUnexpected(m_errorCode);
 
-    if (errorCode)
-        return nullptr;
-
-    if (m_chunks.isEmpty()) {
-        if (m_ended)
-            atEOF = true;
-        return nullptr;
-    }
-
-    RefPtr<SharedBuffer> chunk = m_chunks.takeFirst();
-    if (m_frontChunkOffset) {
-        chunk = SharedBuffer::create(chunk->span().subspan(m_frontChunkOffset));
-        m_frontChunkOffset = 0;
-    }
-
-    if (m_chunks.isEmpty() && m_ended)
-        atEOF = true;
-
-    return chunk;
+    return std::make_pair(WTF::move(m_chunks), m_ended);
 }
 
 bool PendingStreamState::hasReadyData()

--- a/Source/WebCore/platform/network/PendingStreamState.h
+++ b/Source/WebCore/platform/network/PendingStreamState.h
@@ -62,8 +62,8 @@ public:
     // Data consumer API
     WEBCORE_EXPORT void setDataAvailableHandler(Function<void()>&&);
     WEBCORE_EXPORT void clearDataAvailableHandler();
-    size_t read(std::span<uint8_t> outBuffer, bool& atEOF, int& errorCode);
-    WEBCORE_EXPORT RefPtr<SharedBuffer> takeNextChunk(bool& atEOF, int& errorCode);
+    Expected<std::pair<size_t, bool>, int> readInto(std::span<uint8_t>);
+    WEBCORE_EXPORT Expected<std::pair<Deque<Ref<SharedBuffer>>, bool>, int> takeAvailableChunks();
     bool hasReadyData();
     WEBCORE_EXPORT void cancel();
 

--- a/Source/WebCore/platform/network/cf/FormDataStreamCFNet.mm
+++ b/Source/WebCore/platform/network/cf/FormDataStreamCFNet.mm
@@ -433,21 +433,19 @@ static CFIndex pendingStreamRead(CFReadStreamRef, UInt8* buffer, CFIndex bufferL
         return -1;
     }
 
-    bool pendingAtEOF = false;
-    int pendingError = 0;
     auto output = unsafeMakeSpan(buffer, static_cast<size_t>(bufferLength));
-    size_t bytesCopied = fields->state->read(output, pendingAtEOF, pendingError);
+    auto result = fields->state->readInto(output);
 
-    if (pendingError) {
+    if (!result) {
         error->domain = kCFStreamErrorDomainMacOSStatus;
-        error->error = pendingError;
+        error->error = result.error();
         *atEOF = FALSE;
         return -1;
     }
 
     error->error = 0;
-    *atEOF = pendingAtEOF ? TRUE : FALSE;
-    return static_cast<CFIndex>(bytesCopied);
+    *atEOF = result->second;
+    return static_cast<CFIndex>(result->first);
 }
 
 static Boolean pendingStreamCanRead(CFReadStreamRef, void* context)

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.cpp
@@ -435,27 +435,23 @@ void WebSWServerToContextConnection::pendingStreamDataAvailable(WebCore::FetchId
     if (!state)
         return;
 
-    while (true) {
-        bool atEOF = false;
-        int errorCode = 0;
-        RefPtr chunk = state->takeNextChunk(atEOF, errorCode);
-        if (errorCode) {
-            connection->send(Messages::WebSWContextManagerConnection::ForwardPendingStreamUploadError { fetchIdentifier }, 0);
-            state->clearDataAvailableHandler();
-            m_requestPendingStreamStates.remove(fetchIdentifier);
-            return;
-        }
-        if (chunk)
-            connection->send(Messages::WebSWContextManagerConnection::ForwardPendingStreamUploadData { fetchIdentifier, IPC::SharedBufferReference { *chunk } }, 0);
-        if (atEOF) {
-            connection->send(Messages::WebSWContextManagerConnection::ForwardPendingStreamUploadEnd { fetchIdentifier }, 0);
-            state->clearDataAvailableHandler();
-            m_requestPendingStreamStates.remove(fetchIdentifier);
-            return;
-        }
-        if (!chunk)
-            return;
+    auto result = state->takeAvailableChunks();
+    if (!result) {
+        connection->send(Messages::WebSWContextManagerConnection::ForwardPendingStreamUploadError { fetchIdentifier }, 0);
+        state->clearDataAvailableHandler();
+        m_requestPendingStreamStates.remove(fetchIdentifier);
+        return;
     }
+
+    for (Ref chunk : result->first)
+        connection->send(Messages::WebSWContextManagerConnection::ForwardPendingStreamUploadData { fetchIdentifier, IPC::SharedBufferReference { WTF::move(chunk) } }, 0);
+
+    if (!result->second)
+        return;
+
+    connection->send(Messages::WebSWContextManagerConnection::ForwardPendingStreamUploadEnd { fetchIdentifier }, 0);
+    state->clearDataAvailableHandler();
+    m_requestPendingStreamStates.remove(fetchIdentifier);
 }
 
 void WebSWServerToContextConnection::cancelPendingStreamUploadForwarding(WebCore::FetchIdentifier fetchIdentifier)

--- a/Source/WebKit/WebProcess/Network/WebResourceLoader.cpp
+++ b/Source/WebKit/WebProcess/Network/WebResourceLoader.cpp
@@ -99,26 +99,23 @@ void WebResourceLoader::initPendingStreamState()
             RefPtr protectedThis = weakThis.get();
             if (!protectedThis || !protectedThis->m_pendingStreamState)
                 return;
-            Ref state = *protectedThis->m_pendingStreamState;
-            while (true) {
-                bool atEOF = false;
-                int errorCode = 0;
-                RefPtr chunk = state->takeNextChunk(atEOF, errorCode);
-                if (errorCode) {
-                    protectedThis->send(Messages::NetworkResourceLoader::PendingStreamError { });
-                    protectedThis->m_pendingStreamState = nullptr;
-                    return;
-                }
-                if (chunk)
-                    protectedThis->send(Messages::NetworkResourceLoader::PendingStreamAppendData { IPC::SharedBufferReference(*chunk) });
-                if (atEOF) {
-                    protectedThis->send(Messages::NetworkResourceLoader::PendingStreamEnd { });
-                    protectedThis->m_pendingStreamState = nullptr;
-                    return;
-                }
-                if (!chunk)
-                    return;
+
+            auto result = protect(protectedThis->m_pendingStreamState)->takeAvailableChunks();
+
+            if (!result) {
+                protectedThis->send(Messages::NetworkResourceLoader::PendingStreamError { });
+                protectedThis->m_pendingStreamState = nullptr;
+                return;
             }
+
+            for (Ref chunk : result->first)
+                protectedThis->send(Messages::NetworkResourceLoader::PendingStreamAppendData { IPC::SharedBufferReference(WTF::move(chunk)) });
+
+            if (!result->second)
+                return;
+
+            protectedThis->send(Messages::NetworkResourceLoader::PendingStreamEnd { });
+            protectedThis->m_pendingStreamState = nullptr;
         });
     });
 }


### PR DESCRIPTION
#### e7be28da94629cd1f6d51d59561da29f830718b2
<pre>
Improve ability to get all chunks of PendingStreamState at once
<a href="https://rdar.apple.com/183322787">rdar://183322787</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=320362">https://bugs.webkit.org/show_bug.cgi?id=320362</a>

Reviewed by Chris Dumez.

We were calling takeNextChunk in a while loop and everytime checking for error or end of stream.
We can improve upon this by making a single takeAllChunks method, that will return either the error, or the chunks and whether enf of stream or not.

We apply this and simplify the call sites.
We do the same for the other read method, that we rename readInto.

Covered by existing tests.

* Source/WebCore/Modules/fetch/FormDataConsumer.cpp:
(WebCore::FormDataConsumer::drainPendingStream):
* Source/WebCore/platform/network/PendingStreamState.cpp:
(WebCore::PendingStreamState::takeAvailableChunks):
(WebCore::PendingStreamState::takeNextChunk): Deleted.
(WebCore::PendingStreamState::readInto):
(WebCore::PendingStreamState::read): Deleted.
* Source/WebCore/platform/network/PendingStreamState.h:
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.cpp:
(WebKit::WebSWServerToContextConnection::pendingStreamDataAvailable):
* Source/WebKit/WebProcess/Network/WebResourceLoader.cpp:
(WebKit::WebResourceLoader::initPendingStreamState):
* Source/WebCore/platform/network/cf/FormDataStreamCFNet.mm:
(WebCore::pendingStreamRead):

Canonical link: <a href="https://commits.webkit.org/318150@main">https://commits.webkit.org/318150@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bc2ce38c611a769235d19ff6fa1df57c080a1b3b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177474 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51412 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45206 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187078 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140721 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fb611f1b-e0c8-4e6e-a7ea-7650d8997d54) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179337 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52704 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51121 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138316 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140721 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/88cd5463-28ed-4cf4-b4c6-5c643a69253c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180430 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41822 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/159065 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118781 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a5aa1002-5fa5-4351-9d27-4a553f55bede) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40483 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/38856 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150890 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38562 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35545 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/43197 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/43090 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189506 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51079 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147413 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39598 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51761 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/35190 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147205 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41923 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123976 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118343 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50269 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13540 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49665 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49905 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49727 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->