### PR TITLE
[git-webkit] revert fails when the original bug's version is no longer active, blocking reverts of older commits

### DIFF
--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/bugzilla.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/bugzilla.py
@@ -49,6 +49,8 @@ class Tracker(GenericTracker):
     NAME = 'Bugzilla'
     DEFAULT_TIMEOUT = 30
     MAX_SUMMARY_LENGTH = 255
+    # FIXME: We should make this class project agnostic by specifying this in trackers.json.
+    DEFAULT_VERSION = 'WebKit Nightly Build'
 
     # Security keywords to detect in title/description.
     # These trigger a prompt to use Security product.
@@ -672,7 +674,7 @@ class Tracker(GenericTracker):
                     continue
                 result[product['name']] = dict(
                     description=product['description'],
-                    versions=[version['name'] for version in product['versions']],
+                    versions=[version['name'] for version in product['versions'] if version['is_active']],
                     components=dict(),
                 )
                 for component in product['components']:
@@ -723,15 +725,19 @@ class Tracker(GenericTracker):
         if component not in self.projects[project]['components']:
             raise ValueError("'{}' is not a recognized component in '{}'".format(component, project))
 
-        if not version:
-            # This is the default option, aligned to webkit-patch behavior.
-            # FIXME: We should make this class project agnostic by specifying this in trackers.json.
-            version = "WebKit Nightly Build"
-            if version not in self.projects[project]['versions']:
-                # If the default option does not exist on the list, we pick the last one from versions.
-                version = self.projects[project]['versions'][-1]
-        if version not in self.projects[project]['versions']:
-            raise ValueError("'{}' is not a recognized version for '{}'".format(version, project))
+        versions = self.projects[project]['versions']
+        if not versions:
+            raise ValueError("'{}' has no active versions on {}".format(project, self.url))
+        if version not in versions:
+            fallback = self.DEFAULT_VERSION if self.DEFAULT_VERSION in versions else versions[-1]
+            # A caller may inherit a version from an existing bug (git-webkit revert does), and that
+            # version may since have been retired. Bugzilla rejects inactive versions, so fall back
+            # to the default instead of failing to file the bug.
+            if version:
+                sys.stderr.write("'{}' is not an active version for '{}', using '{}' instead\n".format(
+                    version, project, fallback,
+                ))
+            version = fallback
 
         keywords = keywords or []
         for keyword in keywords:

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/bugzilla.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/bugzilla.py
@@ -393,7 +393,7 @@ class Bugzilla(Base, mocks.Requests):
                     ) for component, details in product['components'].items()],
                     versions=[dict(
                         name=version,
-                        is_active=True,
+                        is_active=version not in product.get('inactive_versions', []),
                     ) for version in product['versions']],
                 )]), url=url,
             )
@@ -434,6 +434,18 @@ class Bugzilla(Base, mocks.Requests):
                     error=True,
                     code=104,
                     message='The text you entered in the Summary field is too long ({} characters, above the maximum length allowed of 255 characters).'.format(len(data['summary'])),
+                )),
+                url=url,
+            )
+
+        inactive_versions = self.projects.get(data['product'], {}).get('inactive_versions', [])
+        if data['version'] in inactive_versions:
+            return mocks.Response(
+                status_code=400,
+                text=json.dumps(dict(
+                    error=True,
+                    code=106,
+                    message="The version value '{}' is not active.".format(data['version']),
                 )),
                 url=url,
             )

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/bugzilla_unittest.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/bugzilla_unittest.py
@@ -20,6 +20,7 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+import copy
 import json
 import logging
 import re
@@ -523,6 +524,70 @@ What component in 'WebKit' should the bug be associated with?:
             self.assertEqual(len(created.title), 255)
             self.assertEqual(created.title, 'A' * 252 + '...')
             self.assertEqual(created.description, 'Creating new bug')
+
+    def test_create_falls_back_to_default_version(self):
+        projects = copy.deepcopy(mocks.PROJECTS)
+        projects['WebKit']['versions'].insert(0, '528+ (Nightly build)')
+        projects['WebKit']['inactive_versions'] = ['528+ (Nightly build)']
+        projects['WebKit']['versions'].append('WebKit Nightly Build')
+
+        with mocks.Bugzilla(self.URL.split('://')[1], environment=wkmocks.Environment(
+                BUGS_EXAMPLE_COM_USERNAME='tcontributor@example.com',
+                BUGS_EXAMPLE_COM_PASSWORD='password',
+        ), projects=projects, issues=mocks.ISSUES):
+            with OutputCapture() as captured:
+                created = bugzilla.Tracker(self.URL).create(
+                    'New bug', 'Creating new bug',
+                    project='WebKit', component='Tables', version='528+ (Nightly build)',
+                )
+            self.assertIsNotNone(created)
+            self.assertEqual(created.version, 'WebKit Nightly Build')
+            self.assertEqual(
+                captured.stderr.getvalue(),
+                "'528+ (Nightly build)' is not an active version for 'WebKit', using 'WebKit Nightly Build' instead\n",
+            )
+
+    def test_create_falls_back_to_last_version(self):
+        projects = copy.deepcopy(mocks.PROJECTS)
+        projects['WebKit']['versions'].insert(0, '528+ (Nightly build)')
+        projects['WebKit']['inactive_versions'] = ['528+ (Nightly build)']
+
+        with mocks.Bugzilla(self.URL.split('://')[1], environment=wkmocks.Environment(
+                BUGS_EXAMPLE_COM_USERNAME='tcontributor@example.com',
+                BUGS_EXAMPLE_COM_PASSWORD='password',
+        ), projects=projects, issues=mocks.ISSUES):
+            with OutputCapture():
+                created = bugzilla.Tracker(self.URL).create(
+                    'New bug', 'Creating new bug',
+                    project='WebKit', component='Tables', version='528+ (Nightly build)',
+                )
+            self.assertIsNotNone(created)
+            self.assertEqual(created.version, 'WebKit Local Build')
+
+    def test_create_no_version_is_silent(self):
+        with mocks.Bugzilla(self.URL.split('://')[1], environment=wkmocks.Environment(
+                BUGS_EXAMPLE_COM_USERNAME='tcontributor@example.com',
+                BUGS_EXAMPLE_COM_PASSWORD='password',
+        ), projects=mocks.PROJECTS, issues=mocks.ISSUES):
+            with OutputCapture() as captured:
+                created = bugzilla.Tracker(self.URL).create(
+                    'New bug', 'Creating new bug',
+                    project='WebKit', component='Tables',
+                )
+            self.assertIsNotNone(created)
+            self.assertEqual(created.version, 'WebKit Local Build')
+            self.assertEqual(captured.stderr.getvalue(), '')
+
+    def test_projects_excludes_inactive_versions(self):
+        projects = copy.deepcopy(mocks.PROJECTS)
+        projects['WebKit']['versions'].insert(0, '528+ (Nightly build)')
+        projects['WebKit']['inactive_versions'] = ['528+ (Nightly build)']
+
+        with mocks.Bugzilla(self.URL.split('://')[1], projects=projects):
+            self.assertEqual(
+                bugzilla.Tracker(self.URL).projects['WebKit']['versions'],
+                ['Other', 'Safari 15', 'Safari Technology Preview', 'WebKit Local Build'],
+            )
 
     def test_set_component(self):
         with mocks.Bugzilla(self.URL.split('://')[1], environment=wkmocks.Environment(


### PR DESCRIPTION
#### b6658b694e0d6c2d19ea810aada91758d1d3daeb
<pre>
[git-webkit] revert fails when the original bug&apos;s version is no longer active, blocking reverts of older commits
<a href="https://bugs.webkit.org/show_bug.cgi?id=320395">https://bugs.webkit.org/show_bug.cgi?id=320395</a>

Reviewed by Aakash Jain.

`git-webkit revert` inherits the project, component, and version of the bug attached to the
commit being reverted. When that bug is old enough that its version has since been retired
in Bugzilla, bug creation failed with a &quot;&lt;version&gt; is not active.&quot; error which aborts the revert
without creating a bug or PR.

Address this by filtering out inactive versions (as was already done for products and components)
and falling back to the default version instead of raising an error.

* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/bugzilla.py:
(Tracker): Hoist the hardcoded default version to a DEFAULT_VERSION constant.
(Tracker.projects): Exclude versions Bugzilla reports as inactive, so callers only ever see
versions a new bug can actually be filed against.
(Tracker.create): Substitute the default version and warn on stderr when the requested version
is inactive, instead of raising. Still raises if the project has no active versions at all.
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/bugzilla.py:
(Bugzilla._product_details): Report versions listed in a project&apos;s new &apos;inactive_versions&apos;
key as inactive rather than marking every version active.
(Bugzilla._create): Reject inactive versions with the same 400 real Bugzilla returns, so the
client-side fallback is tested against server enforcement.
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/bugzilla_unittest.py:
(TestBugzilla.test_create_falls_back_to_default_version): An inactive version is replaced
by the default and the substitution is reported on stderr.
(TestBugzilla.test_create_falls_back_to_last_version): When the default is itself inactive,
the last remaining active version is used.
(TestBugzilla.test_create_no_version_is_silent): Omitting a version still picks the default
without emitting a warning.
(TestBugzilla.test_projects_excludes_inactive_versions): Inactive versions are absent from
the project&apos;s version list.

Canonical link: <a href="https://commits.webkit.org/318263@main">https://commits.webkit.org/318263@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7376dcb449fc6e715c686d7b1de29b83897ecd4e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177032 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50969 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/44764 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186635 "Build is in progress. Recent messages:Printed configuration; Checked out pull request; Compiled WebKit") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140268 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178895 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/52262 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/50655 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/137937 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140268 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179988 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/52262 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/44764 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/118406 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/176355 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/52262 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/50655 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/251/builds/375 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/44764 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/52262 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/44764 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/35103 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/38303 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/42743 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/50655 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/189058 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/176435 "Passed tests") | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/50636 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/44764 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/189058 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/51319 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/44764 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/189058 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26959 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/51319 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/123533 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/117820 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/49824 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/44764 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/49223 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/49460 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/49284 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->