### PR TITLE
AX: WebKit should only expose href-less SVG anchors as links if they have a click handler (matching HTML anchors)

### DIFF
--- a/LayoutTests/accessibility/svg-anchor-with-click-handler-is-link-expected.txt
+++ b/LayoutTests/accessibility/svg-anchor-with-click-handler-is-link-expected.txt
@@ -1,0 +1,20 @@
+This test ensures an href-less SVG anchor is only exposed as a link when it has a click handler, matching HTML anchors.
+
+PASS: isExposedAsLink('anchor-with-onclick') === true
+PASS: isExposedAsLink('anchor-without-handler') === false
+PASS: isExposedAsLink('href-toggle-anchor') === true
+PASS: isExposedAsLink('dynamic-anchor-with-onclick') === true
+PASS: isExposedAsLink('click-toggle-anchor') === true
+PASS: isExposedAsLink('click-toggle-anchor') === false
+PASS: isExposedAsLink('href-toggle-anchor') === false
+PASS: isExposedAsLink('href-toggle-anchor') === true
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Anchor with onclick
+Anchor without click handler or href
+Anchor that gains then loses a click handler
+Anchor that loses then regains its href
+Dynamically added SVG anchor with onclick
+

--- a/LayoutTests/accessibility/svg-anchor-with-click-handler-is-link.html
+++ b/LayoutTests/accessibility/svg-anchor-with-click-handler-is-link.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../resources/accessibility-helper.js"></script>
+<script src="../resources/js-test.js"></script>
+</head>
+<body>
+
+<svg width="400" height="200" xmlns="http://www.w3.org/2000/svg">
+  <a onclick="this.dataset.clicked = 'true'" id="anchor-with-onclick"><text x="10" y="20">Anchor with onclick</text></a>
+  <a id="anchor-without-handler"><text x="10" y="50">Anchor without click handler or href</text></a>
+  <a id="click-toggle-anchor"><text x="10" y="80">Anchor that gains then loses a click handler</text></a>
+  <a href="#destination" id="href-toggle-anchor"><text x="10" y="110">Anchor that loses then regains its href</text></a>
+</svg>
+
+<script>
+var output = "This test ensures an href-less SVG anchor is only exposed as a link when it has a click handler, matching HTML anchors.\n\n";
+
+function isExposedAsLink(id) {
+    var element = accessibilityController.accessibleElementById(id);
+    return !!element && element.role.toLowerCase().includes("link");
+}
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    output += expect("isExposedAsLink('anchor-with-onclick')", "true");
+    output += expect("isExposedAsLink('anchor-without-handler')", "false");
+    output += expect("isExposedAsLink('href-toggle-anchor')", "true");
+
+    var clickHandler = () => { };
+    var svgNS = "http://www.w3.org/2000/svg";
+
+    setTimeout(async function() {
+        var svg = document.querySelector("svg");
+        var dynamicAnchor = document.createElementNS(svgNS, "a");
+        dynamicAnchor.id = "dynamic-anchor-with-onclick";
+        var text = document.createElementNS(svgNS, "text");
+        text.setAttribute("x", "10");
+        text.setAttribute("y", "140");
+        text.textContent = "Dynamically added SVG anchor with onclick";
+        dynamicAnchor.appendChild(text);
+        dynamicAnchor.setAttribute("onclick", "this.dataset.clicked = 'true'");
+        svg.appendChild(dynamicAnchor);
+        output += await expectAsync("isExposedAsLink('dynamic-anchor-with-onclick')", "true");
+
+        document.getElementById("click-toggle-anchor").addEventListener("click", clickHandler);
+        output += await expectAsync("isExposedAsLink('click-toggle-anchor')", "true");
+
+        document.getElementById("click-toggle-anchor").removeEventListener("click", clickHandler);
+        output += await expectAsync("isExposedAsLink('click-toggle-anchor')", "false");
+
+        document.getElementById("href-toggle-anchor").removeAttribute("href");
+        output += await expectAsync("isExposedAsLink('href-toggle-anchor')", "false");
+
+        document.getElementById("href-toggle-anchor").setAttribute("href", "#destination");
+        output += await expectAsync("isExposedAsLink('href-toggle-anchor')", "true");
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -129,7 +129,9 @@
 #include "RenderTableCell.h"
 #include "RenderTableRow.h"
 #include "RenderView.h"
+#include "SVGAElement.h"
 #include "SVGElement.h"
+#include "SVGElementTypeHelpers.h"
 #include "ScriptDisallowedScope.h"
 #include "ScrollView.h"
 #include "SelectPopoverElement.h"
@@ -1641,7 +1643,8 @@ void AXObjectCache::handleClickHandlerChanged(Node& node, const AtomString& even
 
     // A hrefless anchor is exposed as a link only when it has a click handler, so adding or removing
     // one can change its role. (An anchor with an href is a link regardless of its click handlers.)
-    if (RefPtr anchor = dynamicDowncast<HTMLAnchorElement>(node); anchor && !anchor->isLink())
+    RefPtr anchor = dynamicDowncast<Element>(node);
+    if ((is<HTMLAnchorElement>(anchor.get()) || is<SVGAElement>(anchor.get())) && !anchor->isLink())
         object->updateRole();
 
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
@@ -3683,8 +3686,8 @@ void AXObjectCache::handleAttributeChange(Element* element, const QualifiedName&
         // An anchor's role depends on whether it is a link (Element::isLink(), i.e. whether it has an
         // href). Recompute the role when href changes so a hrefless anchor with a click handler can
         // become a link, and vice versa.
-        if (RefPtr anchor = dynamicDowncast<HTMLAnchorElement>(element)) {
-            if (RefPtr object = get(*anchor))
+        if (is<HTMLAnchorElement>(element) || is<SVGAElement>(element)) {
+            if (RefPtr object = get(*element))
                 object->updateRole();
         }
     }

--- a/Source/WebCore/accessibility/AccessibilitySVGObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilitySVGObject.cpp
@@ -393,8 +393,10 @@ AccessibilityRole AccessibilitySVGObject::determineAccessibilityRole()
         return AccessibilityRole::SVGTextPath;
     if (m_renderer->isRenderSVGTSpan())
         return AccessibilityRole::SVGTSpan;
-    if (is<SVGAElement>(element))
-        return AccessibilityRole::Link;
+    if (is<SVGAElement>(element)) {
+        if (element->isLink() || hasClickHandler())
+            return AccessibilityRole::Link;
+    }
 
     return AccessibilityRenderObject::determineAccessibilityRole();
 }


### PR DESCRIPTION
#### 7c4388cfb93e553c0e3be53306cc847d1b2629ed
<pre>
AX: WebKit should only expose href-less SVG anchors as links if they have a click handler (matching HTML anchors)
<a href="https://rdar.apple.com/181924326">rdar://181924326</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=319107">https://bugs.webkit.org/show_bug.cgi?id=319107</a>

Reviewed by Tyler Wilcock.

Introduces or guard clause within SVGAElement. This if statement only assigns an AccessibilityRole::Link if the element has an href link or has a click handler. Bare anchor svgs will no longer emit an AcessibilityRole::Link. Also, changes were made to update SVG objects on the AXIsolated Tree as well.

Test: accessibility/svg-anchor-with-click-handler-is-link.html

* LayoutTests/accessibility/svg-anchor-with-click-handler-is-link-expected.txt: Added.
* LayoutTests/accessibility/svg-anchor-with-click-handler-is-link.html: Added.
* Source/WebCore/accessibility/AccessibilitySVGObject.cpp:
(WebCore::AccessibilitySVGObject::determineAccessibilityRole):
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::handleClickHandlerChanged):
(WebCore::AXObjectCache::handleAttributeChange):

Canonical link: <a href="https://commits.webkit.org/318186@main">https://commits.webkit.org/318186@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e6bd00f96fd4ba67fc6254b5403aab19b690f237

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177145 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51082 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44877 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186748 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140381 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179008 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52375 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50768 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138026 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140381 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180101 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41530 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158787 "Found 1 new API test failure: TestWebKitAPI.UnifiedPDF.PDFHUDMultiplePluginsDoNotInterceptHitTesting (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118493 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40186 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38561 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150596 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38286 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-highlight-api/painting/custom-highlight-dynamic-font-metrics-001.html (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35216 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42860 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42795 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189174 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50749 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/158326 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147111 "Passed tests") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39614 "Build is in progress. Recent messages:OS: Tahoe (26.5.1), Xcode: 26.5; Checked out pull request; Reviewed by Tyler Wilcock; Compiled WebKit (warnings); Ignored 5 pre-existing failure based on results-db; Uploaded test results; Canonicalized commit; Pushed commit to WebKit repository") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51432 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34910 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146905 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41635 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123646 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/117940 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49937 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13266 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49336 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49573 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49397 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->