### PR TITLE
[JSC] Add an 8-byte SWAR fast path to JSON.stringify's stringCopyUpconvert for short strings

### DIFF
--- a/JSTests/microbenchmarks/json-stringify-short-strings-upconvert.js
+++ b/JSTests/microbenchmarks/json-stringify-short-strings-upconvert.js
@@ -1,0 +1,5 @@
+const value = { wide: "\u{1F600}" };
+for (let i = 0; i < 200; ++i)
+    value["abcdefgh" + i] = "ijklmnop" + i;
+for (let i = 0; i < 5e4; ++i)
+    JSON.stringify(value);

--- a/Source/JavaScriptCore/runtime/JSONObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSONObject.cpp
@@ -41,6 +41,7 @@
 #include "VMInlines.h"
 #include <charconv>
 #include <wtf/MathExtras.h>
+#include <wtf/UnalignedAccess.h>
 #include <wtf/dragonbox/dragonbox_to_chars.h>
 #include <wtf/text/EscapedFormsForJSON.h>
 #include <wtf/text/MakeString.h>
@@ -1161,9 +1162,18 @@ static ALWAYS_INLINE bool eightByteRangeNeedsJSONEscape(uint64_t word)
 template<typename CharType>
 static ALWAYS_INLINE uint64_t copyEightBytesAndLoad(const CharType* source, CharType* destination)
 {
-    uint64_t word;
-    memcpySpan(std::span<uint8_t, 8> { std::bit_cast<uint8_t*>(&word), 8 }, std::span<const CharType, 8> { source, 8 });
-    memcpySpan(std::span<CharType, 8> { destination, 8 }, std::span<const uint8_t, 8> { std::bit_cast<const uint8_t*>(&word), 8 });
+    uint64_t word = WTF::unalignedLoad<uint64_t>(source);
+    WTF::unalignedStore<uint64_t>(destination, word);
+    return word;
+}
+
+static ALWAYS_INLINE uint64_t upconvertEightBytesAndLoad(const Latin1Character* source, char16_t* destination)
+{
+    uint64_t word = WTF::unalignedLoad<uint64_t>(source);
+    uint64_t low = zeroExtendBytesToHalfwords(static_cast<uint32_t>(word));
+    uint64_t high = zeroExtendBytesToHalfwords(static_cast<uint32_t>(word >> 32));
+    WTF::unalignedStore<uint64_t>(destination, low);
+    WTF::unalignedStore<uint64_t>(destination + 4, high);
     return word;
 }
 
@@ -1271,6 +1281,17 @@ static ALWAYS_INLINE bool stringCopyUpconvert(std::span<const Latin1Character> s
         return SIMD::isNonZero(accumulated);
     }
 #endif
+    if (span.size() >= 8) {
+        const auto* ptr = span.data();
+        const auto* end = ptr + span.size();
+        auto* cursorEnd = cursor + span.size();
+        uint64_t accumulated = 0;
+        for (; ptr + 8 <= end; ptr += 8, cursor += 8)
+            accumulated |= eightByteRangeNeedsJSONEscape(upconvertEightBytesAndLoad(ptr, cursor));
+        if (ptr < end)
+            accumulated |= eightByteRangeNeedsJSONEscape(upconvertEightBytesAndLoad(end - 8, cursorEnd - 8));
+        return accumulated;
+    }
     for (auto character : span) {
         if (WTF::escapedFormsForJSON[character]) [[unlikely]]
             return true;

--- a/Source/WTF/wtf/MathExtras.h
+++ b/Source/WTF/wtf/MathExtras.h
@@ -368,6 +368,15 @@ constexpr bool hasZeroByte(T value)
     return (value - lowBits) & ~value & highBits;
 }
 
+// "Interleave bits by Binary Magic Numbers" at https://graphics.stanford.edu/~seander/bithacks.html.
+constexpr uint64_t zeroExtendBytesToHalfwords(uint32_t value)
+{
+    uint64_t result = value;
+    result = (result | (result << 16)) & 0x0000FFFF0000FFFFULL;
+    result = (result | (result << 8)) & 0x00FF00FF00FF00FFULL;
+    return result;
+}
+
 template<typename T>
 constexpr T divideRoundedUp(T a, T b)
 {

--- a/Tools/TestWebKitAPI/Tests/WTF/MathExtras.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/MathExtras.cpp
@@ -729,6 +729,38 @@ TEST(WTF, hasZeroByte)
     testHasZeroByte<uint64_t>();
 }
 
+TEST(WTF, zeroExtendBytesToHalfwords)
+{
+    auto referenceWiden = [](uint32_t value) -> uint64_t {
+        uint64_t result = 0;
+        for (unsigned i = 0; i < 4; ++i) {
+            uint8_t byte = static_cast<uint8_t>(value >> (i * 8));
+            result |= static_cast<uint64_t>(byte) << (i * 16);
+        }
+        return result;
+    };
+
+    EXPECT_EQ(zeroExtendBytesToHalfwords(0), 0ULL);
+    EXPECT_EQ(zeroExtendBytesToHalfwords(0xFFFFFFFFU), 0x00FF00FF00FF00FFULL);
+    EXPECT_EQ(zeroExtendBytesToHalfwords(0xDDCCBBAAU), 0x00DD00CC00BB00AAULL);
+
+    // Exhaustive per byte value at every position, with the other three bytes held to a
+    // clean nonzero pattern, matching testHasZeroByte's style above.
+    for (size_t position = 0; position < 4; ++position) {
+        for (unsigned byteValue = 0; byteValue <= 0xFF; ++byteValue) {
+            uint32_t word = 0;
+            for (size_t i = 0; i < 4; ++i)
+                word |= (i == position ? byteValue : 0x78) << (i * 8);
+            EXPECT_EQ(zeroExtendBytesToHalfwords(word), referenceWiden(word));
+        }
+    }
+
+    // A handful of full-width sampled values, cross-checked against the same reference.
+    static constexpr uint32_t samples[] = { 0x00000000, 0xFFFFFFFF, 0x01020304, 0x80808080, 0x7F7F7F7F, 0xA5A5A5A5, 0x12345678, 0xFF00FF00, 0x00FF00FF };
+    for (uint32_t sample : samples)
+        EXPECT_EQ(zeroExtendBytesToHalfwords(sample), referenceWiden(sample));
+}
+
 TEST(WTF, divideRoundedUp)
 {
     // Basic rounding behavior.


### PR DESCRIPTION
#### 1d355c27ea88a9e50184d16b7a76adb1ed6492bb
<pre>
[JSC] Add an 8-byte SWAR fast path to JSON.stringify&apos;s stringCopyUpconvert for short strings
<a href="https://bugs.webkit.org/show_bug.cgi?id=320419">https://bugs.webkit.org/show_bug.cgi?id=320419</a>
<a href="https://rdar.apple.com/183378922">rdar://183378922</a>

Reviewed by Yusuke Suzuki.

stringCopyUpconvert() is stringCopySameType()&apos;s Latin1-to-char16_t upconvert
sibling and has the same gap: a scalar byte-at-a-time fallback and a 16-byte
SIMD fast path, but nothing in between, so strings shorter than 16 bytes
always took the scalar loop.

Add the same 8-byte SWAR tier. Widening 4 packed Latin1 bytes into 4
char16_t lanes needs an extra step beyond stringCopySameType&apos;s plain copy,
so this adds WTF::zeroExtendBytesToHalfwords(), a small bit-doubling
&quot;spread&quot; helper, and reuses it instead of an 8-instruction unrolled
extract-and-store loop.

                                                   ToT                     Patched

json-stringify-short-strings-upconvert      174.2817+-5.1099     ^    144.8684+-5.8863        ^ definitely 1.2030x faster

Tests: JSTests/microbenchmarks/json-stringify-short-strings-upconvert.js
       Tools/TestWebKitAPI/Tests/WTF/MathExtras.cpp

Canonical link: <a href="https://commits.webkit.org/318078@main">https://commits.webkit.org/318078@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9687e9c2daeda0e990e15b9ce2c78bd4992ba7c4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177140 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51077 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44872 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186743 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140376 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/965d02f2-e23c-40e0-9750-8a3d1a52fcd3) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179003 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52370 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50763 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138022 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140376 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fb417128-a4a4-44bd-82e5-6c0e0cf35a2e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180096 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41531 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158790 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118489 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/08196c4f-c653-47c7-b9da-e4082df282f6) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40187 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38558 "Passed tests") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/251/builds/458 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/7294 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150597 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38289 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35211 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/38411 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42877 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42793 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189169 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50744 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147106 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51427 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34913 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146900 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26881 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41638 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123641 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117931 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49932 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13269 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49331 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49568 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49392 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->