### PR TITLE
[ iOS ] http/tests/site-isolation/fullscreen.html is a constant text failure

### DIFF
--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -8054,8 +8054,6 @@ fast/forms/input-password-logical-widths.html [ Failure ]
 # <rdar://160314418> Tap-and-half selection gesture is broken in WebKit
 editing/selection/ios/select-text-using-tap-and-half.html [ Skip ]
 
-webkit.org/b/296338 http/tests/site-isolation/fullscreen.html [ Pass Failure ]
-
 webkit.org/b/310677 [ Release ] compositing/iframes/overlapped-nested-iframes.html [ Pass Failure ]
 
 # webkit.org/b/296017 7x imported/w3c/web-platform-tests/css/css-shapes/shape-outside/shape-image/shape-image (layout-tests) are flakey image failures

--- a/LayoutTests/platform/ios/http/tests/site-isolation/fullscreen-expected.txt
+++ b/LayoutTests/platform/ios/http/tests/site-isolation/fullscreen-expected.txt
@@ -1,0 +1,15 @@
+supportsFullScreen() == true
+enterFullScreenForElement()
+beganEnterFullScreen() - initialRect.size: {300, 150}, finalRect.size: {800, 600}
+beganEnterFullScreen() - initialRect.origin: {8, 8}, finalRect.origin: {-8, -8}
+exitFullScreenForElement()
+beganExitFullScreen() - initialRect.size: {800, 600}, finalRect.size: {300, 150}
+beganExitFullScreen() - initialRect.origin: {-8, -8}, finalRect.origin: {8, 8}
+
+Size after entering fullscreen: 600x800
+iframe border style after transition: 0px none rgb(0, 0, 0)
+
+Size after exiting fullscreen: 150x300
+iframe border style after transition: 0px inset rgb(0, 0, 0)
+
+


### PR DESCRIPTION
#### 4a95db7eb32a0e6f00a76fad355d5e71b8bdceaa
<pre>
[ iOS ] http/tests/site-isolation/fullscreen.html is a constant text failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=320421">https://bugs.webkit.org/show_bug.cgi?id=320421</a>
<a href="https://rdar.apple.com/156429277">rdar://156429277</a>

Reviewed by Alex Christensen.

The generic expected result records beganEnterFullScreen()/beganExitFullScreen() origins of
{8, 442}, which is the fullscreen element&apos;s position in macOS AppKit bottom-left screen coordinates
(600 - 8 - 150 = 442). iOS uses a top-left coordinate system, so the same cross-origin iframe at
page offset (8, 8) is reported as {8, 8}. iOS therefore produced a deterministic text mismatch
against the macOS baseline (50/50 locally) rather than a genuine flake.

Add an iOS-specific baseline with the correct top-left coordinates and remove the Pass/Failure
expectation so the test is enforced on iOS.

* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/ios/http/tests/site-isolation/fullscreen-expected.txt: Added.

Canonical link: <a href="https://commits.webkit.org/318084@main">https://commits.webkit.org/318084@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/850db5b8aab4a53488152f4f4f5fcdb877abe0c4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177125 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51062 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44857 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186728 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140361 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9eddf7a9-99e5-4188-b97e-a6bf8096a000) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52355 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50748 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138006 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140361 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d42805c0-8d98-415f-8dd3-72d7f8c98ba7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180081 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41508 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158769 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118473 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/50c62157-0e24-4ffe-822c-e5aaae7c746c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40164 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38540 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150574 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38268 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35196 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42758 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189154 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50729 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147089 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39559 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51412 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34892 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146882 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41617 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117913 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49917 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13248 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49316 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49553 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49377 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->