### PR TITLE
CacheStorage size accounting can underflow and persist a corrupt size

### DIFF
--- a/Source/WebKit/NetworkProcess/storage/CacheStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageManager.cpp
@@ -427,7 +427,7 @@ void CacheStorageManager::sizeDecreased(uint64_t amount)
     if (!m_size || !amount)
         return;
 
-    m_size = *m_size - amount;
+    m_size = *m_size > amount ? *m_size - amount : 0;
     writeSizeFile(m_path, *m_size);
 }
 


### PR DESCRIPTION
#### 5d91250a8529e04434ea11a12669ac533bb17e77
<pre>
CacheStorage size accounting can underflow and persist a corrupt size
<a href="https://bugs.webkit.org/show_bug.cgi?id=320408">https://bugs.webkit.org/show_bug.cgi?id=320408</a>

Reviewed by Youenn Fablet.

CacheStorageManager::sizeDecreased() subtracted the given amount from m_size
without checking that it did not exceed the current value. m_size is a uint64_t,
so if the amount ever exceeds the tracked size the subtraction wraps to a value
near UINT64_MAX, which is then written to the cache&apos;s size file and used for
quota accounting, effectively corrupting quota reporting for the origin until
the size is re-initialized.

The tracked size is normally kept consistent (increments and decrements are
balanced in putRecordsInStore), but removeRecords() and removeAllRecords() call
sizeDecreased() directly, outside the space-request/initialization path, so the
in-memory accounting and the asynchronously-measured cache size can in theory
drift and the decrement can exceed m_size.

Clamp the subtraction at zero, matching the saturating arithmetic used elsewhere
in this code.

* Source/WebKit/NetworkProcess/storage/CacheStorageManager.cpp:
(WebKit::CacheStorageManager::sizeDecreased):

Canonical link: <a href="https://commits.webkit.org/318204@main">https://commits.webkit.org/318204@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ac7843c05bfb23baae89a8b193ef5bb78399a0a9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177089 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51026 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44821 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186692 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140325 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e6e4c6b7-e32f-4ba4-b68e-c25076751747) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52319 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50712 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137981 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140325 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/803c4728-79a5-458a-b468-4f5f5721c11c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180045 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41486 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158750 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118449 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/41a3a34f-50da-4380-967c-9fd6a4f1e250) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40142 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38511 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150552 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38249 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35160 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42801 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42729 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189118 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50693 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147062 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39629 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51376 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34873 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146853 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41600 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123590 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117877 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49881 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13229 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49280 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49517 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49341 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->