### PR TITLE
[Site Isolation][iOS] Long tap does not select a word inside a cross-origin iframe

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7553,6 +7553,7 @@ imported/w3c/web-platform-tests/css/css-color/deprecated-sameas-002.html [ Image
 http/tests/ipc/write-web-archive-frame-ancestry-check.html [ Skip ]
 
 http/tests/site-isolation/touch-events [ Skip ]
+http/tests/site-isolation/ios [ Skip ]
 http/tests/site-isolation/iframe-dark-mode-print.html [ ImageOnlyFailure ]
 
 # CSS syntax

--- a/LayoutTests/http/tests/site-isolation/ios/long-press-selection-highlight-position-in-cross-origin-iframe-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/ios/long-press-selection-highlight-position-in-cross-origin-iframe-expected.txt
@@ -1,0 +1,10 @@
+Long-pressing text inside a cross-origin iframe should draw the selection highlight at the correct position in the top-level page (offset by the iframe's location), not at the cross-origin subframe's local coordinates.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS selectionTop is >= iframeTop - 20
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/site-isolation/ios/long-press-selection-highlight-position-in-cross-origin-iframe.html
+++ b/LayoutTests/http/tests/site-isolation/ios/long-press-selection-highlight-position-in-cross-origin-iframe.html
@@ -1,0 +1,35 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<script src="/js-test-resources/js-test.js"></script>
+<script src="/js-test-resources/ui-helper.js"></script>
+<script>
+description("Long-pressing text inside a cross-origin iframe should draw the selection highlight at the correct position in the top-level page (offset by the iframe's location), not at the cross-origin subframe's local coordinates.");
+jsTestIsAsync = true;
+
+const iframeTop = 100;
+let selectionTop;
+
+addEventListener("message", async (event) => {
+    if (event.data !== "ready")
+      return;
+
+    await UIHelper.longPressAtPoint(30, iframeTop + 12);
+
+    let didFail = false;
+    setTimeout(() => {
+        testFailed("Selection did not appear");
+        finishJSTest();
+        didFail = true;
+    }, 3000);
+
+    await UIHelper.waitForSelectionToAppear();
+    if (didFail)
+        return;
+
+    const rects = await UIHelper.getUISelectionViewRects();
+    selectionTop = rects.length ? rects[0].top : -1;
+
+    shouldBeGreaterThanOrEqual("selectionTop", "iframeTop - 20");
+    finishJSTest();
+});
+</script>
+<iframe style="position: absolute; left: 0; top: 100px; width: 400px; height: 300px; border: none;" src="http://localhost:8000/site-isolation/resources/selectable-text-frame.html"></iframe>

--- a/LayoutTests/http/tests/site-isolation/ios/long-press-selects-word-in-cross-origin-iframe-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/ios/long-press-selects-word-in-cross-origin-iframe-expected.txt
@@ -1,0 +1,10 @@
+Long-pressing text inside a cross-origin iframe should select a word in that iframe, not select the whole iframe element in the parent frame.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS A word was selected inside the cross-origin iframe.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/site-isolation/ios/long-press-selects-word-in-cross-origin-iframe.html
+++ b/LayoutTests/http/tests/site-isolation/ios/long-press-selects-word-in-cross-origin-iframe.html
@@ -1,0 +1,31 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<script src="/js-test-resources/js-test.js"></script>
+<script src="/js-test-resources/ui-helper.js"></script>
+<script>
+description("Long-pressing text inside a cross-origin iframe should select a word in that iframe, not select the whole iframe element in the parent frame.");
+jsTestIsAsync = true;
+
+let done = false;
+window.lastReportedSelection = "";
+addEventListener("message", async (event) => {
+    if (event.data === "ready") {
+        // The iframe is at (0, 0); long-press over the "Hello" text near the top-left.
+        await UIHelper.longPressAtPoint(30, 12);
+        setTimeout(() => {
+            if (done)
+                return;
+            done = true;
+            testFailed("Long press did not select a word inside the cross-origin iframe (iframe selection was: '" + window.lastReportedSelection + "').");
+            finishJSTest();
+        }, 3000);
+    } else if (typeof event.data === "string" && event.data.startsWith("selection:")) {
+        window.lastReportedSelection = event.data.substring("selection:".length);
+        if (window.lastReportedSelection.length && !done) {
+            done = true;
+            testPassed("A word was selected inside the cross-origin iframe.");
+            finishJSTest();
+        }
+    }
+});
+</script>
+<iframe style="position: absolute; left: 0; top: 0; width: 400px; height: 300px; border: none;" src="http://localhost:8000/site-isolation/resources/selectable-text-frame.html"></iframe>

--- a/LayoutTests/http/tests/site-isolation/ios/long-press-selects-word-in-scrolled-cross-origin-iframe-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/ios/long-press-selects-word-in-scrolled-cross-origin-iframe-expected.txt
@@ -1,0 +1,10 @@
+Long-pressing text inside a scrolled cross-origin iframe should select the word actually under the finger, accounting for the subframe's scroll offset (not double-counting or ignoring it).
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS selectedToken is "token3"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/site-isolation/ios/long-press-selects-word-in-scrolled-cross-origin-iframe.html
+++ b/LayoutTests/http/tests/site-isolation/ios/long-press-selects-word-in-scrolled-cross-origin-iframe.html
@@ -1,0 +1,35 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<script src="/js-test-resources/js-test.js"></script>
+<script src="/js-test-resources/ui-helper.js"></script>
+<script>
+description("Long-pressing text inside a scrolled cross-origin iframe should select the word actually under the finger, accounting for the subframe's scroll offset (not double-counting or ignoring it).");
+jsTestIsAsync = true;
+
+// The iframe is at (0, 0). Its content lines are 40px tall and it is scrolled down by
+// 120px (3 lines) before it signals readiness. A long-press at viewport y=20 inside the
+// iframe therefore lands on contents y = 20 + 120 = 140, i.e. the 4th line ("token3").
+let selectedToken = "";
+addEventListener("message", (event) => {
+    if (event.data === "ready")
+        runTest();
+    else if (typeof event.data === "string" && event.data.startsWith("selection:")) {
+        const selection = event.data.substring("selection:".length);
+        if (selection.length)
+            selectedToken = selection;
+    }
+});
+
+async function runTest() {
+    await UIHelper.ensurePresentationUpdate();
+    // The long press is occasionally delivered before the subframe is ready to process it,
+    // producing no selection; retry until a word is selected inside the iframe.
+    for (let attempt = 0; attempt < 20 && !selectedToken.length; ++attempt) {
+        await UIHelper.longPressAtPoint(30, 20);
+        for (let frame = 0; frame < 10 && !selectedToken.length; ++frame)
+            await UIHelper.animationFrame();
+    }
+    shouldBeEqualToString("selectedToken", "token3");
+    finishJSTest();
+}
+</script>
+<iframe style="position: absolute; left: 0; top: 0; width: 400px; height: 300px; border: none;" src="http://localhost:8000/site-isolation/resources/scrollable-selectable-text-frame.html"></iframe>

--- a/LayoutTests/http/tests/site-isolation/resources/scrollable-selectable-text-frame.html
+++ b/LayoutTests/http/tests/site-isolation/resources/scrollable-selectable-text-frame.html
@@ -1,0 +1,25 @@
+<body style="margin: 0; font: 20px/40px monospace;">
+<div id="content"></div>
+<script>
+// Each line is 40px tall and starts with a unique token, so the word returned by a
+// long-press reveals which content line was actually hit.
+let markup = "";
+for (let i = 0; i < 30; i++)
+    markup += `<div style="height: 40px;">token${i} selectable line</div>`;
+document.getElementById("content").innerHTML = markup;
+
+document.addEventListener("selectionchange", () => {
+    window.top.postMessage("selection:" + getSelection().toString(), "*");
+});
+
+// Scroll the frame by a known amount before signaling readiness so the parent can
+// verify that hit-testing accounts for the subframe's scroll offset.
+const scrollTop = 120;
+document.scrollingElement.scrollTop = scrollTop;
+requestAnimationFrame(() => {
+    requestAnimationFrame(() => {
+        window.top.postMessage("ready", "*");
+    });
+});
+</script>
+</body>

--- a/LayoutTests/http/tests/site-isolation/resources/selectable-text-frame.html
+++ b/LayoutTests/http/tests/site-isolation/resources/selectable-text-frame.html
@@ -1,0 +1,9 @@
+<body style="margin: 0; font: 20px monospace;">
+Hello world this is selectable text inside a cross origin iframe.
+<script>
+document.addEventListener("selectionchange", () => {
+    window.top.postMessage("selection:" + getSelection().toString(), "*");
+});
+window.top.postMessage("ready", "*");
+</script>
+</body>

--- a/Source/WebCore/accessibility/AccessibilityScrollView.cpp
+++ b/Source/WebCore/accessibility/AccessibilityScrollView.cpp
@@ -401,7 +401,7 @@ void AccessibilityScrollView::addRemoteFrameChild()
             RefPtr parentAXScrollView = frameRootScrollView();
             if (RefPtr parentScrollView = parentAXScrollView ? parentAXScrollView->scrollView() : nullptr)
                 iframePosition = parentScrollView->contentsToView(iframePosition);
-            scrollFrame->updateRemoteFrameAccessibilityOffset(iframePosition);
+            scrollFrame->updateRemoteFrameOffsetInMainFrame(iframePosition);
 
 #if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
             InheritedFrameState state { isHostingFrameHidden(), isHostingFrameInert(), isHostingFrameRenderHidden() };

--- a/Source/WebCore/page/RemoteFrame.cpp
+++ b/Source/WebCore/page/RemoteFrame.cpp
@@ -115,9 +115,9 @@ void RemoteFrame::loadFrameRequest(FrameLoadRequest&& request, Event*)
     m_client->changeLocation(WTF::move(request), std::nullopt);
 }
 
-void RemoteFrame::updateRemoteFrameAccessibilityOffset(IntPoint offset)
+void RemoteFrame::updateRemoteFrameOffsetInMainFrame(IntPoint offset)
 {
-    m_client->updateRemoteFrameAccessibilityOffset(frameID(), offset);
+    m_client->updateRemoteFrameOffsetInMainFrame(frameID(), offset);
 }
 
 #if ENABLE(ACCESSIBILITY_LOCAL_FRAME)

--- a/Source/WebCore/page/RemoteFrame.h
+++ b/Source/WebCore/page/RemoteFrame.h
@@ -79,7 +79,7 @@ public:
 
     String renderTreeAsText(size_t baseIndent, OptionSet<RenderAsTextFlag>);
     void bindRemoteAccessibilityFrames(int processIdentifier, AccessibilityRemoteToken, CompletionHandler<void(AccessibilityRemoteToken, int)>&&);
-    void updateRemoteFrameAccessibilityOffset(IntPoint);
+    void updateRemoteFrameOffsetInMainFrame(IntPoint);
 #if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
     void updateRemoteFrameAccessibilityInheritedState(const InheritedFrameState&);
 #endif

--- a/Source/WebCore/page/RemoteFrameClient.h
+++ b/Source/WebCore/page/RemoteFrameClient.h
@@ -64,7 +64,7 @@ public:
     virtual void closePage() = 0;
     virtual void bindRemoteAccessibilityFrames(int processIdentifier, FrameIdentifier target, AccessibilityRemoteToken dataToken, CompletionHandler<void(AccessibilityRemoteToken, int)>&&) = 0;
     virtual void unbindRemoteAccessibilityFrames(int) = 0;
-    virtual void updateRemoteFrameAccessibilityOffset(FrameIdentifier target, IntPoint) = 0;
+    virtual void updateRemoteFrameOffsetInMainFrame(FrameIdentifier target, IntPoint) = 0;
 #if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
     virtual void updateRemoteFrameAccessibilityInheritedState(FrameIdentifier target, const InheritedFrameState&) = 0;
 #endif

--- a/Source/WebCore/page/RemoteFrameGeometryTransformer.cpp
+++ b/Source/WebCore/page/RemoteFrameGeometryTransformer.cpp
@@ -42,6 +42,11 @@ RemoteFrameGeometryTransformer::RemoteFrameGeometryTransformer(RemoteFrameGeomet
 
 RemoteFrameGeometryTransformer& RemoteFrameGeometryTransformer::operator=(RemoteFrameGeometryTransformer&&) = default;
 
+// The returned point is in the remote frame's root-view coordinates (i.e. relative to the remote
+// frame's origin, without the remote frame's own scroll offset applied). Consumers deliver it into
+// the remote frame's process as a root-view point, where it is converted to contents coordinates
+// (re-applying the remote frame's scroll) during hit-testing. Using rootViewToContents() here would
+// apply the remote frame's scroll offset a second time.
 IntPoint RemoteFrameGeometryTransformer::transformToRemoteFrameCoordinates(IntPoint pointInContents) const
 {
     return Ref { m_remoteView }->convertFromRootView(Ref { m_localView }->contentsToRootView(pointInContents));

--- a/Source/WebCore/page/RemoteFrameView.cpp
+++ b/Source/WebCore/page/RemoteFrameView.cpp
@@ -57,6 +57,12 @@ void RemoteFrameView::setFrameRect(const IntRect& newRect)
     if (newRect != oldRect) {
         m_frame->client().frameRectDidChange(newRect);
 
+        // Push this remote frame's origin within its immediate parent to its process. The UI process
+        // accumulates these across ancestors into a cumulative main-frame offset (see
+        // WebPageProxy::updateRemoteFrameOffsetInMainFrame), which the frame's process uses to emit
+        // selection rects in main-frame coordinates (and for accessibility).
+        m_frame->updateRemoteFrameOffsetInMainFrame(newRect.location());
+
 #if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
         if (AXObjectCache::accessibilityEnabled()) {
             if (RefPtr page = m_frame->page())

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewTestingIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewTestingIOS.mm
@@ -445,9 +445,8 @@ static void dumpUIView(TextStream& ts, UIView *view, bool traverse)
 
 - (void)_selectionBoundingRectInMainFrameCoordinatesForTesting:(void (^)(CGRect))completionHandler
 {
-    _page->convertEditorStateSelectionRectToMainFrameCoordinates(_page->selectionBoundingRectInRootViewCoordinates(), [completionHandler = makeBlockPtr(completionHandler)](WebCore::FloatRect rect) {
-        completionHandler(rect);
-    });
+    // The editor state's selection rects are already in main-frame coordinates.
+    completionHandler(_page->selectionBoundingRectInRootViewCoordinates());
 }
 
 - (UIGestureRecognizer *)_imageAnalysisGestureRecognizer

--- a/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
@@ -2184,12 +2184,26 @@ void WebPageProxy::clearAccessibilityIsolatedTree()
 #endif
 #endif // PLATFORM(MAC)
 
-void WebPageProxy::selectWithGesture(IntPoint point, GestureType gestureType, GestureRecognizerState gestureState, bool isInteractingWithFocusedElement, CompletionHandler<void(const IntPoint&, GestureType, GestureRecognizerState, OptionSet<SelectionFlags>)>&& callback)
+void WebPageProxy::selectWithGesture(std::optional<WebCore::FrameIdentifier> frameID, IntPoint point, GestureType gestureType, GestureRecognizerState gestureState, bool isInteractingWithFocusedElement, CompletionHandler<void(const IntPoint&, GestureType, GestureRecognizerState, OptionSet<SelectionFlags>)>&& callback)
 {
     if (!hasRunningProcess())
         return callback({ }, GestureType::Loupe, GestureRecognizerState::Possible, { });
 
-    WTF::protect(legacyMainFrameProcess())->sendWithAsyncReply(Messages::WebPage::SelectWithGesture(point, gestureType, gestureState, isInteractingWithFocusedElement), WTF::move(callback), webPageIDInMainFrameProcess());
+    sendWithAsyncReplyToProcessContainingFrame(frameID, Messages::WebPage::SelectWithGesture(frameID, point, gestureType, gestureState, isInteractingWithFocusedElement), Messages::WebPage::SelectWithGesture::Reply { [weakThis = WeakPtr { *this }, pointInContentViewCoordinates = point, gestureType, gestureState, isInteractingWithFocusedElement, callback = WTF::move(callback)](const IntPoint& point, GestureType innerGestureType, GestureRecognizerState innerGestureState, OptionSet<SelectionFlags> flags, std::optional<WebCore::RemoteUserInputEventData> remoteUserInputEventData) mutable {
+        RefPtr protectedThis = weakThis.get();
+        if (protectedThis && remoteUserInputEventData) {
+            // The gesture landed on a cross-origin frame; re-dispatch it into that frame's process.
+            // Keep reporting the original gesture location in content-view coordinates: the subframe
+            // reports the point in its own coordinates, but selectionChangedWithGesture() (UIKit)
+            // expects content-view coordinates.
+            protectedThis->selectWithGesture(remoteUserInputEventData->targetFrameID, roundedIntPoint(FloatPoint { remoteUserInputEventData->transformedPoint }), gestureType, gestureState, isInteractingWithFocusedElement,
+                [pointInContentViewCoordinates, callback = WTF::move(callback)](const IntPoint&, GestureType gestureType, GestureRecognizerState gestureState, OptionSet<SelectionFlags> flags) mutable {
+                callback(pointInContentViewCoordinates, gestureType, gestureState, flags);
+            });
+            return;
+        }
+        callback(point, innerGestureType, innerGestureState, flags);
+    } });
 }
 
 void WebPageProxy::didReceivePositionInformation(const InteractionInformationAtPosition& info)
@@ -2215,16 +2229,22 @@ void WebPageProxy::selectPositionAtPoint(WebCore::IntPoint point, bool isInterac
     }, webPageIDInMainFrameProcess());
 }
 
-void WebPageProxy::selectTextWithGranularityAtPoint(WebCore::IntPoint point, WebCore::TextGranularity granularity, bool isInteractingWithFocusedElement, CompletionHandler<void()>&& callbackFunction)
+void WebPageProxy::selectTextWithGranularityAtPoint(std::optional<WebCore::FrameIdentifier> frameID, WebCore::IntPoint point, WebCore::TextGranularity granularity, bool isInteractingWithFocusedElement, CompletionHandler<void()>&& callbackFunction)
 {
     if (!hasRunningProcess()) {
         callbackFunction();
         return;
     }
 
-    protect(legacyMainFrameProcess())->sendWithAsyncReply(Messages::WebPage::SelectTextWithGranularityAtPoint(point, granularity, isInteractingWithFocusedElement), [callbackFunction = WTF::move(callbackFunction), backgroundActivity = protect(m_legacyMainFrameProcess->throttler())->backgroundActivity("WebPageProxy::selectTextWithGranularityAtPoint"_s)] mutable {
+    sendWithAsyncReplyToProcessContainingFrame(frameID, Messages::WebPage::SelectTextWithGranularityAtPoint(frameID, point, granularity, isInteractingWithFocusedElement), Messages::WebPage::SelectTextWithGranularityAtPoint::Reply { [weakThis = WeakPtr { *this }, granularity, isInteractingWithFocusedElement, callbackFunction = WTF::move(callbackFunction)](std::optional<WebCore::RemoteUserInputEventData> remoteUserInputEventData) mutable {
+        RefPtr protectedThis = weakThis.get();
+        if (protectedThis && remoteUserInputEventData) {
+            // The gesture landed on a cross-origin frame; re-dispatch it into that frame's process.
+            protectedThis->selectTextWithGranularityAtPoint(remoteUserInputEventData->targetFrameID, roundedIntPoint(FloatPoint { remoteUserInputEventData->transformedPoint }), granularity, isInteractingWithFocusedElement, WTF::move(callbackFunction));
+            return;
+        }
         callbackFunction();
-    }, webPageIDInMainFrameProcess());
+    } });
 }
 
 void WebPageProxy::updateSelectionWithExtentPoint(WebCore::IntPoint point, bool isInteractingWithFocusedElement, RespectSelectionAnchor respectSelectionAnchor, CompletionHandler<void(bool)>&& callback)

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -18954,6 +18954,8 @@ INSTANTIATE_SEND_WITH_ASYNC_REPLY_TO_PROCESS_CONTAINING_FRAME(WebPage::CommitPot
 INSTANTIATE_SEND_WITH_ASYNC_REPLY_TO_PROCESS_CONTAINING_FRAME(WebPage::PotentialTapAtPosition);
 #endif
 #if PLATFORM(IOS_FAMILY)
+INSTANTIATE_SEND_WITH_ASYNC_REPLY_TO_PROCESS_CONTAINING_FRAME(WebPage::SelectWithGesture);
+INSTANTIATE_SEND_WITH_ASYNC_REPLY_TO_PROCESS_CONTAINING_FRAME(WebPage::SelectTextWithGranularityAtPoint);
 INSTANTIATE_SEND_WITH_ASYNC_REPLY_TO_PROCESS_CONTAINING_FRAME(WebPage::ApplyAutocorrection);
 INSTANTIATE_SEND_WITH_ASYNC_REPLY_TO_PROCESS_CONTAINING_FRAME(WebPage::DrawToImage);
 INSTANTIATE_SEND_WITH_ASYNC_REPLY_TO_PROCESS_CONTAINING_FRAME(WebPage::DrawToPDFiOS);
@@ -19180,9 +19182,38 @@ void WebPageProxy::bindRemoteAccessibilityFrames(int processIdentifier, WebCore:
     completionHandler(frameDataToken, frameProcessIdentifier);
 }
 
-void WebPageProxy::updateRemoteFrameAccessibilityOffset(WebCore::FrameIdentifier frameID, WebCore::IntPoint offset)
+void WebPageProxy::updateRemoteFrameOffsetInMainFrame(WebCore::FrameIdentifier frameID, WebCore::IntPoint offset)
 {
-    sendToProcessContainingFrame(frameID, Messages::WebPage::UpdateRemotePageAccessibilityOffset(frameID, offset));
+    // The offset pushed from the web process is this frame's origin within its immediate parent
+    // frame. To convert selection rects to main-frame coordinates, each frame's process needs the
+    // cumulative offset (the sum of its ancestors' origins). Record the per-parent offset here and
+    // recompute the cumulative offset for this frame and its descendants, so out-of-order arrival of
+    // ancestor and descendant offsets converges to the correct result.
+    internals().remoteFrameOffsetsInParent.set(frameID, offset);
+
+    RefPtr frame = WebFrameProxy::webFrame(frameID);
+    if (!frame)
+        return;
+
+    pushCumulativeOffsetInMainFrame(*frame);
+    for (RefPtr descendant = frame->traverseNext(frame.get()); descendant; descendant = descendant->traverseNext(frame.get()))
+        pushCumulativeOffsetInMainFrame(*descendant);
+}
+
+void WebPageProxy::pushCumulativeOffsetInMainFrame(WebFrameProxy& frame)
+{
+    auto frameID = frame.frameID();
+    auto it = internals().remoteFrameOffsetsInParent.find(frameID);
+    if (it == internals().remoteFrameOffsetsInParent.end())
+        return;
+
+    WebCore::IntPoint cumulativeOffset;
+    for (RefPtr ancestor = &frame; ancestor; ancestor = ancestor->parentFrame()) {
+        if (auto ancestorOffset = internals().remoteFrameOffsetsInParent.getOptional(ancestor->frameID()))
+            cumulativeOffset.moveBy(*ancestorOffset);
+    }
+
+    sendToProcessContainingFrame(frameID, Messages::WebPage::UpdateRemotePageOffsetInMainFrame(frameID, cumulativeOffset));
 }
 
 #if ENABLE(ACCESSIBILITY_LOCAL_FRAME)

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1179,15 +1179,13 @@ public:
 #if PLATFORM(COCOA)
     void scrollingNodeScrollViewDidScroll(WebCore::ScrollingNodeID);
     WebCore::FloatRect selectionBoundingRectInRootViewCoordinates() const;
-    // Maps a selection rect from the focused frame's root-view space to main-frame coordinates.
-    void convertEditorStateSelectionRectToMainFrameCoordinates(WebCore::FloatRect, CompletionHandler<void(WebCore::FloatRect)>&&);
 #endif
 
     void processWillSuspend();
     void processDidResume();
 
 #if PLATFORM(COCOA)
-    void selectWithGesture(WebCore::IntPoint, GestureType, GestureRecognizerState, bool isInteractingWithFocusedElement, CompletionHandler<void(const WebCore::IntPoint&, GestureType, GestureRecognizerState, OptionSet<SelectionFlags>)>&&);
+    void selectWithGesture(std::optional<WebCore::FrameIdentifier>, WebCore::IntPoint, GestureType, GestureRecognizerState, bool isInteractingWithFocusedElement, CompletionHandler<void(const WebCore::IntPoint&, GestureType, GestureRecognizerState, OptionSet<SelectionFlags>)>&&);
 
     void didReceivePositionInformation(const InteractionInformationAtPosition&);
     void requestPositionInformation(const InteractionInformationRequest&);
@@ -1195,7 +1193,7 @@ public:
     void selectPositionAtPoint(WebCore::IntPoint, bool isInteractingWithFocusedElement, CompletionHandler<void()>&&);
     void updateSelectionWithExtentPoint(WebCore::IntPoint, bool isInteractingWithFocusedElement, RespectSelectionAnchor, CompletionHandler<void(bool)>&&);
     void updateSelectionWithExtentPointAndBoundary(WebCore::IntPoint, WebCore::TextGranularity, bool isInteractingWithFocusedElement, TextInteractionSource, CompletionHandler<void(bool)>&&);
-    void selectTextWithGranularityAtPoint(WebCore::IntPoint, WebCore::TextGranularity, bool isInteractingWithFocusedElement, CompletionHandler<void()>&&);
+    void selectTextWithGranularityAtPoint(std::optional<WebCore::FrameIdentifier>, WebCore::IntPoint, WebCore::TextGranularity, bool isInteractingWithFocusedElement, CompletionHandler<void()>&&);
 #endif
 
 #if PLATFORM(IOS_FAMILY)
@@ -3656,7 +3654,8 @@ private:
     void addMessageToConsoleForTesting(String&&);
     void frameTextForTesting(WebCore::FrameIdentifier, CompletionHandler<void(String&&)>&&);
     void bindRemoteAccessibilityFrames(int processIdentifier, WebCore::FrameIdentifier, WebCore::AccessibilityRemoteToken dataToken, CompletionHandler<void(WebCore::AccessibilityRemoteToken, int)>&&);
-    void updateRemoteFrameAccessibilityOffset(WebCore::FrameIdentifier, WebCore::IntPoint);
+    void updateRemoteFrameOffsetInMainFrame(WebCore::FrameIdentifier, WebCore::IntPoint);
+    void pushCumulativeOffsetInMainFrame(WebFrameProxy&);
 #if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
     void updateRemoteFrameAccessibilityInheritedState(WebCore::FrameIdentifier, const WebCore::InheritedFrameState&);
 #endif

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -659,7 +659,7 @@ messages -> WebPageProxy {
     [EnabledBy=SiteIsolationEnabled] DispatchCrossOriginBeforeUnloadCheckForFrame(WebCore::FrameIdentifier frameID, WebCore::SecurityOriginData navigatingFrameOrigin)
     AddMessageToConsoleForTesting(String message) AllowedWhenWaitingForSyncReply
     [EnabledBy=SiteIsolationEnabled] BindRemoteAccessibilityFrames(int processIdentifier, WebCore::FrameIdentifier frameID, struct WebCore::AccessibilityRemoteToken dataToken) -> (struct WebCore::AccessibilityRemoteToken token, int processIdentifier) Synchronous
-    [EnabledBy=SiteIsolationEnabled] UpdateRemoteFrameAccessibilityOffset(WebCore::FrameIdentifier frameID, WebCore::IntPoint offset)
+    [EnabledBy=SiteIsolationEnabled] UpdateRemoteFrameOffsetInMainFrame(WebCore::FrameIdentifier frameID, WebCore::IntPoint offset)
 #if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
     [EnabledBy=SiteIsolationEnabled] UpdateRemoteFrameAccessibilityInheritedState(WebCore::FrameIdentifier frameID, struct WebCore::InheritedFrameState state)
 #endif

--- a/Source/WebKit/UIProcess/WebPageProxy.swift
+++ b/Source/WebKit/UIProcess/WebPageProxy.swift
@@ -37,6 +37,7 @@ extension WebKit.WebPageProxy {
     ) async {
         await withCheckedContinuation { continuation in
             selectWithGesture(
+                nil,
                 point,
                 type,
                 state,
@@ -65,6 +66,7 @@ extension WebKit.WebPageProxy {
     ) async {
         await withCheckedContinuation { continuation in
             selectTextWithGranularityAtPoint(
+                nil,
                 point,
                 granularity,
                 isInteractingWithFocusedElement,

--- a/Source/WebKit/UIProcess/WebPageProxyInternals.h
+++ b/Source/WebKit/UIProcess/WebPageProxyInternals.h
@@ -53,7 +53,9 @@
 #include "WindowKind.h"
 #include <WebCore/BackForwardItemIdentifier.h>
 #include <WebCore/CornerRadii.h>
+#include <WebCore/FrameIdentifier.h>
 #include <WebCore/FrameLoaderTypes.h>
+#include <WebCore/IntPointHash.h>
 #include <WebCore/PrivateClickMeasurement.h>
 #include <WebCore/RegistrableDomain.h>
 #include <WebCore/ResourceRequest.h>
@@ -293,6 +295,11 @@ public:
     HashMap<WebCore::SleepDisablerIdentifier, std::unique_ptr<WebCore::SleepDisabler>> sleepDisablers;
 
     HashMap<WebCore::BackForwardItemIdentifier, Vector<Ref<WebFrameProxy>>> pendingBackForwardCachedChildren;
+
+    // Each cross-origin remote frame's origin within its immediate parent frame, keyed by frame ID.
+    // Used to compute each frame's cumulative offset in main-frame coordinates (see
+    // WebPageProxy::updateRemoteFrameOffsetInMainFrame).
+    HashMap<WebCore::FrameIdentifier, WebCore::IntPoint> remoteFrameOffsetsInParent;
 
 #if ENABLE(APPLE_PAY)
     RefPtr<WebPaymentCoordinatorProxy> paymentCoordinator;

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -4407,10 +4407,9 @@ FOR_EACH_PRIVATE_WKCONTENTVIEW_ACTION(FORWARD_ACTION_TO_WKWEBVIEW)
         auto selectionContext = makeString(textBefore, selectedText, textAfter);
         NSRange selectedRangeInContext = NSMakeRange(textBefore.length(), selectedText.length());
 
-        page->convertEditorStateSelectionRectToMainFrameCoordinates(presentationRect, [view, selectionContext, selectedRangeInContext](WebCore::FloatRect convertedRect) {
-            if (auto textSelectionAssistant = view->_textInteractionWrapper)
-                [textSelectionAssistant lookup:selectionContext.createNSString().get() withRange:selectedRangeInContext fromRect:convertedRect];
-        });
+        // The editor state's selection rects are already in main-frame coordinates.
+        if (auto textSelectionAssistant = view->_textInteractionWrapper)
+            [textSelectionAssistant lookup:selectionContext.createNSString().get() withRange:selectedRangeInContext fromRect:presentationRect];
     });
 }
 
@@ -4436,9 +4435,8 @@ FOR_EACH_PRIVATE_WKCONTENTVIEW_ACTION(FORWARD_ACTION_TO_WKWEBVIEW)
         if (selectionGeometries.isEmpty())
             return;
 
-        page->convertEditorStateSelectionRectToMainFrameCoordinates(selectionGeometries.first().rect(), [view, string](WebCore::FloatRect convertedRect) {
-            [view->_textInteractionWrapper showShareSheetFor:string.createNSString().get() fromRect:convertedRect];
-        });
+        // The editor state's selection rects are already in main-frame coordinates.
+        [view->_textInteractionWrapper showShareSheetFor:string.createNSString().get() fromRect:selectionGeometries.first().rect()];
     });
 }
 
@@ -4466,9 +4464,8 @@ FOR_EACH_PRIVATE_WKCONTENTVIEW_ACTION(FORWARD_ACTION_TO_WKWEBVIEW)
         if (page->editorState().visualData->selectionGeometries.isEmpty())
             return;
 
-        page->convertEditorStateSelectionRectToMainFrameCoordinates(page->selectionBoundingRectInRootViewCoordinates(), [strongSelf, string](WebCore::FloatRect convertedRect) {
-            [strongSelf->_textInteractionWrapper translate:string.createNSString().get() fromRect:convertedRect];
-        });
+        // selectionBoundingRectInRootViewCoordinates() is already in main-frame coordinates.
+        [strongSelf->_textInteractionWrapper translate:string.createNSString().get() fromRect:page->selectionBoundingRectInRootViewCoordinates()];
     });
 }
 
@@ -4488,12 +4485,8 @@ FOR_EACH_PRIVATE_WKCONTENTVIEW_ACTION(FORWARD_ACTION_TO_WKWEBVIEW)
     if (selectionGeometries.isEmpty())
         return;
     RetainPtr selectedText = [self selectedText];
-    page->convertEditorStateSelectionRectToMainFrameCoordinates(selectionGeometries.first().rect(), [weakSelf = WeakObjCPtr<WKContentView>(self), selectedText](WebCore::FloatRect convertedRect) {
-        auto strongSelf = weakSelf.get();
-        if (!strongSelf)
-            return;
-        [strongSelf->_textInteractionWrapper showTextServiceFor:selectedText.get() fromRect:convertedRect];
-    });
+    // The editor state's selection rects are already in main-frame coordinates.
+    [_textInteractionWrapper showTextServiceFor:selectedText.get() fromRect:selectionGeometries.first().rect()];
 }
 
 - (NSString *)selectedText
@@ -5565,7 +5558,7 @@ static void selectionChangedWithTouch(WKTextInteractionWrapper *interaction, con
 
     _autocorrectionContextNeedsUpdate = YES;
     _usingGestureForSelection = YES;
-    protect(_page)->selectWithGesture(WebCore::IntPoint(point), toGestureType(gestureType), toGestureRecognizerState(state), self._hasFocusedElement, [self, strongSelf = retainPtr(self), state, flags](const WebCore::IntPoint& point, WebKit::GestureType gestureType, WebKit::GestureRecognizerState gestureState, OptionSet<WebKit::SelectionFlags> innerFlags) {
+    protect(_page)->selectWithGesture(std::nullopt, WebCore::IntPoint(point), toGestureType(gestureType), toGestureRecognizerState(state), self._hasFocusedElement, [self, strongSelf = retainPtr(self), state, flags](const WebCore::IntPoint& point, WebKit::GestureType gestureType, WebKit::GestureRecognizerState gestureState, OptionSet<WebKit::SelectionFlags> innerFlags) {
         selectionChangedWithGesture(_textInteractionWrapper.get(), point, gestureType, gestureState, toSelectionFlags(flags) | innerFlags);
         if (state == UIGestureRecognizerStateEnded || state == UIGestureRecognizerStateCancelled)
             _usingGestureForSelection = NO;
@@ -5946,7 +5939,7 @@ static void logTextInteraction(const char* methodName, UIGestureRecognizer *loup
     _usingMouseDragForSelection = [_mouseInteraction mouseTouchGestureRecognizer]._wk_hasRecognizedOrEnded;
 #endif
     ++_suppressNonEditableSingleTapTextInteractionCount;
-    protect(_page)->selectTextWithGranularityAtPoint(WebCore::IntPoint(point), toWKTextGranularity(granularity), self._hasFocusedElement, [view = retainPtr(self), selectionHandler = makeBlockPtr(completionHandler)] {
+    protect(_page)->selectTextWithGranularityAtPoint(std::nullopt, WebCore::IntPoint(point), toWKTextGranularity(granularity), self._hasFocusedElement, [view = retainPtr(self), selectionHandler = makeBlockPtr(completionHandler)] {
         selectionHandler();
         view->_usingGestureForSelection = NO;
         --view->_suppressNonEditableSingleTapTextInteractionCount;

--- a/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
@@ -1198,7 +1198,7 @@ void WebPageProxy::didUpdateEditorState(const EditorState& oldEditorState, const
     
     if (newEditorState.shouldIgnoreSelectionChanges)
         return;
-    
+
     updateFontAttributesAfterEditorStateChange();
     // We always need to notify the client on iOS to make sure the selection is redrawn,
     // even during composition to support phrase boundary gesture.
@@ -1298,18 +1298,6 @@ WebCore::FloatRect WebPageProxy::selectionBoundingRectInRootViewCoordinates() co
         bounds = visualData.caretRectAtStart;
 
     return bounds;
-}
-
-void WebPageProxy::convertEditorStateSelectionRectToMainFrameCoordinates(WebCore::FloatRect rect, CompletionHandler<void(WebCore::FloatRect)>&& completionHandler)
-{
-    if (!editorState().hasVisualData()) {
-        completionHandler(rect);
-        return;
-    }
-
-    convertRectToMainFrameCoordinates(rect, editorState().visualData->rootFrameID, [rect, completionHandler = WTF::move(completionHandler)](std::optional<WebCore::FloatRect> convertedRect) mutable {
-        completionHandler(convertedRect.value_or(rect));
-    });
 }
 
 void WebPageProxy::requestDocumentEditingContext(WebKit::DocumentEditingContextRequest&& request, CompletionHandler<void(WebKit::DocumentEditingContext&&)>&& completionHandler)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.cpp
@@ -151,10 +151,10 @@ void WebRemoteFrameClient::unbindRemoteAccessibilityFrames(int processIdentifier
 #endif
 }
 
-void WebRemoteFrameClient::updateRemoteFrameAccessibilityOffset(WebCore::FrameIdentifier frameID, WebCore::IntPoint offset)
+void WebRemoteFrameClient::updateRemoteFrameOffsetInMainFrame(WebCore::FrameIdentifier frameID, WebCore::IntPoint offset)
 {
     if (RefPtr page = m_frame->page())
-        page->send(Messages::WebPageProxy::UpdateRemoteFrameAccessibilityOffset(frameID, offset));
+        page->send(Messages::WebPageProxy::UpdateRemoteFrameOffsetInMainFrame(frameID, offset));
 }
 
 #if ENABLE(ACCESSIBILITY_LOCAL_FRAME)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.h
@@ -51,7 +51,7 @@ private:
     String layerTreeAsText(size_t baseIndent, OptionSet<WebCore::LayerTreeAsTextOptions>) final;
     void bindRemoteAccessibilityFrames(int processIdentifier, WebCore::FrameIdentifier, WebCore::AccessibilityRemoteToken, CompletionHandler<void(WebCore::AccessibilityRemoteToken, int)>&&) final;
     void unbindRemoteAccessibilityFrames(int) final;
-    void updateRemoteFrameAccessibilityOffset(WebCore::FrameIdentifier, WebCore::IntPoint) final;
+    void updateRemoteFrameOffsetInMainFrame(WebCore::FrameIdentifier, WebCore::IntPoint) final;
 #if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
     void updateRemoteFrameAccessibilityInheritedState(WebCore::FrameIdentifier, const WebCore::InheritedFrameState&) final;
 #endif

--- a/Source/WebKit/WebProcess/WebCoreSupport/cocoa/WebLocalFrameLoaderClientCocoa.mm
+++ b/Source/WebKit/WebProcess/WebCoreSupport/cocoa/WebLocalFrameLoaderClientCocoa.mm
@@ -37,7 +37,7 @@ using namespace WebCore;
 WebCore::IntPoint WebLocalFrameLoaderClient::accessibilityRemoteFrameOffset()
 {
     RefPtr webPage = m_frame->page();
-    return webPage ? webPage->accessibilityRemoteFrameOffset() : IntPoint();
+    return webPage ? webPage->remoteFrameOffsetInMainFrame() : IntPoint();
 }
 
 RemoteAXObjectRef WebLocalFrameLoaderClient::accessibilityRemoteObject()

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -2463,23 +2463,50 @@ bool WebPage::shouldAllowSingleClickToChangeSelection(WebCore::Node& targetNode,
     return true;
 }
 
-void WebPage::selectWithGesture(const IntPoint& point, GestureType gestureType, GestureRecognizerState gestureState, bool isInteractingWithFocusedElement, CompletionHandler<void(const WebCore::IntPoint&, GestureType, GestureRecognizerState, OptionSet<SelectionFlags>)>&& completionHandler)
+static std::optional<WebCore::RemoteUserInputEventData> remoteUserInputEventDataForSelectionGesture(WebCore::LocalFrame* localRootFrame, WebCore::IntPoint point)
+{
+    if (!localRootFrame)
+        return std::nullopt;
+
+    FloatPoint adjustedPoint;
+    RefPtr frameOwner = dynamicDowncast<HTMLFrameOwnerElement>(localRootFrame->nodeRespondingToClickEvents(point, adjustedPoint));
+    RefPtr remoteFrame = frameOwner ? dynamicDowncast<RemoteFrame>(frameOwner->contentFrame()) : nullptr;
+    if (!remoteFrame)
+        return std::nullopt;
+
+    RefPtr localRootView = localRootFrame->view();
+    RefPtr remoteFrameView = remoteFrame->view();
+    if (!localRootView || !remoteFrameView)
+        return std::nullopt;
+
+    RemoteFrameGeometryTransformer transformer(remoteFrameView.releaseNonNull(), localRootView.releaseNonNull(), remoteFrame->frameID());
+    return WebCore::RemoteUserInputEventData { remoteFrame->frameID(), transformer.transformToRemoteFrameCoordinates(FloatPoint { point }) };
+}
+
+void WebPage::selectWithGesture(std::optional<WebCore::FrameIdentifier> frameID, const IntPoint& point, GestureType gestureType, GestureRecognizerState gestureState, bool isInteractingWithFocusedElement, CompletionHandler<void(const WebCore::IntPoint&, GestureType, GestureRecognizerState, OptionSet<SelectionFlags>, std::optional<WebCore::RemoteUserInputEventData>)>&& completionHandler)
 {
     SetForScope userIsInteractingChange { m_userIsInteracting, true };
 
-    if (gestureState == GestureRecognizerState::Began)
-        updateFocusBeforeSelectingTextAtLocation(point);
+    RefPtr localRootFrame = this->localRootFrame(frameID);
 
-    RefPtr frame = m_page->focusController().focusedOrMainFrame();
+    if (auto remoteUserInputEventData = remoteUserInputEventDataForSelectionGesture(localRootFrame.get(), point)) {
+        completionHandler(point, gestureType, gestureState, { }, WTF::move(remoteUserInputEventData));
+        return;
+    }
+
+    if (gestureState == GestureRecognizerState::Began)
+        updateFocusBeforeSelectingTextAtLocation(frameID, point);
+
+    RefPtr<WebCore::LocalFrame> frame = frameID ? localRootFrame : RefPtr { m_page->focusController().focusedOrMainFrame() };
     if (!frame) {
-        completionHandler({ }, gestureType, gestureState, { });
+        completionHandler({ }, gestureType, gestureState, { }, std::nullopt);
         return;
     }
 
     VisiblePosition position = visiblePositionInFocusedNodeForPoint(*frame, point, isInteractingWithFocusedElement);
 
     if (position.isNull()) {
-        completionHandler(point, gestureType, gestureState, { });
+        completionHandler(point, gestureType, gestureState, { }, std::nullopt);
         return;
     }
     std::optional<SimpleRange> range;
@@ -2600,17 +2627,17 @@ void WebPage::selectWithGesture(const IntPoint& point, GestureType gestureType, 
     if (range)
         WTF::protect(frame->selection())->setSelectedRange(range, position.affinity(), WebCore::FrameSelection::ShouldCloseTyping::Yes, UserTriggered::Yes);
 
-    completionHandler(point, gestureType, gestureState, flags);
+    completionHandler(point, gestureType, gestureState, flags, std::nullopt);
 }
 
-void WebPage::updateFocusBeforeSelectingTextAtLocation(const IntPoint& point)
+void WebPage::updateFocusBeforeSelectingTextAtLocation(std::optional<WebCore::FrameIdentifier> frameID, const IntPoint& point)
 {
     static constexpr OptionSet hitType { HitTestRequest::Type::ReadOnly, HitTestRequest::Type::Active, HitTestRequest::Type::AllowVisibleChildFrameContentOnly };
-    RefPtr localMainFrame = m_page->localMainFrame();
-    if (!localMainFrame)
+    RefPtr localRootFrame = this->localRootFrame(frameID);
+    if (!localRootFrame)
         return;
 
-    auto result = localMainFrame->eventHandler().hitTestResultAtPoint(point, hitType);
+    auto result = localRootFrame->eventHandler().hitTestResultAtPoint(point, hitType);
     RefPtr hitNode = result.innerNode();
     if (!hitNode || !hitNode->renderer())
         return;
@@ -2750,7 +2777,7 @@ void WebPage::selectPositionAtPoint(WebCore::IntPoint point, bool isInteractingW
 {
     SetForScope userIsInteractingChange { m_userIsInteracting, true };
 
-    updateFocusBeforeSelectingTextAtLocation(point);
+    updateFocusBeforeSelectingTextAtLocation(std::nullopt, point);
 
     RefPtr frame = m_page->focusController().focusedOrMainFrame();
     if (!frame)
@@ -2790,11 +2817,11 @@ std::optional<SimpleRange> WebPage::rangeForGranularityAtPoint(LocalFrame& frame
     return std::nullopt;
 }
 
-void WebPage::setSelectionRange(WebCore::IntPoint point, WebCore::TextGranularity granularity, bool isInteractingWithFocusedElement)
+void WebPage::setSelectionRange(std::optional<WebCore::FrameIdentifier> frameID, WebCore::IntPoint point, WebCore::TextGranularity granularity, bool isInteractingWithFocusedElement)
 {
-    updateFocusBeforeSelectingTextAtLocation(point);
+    updateFocusBeforeSelectingTextAtLocation(frameID, point);
 
-    RefPtr frame = m_page->focusController().focusedOrMainFrame();
+    RefPtr<WebCore::LocalFrame> frame = frameID ? this->localRootFrame(frameID) : RefPtr { m_page->focusController().focusedOrMainFrame() };
     if (!frame)
         return;
 
@@ -2979,32 +3006,39 @@ void WebPage::cancelAutoscroll()
 #endif
 }
 
-void WebPage::selectTextWithGranularityAtPoint(WebCore::IntPoint point, WebCore::TextGranularity granularity, bool isInteractingWithFocusedElement, CompletionHandler<void()>&& completionHandler)
+void WebPage::selectTextWithGranularityAtPoint(std::optional<WebCore::FrameIdentifier> frameID, WebCore::IntPoint point, WebCore::TextGranularity granularity, bool isInteractingWithFocusedElement, CompletionHandler<void(std::optional<WebCore::RemoteUserInputEventData>)>&& completionHandler)
 {
     SetForScope userIsInteractingChange { m_userIsInteracting, true };
 
+    RefPtr localRootFrame = this->localRootFrame(frameID);
+
+    if (auto remoteUserInputEventData = remoteUserInputEventDataForSelectionGesture(localRootFrame.get(), point)) {
+        completionHandler(WTF::move(remoteUserInputEventData));
+        return;
+    }
+
 #if PLATFORM(IOS_FAMILY)
     if (!m_potentialTapNode) {
-        setSelectionRange(point, granularity, isInteractingWithFocusedElement);
-        completionHandler();
+        setSelectionRange(frameID, point, granularity, isInteractingWithFocusedElement);
+        completionHandler(std::nullopt);
         return;
     }
 
     if (auto selectionChangedHandler = std::exchange(m_selectionChangedHandler, { }))
         selectionChangedHandler();
 
-    m_selectionChangedHandler = [point, granularity, isInteractingWithFocusedElement, completionHandler = WTF::move(completionHandler), weakThis = WeakPtr { *this }]() mutable {
+    m_selectionChangedHandler = [frameID, point, granularity, isInteractingWithFocusedElement, completionHandler = WTF::move(completionHandler), weakThis = WeakPtr { *this }]() mutable {
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis) {
-            completionHandler();
+            completionHandler(std::nullopt);
             return;
         }
-        protectedThis->setSelectionRange(point, granularity, isInteractingWithFocusedElement);
-        completionHandler();
+        protectedThis->setSelectionRange(frameID, point, granularity, isInteractingWithFocusedElement);
+        completionHandler(std::nullopt);
     };
 #else
-    setSelectionRange(point, granularity, isInteractingWithFocusedElement);
-    completionHandler();
+    setSelectionRange(frameID, point, granularity, isInteractingWithFocusedElement);
+    completionHandler(std::nullopt);
 #endif
 }
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -1985,7 +1985,7 @@ void WebPage::resolveAccessibilityHitTestForTesting(WebCore::FrameIdentifier, co
     completionHandler({ });
 }
 
-void WebPage::updateRemotePageAccessibilityOffset(WebCore::FrameIdentifier, WebCore::IntPoint)
+void WebPage::updateRemotePageOffsetInMainFrame(WebCore::FrameIdentifier, WebCore::IntPoint)
 {
 }
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1113,20 +1113,20 @@ public:
 #if PLATFORM(COCOA)
     bool shouldAllowSingleClickToChangeSelection(WebCore::Node& targetNode, const WebCore::VisibleSelection& newSelection, WebCore::MouseEventInputSource);
     HashMap<WebCore::FrameIdentifier, WebCore::AttributedString> attributedStringsForRemoteFrames(WebCore::FrameIdentifier rootFrameIdentifier, const Vector<WebCore::FrameIdentifier>&);
-    void selectWithGesture(const WebCore::IntPoint&, GestureType, GestureRecognizerState, bool isInteractingWithFocusedElement, CompletionHandler<void(const WebCore::IntPoint&, GestureType, GestureRecognizerState, OptionSet<SelectionFlags>)>&&);
-    void updateFocusBeforeSelectingTextAtLocation(const WebCore::IntPoint&);
+    void selectWithGesture(std::optional<WebCore::FrameIdentifier>, const WebCore::IntPoint&, GestureType, GestureRecognizerState, bool isInteractingWithFocusedElement, CompletionHandler<void(const WebCore::IntPoint&, GestureType, GestureRecognizerState, OptionSet<SelectionFlags>, std::optional<WebCore::RemoteUserInputEventData>)>&&);
+    void updateFocusBeforeSelectingTextAtLocation(std::optional<WebCore::FrameIdentifier>, const WebCore::IntPoint&);
     WebCore::VisiblePosition visiblePositionInFocusedNodeForPoint(const WebCore::LocalFrame&, const WebCore::IntPoint&, bool isInteractingWithFocusedElement);
 
     void requestPositionInformation(const InteractionInformationRequest&);
     InteractionInformationAtPosition positionInformation(const InteractionInformationRequest&);
 
     std::optional<WebCore::SimpleRange> rangeForGranularityAtPoint(WebCore::LocalFrame&, const WebCore::IntPoint&, WebCore::TextGranularity, bool isInteractingWithFocusedElement);
-    void setSelectionRange(WebCore::IntPoint, WebCore::TextGranularity, bool);
+    void setSelectionRange(std::optional<WebCore::FrameIdentifier>, WebCore::IntPoint, WebCore::TextGranularity, bool);
 
     void selectPositionAtPoint(WebCore::IntPoint, bool isInteractingWithFocusedElement, CompletionHandler<void()>&&);
     void updateSelectionWithExtentPoint(WebCore::IntPoint, bool isInteractingWithFocusedElement, RespectSelectionAnchor, CompletionHandler<void(bool)>&&);
     void updateSelectionWithExtentPointAndBoundary(WebCore::IntPoint, WebCore::TextGranularity, bool isInteractingWithFocusedElement, TextInteractionSource, CompletionHandler<void(bool)>&&);
-    void selectTextWithGranularityAtPoint(WebCore::IntPoint, WebCore::TextGranularity, bool isInteractingWithFocusedElement, CompletionHandler<void()>&&);
+    void selectTextWithGranularityAtPoint(std::optional<WebCore::FrameIdentifier>, WebCore::IntPoint, WebCore::TextGranularity, bool isInteractingWithFocusedElement, CompletionHandler<void(std::optional<WebCore::RemoteUserInputEventData>)>&&);
 #endif // PLATFORM(COCOA)
 
 #if ENABLE(TWO_PHASE_CLICKS)
@@ -1346,7 +1346,7 @@ public:
     void registerUIProcessAccessibilityTokens(WebCore::AccessibilityRemoteToken elementToken, WebCore::AccessibilityRemoteToken windowToken);
     void registerRemoteFrameAccessibilityTokens(pid_t, WebCore::AccessibilityRemoteToken, WebCore::FrameIdentifier);
     WKAccessibilityWebPageObject* NODELETE accessibilityRemoteObject();
-    WebCore::IntPoint accessibilityRemoteFrameOffset();
+    WebCore::IntPoint remoteFrameOffsetInMainFrame();
     void createMockAccessibilityElement(pid_t);
     void sendAccessibilityTokenIfNeeded();
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
@@ -2773,7 +2773,7 @@ private:
     void layerTreeAsTextForTesting(WebCore::FrameIdentifier, uint64_t baseIndent, OptionSet<WebCore::LayerTreeAsTextOptions>, CompletionHandler<void(String&&)>&&);
     void frameTextForTesting(WebCore::FrameIdentifier, CompletionHandler<void(String&&)>&&);
     void bindRemoteAccessibilityFrames(int processIdentifier, WebCore::FrameIdentifier, WebCore::AccessibilityRemoteToken, CompletionHandler<void(WebCore::AccessibilityRemoteToken, int)>&&);
-    void updateRemotePageAccessibilityOffset(WebCore::FrameIdentifier, WebCore::IntPoint);
+    void updateRemotePageOffsetInMainFrame(WebCore::FrameIdentifier, WebCore::IntPoint);
 #if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
     void updateRemotePageAccessibilityInheritedState(WebCore::FrameIdentifier, const WebCore::InheritedFrameState&);
     void updateRemotePageAccessibilityScreenPosition(WebCore::FrameIdentifier, const WebCore::AXFrameGeometry&);
@@ -2913,6 +2913,14 @@ private:
 
     RetainPtr<WKAccessibilityWebPageObject> m_mockAccessibilityElement;
     bool m_needsAccessibilityTokenTransfer { false };
+
+    // This frame's content origin in top-level (main-frame) coordinates, pushed from the UI process
+    // (which accumulates each ancestor's origin) when this page hosts a cross-origin subframe. Used
+    // to convert selection rects to main-frame coordinates in the web process, and surfaced to
+    // accessibility via remoteFrameOffsetInMainFrame().
+    // FIXME (bug 320410): the accumulated offset does not yet account for scrolling of intermediate
+    // ancestor frames; only the innermost frame's own scroll is applied (during hit-testing).
+    WebCore::IntPoint m_remoteFrameOffsetInMainFrame;
 #endif
 
 #if HAVE(NSVIEW_CORNER_CONFIGURATION)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -70,12 +70,12 @@ messages -> WebPage WantsAsyncDispatchMessage {
     SetLastKnownMousePosition(WebCore::FrameIdentifier frameID, WebCore::DoublePoint eventPoint, WebCore::DoublePoint globalPoint, enum:uint8_t std::optional<WebCore::LastKnownMousePositionSource> source);
 
 #if PLATFORM(COCOA)
-    SelectWithGesture(WebCore::IntPoint point, enum:uint8_t WebKit::GestureType gestureType, enum:uint8_t WebKit::GestureRecognizerState gestureState, bool isInteractingWithFocusedElement) -> (WebCore::IntPoint point, enum:uint8_t WebKit::GestureType gestureType, enum:uint8_t WebKit::GestureRecognizerState gestureState, OptionSet<WebKit::SelectionFlags> flags)
+    SelectWithGesture(std::optional<WebCore::FrameIdentifier> frameID, WebCore::IntPoint point, enum:uint8_t WebKit::GestureType gestureType, enum:uint8_t WebKit::GestureRecognizerState gestureState, bool isInteractingWithFocusedElement) -> (WebCore::IntPoint point, enum:uint8_t WebKit::GestureType gestureType, enum:uint8_t WebKit::GestureRecognizerState gestureState, OptionSet<WebKit::SelectionFlags> flags, struct std::optional<WebCore::RemoteUserInputEventData> remoteUserInputEventData)
     RequestPositionInformation(struct WebKit::InteractionInformationRequest request)
     SelectPositionAtPoint(WebCore::IntPoint point, bool isInteractingWithFocusedElement) -> ()
     UpdateSelectionWithExtentPoint(WebCore::IntPoint point, bool isInteractingWithFocusedElement, enum:bool WebKit::RespectSelectionAnchor respectSelectionAnchor) -> (bool endIsMoving)
     UpdateSelectionWithExtentPointAndBoundary(WebCore::IntPoint point, enum:uint8_t WebCore::TextGranularity granularity, bool isInteractingWithFocusedElement, enum:uint8_t WebKit::TextInteractionSource sources) -> (bool endIsMoving)
-    SelectTextWithGranularityAtPoint(WebCore::IntPoint point, enum:uint8_t WebCore::TextGranularity granularity, bool isInteractingWithFocusedElement) -> ()
+    SelectTextWithGranularityAtPoint(std::optional<WebCore::FrameIdentifier> frameID, WebCore::IntPoint point, enum:uint8_t WebCore::TextGranularity granularity, bool isInteractingWithFocusedElement) -> (struct std::optional<WebCore::RemoteUserInputEventData> remoteUserInputEventData)
 #endif
 
 #if ENABLE(TWO_PHASE_CLICKS)
@@ -562,7 +562,7 @@ messages -> WebPage WantsAsyncDispatchMessage {
     CopyLinkWithHighlight()
 
     BindRemoteAccessibilityFrames(int processIdentifier, WebCore::FrameIdentifier frameID, struct WebCore::AccessibilityRemoteToken dataToken) -> (struct WebCore::AccessibilityRemoteToken token, int processIdentifier) Synchronous
-    UpdateRemotePageAccessibilityOffset(WebCore::FrameIdentifier frameID, WebCore::IntPoint offset);
+    UpdateRemotePageOffsetInMainFrame(WebCore::FrameIdentifier frameID, WebCore::IntPoint offset);
 #if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
     UpdateRemotePageAccessibilityInheritedState(WebCore::FrameIdentifier frameID, struct WebCore::InheritedFrameState state);
     UpdateRemotePageAccessibilityScreenPosition(WebCore::FrameIdentifier frameID, struct WebCore::AXFrameGeometry geometry);

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -460,6 +460,26 @@ void WebPage::getPlatformEditorState(LocalFrame& frame, EditorState& result) con
         if (shouldComputeEnclosingLayerID)
             computeEnclosingLayerID(result, selection);
     }
+
+    // When the selection is in a cross-origin subframe, the rects above are in this frame's local
+    // root-view coordinates. Offset them by the frame's origin within the top-level page (pushed from
+    // the parent process) so they're in main-frame coordinates, and UIKit reads the correct location
+    // synchronously without a UI-process round-trip.
+    if (auto& remoteFrameOffset = m_remoteFrameOffsetInMainFrame; !remoteFrameOffset.isZero()) {
+        auto offset = toIntSize(remoteFrameOffset);
+        auto moveGeometries = [&](Vector<SelectionGeometry>& geometries) {
+            for (auto& geometry : geometries)
+                geometry.move(offset.width(), offset.height());
+        };
+        visualData.caretRectAtStart.move(offset);
+        visualData.caretRectAtEnd.move(offset);
+        visualData.selectionClipRect.move(offset);
+        visualData.editableRootBounds.move(offset);
+        visualData.markedTextCaretRectAtStart.move(offset);
+        visualData.markedTextCaretRectAtEnd.move(offset);
+        moveGeometries(visualData.selectionGeometries);
+        moveGeometries(visualData.markedTextRects);
+    }
 }
 
 void WebPage::platformWillPerformEditingCommand()
@@ -722,14 +742,13 @@ void WebPage::getSelectionContext(CompletionHandler<void(const String&, const St
     completionHandler(selectedText, textBefore, textAfter);
 }
     
-void WebPage::updateRemotePageAccessibilityOffset(WebCore::FrameIdentifier, WebCore::IntPoint offset)
+void WebPage::updateRemotePageOffsetInMainFrame(WebCore::FrameIdentifier, WebCore::IntPoint offset)
 {
-#if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
-    // With local frame support, position data is sent from the UI process in frameScreenPosition.
-    UNUSED_PARAM(offset);
-#else
-    [protect(accessibilityRemoteObject()) setRemoteFrameOffset:offset];
-#endif
+    // Store the offset unconditionally (even when accessibility is not active) so that
+    // remoteFrameOffsetInMainFrame() returns it for both accessibility and selection; the latter is
+    // used by getPlatformEditorStateCommon() to convert selection rects to main-frame coordinates in
+    // the web process.
+    m_remoteFrameOffsetInMainFrame = offset;
 }
 
 static RetainPtr<NSDictionary> createAccessibillityTokenDictionary(WebCore::AccessibilityRemoteToken elementToken)
@@ -772,9 +791,9 @@ void WebPage::getDataSelectionForPasteboard(const String, CompletionHandler<void
     completionHandler({ });
 }
 
-WebCore::IntPoint WebPage::accessibilityRemoteFrameOffset()
+WebCore::IntPoint WebPage::remoteFrameOffsetInMainFrame()
 {
-    return [m_mockAccessibilityElement accessibilityRemoteFrameOffset];
+    return m_remoteFrameOffsetInMainFrame;
 }
 
 bool WebPage::platformCanHandleRequest(const WebCore::ResourceRequest& request)

--- a/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
@@ -471,7 +471,7 @@ bool WebPage::performNonEditingBehaviorForSelector(const String& selector, Keybo
     return didPerformAction;
 }
 
-void WebPage::updateRemotePageAccessibilityOffset(WebCore::FrameIdentifier, WebCore::IntPoint offset)
+void WebPage::updateRemotePageOffsetInMainFrame(WebCore::FrameIdentifier, WebCore::IntPoint offset)
 {
 #if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
     // With local frame support, position data is sent from the UI process in frameScreenPosition.
@@ -550,7 +550,7 @@ void WebPage::getDataSelectionForPasteboard(const String pasteboardType, Complet
     completionHandler(buffer.releaseNonNull());
 }
 
-WebCore::IntPoint WebPage::accessibilityRemoteFrameOffset()
+WebCore::IntPoint WebPage::remoteFrameOffsetInMainFrame()
 {
     return [m_mockAccessibilityElement accessibilityRemoteFrameOffset];
 }


### PR DESCRIPTION
#### 74c70a5bc37390b462456e98ffc3a00c6c8a172f
<pre>
[Site Isolation][iOS] Long tap does not select a word inside a cross-origin iframe
<a href="https://bugs.webkit.org/show_bug.cgi?id=320410">https://bugs.webkit.org/show_bug.cgi?id=320410</a>

Reviewed by Simon Fraser.

On iOS with site isolation enabled, text-selection gestures inside a cross-origin iframe were broken in
several ways because the gesture machinery assumed the selection target lived in the main frame&apos;s process:

  * Long-pressing text in a cross-origin iframe selected the whole iframe element in the parent frame
    instead of a word inside it, because the gesture was never routed into the subframe&apos;s process.
  * Focus never moved into the subframe: updateFocusBeforeSelectingTextAtLocation() used localMainFrame(),
    which is null in the subframe&apos;s process.
  * The selection highlight was drawn at the wrong offset, since the subframe reports selection rects in
    its own local root-view coordinates rather than offset by the iframe&apos;s position in the top-level page.
  * The highlight &quot;flashed&quot; at the wrong location on touch-down and only corrected on move/up, because
    UIKit reads selection rects synchronously mid-gesture, so any asynchronous UI-process coordinate
    conversion arrives too late.
  * After scrolling the iframe, tapping, clicking links, and selecting all hit-tested at the wrong location
    due to double conversions of coordinates.

Fixes: route selectWithGesture and selectTextWithGranularityAtPoint into the process containing the target
frame via RemoteUserInputEventData, fix focus to use localRootFrame(), and convert selection rects to
main-frame coordinates in the web process (rather than the UI process) so UIKit reads correct coordinates
synchronously. The web process obtains the frame&apos;s offset within the top-level page through a channel
pushed from the parent process.

The scrolling bug was a double-applied scroll offset: RemoteFrameGeometryTransformer converted a point all
the way to the remote frame&apos;s contents coordinates (via rootViewToContents()), but every consumer delivers
the transformed point into the remote frame&apos;s process as a root-view point and re-converts it with
rootViewToContents(), applying the remote frame&apos;s scroll offset a second time. Transform to the remote
frame&apos;s root-view coordinates (convertFromRootView()) instead, so scroll is applied exactly once during
hit-testing. This is the shared input transform, so it fixes tap, link activation, and selection alike.

Also rename the offset plumbing that was reusing the accessibility offset channel: the value it carries
(a remote frame&apos;s content origin in main-frame coordinates) is the same for accessibility and selection,
so drop the misleading &quot;Accessibility&quot; qualifier and store it unconditionally rather than only when
accessibility is active. The accessibility-specific WebCore client interface and the Mac accessibility
element accessor keep their existing names.

* LayoutTests/TestExpectations: Skip http/tests/site-isolation/ios by default.
* LayoutTests/http/tests/site-isolation/ios/long-press-selection-highlight-position-in-cross-origin-iframe-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/ios/long-press-selection-highlight-position-in-cross-origin-iframe.html: Added.
* LayoutTests/http/tests/site-isolation/ios/long-press-selects-word-in-cross-origin-iframe-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/ios/long-press-selects-word-in-cross-origin-iframe.html: Added.
* LayoutTests/http/tests/site-isolation/ios/long-press-selects-word-in-scrolled-cross-origin-iframe-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/ios/long-press-selects-word-in-scrolled-cross-origin-iframe.html: Added.
* LayoutTests/http/tests/site-isolation/resources/scrollable-selectable-text-frame.html: Added.
* LayoutTests/http/tests/site-isolation/resources/selectable-text-frame.html: Added.
* Source/WebCore/accessibility/AccessibilityScrollView.cpp: Updated for the rename.
(WebCore::AccessibilityScrollView::addRemoteFrameChild):
* Source/WebCore/page/RemoteFrame.cpp:
(WebCore::RemoteFrame::updateRemoteFrameOffsetInMainFrame): Renamed from
(WebCore::RemoteFrame::updateRemoteFrameAccessibilityOffset): Deleted.
updateRemoteFrameAccessibilityOffset.
* Source/WebCore/page/RemoteFrame.h:
* Source/WebCore/page/RemoteFrameClient.h: Ditto.
* Source/WebCore/page/RemoteFrameGeometryTransformer.cpp:
(WebCore::RemoteFrameGeometryTransformer::transformToRemoteFrameCoordinates const):
root-view coordinates instead of contents coordinates so the remote frame&apos;s scroll offset is not applied twice.
* Source/WebCore/page/RemoteFrameView.cpp:
(WebCore::RemoteFrameView::setFrameRect): Push the frame&apos;s origin in main-frame coordinates to its process.
* Source/WebKit/UIProcess/API/ios/WKWebViewTestingIOS.mm:
(-[WKWebView _selectionBoundingRectInMainFrameCoordinatesForTesting:]): Read the rect directly.
* Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm:
(WebKit::WebPageProxy::selectWithGesture):
(WebKit::WebPageProxy::selectTextWithGranularityAtPoint): Re-dispatch into the remote frame, reporting
the gesture point in content-view coordinates.
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::updateRemoteFrameOffsetInMainFrame): Renamed.
(WebKit::WebPageProxy::pushCumulativeOffsetInMainFrame):
(WebKit::WebPageProxy::updateRemoteFrameAccessibilityOffset): Deleted.
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.messages.in: Renamed message; added frame-routed selection.
* Source/WebKit/UIProcess/WebPageProxy.swift: Updated selection callers.
* Source/WebKit/UIProcess/WebPageProxyInternals.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm: Pass the target frame identifier; read converted
(-[WKContentView lookupForWebView:]):
(-[WKContentView shareForWebView:]):
(-[WKContentView translateForWebView:]):
(-[WKContentView addShortcutForWebView:]):
(-[WKContentView changeSelectionWithGestureAt:withGesture:withState:withFlags:]):
(-[WKContentView selectTextWithGranularity:atPoint:completionHandler:]):
rects from the editor state directly at the menu callsites.
* Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm: Removed the UI-process selection-rect conversion path in
(WebKit::WebPageProxy::didUpdateEditorState):
(WebKit::WebPageProxy::convertEditorStateSelectionRectToMainFrameCoordinates): Deleted.
favor of web-process conversion.
* Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.cpp:
(WebKit::WebRemoteFrameClient::updateRemoteFrameOffsetInMainFrame): Renamed.
(WebKit::WebRemoteFrameClient::updateRemoteFrameAccessibilityOffset): Deleted.
* Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.h:
* Source/WebKit/WebProcess/WebCoreSupport/cocoa/WebLocalFrameLoaderClientCocoa.mm:
(WebKit::WebLocalFrameLoaderClient::accessibilityRemoteFrameOffset): Call the renamed WebPage getter.
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::remoteUserInputEventDataForSelectionGesture):
(WebKit::WebPage::selectWithGesture):
(WebKit::WebPage::updateFocusBeforeSelectingTextAtLocation):
(WebKit::WebPage::selectPositionAtPoint):
(WebKit::WebPage::setSelectionRange): Use localRootFrame(frameID).
(WebKit::WebPage::selectTextWithGranularityAtPoint): Re-route to the remote subframe.
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::updateRemotePageOffsetInMainFrame): Renamed from
(WebKit::WebPage::updateRemotePageAccessibilityOffset): Deleted.
updateRemotePageAccessibilityOffset.
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::getPlatformEditorState const):
(WebKit::WebPage::updateRemotePageOffsetInMainFrame):
(WebKit::WebPage::remoteFrameOffsetInMainFrame): Renamed; store the offset unconditionally.
(WebKit::WebPage::updateRemotePageAccessibilityOffset): Deleted.
(WebKit::WebPage::accessibilityRemoteFrameOffset): Deleted.
* Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm:
(WebKit::WebPage::updateRemotePageOffsetInMainFrame):
(WebKit::WebPage::remoteFrameOffsetInMainFrame): Renamed.
(WebKit::WebPage::updateRemotePageAccessibilityOffset): Deleted.
(WebKit::WebPage::accessibilityRemoteFrameOffset): Deleted.

Canonical link: <a href="https://commits.webkit.org/318296@main">https://commits.webkit.org/318296@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b465cd41b920918b5f17d5d177f3b287941205cf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177855 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51793 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45587 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187465 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/141102 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179718 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53085 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51502 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138631 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/141102 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180811 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42173 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159377 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119094 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ba5ca278-9474-4b08-93a2-e92210cb7eba) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40836 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39184 "Found 1 new API test failure: TestWebKitAPI.SiteIsolation.MultiProcessBFCacheSameSiteWithCrossSiteIframeMultipleCycles (failure)") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151241 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38872 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35926 "Built successfully") | | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44384 "Found 1 new failure in wasm/WasmConstExprGenerator.cpp") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43420 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189894 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51460 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/158908 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147754 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52142 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35501 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147539 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26972 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42249 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124394 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118825 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50650 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13851 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50046 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50286 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50108 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->