### PR TITLE
[GFC][LayoutIntegrationUtils] Clarify intent of integration helper functions.

### DIFF
--- a/Source/WebCore/layout/LayoutState.cpp
+++ b/Source/WebCore/layout/LayoutState.cpp
@@ -152,9 +152,9 @@ void LayoutState::destroyBlockFormattingState(const ElementBox& formattingContex
     m_blockFormattingStates.remove(formattingContextRoot);
 }
 
-void LayoutState::layoutWithFormattingContextForBox(const ElementBox& box, std::optional<LayoutUnit> widthConstraint, std::optional<LayoutUnit> heightConstraint) const
+void LayoutState::layoutWithFormattingContextForBox(const ElementBox& box, std::optional<LayoutUnit> overridingBorderBoxLogicalWidth, std::optional<LayoutUnit> overridingBorderBoxLogicalHeight) const
 {
-    const_cast<LayoutState&>(*this).m_formattingContextLayoutFunction(box, widthConstraint, heightConstraint, const_cast<LayoutState&>(*this));
+    const_cast<LayoutState&>(*this).m_formattingContextLayoutFunction(box, overridingBorderBoxLogicalWidth, overridingBorderBoxLogicalHeight, const_cast<LayoutState&>(*this));
 }
 
 LayoutUnit LayoutState::logicalWidthWithFormattingContextForBox(const ElementBox& box, LayoutIntegration::LogicalWidthType logicalWidthType) const

--- a/Source/WebCore/layout/LayoutState.h
+++ b/Source/WebCore/layout/LayoutState.h
@@ -104,9 +104,9 @@ public:
 
     const ElementBox& root() const { return m_rootContainer; }
 
-    // A height constraint is primarily given by Grid Formatting Contexts since it is able to determine
+    // An overridingBorderBoxLogicalHeight is primarily given by Grid Formatting Contexts since it is able to determine
     // one for grid items in many cases which drives the use of setOverridingBorderBoxLogicalHeight.
-    void layoutWithFormattingContextForBox(const ElementBox&, std::optional<LayoutUnit> widthConstraint, std::optional<LayoutUnit> heightConstraint) const;
+    void layoutWithFormattingContextForBox(const ElementBox&, std::optional<LayoutUnit> overridingBorderBoxLogicalWidth, std::optional<LayoutUnit> overridingBorderBoxLogicalHeight) const;
     LayoutUnit logicalWidthWithFormattingContextForBox(const ElementBox&, LayoutIntegration::LogicalWidthType) const;
     LayoutUnit logicalHeightWithFormattingContextForBox(const ElementBox&, LayoutIntegration::LogicalHeightType) const;
     void layoutWithFormattingContextForBlockInInline(const Layout::ElementBox& block, LayoutPoint blockLineLogicalTopLeft, const InlineLayoutState&) const;

--- a/Source/WebCore/layout/integration/LayoutIntegrationFormattingContextLayout.cpp
+++ b/Source/WebCore/layout/integration/LayoutIntegrationFormattingContextLayout.cpp
@@ -52,39 +52,45 @@ static inline const Layout::ElementBox& rootLayoutBox(const Layout::ElementBox& 
     return *ancestor;
 }
 
-// FIXME: Rename widthConstraint/heightConstraint to borderBoxLogicalWidth/borderBoxLogicalHeight; they are an
-// overriding border-box size to lay the box out at, not a constraint.
-static void layoutBoxWithOverridingBorderBoxSize(RenderBox& renderer, std::optional<LayoutUnit> widthConstraint, std::optional<LayoutUnit> heightConstraint)
+static void layoutRendererWithOverridingBorderBoxSize(RenderBox& renderer, std::optional<LayoutUnit> overridingBorderBoxLogicalWidth, std::optional<LayoutUnit> overridingBorderBoxLogicalHeight)
 {
-    if (widthConstraint) {
-        renderer.setOverridingBorderBoxLogicalWidth(*widthConstraint);
+    if (overridingBorderBoxLogicalWidth) {
+        renderer.setOverridingBorderBoxLogicalWidth(*overridingBorderBoxLogicalWidth);
         renderer.setNeedsLayout(MarkingBehavior::MarkOnlyThis);
     }
 
-    if (heightConstraint) {
-        renderer.setOverridingBorderBoxLogicalHeight(*heightConstraint);
+    if (overridingBorderBoxLogicalHeight) {
+        renderer.setOverridingBorderBoxLogicalHeight(*overridingBorderBoxLogicalHeight);
         renderer.setNeedsLayout(MarkingBehavior::MarkOnlyThis);
     }
 
     renderer.layoutIfNeeded();
 
-    if (widthConstraint)
+    if (overridingBorderBoxLogicalWidth)
         renderer.clearOverridingBorderBoxLogicalWidth();
 
-    if (heightConstraint)
+    if (overridingBorderBoxLogicalHeight)
         renderer.clearOverridingBorderBoxLogicalHeight();
 }
 
-void layoutWithFormattingContextForBox(const Layout::ElementBox& box, std::optional<LayoutUnit> widthConstraint, std::optional<LayoutUnit> heightConstraint, Layout::LayoutState& layoutState)
+// Lay the renderer out at the given overriding border-box size, then feed the result back into modern
+// layout's BoxGeometry. containingBlockInlineSize is the inline size positions resolve against.
+static void layoutRendererAndUpdateBoxGeometry(const Layout::ElementBox& box, RenderBox& renderer, std::optional<LayoutUnit> overridingBorderBoxLogicalWidth, std::optional<LayoutUnit> overridingBorderBoxLogicalHeight, LayoutUnit containingBlockInlineSize, Layout::LayoutState& layoutState)
 {
-    CheckedRef renderer = downcast<RenderBox>(*box.rendererForIntegration());
-    layoutBoxWithOverridingBorderBoxSize(renderer.get(), widthConstraint, heightConstraint);
+    layoutRendererWithOverridingBorderBoxSize(renderer, overridingBorderBoxLogicalWidth, overridingBorderBoxLogicalHeight);
 
     auto updater = BoxGeometryUpdater { layoutState, rootLayoutBox(box) };
-    updater.updateBoxGeometryAfterIntegrationLayout(box, widthConstraint.value_or(renderer->containingBlock()->contentBoxLogicalWidth()));
+    updater.updateBoxGeometryAfterIntegrationLayout(box, containingBlockInlineSize);
 }
 
-void layoutGridItemWithFormattingContext(const Layout::ElementBox& box, std::optional<LayoutUnit> widthConstraint, std::optional<LayoutUnit> heightConstraint, LayoutUnit gridAreaInlineSize, Layout::LayoutState& layoutState)
+void layoutWithFormattingContextForBox(const Layout::ElementBox& box, std::optional<LayoutUnit> overridingBorderBoxLogicalWidth, std::optional<LayoutUnit> overridingBorderBoxLogicalHeight, Layout::LayoutState& layoutState)
+{
+    CheckedRef renderer = downcast<RenderBox>(*box.rendererForIntegration());
+    auto containingBlockInlineSize = overridingBorderBoxLogicalWidth.value_or(renderer->containingBlock()->contentBoxLogicalWidth());
+    layoutRendererAndUpdateBoxGeometry(box, renderer.get(), overridingBorderBoxLogicalWidth, overridingBorderBoxLogicalHeight, containingBlockInlineSize, layoutState);
+}
+
+void layoutGridItemWithFormattingContext(const Layout::ElementBox& box, std::optional<LayoutUnit> overridingBorderBoxLogicalWidth, std::optional<LayoutUnit> overridingBorderBoxLogicalHeight, LayoutUnit gridAreaInlineSize, Layout::LayoutState& layoutState)
 {
     ASSERT(box.isGridItem());
     CheckedRef renderer = downcast<RenderBox>(*box.rendererForIntegration());
@@ -93,12 +99,7 @@ void layoutGridItemWithFormattingContext(const Layout::ElementBox& box, std::opt
     // descendants resolve percentage/calc sizes against it during layout, and resolve the item's own geometry
     // against it below rather than against the grid container's content box.
     renderer->setGridAreaContentLogicalWidth(gridAreaInlineSize);
-
-    layoutBoxWithOverridingBorderBoxSize(renderer.get(), widthConstraint, heightConstraint);
-
-    auto updater = BoxGeometryUpdater { layoutState, rootLayoutBox(box) };
-    updater.updateBoxGeometryAfterIntegrationLayout(box, gridAreaInlineSize);
-
+    layoutRendererAndUpdateBoxGeometry(box, renderer.get(), overridingBorderBoxLogicalWidth, overridingBorderBoxLogicalHeight, gridAreaInlineSize, layoutState);
     renderer->clearGridAreaContentSize();
 }
 

--- a/Source/WebCore/layout/integration/LayoutIntegrationFormattingContextLayout.h
+++ b/Source/WebCore/layout/integration/LayoutIntegrationFormattingContextLayout.h
@@ -40,8 +40,8 @@ class LayoutState;
 
 namespace LayoutIntegration {
 
-void layoutWithFormattingContextForBox(const Layout::ElementBox&, std::optional<LayoutUnit> widthConstraint, std::optional<LayoutUnit> heightConstraint, Layout::LayoutState&);
-void layoutGridItemWithFormattingContext(const Layout::ElementBox&, std::optional<LayoutUnit> widthConstraint, std::optional<LayoutUnit> heightConstraint, LayoutUnit gridAreaInlineSize, Layout::LayoutState&);
+void layoutWithFormattingContextForBox(const Layout::ElementBox&, std::optional<LayoutUnit> overridingBorderBoxLogicalWidth, std::optional<LayoutUnit> overridingBorderBoxLogicalHeight, Layout::LayoutState&);
+void layoutGridItemWithFormattingContext(const Layout::ElementBox&, std::optional<LayoutUnit> overridingBorderBoxLogicalWidth, std::optional<LayoutUnit> overridingBorderBoxLogicalHeight, LayoutUnit gridAreaInlineSize, Layout::LayoutState&);
 
 enum class LogicalWidthType : uint8_t  {
     MaxContentContribution,

--- a/Source/WebCore/layout/integration/LayoutIntegrationUtils.cpp
+++ b/Source/WebCore/layout/integration/LayoutIntegrationUtils.cpp
@@ -60,9 +60,9 @@ IntegrationUtils::IntegrationUtils(const LayoutState& globalLayoutState)
 {
 }
 
-void IntegrationUtils::layoutWithFormattingContextForBox(const ElementBox& box, std::optional<LayoutUnit> widthConstraint, std::optional<LayoutUnit> heightConstraint) const
+void IntegrationUtils::layoutWithFormattingContextForBox(const ElementBox& box, std::optional<LayoutUnit> overridingBorderBoxLogicalWidth, std::optional<LayoutUnit> overridingBorderBoxLogicalHeight) const
 {
-    m_globalLayoutState->layoutWithFormattingContextForBox(box, widthConstraint, heightConstraint);
+    m_globalLayoutState->layoutWithFormattingContextForBox(box, overridingBorderBoxLogicalWidth, overridingBorderBoxLogicalHeight);
 }
 
 std::pair<LayoutUnit, LayoutUnit> IntegrationUtils::borderAndPaddingForGridItem(const ElementBox& box, LayoutUnit gridAreaInlineSize) const
@@ -78,10 +78,10 @@ std::pair<LayoutUnit, LayoutUnit> IntegrationUtils::borderAndPaddingForGridItem(
     return { inlineBorderAndPadding, blockBorderAndPadding };
 }
 
-void IntegrationUtils::layoutGridItem(const ElementBox& box, std::optional<LayoutUnit> widthConstraint, std::optional<LayoutUnit> heightConstraint, LayoutUnit gridAreaInlineSize) const
+void IntegrationUtils::layoutGridItem(const ElementBox& box, std::optional<LayoutUnit> overridingBorderBoxLogicalWidth, std::optional<LayoutUnit> overridingBorderBoxLogicalHeight, LayoutUnit gridAreaInlineSize) const
 {
     ASSERT(box.isGridItem());
-    LayoutIntegration::layoutGridItemWithFormattingContext(box, widthConstraint, heightConstraint, gridAreaInlineSize, const_cast<LayoutState&>(m_globalLayoutState.get()));
+    LayoutIntegration::layoutGridItemWithFormattingContext(box, overridingBorderBoxLogicalWidth, overridingBorderBoxLogicalHeight, gridAreaInlineSize, const_cast<LayoutState&>(m_globalLayoutState.get()));
 }
 
 LayoutUnit IntegrationUtils::maxContentWidth(const ElementBox& box) const

--- a/Source/WebCore/layout/integration/LayoutIntegrationUtils.h
+++ b/Source/WebCore/layout/integration/LayoutIntegrationUtils.h
@@ -44,9 +44,9 @@ class IntegrationUtils {
 public:
     IntegrationUtils(const LayoutState&);
 
-    void layoutWithFormattingContextForBox(const ElementBox&, std::optional<LayoutUnit> widthConstraint = { }, std::optional<LayoutUnit> heightConstraint = { }) const;
+    void layoutWithFormattingContextForBox(const ElementBox&, std::optional<LayoutUnit> overridingBorderBoxLogicalWidth = { }, std::optional<LayoutUnit> overridingBorderBoxLogicalHeight = { }) const;
     std::pair<LayoutUnit, LayoutUnit> borderAndPaddingForGridItem(const ElementBox&, LayoutUnit gridAreaInlineSize) const;
-    void layoutGridItem(const ElementBox&, std::optional<LayoutUnit> widthConstraint, std::optional<LayoutUnit> heightConstraint, LayoutUnit gridAreaInlineSize) const;
+    void layoutGridItem(const ElementBox&, std::optional<LayoutUnit> overridingBorderBoxLogicalWidth, std::optional<LayoutUnit> overridingBorderBoxLogicalHeight, LayoutUnit gridAreaInlineSize) const;
     LayoutUnit maxContentWidth(const ElementBox&) const;
     LayoutUnit maxContentWidthForGridItem(const ElementBox&, LayoutUnit gridAreaInlineSize) const;
     LayoutUnit minContentWidth(const ElementBox&) const;


### PR DESCRIPTION
#### 2fe096a108bcb780001c4b882807bbe42021e27d
<pre>
[GFC][LayoutIntegrationUtils] Clarify intent of integration helper functions.
<a href="https://bugs.webkit.org/show_bug.cgi?id=320259">https://bugs.webkit.org/show_bug.cgi?id=320259</a>
&lt;<a href="https://rdar.apple.com/183165448">rdar://183165448</a>&gt;

Reviewed by Alan Baradlay.

This PR renames widthConstraint/heightConstraint to overridingBorderBoxLogicalWidth/Height
across *FC to better represent what they do.

This PR also renames the misnamed static layoutBoxWithOverridingBorderBoxSize()
to layoutRendererWithOverridingBorderBoxSize(), since it operates on a RenderBox
rather than a Layout::Box. This also cleans up the shared code for two layout entry
points into a new layoutRendererAndUpdateBoxGeometry() helper.

No behavior change.

* Source/WebCore/layout/LayoutState.cpp:
(WebCore::Layout::LayoutState::layoutWithFormattingContextForBox const):
* Source/WebCore/layout/LayoutState.h:
* Source/WebCore/layout/integration/LayoutIntegrationFormattingContextLayout.cpp:
(WebCore::LayoutIntegration::layoutRendererWithOverridingBorderBoxSize):
(WebCore::LayoutIntegration::layoutRendererAndUpdateBoxGeometry):
(WebCore::LayoutIntegration::layoutWithFormattingContextForBox):
(WebCore::LayoutIntegration::layoutGridItemWithFormattingContext):
(WebCore::LayoutIntegration::layoutBoxWithOverridingBorderBoxSize): Deleted.
* Source/WebCore/layout/integration/LayoutIntegrationFormattingContextLayout.h:
* Source/WebCore/layout/integration/LayoutIntegrationUtils.cpp:
(WebCore::Layout::IntegrationUtils::layoutWithFormattingContextForBox const):
(WebCore::Layout::IntegrationUtils::layoutGridItem const):
* Source/WebCore/layout/integration/LayoutIntegrationUtils.h:
(WebCore::Layout::IntegrationUtils::layoutWithFormattingContextForBox):

Canonical link: <a href="https://commits.webkit.org/318206@main">https://commits.webkit.org/318206@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cdbc4e1558238645d8f3a40ed16e1911dfe3a731

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177054 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50991 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44786 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186657 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140290 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6f71baa2-4392-4090-a0a7-cbfa4d38a47b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178917 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52284 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50677 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137954 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140290 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180010 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41457 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158727 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118423 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/030c1a49-05e6-473f-b7bf-d2bfec0fba13) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40113 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38485 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150523 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38227 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35125 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42765 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42703 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189081 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50658 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147036 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51341 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34851 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146827 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26940 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41574 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123555 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117842 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49846 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13207 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49245 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49482 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49306 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->