### PR TITLE
WebTransport: resolve pending promise when a connection or group is cancelled before becoming ready

### DIFF
--- a/Source/WebKit/NetworkProcess/webtransport/cocoa/NetworkTransportSessionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/webtransport/cocoa/NetworkTransportSessionCocoa.mm
@@ -376,7 +376,9 @@ void NetworkTransportSession::initialize(CompletionHandler<void(std::optional<We
             }
             return creationCompletionHandler(std::nullopt);
         case nw_connection_group_state_cancelled:
-            return;
+            // A group cancelled before it became ready must still resolve the completion
+            // handler, otherwise the captured one-shot CompletionHandler is destroyed uncalled.
+            return creationCompletionHandler(std::nullopt);
         }
         RELEASE_ASSERT_NOT_REACHED();
     }).get());

--- a/Source/WebKit/NetworkProcess/webtransport/cocoa/NetworkTransportStreamCocoa.mm
+++ b/Source/WebKit/NetworkProcess/webtransport/cocoa/NetworkTransportStreamCocoa.mm
@@ -61,7 +61,12 @@ void NetworkTransportStream::start(NetworkTransportStreamReadyHandler&& readyHan
         case nw_connection_state_invalid:
         case nw_connection_state_waiting:
         case nw_connection_state_preparing:
+            return;
         case nw_connection_state_cancelled:
+            // A connection cancelled before it became ready must still resolve the ready
+            // handler, otherwise the captured one-shot CompletionHandler is destroyed uncalled.
+            if (readyHandler)
+                readyHandler(std::nullopt);
             return;
         case nw_connection_state_ready: {
             if (!protectedThis)


### PR DESCRIPTION
#### 2d530bfeaa4658acd955ed694afa41d2d1a4aebb
<pre>
WebTransport: resolve pending promise when a connection or group is cancelled before becoming ready
<a href="https://bugs.webkit.org/show_bug.cgi?id=320424">https://bugs.webkit.org/show_bug.cgi?id=320424</a>

Reviewed by Alex Christensen.

The Network.framework state-changed handlers for a WebTransport stream connection and
for the session&apos;s connection group treated the terminal nw_connection_state_cancelled /
nw_connection_group_state_cancelled transition as a silent return, without invoking the
one-shot CompletionHandler they had captured.

When a session or stream is cancelled before it ever reaches the ready state -- e.g. the
page calls WebTransport.close() (or creates then tears down a stream) while the QUIC
connection is still being established -- terminate() cancels the underlying nw_connection /
nw_connection_group, the cancelled state is delivered, and the captured handler is never
called. When Network.framework later releases the block, the CompletionHandler is destroyed
uncalled: an assertion failure in debug builds, and in release builds a never-settled IPC
async reply, leaving the corresponding JS promise (WebTransport.ready,
createBidirectionalStream()) pending until the whole connection is torn down.

Handle the cancelled transition the same way the datagram connection already does: resolve
the handler with a failure result. NetworkTransportStream::start calls readyHandler(nullopt)
when it is still pending (guarded like the existing failed branch, since cancelled can also
fire after ready/failed during normal teardown), which also covers the createStream reply
captured inside that handler. NetworkTransportSession::initialize calls
creationCompletionHandler(nullopt), which already self-guards against being called twice.

* Source/WebKit/NetworkProcess/webtransport/cocoa/NetworkTransportSessionCocoa.mm:
(WebKit::NetworkTransportSession::initialize):
* Source/WebKit/NetworkProcess/webtransport/cocoa/NetworkTransportStreamCocoa.mm:
(WebKit::NetworkTransportStream::start):

Canonical link: <a href="https://commits.webkit.org/318131@main">https://commits.webkit.org/318131@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cf3b21ada8145db466cb83530850712795b3ab3c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177130 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51067 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44862 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186733 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140366 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8223856f-1204-4ef8-9b43-8edc0f2b476f) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52360 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50753 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138011 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140366 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f7149009-292b-432a-8fd8-6bfdf663f104) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180086 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41513 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158771 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118478 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2f15d31b-54f5-4428-a74e-1cde4dc53aaf) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40169 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38545 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150579 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38270 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35201 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42844 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42763 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189159 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50734 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147095 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39586 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51417 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34894 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/bfcache/held.tentative.https.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146888 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41621 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123631 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117918 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49922 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13250 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49321 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49558 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49382 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->