### PR TITLE
[GFC] Use UnplacedGridItem::GridPosition when determining item position type.

### DIFF
--- a/Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.cpp
@@ -87,23 +87,13 @@ UnplacedGridItems GridFormattingContext::constructUnplacedGridItems() const
             gridItemRowEnd
         };
 
-        // Check if this item is fully explicitly positioned
-        bool fullyExplicitlyPositionedItem = gridItemColumnStart.isExplicit()
-            && gridItemColumnEnd.isExplicit()
-            && gridItemRowStart.isExplicit()
-            && gridItemRowEnd.isExplicit();
-
-        // FIXME: support definite row/column positioning
-        // We should place items with definite row or column positions
-        // but currently we only support fully explicitly positioned items.
-        // See: https://www.w3.org/TR/css-grid-1/#auto-placement-algo
-        if (fullyExplicitlyPositionedItem) {
+        // https://drafts.csswg.org/css-grid-1/#auto-placement-algo
+        if (unplacedGridItem.hasDefiniteColumnPosition() && unplacedGridItem.hasDefiniteRowPosition())
             unplacedGridItems.nonAutoPositionedItems.append(unplacedGridItem);
-        } else if (unplacedGridItem.hasDefiniteRowPosition()) {
+        else if (unplacedGridItem.hasDefiniteRowPosition())
             unplacedGridItems.definiteRowPositionedItems.append(unplacedGridItem);
-        } else {
+        else
             unplacedGridItems.autoPositionedItems.append(unplacedGridItem);
-        }
     }
     return unplacedGridItems;
 }


### PR DESCRIPTION
#### 0e3f9c7406374f46e0cf330b2ef7723b76f5245c
<pre>
[GFC] Use UnplacedGridItem::GridPosition when determining item position type.
<a href="https://bugs.webkit.org/show_bug.cgi?id=320385">https://bugs.webkit.org/show_bug.cgi?id=320385</a>
<a href="https://rdar.apple.com/problem/183345808">rdar://problem/183345808</a>

Reviewed by Alan Baradlay.

When constructing the list of unplaced grid items, GridFormattingContext
decided which placement bucket an item belongs to by inspecting the raw
computed style and requiring all four grid-{column,row}-{start,end}
values to be explicit before treating the item as non-auto-positioned.

That test is stricter than the spec&apos;s notion of a definite position. An
axis is definite when either of its edges references an explicit line, so
a placement like grid-column: 2 (explicit start, auto end) is definite
even though it is not &quot;fully explicit&quot;. Such an item has a definite
position in both axes, but because it was not fully explicit it was
routed to definiteRowPositionedItems, which ignores the definite column
and auto-places the item in the column axis, landing it in the wrong
column.

Now that an UnplacedGridItem resolves and stores its position when it is
constructed, classify it from that resolved position instead: an item
with a definite position in both axes is non-auto-positioned, an item
with only a definite row is locked to that row, and everything else is
auto-positioned.

Canonical link: <a href="https://commits.webkit.org/318034@main">https://commits.webkit.org/318034@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6a7c95b4d3be1cd30cbff6ed766f3c85a281f133

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176995 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50932 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44727 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186598 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140231 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178858 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52225 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50618 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137910 "6 flakes 1 failures") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140231 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fd0405ba-83e8-4259-8514-e9671470494b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179951 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41418 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158694 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118379 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40074 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38440 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150484 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38194 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35066 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42735 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42658 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189021 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50599 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146996 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39525 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51282 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34818 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146783 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41540 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123496 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117783 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49787 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13174 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49186 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49423 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49247 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->