### PR TITLE
REGRESSION(316238@main): YouTube captions become infinitely tall in iPhone fullscreen

### DIFF
--- a/Source/WebCore/Modules/modern-media-controls/media/YouTubeCaptionQuirk.js
+++ b/Source/WebCore/Modules/modern-media-controls/media/YouTubeCaptionQuirk.js
@@ -173,14 +173,14 @@
             if (this._getIsInline()) {
                 this._mirrorTrack.mode = 'hidden';
                 if (captionContainer)
-                    captionContainer.style.removeProperty('display');
+                    captionContainer.style.removeProperty('visibility');
                 return;
             }
 
             this._player.loadModule('captions');
             this._mirrorTrack.mode = 'showing';
             if (captionContainer)
-                captionContainer.style.setProperty('display', 'none', 'important');
+                captionContainer.style.setProperty('visibility', 'hidden', 'important');
         }
 
         _handleMediaSessionAction(details) {


### PR DESCRIPTION
#### f67b7993605d66a0198231ba0de8a056bdf1ed9d
<pre>
REGRESSION(316238@main): YouTube captions become infinitely tall in iPhone fullscreen
<a href="https://rdar.apple.com/182808868">rdar://182808868</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=320374">https://bugs.webkit.org/show_bug.cgi?id=320374</a>

Reviewed by Simon Fraser.

In 316238@main, in order to work around an issue where both YouTube&apos;s custom-rendered
subtitles and quirk-derived system subtitles were displayed simultanously, YouTube&apos;s
own subtitle divs were hidden with `display:none`. However this broke their ability to
detect that subtitles have grown too tall inside the video viewport, and they fail to
remove those generated subtitles when adding new ones.

Switch from `display:none` to `visibility:hidden` so that size detection works the way
YouTube expects, even though the subtitles are not displayed.

* Source/WebCore/Modules/modern-media-controls/media/YouTubeCaptionQuirk.js:
(CaptionMirror.prototype._handlePresentationModeChanged):

Canonical link: <a href="https://commits.webkit.org/317999@main">https://commits.webkit.org/317999@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bffcf6edf2df47ecab21b71081f4f64f767a9bb6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176976 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50913 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44708 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186579 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140212 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7a7ccc75-673c-4752-96d0-58bec9d7873a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178839 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52206 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50599 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137888 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140212 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179932 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41399 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158677 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118357 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/436fd25f-3758-44ae-a1db-d94483b4f725) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40055 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38421 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150465 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38177 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35047 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42666 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/42639 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189002 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50580 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146969 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39509 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51263 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/34801 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146765 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41522 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123476 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117764 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49768 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13157 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49167 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49404 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49228 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->