### PR TITLE
[Build perf] CMake benchmark should target SDK version, not host OS version

### DIFF
--- a/Tools/Scripts/measure-build-time
+++ b/Tools/Scripts/measure-build-time
@@ -371,14 +371,16 @@ def run_test(name: str, command: str, stdout_filter: str | None = None) -> TestR
 
 DEFAULT_MAKE_COMMAND = (
     'make -C {workspace_dir} {configuration} ARGS="'
-    'WK_MACOSX_DEPLOYMENT_TARGET= COMPILATION_CACHE_ENABLE_CACHING=NO -showBuildTimingSummary'
+    'WK_MACOSX_DEPLOYMENT_TARGET={sdk_version} COMPILATION_CACHE_ENABLE_CACHING=NO '
+    '-showBuildTimingSummary'
     '"'
 )
 DEFAULT_CMAKE_BUILD_COMMAND = (
     'xcrun ninja -C {build_dir}'
 )
 DEFAULT_CMAKE_CONFIGURE_COMMAND = (
-    'xcrun cmake -S {source_dir} -B {build_dir} --preset {preset}'
+    'xcrun cmake -S {source_dir} -B {build_dir} --preset {preset} '
+    '-DCMAKE_OSX_DEPLOYMENT_TARGET={sdk_version}'
 )
 
 class Arguments(argparse.Namespace):
@@ -459,11 +461,19 @@ def get_args() -> Arguments:
         parser.error('--build-command must be provided when using a custom '
                      '--configure-command')
 
+    internal_dir = args.source_dir / '../Internal/WebKit'
+    sdk_version = subprocess.check_output(
+        ('xcodebuild', '-version', '-sdk',
+         'macosx.internal' if internal_dir.exists() else 'macosx',
+         'SDKVersion'),
+        text=True
+    ).rstrip()
+
     if args.make:
-        internal_dir = args.source_dir / '../Internal/WebKit'
         args.build_command = DEFAULT_MAKE_COMMAND.format(
             configuration=args.configuration.lower(),
-            workspace_dir=str(internal_dir if internal_dir.exists() else args.source_dir)
+            workspace_dir=str(internal_dir if internal_dir.exists() else args.source_dir),
+            sdk_version=sdk_version,
         )
     elif args.cmake:
         args.build_command = DEFAULT_CMAKE_BUILD_COMMAND.format(
@@ -477,6 +487,7 @@ def get_args() -> Arguments:
             build_dir=str(args.build_dir),
             source_dir=str(args.source_dir),
             preset=cmake_preset,
+            sdk_version=sdk_version,
         )
     if not args.metric_key:
         # e.g. "BuildTime-Debug"


### PR DESCRIPTION
#### 578c895afd5329d97a025ee5b3824c5850bff5b6
<pre>
[Build perf] CMake benchmark should target SDK version, not host OS version
<a href="https://bugs.webkit.org/show_bug.cgi?id=320407">https://bugs.webkit.org/show_bug.cgi?id=320407</a>
<a href="https://rdar.apple.com/183367343">rdar://183367343</a>

Unreviewed CI fix. We already fixed this for Xcode in 317445@main, but I
didn&apos;t realize CMake needed it too.

* Tools/Scripts/measure-build-time:
(get_args):

Canonical link: <a href="https://commits.webkit.org/318023@main">https://commits.webkit.org/318023@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d6a390d9d1f2bd50b6b18ed8b3bfb8e64f192bb4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177093 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51030 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/44825 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/186696 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140329 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4842e8d8-a838-4b60-b85a-a6595c3ed83b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178956 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/52323 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50716 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/186696 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140329 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/420eb5e3-8e9f-4e53-ac6e-4fa53f3537ca) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180049 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/52323 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/44825 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/186696 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/52323 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/38516 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/186696 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/44825 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/52323 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/44825 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35164 "Built successfully") | | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/42734 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189122 "Built successfully") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/50697 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/44825 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/147064 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/51380 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/44825 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/146855 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26857 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/51380 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/117881 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/49885 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/44825 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/49284 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/49521 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/49345 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->