### PR TITLE
[CSS Scroll Snap] Re-snap should prefer the block-axis box when the two axes conflict

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/snap-after-relayout/snap-to-different-targets-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/snap-after-relayout/snap-to-different-targets-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Scroller should snap to at least one of the targets if unable to snap to both after a layout change. assert_true: expected true got false
+PASS Scroller should snap to at least one of the targets if unable to snap to both after a layout change.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/snap-to-combination-of-two-elements-2-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/snap-to-combination-of-two-elements-2-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Snap to points of combinations of two different elements assert_equals: expected 250 but got 200
+FAIL Snap to points of combinations of two different elements assert_equals: expected 50 but got 200
 

--- a/Source/WebCore/page/scrolling/ScrollSnapOffsetsInfo.cpp
+++ b/Source/WebCore/page/scrolling/ScrollSnapOffsetsInfo.cpp
@@ -542,7 +542,8 @@ void updateSnapOffsetsForScrollableArea(ScrollableArea& scrollableArea, const Re
         horizontalSnapOffsets,
         verticalSnapOffsets,
         snapAreas,
-        snapAreasIDs
+        snapAreasIDs,
+        scrollerHasVerticalWritingMode
     });
 }
 
@@ -581,7 +582,8 @@ static ScrollSnapOffsetsInfo<OutputType, OutputRectType> convertOffsetInfo(const
         convertOffsets(input.horizontalSnapOffsets),
         convertOffsets(input.verticalSnapOffsets),
         convertRects(input.snapAreas),
-        input.snapAreasIDs
+        input.snapAreasIDs,
+        input.scrollerHasVerticalWritingMode
     };
 }
 

--- a/Source/WebCore/page/scrolling/ScrollSnapOffsetsInfo.h
+++ b/Source/WebCore/page/scrolling/ScrollSnapOffsetsInfo.h
@@ -65,10 +65,13 @@ struct ScrollSnapOffsetsInfo {
     Vector<SnapOffset<UnitType>> verticalSnapOffsets;
     Vector<RectType> snapAreas;
     Vector<NodeIdentifier> snapAreasIDs;
+    bool scrollerHasVerticalWritingMode { false };
+
+    ScrollEventAxis blockAxis() const { return scrollerHasVerticalWritingMode ? ScrollEventAxis::Horizontal : ScrollEventAxis::Vertical; }
 
     bool isEqual(const ScrollSnapOffsetsInfo<UnitType, RectType>& other) const
     {
-        return strictness == other.strictness && horizontalSnapOffsets == other.horizontalSnapOffsets && verticalSnapOffsets == other.verticalSnapOffsets && snapAreas == other.snapAreas;
+        return strictness == other.strictness && horizontalSnapOffsets == other.horizontalSnapOffsets && verticalSnapOffsets == other.verticalSnapOffsets && snapAreas == other.snapAreas && scrollerHasVerticalWritingMode == other.scrollerHasVerticalWritingMode;
     }
 
     bool isEmpty() const

--- a/Source/WebCore/platform/ScrollSnapAnimatorState.cpp
+++ b/Source/WebCore/platform/ScrollSnapAnimatorState.cpp
@@ -105,28 +105,31 @@ float ScrollSnapAnimatorState::adjustedScrollDestination(ScrollEventAxis axis, F
     return offset * pageScale;
 }
 
+// The snap offset nodeID contributes to in this axis, plus nodeID's own area at that offset: a box can
+// be any of the areas sharing an offset, not just its representative snapTargetID, so we find both here.
+auto ScrollSnapAnimatorState::snapOffsetAndAreaIndicesForNode(ScrollEventAxis axis, NodeIdentifier nodeID) const -> std::optional<SnapOffsetAndAreaIndices>
+{
+    const auto& snapOffsets = snapOffsetsForAxis(axis);
+    const auto& areaIDs = m_snapOffsetsInfo.snapAreasIDs;
+
+    for (unsigned offsetIndex = 0; offsetIndex < snapOffsets.size(); ++offsetIndex) {
+        const auto& offset = snapOffsets[offsetIndex];
+        for (auto areaIndex : offset.snapAreaIndices) {
+            if (areaIndex < areaIDs.size() && areaIDs[areaIndex] == nodeID)
+                return SnapOffsetAndAreaIndices { offsetIndex, areaIndex };
+        }
+        if (offset.snapTargetID == nodeID)
+            return SnapOffsetAndAreaIndices { offsetIndex, std::nullopt };
+    }
+    return std::nullopt;
+}
+
 // Returns the index of the snap offset that nodeID contributes to, if any.
 std::optional<unsigned> ScrollSnapAnimatorState::snapOffsetIndexForNode(ScrollEventAxis axis, NodeIdentifier nodeID) const
 {
-    const auto& snapOffsets = snapOffsetsForAxis(axis);
-
-    // A single snap offset can be shared by several snap areas, but only one of them is recorded
-    // as the offset's representative snapTargetID. Our box may be one of the other areas at that
-    // offset, so check every area contributing to the offset, not just snapTargetID.
-    auto offsetContainsBox = [&](const SnapOffset<LayoutUnit>& offset) {
-        if (offset.snapTargetID == nodeID)
-            return true;
-        for (auto areaIndex : offset.snapAreaIndices) {
-            if (areaIndex < m_snapOffsetsInfo.snapAreasIDs.size() && m_snapOffsetsInfo.snapAreasIDs[areaIndex] == nodeID)
-                return true;
-        }
-        return false;
-    };
-
-    auto found = snapOffsets.findIf(offsetContainsBox);
-    if (found == notFound)
-        return std::nullopt;
-    return found;
+    if (auto indices = snapOffsetAndAreaIndicesForNode(axis, nodeID))
+        return indices->offsetIndex;
+    return std::nullopt;
 }
 
 // Returns whether the snap point is changed or not
@@ -142,24 +145,26 @@ bool ScrollSnapAnimatorState::preserveCurrentTargetForAxis(ScrollEventAxis axis,
     return true;
 }
 
+// The first box among this axis's snap offsets carrying flag as the offset's representative target and
+// accepted by isEligible; callers ask for isFocused before isTarget to get the spec's preference order.
+Markable<NodeIdentifier> ScrollSnapAnimatorState::flaggedNodeForAxis(ScrollEventAxis axis, bool SnapOffset<LayoutUnit>::*flag, NOESCAPE const SnapOffsetPredicate& isEligible) const
+{
+    for (const auto& offset : snapOffsetsForAxis(axis)) {
+        if (offset.*flag && offset.snapTargetID && (!isEligible || isEligible(offset)))
+            return offset.snapTargetID;
+    }
+    return { };
+}
+
 // The focused (then fragment-targeted) box among all of this axis's snap offsets, evaluated fresh so
 // a focus/:target change can be detected. Unlike focusedOrTargetedBox() this is not restricted to the
 // currently-snapped boxes and does not apply the cross-axis visibility filter: it is only a change
 // signal, not a selection.
 Markable<NodeIdentifier> ScrollSnapAnimatorState::focusedOrTargetedNodeForAxis(ScrollEventAxis axis) const
 {
-    const auto& offsets = snapOffsetsForAxis(axis);
-    auto findFlagged = [&](bool SnapOffset<LayoutUnit>::*flag) -> Markable<NodeIdentifier> {
-        for (const auto& offset : offsets) {
-            if (offset.*flag && offset.snapTargetID)
-                return offset.snapTargetID;
-        }
-        return { };
-    };
-
-    if (auto box = findFlagged(&SnapOffset<LayoutUnit>::isFocused))
+    if (auto box = flaggedNodeForAxis(axis, &SnapOffset<LayoutUnit>::isFocused))
         return box;
-    return findFlagged(&SnapOffset<LayoutUnit>::isTarget);
+    return flaggedNodeForAxis(axis, &SnapOffset<LayoutUnit>::isTarget);
 }
 
 Vector<SnapOffset<LayoutUnit>> ScrollSnapAnimatorState::currentlySnappedOffsetsForAxis(ScrollEventAxis axis) const
@@ -316,10 +321,11 @@ bool ScrollSnapAnimatorState::isSnapAreaVisibleInCrossAxis(size_t areaIndex, Scr
 // it isn't a valid snap position, so it must not win the preference.
 std::optional<NodeIdentifier> ScrollSnapAnimatorState::focusedOrTargetedBox(ScrollEventAxis axis, const HashSet<NodeIdentifier>& snappedBoxes) const
 {
-    const auto& offsets = snapOffsetsForAxis(axis);
     const auto& areaIDs = m_snapOffsetsInfo.snapAreasIDs;
 
-    auto representativeAreaIsVisible = [&](const SnapOffset<LayoutUnit>& offset) {
+    SnapOffsetPredicate isEligible = [&](const SnapOffset<LayoutUnit>& offset) {
+        if (!snappedBoxes.contains(*offset.snapTargetID))
+            return false;
         for (auto areaIndex : offset.snapAreaIndices) {
             if (areaIndex < areaIDs.size() && areaIDs[areaIndex] == *offset.snapTargetID)
                 return isSnapAreaVisibleInCrossAxis(areaIndex, axis);
@@ -327,20 +333,62 @@ std::optional<NodeIdentifier> ScrollSnapAnimatorState::focusedOrTargetedBox(Scro
         return true;
     };
 
-    auto findFlagged = [&](bool SnapOffset<LayoutUnit>::*flag) -> std::optional<NodeIdentifier> {
-        auto found = std::ranges::find_if(offsets, [&](const SnapOffset<LayoutUnit>& offset) {
-            return offset.snapTargetID && snappedBoxes.contains(*offset.snapTargetID) && offset.*flag && representativeAreaIsVisible(offset);
-        });
-        if (found != offsets.end())
-            return *found->snapTargetID;
-        return std::nullopt;
-    };
-
-    if (auto box = findFlagged(&SnapOffset<LayoutUnit>::isFocused))
-        return box;
-    if (auto box = findFlagged(&SnapOffset<LayoutUnit>::isTarget))
-        return box;
+    if (auto box = flaggedNodeForAxis(axis, &SnapOffset<LayoutUnit>::isFocused, isEligible))
+        return *box;
+    if (auto box = flaggedNodeForAxis(axis, &SnapOffset<LayoutUnit>::isTarget, isEligible))
+        return *box;
     return std::nullopt;
+}
+
+// The snap area rect (scroll-offset space) and this axis's snap offset for the area contributed by
+// nodeID, if it establishes an offset in this axis. The rect lets us test whether both axes' boxes coexist.
+std::optional<std::pair<LayoutRect, LayoutUnit>> ScrollSnapAnimatorState::snapAreaAndOffsetForNode(ScrollEventAxis axis, NodeIdentifier nodeID) const
+{
+    auto indices = snapOffsetAndAreaIndicesForNode(axis, nodeID);
+    if (!indices || !indices->areaIndex || *indices->areaIndex >= m_snapOffsetsInfo.snapAreas.size())
+        return std::nullopt;
+
+    return std::make_pair(m_snapOffsetsInfo.snapAreas[*indices->areaIndex], snapOffsetsForAxis(axis)[indices->offsetIndex].offset);
+}
+
+// Per https://drafts.csswg.org/css-scroll-snap/#re-snap, when the two axes pick different boxes that
+// can't both be snapped (snapping one pushes the other offscreen), collapse to one: focused, then
+// targeted, then the block-axis box. Returns nullopt when both boxes can be snapped simultaneously.
+std::optional<NodeIdentifier> ScrollSnapAnimatorState::resolvePreferredBoxForAxisConflict(NodeIdentifier horizontalBox, NodeIdentifier verticalBox) const
+{
+    if (horizontalBox == verticalBox)
+        return std::nullopt;
+
+    auto horizontal = snapAreaAndOffsetForNode(ScrollEventAxis::Horizontal, horizontalBox);
+    auto vertical = snapAreaAndOffsetForNode(ScrollEventAxis::Vertical, verticalBox);
+    if (!horizontal || !vertical)
+        return std::nullopt;
+
+    if (m_lastViewportSize.isEmpty())
+        return std::nullopt;
+
+    // Both boxes can be snapped only if both areas still intersect the snapport at the combined
+    // position (the x that aligns the H box, the y that aligns the V box); else it's a conflict.
+    LayoutPoint combinedOffset(horizontal->second, vertical->second);
+    auto areaIntersectsSnapport = [&](const LayoutRect& area) {
+        LayoutRect snapport(combinedOffset, m_lastViewportSize);
+        return area.intersects(snapport);
+    };
+    if (areaIntersectsSnapport(horizontal->first) && areaIntersectsSnapport(vertical->first))
+        return std::nullopt;
+
+    // Conflict: prefer focused, then targeted, then the block-axis box.
+    SnapOffsetPredicate isConflictingBox = [&](const SnapOffset<LayoutUnit>& offset) {
+        return *offset.snapTargetID == horizontalBox || *offset.snapTargetID == verticalBox;
+    };
+    for (auto flag : { &SnapOffset<LayoutUnit>::isFocused, &SnapOffset<LayoutUnit>::isTarget }) {
+        for (auto axis : { ScrollEventAxis::Horizontal, ScrollEventAxis::Vertical }) {
+            if (auto box = flaggedNodeForAxis(axis, flag, isConflictingBox))
+                return *box;
+        }
+    }
+
+    return m_snapOffsetsInfo.blockAxis() == ScrollEventAxis::Horizontal ? horizontalBox : verticalBox;
 }
 
 bool ScrollSnapAnimatorState::resnapAfterLayout(ScrollOffset scrollOffset, const ScrollExtents& scrollExtents, float pageScale)
@@ -389,6 +437,14 @@ bool ScrollSnapAnimatorState::resnapAfterLayout(ScrollOffset scrollOffset, const
 
     auto targetForHorizontalAxis = targetForAxis(ScrollEventAxis::Horizontal, previousSnapTargetForHorizontalAxis, focusOrTargetChangedX);
     auto targetForVerticalAxis = targetForAxis(ScrollEventAxis::Vertical, previousSnapTargetForVerticalAxis, focusOrTargetChangedY);
+
+    // §4.1.3 "prefer block axis": if the two axes' boxes conflict, collapse both onto the one box.
+    if (targetForHorizontalAxis && targetForVerticalAxis) {
+        if (auto preferredBox = resolvePreferredBoxForAxisConflict(*targetForHorizontalAxis, *targetForVerticalAxis)) {
+            targetForHorizontalAxis = *preferredBox;
+            targetForVerticalAxis = *preferredBox;
+        }
+    }
 
     if (targetForHorizontalAxis)
         snapPointChanged |= preserveCurrentTargetForAxis(ScrollEventAxis::Horizontal, *targetForHorizontalAxis);

--- a/Source/WebCore/platform/ScrollSnapAnimatorState.h
+++ b/Source/WebCore/platform/ScrollSnapAnimatorState.h
@@ -33,6 +33,7 @@
 #include <WebCore/ScrollAnimationMomentum.h>
 #include <WebCore/ScrollSnapOffsetsInfo.h>
 #include <WebCore/ScrollTypes.h>
+#include <wtf/Function.h>
 #include <wtf/HashSet.h>
 #include <wtf/MonotonicTime.h>
 #include <wtf/TZoneMalloc.h>
@@ -102,7 +103,17 @@ private:
 
     bool preserveCurrentTargetForAxis(ScrollEventAxis, NodeIdentifier);
 
+    struct SnapOffsetAndAreaIndices {
+        unsigned offsetIndex { 0 };
+        std::optional<size_t> areaIndex;
+    };
+    std::optional<SnapOffsetAndAreaIndices> snapOffsetAndAreaIndicesForNode(ScrollEventAxis, NodeIdentifier) const;
+
     std::optional<unsigned> snapOffsetIndexForNode(ScrollEventAxis, NodeIdentifier) const;
+
+    using SnapOffsetPredicate = Function<bool(const SnapOffset<LayoutUnit>&)>;
+    Markable<NodeIdentifier> flaggedNodeForAxis(ScrollEventAxis, bool SnapOffset<LayoutUnit>::*flag, NOESCAPE const SnapOffsetPredicate& isEligible = { }) const;
+
     Markable<NodeIdentifier> focusedOrTargetedNodeForAxis(ScrollEventAxis) const;
 
     Vector<SnapOffset<LayoutUnit>> currentlySnappedOffsetsForAxis(ScrollEventAxis) const;
@@ -116,6 +127,14 @@ private:
     // The snap areas aligned at this axis's active offset with enclosing ancestors removed, in tree
     // order — the per-axis candidate list after the spec's ancestor-removal step.
     Vector<size_t, 1> innermostAlignedAreaIndicesForAxis(ScrollEventAxis) const;
+
+    // On a block/inline axis conflict (both boxes can't be snapped), the single box both axes snap to
+    // per https://drafts.csswg.org/css-scroll-snap/#re-snap: focused, then targeted, then block axis.
+    // nullopt when there's no conflict.
+    std::optional<NodeIdentifier> resolvePreferredBoxForAxisConflict(NodeIdentifier horizontalBox, NodeIdentifier verticalBox) const;
+
+    // The snap area rect (scroll-offset space) for the box establishing this axis's snap offset.
+    std::optional<std::pair<LayoutRect, LayoutUnit>> snapAreaAndOffsetForNode(ScrollEventAxis, NodeIdentifier) const;
 
     // This axis's focused/targeted snapped box, skipping any whose area is off-screen in a
     // non-snapping cross axis.

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -2876,6 +2876,7 @@ using WebCore::ScrollRequestData = Vector<WebCore::RequestedScrollData, 2>;
     Vector<WebCore::FloatSnapOffset> verticalSnapOffsets;
     Vector<WebCore::FloatRect> snapAreas;
     Vector<WebCore::NodeIdentifier> snapAreasIDs;
+    bool scrollerHasVerticalWritingMode;
 }
 
 enum class WebCore::ScrollSnapStop : bool;


### PR DESCRIPTION
#### ff1e94f74356e1ce4245e2a157e1c3e6a2889545
<pre>
[CSS Scroll Snap] Re-snap should prefer the block-axis box when the two axes conflict
<a href="https://bugs.webkit.org/show_bug.cgi?id=320406">https://bugs.webkit.org/show_bug.cgi?id=320406</a>
<a href="https://rdar.apple.com/183366125">rdar://183366125</a>

Reviewed by Simon Fraser.

Re-snapping after a layout change selects a snap target per axis
independently. When the block-axis box and inline-axis box differ and
cannot both be snapped (snapping to one leaves the other outside the
snapport), css-scroll-snap requires resolving to a single box: &quot;it must
prefer the focused box, followed by the targeted box, followed by the
block axis if neither box is focused or targeted&quot; [1]. WebKit kept the
two independently-selected boxes, so the scroller followed neither.

Detect the conflict in resnapAfterLayout(): form the combined snap
position (the inline box&apos;s offset in one axis, the block box&apos;s offset in
the other) and check whether both areas still intersect the snapport
there. If they do, both boxes can be snapped and per-axis selection
stands. If they do not, collapse both axes onto one box, preferring
focused, then targeted, then the block-axis box. Which physical axis is
the block axis depends on the snap container&apos;s writing mode, so plumb
scrollerHasVerticalWritingMode onto LayoutScrollSnapOffsetsInfo (computed
where offsets are built and serialized to the scrolling thread).

Resolving the conflict needs a box&apos;s snap area as well as its offset, and
it needs the focused/targeted preference over a restricted set of boxes,
so two lookups are factored out for it: snapOffsetAndAreaIndicesForNode()
finds a box&apos;s offset and its own area in one pass over the offset&apos;s areas
(snapOffsetIndexForNode() now projects it), and flaggedNodeForAxis() finds
an axis&apos;s focused or targeted box under a caller-supplied filter, shared
with focusedOrTargetedNodeForAxis() and focusedOrTargetedBox().

[1] <a href="https://drafts.csswg.org/css-scroll-snap/#re-snap">https://drafts.csswg.org/css-scroll-snap/#re-snap</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/snap-after-relayout/snap-to-different-targets-expected.txt: Progression
* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/snap-to-combination-of-two-elements-2-expected.txt: Rebaseline (matches Chrome)
* Source/WebCore/page/scrolling/ScrollSnapOffsetsInfo.cpp:
(WebCore::updateSnapOffsetsForScrollableArea):
(WebCore::convertOffsetInfo):
* Source/WebCore/page/scrolling/ScrollSnapOffsetsInfo.h:
(WebCore::ScrollSnapOffsetsInfo::blockAxis const):
(WebCore::ScrollSnapOffsetsInfo::isEqual const):
* Source/WebCore/platform/ScrollSnapAnimatorState.cpp:
(WebCore::ScrollSnapAnimatorState::snapOffsetAndAreaIndicesForNode const):
(WebCore::ScrollSnapAnimatorState::snapOffsetIndexForNode const):
(WebCore::ScrollSnapAnimatorState::flaggedNodeForAxis const):
(WebCore::ScrollSnapAnimatorState::focusedOrTargetedNodeForAxis const):
(WebCore::ScrollSnapAnimatorState::focusedOrTargetedBox const):
(WebCore::ScrollSnapAnimatorState::snapAreaAndOffsetForNode const):
(WebCore::ScrollSnapAnimatorState::resolvePreferredBoxForAxisConflict const):
(WebCore::ScrollSnapAnimatorState::resnapAfterLayout):
* Source/WebCore/platform/ScrollSnapAnimatorState.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/318343@main">https://commits.webkit.org/318343@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f878c3c2eb0d689b0704c027a7bdcae6380b179e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177721 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51659 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45453 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187329 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140968 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a624921b-45d2-4ff1-b951-dc113cb3c777) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179584 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52951 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51368 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138522 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140968 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/027d754f-bedd-44ba-95cc-792b2546a051) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180677 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42044 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159267 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118986 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/60d5430a-fe92-4145-aced-b09615960eb3) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40706 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39069 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151112 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38763 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35792 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/43444 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43304 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189758 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51326 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147636 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39719 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52008 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35391 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147422 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42138 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124223 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118654 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50516 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13740 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49912 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50152 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49974 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->