### PR TITLE
[JSC] Eagerly build AST for likely IIFEs, without sharing a ParserArena

### DIFF
--- a/JSTests/stress/eager-iife-column-tracking.js
+++ b/JSTests/stress/eager-iife-column-tracking.js
@@ -1,0 +1,37 @@
+//@ requireOptions("--useEagerIIFEParsing=true")
+
+// Column numbers inside eagerly parsed IIFEs must be tracked correctly. That is not a given
+// because on the eager parsing path the start offset is absolute and not relative to the
+// enclosing function start as it is during the normal lazy parse.
+
+function assert(condition, message) {
+    if (!condition)
+        throw new Error(message);
+}
+
+function getFirstFrameColumn(e) {
+    var line = e.stack.split('\n')[0];
+    var match = line.match(/:(\d+)$/);
+    assert(match, "Could not parse column from stack frame: " + line);
+    return parseInt(match[1]);
+}
+
+// Case 1: same-line nested function in IIFE.
+try { (function() { (function() { throw new Error(); })(); })(); } catch(e) { assert(getFirstFrameColumn(e) === 50, "Case 1: expected column 50, got " + getFirstFrameColumn(e)); }
+
+// Case 2: multi-line — nested function on a different line than IIFE's '('.
+try {
+    (function() {
+        (function() { throw new Error(); })();
+    })();
+} catch(e) { assert(getFirstFrameColumn(e) === 38, "Case 2: expected column 38, got " + getFirstFrameColumn(e)); }
+
+// Case 3: deeper nesting — IIFE inside IIFE, same line.
+try { (function() { (function() { (function() { throw new Error(); })(); })(); })(); } catch(e) { assert(getFirstFrameColumn(e) === 64, "Case 3: expected column 64, got " + getFirstFrameColumn(e)); }
+
+// Case 4: multi-line, inner function offset within the line.
+try {
+    (function() {
+        var x = 1; (function() { throw new Error(); })();
+    })();
+} catch(e) { assert(getFirstFrameColumn(e) === 49, "Case 4: expected column 49, got " + getFirstFrameColumn(e)); }

--- a/JSTests/stress/eager-iife-detection.js
+++ b/JSTests/stress/eager-iife-detection.js
@@ -1,0 +1,57 @@
+//@ requireOptions("--useEagerIIFEParsing=true", "--useDollarVM=1")
+
+function assertCounts({detected, succeeded}, src) {
+    const initialDetected = $vm.iifeDetectionCount();
+    const initialSucceeded = $vm.iifeSuccessCount();
+    eval(src);
+    const actualDetected = $vm.iifeDetectionCount() - initialDetected;
+    const actualSucceeded = $vm.iifeSuccessCount() - initialSucceeded;
+    if (actualDetected !== detected || actualSucceeded !== succeeded)
+        throw new Error(`${JSON.stringify(src)}: expected {detected:${detected}, succeeded:${succeeded}}, got {detected:${actualDetected}, succeeded:${actualSucceeded}}`);
+}
+
+// === True IIFEs — every detection succeeds. ===
+
+assertCounts({detected: 1, succeeded: 1}, "(function() { return 1; })();");
+assertCounts({detected: 1, succeeded: 1}, "(function() { return 2; }());");
+assertCounts({detected: 1, succeeded: 1}, "!function() { return 3; }();");
+assertCounts({detected: 1, succeeded: 1}, "(function(x) { return x; })(1);");
+assertCounts({detected: 1, succeeded: 1}, "(function(x, y) { return x + y; })(1, 2);");
+assertCounts({detected: 1, succeeded: 1}, "(function(x, y, z) { return x + y + z; })(1, 2, 3);");
+assertCounts({detected: 1, succeeded: 1}, "!function(z) { return z; }(4);");
+
+
+// === Not IIFEs — neither detected nor eager-parsed. ===
+
+// Function expression passed as call argument; the `(` opens a call
+// arg list, not a parenthesised expression.
+assertCounts({detected: 0, succeeded: 0}, "function callWith(fn) { return fn(); } callWith(function() { return 4; });");
+
+// Object property, array element, variable initializer.
+assertCounts({detected: 0, succeeded: 0}, "var obj = { fn: function() { return 5; } };");
+assertCounts({detected: 0, succeeded: 0}, "var f = function() { return 6; };");
+assertCounts({detected: 0, succeeded: 0}, "var arr = [function() { return 7; }];");
+
+// Function declaration — not even a function expression.
+assertCounts({detected: 0, succeeded: 0}, "function decl() { return 8; }");
+
+// `+function()` — the detector only fires for `!`, not other unary
+// prefixes.
+assertCounts({detected: 0, succeeded: 0}, "+function() { return 10; }();");
+
+
+// === Nested IIFE — both outer and inner detect and succeed. ===
+
+assertCounts({detected: 2, succeeded: 2},
+    "(function() { return (function() { return 14; })(); })();");
+
+
+// === Empty-body IIFE — detected but does NOT succeed because we are not creating and caching ASTs for those until they are needed.
+
+assertCounts({detected: 1, succeeded: 0}, "(function() {})();");
+assertCounts({detected: 1, succeeded: 0}, "!function() {}();");
+
+
+// === Parenthesised function expression without a following call (false positive - not really an IIFE).
+
+assertCounts({detected: 1, succeeded: 1}, "var g = (function() { return 11; }); g();");

--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -818,6 +818,7 @@
 		234E91BF2EE2571E000BAE2C /* JSWebAssemblySuspendError.h in Headers */ = {isa = PBXBuildFile; fileRef = 234E91BD2EE2571E000BAE2C /* JSWebAssemblySuspendError.h */; };
 		234E91C52EE25777000BAE2C /* WebAssemblySuspendErrorPrototype.h in Headers */ = {isa = PBXBuildFile; fileRef = 234E91C32EE25777000BAE2C /* WebAssemblySuspendErrorPrototype.h */; };
 		234E91C62EE25777000BAE2C /* WebAssemblySuspendErrorConstructor.h in Headers */ = {isa = PBXBuildFile; fileRef = 234E91C12EE25777000BAE2C /* WebAssemblySuspendErrorConstructor.h */; };
+		235A9D742F983D1600A1E8FE /* EagerIIFERegistry.h in Headers */ = {isa = PBXBuildFile; fileRef = 235A9D722F983D0100A1E8FE /* EagerIIFERegistry.h */; };
 		237C93DD2E95A87900F62455 /* WebAssemblySuspendingConstructor.h in Headers */ = {isa = PBXBuildFile; fileRef = 237C93D92E95A85F00F62455 /* WebAssemblySuspendingConstructor.h */; };
 		237C93DE2E95A89A00F62455 /* WebAssemblySuspendingPrototype.h in Headers */ = {isa = PBXBuildFile; fileRef = 237C93DB2E95A85F00F62455 /* WebAssemblySuspendingPrototype.h */; };
 		23863EEB2E5EC93E00E57879 /* WebAssemblyBuiltinTrampoline.h in Headers */ = {isa = PBXBuildFile; fileRef = 23863EEA2E5EC92900E57879 /* WebAssemblyBuiltinTrampoline.h */; };
@@ -4099,6 +4100,8 @@
 		234E91C22EE25777000BAE2C /* WebAssemblySuspendErrorConstructor.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = WebAssemblySuspendErrorConstructor.cpp; path = js/WebAssemblySuspendErrorConstructor.cpp; sourceTree = "<group>"; };
 		234E91C32EE25777000BAE2C /* WebAssemblySuspendErrorPrototype.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = WebAssemblySuspendErrorPrototype.h; path = js/WebAssemblySuspendErrorPrototype.h; sourceTree = "<group>"; };
 		234E91C42EE25777000BAE2C /* WebAssemblySuspendErrorPrototype.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = WebAssemblySuspendErrorPrototype.cpp; path = js/WebAssemblySuspendErrorPrototype.cpp; sourceTree = "<group>"; };
+		235A9D722F983D0100A1E8FE /* EagerIIFERegistry.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = EagerIIFERegistry.h; sourceTree = "<group>"; };
+		235A9D732F983D0100A1E8FE /* EagerIIFERegistry.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = EagerIIFERegistry.cpp; sourceTree = "<group>"; };
 		237C93D92E95A85F00F62455 /* WebAssemblySuspendingConstructor.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = WebAssemblySuspendingConstructor.h; path = js/WebAssemblySuspendingConstructor.h; sourceTree = "<group>"; };
 		237C93DA2E95A85F00F62455 /* WebAssemblySuspendingConstructor.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = WebAssemblySuspendingConstructor.cpp; path = js/WebAssemblySuspendingConstructor.cpp; sourceTree = "<group>"; };
 		237C93DB2E95A85F00F62455 /* WebAssemblySuspendingPrototype.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = WebAssemblySuspendingPrototype.h; path = js/WebAssemblySuspendingPrototype.h; sourceTree = "<group>"; };
@@ -8538,6 +8541,8 @@
 			isa = PBXGroup;
 			children = (
 				A7A7EE7411B98B8D0065A14F /* ASTBuilder.h */,
+				235A9D732F983D0100A1E8FE /* EagerIIFERegistry.cpp */,
+				235A9D722F983D0100A1E8FE /* EagerIIFERegistry.h */,
 				93F1981A08245AAE001E9ABC /* Keywords.table */,
 				F692A8650255597D01FF60F7 /* Lexer.cpp */,
 				F692A8660255597D01FF60F7 /* Lexer.h */,
@@ -11705,6 +11710,7 @@
 				E350708A1DC49BBF0089BCD6 /* DOMJITSignature.h in Headers */,
 				A70447EE17A0BD7000F5898E /* DumpContext.h in Headers */,
 				FFF79F9D2FB2F1B2003FF02A /* DurationArithmetic.h in Headers */,
+				235A9D742F983D1600A1E8FE /* EagerIIFERegistry.h in Headers */,
 				145FF2C8243BB9D600569E71 /* ECMAMode.h in Headers */,
 				2A83638618D7D0EE0000EBCC /* EdenGCActivityCallback.h in Headers */,
 				1AB2A6FB9608AD5DF73332D4 /* EmbedderArrayLike.h in Headers */,

--- a/Source/JavaScriptCore/Sources.txt
+++ b/Source/JavaScriptCore/Sources.txt
@@ -711,6 +711,7 @@ llint/LLIntExceptions.cpp
 llint/LLIntSlowPaths.cpp
 llint/LLIntThunks.cpp
 
+parser/EagerIIFERegistry.cpp
 parser/Lexer.cpp
 parser/LexerUnicodeProperties.cpp
 parser/ModuleAnalyzer.cpp

--- a/Source/JavaScriptCore/parser/ASTBuilder.h
+++ b/Source/JavaScriptCore/parser/ASTBuilder.h
@@ -531,7 +531,7 @@ public:
         double name, const ParserFunctionInfo<ASTBuilder>& functionInfo, ClassElementTag tag)
     {
         functionInfo.body->setLoc(functionInfo.startLine, functionInfo.endLine, location.startOffset, location.lineStartOffset);
-        const Identifier& ident = parserArena.identifierArena().makeNumericIdentifier(vm, name);
+        SUPPRESS_UNCOUNTED_ARG const Identifier& ident = parserArena.identifierArena().makeNumericIdentifier(vm, name);
         functionInfo.body->setEcmaName(ident);
         SourceCode source = m_sourceCode->subExpression(functionInfo.startOffset, functionInfo.endOffset, functionInfo.startLine, functionInfo.parametersStartColumn);
         MethodDefinitionNode* methodDef = new (m_parserArena) MethodDefinitionNode(location, vm.propertyNames->nullIdentifier, functionInfo.body, source);
@@ -559,7 +559,7 @@ public:
     }
     PropertyNode* createProperty(VM& vm, ParserArena& parserArena, double propertyName, ExpressionNode* node, PropertyNode::Type type, SuperBinding superBinding, ClassElementTag tag)
     {
-        return new (m_parserArena) PropertyNode(parserArena.identifierArena().makeNumericIdentifier(vm, propertyName), node, type, superBinding, tag);
+        SUPPRESS_UNCOUNTED_ARG return new (m_parserArena) PropertyNode(parserArena.identifierArena().makeNumericIdentifier(vm, propertyName), node, type, superBinding, tag);
     }
     PropertyNode* createProperty(ExpressionNode* propertyName, ExpressionNode* node, PropertyNode::Type type, SuperBinding superBinding, ClassElementTag tag) { return new (m_parserArena) PropertyNode(propertyName, node, type, superBinding, tag); }
     PropertyNode* createProperty(const Identifier* identifier, ExpressionNode* propertyName, ExpressionNode* node, PropertyNode::Type type, SuperBinding superBinding, ClassElementTag tag) { return new (m_parserArena) PropertyNode(*identifier, propertyName, node, type, superBinding, tag); }

--- a/Source/JavaScriptCore/parser/EagerIIFERegistry.cpp
+++ b/Source/JavaScriptCore/parser/EagerIIFERegistry.cpp
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "EagerIIFERegistry.h"
+
+#include "IdentifierInlines.h"
+
+namespace JSC {
+
+EagerIIFERegistry::~EagerIIFERegistry()
+{
+    clear();
+}
+
+void EagerIIFERegistry::clear()
+{
+    m_map.clear();
+}
+
+void EagerIIFERegistry::add(int sourcePosition, std::unique_ptr<FunctionNode> node)
+{
+    m_map.add(sourcePosition, WTF::move(node));
+}
+
+std::unique_ptr<FunctionNode> EagerIIFERegistry::take(int sourcePosition)
+{
+    return m_map.take(sourcePosition);
+}
+
+} // namespace JSC

--- a/Source/JavaScriptCore/parser/EagerIIFERegistry.h
+++ b/Source/JavaScriptCore/parser/EagerIIFERegistry.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "Nodes.h"
+#include <wtf/InlineMap.h>
+#include <wtf/RefCounted.h>
+
+namespace JSC {
+
+class EagerIIFERegistry final : public RefCounted<EagerIIFERegistry> {
+public:
+    static Ref<EagerIIFERegistry> create() { return adoptRef(*new EagerIIFERegistry); }
+    ~EagerIIFERegistry();
+
+    void clear();
+    void add(int sourcePosition, std::unique_ptr<FunctionNode>);
+    std::unique_ptr<FunctionNode> take(int sourcePosition);
+
+private:
+    EagerIIFERegistry() { }
+
+    InlineMap<int, std::unique_ptr<FunctionNode>, 4, WTF::IntHash<int>, WTF::UnsignedWithZeroKeyHashTraits<int>> m_map;
+};
+
+} // namespace JSC

--- a/Source/JavaScriptCore/parser/Lexer.h
+++ b/Source/JavaScriptCore/parser/Lexer.h
@@ -63,6 +63,7 @@ public:
 
     // Functions to set up parsing.
     void setCode(const SourceCode&, ParserArena*);
+    IdentifierArena* identifierArena() const { return m_arena; }
     void setIsReparsingFunction() { m_isReparsingFunction = true; }
     bool isReparsingFunction() const { return m_isReparsingFunction; }
 
@@ -210,7 +211,7 @@ private:
     // Fields up to m_sourceURLDirective are arranged according to access frequency
     // and affinity; do not rearrange without careful analysis.
     VM& m_vm;
-    IdentifierArena* m_arena;
+    SUPPRESS_UNCOUNTED_MEMBER IdentifierArena* m_arena;
     const T* m_code;
     const T* m_codeStart;
     const T* m_codeEnd;
@@ -298,22 +299,22 @@ template<typename T>
 template<typename CharacterType>
 ALWAYS_INLINE const Identifier* Lexer<T>::makeIdentifier(std::span<const CharacterType> characters)
 {
-    return &m_arena->makeIdentifier(m_vm, characters);
+    SUPPRESS_UNCOUNTED_ARG return &m_arena->makeIdentifier(m_vm, characters);
 }
 
 template <>
 ALWAYS_INLINE const Identifier* Lexer<Latin1Character>::makeRightSizedIdentifier(std::span<const char16_t> characters, char16_t)
 {
-    return &m_arena->makeLatin1Identifier(m_vm, characters);
+    SUPPRESS_UNCOUNTED_ARG return &m_arena->makeLatin1Identifier(m_vm, characters);
 }
 
 template <>
 ALWAYS_INLINE const Identifier* Lexer<char16_t>::makeRightSizedIdentifier(std::span<const char16_t> characters, char16_t orAllChars)
 {
     if (!(orAllChars & ~0xff))
-        return &m_arena->makeLatin1Identifier(m_vm, characters);
+        SUPPRESS_UNCOUNTED_ARG return &m_arena->makeLatin1Identifier(m_vm, characters);
 
-    return &m_arena->makeIdentifier(m_vm, characters);
+    SUPPRESS_UNCOUNTED_ARG return &m_arena->makeIdentifier(m_vm, characters);
 }
 
 template <typename T>
@@ -339,13 +340,13 @@ ALWAYS_INLINE void Lexer<char16_t>::setCodeStart(StringView sourceString)
 template <typename T>
 ALWAYS_INLINE const Identifier* Lexer<T>::makeLatin1Identifier(std::span<const Latin1Character> characters)
 {
-    return &m_arena->makeIdentifier(m_vm, characters);
+    SUPPRESS_UNCOUNTED_ARG return &m_arena->makeIdentifier(m_vm, characters);
 }
 
 template <typename T>
 ALWAYS_INLINE const Identifier* Lexer<T>::makeLatin1Identifier(std::span<const char16_t> characters)
 {
-    return &m_arena->makeLatin1Identifier(m_vm, characters);
+    SUPPRESS_UNCOUNTED_ARG return &m_arena->makeLatin1Identifier(m_vm, characters);
 }
 
 #if ASSERT_ENABLED

--- a/Source/JavaScriptCore/parser/Parser.cpp
+++ b/Source/JavaScriptCore/parser/Parser.cpp
@@ -87,8 +87,44 @@
 namespace JSC {
 
 std::atomic<unsigned> globalParseCount { 0 };
+std::atomic<unsigned> globalIIFEDetectionCount { 0 };
+std::atomic<unsigned> globalIIFESuccessCount { 0 };
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(ModuleScopeData);
+
+// When the parser encounters an immediately-invoked function expression (IIFE), it can
+// build the AST right away instead of the usual syntax-checking parse followed by a full
+// AST-building reparse.
+//
+// EagerIIFEParseScope and EagerIIFEParseState work together to enable this optimization.
+// EagerIIFEParseScope is created as a local in parseFunctionInfo when an IIFE candidate
+// is detected. It owns a separate ParserArena and ASTBuilder, and constructs an
+// EagerIIFEParseState that installs itself into the parser, redirecting the parser's
+// current arena. The scope's ParserArena shares its IdentifierArena with the parent
+// arena, so identifiers can be freely shared between ASTs. The FunctionNode created for
+// the IIFE takes ownership of the scope's arena contents (including a reference to the
+// shared IdentifierArena) via swap, keeping it alive until the AST is destroyed.
+
+template<typename LexerType>
+class EagerIIFEParseScope {
+public:
+    EagerIIFEParseScope(Parser<LexerType>* parser, unsigned startOffset)
+        : m_arena(Ref { parser->m_currentArena->identifierArena() })
+        , m_builder(const_cast<VM&>(parser->m_vm), m_arena, const_cast<SourceCode*>(parser->m_source))
+        , m_parseState(*parser, &m_builder, m_arena, startOffset)
+    { }
+
+private:
+    ParserArena m_arena;
+    ASTBuilder m_builder;
+    Parser<LexerType>::EagerIIFEParseState m_parseState;
+};
+
+template <typename LexerType>
+CodeFeatures Parser<LexerType>::EagerIIFEParseState::features() const { return m_builder->features(); }
+
+template <typename LexerType>
+int Parser<LexerType>::EagerIIFEParseState::numConstants() const { return m_builder->numConstants(); }
 
 ALWAYS_INLINE static SourceParseMode getAsyncFunctionBodyParseMode(SourceParseMode parseMode)
 {
@@ -144,11 +180,13 @@ Parser<LexerType>::Parser(VM& vm, const SourceCode& source, ImplementationVisibi
 {
     m_lexer = makeUnique<LexerType>(vm, builtinMode, scriptMode);
     m_lexer->setCode(source, &m_parserArena);
+    setCurrentArena(m_parserArena);
     m_token.m_startPosition.line = source.firstLine().oneBasedInt();
     m_token.m_startPosition.offset = source.startOffset();
     m_token.m_startPosition.lineStartOffset = source.startOffset();
     m_token.m_endPosition.offset = source.startOffset();
     m_functionCache = vm.addSourceProviderCache(source.provider());
+    m_eagerIIFERegistry = vm.addEagerIIFERegistry(source.provider());
 
     Scope* scope = pushScope();
     scope->setLexicallyScopedFeatures(lexicallyScopedFeatures);
@@ -215,6 +253,7 @@ static ALWAYS_INLINE bool NODELETE isPrivateFieldName(UniquedStringImpl* uid)
 template <typename LexerType>
 Expected<typename Parser<LexerType>::ParseInnerResult, String> Parser<LexerType>::parseInner(const Identifier& calleeName, ParsingContext parsingContext, std::optional<int> functionConstructorParametersEndPosition, const FixedVector<UnlinkedFunctionExecutable::ClassElementDefinition>* classElementDefinitions, const PrivateNameEnvironment* parentScopePrivateNames)
 {
+    ASSERT(m_currentArena == &m_parserArena);
     ASTBuilder context(const_cast<VM&>(m_vm), m_parserArena, const_cast<SourceCode*>(m_source));
     SourceParseMode parseMode = sourceParseMode();
     Scope* scope = currentScope();
@@ -321,21 +360,7 @@ Expected<typename Parser<LexerType>::ParseInnerResult, String> Parser<LexerType>
             context.propagateArgumentsUse();
     }
 
-    CodeFeatures features = context.features();
-    if (scope->shadowsArguments())
-        features |= ShadowsArgumentsFeature;
-    if (m_seenTaggedTemplateInNonReparsingFunctionMode)
-        features |= NoEvalCacheFeature;
-    if (scope->hasNonSimpleParameterList())
-        features |= NonSimpleParameterListFeature;
-    if (scope->usesImportMeta())
-        features |= ImportMetaFeature;
-    if (m_seenArgumentsDotLength && scope->hasDeclaredGlobalArguments())
-        features |= ArgumentsFeature;
-    if (scope->asyncFunctionBodyDoesNotUseAwait())
-        features |= AsyncFunctionWithoutAwaitFeature;
-    if (scope->usesAwait())
-        features |= AwaitFeature;
+    CodeFeatures features = collectCodeFeatures(context.features(), scope);
 
 #if ASSERT_ENABLED
     if (m_parsingBuiltin && isProgramParseMode(parseMode)) {
@@ -353,6 +378,26 @@ Expected<typename Parser<LexerType>::ParseInnerResult, String> Parser<LexerType>
 #endif // ASSERT_ENABLED
 
     return ParseInnerResult { parameters, sourceElements, scope->takeFunctionDeclarations(), scope->takeDeclaredVariables(), scope->takeLexicalEnvironment(), features, context.numConstants() };
+}
+
+template <typename LexerType>
+CodeFeatures Parser<LexerType>::collectCodeFeatures(CodeFeatures features, Scope* scope)
+{
+    if (scope->shadowsArguments())
+        features |= ShadowsArgumentsFeature;
+    if (scope->hasNonSimpleParameterList())
+        features |= NonSimpleParameterListFeature;
+    if (m_seenTaggedTemplateInNonReparsingFunctionMode)
+        features |= NoEvalCacheFeature;
+    if (scope->usesImportMeta())
+        features |= ImportMetaFeature;
+    if (m_seenArgumentsDotLength && scope->hasDeclaredGlobalArguments())
+        features |= ArgumentsFeature;
+    if (scope->asyncFunctionBodyDoesNotUseAwait())
+        features |= AsyncFunctionWithoutAwaitFeature;
+    if (scope->usesAwait())
+        features |= AwaitFeature;
+    return features;
 }
 
 template <typename LexerType>
@@ -1391,14 +1436,14 @@ template <class TreeBuilder> TreeDestructuringPattern Parser<LexerType>::parseDe
                 switch (m_token.m_type) {
                 case DOUBLE:
                 case INTEGER:
-                    propertyName = &m_parserArena.identifierArena().makeNumericIdentifier(const_cast<VM&>(m_vm), m_token.m_data.doubleValue);
+                    propertyName = &m_currentArena->identifierArena().makeNumericIdentifier(const_cast<VM&>(m_vm), m_token.m_data.doubleValue);
                     break;
                 case STRING:
                     propertyName = m_token.m_data.ident;
                     wasString = true;
                     break;
                 case BIGINT:
-                    propertyName = m_parserArena.identifierArena().makeBigIntDecimalIdentifier(const_cast<VM&>(m_vm), *m_token.m_data.bigIntString, m_token.m_data.radix);
+                    propertyName = m_currentArena->identifierArena().makeBigIntDecimalIdentifier(const_cast<VM&>(m_vm), *m_token.m_data.bigIntString, m_token.m_data.radix);
                     failIfFalse(propertyName, "Cannot parse big int property name");
                     break;
                 case OPENBRACKET:
@@ -2378,7 +2423,9 @@ template <class TreeBuilder> TreeFunctionBody Parser<LexerType>::parseFunctionBo
         else
             failIfFalse(parseArrowFunctionSingleExpressionBodySourceElements(syntaxChecker), "Cannot parse body of this arrow function");
     } else {
-        if (m_debuggerParseData)
+        if (m_iifeParseState && !m_iifeParseState->isInUse()) [[unlikely]]
+            failIfFalse(m_iifeParseState->parseSourceElements(CheckForStrictMode), bodyType == StandardFunctionBodyBlock ? "Cannot parse body of this function" : "Cannot parse body of this arrow function");
+        else if (m_debuggerParseData)
             failIfFalse(parseSourceElements(context, CheckForStrictMode), bodyType == StandardFunctionBodyBlock ? "Cannot parse body of this function" : "Cannot parse body of this arrow function");
         else
             failIfFalse(parseSourceElements(syntaxChecker, CheckForStrictMode), bodyType == StandardFunctionBodyBlock ? "Cannot parse body of this function" : "Cannot parse body of this arrow function");
@@ -2572,7 +2619,7 @@ template <class TreeBuilder> typename TreeBuilder::FormalParameterList Parser<Le
 }
 
 template <typename LexerType>
-template <class TreeBuilder> bool Parser<LexerType>::parseFunctionInfo(TreeBuilder& context, FunctionNameRequirements requirements, bool nameIsInContainingScope, ConstructorKind constructorKind, SuperBinding expectedSuperBinding, unsigned functionStart, ParserFunctionInfo<TreeBuilder>& functionInfo, FunctionDefinitionType functionDefinitionType, std::optional<int> functionConstructorParametersEndPosition)
+template <class TreeBuilder, bool ExpectIIFE> bool Parser<LexerType>::parseFunctionInfo(TreeBuilder& context, FunctionNameRequirements requirements, bool nameIsInContainingScope, ConstructorKind constructorKind, SuperBinding expectedSuperBinding, unsigned functionStart, ParserFunctionInfo<TreeBuilder>& functionInfo, FunctionDefinitionType functionDefinitionType, std::optional<int> functionConstructorParametersEndPosition)
 {
     auto mode = sourceParseMode();
     RELEASE_ASSERT(isFunctionParseMode(mode));
@@ -2599,83 +2646,10 @@ template <class TreeBuilder> bool Parser<LexerType>::parseFunctionInfo(TreeBuild
     int startColumn = -1;
     FunctionBodyType functionBodyType;
 
-    auto tryLoadCachedFunction = [&] () -> bool {
-        if (!Options::useSourceProviderCache()) [[unlikely]]
-            return false;
-
-        if (m_debuggerParseData) [[unlikely]]
-            return false;
-
-        ASSERT(parametersStart != -1);
-        ASSERT(startColumn != -1);
-
-        // If we know about this function already, we can use the cached info and skip the parser to the end of the function.
-        if (const SourceProviderCacheItem* cachedInfo = TreeBuilder::CanUseFunctionCache ? findCachedFunctionInfo(parametersStart) : nullptr) {
-            // If we're in a strict context, the cached function info must say it was strict too.
-            ASSERT(!strictMode() || (cachedInfo->lexicallyScopedFeatures() & StrictModeLexicallyScopedFeature));
-            JSTokenLocation endLocation;
-
-            ConstructorKind constructorKind = static_cast<ConstructorKind>(cachedInfo->constructorKind);
-            SuperBinding expectedSuperBinding = static_cast<SuperBinding>(cachedInfo->expectedSuperBinding);
-
-            endLocation.line = cachedInfo->lastTokenLine;
-            endLocation.startOffset = cachedInfo->lastTokenStartOffset;
-            endLocation.lineStartOffset = cachedInfo->lastTokenLineStartOffset;
-            ASSERT(endLocation.startOffset >= endLocation.lineStartOffset);
-
-            bool endColumnIsOnStartLine = endLocation.line == functionInfo.startLine;
-            unsigned currentLineStartOffset = m_lexer->currentLineStartOffset();
-            unsigned bodyEndColumn = endColumnIsOnStartLine ? endLocation.startOffset - currentLineStartOffset : endLocation.startOffset - endLocation.lineStartOffset;
-
-            ASSERT(endLocation.startOffset >= endLocation.lineStartOffset);
-            
-            FunctionBodyType functionBodyType;
-            if (SourceParseModeSet(SourceParseMode::ArrowFunctionMode, SourceParseMode::AsyncArrowFunctionMode).contains(mode)) [[unlikely]]
-                functionBodyType = cachedInfo->isBodyArrowExpression ?  ArrowFunctionBodyExpression : ArrowFunctionBodyBlock;
-            else
-                functionBodyType = StandardFunctionBodyBlock;
-
-            SuperBinding functionSuperBinding = adjustSuperBindingForBaseConstructor(constructorKind, expectedSuperBinding, mode, cachedInfo->needsSuperBinding, cachedInfo->usesEval, cachedInfo->innerArrowFunctionFeatures);
-
-            functionInfo.body = context.createFunctionMetadata(
-                startLocation, endLocation, startColumn, bodyEndColumn, functionStart,
-                functionNameStart, parametersStart, static_cast<ImplementationVisibility>(cachedInfo->implementationVisibility),
-                cachedInfo->lexicallyScopedFeatures(), constructorKind, functionSuperBinding,
-                cachedInfo->parameterCount,
-                mode, functionBodyType == ArrowFunctionBodyExpression);
-            functionInfo.endOffset = cachedInfo->endFunctionOffset;
-            functionInfo.parameterCount = cachedInfo->parameterCount;
-
-            functionScope->restoreFromSourceProviderCache(cachedInfo);
-            popScope(functionScope, TreeBuilder::NeedsFreeVariableInfo);
-            
-            m_token = cachedInfo->endFunctionToken();
-
-            if (endColumnIsOnStartLine)
-                m_token.m_startPosition.lineStartOffset = currentLineStartOffset;
-
-            m_lexer->setOffset(m_token.m_endPosition.offset, m_token.m_startPosition.lineStartOffset);
-            m_lexer->setLineNumber(m_token.m_startPosition.line);
-
-            switch (functionBodyType) {
-            case ArrowFunctionBodyExpression:
-                next();
-                context.setEndOffset(functionInfo.body, m_lexer->currentOffset());
-                break;
-            case ArrowFunctionBodyBlock:
-            case StandardFunctionBodyBlock:
-                context.setEndOffset(functionInfo.body, m_lexer->currentOffset());
-                next();
-                break;
-            }
-            functionInfo.endLine = m_lastTokenLocation.line;
-            return true;
-        }
-
-        return false;
-    };
-
     SyntaxChecker syntaxChecker(const_cast<VM&>(m_vm), m_lexer.get());
+
+    using EagerIIFEScopeType = std::conditional_t<ExpectIIFE, std::optional<EagerIIFEParseScope<LexerType>>, std::monostate>;
+    [[maybe_unused]] EagerIIFEScopeType eagerIIFEParseScope;
 
     ParserState oldState;
     if ((SourceParseModeSet(SourceParseMode::ArrowFunctionMode, SourceParseMode::AsyncArrowFunctionMode).contains(mode))) [[unlikely]] {
@@ -2687,7 +2661,7 @@ template <class TreeBuilder> bool Parser<LexerType>::parseFunctionInfo(TreeBuild
         functionInfo.startOffset = parametersStart;
         functionInfo.parametersStartColumn = startColumn;
 
-        if (tryLoadCachedFunction())
+        if (tryLoadCachedFunctionInfo<TreeBuilder>(context, functionInfo, functionScope, startLocation, parametersStart, startColumn, functionStart, functionNameStart, mode))
             return true;
 
         m_parserState.lastFunctionName = lastFunctionName;
@@ -2761,19 +2735,47 @@ template <class TreeBuilder> bool Parser<LexerType>::parseFunctionInfo(TreeBuild
         startLocation = tokenLocation();
         functionInfo.startLine = tokenLine();
         startColumn = tokenColumn();
+        if constexpr (ExpectIIFE) {
+            // If we are parsing a function nested inside an eagerly parsed IIFE, and we
+            // are still on the same line where the IIFE started, the start column needs
+            // to be adjusted. During lazy parsing the startColumn of this function would
+            // be relative to the start of the IIFE, but during eager parsing it is
+            // relative to the start of the source code containing the IIFE.
+            if (m_iifeParseState
+                && m_iifeParseState->isInUse()
+                && tokenLineStart() <= m_iifeParseState->startOffset()) [[unlikely]] {
+                int adjustment = m_iifeParseState->startOffset() - tokenLineStart();
+                startColumn -= adjustment;
+            }
+        }
         functionInfo.parametersStartColumn = startColumn;
 
         parametersStart = m_token.m_startPosition.offset;
         functionInfo.startOffset = parametersStart;
 
-        if (tryLoadCachedFunction())
+        if (tryLoadCachedFunctionInfo<TreeBuilder>(context, functionInfo, functionScope, startLocation, parametersStart, startColumn, functionStart, functionNameStart, mode))
             return true;
+
+        if constexpr (ExpectIIFE && std::is_same_v<TreeBuilder, ASTBuilder>) {
+            if (Options::useEagerIIFEParsing()
+                && mode == SourceParseMode::NormalFunctionMode
+                && functionDefinitionType == FunctionDefinitionType::Expression
+                && !m_debuggerParseData
+                && m_eagerIIFERegistry) [[unlikely]]
+                eagerIIFEParseScope.emplace(this, parametersStart);
+        }
 
         m_parserState.lastFunctionName = lastFunctionName;
         oldState = internalSaveParserState(context);
         {
             SetForScope overrideAllowAwait(m_parserState.allowAwait, !isAsyncFunctionParseMode(mode));
-            parseFunctionParameters(syntaxChecker, functionInfo);
+            if constexpr (ExpectIIFE) {
+                if (m_iifeParseState && !m_iifeParseState->isInUse()) [[unlikely]]
+                    m_iifeParseState->template parseFunctionParameters<TreeBuilder>(functionInfo);
+                else
+                    parseFunctionParameters(syntaxChecker, functionInfo);
+            } else
+                parseFunctionParameters(syntaxChecker, functionInfo);
             propagateError();
         }
         
@@ -2812,10 +2814,6 @@ template <class TreeBuilder> bool Parser<LexerType>::parseFunctionInfo(TreeBuild
         return IterationStatus::Continue;
     });
 
-    auto performParsingFunctionBody = [&] {
-        return parseFunctionBody(context, syntaxChecker, startLocation, startColumn, functionStart, functionNameStart, parametersStart, constructorKind, expectedSuperBinding, functionBodyType, functionInfo.parameterCount);
-    };
-
     ImplementationVisibility implementationVisibility = this->implementationVisibility();
     if (isGeneratorOrAsyncFunctionWrapperParseMode(mode)) {
         AutoPopScope generatorBodyScope(this, pushScope());
@@ -2832,7 +2830,7 @@ template <class TreeBuilder> bool Parser<LexerType>::parseFunctionInfo(TreeBuild
         if (functionScope->hasNonSimpleParameterList())
             generatorBodyScope->setHasNonSimpleParameterList();
 
-        functionInfo.body = performParsingFunctionBody();
+        functionInfo.body = parseFunctionBodyForFunctionInfo(context, syntaxChecker, startLocation, startColumn, functionStart, functionNameStart, parametersStart, constructorKind, expectedSuperBinding, functionBodyType, functionInfo.parameterCount);
 
         // When a generator has a "use strict" directive, a generator function wrapping it should be strict mode.
         if  (generatorBodyScope->strictMode())
@@ -2841,8 +2839,8 @@ template <class TreeBuilder> bool Parser<LexerType>::parseFunctionInfo(TreeBuild
         implementationVisibility = generatorBodyScope->implementationVisibility();
         popScope(generatorBodyScope, TreeBuilder::NeedsFreeVariableInfo);
     } else
-        functionInfo.body = performParsingFunctionBody();
-    
+        functionInfo.body = parseFunctionBodyForFunctionInfo(context, syntaxChecker, startLocation, startColumn, functionStart, functionNameStart, parametersStart, constructorKind, expectedSuperBinding, functionBodyType, functionInfo.parameterCount);
+
     restoreParserState(context, oldState);
     failIfFalse(functionInfo.body, "Cannot parse the body of this ", stringForFunctionMode(mode));
     context.setEndOffset(functionInfo.body, m_lexer->currentOffset());
@@ -2892,9 +2890,16 @@ template <class TreeBuilder> bool Parser<LexerType>::parseFunctionInfo(TreeBuild
     }
 
     bool functionScopeWasStrictMode = functionScope->strictMode();
-    
-    popScope(functionScope, TreeBuilder::NeedsFreeVariableInfo);
-    
+
+    if constexpr (ExpectIIFE) {
+        if (m_iifeParseState && m_iifeParseState->sourceElements()) [[unlikely]] {
+            ASSERT(m_iifeParseState->functionParameters());
+            popScopeAndBuildFunctionNode(functionScope, functionInfo, startLocation, startColumn);
+        } else
+            popScope(functionScope, TreeBuilder::NeedsFreeVariableInfo);
+    } else
+        popScope(functionScope, TreeBuilder::NeedsFreeVariableInfo);
+
     if (functionBodyType != ArrowFunctionBodyExpression)
         consumeOrFail(CLOSEBRACE, "Expected a closing '}' after a ", stringForFunctionMode(mode), " body");
     else {
@@ -2913,6 +2918,158 @@ template <class TreeBuilder> bool Parser<LexerType>::parseFunctionInfo(TreeBuild
     
     functionInfo.endLine = m_lastTokenLocation.line;
     return true;
+}
+
+template <typename LexerType>
+template <class TreeBuilder>
+ALWAYS_INLINE TreeFunctionBody Parser<LexerType>::parseFunctionBodyForFunctionInfo(TreeBuilder& context, SyntaxChecker& syntaxChecker, const JSTokenLocation& startLocation, int startColumn, unsigned functionStart, int functionNameStart, int parametersStart, ConstructorKind constructorKind, SuperBinding expectedSuperBinding, FunctionBodyType functionBodyType, unsigned parameterCount)
+{
+    return parseFunctionBody(context, syntaxChecker, startLocation, startColumn, functionStart, functionNameStart, parametersStart, constructorKind, expectedSuperBinding, functionBodyType, parameterCount);
+}
+
+template <typename LexerType>
+template <class TreeBuilder>
+ALWAYS_INLINE bool Parser<LexerType>::tryLoadCachedFunctionInfo(TreeBuilder& context, ParserFunctionInfo<TreeBuilder>& functionInfo, AutoPopScope& functionScope, const JSTokenLocation& startLocation, int parametersStart, int startColumn, unsigned functionStart, int functionNameStart, SourceParseMode mode)
+{
+    if (!Options::useSourceProviderCache()) [[unlikely]]
+        return false;
+
+    if (m_debuggerParseData) [[unlikely]]
+        return false;
+
+    ASSERT(parametersStart != -1);
+    ASSERT(startColumn != -1);
+
+    // If we know about this function already, we can use the cached info and skip the parser to the end of the function.
+    if (const SourceProviderCacheItem* cachedInfo = TreeBuilder::CanUseFunctionCache ? findCachedFunctionInfo(parametersStart) : nullptr) {
+        // If we're in a strict context, the cached function info must say it was strict too.
+        ASSERT(!strictMode() || (cachedInfo->lexicallyScopedFeatures() & StrictModeLexicallyScopedFeature));
+        JSTokenLocation endLocation;
+
+        ConstructorKind constructorKind = static_cast<ConstructorKind>(cachedInfo->constructorKind);
+        SuperBinding expectedSuperBinding = static_cast<SuperBinding>(cachedInfo->expectedSuperBinding);
+
+        endLocation.line = cachedInfo->lastTokenLine;
+        endLocation.startOffset = cachedInfo->lastTokenStartOffset;
+        endLocation.lineStartOffset = cachedInfo->lastTokenLineStartOffset;
+        ASSERT(endLocation.startOffset >= endLocation.lineStartOffset);
+
+        bool endColumnIsOnStartLine = endLocation.line == functionInfo.startLine;
+        unsigned currentLineStartOffset = m_lexer->currentLineStartOffset();
+        unsigned bodyEndColumn = endColumnIsOnStartLine ? endLocation.startOffset - currentLineStartOffset : endLocation.startOffset - endLocation.lineStartOffset;
+
+        ASSERT(endLocation.startOffset >= endLocation.lineStartOffset);
+
+        FunctionBodyType functionBodyType;
+        if (SourceParseModeSet(SourceParseMode::ArrowFunctionMode, SourceParseMode::AsyncArrowFunctionMode).contains(mode)) [[unlikely]]
+            functionBodyType = cachedInfo->isBodyArrowExpression ?  ArrowFunctionBodyExpression : ArrowFunctionBodyBlock;
+        else
+            functionBodyType = StandardFunctionBodyBlock;
+
+        SuperBinding functionSuperBinding = adjustSuperBindingForBaseConstructor(constructorKind, expectedSuperBinding, mode, cachedInfo->needsSuperBinding, cachedInfo->usesEval, cachedInfo->innerArrowFunctionFeatures);
+
+        functionInfo.body = context.createFunctionMetadata(
+            startLocation, endLocation, startColumn, bodyEndColumn, functionStart,
+            functionNameStart, parametersStart, static_cast<ImplementationVisibility>(cachedInfo->implementationVisibility),
+            cachedInfo->lexicallyScopedFeatures(), constructorKind, functionSuperBinding,
+            cachedInfo->parameterCount,
+            mode, functionBodyType == ArrowFunctionBodyExpression);
+        functionInfo.endOffset = cachedInfo->endFunctionOffset;
+        functionInfo.parameterCount = cachedInfo->parameterCount;
+
+        functionScope->restoreFromSourceProviderCache(cachedInfo);
+        popScope(functionScope, TreeBuilder::NeedsFreeVariableInfo);
+
+        m_token = cachedInfo->endFunctionToken();
+
+        if (endColumnIsOnStartLine)
+            m_token.m_startPosition.lineStartOffset = currentLineStartOffset;
+
+        m_lexer->setOffset(m_token.m_endPosition.offset, m_token.m_startPosition.lineStartOffset);
+        m_lexer->setLineNumber(m_token.m_startPosition.line);
+
+        switch (functionBodyType) {
+        case ArrowFunctionBodyExpression:
+            next();
+            context.setEndOffset(functionInfo.body, m_lexer->currentOffset());
+            break;
+        case ArrowFunctionBodyBlock:
+        case StandardFunctionBodyBlock:
+            context.setEndOffset(functionInfo.body, m_lexer->currentOffset());
+            next();
+            break;
+        }
+        functionInfo.endLine = m_lastTokenLocation.line;
+        return true;
+    }
+
+    return false;
+}
+
+template <typename LexerType>
+template <class TreeBuilder>
+NEVER_INLINE void Parser<LexerType>::popScopeAndBuildFunctionNode(AutoPopScope& functionScope, ParserFunctionInfo<TreeBuilder>& functionInfo, const JSTokenLocation& startLocation, int startColumn)
+{
+    // Finalize sloppy-mode function hoisting before collecting scope data.
+    // This adds hoisted function names to declaredVariables and sets
+    // isSloppyModeHoistedFunction on the FunctionMetadataNodes, matching
+    // what parseInner() does during a normal reparse.
+    if (!functionScope->strictMode()) {
+        functionScope->finalizeSloppyModeFunctionHoisting();
+        // Clear candidates so they don't bubble up to outer scopes
+        // when popScope runs — the metadata nodes belong to the cached
+        // FunctionNode and must not be mutated by outer finalization.
+        functionScope->clearSloppyModeFunctionHoistingCandidates();
+    }
+
+    CodeFeatures features = collectCodeFeatures(m_iifeParseState->features(), functionScope.scope());
+    int numConstants = m_iifeParseState->numConstants();
+    LexicallyScopedFeatures lexFeatures = functionScope->lexicallyScopedFeatures();
+    InnerArrowFunctionCodeFeatures innerFeatures = functionScope->innerArrowFunctionFeatures();
+
+    VariableEnvironment varDeclarations = functionScope->declaredVariables();
+    IdentifierSet capturedVariables;
+    functionScope->getCapturedVars(capturedVariables);
+    for (auto& entry : capturedVariables)
+        varDeclarations.markVariableAsCaptured(entry.get());
+
+    auto [lexicalEnvironment, functionDeclarations] = popScope(functionScope, TreeBuilder::NeedsFreeVariableInfo);
+
+    SourceCode functionSource = m_source->subExpression(
+        functionInfo.startOffset, functionInfo.endOffset,
+        functionInfo.startLine, functionInfo.parametersStartColumn);
+
+    JSTokenLocation endLocation;
+    endLocation.line = m_lastTokenLocation.line;
+    endLocation.startOffset = functionInfo.endOffset;
+    endLocation.lineStartOffset = m_lastTokenLocation.lineStartOffset;
+
+    auto functionNode = makeUnique<FunctionNode>(
+        *m_currentArena,
+        startLocation,
+        endLocation,
+        startColumn,
+        tokenColumn(),
+        m_iifeParseState->sourceElements(),
+        WTF::move(varDeclarations),
+        WTF::move(functionDeclarations),
+        WTF::move(lexicalEnvironment),
+        m_iifeParseState->functionParameters(),
+        functionSource,
+        features,
+        lexFeatures,
+        innerFeatures,
+        numConstants,
+        nullptr /* moduleScopeData */);
+
+    functionNode->setLoc(functionInfo.startLine, m_lastTokenLocation.line, m_lastTokenLocation.endOffset, m_lastTokenLocation.lineStartOffset);
+    functionNode->setEndOffset(functionInfo.endOffset);
+    functionNode->finishParsing(
+        functionInfo.name ? *functionInfo.name : m_vm.propertyNames->nullIdentifier,
+        FunctionMode::FunctionExpression);
+
+    m_eagerIIFERegistry->add(functionInfo.startOffset, WTF::move(functionNode));
+    globalIIFESuccessCount++;
 }
 
 static NO_RETURN_DUE_TO_CRASH FunctionMetadataNode* NODELETE getMetadata(ParserFunctionInfo<SyntaxChecker>&) { RELEASE_ASSERT_NOT_REACHED(); }
@@ -3213,7 +3370,7 @@ parseMethod:
             next();
             break;
         case BIGINT:
-            ident = m_parserArena.identifierArena().makeBigIntDecimalIdentifier(const_cast<VM&>(m_vm), *m_token.m_data.bigIntString, m_token.m_data.radix);
+            ident = m_currentArena->identifierArena().makeBigIntDecimalIdentifier(const_cast<VM&>(m_vm), *m_token.m_data.bigIntString, m_token.m_data.radix);
             failIfFalse(ident, "Cannot parse big int property name");
             next();
             break;
@@ -3248,7 +3405,7 @@ parseMethod:
         }
         case DOUBLE:
         case INTEGER:
-            ident = &m_parserArena.identifierArena().makeNumericIdentifier(const_cast<VM&>(m_vm), m_token.m_data.doubleValue);
+            ident = &m_currentArena->identifierArena().makeNumericIdentifier(const_cast<VM&>(m_vm), m_token.m_data.doubleValue);
             ASSERT(ident);
             next();
             break;
@@ -3329,9 +3486,9 @@ parseMethod:
 
             if (computedPropertyName) {
                 if (tag == ClassElementTag::Instance)
-                    ident = &m_parserArena.identifierArena().makePrivateIdentifier(m_vm, instanceComputedNamePrefix, nextInstanceComputedFieldID++);
+                    ident = &m_currentArena->identifierArena().makePrivateIdentifier(m_vm, instanceComputedNamePrefix, nextInstanceComputedFieldID++);
                 else
-                    ident = &m_parserArena.identifierArena().makePrivateIdentifier(m_vm, staticComputedNamePrefix, nextStaticComputedFieldID++);
+                    ident = &m_currentArena->identifierArena().makePrivateIdentifier(m_vm, staticComputedNamePrefix, nextStaticComputedFieldID++);
                 DeclarationResultMask declarationResult = classScope->declareLexicalVariable(ident, true);
                 ASSERT_UNUSED(declarationResult, declarationResult == DeclarationResult::Valid);
                 classScope->useVariable(ident, false);
@@ -3364,7 +3521,7 @@ parseMethod:
             m_statementDepth = 0;
             failIfFalse(parseBlockStatement(context, BlockType::StaticBlock), "Cannot parse class static block");
             auto* symbolImpl = std::bit_cast<SymbolImpl*>(m_vm.propertyNames->builtinNames().staticInitializerBlockPrivateName().impl());
-            ident = &m_parserArena.identifierArena().makeIdentifier(const_cast<VM&>(m_vm), symbolImpl);
+            ident = &m_currentArena->identifierArena().makeIdentifier(const_cast<VM&>(m_vm), symbolImpl);
             property = context.createProperty(ident, type, SuperBinding::Needed, tag);
             classScope->markLastUsedVariablesSetAsCaptured(usedVariablesSize);
         } else {
@@ -4727,7 +4884,7 @@ namedProperty:
     case DOUBLE:
     case INTEGER: {
         unsigned functionStart = timesPosition.value_or(asyncPosition.value_or(m_token.m_startPosition));
-        const Identifier& ident = m_parserArena.identifierArena().makeNumericIdentifier(const_cast<VM&>(m_vm), m_token.m_data.doubleValue);
+        const Identifier& ident = m_currentArena->identifierArena().makeNumericIdentifier(const_cast<VM&>(m_vm), m_token.m_data.doubleValue);
         next();
 
         if (match(OPENPAREN)) {
@@ -4745,7 +4902,7 @@ namedProperty:
         return context.createProperty(&ident, node, PropertyNode::Constant, SuperBinding::NotNeeded, InferName::Allowed, ClassElementTag::No);
     }
     case BIGINT: {
-        const Identifier* ident = m_parserArena.identifierArena().makeBigIntDecimalIdentifier(const_cast<VM&>(m_vm), *m_token.m_data.bigIntString, m_token.m_data.radix);
+        const Identifier* ident = m_currentArena->identifierArena().makeBigIntDecimalIdentifier(const_cast<VM&>(m_vm), *m_token.m_data.bigIntString, m_token.m_data.radix);
         failIfFalse(ident, "Cannot parse big int property name");
         unsigned functionStart = timesPosition.value_or(asyncPosition.value_or(m_token.m_startPosition));
         next();
@@ -4839,7 +4996,7 @@ template <class TreeBuilder> TreeProperty Parser<LexerType>::parseGetterSetter(T
         numericPropertyName = m_token.m_data.doubleValue;
         next();
     } else if (match(BIGINT)) {
-        stringPropertyName = m_parserArena.identifierArena().makeBigIntDecimalIdentifier(const_cast<VM&>(m_vm), *m_token.m_data.bigIntString, m_token.m_data.radix);
+        stringPropertyName = m_currentArena->identifierArena().makeBigIntDecimalIdentifier(const_cast<VM&>(m_vm), *m_token.m_data.bigIntString, m_token.m_data.radix);
         failIfFalse(stringPropertyName, "Cannot parse big int property name");
         next();
     } else if (consume(OPENBRACKET)) [[likely]] {
@@ -4874,7 +5031,7 @@ template <class TreeBuilder> TreeProperty Parser<LexerType>::parseGetterSetter(T
     if (computedPropertyName)
         return context.createGetterOrSetterProperty(location, static_cast<PropertyNode::Type>(type | PropertyNode::Computed), computedPropertyName, info, tag);
 
-    return context.createGetterOrSetterProperty(const_cast<VM&>(m_vm), m_parserArena, location, type, numericPropertyName, info, tag);
+    return context.createGetterOrSetterProperty(const_cast<VM&>(m_vm), *m_currentArena, location, type, numericPropertyName, info, tag);
 }
 
 template <typename LexerType>
@@ -5022,6 +5179,7 @@ template <typename LexerType>
 template <class TreeBuilder> TreeExpression Parser<LexerType>::parseFunctionExpression(TreeBuilder& context)
 {
     ASSERT(match(FUNCTION));
+    bool isLikelyIIFE = tokenStart() == m_latestParenExpressionStart || m_lastTokenType == EXCLAMATION;
     SetForScope nonLHSCountScope(m_parserState.nonLHSCount);
     JSTokenLocation location(tokenLocation());
     unsigned functionStart = tokenStart();
@@ -5036,7 +5194,11 @@ template <class TreeBuilder> TreeExpression Parser<LexerType>::parseFunctionExpr
     ConstructorKind constructorKind = currentScope()->isGlobalCode() ? m_constructorKindForTopLevelFunctionExpressions : ConstructorKind::None;
     SuperBinding expectedSuperBinding = constructorKind == ConstructorKind::Extends ? SuperBinding::Needed : SuperBinding::NotNeeded;
 
-    failIfFalse((parseFunctionInfo(context, FunctionNameRequirements::None, false, constructorKind, expectedSuperBinding, functionStart, functionInfo, FunctionDefinitionType::Expression)), "Cannot parse function expression");
+    if (isLikelyIIFE) [[unlikely]] {
+        globalIIFEDetectionCount++;
+        failIfFalse((parseFunctionInfo<TreeBuilder, true>(context, FunctionNameRequirements::None, false, constructorKind, expectedSuperBinding, functionStart, functionInfo, FunctionDefinitionType::Expression, std::nullopt)), "Cannot parse function expression");
+    } else
+        failIfFalse((parseFunctionInfo(context, FunctionNameRequirements::None, false, constructorKind, expectedSuperBinding, functionStart, functionInfo, FunctionDefinitionType::Expression, std::nullopt)), "Cannot parse function expression");
     return context.createFunctionExpr(location, functionInfo);
 }
 
@@ -5187,6 +5349,7 @@ template <class TreeBuilder> TreeExpression Parser<LexerType>::parsePrimaryExpre
         return parseArrayLiteral(context);
     case OPENPAREN: {
         next();
+        m_latestParenExpressionStart = tokenStart();
         SetForScope nonLHSCountScope(m_parserState.nonLHSCount);
         TreeExpression result = parseExpression(context);
         handleProductionOrFail(CLOSEPAREN, ")", "end", "compound expression");

--- a/Source/JavaScriptCore/parser/Parser.h
+++ b/Source/JavaScriptCore/parser/Parser.h
@@ -22,6 +22,7 @@
 
 #pragma once
 
+#include "EagerIIFERegistry.h"
 #include "ExecutableInfo.h"
 #include "Lexer.h"
 #include "ModuleScopeData.h"
@@ -48,8 +49,10 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace JSC {
 
+class ASTBuilder;
 class FunctionMetadataNode;
 class FunctionParameters;
+template <typename LexerType> class EagerIIFEParseScope;
 class Identifier;
 class VM;
 class SourceCode;
@@ -150,6 +153,8 @@ ALWAYS_INLINE static bool isContextualKeyword(const JSToken& token)
 }
 
 JS_EXPORT_PRIVATE extern std::atomic<unsigned> globalParseCount;
+JS_EXPORT_PRIVATE extern std::atomic<unsigned> globalIIFEDetectionCount;
+JS_EXPORT_PRIVATE extern std::atomic<unsigned> globalIIFESuccessCount;
 
 struct Scope {
     WTF_MAKE_NONCOPYABLE(Scope);
@@ -831,6 +836,7 @@ public:
     bool hasNonSimpleParameterList() const { return m_hasNonSimpleParameterList; }
 
     bool hasSloppyModeFunctionHoistingCandidates() const { return !m_sloppyModeFunctionHoistingCandidates.isEmpty(); }
+    void clearSloppyModeFunctionHoistingCandidates() { m_sloppyModeFunctionHoistingCandidates.clear(); }
 
     void copyCapturedVariablesToVector(const UniquedStringImplPtrSet& usedVariables, Vector<UniquedStringImpl*, 8>& vector)
     {
@@ -1048,6 +1054,8 @@ typedef SegmentedVector<Scope, 20, 10> ScopeStack;
 enum class ArgumentType { Normal, Spread };
 enum class ParsingContext { Normal, FunctionConstructor };
 
+static constexpr unsigned NoSourceOffset = UINT_MAX;
+
 template <typename LexerType>
 class JSC_CACHE_LINE_ALIGNED Parser {
     WTF_MAKE_NONCOPYABLE(Parser);
@@ -1170,6 +1178,98 @@ private:
         Scope* m_scope;
         Parser* m_parser;
     };
+
+    // A specialized parser state activated in parseFunctionInfo() to parse a likely IIFE.
+    // See also EagerIIFEParseScope in Parser.cpp.
+    //
+    // The parse state redirects the parser's current arena so that objects created while
+    // the parse state is installed are created in the scope's arena instead of the main
+    // arena of the parser. It also provides methods to parse the function's parameters
+    // and body using an ASTBuilder instead of a SyntaxChecker, collecting the resulting
+    // FunctionParameters and SourceElements.
+    //
+    // Because IIFE parameters and body may themselves contain nested function definitions
+    // (including nested IIFEs), the IIFE parse state marks itself as isInUse while
+    // parsing those constructs. This prevents nested functions from mistakenly reusing
+    // the outer IIFE's parse state — they follow the normal syntax-checking path instead,
+    // or set up their own eager parse state if they are IIFEs too.
+
+    class EagerIIFEParseState {
+    public:
+        EagerIIFEParseState(Parser& parser, ASTBuilder* builder, ParserArena& arena, unsigned startOffset)
+            : m_parser(parser)
+            , m_builder(builder)
+            , m_startOffset(startOffset)
+            , m_savedArena(parser.m_currentArena)
+            , m_savedIIFEParseState(parser.m_iifeParseState)
+            , m_savedSeenTaggedTemplate(parser.m_seenTaggedTemplateInNonReparsingFunctionMode)
+            , m_savedSeenPrivateNameUse(parser.m_seenPrivateNameUseInNonReparsingFunctionMode)
+            , m_savedSeenArgumentsDotLength(parser.m_seenArgumentsDotLength)
+        {
+            parser.setCurrentArena(arena);
+            parser.m_iifeParseState = this;
+            // Reset parser-wide "seen-anywhere" flags so the IIFE body is parsed in
+            // isolation, matching what a lazy reparse (a fresh Parser instance) would
+            // observe. The destructor ORs the IIFE's contribution back into the outer
+            // parser so it still observes everything that was lexically inside its source.
+            parser.m_seenTaggedTemplateInNonReparsingFunctionMode = false;
+            parser.m_seenPrivateNameUseInNonReparsingFunctionMode = false;
+            parser.m_seenArgumentsDotLength = false;
+        }
+
+        ~EagerIIFEParseState()
+        {
+            m_parser.setCurrentArena(*m_savedArena);
+            m_parser.m_iifeParseState = m_savedIIFEParseState;
+            m_parser.m_seenTaggedTemplateInNonReparsingFunctionMode |= m_savedSeenTaggedTemplate;
+            m_parser.m_seenPrivateNameUseInNonReparsingFunctionMode |= m_savedSeenPrivateNameUse;
+            m_parser.m_seenArgumentsDotLength |= m_savedSeenArgumentsDotLength;
+        }
+
+        template <typename TreeBuilder>
+        void parseFunctionParameters(ParserFunctionInfo<TreeBuilder>& functionInfo)
+        {
+            ASSERT(!m_functionParameters);
+            m_isInUse = true;
+            m_functionParameters = m_parser.parseFunctionParameters(*m_builder, functionInfo);
+            m_isInUse = false;
+        }
+
+        SourceElements* parseSourceElements(SourceElementsMode mode)
+        {
+            ASSERT(!m_sourceElements);
+            m_isInUse = true;
+            m_sourceElements = m_parser.parseSourceElements(*m_builder, mode);
+            m_isInUse = false;
+            return m_sourceElements;
+        }
+
+        bool isInUse() const { return m_isInUse; }
+        unsigned startOffset() const { return m_startOffset; }
+
+        CodeFeatures features() const;
+        int numConstants() const;
+        FunctionParameters* functionParameters() const { return m_functionParameters; }
+        SourceElements* sourceElements() const { return m_sourceElements; }
+
+    private:
+        Parser& m_parser;
+        ASTBuilder* m_builder;
+        bool m_isInUse { false };
+        unsigned m_startOffset;
+
+        ParserArena* m_savedArena;
+        EagerIIFEParseState* m_savedIIFEParseState;
+        bool m_savedSeenTaggedTemplate;
+        bool m_savedSeenPrivateNameUse;
+        bool m_savedSeenArgumentsDotLength;
+
+        FunctionParameters* m_functionParameters { nullptr };
+        SourceElements* m_sourceElements { nullptr };
+    };
+
+    friend class EagerIIFEParseState;
+    friend class EagerIIFEParseScope<LexerType>;
 
     ALWAYS_INLINE DestructuringKind destructuringKindFromDeclarationType(DeclarationType type)
     {
@@ -1833,8 +1933,13 @@ private:
     template <class TreeBuilder> ALWAYS_INLINE TreeExpression createResolveAndUseVariable(TreeBuilder&, const Identifier*, bool isEval, const JSTextPosition&, const JSTokenLocation&);
 
     enum class FunctionDefinitionType { Expression, Declaration, Method };
-    template <class TreeBuilder> NEVER_INLINE bool parseFunctionInfo(TreeBuilder&, FunctionNameRequirements, bool nameIsInContainingScope, ConstructorKind, SuperBinding, unsigned functionStart, ParserFunctionInfo<TreeBuilder>&, FunctionDefinitionType, std::optional<int> functionConstructorParametersEndPosition = std::nullopt);
-    
+    template <class TreeBuilder, bool ExpectIIFE = false> NEVER_INLINE bool parseFunctionInfo(TreeBuilder&, FunctionNameRequirements, bool nameIsInContainingScope, ConstructorKind, SuperBinding, unsigned functionStart, ParserFunctionInfo<TreeBuilder>&, FunctionDefinitionType, std::optional<int> functionConstructorParametersEndPosition = std::nullopt);
+    template <class TreeBuilder> ALWAYS_INLINE TreeFunctionBody parseFunctionBodyForFunctionInfo(TreeBuilder& context, SyntaxChecker&, const JSTokenLocation& startLocation, int startColumn, unsigned functionStart, int functionNameStart, int parametersStart, ConstructorKind, SuperBinding expectedSuperBinding, FunctionBodyType, unsigned parameterCount);
+    template <class TreeBuilder> ALWAYS_INLINE bool tryLoadCachedFunctionInfo(TreeBuilder& context, ParserFunctionInfo<TreeBuilder>&, AutoPopScope& functionScope, const JSTokenLocation& startLocation, int parametersStart, int startColumn, unsigned functionStart, int functionNameStart, SourceParseMode);
+
+    template <class TreeBuilder> NEVER_INLINE void popScopeAndBuildFunctionNode(AutoPopScope& functionScope, ParserFunctionInfo<TreeBuilder>&, const JSTokenLocation& startLocation, int startColumn);
+    [[nodiscard]] CodeFeatures collectCodeFeatures(CodeFeatures, Scope*);
+
     template <class TreeBuilder> ALWAYS_INLINE bool isArrowFunctionParameters(TreeBuilder&);
     
     template <class TreeBuilder, class FunctionInfoType> NEVER_INLINE typename TreeBuilder::FormalParameterList parseFunctionParameters(TreeBuilder&, FunctionInfoType&);
@@ -2085,6 +2190,11 @@ private:
         m_errorMessage = String();
     }
 
+    ALWAYS_INLINE void setCurrentArena(ParserArena& arena) {
+        ASSERT(m_lexer->identifierArena() == &arena.identifierArena());
+        m_currentArena = &arena;
+    }
+
     // Fields up to m_parserState are arranged according to access frequency and affinity;
     // do not rearrange without careful analysis.
     VM& m_vm;
@@ -2107,6 +2217,7 @@ private:
     bool m_insideSwitchCaseBody { false };
     // offset 192
     ParserState m_parserState;
+    unsigned m_latestParenExpressionStart { NoSourceOffset };
     SourceParseMode m_parseMode;
     ConstructorKind m_constructorKindForTopLevelFunctionExpressions { ConstructorKind::None };
     bool m_isInsideOrdinaryFunction;
@@ -2119,6 +2230,9 @@ private:
     RefPtr<SourceProviderCache> m_functionCache;
     CallOrApplyDepthScope* m_callOrApplyDepthScope { nullptr };
     RefPtr<ModuleScopeData> m_moduleScopeData;
+    ParserArena* m_currentArena { nullptr };
+    EagerIIFEParseState* m_iifeParseState { nullptr };
+    RefPtr<EagerIIFERegistry> m_eagerIIFERegistry;
     JSParserScriptMode m_scriptMode;
     SuperBinding m_superBinding;
     bool m_hasStackOverflow;
@@ -2161,6 +2275,26 @@ std::unique_ptr<ParsedNode> Parser<LexerType>::parse(ParserError& error, const I
 
     if (ParsedNode::scopeIsFunction)
         m_lexer->setIsReparsingFunction();
+
+    if constexpr (std::is_same_v<ParsedNode, FunctionNode>) {
+        if (m_eagerIIFERegistry) {
+            // The cache is keyed only by source offset; we do not validate that the
+            // requested parse context (lexicallyScopedFeatures, derivedContextType,
+            // evalContextType, parentScopePrivateNames, etc.) matches the context
+            // under which the cached FunctionNode was eagerly built. This is safe
+            // today because each UnlinkedFunctionExecutable that triggers a function
+            // reparse was created during the same outer parse that populated this
+            // entry, so contexts match by construction. If a future change ever
+            // allows the same SourceProvider to be parsed under multiple distinct
+            // contexts with cache entries surviving across them, this lookup would
+            // need to validate (or key on) the context as SourceProviderCacheItem
+            // does at Parser.cpp:2659.
+            if (auto cached = m_eagerIIFERegistry->take(m_source->startOffset())) {
+                m_lexer->clear();
+                return std::unique_ptr<ParsedNode>(cached.release());
+            }
+        }
+    }
 
     errLine = -1;
     errMsg = String();

--- a/Source/JavaScriptCore/parser/ParserArena.cpp
+++ b/Source/JavaScriptCore/parser/ParserArena.cpp
@@ -46,6 +46,13 @@ ParserArena::ParserArena()
 {
 }
 
+ParserArena::ParserArena(Ref<IdentifierArena>&& shared)
+    : m_freeableMemory(nullptr)
+    , m_freeablePoolEnd(nullptr)
+    , m_identifierArena(WTF::move(shared))
+{
+}
+
 inline void* ParserArena::freeablePool()
 {
     ASSERT(m_freeablePoolEnd);

--- a/Source/JavaScriptCore/parser/ParserArena.h
+++ b/Source/JavaScriptCore/parser/ParserArena.h
@@ -30,6 +30,7 @@
 #include <JavaScriptCore/MathCommon.h>
 #include <array>
 #include <type_traits>
+#include <wtf/RefCounted.h>
 #include <wtf/SegmentedVector.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
@@ -39,13 +40,10 @@ namespace JSC {
     class ParserArenaDeletable;
 
     DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(IdentifierArena);
-    class IdentifierArena {
+    class IdentifierArena : public RefCounted<IdentifierArena> {
         WTF_DEPRECATED_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(IdentifierArena, IdentifierArena);
     public:
-        IdentifierArena()
-        {
-            clear();
-        }
+        static Ref<IdentifierArena> create() { return adoptRef(*new IdentifierArena); }
 
         template <typename T>
         ALWAYS_INLINE const Identifier& makeIdentifier(VM&, std::span<const T> characters);
@@ -70,6 +68,11 @@ namespace JSC {
         }
 
     private:
+        IdentifierArena()
+        {
+            clear();
+        }
+
         IdentifierVector m_identifiers;
         std::array<Identifier*, MaximumCachableCharacter> m_shortIdentifiers;
         std::array<Identifier*, MaximumCachableCharacter> m_recentIdentifiers;
@@ -151,13 +154,17 @@ namespace JSC {
         WTF_MAKE_NONCOPYABLE(ParserArena);
     public:
         ParserArena();
+        explicit ParserArena(Ref<IdentifierArena>&&);
         ~ParserArena();
 
         void swap(ParserArena& otherArena)
         {
             std::swap(m_freeableMemory, otherArena.m_freeableMemory);
             std::swap(m_freeablePoolEnd, otherArena.m_freeablePoolEnd);
-            m_identifierArena.swap(otherArena.m_identifierArena);
+            if (m_identifierArena)
+                otherArena.m_identifierArena = m_identifierArena;
+            else
+                m_identifierArena = otherArena.m_identifierArena;
             m_freeablePools.swap(otherArena.m_freeablePools);
             m_deletableObjects.swap(otherArena.m_deletableObjects);
         }
@@ -191,7 +198,7 @@ namespace JSC {
         IdentifierArena& identifierArena()
         {
             if (!m_identifierArena) [[unlikely]]
-                m_identifierArena = makeUnique<IdentifierArena>();
+                m_identifierArena = IdentifierArena::create();
             return *m_identifierArena;
         }
 
@@ -210,7 +217,7 @@ namespace JSC {
         char* m_freeableMemory;
         char* m_freeablePoolEnd;
 
-        std::unique_ptr<IdentifierArena> m_identifierArena;
+        RefPtr<IdentifierArena> m_identifierArena;
         Vector<void*> m_freeablePools;
         Vector<ParserArenaDeletable*> m_deletableObjects;
     };

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -559,6 +559,7 @@ bool hasCapacityToUseLargeGigacage();
     v(Bool, useSuperSampler, false, Normal, nullptr) \
     \
     v(Bool, useSourceProviderCache, true, Normal, "If false, the parser will not use the source provider cache. It's good to verify everything works when this is false. Because the cache is so successful, it can mask bugs."_s) \
+    v(Bool, useEagerIIFEParsing, true, Normal, "Eagerly build AST for likely IIFEs during the initial parse."_s) \
     v(Bool, useCodeCache, true, Normal, "If false, the unlinked byte code cache will not be used."_s) \
     \
     v(Bool, useWasm, canUseWasm(), Normal, "Expose the Wasm global object."_s) \

--- a/Source/JavaScriptCore/runtime/VM.cpp
+++ b/Source/JavaScriptCore/runtime/VM.cpp
@@ -48,6 +48,7 @@
 #include "DeferredWorkTimer.h"
 #include "Disassembler.h"
 #include "DoublePredictionFuzzerAgent.h"
+#include "EagerIIFERegistry.h"
 #include "ErrorInstance.h"
 #include "EvalCodeBlockInlines.h"
 #include "EvalExecutableInlines.h"
@@ -1049,9 +1050,18 @@ SourceProviderCache* VM::addSourceProviderCache(SourceProvider* sourceProvider)
     return addResult.iterator->value.get();
 }
 
+EagerIIFERegistry* VM::addEagerIIFERegistry(SourceProvider* sourceProvider)
+{
+    auto addResult = eagerIIFERegistryMap.add(sourceProvider, nullptr);
+    if (addResult.isNewEntry)
+        addResult.iterator->value = EagerIIFERegistry::create();
+    return addResult.iterator->value.get();
+}
+
 void VM::clearSourceProviderCaches()
 {
     sourceProviderCacheMap.clear();
+    eagerIIFERegistryMap.clear();
 }
 
 bool VM::hasExceptionsAfterHandlingTraps()

--- a/Source/JavaScriptCore/runtime/VM.h
+++ b/Source/JavaScriptCore/runtime/VM.h
@@ -113,6 +113,7 @@ class CompactTDZEnvironmentMap;
 class ConservativeRoots;
 class ControlFlowProfiler;
 class CrossTaskToken;
+class EagerIIFERegistry;
 class Exception;
 class ExceptionScope;
 class FuzzerAgent;
@@ -736,10 +737,12 @@ public:
     static void computeCanUseJIT();
 
     SourceProviderCache* addSourceProviderCache(SourceProvider*);
+    EagerIIFERegistry* addEagerIIFERegistry(SourceProvider*);
     void clearSourceProviderCaches();
 
     typedef UncheckedKeyHashMap<RefPtr<SourceProvider>, RefPtr<SourceProviderCache>> SourceProviderCacheMap;
     SourceProviderCacheMap sourceProviderCacheMap;
+    UncheckedKeyHashMap<RefPtr<SourceProvider>, RefPtr<EagerIIFERegistry>> eagerIIFERegistryMap;
 #if ENABLE(JIT)
     std::unique_ptr<JITThunks> jitStubs;
     MacroAssemblerCodeRef<JITThunkPtrTag> getCTIStub(ThunkGenerator);

--- a/Source/JavaScriptCore/tools/JSDollarVM.cpp
+++ b/Source/JavaScriptCore/tools/JSDollarVM.cpp
@@ -2218,6 +2218,8 @@ static JSC_DECLARE_HOST_FUNCTION(functionDeltaBetweenButterflies);
 static JSC_DECLARE_HOST_FUNCTION(functionCurrentCPUTime);
 static JSC_DECLARE_HOST_FUNCTION(functionTotalGCTime);
 static JSC_DECLARE_HOST_FUNCTION(functionParseCount);
+static JSC_DECLARE_HOST_FUNCTION(functionIIFEDetectionCount);
+static JSC_DECLARE_HOST_FUNCTION(functionIIFESuccessCount);
 static JSC_DECLARE_HOST_FUNCTION(functionIsWasmSupported);
 static JSC_DECLARE_HOST_FUNCTION(functionWasmCanonicalTypeCount);
 static JSC_DECLARE_HOST_FUNCTION(functionMake16BitStringIfPossible);
@@ -3980,6 +3982,18 @@ JSC_DEFINE_HOST_FUNCTION(functionParseCount, (JSGlobalObject*, CallFrame*))
     return JSValue::encode(jsNumber(globalParseCount.load()));
 }
 
+JSC_DEFINE_HOST_FUNCTION(functionIIFEDetectionCount, (JSGlobalObject*, CallFrame*))
+{
+    DollarVMAssertScope assertScope;
+    return JSValue::encode(jsNumber(globalIIFEDetectionCount.load()));
+}
+
+JSC_DEFINE_HOST_FUNCTION(functionIIFESuccessCount, (JSGlobalObject*, CallFrame*))
+{
+    DollarVMAssertScope assertScope;
+    return JSValue::encode(jsNumber(globalIIFESuccessCount.load()));
+}
+
 JSC_DEFINE_HOST_FUNCTION(functionIsWasmSupported, (JSGlobalObject*, CallFrame*))
 {
     DollarVMAssertScope assertScope;
@@ -4657,6 +4671,8 @@ void JSDollarVM::finishCreation(VM& vm)
     addFunction(vm, alwaysAllow, "totalGCTime"_s, functionTotalGCTime, 0);
 
     addFunction(vm, alwaysAllow, "parseCount"_s, functionParseCount, 0);
+    addFunction(vm, alwaysAllow, "iifeDetectionCount"_s, functionIIFEDetectionCount, 0);
+    addFunction(vm, alwaysAllow, "iifeSuccessCount"_s, functionIIFESuccessCount, 0);
 
     addFunction(vm, alwaysAllow, "isWasmSupported"_s, functionIsWasmSupported, 0);
     addFunction(vm, alwaysAllow, "wasmCanonicalTypeCount"_s, functionWasmCanonicalTypeCount, 0);


### PR DESCRIPTION
#### 3bcadabc9dff8e606c2424b1be15fd7261716ede
<pre>
[JSC] Eagerly build AST for likely IIFEs, without sharing a ParserArena
<a href="https://bugs.webkit.org/show_bug.cgi?id=320392">https://bugs.webkit.org/show_bug.cgi?id=320392</a>
<a href="https://rdar.apple.com/183349327">rdar://183349327</a>

Reviewed by NOBODY (OOPS!).

This patch detects likely IIFEs (immediately invoked function expressions) and builds
their AST right away, bypassing the usual initial syntax check.

In general, we can&apos;t tell if a function expression is immediately invoked until after we
parse it, but the following heuristic catches most real-world cases. A function expression
is expected to be an IIFE if the token preceding the `function` keyword is either `(`
which starts a primary expression or a `!` (`!` is commonly used by minifiers to introduce
a function expression using one fewer character than wrapping it in parentheses).

Key changes:

- IdentifierArena is shared between the top-level ParserArena and the per-IIFE
  ParserArenas. This is necessary because identifiers may be shared between the top level
  and IIFEs.

- parseFunctionInfo() is templatized on a `bool ExpectIIFE` parameter that gates the
  IIFE-only code paths via `if constexpr`. One or the other template instance is called
  depending on whether the IIFE detection heuristic triggers. This is necessary to ensure
  zero overhead in the common non-IIFE case, as this function is very hot.

- Two lambdas inside parseFunctionInfo() are lifted into ALWAYS_INLINE member helpers:
    - parseFunctionBodyForFunctionInfo (was performParsingFunctionBody lambda)
    - tryLoadCachedFunctionInfo (was tryLoadCachedFunction lambda)
  Performance testing after the templatization showed an about 0.8% regression in
  parseFunctionInfo&lt;false&gt;() compared to the baseline, despite them being semantically
  identical. The cause was a different register allocation decision made by clang at
  those lambda call sites. Converting the lambdas to members recovers the regression.

- Eager IIFE parsing is controlled by two classes, EagerIIFEParseScope and
  EagerIIFEParseState. The scope is created in parseFunctionInfo&lt;true&gt;() when the IIFE
  prediction heuristic triggers. The scope contains an ASTBuilder to use for the IIFE and
  an EagerIIFEParseState. The state collects parsing artifacts such as function
  parameter and source elements until we are ready to create the final FunctionNode.
  When parseFunctionInfo() exits, the scope is destroyed and its destructor returns the
  parser into the original state.

- At the end of parseFunctionInfo of an expected IIFE we create a FunctionNode stored in
  m_eagerIIFERegistry. When the function is invoked for the first time, Parser::parse()
  checks the cache and takes the ready-to-use AST if found.

Testing:
    - Added JSTests/stress/eager-iife-detection.js to verify that the detection
    heuristic fires (and eager parsing succeeds) on the expected constructs and
    does not fire on lookalikes. The test uses two new $vm helpers exposed by
    JSDollarVM (iifeDetectionCount / iifeSuccessCount).
    - Added JSTests/stress/eager-iife-column-tracking.js to test the source column
    adjustment required on the first line of IIFEs, as uncovered by one of the layout
    tests.
    - Regression-checked by existing tests.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3bcadabc9dff8e606c2424b1be15fd7261716ede

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177154 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51091 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44886 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186757 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/140390 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6ea01f4f-bb89-4efa-81b8-f362ac6a8853) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179017 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52384 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50872 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138042 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96291 "2 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/abed6e3a-d4fe-4bfc-8443-c1e4b0735ca4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180110 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41545 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158799 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118509 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/45c1c725-947f-4ac1-8b9a-10263da00dbc) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40201 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38662 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/478 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/7303 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150611 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38298 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35225 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/38425 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42870 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42876 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189183 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50758 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147123 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51441 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34922 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146917 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41651 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123655 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117951 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49946 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13278 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49345 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49582 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49406 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->