### PR TITLE
[Web Automation] Apply the session's Site Isolation preference to vended automation pages

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/_WKAutomationSession.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKAutomationSession.mm
@@ -50,7 +50,7 @@
     if (!(self = [super init]))
         return nil;
 
-    API::Object::constructInWrapper<WebKit::WebAutomationSession>(self);
+    API::Object::constructInWrapper<WebKit::WebAutomationSession>(self, [configuration siteIsolationEnabled]);
 
     _configuration = adoptNS([configuration copy]);
 

--- a/Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp
+++ b/Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp
@@ -47,6 +47,7 @@
 #include "WebOpenPanelResultListenerProxy.h"
 #include "WebPageInspectorController.h"
 #include "WebPageProxy.h"
+#include "WebPreferences.h"
 #include "WebProcessPool.h"
 #include <JavaScriptCore/ConsoleTypes.h>
 #include <JavaScriptCore/InspectorBackendDispatcher.h>
@@ -153,8 +154,9 @@ void WebAutomationSession::Debuggable::disconnect(Inspector::FrontendChannel& ch
 }
 #endif // ENABLE(REMOTE_INSPECTOR)
 
-WebAutomationSession::WebAutomationSession()
+WebAutomationSession::WebAutomationSession(bool siteIsolationEnabled)
     : m_client(makeUnique<API::AutomationSessionClient>())
+    , m_siteIsolationEnabled(siteIsolationEnabled)
     , m_frontendRouter(FrontendRouter::create())
     , m_backendDispatcher(BackendDispatcher::create(m_frontendRouter.copyRef()))
     , m_domainDispatcher(AutomationBackendDispatcher::create(m_backendDispatcher, this))
@@ -543,6 +545,12 @@ void WebAutomationSession::createBrowsingContext(std::optional<Inspector::Protoc
         ASYNC_FAIL_WITH_PREDEFINED_ERROR_AND_DETAILS_IF(!page, InternalError, "The remote session failed to create a new browsing context."_s);
 
         RefPtr protectedPage = page;
+
+        if (protectedThis->siteIsolationEnabled()) {
+            Ref preferences = protectedPage->preferences();
+            preferences->setSiteIsolationEnabled(true);
+        }
+
         // WebDriver allows running commands in a browsing context which has not done any loads yet. Force WebProcess to be created so it can receive messages.
         protectedPage->launchInitialProcessIfNecessary();
 

--- a/Source/WebKit/UIProcess/Automation/WebAutomationSession.h
+++ b/Source/WebKit/UIProcess/Automation/WebAutomationSession.h
@@ -141,7 +141,7 @@ friend class InspectorPassthroughChannel;
 #endif
 
 public:
-    WebAutomationSession();
+    WebAutomationSession(bool siteIsolationEnabled = false);
     ~WebAutomationSession() override;
 
     void ref() const final { API::Object::ref(); }
@@ -172,6 +172,8 @@ public:
 
     void setSessionIdentifier(const String& sessionIdentifier) { m_sessionIdentifier = sessionIdentifier; }
     String sessionIdentifier() const { return m_sessionIdentifier; }
+
+    bool siteIsolationEnabled() const { return m_siteIsolationEnabled; }
 
     WebProcessPool* NODELETE processPool() const;
     void setProcessPool(WebProcessPool*);
@@ -419,6 +421,7 @@ private:
 
     std::unique_ptr<API::AutomationSessionClient> m_client;
     String m_sessionIdentifier { "Untitled Session"_s };
+    const bool m_siteIsolationEnabled;
     const Ref<Inspector::FrontendRouter> m_frontendRouter;
     const Ref<Inspector::BackendDispatcher> m_backendDispatcher;
     const Ref<Inspector::AutomationBackendDispatcher> m_domainDispatcher;

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -2314,7 +2314,7 @@ std::tuple<Ref<WebProcessProxy>, RefPtr<SuspendedPageProxy>, ASCIILiteral> WebPr
     if (!m_configuration->processSwapsOnNavigation())
         return { WTF::move(sourceProcess), nullptr, "Feature is disabled"_s };
 
-    if (m_automationSession)
+    if (m_automationSession && !protect(page.preferences())->siteIsolationEnabled())
         return { WTF::move(sourceProcess), nullptr, "An automation session is active"_s };
 
     // Redirects to a different scheme for which the client has registered their own custom handler.


### PR DESCRIPTION
#### 6dd9ed3d3ea1fd36f678f2652c05097f61b0caa7
<pre>
[Web Automation] Apply the session&apos;s Site Isolation preference to vended automation pages
<a href="https://bugs.webkit.org/show_bug.cgi?id=296394">https://bugs.webkit.org/show_bug.cgi?id=296394</a>
<a href="https://rdar.apple.com/178913733">rdar://178913733</a>

Reviewed by Qianlang Chen and Sihui Liu.

An automation session created with siteIsolationEnabled had no way to carry that
preference onto the pages it vends: the flag lived on the
_WKAutomationSessionConfiguration but was never applied to a new browsing context&apos;s
WebPreferences, so Site Isolation never engaged for automation-driven pages.

Stamp the configuration&apos;s siteIsolationEnabled onto WebAutomationSession at
session-creation time, then in createBrowsingContext() inject it into the vended
page&apos;s WebPreferences before process assignment. Only the vended automation page is affected;
sibling pool pages keep their own preferences.

Update `WebProcessPool` to override keeping frames in the same process when site isolation is enabled.
That behavior was introduced in <a href="https://commits.webkit.org/201369@main">https://commits.webkit.org/201369@main</a> as a guard against PSON (process swap on nagivation)
to force keeping automation sessions working the same process.

Automation was built on a single-process-per-page assumption that predates both PSON and site isolation.
`WebAutomationSession` (UI process) drives one `WebAutomationSessionProxy` per `WebProcess`,
and it caches state that only means anything inside a specific WebProcess:
- injected JS atoms,
- element/node handles
- the current frame handle.

* Source/WebKit/UIProcess/API/Cocoa/_WKAutomationSession.mm:
(-[_WKAutomationSession initWithConfiguration:]):
* Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp:
(WebKit::WebAutomationSession::WebAutomationSession):
(WebKit::WebAutomationSession::createBrowsingContext):
* Source/WebKit/UIProcess/Automation/WebAutomationSession.h:
* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::processForNavigationInternal):

Canonical link: <a href="https://commits.webkit.org/319024@main">https://commits.webkit.org/319024@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/721a97808b5c5ac40db7ec154d672ee766cc57d1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178956 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52895 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46690 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188785 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/143265 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b702bacd-5a3e-4923-91a7-4d4c5aef7e75) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54188 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52605 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139541 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96730 "1 flakes 2 failures") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/51ef83e7-45e5-4372-832f-66eb6bde8c4f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181913 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43131 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160293 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119987 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/43bdf33d-9315-4dab-a8dc-31aa0421da26) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41802 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40147 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/1963 "Build is in progress. Recent messages:") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152201 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39796 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/92 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45501 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44393 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191005 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52565 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148759 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40141 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53245 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36421 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148511 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43204 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125515 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/120260 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51763 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14774 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51148 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51389 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51209 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->