### PR TITLE
[EWS] macOS-Sequoia-Release-Site-Isolation-Tests-EWS does not retry tests before reporting results

### DIFF
--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -4092,6 +4092,9 @@ class RunWebKitTests(shell.Test, ResultsDBReportMixin, AddToLogMixin, ShellMixin
 
         return result
 
+    def rerun_step(self):
+        return ReRunWebKitTests()
+
     def evaluateCommand(self, cmd):
         rc = self.evaluateResult(cmd)
         previous_build_summary = self.getProperty('build_summary', '')
@@ -4138,7 +4141,7 @@ class RunWebKitTests(shell.Test, ResultsDBReportMixin, AddToLogMixin, ShellMixin
             if GitHub.NO_FAILURE_LIMITS_LABEL not in self.getProperty('github_labels', []):
                 steps_to_add += [
                     KillOldProcesses(),
-                    ReRunWebKitTests(),
+                    self.rerun_step(),
                 ]
             elif platform != 'win':
                 steps_to_add += [
@@ -4269,89 +4272,6 @@ class RunWebKitTestsInSiteIsolationMode(RunWebKitTestsInStressMode):
 
     def doStepIf(self, step):
         return self.getProperty('modified_tests', False) and self.getProperty('stress_mode_passed', False)
-
-
-class RunWebKitTestsEWSSiteIsolation(RunWebKitTests):
-    reports_to_results_db = False
-    name = 'layout-tests-site-isolation'
-
-    def results_db_query_configuration(self) -> dict:
-        # Use flavor='site-isolation' without a platform filter so that results from
-        # Apple-Tahoe-Release-WK2-Site-Isolation-Tree-Tests (the closest post-commit queue)
-        # are consulted. Once a mac-sequoia site-isolation post-commit bot exists its
-        # results will automatically be included as well.
-        configuration = super().results_db_query_configuration()
-        configuration['flavor'] = 'site-isolation'
-        configuration.pop('platform')
-        return configuration
-
-    @defer.inlineCallbacks
-    def filter_failures_using_results_db(self, failing_tests):
-        self.failing_tests_filtered = failing_tests.copy()
-        identifier = self.getProperty('identifier', None)
-        configuration = self.results_db_query_configuration()
-
-        yield self._addToLog(self.results_db_log_name, f'Checking Results database for failing tests. Identifier: {identifier}, configuration: {configuration}')
-        has_commit = False
-        if failing_tests and identifier:
-            has_commit = yield ResultsDatabase.has_commit(commit=identifier)
-            if not has_commit:
-                yield self._addToLog(self.results_db_log_name, f"'{identifier}' could not be found on the results database, falling back to tip-of-tree\n")
-
-        for test in failing_tests:
-            data = yield ResultsDatabase.is_test_pre_existing_failure(
-                test, configuration=configuration,
-                commit=identifier if has_commit else None,
-            )
-            yield self._addToLog(self.results_db_log_name, f"\n{test}: pass_rate: {data['pass_rate']}, pre-existing-failure={data['is_existing_failure']}\nResponse from results-db: {data['raw_data']}\n{data['logs']}")
-            if data['is_existing_failure']:
-                self.preexisting_failures_in_results_db.append(test)
-                self.failing_tests_filtered.remove(test)
-            else:
-                break
-
-    def evaluateCommand(self, cmd):
-        rc = self.evaluateResult(cmd)
-        previous_build_summary = self.getProperty('build_summary', '')
-        steps_to_add = []
-
-        if SHOULD_FILTER_LOGS is True:
-            steps_to_add = [
-                GenerateS3URL(
-                    f"{self.getProperty('fullPlatform')}-{self.getProperty('archForUpload')}-{self.getProperty('configuration')}-{self.name}",
-                    extension='txt',
-                    additions=f'{self.build.number}',
-                    content_type='text/plain',
-                ), UploadFileToS3(
-                    'logs.txt',
-                    links={self.name: 'Full logs'},
-                    content_type='text/plain',
-                )
-            ]
-
-        if rc == SUCCESS or rc == WARNINGS:
-            message = 'Passed layout tests'
-            self.descriptionDone = message
-            self.build.results = SUCCESS
-            if RunWebKitTestsInStressMode.FAILURE_MSG_IN_STRESS_MODE not in previous_build_summary:
-                self.setProperty('build_summary', message)
-        elif (self.preexisting_failures_in_results_db and len(self.failing_tests_filtered) == 0):
-            message = f"Ignored pre-existing failure: {', '.join(self.preexisting_failures_in_results_db)}"
-            self.descriptionDone = message
-            self.build.results = SUCCESS
-            if RunWebKitTestsInStressMode.FAILURE_MSG_IN_STRESS_MODE not in previous_build_summary:
-                self.setProperty('build_summary', message)
-            steps_to_add += [ArchiveTestResults(), UploadTestResults(), ExtractTestResults()]
-            self.build.addStepsAfterCurrentStep(steps_to_add)
-            return WARNINGS
-        else:
-            steps_to_add += [
-                ArchiveTestResults(),
-                UploadTestResults(),
-                ExtractTestResults(),
-            ]
-        self.build.addStepsAfterCurrentStep(steps_to_add)
-        return rc
 
 
 class ReRunWebKitTests(RunWebKitTests):
@@ -4613,6 +4533,29 @@ class RunWebKitTestsWithoutChange(RunWebKitTests):
                 continue
             positional_test_paths.append(argument)
         return positional_test_paths
+
+
+class SiteIsolationResultsDBMixin(object):
+    reports_to_results_db = False
+
+    def results_db_query_configuration(self) -> dict:
+        # Use flavor='site-isolation' without a platform filter so that results from
+        # Apple-Tahoe-Release-WK2-Site-Isolation-Tree-Tests (the closest post-commit queue) are consulted.
+        configuration = super().results_db_query_configuration()
+        configuration['flavor'] = 'site-isolation'
+        configuration.pop('platform', None)
+        return configuration
+
+
+class RunWebKitTestsEWSSiteIsolation(SiteIsolationResultsDBMixin, RunWebKitTests):
+    name = 'layout-tests-site-isolation'
+
+    def rerun_step(self):
+        return ReRunWebKitTestsEWSSiteIsolation()
+
+
+class ReRunWebKitTestsEWSSiteIsolation(SiteIsolationResultsDBMixin, ReRunWebKitTests):
+    name = 're-run-layout-tests-site-isolation'
 
 
 class AnalyzeLayoutTestsResults(ResultsDBReportMixin, buildstep.BuildStep, BugzillaMixin, GitHubMixin):

--- a/Tools/CISupport/ews-build/steps_unittest.py
+++ b/Tools/CISupport/ews-build/steps_unittest.py
@@ -2765,6 +2765,110 @@ class TestRunWebKitTestsWithoutChange(BuildStepMixinAdditions, unittest.TestCase
             return self.run_step()
 
 
+class TestRunWebKitTestsEWSSiteIsolation(BuildStepMixinAdditions, unittest.TestCase):
+    def setUp(self):
+        self.longMessage = True
+        self.jsonFileName = 'layout-test-results/full_results.json'
+        return self.setup_test_build_step()
+
+    def tearDown(self):
+        return self.tear_down_test_build_step()
+
+    def configureStep(self):
+        self.setup_step(RunWebKitTestsEWSSiteIsolation())
+        self.property_exceed_failure_limit = 'first_results_exceed_failure_limit'
+        self.property_failures = 'first_run_failures'
+        RunWebKitTestsEWSSiteIsolation.filter_failures_using_results_db = lambda x, failing_tests: ''
+
+    def test_success(self):
+        self.configureStep()
+        self.setProperty('platform', 'mac-sequoia')
+        self.setProperty('fullPlatform', 'mac-sequoia')
+        self.setProperty('configuration', 'release')
+        self.setProperty('additionalArguments', ['imported/w3c/web-platform-tests', '--site-isolation-enabled-by-default', '--exclude-tests', 'imported/w3c/web-platform-tests/css'])
+        self.expectRemoteCommands(
+            ExpectShell(workdir='wkdir',
+                        logfiles={'json': self.jsonFileName},
+                        log_environ=False,
+                        timeout=19800,
+                        command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', 'python3 Tools/Scripts/run-webkit-tests --no-build --no-show-results --no-new-test-results --clobber-old-results --release --results-directory layout-test-results --debug-rwt-logging --exit-after-n-failures 60 --skip-failing-tests imported/w3c/web-platform-tests --site-isolation-enabled-by-default --exclude-tests imported/w3c/web-platform-tests/css 2>&1 | Tools/Scripts/filter-test-logs layout'],
+                        )
+            .exit(0),
+        )
+        self.expect_outcome(result=SUCCESS, state_string='Passed layout tests')
+        return self.run_step()
+
+    def test_failure(self):
+        self.configureStep()
+        self.setProperty('platform', 'mac-sequoia')
+        self.setProperty('fullPlatform', 'mac-sequoia')
+        self.setProperty('configuration', 'release')
+        self.setProperty('additionalArguments', ['imported/w3c/web-platform-tests', '--site-isolation-enabled-by-default', '--exclude-tests', 'imported/w3c/web-platform-tests/css'])
+        self.expectRemoteCommands(
+            ExpectShell(workdir='wkdir',
+                        logfiles={'json': self.jsonFileName},
+                        log_environ=False,
+                        timeout=19800,
+                        command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', 'python3 Tools/Scripts/run-webkit-tests --no-build --no-show-results --no-new-test-results --clobber-old-results --release --results-directory layout-test-results --debug-rwt-logging --exit-after-n-failures 60 --skip-failing-tests imported/w3c/web-platform-tests --site-isolation-enabled-by-default --exclude-tests imported/w3c/web-platform-tests/css 2>&1 | Tools/Scripts/filter-test-logs layout'],
+                        )
+            .log('stdio', stdout='9 failures found.')
+            .exit(2),
+        )
+        self.expect_outcome(result=FAILURE, state_string='layout-tests (failure)')
+        return self.run_step()
+
+    def test_results_db_query_configuration_uses_site_isolation_flavor(self):
+        self.setup_step(RunWebKitTestsEWSSiteIsolation())
+        self.setProperty('platform', 'mac-sequoia')
+        self.setProperty('configuration', 'release')
+        self.assertEqual(self.get_nth_step(0).results_db_query_configuration(), {'flavor': 'site-isolation', 'style': 'release'})
+
+    def test_failure_schedules_site_isolation_rerun(self):
+        self.configureStep()
+        self.setProperty('platform', 'mac-sequoia')
+        self.setProperty('fullPlatform', 'mac-sequoia')
+        self.setProperty('configuration', 'release')
+        next_steps = []
+        self.patch(self.build, 'addStepsAfterCurrentStep', lambda s: next_steps.extend(s))
+        self.patch(RunWebKitTestsEWSSiteIsolation, 'evaluateResult', lambda s, r: r)
+        self.get_nth_step(0).evaluateCommand(FAILURE)
+        self.assertTrue(any(isinstance(step, ReRunWebKitTestsEWSSiteIsolation) for step in next_steps))
+        self.assertFalse(any(type(step) is ReRunWebKitTests for step in next_steps))
+
+
+class TestReRunWebKitTestsEWSSiteIsolation(BuildStepMixinAdditions, unittest.TestCase):
+    def setUp(self):
+        self.longMessage = True
+        self.jsonFileName = 'layout-test-results/full_results.json'
+        return self.setup_test_build_step()
+
+    def tearDown(self):
+        return self.tear_down_test_build_step()
+
+    def configureStep(self):
+        self.setup_step(ReRunWebKitTestsEWSSiteIsolation())
+        ReRunWebKitTestsEWSSiteIsolation.filter_failures_using_results_db = lambda x, failing_tests: ''
+
+    def test_results_db_query_configuration_uses_site_isolation_flavor(self):
+        self.configureStep()
+        self.setProperty('configuration', 'debug')
+        self.assertEqual(self.get_nth_step(0).results_db_query_configuration(), {'flavor': 'site-isolation', 'style': 'debug'})
+
+    def test_failure_schedules_clean_tree_run(self):
+        self.configureStep()
+        self.setProperty('platform', 'mac-sequoia')
+        self.setProperty('fullPlatform', 'mac-sequoia')
+        self.setProperty('configuration', 'release')
+        self.setProperty('first_run_failures', ['imported/w3c/web-platform-tests/test1.html'])
+        self.setProperty('second_run_failures', ['imported/w3c/web-platform-tests/test1.html'])
+        next_steps = []
+        self.patch(self.build, 'addStepsAfterCurrentStep', lambda s: next_steps.extend(s))
+        self.patch(ReRunWebKitTestsEWSSiteIsolation, 'evaluateResult', lambda s, r: r)
+        self.get_nth_step(0).evaluateCommand(FAILURE)
+        self.assertTrue(any(isinstance(step, RunWebKitTestsWithoutChange) for step in next_steps))
+        self.assertTrue(any(isinstance(step, ValidateChange) for step in next_steps))
+
+
 class TestRunWebKit1Tests(BuildStepMixinAdditions, unittest.TestCase):
     def setUp(self):
         self.longMessage = True


### PR DESCRIPTION
#### c51356d573bee3e638d384c19944d4f857ec6245
<pre>
[EWS] macOS-Sequoia-Release-Site-Isolation-Tests-EWS does not retry tests before reporting results
<a href="https://bugs.webkit.org/show_bug.cgi?id=319725">https://bugs.webkit.org/show_bug.cgi?id=319725</a>
<a href="https://rdar.apple.com/182558497">rdar://182558497</a>

Reviewed by Aakash Jain.

The Site-Isolation-Tests EWS queue reported a change as failing after a single test run, skipping
the retry ladder that every other layout-test queue uses to avoid blaming a change for flaky or
pre-existing failures.

The queue can reuse the existing ladder as-is. Both the first run and the re-run need the site-isolation
flavor, since each consults results-db and can pass the build early when every failure is already known.
Without it the re-run would query regular WK2 history for this queue, which could mark a
site-isolation-specific regression as pre-existing and hide it.

* Tools/CISupport/ews-build/steps.py:
(RunWebKitTests.rerun_step): Added, so a queue can substitute its own re-run step.
(RunWebKitTests.evaluateCommand): Use rerun_step().
(RunWebKitTestsInSiteIsolationMode.doStepIf):
(SiteIsolationResultsDBMixin): Added, holding the site-isolation results-db flavor and reports_to_results_db
for both site-isolation steps.
(SiteIsolationResultsDBMixin.results_db_query_configuration): Moved from RunWebKitTestsEWSSiteIsolation.
(RunWebKitTestsEWSSiteIsolation): Moved below ReRunWebKitTests so it can reference the re-run step.
Removed the single-run evaluateCommand and the filter_failures_using_results_db override that duplicated
the base implementation.
(RunWebKitTestsEWSSiteIsolation.rerun_step):
(ReRunWebKitTestsEWSSiteIsolation): Added, the re-run step for this queue.
(RunWebKitTestsEWSSiteIsolation.results_db_query_configuration): Deleted.
(RunWebKitTestsEWSSiteIsolation.filter_failures_using_results_db): Deleted.
(RunWebKitTestsEWSSiteIsolation.evaluateCommand): Deleted.
* Tools/CISupport/ews-build/steps_unittest.py: Add unit tests.

Canonical link: <a href="https://commits.webkit.org/319404@main">https://commits.webkit.org/319404@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e991a6acffeb352f16f088852ccc6e113c60b6ba

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181377 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/55324 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/49126 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/191600 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/145703 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183239 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/56628 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/55045 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/191600 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/145703 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184332 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/56628 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/49126 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/191600 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/56628 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/55045 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/191600 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/49126 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/56628 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/49126 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-gcc~~](https://ews-build.webkit.org/#/builders/284/builds/2756 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/55045 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/193528 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/180778 "Passed tests") | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/54993 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/49126 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/193528 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/55680 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/49126 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/193528 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27536 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/55680 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/123562 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/54196 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/49126 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/53578 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/53816 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/53643 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->