### PR TITLE
[GFC] Apply a grid item's negative line offset when constructing UnplacedGridItem

### DIFF
--- a/Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.cpp
@@ -60,15 +60,30 @@ UnplacedGridItems GridFormattingContext::constructUnplacedGridItems() const
         int order;
     };
 
+    int minimumColumnLine = 0;
+    int minimumRowLine = 0;
     Vector<GridItem> gridItems;
     for (CheckedRef gridItem : childrenOfType<ElementBox>(m_gridBox)) {
         if (gridItem->isOutOfFlowPositioned())
             continue;
 
-        gridItems.append({ gridItem, gridItem->style().order().value });
+        CheckedRef gridItemStyle = gridItem->style();
+        if (auto columnRange = UnplacedGridItem::resolveDefinitePosition(gridItemStyle->gridItemColumnStart(), gridItemStyle->gridItemColumnEnd())) {
+            auto [startLine, endLine] = *columnRange;
+            minimumColumnLine = std::min({ minimumColumnLine, startLine, endLine });
+        }
+        if (auto rowRange = UnplacedGridItem::resolveDefinitePosition(gridItemStyle->gridItemRowStart(), gridItemStyle->gridItemRowEnd())) {
+            auto [startLine, endLine] = *rowRange;
+            minimumRowLine = std::min({ minimumRowLine, startLine, endLine });
+        }
+
+        gridItems.append({ gridItem, gridItemStyle->order().value });
     }
 
     std::ranges::stable_sort(gridItems, { }, &GridItem::order);
+
+    size_t columnNegativeLineOffset = minimumColumnLine < 0 ? static_cast<size_t>(-minimumColumnLine) : 0;
+    size_t rowNegativeLineOffset = minimumRowLine < 0 ? static_cast<size_t>(-minimumRowLine) : 0;
 
     UnplacedGridItems unplacedGridItems;
     for (auto& gridItem : gridItems) {
@@ -84,7 +99,9 @@ UnplacedGridItems GridFormattingContext::constructUnplacedGridItems() const
             gridItemColumnStart,
             gridItemColumnEnd,
             gridItemRowStart,
-            gridItemRowEnd
+            gridItemRowEnd,
+            columnNegativeLineOffset,
+            rowNegativeLineOffset
         };
 
         // https://drafts.csswg.org/css-grid-1/#auto-placement-algo

--- a/Source/WebCore/layout/formattingContexts/grid/GridLayout.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayout.cpp
@@ -63,26 +63,18 @@ GridLayout::GridLayout(const GridFormattingContext& gridFormattingContext)
 
 GridDimensions GridLayout::calculateInitialImplicitGridDimensions(const UnplacedGridItems& unplacedGridItems, size_t explicitColumnsCount, size_t explicitRowsCount)
 {
-    int minimumRowIndex = 0;
-    int minimumColumnIndex = 0;
-    int maximumRowIndex = static_cast<int>(explicitRowsCount);
-    int maximumColumnIndex = static_cast<int>(explicitColumnsCount);
+    size_t maximumColumnIndex = explicitColumnsCount;
+    size_t maximumRowIndex = explicitRowsCount;
 
     auto updateGridBounds = [&](const UnplacedGridItem& item) {
         if (item.hasDefiniteRowPosition()) {
             auto [rowStart, rowEnd] = item.definiteRowStartEnd();
-            minimumRowIndex = std::min(minimumRowIndex, rowStart);
-            minimumRowIndex = std::min(minimumRowIndex, rowEnd);
-            maximumRowIndex = std::max(maximumRowIndex, rowStart);
-            maximumRowIndex = std::max(maximumRowIndex, rowEnd);
+            maximumRowIndex = std::max({ maximumRowIndex, rowStart, rowEnd });
         }
 
         if (item.hasDefiniteColumnPosition()) {
             auto [columnStart, columnEnd] = item.definiteColumnStartEnd();
-            minimumColumnIndex = std::min(minimumColumnIndex, columnStart);
-            minimumColumnIndex = std::min(minimumColumnIndex, columnEnd);
-            maximumColumnIndex = std::max(maximumColumnIndex, columnStart);
-            maximumColumnIndex = std::max(maximumColumnIndex, columnEnd);
+            maximumColumnIndex = std::max({ maximumColumnIndex, columnStart, columnEnd });
         }
     };
 
@@ -91,30 +83,16 @@ GridDimensions GridLayout::calculateInitialImplicitGridDimensions(const Unplaced
     for (const auto& item : unplacedGridItems.definiteRowPositionedItems)
         updateGridBounds(item);
 
-    size_t rowOffset = minimumRowIndex < 0 ? static_cast<size_t>(-minimumRowIndex) : 0;
-    size_t columnOffset = minimumColumnIndex < 0 ? static_cast<size_t>(-minimumColumnIndex) : 0;
-
     return {
-        rowOffset,
-        columnOffset,
-        static_cast<size_t>(maximumColumnIndex) + columnOffset,
-        static_cast<size_t>(maximumRowIndex) + rowOffset
+        maximumColumnIndex,
+        maximumRowIndex
     };
 }
 
-ImplicitGrid GridLayout::constructInitialImplicitGrid(UnplacedGridItems& unplacedGridItems, size_t explicitColumnsCount, size_t explicitRowsCount)
+ImplicitGrid GridLayout::constructInitialImplicitGrid(const UnplacedGridItems& unplacedGridItems, size_t explicitColumnsCount, size_t explicitRowsCount)
 {
-    // Calculate grid dimensions (offsets and total size) for negative grid line positions
     auto initialDimensions = calculateInitialImplicitGridDimensions(
         unplacedGridItems, explicitColumnsCount, explicitRowsCount);
-
-    // Normalize all grid item positions by applying the offsets
-    for (auto& item : unplacedGridItems.nonAutoPositionedItems)
-        item.applyGridOffsets(initialDimensions.rowOffset, initialDimensions.columnOffset);
-    for (auto& item : unplacedGridItems.definiteRowPositionedItems)
-        item.applyGridOffsets(initialDimensions.rowOffset, initialDimensions.columnOffset);
-    for (auto& item : unplacedGridItems.autoPositionedItems)
-        item.applyGridOffsets(initialDimensions.rowOffset, initialDimensions.columnOffset);
 
     ImplicitGrid implicitGrid(initialDimensions.totalColumns, initialDimensions.totalRows);
     // 3. Determine the columns in the implicit grid.

--- a/Source/WebCore/layout/formattingContexts/grid/GridLayout.h
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayout.h
@@ -47,8 +47,6 @@ struct GridLayoutState;
 struct UsedMargins;
 
 struct GridDimensions {
-    size_t rowOffset { 0 };
-    size_t columnOffset { 0 };
     size_t totalColumns { 0 };
     size_t totalRows { 0 };
 };
@@ -74,8 +72,8 @@ private:
     auto placeGridItems(UnplacedGridItems&, const Vector<Style::GridTrackSize>& gridTemplateColumnsTrackSizes,
         const Vector<Style::GridTrackSize>& gridTemplateRowsTrackSizes, GridAutoFlowOptions);
 
-    GridDimensions calculateInitialImplicitGridDimensions(const UnplacedGridItems&, size_t explicitColumnsCount, size_t explicitRowsCount);
-    ImplicitGrid constructInitialImplicitGrid(UnplacedGridItems&, size_t explicitColumnsCount, size_t explicitRowsCount);
+    static GridDimensions calculateInitialImplicitGridDimensions(const UnplacedGridItems&, size_t explicitColumnsCount, size_t explicitRowsCount);
+    ImplicitGrid constructInitialImplicitGrid(const UnplacedGridItems&, size_t explicitColumnsCount, size_t explicitRowsCount);
 
     static TrackSizingFunctions convertGridTrackSizeToTrackSizingFunctions(const Style::GridTrackSize&, const Style::ZoomFactor&);
     static TrackSizingFunctionsList generateImplicitTrackSizingFunctions(size_t explicitTracksCount, size_t totalTracksCount, const Style::GridTrackSizes& gridAutoTrackSizes, const Style::ZoomFactor&);

--- a/Source/WebCore/layout/formattingContexts/grid/ImplicitGrid.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/ImplicitGrid.cpp
@@ -51,9 +51,8 @@ ImplicitGrid::ImplicitGrid(size_t totalColumnsCount, size_t totalRowsCount)
 void ImplicitGrid::insertUnplacedGridItem(const UnplacedGridItem& unplacedGridItem)
 {
     // https://drafts.csswg.org/css-grid/#common-uses-numeric
-    // Grid positions have already been normalized to non-negative matrix indices.
-    auto [columnStart, columnEnd] = unplacedGridItem.normalizedColumnStartEnd();
-    auto [rowStart, rowEnd] = unplacedGridItem.normalizedRowStartEnd();
+    auto [columnStart, columnEnd] = unplacedGridItem.definiteColumnStartEnd();
+    auto [rowStart, rowEnd] = unplacedGridItem.definiteRowStartEnd();
 
     // Multi-cell items (spanning multiple columns) are not yet supported.
     if (columnEnd - columnStart > 1) {
@@ -106,25 +105,25 @@ void ImplicitGrid::insertDefiniteRowItem(const UnplacedGridItem& unplacedGridIte
     ASSERT(columnSpan == 1);
 
     ASSERT(unplacedGridItem.hasDefiniteRowPosition() && !unplacedGridItem.hasDefiniteColumnPosition());
-    auto [normalizedRowStart, normalizedRowEnd] = unplacedGridItem.normalizedRowStartEnd();
+    auto [rowStart, rowEnd] = unplacedGridItem.definiteRowStartEnd();
     // FIXME: Support multi-row spans
-    ASSERT(normalizedRowEnd - normalizedRowStart == 1);
+    ASSERT(rowEnd - rowStart == 1);
 
-    std::optional<size_t> columnPosition = findColumnPositionForDefiniteRowItem(normalizedRowStart, normalizedRowEnd, columnSpan, autoFlowOptions);
+    std::optional<size_t> columnPosition = findColumnPositionForDefiniteRowItem(rowStart, rowEnd, columnSpan, autoFlowOptions);
 
     if (!columnPosition) {
-        growGridColumnsToFit(columnSpan, normalizedRowStart, normalizedRowEnd);
+        growGridColumnsToFit(columnSpan, rowStart, rowEnd);
 
         // Retry finding position in the grown grid
-        columnPosition = findColumnPositionForDefiniteRowItem(normalizedRowStart, normalizedRowEnd, columnSpan, autoFlowOptions);
+        columnPosition = findColumnPositionForDefiniteRowItem(rowStart, rowEnd, columnSpan, autoFlowOptions);
         ASSERT(columnPosition);
-        ASSERT(isCellRangeEmpty(*columnPosition, *columnPosition + columnSpan, normalizedRowStart, normalizedRowEnd));
+        ASSERT(isCellRangeEmpty(*columnPosition, *columnPosition + columnSpan, rowStart, rowEnd));
     }
 
-    insertItemInArea(unplacedGridItem, *columnPosition, *columnPosition + columnSpan, normalizedRowStart, normalizedRowEnd);
+    insertItemInArea(unplacedGridItem, *columnPosition, *columnPosition + columnSpan, rowStart, rowEnd);
 
     if (autoFlowOptions.strategy != PackingStrategy::Dense) {
-        for (size_t row = normalizedRowStart; row < normalizedRowEnd; ++row)
+        for (size_t row = rowStart; row < rowEnd; ++row)
             m_rowCursors.set(row, *columnPosition + columnSpan);
     }
 }
@@ -139,7 +138,7 @@ void ImplicitGrid::determineImplicitGridColumns(const Vector<UnplacedGridItem>& 
     // of the implicit grid as necessary to accommodate those items."
     for (const auto& item : autoPositionedItems) {
         if (item.hasDefiniteColumnPosition()) {
-            auto [columnStart, columnEnd] = item.normalizedColumnStartEnd();
+            auto [columnStart, columnEnd] = item.definiteColumnStartEnd();
             requiredColumns = std::max(requiredColumns, columnEnd);
         }
     }
@@ -195,28 +194,28 @@ std::optional<size_t> ImplicitGrid::findFirstAvailableColumnPosition(size_t rowS
     // If we are unable to find a valid position, signal that we need to grow the grid.
     return std::nullopt;
 }
-std::optional<size_t> ImplicitGrid::findColumnPositionForDefiniteRowItem(size_t normalizedRowStart, size_t normalizedRowEnd, size_t columnSpan, GridAutoFlowOptions autoFlowOptions) const
+std::optional<size_t> ImplicitGrid::findColumnPositionForDefiniteRowItem(size_t rowStart, size_t rowEnd, size_t columnSpan, GridAutoFlowOptions autoFlowOptions) const
 {
     if (autoFlowOptions.strategy == PackingStrategy::Dense) {
         // Dense packing: always start searching from column 0
-        return findFirstAvailableColumnPosition(normalizedRowStart, normalizedRowEnd, columnSpan, 0);
+        return findFirstAvailableColumnPosition(rowStart, rowEnd, columnSpan, 0);
     }
     // Sparse packing: use per-row cursors to maintain placement order
     // For multi-row items, use the maximum cursor position across all spanned rows
     ASSERT(autoFlowOptions.strategy == PackingStrategy::Sparse);
     size_t startSearchColumn = 0;
-    for (size_t row = normalizedRowStart; row < normalizedRowEnd; ++row)
+    for (size_t row = rowStart; row < rowEnd; ++row)
         startSearchColumn = std::max(startSearchColumn, m_rowCursors.get(row));
-    return findFirstAvailableColumnPosition(normalizedRowStart, normalizedRowEnd, columnSpan, startSearchColumn);
+    return findFirstAvailableColumnPosition(rowStart, rowEnd, columnSpan, startSearchColumn);
 }
 
-void ImplicitGrid::growGridColumnsToFit(size_t columnSpan, size_t normalizedRowStart, size_t normalizedRowEnd)
+void ImplicitGrid::growGridColumnsToFit(size_t columnSpan, size_t rowStart, size_t rowEnd)
 {
     auto currentColumnsCount = columnsCount();
 
     // Find the last occupied column in the spanned rows
     size_t lastOccupiedColumn = 0;
-    for (size_t row = normalizedRowStart; row < normalizedRowEnd; ++row) {
+    for (size_t row = rowStart; row < rowEnd; ++row) {
         for (size_t column = currentColumnsCount; column > 0; --column) {
             if (!m_gridMatrix[row][column - 1].isEmpty()) {
                 lastOccupiedColumn = std::max(lastOccupiedColumn, column - 1);
@@ -271,7 +270,7 @@ void ImplicitGrid::placeAutoPositionedItemWithDefiniteColumn(const UnplacedGridI
 
     // Items with definite column position and auto row position
     // Search vertically down the specified column.
-    auto [normalizedColumnStart, normalizedColumnEnd] = item.normalizedColumnStartEnd();
+    auto [columnStart, columnEnd] = item.definiteColumnStartEnd();
     auto rowSpan = item.rowSpanSize();
 
     if (autoFlowOptions.strategy == PackingStrategy::Dense) {
@@ -280,21 +279,21 @@ void ImplicitGrid::placeAutoPositionedItemWithDefiniteColumn(const UnplacedGridI
     } else {
         // Sparse packing: Check if we would be going backwards (to earlier column)
         // If so, advance the row count to avoid backtracking.
-        if (normalizedColumnStart < m_autoPlacementCursorColumn)
+        if (columnStart < m_autoPlacementCursorColumn)
             ++m_autoPlacementCursorRow;
     }
 
     // "Set the column position of the cursor to the grid item's column-start line."
-    m_autoPlacementCursorColumn = normalizedColumnStart;
+    m_autoPlacementCursorColumn = columnStart;
 
     // Increment the cursor's row position until a value is found where the grid item
     // does not overlap any occupied grid cells (creating new rows in the implicit grid as necessary).
     while (true) {
         growRowsToFit(m_autoPlacementCursorRow + rowSpan - 1);
 
-        if (isCellRangeEmpty(normalizedColumnStart, normalizedColumnEnd, m_autoPlacementCursorRow, m_autoPlacementCursorRow + rowSpan)) {
+        if (isCellRangeEmpty(columnStart, columnEnd, m_autoPlacementCursorRow, m_autoPlacementCursorRow + rowSpan)) {
             // Set the item's row-start line to the cursor's row position.
-            insertItemInArea(item, normalizedColumnStart, normalizedColumnEnd,
+            insertItemInArea(item, columnStart, columnEnd,
                 m_autoPlacementCursorRow, m_autoPlacementCursorRow + rowSpan);
             // Cursor remains at the placed position (row at placed row, column was already set).
             break;

--- a/Source/WebCore/layout/formattingContexts/grid/ImplicitGrid.h
+++ b/Source/WebCore/layout/formattingContexts/grid/ImplicitGrid.h
@@ -55,8 +55,8 @@ public:
 private:
     using RowCursors = HashMap<size_t, size_t, WTF::DefaultHash<size_t>, WTF::UnsignedWithZeroKeyHashTraits<size_t>>;
     std::optional<size_t> NODELETE findFirstAvailableColumnPosition(size_t rowStart, size_t rowEnd, size_t columnSpan, size_t startSearchColumn) const;
-    std::optional<size_t> findColumnPositionForDefiniteRowItem(size_t normalizedRowStart, size_t normalizedRowEnd, size_t columnSpan, GridAutoFlowOptions) const;
-    void growGridColumnsToFit(size_t columnSpan, size_t normalizedRowStart, size_t normalizedRowEnd);
+    std::optional<size_t> findColumnPositionForDefiniteRowItem(size_t rowStart, size_t rowEnd, size_t columnSpan, GridAutoFlowOptions) const;
+    void growGridColumnsToFit(size_t columnSpan, size_t rowStart, size_t rowEnd);
     bool NODELETE isCellRangeEmpty(size_t columnStart, size_t columnEnd, size_t rowStart, size_t rowEnd) const;
     void insertItemInArea(const UnplacedGridItem&, size_t columnStart, size_t columnEnd, size_t rowStart, size_t rowEnd);
 

--- a/Source/WebCore/layout/formattingContexts/grid/UnplacedGridItem.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/UnplacedGridItem.cpp
@@ -43,12 +43,12 @@ static int explicitLineToIndex(const Style::GridPosition& position)
     return line > 0 ? line - 1 : line;
 }
 
-UnplacedGridItem::GridPosition UnplacedGridItem::GridPosition::create(const Style::GridPosition& start, const Style::GridPosition& end)
+UnplacedGridItem::GridPosition UnplacedGridItem::GridPosition::create(const Style::GridPosition& start, const Style::GridPosition& end, size_t negativeLineOffset)
 {
-    // An axis is only definite when one of its edges references an explicit line. Anything
-    // else (auto/auto, span/auto, auto/span) is auto-positioned; carry the span forward for
-    // the placement algorithm to resolve.
-    if (!start.isExplicit() && !end.isExplicit()) {
+    auto explicitRange = UnplacedGridItem::resolveDefinitePosition(start, end);
+    if (!explicitRange) {
+        // An axis with no explicit line is auto-positioned; carry the span forward for the
+        // placement algorithm to resolve.
         size_t span = 1;
         if (start.isSpan())
             span = start.spanPosition();
@@ -56,6 +56,29 @@ UnplacedGridItem::GridPosition UnplacedGridItem::GridPosition::create(const Styl
             span = end.spanPosition();
         return AutoPosition { span };
     }
+
+    // Shift the resolved range forward by the negative-line offset. The offset is the magnitude of
+    // the most-negative line across all items, so applying it maps every line to a non-negative
+    // matrix index.
+    auto [rawStartLine, rawEndLine] = *explicitRange;
+    int startLine = rawStartLine + static_cast<int>(negativeLineOffset);
+    int endLine = rawEndLine + static_cast<int>(negativeLineOffset);
+
+    ASSERT(startLine >= 0 && endLine >= 0);
+    // The range is always forward. The span/auto branches derive endLine from startLine, and the
+    // explicit/explicit branch only reaches GFC for single-track placements: grid coverage requires
+    // the end line to be exactly one past the start (a distance of 1), so an inverted placement like
+    // grid-column: 3 / 1 stays on the legacy path and can never underflow span() here.
+    ASSERT(startLine <= endLine);
+    return DefinitePosition { static_cast<size_t>(startLine), static_cast<size_t>(endLine) };
+}
+
+std::optional<std::pair<int, int>> UnplacedGridItem::resolveDefinitePosition(const Style::GridPosition& start, const Style::GridPosition& end)
+{
+    // An axis is only definite when one of its edges references an explicit line. Anything
+    // else (auto/auto, span/auto, auto/span) is auto-positioned and has no explicit line range.
+    if (!start.isExplicit() && !end.isExplicit())
+        return { };
 
     int startLine = 0;
     int endLine = 0;
@@ -77,15 +100,7 @@ UnplacedGridItem::GridPosition UnplacedGridItem::GridPosition::create(const Styl
         startLine = endLine - 1;
     }
 
-    // Negative line placement is not yet supported (grid coverage keeps such items on the
-    // legacy path), so the resolved lines are non-negative and safe to store as unsigned.
-    ASSERT(startLine >= 0 && endLine >= 0);
-    // The range is always forward. The span/auto branches derive endLine from startLine, and the
-    // explicit/explicit branch only reaches GFC for single-track placements: grid coverage requires
-    // the end line to be exactly one past the start (a distance of 1), so an inverted placement like
-    // grid-column: 3 / 1 stays on the legacy path and can never underflow span() here.
-    ASSERT(startLine <= endLine);
-    return DefinitePosition { static_cast<size_t>(startLine), static_cast<size_t>(endLine) };
+    return std::pair { startLine, endLine };
 }
 
 size_t UnplacedGridItem::GridPosition::span() const
@@ -96,42 +111,18 @@ size_t UnplacedGridItem::GridPosition::span() const
 }
 
 UnplacedGridItem::UnplacedGridItem(const ElementBox& layoutBox, Style::GridPosition columnStart, Style::GridPosition columnEnd,
-    Style::GridPosition rowStart, Style::GridPosition rowEnd)
+    Style::GridPosition rowStart, Style::GridPosition rowEnd, size_t columnNegativeLineOffset, size_t rowNegativeLineOffset)
     : m_layoutBox(layoutBox)
-    , m_columnPosition(GridPosition::create(columnStart, columnEnd))
-    , m_rowPosition(GridPosition::create(rowStart, rowEnd))
+    , m_columnPosition(GridPosition::create(columnStart, columnEnd, columnNegativeLineOffset))
+    , m_rowPosition(GridPosition::create(rowStart, rowEnd, rowNegativeLineOffset))
 {
 }
 
 UnplacedGridItem::UnplacedGridItem(WTF::HashTableEmptyValueType)
     : m_layoutBox(WTF::HashTableEmptyValue)
-    , m_columnPosition(GridPosition::create(Style::ComputedStyle::initialGridItemColumnStart(), Style::ComputedStyle::initialGridItemColumnEnd()))
-    , m_rowPosition(GridPosition::create(Style::ComputedStyle::initialGridItemRowStart(), Style::ComputedStyle::initialGridItemRowEnd()))
+    , m_columnPosition(GridPosition::create(Style::ComputedStyle::initialGridItemColumnStart(), Style::ComputedStyle::initialGridItemColumnEnd(), 0))
+    , m_rowPosition(GridPosition::create(Style::ComputedStyle::initialGridItemRowStart(), Style::ComputedStyle::initialGridItemRowEnd(), 0))
 {
-}
-
-size_t UnplacedGridItem::normalizedColumnStart() const
-{
-    ASSERT(m_hasAppliedGridOffsets);
-    return m_columnPosition.definitePosition().startLine + m_columnNormalizationOffset;
-}
-
-size_t UnplacedGridItem::normalizedColumnEnd() const
-{
-    ASSERT(m_hasAppliedGridOffsets);
-    return m_columnPosition.definitePosition().endLine + m_columnNormalizationOffset;
-}
-
-size_t UnplacedGridItem::normalizedRowStart() const
-{
-    ASSERT(m_hasAppliedGridOffsets);
-    return m_rowPosition.definitePosition().startLine + m_rowNormalizationOffset;
-}
-
-size_t UnplacedGridItem::normalizedRowEnd() const
-{
-    ASSERT(m_hasAppliedGridOffsets);
-    return m_rowPosition.definitePosition().endLine + m_rowNormalizationOffset;
 }
 
 bool UnplacedGridItem::hasDefiniteRowPosition() const
@@ -164,42 +155,16 @@ size_t UnplacedGridItem::rowSpanSize() const
     return m_rowPosition.span();
 }
 
-std::pair<int, int> UnplacedGridItem::definiteRowStartEnd() const
+std::pair<size_t, size_t> UnplacedGridItem::definiteRowStartEnd() const
 {
     auto& definitePosition = m_rowPosition.definitePosition();
-    return { static_cast<int>(definitePosition.startLine), static_cast<int>(definitePosition.endLine) };
+    return { definitePosition.startLine, definitePosition.endLine };
 }
 
-std::pair<int, int> UnplacedGridItem::definiteColumnStartEnd() const
+std::pair<size_t, size_t> UnplacedGridItem::definiteColumnStartEnd() const
 {
     auto& definitePosition = m_columnPosition.definitePosition();
-    return { static_cast<int>(definitePosition.startLine), static_cast<int>(definitePosition.endLine) };
-}
-
-std::pair<size_t, size_t> UnplacedGridItem::normalizedRowStartEnd() const
-{
-    ASSERT(m_hasAppliedGridOffsets);
-    auto rowStart = normalizedRowStart();
-    auto rowEnd = normalizedRowEnd();
-
-    // Handle inverted ranges by swapping start and end
-    if (rowEnd < rowStart)
-        return { rowEnd, rowStart };
-
-    return { rowStart, rowEnd };
-}
-
-std::pair<size_t, size_t> UnplacedGridItem::normalizedColumnStartEnd() const
-{
-    ASSERT(m_hasAppliedGridOffsets);
-    auto columnStart = normalizedColumnStart();
-    auto columnEnd = normalizedColumnEnd();
-
-    // Handle inverted ranges by swapping start and end
-    if (columnEnd < columnStart)
-        return { columnEnd, columnStart };
-
-    return { columnStart, columnEnd };
+    return { definitePosition.startLine, definitePosition.endLine };
 }
 
 bool UnplacedGridItem::operator==(const UnplacedGridItem& other) const
@@ -214,14 +179,6 @@ bool UnplacedGridItem::operator==(const UnplacedGridItem& other) const
         return isEmpty;
 
     return m_layoutBox.ptr() == other.m_layoutBox.ptr() && m_columnPosition == other.m_columnPosition && m_rowPosition == other.m_rowPosition;
-}
-
-void UnplacedGridItem::applyGridOffsets(size_t rowOffset, size_t columnOffset)
-{
-    ASSERT(!m_hasAppliedGridOffsets);
-    m_rowNormalizationOffset = rowOffset;
-    m_columnNormalizationOffset = columnOffset;
-    m_hasAppliedGridOffsets = true;
 }
 
 void add(Hasher& hasher, const WebCore::Layout::UnplacedGridItem& unplacedGridItem)

--- a/Source/WebCore/layout/formattingContexts/grid/UnplacedGridItem.h
+++ b/Source/WebCore/layout/formattingContexts/grid/UnplacedGridItem.h
@@ -59,7 +59,7 @@ private:
 
     class GridPosition {
     public:
-        static GridPosition create(const Style::GridPosition& start, const Style::GridPosition& end);
+        static GridPosition create(const Style::GridPosition& start, const Style::GridPosition& end, size_t negativeLineOffset);
 
         bool isDefinite() const { return std::holds_alternative<DefinitePosition>(m_position); }
         bool isAuto() const { return std::holds_alternative<AutoPosition>(m_position); }
@@ -82,7 +82,7 @@ private:
     };
 
 public:
-    UnplacedGridItem(const ElementBox&, Style::GridPosition columnStart, Style::GridPosition columnEnd, Style::GridPosition rowStart, Style::GridPosition rowEnd);
+    UnplacedGridItem(const ElementBox&, Style::GridPosition columnStart, Style::GridPosition columnEnd, Style::GridPosition rowStart, Style::GridPosition rowEnd, size_t columnNegativeLineOffset, size_t rowNegativeLineOffset);
     UnplacedGridItem(WTF::HashTableEmptyValueType);
 
     bool operator==(const UnplacedGridItem& other) const;
@@ -91,11 +91,6 @@ public:
     bool isHashTableEmptyValue() const { return m_layoutBox.isHashTableEmptyValue(); }
     static constexpr bool safeToCompareToHashTableEmptyOrDeletedValue = true;
 
-    size_t normalizedColumnStart() const;
-    size_t normalizedColumnEnd() const;
-    size_t normalizedRowStart() const;
-    size_t normalizedRowEnd() const;
-
     bool NODELETE hasDefiniteRowPosition() const;
     bool NODELETE hasDefiniteColumnPosition() const;
     bool NODELETE hasAutoColumnPosition() const;
@@ -103,8 +98,13 @@ public:
     size_t columnSpanSize() const;
     size_t rowSpanSize() const;
 
-    std::pair<size_t, size_t> normalizedRowStartEnd() const;
-    std::pair<size_t, size_t> normalizedColumnStartEnd() const;
+    std::pair<size_t, size_t> definiteRowStartEnd() const;
+    std::pair<size_t, size_t> definiteColumnStartEnd() const;
+
+    // Resolves the raw (pre-normalization) 0-based explicit line range [start, end) for an axis, or
+    // std::nullopt when the axis is auto-positioned. Lines may be negative for negative line
+    // placements; the negative-line offset is applied later in GridPosition::create().
+    static std::optional<std::pair<int, int>> resolveDefinitePosition(const Style::GridPosition& start, const Style::GridPosition& end);
 
 private:
     CheckedRef<const ElementBox> m_layoutBox;
@@ -113,23 +113,7 @@ private:
     GridPosition m_columnPosition;
     GridPosition m_rowPosition;
 
-    std::pair<int, int> definiteRowStartEnd() const;
-    std::pair<int, int> definiteColumnStartEnd() const;
-
-    void NODELETE applyGridOffsets(size_t rowOffset, size_t columnOffset);
-
-    // Offsets applied to normalize negative grid positions to non-negative matrix indices.
-    size_t m_rowNormalizationOffset { 0 };
-    size_t m_columnNormalizationOffset { 0 };
-
-    // Flag to track whether applyGridOffsets() has been called.
-    // This helps catch bugs where normalized methods are used before offsets are applied,
-    // or where offsets are applied multiple times.
-    bool m_hasAppliedGridOffsets { false };
-
     friend class GridFormattingContext;
-    friend class GridLayout;
-    friend class PlacedGridItem;
     friend void add(Hasher&, const WebCore::Layout::UnplacedGridItem&);
 };
 


### PR DESCRIPTION
#### 7be8af50b716ba102581dc35e626637cfa45c693
<pre>
[GFC] Apply a grid item&apos;s negative line offset when constructing UnplacedGridItem
<a href="https://bugs.webkit.org/show_bug.cgi?id=320382">https://bugs.webkit.org/show_bug.cgi?id=320382</a>
<a href="https://rdar.apple.com/problem/183344674">rdar://problem/183344674</a>

Reviewed by Alan Baradlay.

When a negative line number is used to position a grid item this causes
us to begin searching from the line from the end of the grid instead of
from the beginning. Depending on the value of this negative line number
we may end up going past the beginning of the explicit grid and create
implicit tracks at the beginning. For example a grid with two explicit
columns with lines L1 L2 L3, a grid item with position -4 / -3 would end
up creating one implicit column in the beginning of the grid.

We currently keep track of where this position is by computing a
normalization offset which basically keeps track of the magnitude of the
negative grid positions. We then shift each grid item&apos;s position by this
offset so that the resulting position is relative to the start of the
impicit grid. We currently have a dedicated API which callers are
expected to use during item placement that contains some debug asserts
to make sure that the normalization offset was computed and applied. To
simplify this API, we can move this logic outside of GridLayout and into
the formatting context since we should be able to compute this
information beforehand. Then, when we create the GridPosition type that
we created recently we can compute and set a position that is relative
to the implicit grid as we create the UnplacedGridItem. We can then get
rid of one of the two APIs we have for getting an item&apos;s position which
should make things overall a bit simpler.

* Source/WebCore/layout/formattingContexts/grid/GridFormattingContext
(WebCore::Layout::GridFormattingContext::constructUnplacedGridItems
We go through all of the grid items already so during this process let&apos;s
try to figure out the largest magnitude of the negative line numbers. We
will then plumb this value into the rest of the code that creates the
UnplacedGridItem and corresponding GridPosition. The resulting
GridPosition will be relative to the implicit grid.

* Source/WebCore/layout/formattingContexts/grid/GridLayout.cpp:
(WebCore::Layout::GridLayout::calculateInitialImplicitGridDimension
Now that we compute the positions relative to the implicit grid itself
the number of columns/tracks is just the maximum of the column/row
positions of the items.

* Source/WebCore/layout/formattingContexts/grid/UnplacedGridItem.cp
(WebCore::Layout::UnplacedGridItem::GridPosition::create):
Take into consideration the offset that we computed earlier inside
GridFormattingContext when we construct the positions of the
UnplacedGridItem now.

(WebCore::Layout::UnplacedGridItem::resolveDefinitePosition):
New helper that is used to determine if a grid item&apos;s position or not
according to:
<a href="https://drafts.csswg.org/css-grid-1/#placement">https://drafts.csswg.org/css-grid-1/#placement</a>

(WebCore::Layout::UnplacedGridItem::definiteRowStartEnd const):
(WebCore::Layout::UnplacedGridItem::definiteColumnStartEnd const):
(WebCore::Layout::UnplacedGridItem::normalizedColumnStart const): D
(WebCore::Layout::UnplacedGridItem::normalizedColumnEnd const): Del
(WebCore::Layout::UnplacedGridItem::normalizedRowStart const): Dele
(WebCore::Layout::UnplacedGridItem::normalizedRowEnd const): Delete
(WebCore::Layout::UnplacedGridItem::normalizedRowStartEnd const): D
(WebCore::Layout::UnplacedGridItem::normalizedColumnStartEnd const)
Now that we no longer have the contept of a normalized position we can
just have the single definite position API.

Canonical link: <a href="https://commits.webkit.org/318071@main">https://commits.webkit.org/318071@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a97b98acb0c2624d7c4cf4c1f50462bd1517ef83

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177153 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51090 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44885 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186756 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140389 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4d129a34-a56a-472f-8329-0b6330d55d9c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179016 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52383 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50776 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138028 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140389 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/50b107b3-6b1b-4f9a-8a4c-a9266ea60d41) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180109 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41539 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158795 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118495 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/72a0abce-d434-419c-ace1-ba29dab2dc07) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40195 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38567 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150605 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38294 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-highlight-api/painting/custom-highlight-dynamic-font-metrics-001.html (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35224 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42869 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42798 "Found 60 new test failures: fast/css-grid-layout/grid-2x2-items-with-borders.html fast/css-grid-layout/grid-item-with-border-track-sizing.html fast/css-grid-layout/nested-grid.html fast/css/container-query-style-sharing.html fast/grid/grid-item-block-content-size-suggestion-crash.html fast/mediastream/applyConstraints-with-takePhoto.html fast/text/grid-selection-gap-painting.html http/tests/cookies/max-partitioned-cookies.https.html http/tests/navigation/redirect-to-random-url-versus-memory-cache.html http/tests/paymentrequest/payment-response-payerPhone-attribute.https.html ... (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189182 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50757 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147117 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39554 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51440 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34918 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146911 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41643 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123654 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117950 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49945 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13274 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49344 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49581 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49405 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->