### PR TITLE
[Site Isolation] [macOS] PDF HUD in cross origin <iframe src=pdf> is unexpectedly offset

### DIFF
--- a/Source/WebKit/UIProcess/mac/WebViewImpl.h
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.h
@@ -44,6 +44,8 @@
 #include <WebCore/DigitalCredentialsRequestData.h>
 #include <WebCore/FocusDirection.h>
 #include <WebCore/HTMLMediaElementIdentifier.h>
+#include <WebCore/IntRect.h>
+#include <WebCore/IntRectHash.h>
 #include <WebCore/KeypressCommand.h>
 #include <WebCore/PlatformPlaybackSessionInterface.h>
 #include <WebCore/ScrollTypes.h>
@@ -292,6 +294,7 @@ public:
 
     void createPDFHUD(PDFPluginIdentifier, WebCore::FrameIdentifier, const WebCore::IntRect&);
     void updatePDFHUDLocation(PDFPluginIdentifier, const WebCore::IntRect&);
+    void convertPDFHUDBoundingBoxToWebViewCoordinates(WebCore::FrameIdentifier, WebCore::IntRect boundingBoxInFrameRootView, CompletionHandler<void(WebCore::IntRect)>&&);
     void removePDFHUD(PDFPluginIdentifier);
     void removeAllPDFHUDs();
     void showPDFHUD(PDFPluginIdentifier);
@@ -1060,6 +1063,8 @@ private:
 #endif
 
     HashMap<WebKit::PDFPluginIdentifier, RetainPtr<WKPDFHUDView>> _pdfHUDViews;
+    // PDF HUDs awaiting their initial async coordinate conversion, mapped to the latest location update.
+    HashMap<WebKit::PDFPluginIdentifier, WebCore::IntRect> m_pdfHUDsPendingCreation;
 
     RetainPtr<WKShareSheet> _shareSheet;
 

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -118,6 +118,7 @@
 #import <WebCore/DragItem.h>
 #import <WebCore/Editor.h>
 #import <WebCore/FixedContainerEdges.h>
+#import <WebCore/FloatRect.h>
 #import <WebCore/FontAttributeChanges.h>
 #import <WebCore/FontAttributes.h>
 #import <WebCore/FrameIdentifier.h>
@@ -1786,28 +1787,77 @@ void WebViewImpl::viewDidEndLiveResize()
     [m_layoutStrategy didEndLiveResize];
 }
 
-void WebViewImpl::createPDFHUD(PDFPluginIdentifier identifier, WebCore::FrameIdentifier frameID, const WebCore::IntRect& rect)
+void WebViewImpl::createPDFHUD(PDFPluginIdentifier identifier, WebCore::FrameIdentifier frameID, const WebCore::IntRect& boundingBoxInFrameRootView)
 {
     removePDFHUD(identifier);
-    RetainPtr hud = adoptNS([[WKPDFHUDView alloc] initWithFrame:rect pluginIdentifier:identifier.toUInt64() frameIdentifier:frameID.toUInt64() webView:m_page->cocoaView().get()]);
-    [m_view.get() addSubview:hud.get()];
-    _pdfHUDViews.add(identifier, WTF::move(hud));
+
+    // The bounding box is in the plugin frame's local root view coordinates.
+    // For cross-origin <iframe> PDFs, this lacks the subframe's offset in the
+    // page, so we need to convert that to top level web view coordinates.
+    m_pdfHUDsPendingCreation.set(identifier, boundingBoxInFrameRootView);
+    convertPDFHUDBoundingBoxToWebViewCoordinates(frameID, boundingBoxInFrameRootView, [weakThis = WeakPtr { *this }, identifier, frameID, requestedBox = boundingBoxInFrameRootView](const WebCore::IntRect& boundingBoxInWebView) {
+        CheckedPtr checkedThis = weakThis.get();
+        if (!checkedThis)
+            return;
+
+        auto latestBoxInFrameRootView = checkedThis->m_pdfHUDsPendingCreation.takeOptional(identifier);
+        // In case the PDF HUD was removed while the conversion was in flight.
+        if (!latestBoxInFrameRootView)
+            return;
+
+        RetainPtr hud = adoptNS([[WKPDFHUDView alloc] initWithFrame:boundingBoxInWebView pluginIdentifier:identifier.toUInt64() frameIdentifier:frameID.toUInt64() webView:checkedThis->m_page->cocoaView()]);
+        [checkedThis->m_view.get() addSubview:hud];
+        checkedThis->_pdfHUDViews.add(identifier, WTF::move(hud));
+
+        // If a HUD update arrived while the conversion was in flight, apply it now that the HUD exists.
+        if (latestBoxInFrameRootView != requestedBox)
+            checkedThis->updatePDFHUDLocation(identifier, *latestBoxInFrameRootView);
+    });
 }
 
-void WebViewImpl::updatePDFHUDLocation(PDFPluginIdentifier identifier, const WebCore::IntRect& rect)
+void WebViewImpl::updatePDFHUDLocation(PDFPluginIdentifier identifier, const WebCore::IntRect& boundingBoxInFrameRootView)
 {
-    if (RetainPtr hud = _pdfHUDViews.get(identifier))
-        [hud setFrame:rect];
+    RetainPtr hud = _pdfHUDViews.get(identifier);
+    if (!hud) {
+        if (auto it = m_pdfHUDsPendingCreation.find(identifier); it != m_pdfHUDsPendingCreation.end())
+            it->value = boundingBoxInFrameRootView;
+        return;
+    }
+
+    convertPDFHUDBoundingBoxToWebViewCoordinates(WebCore::FrameIdentifier { [hud frameIdentifier] }, boundingBoxInFrameRootView, [weakThis = WeakPtr { *this }, identifier](const WebCore::IntRect& boundingBoxInWebView) {
+        CheckedPtr checkedThis = weakThis.get();
+        if (!checkedThis)
+            return;
+        if (RetainPtr hud = checkedThis->_pdfHUDViews.get(identifier))
+            [hud setFrame:boundingBoxInWebView];
+    });
+}
+
+void WebViewImpl::convertPDFHUDBoundingBoxToWebViewCoordinates(WebCore::FrameIdentifier pluginFrameID, WebCore::IntRect boundingBoxInFrameRootView, CompletionHandler<void(WebCore::IntRect)>&& completionHandler)
+{
+    RefPtr frame = WebFrameProxy::webFrame(pluginFrameID);
+    if (!frame)
+        return completionHandler(boundingBoxInFrameRootView);
+
+    m_page->convertRectToMainFrameCoordinates(boundingBoxInFrameRootView, frame->rootFrame()->frameID(), [completionHandler = WTF::move(completionHandler), fallback = boundingBoxInFrameRootView](std::optional<WebCore::FloatRect> boundingBoxInWebView) mutable {
+        completionHandler(boundingBoxInWebView
+            .transform([](const auto& floatRect) {
+                return WebCore::enclosingIntRect(floatRect);
+            })
+            .value_or(fallback));
+    });
 }
 
 void WebViewImpl::removePDFHUD(PDFPluginIdentifier identifier)
 {
+    m_pdfHUDsPendingCreation.remove(identifier);
     if (RetainPtr hud = _pdfHUDViews.take(identifier))
         [hud removeFromSuperview];
 }
 
 void WebViewImpl::removeAllPDFHUDs()
 {
+    m_pdfHUDsPendingCreation.clear();
     for (auto& hud : _pdfHUDViews.values())
         [hud removeFromSuperview];
     _pdfHUDViews.clear();

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/UnifiedPDFTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/UnifiedPDFTests.mm
@@ -758,6 +758,91 @@ UNIFIED_PDF_TEST(PDFHUDMultipleIFrames)
     EXPECT_TRUE(hadRightFrame);
 }
 
+enum class PDFEmbedElement : uint8_t { IFrame, Embed, Object };
+
+class EmbeddedPDFHUDSiteIsolation : public testing::TestWithParam<std::tuple<PDFEmbedElement, bool, bool>> {
+public:
+    PDFEmbedElement embedElement() const { return std::get<0>(GetParam()); }
+    bool crossOrigin() const { return std::get<1>(GetParam()); }
+    bool siteIsolationEnabled() const { return std::get<2>(GetParam()); }
+
+    String mainHTML() const
+    {
+        auto pdfURL = makeString("https://"_s, crossOrigin() ? "webkit.org"_s : "example.com"_s, "/test.pdf"_s);
+        auto layout = "width='300' height='150' style='position:absolute; left:10px; top:28px; border:0'"_s;
+        switch (embedElement()) {
+        case PDFEmbedElement::IFrame:
+            return makeString("<iframe "_s, layout, " src='"_s, pdfURL, "'></iframe>"_s);
+        case PDFEmbedElement::Embed:
+            return makeString("<embed "_s, layout, " src='"_s, pdfURL, "'>"_s);
+        case PDFEmbedElement::Object:
+            return makeString("<object "_s, layout, " type='application/pdf' data='"_s, pdfURL, "'></object>"_s);
+        }
+        ASSERT_NOT_REACHED();
+        return { };
+    }
+
+    static std::string testNameGenerator(testing::TestParamInfo<std::tuple<PDFEmbedElement, bool, bool>> info)
+    {
+        std::string element = [embedElement = std::get<0>(info.param)] {
+            switch (embedElement) {
+            case PDFEmbedElement::IFrame:
+                return "IFrame";
+            case PDFEmbedElement::Embed:
+                return "Embed";
+            case PDFEmbedElement::Object:
+                return "Object";
+            }
+            ASSERT_NOT_REACHED();
+            return "";
+        }();
+        return element
+            + (std::get<1>(info.param) ? "_CrossOrigin" : "_SameOrigin")
+            + (std::get<2>(info.param) ? "_SiteIsolationEnabled" : "_SiteIsolationDisabled");
+    }
+};
+
+TEST_P(EmbeddedPDFHUDSiteIsolation, HUDMatchesOffset)
+{
+    HTTPServer server { {
+        { "/main"_s, HTTPResponse { { { "Content-Type"_s, "text/html"_s } }, mainHTML() } },
+        { "/test.pdf"_s, HTTPResponse { { { "Content-Type"_s, "application/pdf"_s } }, testPDFData() } },
+    }, HTTPServer::Protocol::HttpsProxy };
+
+    RetainPtr configuration = server.httpsProxyConfiguration();
+    for (_WKFeature *feature in [WKPreferences _features]) {
+        NSString *key = feature.key;
+        if ([key isEqualToString:@"UnifiedPDFEnabled"] || [key isEqualToString:@"PDFPluginHUDEnabled"])
+            [[configuration preferences] _setEnabled:YES forFeature:feature];
+        else if ([key isEqualToString:@"SiteIsolationEnabled"])
+            [[configuration preferences] _setEnabled:siteIsolationEnabled() forFeature:feature];
+    }
+
+    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    [navigationDelegate allowAnyTLSCertificate];
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration addToWindow:YES]);
+    [webView _setWindowOcclusionDetectionEnabled:NO];
+    [[webView window] makeKeyAndOrderFront:nil];
+    [[webView window] orderFrontRegardless];
+    [webView setNavigationDelegate:navigationDelegate];
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/main"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    TestWebKitAPI::Util::waitFor([webView] {
+        return [webView _pdfHUDs].count;
+    });
+
+    RetainPtr<NSView> hud = [webView _pdfHUDs].anyObject;
+
+    TestWebKitAPI::Util::waitFor([hud] {
+        return !NSEqualPoints([hud frame].origin, NSZeroPoint);
+    });
+
+    checkFrame([hud frame], 10, 28, 300, 150);
+}
+
+INSTANTIATE_TEST_SUITE_P(UnifiedPDF, EmbeddedPDFHUDSiteIsolation, testing::Combine(testing::Values(PDFEmbedElement::IFrame, PDFEmbedElement::Embed, PDFEmbedElement::Object), testing::Bool(), testing::Bool()), &EmbeddedPDFHUDSiteIsolation::testNameGenerator);
+
 UNIFIED_PDF_TEST(PDFHUDLoadPDFTypeWithPluginsBlocked)
 {
     RetainPtr configuration = configurationForWebViewTestingUnifiedPDF(true);


### PR DESCRIPTION
#### bbc90c010446b48541978c95b55d83151583dfb8
<pre>
[Site Isolation] [macOS] PDF HUD in cross origin &lt;iframe src=pdf&gt; is unexpectedly offset
<a href="https://bugs.webkit.org/show_bug.cgi?id=320358">https://bugs.webkit.org/show_bug.cgi?id=320358</a>
<a href="https://rdar.apple.com/162548811">rdar://162548811</a>

Reviewed by Richard Robinson and Aditya Keerthi.

A PDF plugin reports its HUD bounding box in its frame tree&apos;s root view
coordinate space. When an embedded PDF is in a site isolated subframe,
that root is the subframe rather than the top-level web view the HUD is
a subview of, so the box lacks the subframe&apos;s offset within the page and
the HUD is drawn at the wrong location.

In this patch, we convert the bounding box from the plugin frame&apos;s local
root to the top-level main frame coordinates in the UI process. Since
this is an async conversion, we defer PDF HUD creation until the frame
has been converted. As such, we introduce a map to keep track of pending
HUD location updates that we apply after HUD creation.

Test: TestWebKitAPI.UnifiedPDF.EmbeddedPDFHUDSiteIsolation

* Source/WebKit/UIProcess/mac/WebViewImpl.h:
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::createPDFHUD):
(WebKit::WebViewImpl::updatePDFHUDLocation):
(WebKit::WebViewImpl::convertPDFHUDBoundingBoxToWebViewCoordinates):
(WebKit::WebViewImpl::removePDFHUD):
(WebKit::WebViewImpl::removeAllPDFHUDs):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/UnifiedPDFTests.mm:
(TestWebKitAPI::EmbeddedPDFHUDSiteIsolation::embedElement const):
(TestWebKitAPI::EmbeddedPDFHUDSiteIsolation::crossOrigin const):
(TestWebKitAPI::EmbeddedPDFHUDSiteIsolation::siteIsolationEnabled const):
(TestWebKitAPI::EmbeddedPDFHUDSiteIsolation::mainHTML const):
(TestWebKitAPI::EmbeddedPDFHUDSiteIsolation::testNameGenerator):
(TestWebKitAPI::TEST_P):
  Covers the matrix of { &lt;iframe&gt;, &lt;embed&gt;, &lt;object&gt; } x { same-origin,
  cross-origin } x { SI disabled, enabled } and asserting that the HUD
  frame lands at the emebedded element&apos;s offset in every case.

Canonical link: <a href="https://commits.webkit.org/318068@main">https://commits.webkit.org/318068@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ee5a9dca9615ab7aa90b4e7978e3a75f1a327631

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177141 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51078 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44873 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186744 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140377 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a07a7757-e7be-4d28-bde0-3fc63a6721ad) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179004 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52371 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50764 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138021 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140377 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b72a4ce2-535b-415c-9a28-27a06d256e39) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180097 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41526 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158783 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118488 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b81a8b91-47dd-4780-987a-4e7645308335) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40182 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38556 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150592 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38282 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35212 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42856 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42791 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189170 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50745 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147107 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51428 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34906 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146901 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26874 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41633 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123642 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117934 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49933 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13262 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49332 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49569 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49393 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->