### PR TITLE
[WKCI][ews-build.webkit.org] Results database queries fail for the GTK and WPE ports because of using lowercase platform name.

### DIFF
--- a/Tools/CISupport/ews-build/results_db.py
+++ b/Tools/CISupport/ews-build/results_db.py
@@ -54,6 +54,12 @@ class ResultsDatabase(object):
     ]
 
     @classmethod
+    def platform_for_query(cls, platform):
+        if platform.lower() in ('gtk', 'wpe'):
+            return platform.upper()
+        return platform
+
+    @classmethod
     @defer.inlineCallbacks
     def make_request(cls, endpoint, suite=None, test=None, commit=None, configuration=None, logger=None):
         logger = logger or (lambda log: None)

--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -3962,7 +3962,7 @@ class RunJavaScriptCoreTests(shell.Test, AddToLogMixin, ShellMixin):
         platform = self.getProperty('platform', None)
         configuration = {}
         if platform:
-            configuration['platform'] = platform
+            configuration['platform'] = ResultsDatabase.platform_for_query(platform)
         style = self.getProperty('configuration', None)
         if style and style in ['debug', 'release']:
             configuration['style'] = style
@@ -4359,7 +4359,7 @@ class RunWebKitTests(shell.Test, AddToLogMixin, ShellMixin):
         platform = self.getProperty('platform', None)
         configuration = {}
         if platform:
-            configuration['platform'] = platform
+            configuration['platform'] = ResultsDatabase.platform_for_query(platform)
         style = self.getProperty('configuration', None)
         if style and style in ['debug', 'release']:
             configuration['style'] = style
@@ -6163,7 +6163,7 @@ class RunAPITests(shell.Test, AddToLogMixin, ShellMixin):
         platform = self.getProperty('platform', None)
         configuration = {}
         if platform:
-            configuration['platform'] = platform
+            configuration['platform'] = ResultsDatabase.platform_for_query(platform)
         style = self.getProperty('configuration', None)
         if style and style in ['debug', 'release']:
             configuration['style'] = style
@@ -8438,7 +8438,7 @@ class FindUnexpectedStaticAnalyzerResults(shell.ShellCommand, AnalyzeChange, Add
         platform = self.getProperty('platform', None)
         configuration = {}
         if platform:
-            configuration['platform'] = platform
+            configuration['platform'] = ResultsDatabase.platform_for_query(platform)
         style = self.getProperty('configuration', None)
         if style and style in ['debug', 'release']:
             configuration['style'] = style

--- a/Tools/CISupport/ews-build/steps_unittest.py
+++ b/Tools/CISupport/ews-build/steps_unittest.py
@@ -3169,6 +3169,27 @@ class TestFilterLayoutTestFailuresUsingResultsDB(BuildStepMixinAdditions, unitte
         )
 
     @defer.inlineCallbacks
+    def test_wpe_platform_is_translated_to_uppercase_for_results_db(self):
+        configurations = []
+
+        def fake_is_pre_existing(cls, test, configuration=None, **kwargs):
+            configurations.append(configuration)
+            return defer.succeed({
+                'is_existing_failure': False, 'pass_rate': 100, 'raw_data': {}, 'logs': '', 'request_failed': False,
+            })
+
+        self.setup_step(RunWebKitTests())
+        step = self.get_nth_step(0)
+        step._addToLog = lambda logName, message: defer.succeed(None)
+        self.setProperty('platform', 'wpe')
+        self.setProperty('configuration', 'release')
+        self.patch(ResultsDatabase, 'is_test_pre_existing_failure', classmethod(fake_is_pre_existing))
+        self.patch(ResultsDatabase, 'has_commit', classmethod(lambda cls, commit=None: defer.succeed(False)))
+
+        yield step.filter_failures_using_results_db(['real.html'])
+        self.assertEqual(configurations, [dict(platform='WPE', style='release')])
+
+    @defer.inlineCallbacks
     def test_caps_number_of_results_db_queries(self):
         # Only the first MAX_FAILURES_TO_CHECK_RESULTS_DB failures are checked against results-db.
         queried = []
@@ -6322,6 +6343,27 @@ class TestFilterAPITestFailuresUsingResultsDB(BuildStepMixinAdditions, unittest.
             ['suite.AlsoFlaky', 'suite.MultipleAccounts', 'suite.real_failure'],
             {'suite.MultipleAccounts', 'suite.AlsoFlaky'},
         )
+
+    @defer.inlineCallbacks
+    def test_gtk_platform_is_translated_to_uppercase_for_results_db(self):
+        configurations = []
+
+        def fake_is_pre_existing(cls, test, configuration=None, **kwargs):
+            configurations.append(configuration)
+            return defer.succeed({
+                'is_existing_failure': False, 'pass_rate': 100, 'raw_data': {}, 'logs': '', 'request_failed': False,
+            })
+
+        self.setup_step(RunAPITests())
+        step = self.get_nth_step(0)
+        step._addToLog = lambda logName, message: defer.succeed(None)
+        self.setProperty('platform', 'gtk')
+        self.setProperty('configuration', 'release')
+        self.patch(ResultsDatabase, 'is_test_pre_existing_failure', classmethod(fake_is_pre_existing))
+        self.patch(ResultsDatabase, 'has_commit', classmethod(lambda cls, commit=None: defer.succeed(False)))
+
+        yield step.filter_api_test_failures_using_results_db(['suite.real_failure'])
+        self.assertEqual(configurations, [dict(platform='GTK', style='release')])
 
     @defer.inlineCallbacks
     def test_caps_number_of_results_db_queries(self):
@@ -11800,6 +11842,13 @@ class TestResultsDatabaseFailureHandling(unittest.TestCase):
 
     def _ok_response(self, payload):
         return TwistedAdditions.Response(status_code=200, content=json.dumps(payload).encode('utf-8'))
+
+    def test_platform_for_query(self):
+        for platform in ('mac', 'ios', 'win', 'playstation', 'watchos', 'tvos', 'visionos'):
+            self.assertEqual(ResultsDatabase.platform_for_query(platform), platform)
+        for platform in ('gtk', 'wpe'):
+            self.assertEqual(ResultsDatabase.platform_for_query(platform), platform.upper())
+            self.assertEqual(ResultsDatabase.platform_for_query(platform), platform.upper())
 
     @defer.inlineCallbacks
     def test_make_request_returns_none_on_no_response(self):


### PR DESCRIPTION
#### 67c65bcbe9f7bb5139b087c237b2864c2d08abb9
<pre>
[WKCI][ews-build.webkit.org] Results database queries fail for the GTK and WPE ports because of using lowercase platform name.
<a href="https://bugs.webkit.org/show_bug.cgi?id=320402">https://bugs.webkit.org/show_bug.cgi?id=320402</a>

Reviewed by Nikolas Zimmermann.

The EWS was failing to query the results database for the GTK and WPE ports due to a
mismatch on the port name. The post-commit bots uploading the results where using all
upper-case for the platform name but the EWS bots were trying to query those results
using lowercase (because lowercase is the default on EWS config.json file) and that
code runs on the EWS server, but on the post-commit bots the port name is decided
by the webkit tooling that runs on the worker rather than by the buildbot server.

More specifically on the worker (post-commit) when uploading the info the uppercase
name is set by computeFullConfiguration() in run-javascriptcore-tests, and in
webkitpy at port.configuration_for_upload() for api and layout tests.

So this was causing that all the queries from the EWS to the results DB were
failing with error (HTTP 400) for GTK and WPE.

Fix this by adding a function platform_for_query() that ensures to return the
upper case name for GTK and WPE when doing the queries to results.webkit.org

* Tools/CISupport/ews-build/results_db.py:
(ResultsDatabase):
(ResultsDatabase.platform_for_query):
* Tools/CISupport/ews-build/steps.py:
(RunJavaScriptCoreTests.filter_failures_using_results_db):
(RunWebKitTests.filter_failures_using_results_db):
(RunAPITests.filter_api_test_failures_using_results_db):
(FindUnexpectedStaticAnalyzerResults.filter_results_using_results_db):
* Tools/CISupport/ews-build/steps_unittest.py:
(TestFilterLayoutTestFailuresUsingResultsDB):
(TestFilterLayoutTestFailuresUsingResultsDB.test_wpe_platform_is_translated_to_uppercase_for_results_db):
(TestFilterLayoutTestFailuresUsingResultsDB.test_wpe_platform_is_translated_to_uppercase_for_results_db.fake_is_pre_existing):

Canonical link: <a href="https://commits.webkit.org/318013@main">https://commits.webkit.org/318013@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5c480d5ec66274c1f2da3b977f92bf6df37d854d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177076 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51013 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/44808 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186679 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140312 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178939 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52306 "Build is in progress. Recent messages:") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50699 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/137973 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140312 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180032 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/52306 "Build is in progress. Recent messages:") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/44808 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/118441 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/52306 "Build is in progress. Recent messages:") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/38503 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/44808 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/52306 "Build is in progress. Recent messages:") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/44808 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35147 "Built successfully") | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/42721 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189105 "Built successfully") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/176479 "Passed tests") | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/50680 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/44808 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/147050 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51363 "Build is in progress. Recent messages:") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/44808 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146841 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26853 "Built successfully and passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/160/builds/51363 "Build is in progress. Recent messages:") | | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/117864 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49868 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/44808 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/49267 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/49504 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/49328 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->