### PR TITLE
Add a debug UI for the PDF HUD

### DIFF
--- a/Source/WebKit/UIProcess/PDF/WKPDFHUDView.swift
+++ b/Source/WebKit/UIProcess/PDF/WKPDFHUDView.swift
@@ -154,6 +154,18 @@ extension WKPDFHUDView {
         saveButton.target = self
         saveButton.action = #selector(saveAction)
 
+        // FIXME: Remove this compiler guard after the Safer C++ bots have Swift 6.4+.
+        #if compiler(>=6.4) && !SWIFT_WEBKIT_TOOLCHAIN
+        if let page = webView?._protectedPage().get(), page.preferences().compositingBordersVisible() {
+            wantsLayer = true
+            layer?.borderWidth = 3
+            layer?.borderColor = NSColor.systemOrange.cgColor
+            barView.wantsLayer = true
+            barView.layer?.borderWidth = 3
+            barView.layer?.borderColor = NSColor.systemPurple.cgColor
+        }
+        #endif
+
         resetHideTimer()
     }
 


### PR DESCRIPTION
#### 5eda8501c9c38260707f908d735ecda495bfb925
<pre>
Add a debug UI for the PDF HUD
<a href="https://bugs.webkit.org/show_bug.cgi?id=320413">https://bugs.webkit.org/show_bug.cgi?id=320413</a>
<a href="https://rdar.apple.com/183375736">rdar://183375736</a>

Reviewed by Richard Robinson and Megan Gardner.

This patch adds some simple debugging visuals for the PDF HUD to help
identify the relevant HUD frames. We key off of CompositingBordersVisible
to display the debug indicators.

We wrap the changes around Swift 6.4 and SWIFT_WEBKIT_TOOLCHAIN presence
-- minimum Swift version with the necessary C++ interop features and the
saferCpp bots (which set SWIFT_WEBKIT_TOOLCHAIN) are still on &lt; 6.4.

* Source/WebKit/UIProcess/PDF/WKPDFHUDView.swift:

Canonical link: <a href="https://commits.webkit.org/318069@main">https://commits.webkit.org/318069@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/922bae7a7c77f27c7beff4b68871f5ebdfc0c97c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177185 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51122 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44917 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186788 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140421 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3073a022-93a8-4b88-b26c-504f06484db6) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52415 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50808 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138061 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140421 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8df4f40a-ebf5-4a6e-b1fe-823b37303475) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180141 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41567 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158824 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118528 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2f08f604-2aac-43d0-a3ee-69b62baa7206) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40228 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38605 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150634 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38323 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35256 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42912 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/42827 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189214 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50789 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147148 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51472 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/34952 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146942 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26875 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41672 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123686 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117992 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49977 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13303 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49376 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49613 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49437 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->