### PR TITLE
[Site Isolation] Autofilled sites should not enter shared process

### DIFF
--- a/Source/WebCore/editing/cocoa/AutofillElements.cpp
+++ b/Source/WebCore/editing/cocoa/AutofillElements.cpp
@@ -125,12 +125,23 @@ std::optional<AutofillElements> AutofillElements::computeAutofillElements(Ref<HT
 
 void AutofillElements::autofill(String username, String password)
 {
-    if (m_username)
+    if (m_username) {
         m_username->setValueForUser(username);
-    if (m_password)
+        if (!username.isEmpty())
+            m_username->didCompleteAutofill();
+    }
+
+    if (m_password) {
         m_password->setValueForUser(password);
-    if (m_secondPassword)
+        if (!password.isEmpty())
+            m_password->didCompleteAutofill();
+    }
+
+    if (m_secondPassword) {
         m_secondPassword->setValueForUser(password);
+        if (!password.isEmpty())
+            m_secondPassword->didCompleteAutofill();
+    }
 }
 
 } // namespace WebCore

--- a/Source/WebCore/html/HTMLInputElement.cpp
+++ b/Source/WebCore/html/HTMLInputElement.cpp
@@ -1519,8 +1519,10 @@ void HTMLInputElement::setAutofilled(bool autoFilled)
     if (autoFilled == m_isAutoFilled)
         return;
 
-    if (autoFilled)
+    if (autoFilled) {
         logUserInteraction();
+        didCompleteAutofill();
+    }
 
     Style::PseudoClassChangeInvalidation styleInvalidation(*this, CSSSelector::PseudoClass::Autofill, autoFilled);
     m_isAutoFilled = autoFilled;
@@ -1594,6 +1596,12 @@ void HTMLInputElement::setAutofillVisibility(AutofillVisibility state)
         setAutofilledAndObscured(true);
         break;
     }
+}
+
+void HTMLInputElement::didCompleteAutofill()
+{
+    if (RefPtr page = document().page())
+        page->chrome().client().didCompleteAutofill(*this);
 }
 
 bool HTMLInputElement::alpha()

--- a/Source/WebCore/html/HTMLInputElement.h
+++ b/Source/WebCore/html/HTMLInputElement.h
@@ -269,6 +269,7 @@ public:
     void setAutofillVisibility(AutofillVisibility);
     bool autofillSpellcheck() const { return !m_isSpellcheckDisabledExceptTextReplacement; }
     void setAutofillSpellcheck(bool value) { m_isSpellcheckDisabledExceptTextReplacement = !value; }
+    void didCompleteAutofill();
 
 #if ENABLE(DRAG_SUPPORT)
     // Returns true if the given DragData has more than one dropped file.

--- a/Source/WebCore/page/ChromeClient.h
+++ b/Source/WebCore/page/ChromeClient.h
@@ -661,6 +661,8 @@ public:
 
     virtual void handleAutoFillButtonClick(HTMLInputElement&) { }
 
+    virtual void didCompleteAutofill(HTMLInputElement&) { }
+
     virtual void inputElementDidResignStrongPasswordAppearance(HTMLInputElement&) { }
 
     virtual void performSwitchHapticFeedback() { }

--- a/Source/WebKit/Sources.txt
+++ b/Source/WebKit/Sources.txt
@@ -677,6 +677,7 @@ UIProcess/WebAuthentication/WebAuthenticationRequestData.cpp
 
 UIProcess/WebsiteData/EnhancedSecuritySitesHolder.cpp
 UIProcess/WebsiteData/EnhancedSecuritySitesPersistence.cpp
+UIProcess/WebsiteData/IsolatedSiteStore.cpp
 UIProcess/WebsiteData/WebDeviceOrientationAndMotionAccessController.cpp
 UIProcess/WebsiteData/WebsiteDataRecord.cpp
 UIProcess/WebsiteData/WebsiteDataStore.cpp @cost:5

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
@@ -1258,6 +1258,11 @@ struct WKWebsiteData {
     return protect(*_websiteDataStore)->hasServiceWorkerBackgroundActivityForTesting();
 }
 
+-(BOOL)_isIsolatedSiteForTesting:(NSURL *)url
+{
+    return protect(*_websiteDataStore)->isIsolatedSiteForTesting(url);
+}
+
 - (void)_getPendingPushMessage:(void(^)(NSDictionary *))completionHandler
 {
     RELEASE_LOG(Push, "Getting pending push message");

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStorePrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStorePrivate.h
@@ -128,6 +128,7 @@ typedef NS_ENUM(uint8_t, _WKRestrictedOpenerType) {
 - (void)_countNonDefaultSessionSets:(void(^)(uint64_t))completionHandler;
 
 -(bool)_hasServiceWorkerBackgroundActivityForTesting WK_API_AVAILABLE(macos(13.0), ios(16.0));
+-(BOOL)_isIsolatedSiteForTesting:(NSURL *)url WK_API_AVAILABLE(macos(27.0), ios(27.0), visionos(27.0));
 -(void)_getPendingPushMessage:(void(^)(NSDictionary *))completionHandler WK_API_AVAILABLE(macos(15.2), ios(18.2));
 -(void)_getPendingPushMessages:(void(^)(NSArray<NSDictionary *> *))completionHandler WK_API_AVAILABLE(macos(13.0), ios(16.0));
 -(void)_processPushMessage:(NSDictionary *)pushMessage completionHandler:(void(^)(bool))completionHandler WK_API_AVAILABLE(macos(13.0), ios(16.0));

--- a/Source/WebKit/UIProcess/BrowsingContextGroup.cpp
+++ b/Source/WebKit/UIProcess/BrowsingContextGroup.cpp
@@ -72,6 +72,8 @@ void BrowsingContextGroup::sharedProcessForSite(WebsiteDataStore& websiteDataSto
             return completionHandler(nullptr);
         if (websitePolicies && !websitePolicies->allowSharedProcess())
             return completionHandler(nullptr);
+        if (websiteDataStore.isolatedSiteStore().contains(site))
+            return completionHandler(nullptr);
     }
     websiteDataStore.fetchDomainsWithUserInteraction([
         protectedThis = Ref { *this },

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -2437,6 +2437,13 @@ void WebProcessProxy::didCollectPrewarmInformation(const WebCore::RegistrableDom
     protect(processPool())->didCollectPrewarmInformation(domain, prewarmInformation);
 }
 
+void WebProcessProxy::didCompleteAutofill(const WebCore::Site& site)
+{
+    MESSAGE_CHECK(!site.isEmpty());
+    if (RefPtr dataStore = websiteDataStore())
+        dataStore->isolatedSiteStore().addSite(site, IsolatedSiteStore::Signal::Autofill);
+}
+
 void WebProcessProxy::activePagesDomainsForTesting(CompletionHandler<void(Vector<String>&&)>&& completionHandler)
 {
     sendWithAsyncReply(Messages::WebProcess::GetActivePagesOriginsForTesting(), WTF::move(completionHandler));

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -745,6 +745,8 @@ private:
 
     void didCollectPrewarmInformation(const WebCore::RegistrableDomain&, const WebCore::PrewarmInformation&);
 
+    void didCompleteAutofill(const WebCore::Site&);
+
     void logDiagnosticMessageForResourceLimitTermination(const String& limitKey);
     
     void updateRegistrationWithDataStore();

--- a/Source/WebKit/UIProcess/WebProcessProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebProcessProxy.messages.in
@@ -58,6 +58,8 @@ messages -> WebProcessProxy WantsDispatchMessage {
 
     DidCollectPrewarmInformation(WebCore::RegistrableDomain domain, struct WebCore::PrewarmInformation prewarmInformation)
 
+    DidCompleteAutofill(WebCore::Site site)
+
 #if PLATFORM(COCOA)
     CacheMediaMIMETypes(Vector<String> types)
     CacheMediaSourceTypeSupported(String type, bool isSupported)

--- a/Source/WebKit/UIProcess/WebsiteData/IsolatedSiteStore.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/IsolatedSiteStore.cpp
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "IsolatedSiteStore.h"
+
+namespace WebKit {
+
+void IsolatedSiteStore::addSite(const WebCore::Site& site, Signal signal)
+{
+    m_sites.add(site.domain(), OptionSet<Signal> { }).iterator->value.add(signal);
+}
+
+OptionSet<IsolatedSiteStore::Signal> IsolatedSiteStore::reasonsFor(const WebCore::Site& site) const
+{
+    auto it = m_sites.find(site.domain());
+    if (it == m_sites.end())
+        return { };
+    return it->value;
+}
+
+bool IsolatedSiteStore::contains(const WebCore::Site& site) const
+{
+    return m_sites.contains(site.domain());
+}
+
+} // namespace WebKit

--- a/Source/WebKit/UIProcess/WebsiteData/IsolatedSiteStore.h
+++ b/Source/WebKit/UIProcess/WebsiteData/IsolatedSiteStore.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <WebCore/RegistrableDomain.h>
+#include <WebCore/Site.h>
+#include <wtf/HashMap.h>
+#include <wtf/OptionSet.h>
+
+namespace WebKit {
+
+class IsolatedSiteStore {
+public:
+    enum class Signal : uint8_t {
+        Autofill = 1 << 0,
+    };
+
+    void addSite(const WebCore::Site&, Signal);
+    OptionSet<Signal> reasonsFor(const WebCore::Site&) const;
+    bool contains(const WebCore::Site&) const;
+
+private:
+    HashMap<WebCore::RegistrableDomain, OptionSet<Signal>> m_sites;
+};
+
+} // namespace WebKit

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
@@ -72,6 +72,7 @@
 #include <WebCore/SearchPopupMenu.h>
 #include <WebCore/SecurityOrigin.h>
 #include <WebCore/SecurityOriginData.h>
+#include <WebCore/Site.h>
 #include <WebCore/StorageUtilities.h>
 #include <WebCore/WebLockRegistry.h>
 #include <algorithm>
@@ -1543,6 +1544,11 @@ void WebsiteDataStore::didHaveUserInteractionForSiteIsolation(const URL& url)
         // notififed of user interaction by the web content process.
         m_pendingDomainsWithUserInteractions.append(registrableDomain);
     }
+}
+
+bool WebsiteDataStore::isIsolatedSiteForTesting(const URL& url) const
+{
+    return m_isolatedSiteStore.contains(WebCore::Site { url });
 }
 
 void WebsiteDataStore::logUserInteraction(const URL& url, CompletionHandler<void()>&& completionHandler)

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
@@ -27,6 +27,7 @@
 
 #include "EnhancedSecurity.h"
 #include "FrameInfoData.h"
+#include "IsolatedSiteStore.h"
 #include "NetworkActivityTracker.h"
 #include "NetworkSessionCreationParameters.h"
 #include "WebDeviceOrientationAndMotionAccessController.h"
@@ -231,6 +232,8 @@ public:
     void dumpResourceLoadStatistics(CompletionHandler<void(const String&)>&&);
     void logTestingEvent(const String&);
     void didHaveUserInteractionForSiteIsolation(const URL&);
+    IsolatedSiteStore& isolatedSiteStore() { return m_isolatedSiteStore; }
+    bool isIsolatedSiteForTesting(const URL&) const;
     void logUserInteraction(const URL&, CompletionHandler<void()>&&);
     void getAllStorageAccessEntries(WebPageProxyIdentifier, CompletionHandler<void(Vector<String>&& domains)>&&);
     void hasHadUserInteraction(const URL&, CompletionHandler<void(bool)>&&);
@@ -626,6 +629,7 @@ private:
     std::optional<HashSet<WebCore::RegistrableDomain>> m_domainsWithUserInteractions;
     Vector<WebCore::RegistrableDomain> m_pendingDomainsWithUserInteractions;
     Vector<CompletionHandler<void(const HashSet<WebCore::RegistrableDomain>&)>> m_domainsWithUserInteractionsCompletionHandler;
+    IsolatedSiteStore m_isolatedSiteStore;
 
     bool m_trackingPreventionDebugMode { false };
     enum class TrackingPreventionEnabled : uint8_t { Default, No, Yes };

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -1060,6 +1060,7 @@
 		3A05FCD62C89095B005EF8CB /* _WKWebPushDaemonConnection.h in Headers */ = {isa = PBXBuildFile; fileRef = 3A05FCCD2C890946005EF8CB /* _WKWebPushDaemonConnection.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		3A05FCD82C890974005EF8CB /* _WKWebPushMessage.h in Headers */ = {isa = PBXBuildFile; fileRef = 3A05FCD02C890946005EF8CB /* _WKWebPushMessage.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		3A05FCDA2C8909A2005EF8CB /* _WKWebPushSubscriptionData.h in Headers */ = {isa = PBXBuildFile; fileRef = 3A05FCD32C890946005EF8CB /* _WKWebPushSubscriptionData.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		3A061A313017E09F00F8873B /* IsolatedSiteStore.h in Headers */ = {isa = PBXBuildFile; fileRef = 3A061A2F3017E09F00F8873B /* IsolatedSiteStore.h */; };
 		3A12CDBB29D4D30200D57EAE /* WebSWRegistrationStore.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AC4C04529D35D1500402716 /* WebSWRegistrationStore.h */; };
 		3A18A2EF2AFF004C00DB976C /* _WKArchiveConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = 3A18A2EE2AFF004C00DB976C /* _WKArchiveConfiguration.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		3A18A2F52B02969900DB976C /* _WKArchiveExclusionRule.h in Headers */ = {isa = PBXBuildFile; fileRef = 3A18A2F32B02969800DB976C /* _WKArchiveExclusionRule.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -5530,6 +5531,8 @@
 		3A05FCDC2C8909D3005EF8CB /* APIWebPushDaemonConnection.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = APIWebPushDaemonConnection.cpp; sourceTree = "<group>"; };
 		3A05FCDD2C8909D3005EF8CB /* APIWebPushMessage.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = APIWebPushMessage.h; sourceTree = "<group>"; };
 		3A05FCDE2C8909D3005EF8CB /* APIWebPushSubscriptionData.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = APIWebPushSubscriptionData.h; sourceTree = "<group>"; };
+		3A061A2F3017E09F00F8873B /* IsolatedSiteStore.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = IsolatedSiteStore.h; sourceTree = "<group>"; };
+		3A061A303017E09F00F8873B /* IsolatedSiteStore.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = IsolatedSiteStore.cpp; sourceTree = "<group>"; };
 		3A068FF32F98A6AC0038FAC7 /* WKXRControllerManager.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WKXRControllerManager.mm; sourceTree = "<group>"; };
 		3A068FF42F98A6AC0038FAC7 /* WKXRTrackingManager.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WKXRTrackingManager.mm; sourceTree = "<group>"; };
 		3A18A2EE2AFF004C00DB976C /* _WKArchiveConfiguration.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _WKArchiveConfiguration.h; sourceTree = "<group>"; };
@@ -10189,6 +10192,8 @@
 				5628440E2ED9E5440080DD29 /* EnhancedSecuritySitesHolder.h */,
 				5628440D2ED9E5250080DD29 /* EnhancedSecuritySitesPersistence.cpp */,
 				5628440C2ED9E50D0080DD29 /* EnhancedSecuritySitesPersistence.h */,
+				3A061A303017E09F00F8873B /* IsolatedSiteStore.cpp */,
+				3A061A2F3017E09F00F8873B /* IsolatedSiteStore.h */,
 				46B0524522668D2400265B97 /* WebDeviceOrientationAndMotionAccessController.cpp */,
 				46B0524422668D2300265B97 /* WebDeviceOrientationAndMotionAccessController.h */,
 				1A4832D81A9D1FD2008B4DFE /* WebsiteDataRecord.cpp */,
@@ -18427,6 +18432,7 @@
 				A73E66BD2AB107C3005FC327 /* IPCEvent.h in Headers */,
 				A31F60A425CC7DB900AF14F4 /* IPCSemaphore.h in Headers */,
 				7BE37F9327C7CA51007A6CD3 /* IPCStreamTesterIdentifier.h in Headers */,
+				3A061A313017E09F00F8873B /* IsolatedSiteStore.h in Headers */,
 				46DBC28C2AF96B9F00E6B63A /* ITPThirdPartyData.h in Headers */,
 				46DBC28D2AF96BA400E6B63A /* ITPThirdPartyDataForSpecificFirstParty.h in Headers */,
 				9B47908F253151CC00EC11AB /* JSIPCBinding.h in Headers */,

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -123,6 +123,7 @@
 #include <WebCore/SecurityOrigin.h>
 #include <WebCore/SecurityOriginData.h>
 #include <WebCore/Settings.h>
+#include <WebCore/Site.h>
 #include <WebCore/SystemPreviewInfo.h>
 #include <WebCore/TextDetectorInterface.h>
 #include <WebCore/TextIndicator.h>
@@ -1989,6 +1990,15 @@ void WebChromeClient::handleAutoFillButtonClick(HTMLInputElement& inputElement)
 
     // Notify the UIProcess.
     page->send(Messages::WebPageProxy::HandleAutoFillButtonClick(UserData(WebProcess::singleton().transformObjectsToHandles(userData.get()).get())));
+}
+
+void WebChromeClient::didCompleteAutofill(HTMLInputElement& inputElement)
+{
+    auto site = Site { inputElement.document().url() };
+    if (site.isEmpty())
+        return;
+
+    protect(WebProcess::singleton().parentProcessConnection())->send(Messages::WebProcessProxy::DidCompleteAutofill(site), 0);
 }
 
 void WebChromeClient::inputElementDidResignStrongPasswordAppearance(HTMLInputElement& inputElement)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
@@ -437,6 +437,8 @@ private:
 
     void handleAutoFillButtonClick(WebCore::HTMLInputElement&) final;
 
+    void didCompleteAutofill(WebCore::HTMLInputElement&) final;
+
     void inputElementDidResignStrongPasswordAppearance(WebCore::HTMLInputElement&) final;
 
     void performSwitchHapticFeedback() final;

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/UserContentController.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/UserContentController.mm
@@ -47,6 +47,7 @@
 #import <WebKit/WKUserScriptPrivate.h>
 #import <WebKit/WKWebViewConfigurationPrivate.h>
 #import <WebKit/WKWebViewPrivate.h>
+#import <WebKit/WKWebsiteDataStorePrivate.h>
 #import <WebKit/WebKit.h>
 #import <WebKit/_WKContentWorldConfiguration.h>
 #import <WebKit/_WKFrameTreeNode.h>
@@ -1368,6 +1369,32 @@ TEST(WKUserContentController, BeforeFocusEvent)
     EXPECT_WK_STREQ([webView _test_waitForAlert], "focus-pass");
     [webView evaluateJavaScript:@"shadowRoot.querySelector('#text2').focus()" completionHandler:nil];
     EXPECT_WK_STREQ([webView _test_waitForAlert], "focus-pass");
+}
+
+TEST(WKUserContentController, AutofillScriptingMarksSiteAsIsolated)
+{
+    RetainPtr webView = adoptNS([TestWKWebView new]);
+    RetainPtr configuration = adoptNS([WKContentWorldConfiguration new]);
+    configuration.get().autofillScriptingEnabled = YES;
+    RetainPtr autofillWorld = [WKContentWorld worldWithConfiguration:configuration.get()];
+
+    NSURL *url = [NSURL URLWithString:@"https://example.com/"];
+    [webView synchronouslyLoadHTMLString:@"<input id='password' type='password'>" baseURL:url];
+
+    WKWebsiteDataStore *dataStore = [webView configuration].websiteDataStore;
+    EXPECT_FALSE([dataStore _isIsolatedSiteForTesting:url]);
+
+    __block bool doneEvaluatingScript = false;
+    [webView evaluateJavaScript:@"document.getElementById('password').value = 'famos'; document.getElementById('password').autofilled = true" inFrame:nil inContentWorld:autofillWorld.get() completionHandler:^(id, NSError *) {
+        doneEvaluatingScript = true;
+    }];
+    TestWebKitAPI::Util::run(&doneEvaluatingScript);
+
+    EXPECT_WK_STREQ("famos", [webView stringByEvaluatingJavaScript:@"document.getElementById('password').value"]);
+
+    EXPECT_TRUE(TestWebKitAPI::Util::waitFor(^{
+        return (bool)[dataStore _isIsolatedSiteForTesting:url];
+    }));
 }
 
 #endif // PLATFORM(MAC)

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/WKWebViewAutofillTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/WKWebViewAutofillTests.mm
@@ -34,6 +34,7 @@
 #import "UIKitSPIForTesting.h"
 #import "WKBrowserEngineDefinitions.h"
 #import <WebKit/WKWebViewPrivate.h>
+#import <WebKit/WKWebsiteDataStorePrivate.h>
 #import <pal/spi/ios/BrowserEngineKitSPI.h>
 #import <wtf/BlockPtr.h>
 
@@ -107,6 +108,28 @@ TEST(WKWebViewAutoFillTests, UsernameAndPasswordField)
 
     [webView evaluateJavaScriptAndWaitForInputSessionToChange:@"document.activeElement.blur()"];
     EXPECT_FALSE([webView acceptsAutoFillLoginCredentials]);
+}
+
+TEST(WKWebViewAutoFillTests, AutofillMarksSiteAsIsolated)
+{
+    RetainPtr webView = adoptNS([[AutoFillTestView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    NSURL *url = [NSURL URLWithString:@"https://example.com/"];
+    [webView synchronouslyLoadHTMLString:@"<input id='user' type='email'><input id='password' type='password'>" baseURL:url];
+
+    WKWebsiteDataStore *dataStore = [webView configuration].websiteDataStore;
+    EXPECT_FALSE([dataStore _isIsolatedSiteForTesting:url]);
+
+    [webView evaluateJavaScriptAndWaitForInputSessionToChange:@"user.focus()"];
+    [webView evaluateJavaScriptAndWaitForInputSessionToChange:@"password.focus()"];
+
+    auto credentialSuggestion = [UITextAutofillSuggestion autofillSuggestionWithUsername:@"frederik" password:@"famos"];
+    [[webView _autofillInputView] insertTextSuggestion:credentialSuggestion];
+
+    EXPECT_WK_STREQ("famos", [webView stringByEvaluatingJavaScript:@"password.value"]);
+
+    EXPECT_TRUE(TestWebKitAPI::Util::waitFor(^{
+        return (bool)[dataStore _isIsolatedSiteForTesting:url];
+    }));
 }
 
 TEST(WKWebViewAutoFillTests, UsernameAndPasswordFieldAcrossShadowBoundaries)


### PR DESCRIPTION
#### 89fdf3d120e33378db776d04a73d6b13766d8bbd
<pre>
[Site Isolation] Autofilled sites should not enter shared process
<a href="https://bugs.webkit.org/show_bug.cgi?id=320396">https://bugs.webkit.org/show_bug.cgi?id=320396</a>
<a href="https://rdar.apple.com/183351796">rdar://183351796</a>

Reviewed by Ryosuke Niwa.

Site Isolation&apos;s shared process mode puts multiple cross-site frames into one WebProcess for performance, trading away
some of the process-boundary protection between the co-located sites. Sites that are likely to contains sensitive data
or capabilities should not be put in the shared process. We currently use user interaction as indicator, but there are
better signals, like whether user has used autofill on the site to fill in credentials. This patch introduces a new
per-session, in-memory IsolatedSiteStore to store these important sites. BrowsingContextGroup::sharedProcessForSite
now consults it and will not put any site it flags in shared process.

In the initial version of IsolatedSiteStore, a site is recorded via two paths that both funnel through
HTMLInputElement::didCompleteAutofill(), which calls ChromeClient::didCompleteAutofill():
- Native autofill: AutofillElements::autofill() calls didCompleteAutofill() after filling in a non-empty
username/password.
- Scripted autofill: HTMLInputElement::setAutofilled(bool) calls didCompleteAutofill() when the field
transitions to autofilled. This is reached by real autofill agents via the existing [EnabledForWorld=allowAutofill]
autofilled IDL attribute, which is only reachable from a JS world with allowAutofill() set. Hooking into this existing,
narrowly-scoped setter avoids adding any overhead to HTMLInputElement&apos;s value setter.

WebChromeClient::didCompleteAutofill computes the WebCore::Site for the input&apos;s document and sends it to the UI process
via the new WebProcessProxy::DidCompleteAutofill IPC message, which forwards it to WebsiteDataStore&apos;s
IsolatedSiteStore::addSite(). The IPC message and IsolatedSiteStore&apos;s interface intentionally carry WebCore::Site
rather than RegistrableDomain so scheme information isn&apos;t discarded before it crosses the process boundary, even though
the store&apos;s internal map is currently keyed by domain only.

Added WKWebsiteDataStore._isIsolatedSiteForTesting: SPI to observe this from tests, and covered both the native-autofill
(iOS) and scripted-autofill (macOS) paths with new API tests.

API tests: WKWebViewAutoFillTests.AutofillMarksSiteAsIsolated
           WKUserContentController.AutofillScriptingMarksSiteAsIsolated

* Source/WebCore/editing/cocoa/AutofillElements.cpp:
(WebCore::AutofillElements::autofill):
* Source/WebCore/html/HTMLInputElement.cpp:
(WebCore::HTMLInputElement::setAutofilled):
(WebCore::HTMLInputElement::didCompleteAutofill):
* Source/WebCore/html/HTMLInputElement.h:
* Source/WebCore/page/ChromeClient.h:
(WebCore::ChromeClient::didCompleteAutofill):
* Source/WebKit/Sources.txt:
* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm:
(-[WKWebsiteDataStore _isIsolatedSiteForTesting:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStorePrivate.h:
* Source/WebKit/UIProcess/BrowsingContextGroup.cpp:
(WebKit::BrowsingContextGroup::sharedProcessForSite):
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::didCompleteAutofill):
* Source/WebKit/UIProcess/WebProcessProxy.h:
* Source/WebKit/UIProcess/WebProcessProxy.messages.in:
* Source/WebKit/UIProcess/WebsiteData/IsolatedSiteStore.cpp: Added.
(WebKit::IsolatedSiteStore::addSite):
(WebKit::IsolatedSiteStore::reasonsFor const):
(WebKit::IsolatedSiteStore::contains const):
* Source/WebKit/UIProcess/WebsiteData/IsolatedSiteStore.h: Added.
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp:
(WebKit::WebsiteDataStore::isIsolatedSiteForTesting const):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h:
(WebKit::WebsiteDataStore::isolatedSiteStore):
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::didCompleteAutofill):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/UserContentController.mm:
(TEST(WKUserContentController, AutofillScriptingMarksSiteAsIsolated)):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/WKWebViewAutofillTests.mm:
(TestWebKitAPI::TEST(WKWebViewAutoFillTests, AutofillMarksSiteAsIsolated)):

Canonical link: <a href="https://commits.webkit.org/318135@main">https://commits.webkit.org/318135@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/07ce8df36fe192ad5e0c250bfe39e739ecad15d2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177335 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51273 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45067 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186938 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140582 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0121643a-d64d-4978-9070-aea07d8a75e2) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179198 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52565 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50982 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138199 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140582 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e327a634-9a8c-46ca-a245-dffab21c1563) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180291 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41695 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158953 "Found 1 new API test failure: TestWebKitAPI.UnifiedPDF.PDFHUDMultiplePluginsDoNotInterceptHitTesting (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118664 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fa280d69-1146-4dac-b8a0-0835250c0af3) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40356 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38737 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150764 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38450 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35406 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/43058 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/42971 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189367 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50939 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147287 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39588 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51622 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35077 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147079 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41802 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123837 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118175 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50130 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13428 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49526 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49766 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49588 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->