### PR TITLE
[bmalloc] MADV_ZERO support latch is inverted in VMAllocate.cpp

### DIFF
--- a/Source/bmalloc/bmalloc/VMAllocate.cpp
+++ b/Source/bmalloc/bmalloc/VMAllocate.cpp
@@ -47,9 +47,9 @@ static void zeroFillLatchIfMadvZeroIsSupported()
 
     int rc = madvise(base, pageSize, MADV_ZERO);
     if (rc)
-        madvZeroSupported = true;
+        madvZeroSupported = errno != ENOTSUP;
     else
-        madvZeroSupported = false;
+        madvZeroSupported = true;
     munmap(base, pageSize);
 }
 


### PR DESCRIPTION
#### 8b8b3e5ee16cd1d31c62cae86a8a1ad4404b6777
<pre>
[bmalloc] MADV_ZERO support latch is inverted in VMAllocate.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=320384">https://bugs.webkit.org/show_bug.cgi?id=320384</a>
<a href="https://rdar.apple.com/183345434">rdar://183345434</a>

Reviewed by Marcus Plutowski.

zeroFillLatchIfMadvZeroIsSupported() probes for kernel MADV_ZERO support by
madvise()ing a scratch page, but recorded the result backwards: a successful
probe latched the feature off and a failing probe latched it on. It also
ignored errno entirely, so it could not distinguish &quot;kernel does not
implement MADV_ZERO&quot; (ENOTSUP) from an incidental failure such as CoW
memory. The function is a copy of libpas&apos;s
pas_page_malloc_zero_fill_latch_if_madv_zero_is_supported(), which gets both
of these right.

The effect is a pessimization rather than a correctness bug, since
vmZeroAndPurge() still checks madvise()&apos;s return value before taking the
fast path: latching off on a supporting kernel loses the optimization, and
latching on for an unsupporting kernel pays a doomed syscall on every call,
which is exactly the overhead the latch exists to avoid. Nothing is
currently affected because BMALLOC_USE_MADV_ZERO is 0 in both arms of its

Latch on success, and on failure only latch off for ENOTSUP, matching libpas.

Testing: ran some JSC stress tests with BMALLOC_USE_MADV_ZERO=1

* Source/bmalloc/bmalloc/VMAllocate.cpp:
(bmalloc::zeroFillLatchIfMadvZeroIsSupported):

Canonical link: <a href="https://commits.webkit.org/318001@main">https://commits.webkit.org/318001@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/511c69a91595d6f1bd776c7fd9b1ea9b27025eee

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176993 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50930 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44725 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186596 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140229 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52223 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50616 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/137907 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140229 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179949 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41427 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/158691 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118376 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/03e1694e-0590-4125-81ce-fadd20c97fc6) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/40083 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/38441 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/251/builds/345 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/7196 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/150493 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38191 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35064 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/38264 "Built successfully and passed tests") | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/42659 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189019 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50597 "Built successfully") | | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146986 "") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39510 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51280 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/34815 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146782 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41538 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117781 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49785 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13171 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49184 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49421 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49245 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->