### PR TITLE
Implement WebTransportReceiveStream pull bytes algorithm

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/receive-stream-pull.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/receive-stream-pull.https.any-expected.txt
@@ -1,0 +1,5 @@
+
+PASS Bytes received before any read are given to later reads
+PASS A BYOB read smaller than the received bytes keeps the rest for later reads
+PASS A read waits for bytes that have not been received yet
+

--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/receive-stream-pull.https.any.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/receive-stream-pull.https.any.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/receive-stream-pull.https.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/receive-stream-pull.https.any.js
@@ -1,0 +1,111 @@
+// META: global=window,worker
+// META: script=resources/webtransport-test-helpers.sub.js
+// META: timeout=long
+
+// Tests the pull steps of a WebTransportReceiveStream:
+// https://w3c.github.io/webtransport/#webtransportreceivestream-pull-bytes
+
+// Returns a bidirectional stream whose readable end receives |data| echoed back
+// by the server, followed by FIN.
+async function echo_bidirectional_stream(wt, data) {
+  const bidi_stream = await wt.createBidirectionalStream();
+  const writer = bidi_stream.writable.getWriter();
+  await writer.write(data);
+  await writer.close();
+  return bidi_stream;
+}
+
+function ascending_bytes(length) {
+  const data = new Uint8Array(length);
+  for (let i = 0; i < data.byteLength; ++i) {
+    data[i] = i;
+  }
+  return data;
+}
+
+promise_test(async t => {
+  const wt = new WebTransport(webtransport_url('echo.py'));
+  await wt.ready;
+
+  const data = ascending_bytes(64);
+  const bidi_stream = await echo_bidirectional_stream(wt, data);
+
+  // Give the echoed bytes and the FIN a chance to be received before anything
+  // reads them, so that the reads below are served from buffered bytes. The test
+  // is valid either way: a read that arrives first waits for the bytes instead.
+  await wait(100);
+
+  const chunks = await read_stream(bidi_stream.readable);
+  const received = new Uint8Array(chunks.reduce((length, chunk) => length + chunk.byteLength, 0));
+  let offset = 0;
+  for (const chunk of chunks) {
+    received.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+
+  // No bytes may be lost when the stream is closed while bytes are still waiting
+  // to be given to the readable end.
+  assert_array_equals(received, data);
+  wt.close();
+}, 'Bytes received before any read are given to later reads');
+
+promise_test(async t => {
+  const wt = new WebTransport(webtransport_url('echo.py'));
+  await wt.ready;
+
+  const data = ascending_bytes(64);
+  const bidi_stream = await echo_bidirectional_stream(wt, data);
+  await wait(100);
+
+  // Read one byte at a time. Each view is smaller than what the server sent, so
+  // the bytes that do not fit in it must be kept for the following reads.
+  const reader = bidi_stream.readable.getReader({mode: 'byob'});
+  for (let i = 0; i < data.byteLength; ++i) {
+    const {value: view, done} = await reader.read(new Uint8Array(1));
+    assert_false(done, `read ${i} should not be done`);
+    assert_array_equals(view, data.subarray(i, i + 1), `read ${i}`);
+  }
+
+  // All the bytes have been read and the server ended its stream, so the next
+  // read closes the readable end.
+  const {value: view, done} = await reader.read(new Uint8Array(1));
+  assert_true(done, 'the last read should be done');
+  assert_equals(view.byteLength, 0, 'the last read should not fill the view');
+  await reader.closed;
+  reader.releaseLock();
+  wt.close();
+}, 'A BYOB read smaller than the received bytes keeps the rest for later reads');
+
+promise_test(async t => {
+  const wt = new WebTransport(webtransport_url('echo.py'));
+  await wt.ready;
+
+  const bidi_stream = await wt.createBidirectionalStream();
+
+  // Read before anything is received. The read has to wait until either a byte is
+  // received or the server ends its stream.
+  const reader = bidi_stream.readable.getReader();
+  const read = reader.read();
+
+  const data = ascending_bytes(8);
+  const writer = bidi_stream.writable.getWriter();
+  await writer.write(data);
+
+  const {value: chunk, done} = await read;
+  assert_false(done, 'the pending read should not be done');
+  assert_greater_than(chunk.byteLength, 0, 'the pending read should receive at least one byte');
+
+  // Read the rest in case the bytes did not all arrive in a single chunk.
+  let received = Array.from(chunk);
+  await writer.close();
+  while (received.length < data.byteLength) {
+    const {value: chunk, done} = await reader.read();
+    assert_false(done, 'the stream should not end before all its bytes are read');
+    received = received.concat(Array.from(chunk));
+  }
+  assert_array_equals(received, Array.from(data));
+
+  assert_true((await reader.read()).done, 'the read after FIN should be done');
+  reader.releaseLock();
+  wt.close();
+}, 'A read waits for bytes that have not been received yet');

--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/receive-stream-pull.https.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/receive-stream-pull.https.any.serviceworker-expected.txt
@@ -1,0 +1,5 @@
+
+PASS Bytes received before any read are given to later reads
+PASS A BYOB read smaller than the received bytes keeps the rest for later reads
+PASS A read waits for bytes that have not been received yet
+

--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/receive-stream-pull.https.any.serviceworker.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/receive-stream-pull.https.any.serviceworker.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/receive-stream-pull.https.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/receive-stream-pull.https.any.sharedworker-expected.txt
@@ -1,0 +1,5 @@
+
+PASS Bytes received before any read are given to later reads
+PASS A BYOB read smaller than the received bytes keeps the rest for later reads
+PASS A read waits for bytes that have not been received yet
+

--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/receive-stream-pull.https.any.sharedworker.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/receive-stream-pull.https.any.sharedworker.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/receive-stream-pull.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/receive-stream-pull.https.any.worker-expected.txt
@@ -1,0 +1,5 @@
+
+PASS Bytes received before any read are given to later reads
+PASS A BYOB read smaller than the received bytes keeps the rest for later reads
+PASS A read waits for bytes that have not been received yet
+

--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/receive-stream-pull.https.any.worker.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/receive-stream-pull.https.any.worker.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/Source/WebCore/Modules/webtransport/DatagramByteSource.cpp
+++ b/Source/WebCore/Modules/webtransport/DatagramByteSource.cpp
@@ -74,6 +74,8 @@ void DatagramByteSource::receiveDatagram(std::span<const uint8_t> datagram, bool
     if (!globalObject)
         return;
 
+    Locker<JSC::JSLock> locker(globalObject->vm().apiLock());
+
     ASSERT(!m_currentOffset);
     tryEnqueuing(*arrayBuffer, *controller, m_promise.releaseNonNull().get(), globalObject);
     if (!withFin)
@@ -117,6 +119,7 @@ void DatagramByteSource::closeStreamIfPossible()
     if (!globalObject)
         return;
 
+    Locker<JSC::JSLock> locker(globalObject->vm().apiLock());
     closeStream(*globalObject, *controller, *promise);
 }
 

--- a/Source/WebCore/Modules/webtransport/WebTransport.cpp
+++ b/Source/WebCore/Modules/webtransport/WebTransport.cpp
@@ -183,6 +183,8 @@ WebTransport::WebTransport(ScriptExecutionContext& context, JSDOMGlobalObject& g
         RefPtr strongThis = weakThis.get();
         if (!strongThis)
             return;
+        if (strongThis->m_state != State::Connecting)
+            return;
         if (!info)
             return strongThis->cleanupWithSessionError();
         strongThis->m_protocol = WTF::move(info->protocol);
@@ -213,6 +215,9 @@ void WebTransport::receiveDatagram(std::span<const uint8_t> datagram, bool withF
 
 void WebTransport::receiveIncomingUnidirectionalStream(WebTransportStreamIdentifier identifier)
 {
+    if (m_state == State::Closed || m_state == State::Failed)
+        return;
+
     RefPtr context = scriptExecutionContext();
     if (!context)
         return;
@@ -221,11 +226,11 @@ void WebTransport::receiveIncomingUnidirectionalStream(WebTransportStreamIdentif
         return;
 
     auto& jsDOMGlobalObject = *downcast<JSDOMGlobalObject>(globalObject);
+
+    Locker<JSC::JSLock> locker(jsDOMGlobalObject.vm().apiLock());
+
     Ref incomingStream = WebTransportReceiveStreamByteSource::create(*this, identifier);
-    auto stream = [&] {
-        Locker<JSC::JSLock> locker(jsDOMGlobalObject.vm().apiLock());
-        return WebTransportReceiveStream::create(identifier, m_session, jsDOMGlobalObject, incomingStream.copyRef());
-    } ();
+    auto stream = WebTransportReceiveStream::create(identifier, m_session, jsDOMGlobalObject, incomingStream.copyRef());
     if (stream.hasException())
         return;
     Ref receiveStream = stream.releaseReturnValue();
@@ -242,16 +247,13 @@ void WebTransport::receiveIncomingUnidirectionalStream(WebTransportStreamIdentif
 static ExceptionOr<Ref<WebTransportBidirectionalStream>> createBidirectionalStream(WebTransport& transport, WebTransportSession& session, JSDOMGlobalObject& globalObject, Ref<WebTransportSendStreamSink>&& sink, Ref<WebTransportReceiveStreamByteSource>&& source, const WebTransportSendStreamOptions& options)
 {
     auto identifier = sink->identifier();
-    auto sendStream = [&] {
-        Locker<JSC::JSLock> locker(globalObject.vm().apiLock());
-        return WebTransportSendStream::create(transport, globalObject, WTF::move(sink), options);
-    } ();
+
+    Locker<JSC::JSLock> locker(globalObject.vm().apiLock());
+
+    auto sendStream = WebTransportSendStream::create(transport, globalObject, WTF::move(sink), options);
     if (sendStream.hasException())
         return sendStream.releaseException();
-    auto receiveStream = [&] {
-        Locker<JSC::JSLock> locker(globalObject.vm().apiLock());
-        return WebTransportReceiveStream::create(identifier, session, globalObject, WTF::move(source));
-    } ();
+    auto receiveStream = WebTransportReceiveStream::create(identifier, session, globalObject, WTF::move(source));
     if (receiveStream.hasException())
         return receiveStream.releaseException();
     return WebTransportBidirectionalStream::create(receiveStream.releaseReturnValue(), sendStream.releaseReturnValue());
@@ -259,6 +261,9 @@ static ExceptionOr<Ref<WebTransportBidirectionalStream>> createBidirectionalStre
 
 void WebTransport::receiveBidirectionalStream(WebTransportStreamIdentifier identifier)
 {
+    if (m_state == State::Closed || m_state == State::Failed)
+        return;
+
     RefPtr context = scriptExecutionContext();
     if (!context)
         return;
@@ -268,6 +273,9 @@ void WebTransport::receiveBidirectionalStream(WebTransportStreamIdentifier ident
 
     Ref sink = WebTransportSendStreamSink::create(*this, identifier);
     auto& jsDOMGlobalObject = *downcast<JSDOMGlobalObject>(globalObject);
+
+    Locker<JSC::JSLock> locker(jsDOMGlobalObject.vm().apiLock());
+
     Ref incomingStream = WebTransportReceiveStreamByteSource::create(*this, identifier);
     auto stream = WebCore::createBidirectionalStream(*this, m_session, jsDOMGlobalObject, sink.copyRef(), incomingStream.copyRef(), WebTransportSendStreamOptions { });
     if (stream.hasException())
@@ -289,6 +297,9 @@ void WebTransport::receiveBidirectionalStream(WebTransportStreamIdentifier ident
 
 void WebTransport::streamReceiveBytes(WebTransportStreamIdentifier identifier, std::span<const uint8_t> span, bool withFin, std::optional<Exception>&& exception)
 {
+    if (m_state == State::Closed || m_state == State::Failed)
+        return;
+
     ASSERT(m_readStreamSources.contains(identifier));
     if (RefPtr source = m_readStreamSources.get(identifier))
         source->receiveBytes(span, withFin, WTF::move(exception));
@@ -502,6 +513,9 @@ void WebTransport::cleanup(Ref<DOMException>&& exception, std::optional<WebTrans
     } ();
 
     // https://www.w3.org/TR/webtransport/#webtransport-cleanup
+    m_bidirectionalStreamSource->stopReceivingIncomingStreams();
+    m_receiveStreamSource->stopReceivingIncomingStreams();
+
     std::exchange(m_sendStreams, { });
     auto sendStreamSinks = std::exchange(m_sendStreamSinks, { });
     for (auto& sink : sendStreamSinks.values())
@@ -656,6 +670,8 @@ void WebTransport::didFail(std::optional<uint32_t>&& code, String&& message)
 
 void WebTransport::didDrain()
 {
+    if (m_state == State::Closed || m_state == State::Failed)
+        return;
     m_state = State::Draining;
     protect(m_draining.second)->resolve();
 }

--- a/Source/WebCore/Modules/webtransport/WebTransportBidirectionalStreamSource.h
+++ b/Source/WebCore/Modules/webtransport/WebTransportBidirectionalStreamSource.h
@@ -35,6 +35,9 @@ class WebTransportBidirectionalStreamSource : public RefCountedReadableStreamSou
 public:
     static Ref<WebTransportBidirectionalStreamSource> create() { return adoptRef(*new WebTransportBidirectionalStreamSource()); }
     bool receiveIncomingStream(JSC::JSGlobalObject&, Ref<WebTransportBidirectionalStream>&);
+
+    void stopReceivingIncomingStreams() { m_isCancelled = true; }
+
 private:
     void setActive() final { }
     void setInactive() final { }

--- a/Source/WebCore/Modules/webtransport/WebTransportReceiveStream.cpp
+++ b/Source/WebCore/Modules/webtransport/WebTransportReceiveStream.cpp
@@ -46,8 +46,10 @@ ExceptionOr<Ref<WebTransportReceiveStream>> WebTransportReceiveStream::create(We
     Ref stream = adoptRef(*new WebTransportReceiveStream(protect(globalObject.scriptExecutionContext()).get(), identifier, session));
     stream->suspendIfNeeded();
 
-    ReadableByteStreamController::PullAlgorithm pullAlgorithm = [source](auto& globalObject, auto&) {
-        return source->pull(globalObject);
+    ReadableByteStreamController::PullAlgorithm pullAlgorithm = [source](auto& globalObject, auto& controller) {
+        auto [promise, deferred] = createPromiseAndWrapper(globalObject);
+        source->pull(globalObject, controller, WTF::move(deferred));
+        return promise;
     };
 
     ReadableByteStreamController::CancelAlgorithm cancelAlgorithm = [source](auto& globalObject, auto&, auto&& reason) {

--- a/Source/WebCore/Modules/webtransport/WebTransportReceiveStreamByteSource.cpp
+++ b/Source/WebCore/Modules/webtransport/WebTransportReceiveStreamByteSource.cpp
@@ -44,22 +44,80 @@
 
 namespace WebCore {
 
-Ref<DOMPromise> WebTransportReceiveStreamByteSource::pull(JSDOMGlobalObject& globalObject)
-{
-    // FIXME: This should implement https://w3c.github.io/webtransport/#webtransportreceivestream-pull-bytes
-    // See DatagramByteSource::pull.
-    auto* promise = JSC::JSPromise::resolvedPromise(&globalObject, JSC::jsUndefined());
-    return DOMPromise::create(globalObject, *promise);
-}
-
 WebTransportReceiveStreamByteSource::WebTransportReceiveStreamByteSource(WebTransport& transport, WebTransportStreamIdentifier identifier)
     : m_transport(transport)
     , m_identifier(identifier)
 {
 }
 
+// https://w3c.github.io/webtransport/#webtransportreceivestream-pull-bytes
+void WebTransportReceiveStreamByteSource::pull(JSDOMGlobalObject& globalObject, ReadableByteStreamController& controller, Ref<DeferredPromise>&& promise)
+{
+    if (m_isCancelled || m_isClosed)
+        return promise->resolve();
+
+    if (m_queue.isEmpty()) {
+        if (!m_finReceived) {
+            ASSERT(!m_pendingPull);
+            m_pendingPull = WTF::move(promise);
+            return;
+        }
+
+        closeStream(globalObject, controller);
+        promise->resolve();
+        return;
+    }
+
+    deliverBytes(globalObject, controller, WTF::move(promise));
+}
+
+void WebTransportReceiveStreamByteSource::deliverBytes(JSDOMGlobalObject& globalObject, ReadableByteStreamController& controller, Ref<DeferredPromise>&& promise)
+{
+    ASSERT(!m_queue.isEmpty());
+    Ref buffer = m_queue.takeFirst();
+    auto byteLength = buffer->byteLength();
+    ASSERT(m_currentOffset < byteLength);
+
+    auto newOffset = controller.pullFromBytes(globalObject, buffer.get(), m_currentOffset);
+    if (newOffset < byteLength) {
+        m_queue.prepend(WTF::move(buffer));
+        m_currentOffset = newOffset;
+    } else
+        m_currentOffset = 0;
+
+    if (m_finReceived && m_queue.isEmpty())
+        closeStream(globalObject, controller);
+
+    promise->resolve();
+}
+
+void WebTransportReceiveStreamByteSource::closeStream(JSDOMGlobalObject& globalObject, ReadableByteStreamController& controller)
+{
+    ASSERT(m_queue.isEmpty());
+    m_isClosed = true;
+    controller.closeAndRespondToPendingPullIntos(globalObject);
+    if (RefPtr transport = m_transport.get())
+        transport->receiveStreamClosed(m_identifier);
+}
+
+void WebTransportReceiveStreamByteSource::errorStream(JSDOMGlobalObject& globalObject, ReadableByteStreamController& controller, const Exception& exception)
+{
+    m_isClosed = true;
+    m_queue.clear();
+    m_currentOffset = 0;
+
+    controller.error(globalObject, exception);
+    if (RefPtr transport = m_transport.get())
+        transport->receiveStreamClosed(m_identifier);
+    if (RefPtr pendingPull = std::exchange(m_pendingPull, nullptr))
+        pendingPull->resolve();
+}
+
 void WebTransportReceiveStreamByteSource::receiveBytes(std::span<const uint8_t> bytes, bool withFin, std::optional<Exception>&& exception)
 {
+    if (withFin)
+        m_finReceived = true;
+
     if (m_isCancelled || m_isClosed)
         return;
 
@@ -73,26 +131,29 @@ void WebTransportReceiveStreamByteSource::receiveBytes(std::span<const uint8_t> 
     if (!controller)
         return;
 
-    if (exception) {
-        controller->error(*globalObject, *exception);
-        if (RefPtr transport = m_transport.get())
-            transport->receiveStreamClosed(m_identifier);
+    Locker<JSC::JSLock> locker(globalObject->vm().apiLock());
+
+    if (exception)
+        return errorStream(*globalObject, *controller, *exception);
+
+    if (bytes.size()) {
+        RefPtr arrayBuffer = ArrayBuffer::tryCreateUninitialized(bytes.size(), 1);
+        if (!arrayBuffer)
+            return errorStream(*globalObject, *controller, Exception { ExceptionCode::RangeError, "Unable to allocate memory for the received bytes"_s });
+        memcpySpan(arrayBuffer->mutableSpan(), bytes);
+        m_queue.append(arrayBuffer.releaseNonNull());
+    }
+
+    if (!m_queue.isEmpty()) {
+        if (RefPtr pendingPull = std::exchange(m_pendingPull, nullptr))
+            deliverBytes(*globalObject, *controller, pendingPull.releaseNonNull());
         return;
     }
 
-    if (bytes.size()) {
-        if (RefPtr arrayBuffer = ArrayBuffer::tryCreateUninitialized(bytes.size(), 1)) {
-            memcpySpan(arrayBuffer->mutableSpan(), bytes);
-            controller->enqueue(*globalObject, *arrayBuffer);
-        }
-        // FIXME: Error the stream if allocation fails.
-    }
-
-    if (withFin) {
-        m_isClosed = true;
-        controller->closeAndRespondToPendingPullIntos(*globalObject);
-        if (RefPtr transport = m_transport.get())
-            transport->receiveStreamClosed(m_identifier);
+    if (m_finReceived) {
+        closeStream(*globalObject, *controller);
+        if (RefPtr pendingPull = std::exchange(m_pendingPull, nullptr))
+            pendingPull->resolve();
     }
 }
 
@@ -101,12 +162,17 @@ void WebTransportReceiveStreamByteSource::receiveError(JSDOMGlobalObject& global
     if (m_isClosed || m_isCancelled)
         return;
     m_isCancelled = true;
+    m_queue.clear();
+    m_currentOffset = 0;
 
     Locker<JSC::JSLock> locker(globalObject.vm().apiLock());
     if (RefPtr stream = m_stream.get()) {
         if (RefPtr controller = stream->controller())
             controller->error(globalObject, error);
     }
+
+    if (RefPtr pendingPull = std::exchange(m_pendingPull, nullptr))
+        pendingPull->resolve();
 
     if (RefPtr transport = m_transport.get())
         transport->receiveStreamClosed(m_identifier);
@@ -121,6 +187,10 @@ void WebTransportReceiveStreamByteSource::cancel(JSC::JSValue reason, Ref<Deferr
     if (m_isCancelled)
         return;
     m_isCancelled = true;
+    m_queue.clear();
+    m_currentOffset = 0;
+    if (RefPtr pendingPull = std::exchange(m_pendingPull, nullptr))
+        pendingPull->resolve();
 
     RefPtr transport = m_transport.get();
     if (!transport)

--- a/Source/WebCore/Modules/webtransport/WebTransportReceiveStreamByteSource.h
+++ b/Source/WebCore/Modules/webtransport/WebTransportReceiveStreamByteSource.h
@@ -26,12 +26,17 @@
 #pragma once
 
 #include "ReadableStreamSource.h"
+#include <wtf/Deque.h>
+
+namespace JSC {
+class ArrayBuffer;
+}
 
 namespace WebCore {
 
-class DOMPromise;
 class DeferredPromise;
 class Exception;
+class ReadableByteStreamController;
 class ReadableStream;
 class WebTransport;
 class WebTransportReceiveStream;
@@ -44,7 +49,7 @@ class WebTransportReceiveStreamByteSource final : public RefCounted<WebTransport
 public:
     static Ref<WebTransportReceiveStreamByteSource> create(WebTransport& transport, WebTransportStreamIdentifier identifier) { return adoptRef(*new WebTransportReceiveStreamByteSource(transport, identifier)); }
 
-    Ref<DOMPromise> pull(JSDOMGlobalObject&);
+    void pull(JSDOMGlobalObject&, ReadableByteStreamController&, Ref<DeferredPromise>&&);
     void receiveBytes(std::span<const uint8_t>, bool, std::optional<Exception>&&);
     void receiveError(JSDOMGlobalObject&, JSC::JSValue error);
     void cancel(JSC::JSValue reason, Ref<DeferredPromise>&&);
@@ -59,8 +64,17 @@ public:
 private:
     WebTransportReceiveStreamByteSource(WebTransport&, WebTransportStreamIdentifier);
 
+    void deliverBytes(JSDOMGlobalObject&, ReadableByteStreamController&, Ref<DeferredPromise>&&);
+    void closeStream(JSDOMGlobalObject&, ReadableByteStreamController&);
+    void errorStream(JSDOMGlobalObject&, ReadableByteStreamController&, const Exception&);
+
     bool m_isCancelled { false };
     bool m_isClosed { false };
+    bool m_finReceived { false };
+
+    Deque<Ref<JSC::ArrayBuffer>> m_queue;
+    size_t m_currentOffset { 0 };
+    RefPtr<DeferredPromise> m_pendingPull;
 
     ThreadSafeWeakPtr<WebTransport> m_transport;
     WeakPtr<ReadableStream> m_stream;

--- a/Source/WebCore/Modules/webtransport/WebTransportReceiveStreamSource.h
+++ b/Source/WebCore/Modules/webtransport/WebTransportReceiveStreamSource.h
@@ -44,6 +44,8 @@ public:
     static Ref<WebTransportReceiveStreamSource> createIncomingStreamsSource() { return adoptRef(*new WebTransportReceiveStreamSource()); }
     bool receiveIncomingStream(JSC::JSGlobalObject&, Ref<WebTransportReceiveStream>&);
 
+    void stopReceivingIncomingStreams() { m_isCancelled = true; }
+
 private:
     WebTransportReceiveStreamSource() = default;
     void setActive() final { }


### PR DESCRIPTION
#### 851b271edd75317ce210f85fd016a79439c62855
<pre>
Implement WebTransportReceiveStream pull bytes algorithm
<a href="https://bugs.webkit.org/show_bug.cgi?id=320390">https://bugs.webkit.org/show_bug.cgi?id=320390</a>
<a href="https://rdar.apple.com/183347616">rdar://183347616</a>

Reviewed by Youenn Fablet.

This makes WebTransport receive streams and bidirectional streams work with byob buffers that
don&apos;t line up exactly with what bytes are received from the network.

Tests: imported/w3c/web-platform-tests/webtransport/receive-stream-pull.https.any.html
       imported/w3c/web-platform-tests/webtransport/receive-stream-pull.https.any.serviceworker.html
       imported/w3c/web-platform-tests/webtransport/receive-stream-pull.https.any.sharedworker.html
       imported/w3c/web-platform-tests/webtransport/receive-stream-pull.https.any.worker.html

* LayoutTests/imported/w3c/web-platform-tests/webtransport/receive-stream-pull.https.any-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/webtransport/receive-stream-pull.https.any.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/webtransport/receive-stream-pull.https.any.js: Added.
(async echo_bidirectional_stream):
(ascending_bytes):
(promise_test.async t):
* LayoutTests/imported/w3c/web-platform-tests/webtransport/receive-stream-pull.https.any.serviceworker-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/webtransport/receive-stream-pull.https.any.serviceworker.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/webtransport/receive-stream-pull.https.any.sharedworker-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/webtransport/receive-stream-pull.https.any.sharedworker.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/webtransport/receive-stream-pull.https.any.worker-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/webtransport/receive-stream-pull.https.any.worker.html: Added.
* Source/WebCore/Modules/webtransport/DatagramByteSource.cpp:
(WebCore::DatagramByteSource::receiveDatagram):
(WebCore::DatagramByteSource::closeStreamIfPossible):
* Source/WebCore/Modules/webtransport/WebTransport.cpp:
(WebCore::WebTransport::WebTransport):
(WebCore::WebTransport::receiveIncomingUnidirectionalStream):
(WebCore::createBidirectionalStream):
(WebCore::WebTransport::receiveBidirectionalStream):
(WebCore::WebTransport::streamReceiveBytes):
(WebCore::WebTransport::cleanup):
(WebCore::WebTransport::didDrain):
* Source/WebCore/Modules/webtransport/WebTransportBidirectionalStreamSource.h:
(WebCore::WebTransportBidirectionalStreamSource::stopReceivingIncomingStreams):
* Source/WebCore/Modules/webtransport/WebTransportReceiveStream.cpp:
(WebCore::WebTransportReceiveStream::create):
* Source/WebCore/Modules/webtransport/WebTransportReceiveStreamByteSource.cpp:
(WebCore::WebTransportReceiveStreamByteSource::pull):
(WebCore::WebTransportReceiveStreamByteSource::deliverBytes):
(WebCore::WebTransportReceiveStreamByteSource::closeStream):
(WebCore::WebTransportReceiveStreamByteSource::errorStream):
(WebCore::WebTransportReceiveStreamByteSource::receiveBytes):
(WebCore::WebTransportReceiveStreamByteSource::receiveError):
(WebCore::WebTransportReceiveStreamByteSource::cancel):
* Source/WebCore/Modules/webtransport/WebTransportReceiveStreamByteSource.h:
* Source/WebCore/Modules/webtransport/WebTransportReceiveStreamSource.h:
(WebCore::WebTransportReceiveStreamSource::stopReceivingIncomingStreams):

Canonical link: <a href="https://commits.webkit.org/318185@main">https://commits.webkit.org/318185@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4660d9a6cb73c1f8ae823f1cb55deab2c4c58fbd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177544 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51482 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45276 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187148 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140791 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179407 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52774 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51191 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138371 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140791 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1523a271-65e2-4bbe-9035-73f58a9c2ff4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180500 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41878 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159121 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118836 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/40539 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/38913 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150946 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38616 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35615 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/43267 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/43147 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189576 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51149 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/158653 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147471 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51831 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/35245 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147262 "Passed tests") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26932 "Build is in progress. Recent messages:OS: Tahoe (26.5.1), Xcode: 26.5; Checked out pull request; Reviewed by Youenn Fablet; Canonicalized commit; Pushed commit to WebKit repository") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41979 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124046 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118458 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50339 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13595 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49735 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49975 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49797 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->