### PR TITLE
[Win] Build fixes August 27

### DIFF
--- a/Source/JavaScriptCore/heap/Heap.h
+++ b/Source/JavaScriptCore/heap/Heap.h
@@ -930,8 +930,11 @@ private:
     size_t m_indexOfNextLogicallyEmptyWeakBlockToSweep { WTF::notFound };
 
 #if ASSERT_ENABLED
-    friend void setTopGCOwnedDataScopeIfNeeded(const JSCell*, const void*);
-    friend void clearTopGCOwnedDataScopeIfNeeded(const JSCell*, const void*);
+    // JS_EXPORT_PRIVATE matches GCOwnedDataScope.h. Heap.h does not include it, so
+    // whichever declaration a translation unit sees first has to carry the attribute:
+    // adding dllimport in a redeclaration is an error under -Wdll-attribute-on-redeclaration.
+    friend JS_EXPORT_PRIVATE void setTopGCOwnedDataScopeIfNeeded(const JSCell*, const void*);
+    friend JS_EXPORT_PRIVATE void clearTopGCOwnedDataScopeIfNeeded(const JSCell*, const void*);
     const void* m_topGCOwnedDataScope { nullptr };
 #endif
     // Use a SegmentedVector rather than a Vector because we don't want to have to copy in order to grow the buffer.

--- a/Source/ThirdParty/skia/CMakeLists.txt
+++ b/Source/ThirdParty/skia/CMakeLists.txt
@@ -239,6 +239,7 @@ add_library(Skia STATIC
     src/core/SkStream.cpp
     src/core/SkStrike.cpp
     src/core/SkStrikeCache.cpp
+    src/core/SkStrikeRef.cpp
     src/core/SkStrikeSpec.cpp
     src/core/SkString.cpp
     src/core/SkStringUtils.cpp

--- a/Source/WTF/wtf/SegmentedVector.h
+++ b/Source/WTF/wtf/SegmentedVector.h
@@ -293,6 +293,8 @@ namespace WTF {
             T* data() { return m_entries; }
 
         private:
+            friend SegmentedVector;
+
             T m_entries[0];
         };
 
@@ -379,7 +381,18 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
         void allocateSegment()
         {
+#if !OS(WINDOWS)
             static_assert(!sizeof(Segment), "Segment must add no header for (sizeof(T) * segSize) to size the buffer");
+#else
+            // The MSVC ABI rounds a class whose only member is a zero-length array up to
+            // alignof(T) instead of the Itanium ABI's 0 bytes, so sizeof() can't express
+            // "no header" here; the entries' offset can. Segment inherits
+            // non-standard-layout from T, which makes offsetof conditionally-supported,
+            // but m_entries is its only member, so the offset is 0 regardless of T's layout.
+            IGNORE_WARNINGS_BEGIN("invalid-offsetof")
+            static_assert(!offsetof(Segment, m_entries), "Segment must add no header for (sizeof(T) * segSize) to size the buffer");
+            IGNORE_WARNINGS_END
+#endif
             size_t segSize = sizeOfSegment(m_segments.size());
             auto* ptr = Malloc::malloc(sizeof(T) * segSize);
             m_segments.append(SegmentPtr(static_cast<Segment*>(ptr), { }));

--- a/Source/WTF/wtf/win/DbgHelperWin.cpp
+++ b/Source/WTF/wtf/win/DbgHelperWin.cpp
@@ -43,7 +43,7 @@ static void initializeSymbols(HANDLE hProc)
     static std::once_flag onceFlag;
     std::call_once(onceFlag, [&]() {
         if (!SymInitialize(hProc, nullptr, TRUE))
-            LOG_ERROR("Failed to initialze symbol information %d", GetLastError());
+            LOG_ERROR("Failed to initialze symbol information %lu", GetLastError());
     });
 }
 

--- a/Source/WTF/wtf/win/ThreadingWin.cpp
+++ b/Source/WTF/wtf/win/ThreadingWin.cpp
@@ -158,7 +158,7 @@ bool Thread::establishHandle(NewThreadContext& data, StackAllocationSpecificatio
     unsigned initFlag = stackSize ? STACK_SIZE_PARAM_IS_A_RESERVATION : 0;
     HANDLE threadHandle = reinterpret_cast<HANDLE>(_beginthreadex(nullptr, stackSize, wtfThreadEntryPoint, &data, initFlag, &threadIdentifier));
     if (!threadHandle) {
-        LOG_ERROR("Failed to create thread at entry point %p with data %p: %ld", wtfThreadEntryPoint, &data, errno);
+        LOG_ERROR("Failed to create thread at entry point %p with data %p: %d", wtfThreadEntryPoint, &data, errno);
         return false;
     }
     establishPlatformSpecificHandle(threadHandle, threadIdentifier);

--- a/Source/WebCore/platform/network/curl/OpenSSLHelper.cpp
+++ b/Source/WebCore/platform/network/curl/OpenSSLHelper.cpp
@@ -184,6 +184,20 @@ WebCore::CertificateInfo::CertificateChain createCertificateChain(X509_STORE_CTX
     return pemDataFromCtx(StackOfX509(ctx));
 }
 
+#if OS(WINDOWS)
+static String toString(const ASN1_STRING* name)
+{
+    unsigned char* data { nullptr };
+    auto length = ASN1_STRING_to_UTF8(&data, name);
+    if (length <= 0)
+        return String();
+
+    String result({ byteCast<Latin1Character>(data), static_cast<size_t>(length) });
+    OPENSSL_free(data);
+    return result;
+}
+#endif
+
 static String getSubjectEntry(const X509* x509, int nid)
 {
     auto subjectName = X509_get_subject_name(x509);

--- a/Source/cmake/OptionsWin.cmake
+++ b/Source/cmake/OptionsWin.cmake
@@ -110,6 +110,13 @@ WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_WEBDRIVER PRIVATE ON)
 
 # No support planned
 
+# The Swift prototype features default on for any Clang host with a new-enough
+# swiftc, which now includes this port. They can't build here: enabling either
+# makes CMAKE_Swift_COMPILER the swiftc-wrapper.sh bash script, which Windows
+# cannot execute ("%1 is not a valid Win32 application").
+WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_BACK_FORWARD_LIST_SWIFT PRIVATE OFF)
+WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_SWIFT_DEMO_URI_SCHEME PRIVATE OFF)
+
 # WebDriver options
 SET_AND_EXPOSE_TO_BUILD(ENABLE_WEBDRIVER_KEYBOARD_INTERACTIONS ON)
 SET_AND_EXPOSE_TO_BUILD(ENABLE_WEBDRIVER_MOUSE_INTERACTIONS ON)

--- a/Tools/TestRunnerShared/TestFeatures.cpp
+++ b/Tools/TestRunnerShared/TestFeatures.cpp
@@ -330,7 +330,7 @@ static std::optional<TestFeatures> parseTestHeaderString(const std::string& pair
         size_t equalsLocation = pairString.find("=", pairStart);
         if (equalsLocation == std::string::npos) {
             if (!path.empty())
-                LOG_ERROR("Malformed option in test header (could not find '=' character) in %s", path.c_str());
+                LOG_ERROR("Malformed option in test header (could not find '=' character) in %s", path.string().c_str());
             else
                 LOG_ERROR("Malformed option in --additional-header option value (could not find '=' character)");
             break;
@@ -340,7 +340,7 @@ static std::optional<TestFeatures> parseTestHeaderString(const std::string& pair
 
         if (!parseTestHeaderFeature(features, key, value, path, keyTypeMap)) {
             if (!path.empty())
-                LOG_ERROR("Unknown key, '%s', in test header in %s", key.c_str(), path.c_str());
+                LOG_ERROR("Unknown key, '%s', in test header in %s", key.c_str(), path.string().c_str());
             else
                 LOG_ERROR("Unknown key, '%s', in --additional-header option value", key.c_str());
         }
@@ -358,7 +358,7 @@ static TestFeatures parseTestHeader(std::filesystem::path path, const std::unord
 
     std::ifstream file(path);
     if (!file.good()) {
-        LOG_ERROR("Could not open file to inspect test headers in %s", path.c_str());
+        LOG_ERROR("Could not open file to inspect test headers in %s", path.string().c_str());
         return { };
     }
 
@@ -371,7 +371,7 @@ static TestFeatures parseTestHeader(std::filesystem::path path, const std::unord
         return { };
     size_t endLocation = options.find(endString, beginLocation);
     if (endLocation == std::string::npos) {
-        LOG_ERROR("Could not find end of test header in %s", path.c_str());
+        LOG_ERROR("Could not find end of test header in %s", path.string().c_str());
         return { };
     }
     std::string pairString = options.substr(beginLocation + beginString.size(), endLocation - (beginLocation + beginString.size()));


### PR DESCRIPTION
#### f2429bc7943a842d3b066cbb4a63bd8930d9388a
<pre>
[Win] Build fixes August 27
<a href="https://bugs.webkit.org/show_bug.cgi?id=320179">https://bugs.webkit.org/show_bug.cgi?id=320179</a>

Unreviewed build fix.

Fix several independent breakages of the Windows build, found by
building main in the Windows EWS configuration now that its image
includes Swift 6.3.3:

* Source/cmake/OptionsWin.cmake:
Opt out of the Swift prototype features like OptionsIOS.cmake does.
They default on for any Clang host with swiftc &gt;= 6.3, which now
includes the Windows bots, and enabling them makes CMAKE_Swift_COMPILER
the swiftc-wrapper.sh bash script, which Windows cannot execute.

* Source/WTF/wtf/SegmentedVector.h:
(WTF::SegmentedVector::allocateSegment):
static_assert(!sizeof(Segment)) from 317919@main only holds for the
Itanium ABI; MSVC sizes the empty Segment as alignof(T). Keep sizeof()
on non-Windows and check offsetof(Segment, m_entries) on Windows.

* Source/JavaScriptCore/heap/Heap.h:
Add JS_EXPORT_PRIVATE to the friend declarations so GCOwnedDataScope.h
does not add dllimport on a redeclaration, an error under
-Wdll-attribute-on-redeclaration.

* Source/ThirdParty/skia/CMakeLists.txt:
Add src/core/SkStrikeRef.cpp, new in the 2026-06-18 Skia update but
missing from the source list, leaving its constructor undefined.

* Source/WebCore/platform/network/curl/OpenSSLHelper.cpp:
(OpenSSL::toString):
Restore toString(), removed by 315672@main as unused; Windows needs it
for getSubjectEntry() and getSubjectAltName(). OS(WINDOWS)-guarded
because the PlayStation port builds without it and fails
-Wunused-function with it present.

* Source/WTF/wtf/win/DbgHelperWin.cpp:
* Source/WTF/wtf/win/ThreadingWin.cpp:
* Tools/TestRunnerShared/TestFeatures.cpp:
Fix -Wformat errors, fatal since LOG_ERROR gained WTF_ATTRIBUTE_PRINTF:
GetLastError() is a DWORD, errno is an int, and
std::filesystem::path::c_str() is wchar_t* on Windows.

Canonical link: <a href="https://commits.webkit.org/318030@main">https://commits.webkit.org/318030@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0a0d48aad429ac3df86ad00ff1ec9358c1b57ec8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176970 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50907 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44702 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186573 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140206 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178833 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52200 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50593 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137892 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140206 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179926 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41405 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158684 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118361 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40061 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38422 "Passed tests") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/251/builds/330 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/7189 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150471 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38184 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35041 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/38241 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42660 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42640 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188996 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50574 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146960 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51257 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34808 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146757 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26861 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41527 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123470 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117758 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49762 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13164 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49161 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49398 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49222 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->