### PR TITLE
Remove incorrect `NODELETE` annotation from `PropertySetCSSDescriptors::reattach()`

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/NoDeleteCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/NoDeleteCheckerExpectations
@@ -6,7 +6,6 @@ Modules/webtransport/WebTransportDatagramsWritable.cpp
 css/CSSComputedStyleDeclaration.cpp
 css/CSSPropertyInitialValues.cpp
 css/DOMMatrixReadOnly.cpp
-css/PropertySetCSSDescriptors.cpp
 css/SelectorChecker.cpp
 css/StyleSheetList.cpp
 css/parser/CSSPropertyParserConsumer+String.cpp

--- a/Source/WebCore/css/CSSFontFaceRule.cpp
+++ b/Source/WebCore/css/CSSFontFaceRule.cpp
@@ -73,7 +73,7 @@ void CSSFontFaceRule::reattach(StyleRuleBase& rule)
 {
     m_fontFaceRule = downcast<StyleRuleFontFace>(rule);
     if (m_propertiesCSSOMWrapper)
-        m_propertiesCSSOMWrapper->reattach(protect(m_fontFaceRule)->mutableProperties());
+        protect(m_propertiesCSSOMWrapper)->reattach(protect(protect(m_fontFaceRule)->mutableProperties()));
 }
 
 } // namespace WebCore

--- a/Source/WebCore/css/CSSPageRule.cpp
+++ b/Source/WebCore/css/CSSPageRule.cpp
@@ -89,7 +89,7 @@ void CSSPageRule::reattach(StyleRuleBase& rule)
 {
     m_pageRule = downcast<StyleRulePage>(rule);
     if (m_propertiesCSSOMWrapper)
-        m_propertiesCSSOMWrapper->reattach(m_pageRule.get().mutableProperties());
+        protect(m_propertiesCSSOMWrapper)->reattach(protect(m_pageRule.get().mutableProperties()));
 }
 
 } // namespace WebCore

--- a/Source/WebCore/css/CSSPositionTryRule.cpp
+++ b/Source/WebCore/css/CSSPositionTryRule.cpp
@@ -96,7 +96,7 @@ void CSSPositionTryRule::reattach(StyleRuleBase& rule)
 {
     m_positionTryRule = downcast<StyleRulePositionTry>(rule);
     if (RefPtr propertiesCSSOMWrapper = m_propertiesCSSOMWrapper)
-        propertiesCSSOMWrapper->reattach(protect(positionTryRule())->mutableProperties());
+        propertiesCSSOMWrapper->reattach(protect(protect(positionTryRule())->mutableProperties()));
 }
 
 String CSSPositionTryRule::name() const

--- a/Source/WebCore/css/PropertySetCSSDescriptors.h
+++ b/Source/WebCore/css/PropertySetCSSDescriptors.h
@@ -46,7 +46,7 @@ public:
     virtual ~PropertySetCSSDescriptors();
 
     void clearParentRule() { m_parentRule = nullptr; }
-    void NODELETE reattach(MutableStyleProperties&);
+    void reattach(MutableStyleProperties&);
 
     virtual StyleRuleType ruleType() const = 0;
 


### PR DESCRIPTION
#### b64f79b00305bf580132d795c6cbd1d3a2ad8ae0
<pre>
Remove incorrect `NODELETE` annotation from `PropertySetCSSDescriptors::reattach()`
<a href="https://bugs.webkit.org/show_bug.cgi?id=320417">https://bugs.webkit.org/show_bug.cgi?id=320417</a>
<a href="https://rdar.apple.com/183378247">rdar://183378247</a>

Reviewed by Chris Dumez.

Drop `NODELETE` from a function that destroys objects since it is a lie.

* Source/WebCore/SaferCPPExpectations/NoDeleteCheckerExpectations:
* Source/WebCore/css/CSSFontFaceRule.cpp:
(WebCore::CSSFontFaceRule::reattach):
* Source/WebCore/css/CSSPageRule.cpp:
(WebCore::CSSPageRule::reattach):
* Source/WebCore/css/CSSPositionTryRule.cpp:
(WebCore::CSSPositionTryRule::reattach):
* Source/WebCore/css/PropertySetCSSDescriptors.h:

Canonical link: <a href="https://commits.webkit.org/318054@main">https://commits.webkit.org/318054@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/039805e2d2b4c2f5fbfef2a2666f6549ceeedbcf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177118 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51055 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44850 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186721 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140354 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178981 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52348 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50741 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137995 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140354 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180074 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41510 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158766 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118462 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40166 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38536 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150576 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38265 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35189 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42831 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42754 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189147 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50722 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147083 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39544 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51405 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34889 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146876 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41611 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123619 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117906 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49910 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13245 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49309 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49546 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49370 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->