### PR TITLE
[Site Isolation] Preserve about:blank inherited origin on history back/forward

### DIFF
--- a/LayoutTests/http/tests/site-isolation/about-blank-history-back-preserves-inherited-origin-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/about-blank-history-back-preserves-inherited-origin-expected.txt
@@ -1,0 +1,14 @@
+An about:blank popup that inherited its opener's origin is still modifiable by the opener after going back to it from a cross-site document.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS popupHistoryLengthAfterAboutBlank is 2
+PASS openerCanModifyInheritedAboutBlank is true
+PASS popupHistoryLengthAfterCrossSiteNavigation is 3
+PASS openerCanModifyCrossSitePopup is false
+PASS openerCanModifyAboutBlankRestoredFromHistory is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/site-isolation/about-blank-history-back-preserves-inherited-origin.html
+++ b/LayoutTests/http/tests/site-isolation/about-blank-history-back-preserves-inherited-origin.html
@@ -1,0 +1,120 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<script src="/js-test-resources/js-test.js"></script>
+</head>
+<body>
+<script>
+// main frame (opener) <- this file, hosted at 127.0.0.1
+//    |
+//    | window.open(), then this frame navigates the popup to about:blank. Because this frame
+//    initiated that navigation, the about:blank inherits this frame's origin (127.0.0.1).
+//
+// The popup then navigates cross-site to localhost, which moves it to another process, and is asked
+// to go back. Restoring the about:blank entry has to restore the origin it originally inherited (127.0.0.1)
+//
+// From HTML Spec: browsing the Web, section 7.4.2.2, Item 23, sub-item 5:
+// https://html.spec.whatwg.org/multipage/browsing-the-web.html#beginning-navigation
+//
+// If url matches about:blank or is about:srcdoc, then:
+//     Set documentState's origin to initiatorOriginSnapshot.
+
+description("An about:blank popup that inherited its opener's origin is still modifiable by the opener after going back to it from a cross-site document.");
+jsTestIsAsync = true;
+
+const sameSiteURL = "http://127.0.0.1:8000/site-isolation/resources/post-message-to-opener.html";
+const crossSiteURL = "http://localhost:8000/site-isolation/resources/history-back-when-asked.html";
+
+let popup;
+let popupHistoryLengthAfterAboutBlank;
+let popupHistoryLengthAfterCrossSiteNavigation;
+let openerCanModifyInheritedAboutBlank;
+let openerCanModifyCrossSitePopup;
+let openerCanModifyAboutBlankRestoredFromHistory;
+
+function openerCanModifyPopupDOM()
+{
+    try {
+        popup.document.body.setAttribute("data-modified-by-opener", "yes");
+        return popup.document.body.getAttribute("data-modified-by-opener") === "yes";
+    } catch (e) {
+        return false;
+    }
+}
+
+function waitUntilCanModifyIs(expected, timeoutMilliseconds = 10000)
+{
+    return new Promise((resolve) => {
+        let elapsed = 0;
+        const poll = () => {
+            if (openerCanModifyPopupDOM() === expected || elapsed >= timeoutMilliseconds) {
+                resolve(openerCanModifyPopupDOM());
+                return;
+            }
+            elapsed += 10;
+            setTimeout(poll, 10);
+        };
+        poll();
+    });
+}
+
+function waitUntilPopupURLIs(url, timeoutMilliseconds = 10000)
+{
+    return new Promise((resolve) => {
+        let elapsed = 0;
+        const poll = () => {
+            let current = "<unreadable>";
+            try { current = popup.location.href; } catch (e) { }
+            if (current === url || elapsed >= timeoutMilliseconds) {
+                resolve(current);
+                return;
+            }
+            elapsed += 10;
+            setTimeout(poll, 10);
+        };
+        poll();
+    });
+}
+
+function messageMatching(predicate)
+{
+    return new Promise((resolve) => {
+        window.addEventListener("message", function handler(event) {
+            if (event.data && predicate(event.data)) {
+                window.removeEventListener("message", handler);
+                resolve(event.data);
+            }
+        });
+    });
+}
+
+(async () => {
+    let firstPageReady = messageMatching(data => data === "initial ping");
+    popup = window.open(sameSiteURL);
+    await firstPageReady;
+
+    popup.location = "about:blank";
+    await waitUntilPopupURLIs("about:blank");
+    openerCanModifyInheritedAboutBlank = await waitUntilCanModifyIs(true);
+    popupHistoryLengthAfterAboutBlank = popup.history.length;
+    shouldBe("popupHistoryLengthAfterAboutBlank", "2");
+    shouldBeTrue("openerCanModifyInheritedAboutBlank");
+
+    let crossSiteReady = messageMatching(data => data.type === "ready");
+    popup.location = crossSiteURL;
+    popupHistoryLengthAfterCrossSiteNavigation = (await crossSiteReady).historyLength;
+    shouldBe("popupHistoryLengthAfterCrossSiteNavigation", "3");
+    openerCanModifyCrossSitePopup = await waitUntilCanModifyIs(false);
+    shouldBeFalse("openerCanModifyCrossSitePopup");
+
+    popup.postMessage("go-back", "*");
+    openerCanModifyAboutBlankRestoredFromHistory = await waitUntilCanModifyIs(true);
+    shouldBeTrue("openerCanModifyAboutBlankRestoredFromHistory");
+
+    popup.close();
+    finishJSTest();
+})();
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/site-isolation/resources/history-back-when-asked.html
+++ b/LayoutTests/http/tests/site-isolation/resources/history-back-when-asked.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<!-- Goes back on request rather than immediately, so the test can verify which process this
+     document committed in before the traversal happens. Cross-origin to the opener, so the request
+     arrives over postMessage: the opener cannot touch this frame's history object. -->
+<script>
+addEventListener("message", (event) => {
+    if (event.data === "go-back")
+        history.back();
+});
+
+if (window.opener)
+    window.opener.postMessage({ type: "ready", historyLength: history.length }, "*");
+</script>
+<body>history-back-when-asked</body>

--- a/LayoutTests/platform/ios-site-isolation/TestExpectations
+++ b/LayoutTests/platform/ios-site-isolation/TestExpectations
@@ -4,7 +4,6 @@
 # Tests that crash #
 ####################
 http/tests/security/top-level-unique-origin2.https.html [ Crash ]
-imported/w3c/web-platform-tests/content-security-policy/inheritance/history.sub.html [ Crash ]
 imported/w3c/web-platform-tests/speculation-rules/prefetch/redirect-url.https.html?origin=cross-site-redirect [ Crash ]
 imported/w3c/web-platform-tests/speculation-rules/speculation-tags/same-site-to-cross-site-redirection-prefetch.https.html [ Crash ]
 swipe/basic-cached-back-swipe.html [ Crash ]
@@ -346,7 +345,6 @@ http/wpt/mediarecorder/MediaRecorder-mock-dataavailable.html [ Failure ]
 http/wpt/mediarecorder/MediaRecorder-webm-AV-audio-video-dataavailable.html [ Failure ]
 http/wpt/webaudio/the-audio-api/the-audioworklet-interface/dynamic-import-is-prohibited.https.html [ Failure ]
 http/wpt/webaudio/the-audio-api/the-audioworklet-interface/exposed-properties.https.html [ Failure ]
-imported/w3c/web-platform-tests/content-security-policy/inheritance/history.sub.html [ Failure ]
 imported/w3c/web-platform-tests/css/css-view-transitions/navigation/no-view-transition-with-cross-origin-redirect.sub.html [ Failure ]
 imported/w3c/web-platform-tests/css/selectors/media/media-playback-state-timing.html [ Failure ]
 imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/srcdoc/srcdoc-history-entries.html [ Failure ]

--- a/LayoutTests/platform/mac-site-isolation/TestExpectations
+++ b/LayoutTests/platform/mac-site-isolation/TestExpectations
@@ -13,7 +13,6 @@ http/tests/security/referrer-policy-header-same-origin.html [ Crash ]
 http/tests/security/referrer-policy-header-strict-origin-when-cross-origin.html [ Crash ]
 http/tests/security/referrer-policy-header-strict-origin.html [ Crash ]
 http/tests/security/referrer-policy-header-unsafe-url.html [ Crash ]
-imported/w3c/web-platform-tests/content-security-policy/inheritance/history.sub.html [ Crash ]
 
 #######################
 # Tests that time out #

--- a/Source/WebKit/Shared/WebBackForwardListItem.h
+++ b/Source/WebKit/Shared/WebBackForwardListItem.h
@@ -31,6 +31,7 @@
 #include "WebPageProxyIdentifier.h"
 #include "WebsiteDataStore.h"
 #include <WebCore/ProcessIdentifier.h>
+#include <WebCore/SecurityOriginData.h>
 #include <wtf/CheckedPtr.h>
 #include <wtf/Ref.h>
 #include <wtf/SwiftBridging.h>
@@ -105,6 +106,9 @@ public:
     void setEnhancedSecurity(EnhancedSecurity state) { m_enhancedSecurity = state; }
     EnhancedSecurity enhancedSecurity() const { return m_enhancedSecurity; }
 
+    const std::optional<WebCore::SecurityOriginData>& initiatorOriginSnapshot() const LIFETIME_BOUND { return m_initiatorOriginSnapshot; }
+    void setInitiatorOriginSnapshot(const WebCore::SecurityOriginData& origin) { m_initiatorOriginSnapshot = origin; }
+
     void updateFrameID(WebCore::FrameIdentifier oldFrameID, WebCore::FrameIdentifier newFrameID);
 
 private:
@@ -129,6 +133,7 @@ private:
     RefPtr<ViewSnapshot> m_snapshot;
 #endif
     EnhancedSecurity m_enhancedSecurity { EnhancedSecurity::Disabled };
+    std::optional<WebCore::SecurityOriginData> m_initiatorOriginSnapshot;
 } SWIFT_SHARED_REFERENCE(refBackForwardListItem, derefBackForwardListItem) SWIFT_RETURNED_AS_UNRETAINED_BY_DEFAULT;
 
 typedef Vector<Ref<WebBackForwardListItem>> BackForwardListItemVector;

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -5844,6 +5844,21 @@ void WebPageProxy::receivedNavigationActionPolicyDecision(WebProcessProxy& proce
 
     Site site { navigation.currentRequest().url() };
     Site mainFrameSite = frame.isMainFrame() ? site : Site { pageLoadState().activeURL() };
+
+    // about:blank inherits the origin of the frame which initiated the navigation to about:blank. On
+    // a back/forward navigation the initiator is the document being navigated away from, so use the
+    // origin snapshotted when the frame first navigated to about:blank instead.
+    auto inheritedOrigin = [&]() -> std::optional<SecurityOriginData> {
+        if (preferences->siteIsolationEnabled() && navigation.currentRequest().url().isAboutBlank()) {
+            if (RefPtr targetItem = frame.isMainFrame() ? navigation.targetItem() : nullptr)
+                return targetItem->initiatorOriginSnapshot();
+            if (navigation.originatingFrameInfo())
+                return navigation.originatingFrameInfo()->securityOrigin;
+        }
+
+        return std::nullopt;
+    }();
+
     auto continueWithProcessForNavigation = [
         this,
         protectedThis = Ref { *this },
@@ -5860,6 +5875,7 @@ void WebPageProxy::receivedNavigationActionPolicyDecision(WebProcessProxy& proce
         replacedDataStoreForWebArchiveLoad,
         site,
         mainFrameSite,
+        inheritedOrigin,
         preferences
     ] (Ref<WebProcessProxy>&& processNavigatingTo, SuspendedPageProxy* destinationSuspendedPage, ASCIILiteral reason) mutable {
         ASSERT(!processNavigatingTo->isInProcessCache());
@@ -5911,7 +5927,7 @@ void WebPageProxy::receivedNavigationActionPolicyDecision(WebProcessProxy& proce
 
             receivedPolicyDecision(policyAction, navigation.ptr(), std::nullopt, WTF::move(navigationAction), WillContinueLoadInNewProcess::Yes, std::nullopt, WTF::move(message), WTF::move(completionHandler));
             Ref bcgForNavigation = suspendedPage ? suspendedPage->browsingContextGroup() : browsingContextGroup.get();
-            continueNavigationInNewProcess(navigation, frame.get(), WTF::move(suspendedPage), bcgForNavigation, WTF::move(processNavigatingTo), processSwapRequestedByClient, ShouldTreatAsContinuingLoad::YesAfterNavigationPolicyDecision, std::nullopt, loadedWebArchive, navigationAction->data().navigationUpgradeToHTTPSBehavior, WebCore::ProcessSwapDisposition::None, replacedDataStoreForWebArchiveLoad.get(), MonotonicTime { });
+            continueNavigationInNewProcess(navigation, frame.get(), WTF::move(suspendedPage), bcgForNavigation, WTF::move(processNavigatingTo), processSwapRequestedByClient, ShouldTreatAsContinuingLoad::YesAfterNavigationPolicyDecision, std::nullopt, loadedWebArchive, navigationAction->data().navigationUpgradeToHTTPSBehavior, WebCore::ProcessSwapDisposition::None, replacedDataStoreForWebArchiveLoad.get(), MonotonicTime { }, inheritedOrigin);
             return;
         }
 
@@ -5989,6 +6005,7 @@ void WebPageProxy::receivedNavigationActionPolicyDecision(WebProcessProxy& proce
         loadedWebArchive,
         frameInfo = FrameInfoData { frameInfo },
         websiteDataStore = websiteDataStore.copyRef(),
+        inheritedOrigin,
         continueWithProcessForNavigation = WTF::move(continueWithProcessForNavigation)
     ](FrameProcess* sharedProcess) mutable {
         if (sharedProcess) {
@@ -6009,7 +6026,7 @@ void WebPageProxy::receivedNavigationActionPolicyDecision(WebProcessProxy& proce
             return;
         }
         auto isolatedProcessType = frame->isMainFrame() ? WebProcessProxy::IsolatedProcessType::MainFrame : WebProcessProxy::IsolatedProcessType::SubFrame;
-        protect(m_configuration->processPool())->processForNavigation(*this, frame, navigation, sourceURL, browsingContextGroup, isolatedProcessType, mainFrameSite, processSwapRequestedByClient, lockdownMode, enhancedSecurity, loadedWebArchive, frameInfo, WTF::move(websiteDataStore), WTF::move(continueWithProcessForNavigation));
+        protect(m_configuration->processPool())->processForNavigation(*this, frame, navigation, sourceURL, browsingContextGroup, isolatedProcessType, mainFrameSite, processSwapRequestedByClient, lockdownMode, enhancedSecurity, loadedWebArchive, frameInfo, WTF::move(websiteDataStore), inheritedOrigin, WTF::move(continueWithProcessForNavigation));
     });
 }
 
@@ -6240,12 +6257,31 @@ void WebPageProxy::destroyProvisionalPage()
     m_provisionalPage = nullptr;
 }
 
-void WebPageProxy::continueNavigationInNewProcess(API::Navigation& navigation, WebFrameProxy& frame, RefPtr<SuspendedPageProxy>&& suspendedPage, BrowsingContextGroup& browsingContextGroup, Ref<WebProcessProxy>&& newProcess, ProcessSwapRequestedByClient processSwapRequestedByClient, ShouldTreatAsContinuingLoad shouldTreatAsContinuingLoad, std::optional<NetworkResourceLoadIdentifier> existingNetworkResourceLoadIdentifierToResume, LoadedWebArchive loadedWebArchive, NavigationUpgradeToHTTPSBehavior navigationUpgradeToHTTPSBehavior, WebCore::ProcessSwapDisposition processSwapDisposition, WebsiteDataStore* replacedDataStoreForWebArchiveLoad, MonotonicTime originalNavigationStartTime)
+void WebPageProxy::continueNavigationInNewProcess(API::Navigation& navigation, WebFrameProxy& frame, RefPtr<SuspendedPageProxy>&& suspendedPage, BrowsingContextGroup& browsingContextGroup, Ref<WebProcessProxy>&& newProcess, ProcessSwapRequestedByClient processSwapRequestedByClient, ShouldTreatAsContinuingLoad shouldTreatAsContinuingLoad, std::optional<NetworkResourceLoadIdentifier> existingNetworkResourceLoadIdentifierToResume, LoadedWebArchive loadedWebArchive, NavigationUpgradeToHTTPSBehavior navigationUpgradeToHTTPSBehavior, WebCore::ProcessSwapDisposition processSwapDisposition, WebsiteDataStore* replacedDataStoreForWebArchiveLoad, MonotonicTime originalNavigationStartTime, const std::optional<SecurityOriginData>& inheritedOrigin)
 {
     WEBPAGEPROXY_RELEASE_LOG(Loading, "continueNavigationInNewProcess: newProcessPID=%i, hasSuspendedPage=%i", newProcess->processID(), !!suspendedPage);
     LOG(Loading, "Continuing navigation %" PRIu64 " '%s' in a new web process", navigation.navigationID().toUInt64(), navigation.loggingString().utf8().data());
     RELEASE_ASSERT(!newProcess->isInProcessCache());
     ASSERT(shouldTreatAsContinuingLoad != ShouldTreatAsContinuingLoad::No);
+
+    Site requestSite { navigation.currentRequest().url() };
+    Site navigationSite { inheritedOrigin ? Site { *inheritedOrigin } : requestSite };
+    // Only a navigation with no site of its own, such as about:blank, may run in the site of another origin.
+    ASSERT(navigationSite == requestSite || requestSite.isEmpty());
+
+    // Check for existing process for site before potentially creating a new one
+    if (m_preferences->siteIsolationEnabled() && frame.isMainFrame() && !suspendedPage && processSwapDisposition == WebCore::ProcessSwapDisposition::None) {
+        if (RefPtr existingFrameProcess = browsingContextGroup.processForSite(navigationSite)) {
+            Ref existing = existingFrameProcess->process();
+            RefPtr newProcessDataStore = newProcess->websiteDataStore();
+            if (existing.ptr() != newProcess.ptr()
+                && existing->canReuseForSiteIsolatedNavigation(newProcessDataStore.get(), newProcess->lockdownMode(), newProcess->enhancedSecurity())) {
+                WEBPAGEPROXY_RELEASE_LOG(ProcessSwapping, "continueNavigationInNewProcess: converging on existing process (pid=%i) already registered for the target site instead of racing new process (pid=%i)", existing->processID(), newProcess->processID());
+                newProcess = WTF::move(existing);
+            }
+        }
+    }
+
     navigation.setProcessID(newProcess->coreProcessIdentifier());
 
     if (navigation.currentRequest().url().protocolIsFile())
@@ -6268,22 +6304,9 @@ void WebPageProxy::continueNavigationInNewProcess(API::Navigation& navigation, W
     RefPtr websitePolicies = navigation.websitePolicies();
     bool isServerSideRedirect = shouldTreatAsContinuingLoad == ShouldTreatAsContinuingLoad::YesAfterNavigationPolicyDecision && navigation.currentRequestIsRedirect();
     bool isProcessSwappingOnNavigationResponse = shouldTreatAsContinuingLoad == ShouldTreatAsContinuingLoad::YesAfterProvisionalLoadStarted;
-    bool shouldInheritOriginFromInitiator = navigation.currentRequest().url().isAboutBlank() && navigation.originatingFrameInfo();
-    Site navigationSite { shouldInheritOriginFromInitiator ? Site { navigation.originatingFrameInfo()->securityOrigin } : Site { navigation.currentRequest().url() } };
 
     Ref preferences = m_preferences;
     if (preferences->siteIsolationEnabled() && (!frame.isMainFrame() || newProcess->coreProcessIdentifier() == frame.process().coreProcessIdentifier())) {
-        // about:blank frames should inherit the origin of the which originated navigation.
-        // If the two frames share origins, they should share the same process.
-        //
-        // From HTML Spec: browsing the Web, section 7.4.2.2, Item 23, sub-item 5:
-        // https://html.spec.whatwg.org/multipage/browsing-the-web.html#beginning-navigation
-        //
-        // If url matches about:blank or is about:srcdoc, then:
-        //     Set documentState's origin to initiatorOriginSnapshot.
-        //     Set documentState's about base URL to initiatorBaseURLSnapshot.
-        std::optional<SecurityOriginData> originator = navigation.currentRequest().url().isAboutBlank() && navigation.originatingFrameInfo() ? std::make_optional(navigation.originatingFrameInfo()->securityOrigin) : std::nullopt;
-
         auto shouldTreatAsContinuingLoad = navigation.currentRequestIsRedirect() ? WebCore::ShouldTreatAsContinuingLoad::YesAfterProvisionalLoadStarted : WebCore::ShouldTreatAsContinuingLoad::YesAfterNavigationPolicyDecision;
 
         // When a child frame's Back/Forward navigation triggers a process swap (Site Isolation),
@@ -6292,7 +6315,7 @@ void WebPageProxy::continueNavigationInNewProcess(API::Navigation& navigation, W
         if (RefPtr frameState = navigation.backForwardFrameState()) {
             WEBPAGEPROXY_RELEASE_LOG(Loading, "continueNavigationInNewProcess: Sending GoToBackForwardItem for child frame to new process, URL=%" SENSITIVE_LOG_STRING, frameState->urlString.utf8().data());
             auto publicSuffix = WebCore::PublicSuffixStore::singleton().publicSuffix(navigation.currentRequest().url());
-            frame.prepareForProvisionalLoadInProcess(newProcess, navigation, browsingContextGroup, originator, [
+            frame.prepareForProvisionalLoadInProcess(newProcess, navigation, browsingContextGroup, inheritedOrigin, [
                 navigationID = navigation.navigationID(),
                 frameState = WTF::move(frameState),
                 shouldTreatAsContinuingLoad,
@@ -6335,7 +6358,7 @@ void WebPageProxy::continueNavigationInNewProcess(API::Navigation& navigation, W
         if (isPendingInitialHistoryItem)
             frame.setIsPendingInitialHistoryItem(true);
 
-        frame.prepareForProvisionalLoadInProcess(newProcess, navigation, browsingContextGroup, originator, [
+        frame.prepareForProvisionalLoadInProcess(newProcess, navigation, browsingContextGroup, inheritedOrigin, [
             loadParameters = WTF::move(loadParameters),
             newProcess = newProcess.copyRef(),
 #if ENABLE(CONTENT_EXTENSIONS)
@@ -8628,6 +8651,16 @@ void WebPageProxy::didCommitLoadForFrame(IPC::Connection& connection, FrameIdent
 #endif
     }
 
+    // Snapshot the initiator origin this about:blank inherited onto its back-forward entry, so a later
+    // traversal can restore it rather than re-deriving it from the live opener, which may not be the
+    // initiator and may since have navigated elsewhere.
+    if (frame->isMainFrame() && navigation && !navigation->targetItem() && request.url().isAboutBlank()) {
+        if (const auto& originatingFrameInfo = navigation->originatingFrameInfo()) {
+            if (RefPtr currentItem = backForwardList().currentItem())
+                currentItem->setInitiatorOriginSnapshot(originatingFrameInfo->securityOrigin);
+        }
+    }
+
     // Reattach iframe subtree from BFCache restore. Always drain the pending entry to avoid
     // leaking iframe processes when the BFCache restore fails (RestoredFromBackForwardCache::No).
     if (frame->isMainFrame() && navigation) {
@@ -10384,7 +10417,7 @@ void WebPageProxy::performProcessSwapForNavigationResponse(API::Navigation& navi
         if (!m_provisionalPage)
             send(Messages::WebPage::StopLoadingDueToProcessSwap());
 
-        continueNavigationInNewProcess(*navigation, *mainFrame, nullptr, browsingContextGroupForSwap, WTF::move(processForNavigation), ProcessSwapRequestedByClient::No, ShouldTreatAsContinuingLoad::YesAfterProvisionalLoadStarted, existingNetworkResourceLoadIdentifierToResume, LoadedWebArchive::No, NavigationUpgradeToHTTPSBehavior::BasedOnPolicy, processSwapDisposition, nullptr, originalNavigationStartTime);
+        continueNavigationInNewProcess(*navigation, *mainFrame, nullptr, browsingContextGroupForSwap, WTF::move(processForNavigation), ProcessSwapRequestedByClient::No, ShouldTreatAsContinuingLoad::YesAfterProvisionalLoadStarted, existingNetworkResourceLoadIdentifierToResume, LoadedWebArchive::No, NavigationUpgradeToHTTPSBehavior::BasedOnPolicy, processSwapDisposition, nullptr, originalNavigationStartTime, std::nullopt);
         completionHandler(true);
     };
 

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -3560,7 +3560,7 @@ private:
 
     void reportPageLoadResult(const WebCore::ResourceError&);
 
-    void continueNavigationInNewProcess(API::Navigation&, WebFrameProxy&, RefPtr<SuspendedPageProxy>&&, BrowsingContextGroup&, Ref<WebProcessProxy>&&, ProcessSwapRequestedByClient, WebCore::ShouldTreatAsContinuingLoad, std::optional<NetworkResourceLoadIdentifier> existingNetworkResourceLoadIdentifierToResume, LoadedWebArchive, WebCore::NavigationUpgradeToHTTPSBehavior, WebCore::ProcessSwapDisposition, WebsiteDataStore* replacedDataStoreForWebArchiveLoad, MonotonicTime originalNavigationStartTime);
+    void continueNavigationInNewProcess(API::Navigation&, WebFrameProxy&, RefPtr<SuspendedPageProxy>&&, BrowsingContextGroup&, Ref<WebProcessProxy>&&, ProcessSwapRequestedByClient, WebCore::ShouldTreatAsContinuingLoad, std::optional<NetworkResourceLoadIdentifier> existingNetworkResourceLoadIdentifierToResume, LoadedWebArchive, WebCore::NavigationUpgradeToHTTPSBehavior, WebCore::ProcessSwapDisposition, WebsiteDataStore* replacedDataStoreForWebArchiveLoad, MonotonicTime originalNavigationStartTime, const std::optional<WebCore::SecurityOriginData>& inheritedOrigin);
     void performProcessSwapForNavigationResponse(API::Navigation&, Ref<BrowsingContextGroup>&&, Ref<WebProcessProxy>&&, WebCore::ProcessSwapDisposition, NetworkResourceLoadIdentifier, MonotonicTime originalNavigationStartTime, CompletionHandler<void(bool)>&&);
 
     void setNeedsFontAttributes(bool);

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -2165,7 +2165,7 @@ unsigned WebProcessPool::prewarmedProcessCountLimit() const
     return m_hasUsedSiteIsolation ? 2 : 1;
 }
 
-void WebProcessPool::processForNavigation(WebPageProxy& page, WebFrameProxy& frame, const API::Navigation& navigation, const URL& sourceURL, BrowsingContextGroup& browsingContextGroup, WebProcessProxy::IsolatedProcessType isolatedProcessType, const Site& mainFrameSite, ProcessSwapRequestedByClient processSwapRequestedByClient, WebProcessProxy::LockdownMode lockdownMode, EnhancedSecurity enhancedSecurity, LoadedWebArchive loadedWebArchive, const FrameInfoData& frameInfo, Ref<WebsiteDataStore>&& dataStore, CompletionHandler<void(Ref<WebProcessProxy>&&, SuspendedPageProxy*, ASCIILiteral)>&& completionHandler)
+void WebProcessPool::processForNavigation(WebPageProxy& page, WebFrameProxy& frame, const API::Navigation& navigation, const URL& sourceURL, BrowsingContextGroup& browsingContextGroup, WebProcessProxy::IsolatedProcessType isolatedProcessType, const Site& mainFrameSite, ProcessSwapRequestedByClient processSwapRequestedByClient, WebProcessProxy::LockdownMode lockdownMode, EnhancedSecurity enhancedSecurity, LoadedWebArchive loadedWebArchive, const FrameInfoData& frameInfo, Ref<WebsiteDataStore>&& dataStore, const std::optional<WebCore::SecurityOriginData>& inheritedOrigin, CompletionHandler<void(Ref<WebProcessProxy>&&, SuspendedPageProxy*, ASCIILiteral)>&& completionHandler)
 {
     Site site { navigation.currentRequest().url() };
 
@@ -2218,7 +2218,7 @@ void WebProcessPool::processForNavigation(WebPageProxy& page, WebFrameProxy& fra
         RefPtr<WebProcessProxy> process;
         if (RefPtr frameProcess = browsingContextGroup.processForSite(site))
             process = &frameProcess->process();
-        if (process && process->websiteDataStore() == dataStore.ptr() && process->websiteDataStore() == &page.websiteDataStore() && !process->isInProcessCache() && process->lockdownMode() == lockdownMode && enhancedSecurityStatesAreConsistent(process->enhancedSecurity(), enhancedSecurity)) {
+        if (process && process->websiteDataStore() == dataStore.ptr() && process->canReuseForSiteIsolatedNavigation(&page.websiteDataStore(), lockdownMode, enhancedSecurity)) {
             protect(dataStore->networkProcess())->addAllowedFirstPartyForCookies(*process, mainFrameSite.domain(), LoadedWebArchive::No, [completionHandler = WTF::move(completionHandler), process, preventProcessShutdownScope = process->shutdownPreventingScope()] () mutable {
                 completionHandler(process.releaseNonNull(), nullptr, "Found process for the same site"_s);
             });
@@ -2227,7 +2227,7 @@ void WebProcessPool::processForNavigation(WebPageProxy& page, WebFrameProxy& fra
     }
 
     ASSERT(isolatedProcessType != WebProcessProxy::IsolatedProcessType::Shared);
-    auto [process, suspendedPage, reason] = processForNavigationInternal(page, frame, navigation, sourceURL, isolatedProcessType, mainFrameSite, processSwapRequestedByClient, lockdownMode, enhancedSecurity, frameInfo, dataStore.copyRef());
+    auto [process, suspendedPage, reason] = processForNavigationInternal(page, frame, navigation, sourceURL, browsingContextGroup, isolatedProcessType, mainFrameSite, processSwapRequestedByClient, lockdownMode, enhancedSecurity, frameInfo, dataStore.copyRef(), inheritedOrigin);
 
     // We are process-swapping so automatic process prewarming would be beneficial if the client has not explicitly enabled / disabled it.
     bool doingAnAutomaticProcessSwap = processSwapRequestedByClient == ProcessSwapRequestedByClient::No && process.ptr() != sourceProcess.ptr();
@@ -2284,7 +2284,7 @@ void WebProcessPool::prepareProcessForNavigation(Ref<WebProcessProxy>&& process,
     });
 }
 
-std::tuple<Ref<WebProcessProxy>, RefPtr<SuspendedPageProxy>, ASCIILiteral> WebProcessPool::processForNavigationInternal(WebPageProxy& page, WebFrameProxy& frame, const API::Navigation& navigation, const URL& pageSourceURL, WebProcessProxy::IsolatedProcessType isolatedProcessType, const Site& mainFrameSite, ProcessSwapRequestedByClient processSwapRequestedByClient, WebProcessProxy::LockdownMode lockdownMode, EnhancedSecurity enhancedSecurity, const FrameInfoData& frameInfo, Ref<WebsiteDataStore>&& dataStore)
+std::tuple<Ref<WebProcessProxy>, RefPtr<SuspendedPageProxy>, ASCIILiteral> WebProcessPool::processForNavigationInternal(WebPageProxy& page, WebFrameProxy& frame, const API::Navigation& navigation, const URL& pageSourceURL, BrowsingContextGroup& browsingContextGroup, WebProcessProxy::IsolatedProcessType isolatedProcessType, const Site& mainFrameSite, ProcessSwapRequestedByClient processSwapRequestedByClient, WebProcessProxy::LockdownMode lockdownMode, EnhancedSecurity enhancedSecurity, const FrameInfoData& frameInfo, Ref<WebsiteDataStore>&& dataStore, const std::optional<WebCore::SecurityOriginData>& inheritedOrigin)
 {
     auto& targetURL = navigation.currentRequest().url();
     auto targetSite = Site { targetURL };
@@ -2331,9 +2331,26 @@ std::tuple<Ref<WebProcessProxy>, RefPtr<SuspendedPageProxy>, ASCIILiteral> WebPr
     }
 
     if (siteIsolationEnabled && navigation.currentRequest().url().isAboutBlank()) {
-        RefPtr navigationOriginatorFrame = navigation.originatingFrameInfo() ? WebFrameProxy::webFrame(navigation.originatingFrameInfo()->frameID) : nullptr;
-        if (navigationOriginatorFrame)
-            return { navigationOriginatorFrame->process(), nullptr, "Frame is navigating to about:blank from a cross site origin. Switching to process that originated navigation."_s };
+        // about:blank runs in the process of the origin it inherits. On a back/forward navigation
+        // that origin was snapshotted when the frame first navigated to about:blank, so look up the
+        // process registered for its site.
+        if (navigation.backForwardFrameLoadType() && inheritedOrigin) {
+            Site inheritedSite { *inheritedOrigin };
+            if (!inheritedSite.isEmpty()) {
+                if (RefPtr frameProcess = browsingContextGroup.processForSite(inheritedSite))
+                    return { frameProcess->process(), nullptr, "Restoring about:blank to the process registered for the origin snapshotted on its back/forward item"_s };
+            }
+        }
+
+        // For a non back/forward navigation, about:blank inherits the origin of the frame which
+        // initiated the navigation to about:blank, so use the process that frame lives in.
+        if (!navigation.backForwardFrameLoadType()) {
+            if (RefPtr navigationOriginatorFrame = navigation.originatingFrameInfo() ? WebFrameProxy::webFrame(navigation.originatingFrameInfo()->frameID) : nullptr) {
+                // The origin resolved by the caller must agree with the process we inherit here.
+                ASSERT(!inheritedOrigin || Site { *inheritedOrigin } == Site { navigation.originatingFrameInfo()->securityOrigin });
+                return { navigationOriginatorFrame->process(), nullptr, "Frame is navigating to about:blank from a cross site origin. Switching to process that originated navigation."_s };
+            }
+        }
     }
 
     // FIXME: We should support process swap when a window has been opened via window.open() without 'noopener'.

--- a/Source/WebKit/UIProcess/WebProcessPool.h
+++ b/Source/WebKit/UIProcess/WebProcessPool.h
@@ -482,7 +482,7 @@ public:
     bool hasBackgroundWebProcessesWithModels() const;
 #endif
 
-    void processForNavigation(WebPageProxy&, WebFrameProxy&, const API::Navigation&, const URL& sourceURL, BrowsingContextGroup&, WebProcessProxy::IsolatedProcessType, const WebCore::Site& mainFrameSite, ProcessSwapRequestedByClient, WebProcessProxy::LockdownMode, EnhancedSecurity, LoadedWebArchive, const FrameInfoData&, Ref<WebsiteDataStore>&&, CompletionHandler<void(Ref<WebProcessProxy>&&, SuspendedPageProxy*, ASCIILiteral)>&&);
+    void processForNavigation(WebPageProxy&, WebFrameProxy&, const API::Navigation&, const URL& sourceURL, BrowsingContextGroup&, WebProcessProxy::IsolatedProcessType, const WebCore::Site& mainFrameSite, ProcessSwapRequestedByClient, WebProcessProxy::LockdownMode, EnhancedSecurity, LoadedWebArchive, const FrameInfoData&, Ref<WebsiteDataStore>&&, const std::optional<WebCore::SecurityOriginData>& inheritedOrigin, CompletionHandler<void(Ref<WebProcessProxy>&&, SuspendedPageProxy*, ASCIILiteral)>&&);
 
     void didReachGoodTimeToPrewarm();
 
@@ -639,7 +639,7 @@ private:
     void platformInitializeWebProcess(const WebProcessProxy&, WebProcessCreationParameters&);
     void platformInvalidateContext();
 
-    std::tuple<Ref<WebProcessProxy>, RefPtr<SuspendedPageProxy>, ASCIILiteral> processForNavigationInternal(WebPageProxy&, WebFrameProxy&, const API::Navigation&, const URL& sourceURL, WebProcessProxy::IsolatedProcessType, const WebCore::Site& mainFrameSite, ProcessSwapRequestedByClient, WebProcessProxy::LockdownMode, EnhancedSecurity, const FrameInfoData&, Ref<WebsiteDataStore>&&);
+    std::tuple<Ref<WebProcessProxy>, RefPtr<SuspendedPageProxy>, ASCIILiteral> processForNavigationInternal(WebPageProxy&, WebFrameProxy&, const API::Navigation&, const URL& sourceURL, BrowsingContextGroup&, WebProcessProxy::IsolatedProcessType, const WebCore::Site& mainFrameSite, ProcessSwapRequestedByClient, WebProcessProxy::LockdownMode, EnhancedSecurity, const FrameInfoData&, Ref<WebsiteDataStore>&&, const std::optional<WebCore::SecurityOriginData>& inheritedOrigin);
     void prepareProcessForNavigation(Ref<WebProcessProxy>&&, WebPageProxy&, SuspendedPageProxy*, ASCIILiteral reason, WebProcessProxy::IsolatedProcessType, const WebCore::Site&, const WebCore::Site& mainFrameSite, const API::Navigation&, WebProcessProxy::LockdownMode, EnhancedSecurity, LoadedWebArchive, Ref<WebsiteDataStore>&&, CompletionHandler<void(Ref<WebProcessProxy>&&, SuspendedPageProxy*, ASCIILiteral)>&&, unsigned previousAttemptsCount = 0);
 
     RefPtr<WebProcessProxy> tryTakePrewarmedProcess(WebsiteDataStore&, WebProcessProxy::LockdownMode, EnhancedSecurity, const API::PageConfiguration&);

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -561,6 +561,14 @@ public:
     LockdownMode lockdownMode() const { return m_lockdownMode; }
     EnhancedSecurity enhancedSecurity() const { return m_enhancedSecurity; }
 
+    bool canReuseForSiteIsolatedNavigation(const WebsiteDataStore* targetDataStore, LockdownMode targetLockdownMode, EnhancedSecurity targetEnhancedSecurity) const
+    {
+        return !isInProcessCache()
+            && websiteDataStore() == targetDataStore
+            && lockdownMode() == targetLockdownMode
+            && enhancedSecurityStatesAreConsistent(enhancedSecurity(), targetEnhancedSecurity);
+    }
+
 #if PLATFORM(COCOA)
     std::optional<audit_token_t> auditToken() const;
 #if !ENABLE(REMOVE_XPC_AND_MACH_SANDBOX_EXTENSIONS_IN_WEBCONTENT)


### PR DESCRIPTION
#### 96f2685e6c54eb69f506fad238aea95604f8cbc4
<pre>
[Site Isolation] Preserve about:blank inherited origin on history back/forward
<a href="https://bugs.webkit.org/show_bug.cgi?id=318255">https://bugs.webkit.org/show_bug.cgi?id=318255</a>
<a href="https://rdar.apple.com/181053307">rdar://181053307</a>

Reviewed by NOBODY (OOPS!).

imported/w3c/web-platform-tests/content-security-policy/inheritance/history.sub.html
is failing with site isolation enabled.

&apos;about:blank&apos; documents inherit their origin from the frame which
initiated navigation to &apos;about:blank&apos;. When that &apos;about:blank&apos; frame
navigates cross-site and then navigates back in the history to
&apos;about:blank&apos; (via history.back()) it should navigate back to an
&apos;about:blank&apos; frame which inherits its origin from it&apos;s original opener.

Before this patch, with site isolation enabled, the cross-site frame
which goes back in history stays in its cross-site process. However,
the HTML spec says that frames that inherit origins should retain the
original inherited origin of it&apos;s navigation initiator.
The test imported/w3c/web-platform-tests/content-security-policy/inheritance/history.sub.html
was failing since the popup remained in its cross-site process
(didn&apos;t return to the opener&apos;s inherited process) and the opener couldn&apos;t
access the &apos;about:blank&apos; frame since it is remote.

This patch restores the about:blank frame&apos;s inherited origin when it
goes back/forward through history. Notably, it restores the inherited origin
that the &apos;about:blank&apos; frame got from the frame that initiated
the original navigation to &apos;about:blank&apos;

A snapshot of the initiating frame&apos;s origin is taken in
WebPageProxy::didCommitLoadForFrame and stored in the current
WebBackForwardListItem. This is preferable to looking
up the live initiator since the iniator could have navigated away to
another origin. This snapshot only applies for main frames
since navigating a subframe back/forward results in the entire main
frame to be navigated.

The snapshotted origin is restored as the &apos;about:blank&apos; frame&apos;s inherited
origin in WebPageProxy::receivedNavigationActionPolicyDecision.
On back/forward navigations, the initial initiator&apos;s snapshotted origin is returned.
On non-back/forward navigations, the initiator of the current navigation
is return.

The inherited origin is included in WebProcessPool::processForNavigation
where the process decision is made. The snapshotted origin is used to
lookup the corresponding process with BrowsingContextGroup::processForSite.
In the case of a non back/forward load, the previous code path is taken
where the &apos;about:blank&apos; frame inherits its process by looking up what
process its initiator lives in based on the initiator&apos;s FrameIdentifier.

After the process is chosen, WebPageProxy::continueNavigationInNewProcess
needs to know the origin that about:blank inherited (regardless of if the
navigation was a back/forward or not).
The inherited origin is captured by the lambda continueNavigationInNewProcess
and passed into WebPageProxy::continueWithProcessForNavigation.

While fixing the issue with origin inheritance, I ran into another crash
where the same site got assigned two different processes on two loads and
an ASSERT was hit for duplicate entries in BrowsingContextGroup::m_processMap.
To fix this, I added a check for existing processes of the same site to
WebPageProxy::continueNavigationInNewProcess so that a duplicate process
is found before the load commits.

This patch fixes imported/w3c/web-platform-tests/content-security-policy/inheritance/history.sub.html
with site isolation enabled.

This patch also adds a new test which targets this scenario exactly:
http/tests/site-isolation/about-blank-history-back-preserves-inherited-origin.html .
It (1) opens an about:blank window, (2) has popup navigate itself
cross-site, then (3) has the popup call history.back(), and finally
(4) verifies that the popup returned to about:blank and inherited the
origin of the frame that initially navigated it to about:blank.

* LayoutTests/http/tests/site-isolation/about-blank-history-back-preserves-inherited-origin-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/about-blank-history-back-preserves-inherited-origin.html: Added.
* LayoutTests/http/tests/site-isolation/resources/history-back-when-asked.html: Added.
* LayoutTests/platform/ios-site-isolation/TestExpectations:
* LayoutTests/platform/mac-site-isolation/TestExpectations:
* Source/WebKit/Shared/WebBackForwardListItem.h:
(WebKit::WebBackForwardListItem::setInitiatorOriginSnapshot):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::receivedNavigationActionPolicyDecision):
(WebKit::WebPageProxy::continueNavigationInNewProcess):
(WebKit::WebPageProxy::didCommitLoadForFrame):
(WebKit::WebPageProxy::performProcessSwapForNavigationResponse):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::processForNavigation):
(WebKit::WebProcessPool::processForNavigationInternal):
* Source/WebKit/UIProcess/WebProcessPool.h:
* Source/WebKit/UIProcess/WebProcessProxy.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/96f2685e6c54eb69f506fad238aea95604f8cbc4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178520 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52458 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46253 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188136 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/141769 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ce447fd4-b66d-4631-b7eb-4d832676c099) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53752 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52168 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139183 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96645 "1 flakes 1 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e4296293-fa3a-4252-923b-6751258a8dac) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181477 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42734 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159925 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119637 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7b73474e-33a2-4cde-93f7-37bff923308b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41400 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39756 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151800 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39425 "Passed tests") | [⏳ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/GTK-GTK3-GCC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45058 "Found 1 new failure in UIProcess/WebPageProxy.cpp") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44832 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190563 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52127 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/159449 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148340 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52808 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36856 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148110 "Passed tests") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42817 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; Passed layout tests; Running layout-tests; Uploaded test results") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125075 "Found 1 new failure in UIProcess/WebPageProxy.cpp") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119711 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51326 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14400 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50711 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50951 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50773 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->