### PR TITLE
[JSC] Add an 8-byte SWAR fast path to JSON.stringify's stringCopySameType for short strings

### DIFF
--- a/Source/JavaScriptCore/runtime/JSONObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSONObject.cpp
@@ -40,6 +40,7 @@
 #include "PropertyNameArray.h"
 #include "VMInlines.h"
 #include <charconv>
+#include <wtf/MathExtras.h>
 #include <wtf/dragonbox/dragonbox_to_chars.h>
 #include <wtf/text/EscapedFormsForJSON.h>
 #include <wtf/text/MakeString.h>
@@ -1149,6 +1150,23 @@ ALWAYS_INLINE void FastStringifier<CharType, bufferMode>::appendInt32(int32_t nu
     }
 }
 
+static ALWAYS_INLINE bool eightByteRangeNeedsJSONEscape(uint64_t word)
+{
+    bool hasControl = hasZeroByte(word & 0xE0E0E0E0E0E0E0E0ULL); // any byte in [0x00,0x1F]?
+    bool hasQuote = hasZeroByte(word ^ 0x2222222222222222ULL); // any byte == '"'?
+    bool hasBackslash = hasZeroByte(word ^ 0x5C5C5C5C5C5C5C5CULL); // any byte == '\\'?
+    return hasControl || hasQuote || hasBackslash;
+}
+
+template<typename CharType>
+static ALWAYS_INLINE uint64_t copyEightBytesAndLoad(const CharType* source, CharType* destination)
+{
+    uint64_t word;
+    memcpySpan(std::span<uint8_t, 8> { std::bit_cast<uint8_t*>(&word), 8 }, std::span<const CharType, 8> { source, 8 });
+    memcpySpan(std::span<CharType, 8> { destination, 8 }, std::span<const uint8_t, 8> { std::bit_cast<const uint8_t*>(&word), 8 });
+    return word;
+}
+
 template<typename CharType>
 static ALWAYS_INLINE bool stringCopySameType(std::span<const CharType> span, CharType* cursor)
 {
@@ -1193,6 +1211,20 @@ static ALWAYS_INLINE bool stringCopySameType(std::span<const CharType> span, Cha
         return SIMD::isNonZero(accumulated);
     }
 #endif
+    if constexpr (sizeof(CharType) == 1) {
+        constexpr size_t narrowStride = 8;
+        if (span.size() >= narrowStride) {
+            const auto* ptr = span.data();
+            const auto* end = ptr + span.size();
+            auto* cursorEnd = cursor + span.size();
+            uint64_t accumulated = 0;
+            for (; ptr + narrowStride <= end; ptr += narrowStride, cursor += narrowStride)
+                accumulated |= eightByteRangeNeedsJSONEscape(copyEightBytesAndLoad(ptr, cursor));
+            if (ptr < end)
+                accumulated |= eightByteRangeNeedsJSONEscape(copyEightBytesAndLoad(end - narrowStride, cursorEnd - narrowStride));
+            return accumulated;
+        }
+    }
     for (auto character : span) {
         if constexpr (sizeof(CharType) != 1) {
             if (U16_IS_SURROGATE(character)) [[unlikely]]

--- a/Source/WTF/wtf/MathExtras.h
+++ b/Source/WTF/wtf/MathExtras.h
@@ -357,6 +357,17 @@ constexpr bool hasTwoOrMoreBitsSet(T value)
     return !hasZeroOrOneBitsSet(value);
 }
 
+// "Determine if a word has a zero byte" at https://graphics.stanford.edu/~seander/bithacks.html
+// (formula credited there to Alan Mycroft, comp.lang.c, April 27 1987).
+template<typename T>
+constexpr bool hasZeroByte(T value)
+{
+    static_assert(std::is_unsigned_v<T>);
+    constexpr T lowBits = static_cast<T>(static_cast<T>(~static_cast<T>(0)) / 0xFF);
+    constexpr T highBits = static_cast<T>(lowBits * 0x80);
+    return (value - lowBits) & ~value & highBits;
+}
+
 template<typename T>
 constexpr T divideRoundedUp(T a, T b)
 {

--- a/Tools/TestWebKitAPI/Tests/WTF/MathExtras.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/MathExtras.cpp
@@ -679,6 +679,56 @@ TEST(WTF, negate)
     EXPECT_EQ(WTF::negate<long long>(0LL), 0LL);
 }
 
+template<typename T>
+static void testHasZeroByte()
+{
+    constexpr size_t byteCount = sizeof(T);
+
+    // No zero byte anywhere.
+    EXPECT_FALSE(hasZeroByte<T>(static_cast<T>(~static_cast<T>(0))));
+
+    // A zero byte at every position, rest set to a clean nonzero byte (0x78).
+    auto wordWithByteAt = [](size_t position, uint8_t byteValue) {
+        T word = 0;
+        for (size_t i = 0; i < byteCount; ++i)
+            word |= static_cast<T>(i == position ? byteValue : 0x78) << (i * 8);
+        return word;
+    };
+    for (size_t position = 0; position < byteCount; ++position)
+        EXPECT_TRUE(hasZeroByte<T>(wordWithByteAt(position, 0x00)));
+
+    // Exhaustive: every byte value at every position must match a plain per-byte reference
+    // check, including values right at the 0x00/0x80/0xFF boundaries where the underlying
+    // subtract-and-mask trick is easiest to get wrong.
+    for (size_t position = 0; position < byteCount; ++position) {
+        for (unsigned byteValue = 0; byteValue <= 0xFF; ++byteValue) {
+            bool expected = !byteValue;
+            EXPECT_EQ(hasZeroByte<T>(wordWithByteAt(position, static_cast<uint8_t>(byteValue))), expected);
+        }
+    }
+
+    // Two zero bytes simultaneously, at every pair of positions, must not miscount or cancel out.
+    if (byteCount >= 2) {
+        for (size_t p1 = 0; p1 < byteCount; ++p1) {
+            for (size_t p2 = 0; p2 < byteCount; ++p2) {
+                if (p1 == p2)
+                    continue;
+                T word = wordWithByteAt(p1, 0x00);
+                word &= ~(static_cast<T>(0xFF) << (p2 * 8));
+                EXPECT_TRUE(hasZeroByte<T>(word));
+            }
+        }
+    }
+}
+
+TEST(WTF, hasZeroByte)
+{
+    testHasZeroByte<uint8_t>();
+    testHasZeroByte<uint16_t>();
+    testHasZeroByte<uint32_t>();
+    testHasZeroByte<uint64_t>();
+}
+
 TEST(WTF, divideRoundedUp)
 {
     // Basic rounding behavior.


### PR DESCRIPTION
#### 656d3c36830f999c3dee135b2fc80e7a3e374128
<pre>
[JSC] Add an 8-byte SWAR fast path to JSON.stringify&apos;s stringCopySameType for short strings
<a href="https://bugs.webkit.org/show_bug.cgi?id=320393">https://bugs.webkit.org/show_bug.cgi?id=320393</a>
<a href="https://rdar.apple.com/183349883">rdar://183349883</a>

Reviewed by Yusuke Suzuki.

stringCopySameType() copies a string&apos;s bytes into the output buffer while
checking for characters that need JSON escaping (&apos;&quot;&apos;, &apos;\&apos;, and control
characters). It had a scalar byte-at-a-time fallback and a 16-byte SIMD fast
path, but nothing in between, so strings shorter than 16 bytes always took
the scalar loop.

Add an intermediate tier for 8-15 byte strings: a SWAR (SIMD-within-a-register)
check that packs 8 bytes into one 64-bit word and tests all of them for
escapable characters at once using plain integer arithmetic. It mirrors the
existing 16-byte tier&apos;s overlapping-tail-read technique, so it never reads or
writes outside the string&apos;s own bounds.

Test: Tools/TestWebKitAPI/Tests/WTF/MathExtras.cpp
Canonical link: <a href="https://commits.webkit.org/318021@main">https://commits.webkit.org/318021@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cfb774a608dce2efde2dabf2e704c13faf636f8f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177015 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50952 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44747 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186618 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140251 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/444908c3-7b65-493e-982a-aeb2924e92e1) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178878 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52245 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50638 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137955 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140251 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1f09a0d3-e663-47e4-b7c6-db0b4ec407a9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179971 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41437 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158710 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118424 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/999983f5-d199-4032-a7fb-7c763379d39e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40093 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38460 "Passed tests") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/251/builds/393 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/7215 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150503 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38210 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35086 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/38286 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/42718 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42678 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189075 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50619 "Built successfully") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/147033 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51302 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/34834 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146824 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26855 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41556 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123516 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117803 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49807 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13190 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49206 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49443 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49267 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->