### PR TITLE
[WebTransport] WPT failure: Close and abort unidirectional stream

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/streams-close.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/streams-close.https.any-expected.txt
@@ -5,7 +5,7 @@ PASS Close outgoing stream / uni
 PASS Abort client-created bidirectional stream
 PASS Abort server-initiated bidirectional stream
 PASS Abort unidirectional stream with WebTransportError
-FAIL Close and abort unidirectional stream assert_unreached: Should have rejected: close_promise Reached unreachable code
+FAIL Close and abort unidirectional stream assert_own_property: expected property "stream-close-info" missing
 PASS Abort unidirectional stream with default error code
 PASS STOP_SENDING coming from server
 PASS RESET_STREAM coming from server

--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/streams-close.https.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/streams-close.https.any.serviceworker-expected.txt
@@ -5,7 +5,7 @@ PASS Close outgoing stream / uni
 PASS Abort client-created bidirectional stream
 PASS Abort server-initiated bidirectional stream
 PASS Abort unidirectional stream with WebTransportError
-FAIL Close and abort unidirectional stream assert_unreached: Should have rejected: close_promise Reached unreachable code
+PASS Close and abort unidirectional stream
 PASS Abort unidirectional stream with default error code
 PASS STOP_SENDING coming from server
 PASS RESET_STREAM coming from server

--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/streams-close.https.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/streams-close.https.any.sharedworker-expected.txt
@@ -5,7 +5,7 @@ PASS Close outgoing stream / uni
 PASS Abort client-created bidirectional stream
 PASS Abort server-initiated bidirectional stream
 PASS Abort unidirectional stream with WebTransportError
-FAIL Close and abort unidirectional stream assert_unreached: Should have rejected: close_promise Reached unreachable code
+PASS Close and abort unidirectional stream
 PASS Abort unidirectional stream with default error code
 PASS STOP_SENDING coming from server
 PASS RESET_STREAM coming from server

--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/streams-close.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/streams-close.https.any.worker-expected.txt
@@ -5,7 +5,7 @@ PASS Close outgoing stream / uni
 PASS Abort client-created bidirectional stream
 PASS Abort server-initiated bidirectional stream
 PASS Abort unidirectional stream with WebTransportError
-FAIL Close and abort unidirectional stream assert_unreached: Should have rejected: close_promise Reached unreachable code
+PASS Close and abort unidirectional stream
 PASS Abort unidirectional stream with default error code
 PASS STOP_SENDING coming from server
 PASS RESET_STREAM coming from server

--- a/Source/WebCore/Modules/filesystem/FileSystemWritableFileStreamSink.cpp
+++ b/Source/WebCore/Modules/filesystem/FileSystemWritableFileStreamSink.cpp
@@ -183,12 +183,13 @@ void FileSystemWritableFileStreamSink::write(ScriptExecutionContext& context, JS
     }
 }
 
-void FileSystemWritableFileStreamSink::close(JSDOMGlobalObject&)
+void FileSystemWritableFileStreamSink::close(JSDOMGlobalObject&, DOMPromiseDeferred<void>&& promise)
 {
     ASSERT(!m_isClosed);
 
     m_isClosed = true;
     protect(m_source)->closeWritable(m_identifier, FileSystemWriteCloseReason::Completed);
+    promise.resolve();
 }
 
 void FileSystemWritableFileStreamSink::abort(JSDOMGlobalObject&, JSC::JSValue, DOMPromiseDeferred<void>&& promise)

--- a/Source/WebCore/Modules/filesystem/FileSystemWritableFileStreamSink.h
+++ b/Source/WebCore/Modules/filesystem/FileSystemWritableFileStreamSink.h
@@ -41,7 +41,7 @@ private:
 
     // WritableStreamSink
     void write(ScriptExecutionContext&, JSC::JSValue, DOMPromiseDeferred<void>&&) final;
-    void close(JSDOMGlobalObject&) final;
+    void close(JSDOMGlobalObject&, DOMPromiseDeferred<void>&&) final;
     void abort(JSDOMGlobalObject&, JSC::JSValue, DOMPromiseDeferred<void>&&) final;
 
     FileSystemWritableFileStreamIdentifier m_identifier;

--- a/Source/WebCore/Modules/mediastream/VideoTrackGenerator.cpp
+++ b/Source/WebCore/Modules/mediastream/VideoTrackGenerator.cpp
@@ -209,17 +209,17 @@ void VideoTrackGenerator::Sink::write(ScriptExecutionContext&, JSC::JSValue valu
     promise.resolve();
 }
 
-void VideoTrackGenerator::Sink::close(JSDOMGlobalObject&)
+void VideoTrackGenerator::Sink::close(JSDOMGlobalObject&, DOMPromiseDeferred<void>&& promise)
 {
     callOnMainThread([source = m_source] {
         source->endImmediatly();
     });
+    promise.resolve();
 }
 
 void VideoTrackGenerator::Sink::abort(JSDOMGlobalObject& globalObject, JSC::JSValue, DOMPromiseDeferred<void>&& promise)
 {
-    close(globalObject);
-    promise.resolve();
+    close(globalObject, WTF::move(promise));
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/mediastream/VideoTrackGenerator.h
+++ b/Source/WebCore/Modules/mediastream/VideoTrackGenerator.h
@@ -90,7 +90,7 @@ private:
         explicit Sink(Ref<Source>&&);
 
         void write(ScriptExecutionContext&, JSC::JSValue, DOMPromiseDeferred<void>&&) final;
-        void close(JSDOMGlobalObject&) final;
+        void close(JSDOMGlobalObject&, DOMPromiseDeferred<void>&&) final;
         void abort(JSDOMGlobalObject&, JSC::JSValue, DOMPromiseDeferred<void>&&) final;
 
         bool m_muted { false };

--- a/Source/WebCore/Modules/streams/StreamTransferUtilities.cpp
+++ b/Source/WebCore/Modules/streams/StreamTransferUtilities.cpp
@@ -342,10 +342,11 @@ private:
             promise.resolve();
         });
     }
-    void close(JSDOMGlobalObject& globalObject) final
+    void close(JSDOMGlobalObject& globalObject, DOMPromiseDeferred<void>&& promise) final
     {
         packAndPostMessage(globalObject, m_port, "close"_s, JSC::jsUndefined());
         m_port->close();
+        promise.resolve();
     }
     void abort(JSDOMGlobalObject& globalObject, JSC::JSValue reason, DOMPromiseDeferred<void>&& promise) final
     {

--- a/Source/WebCore/Modules/streams/WritableStreamSink.cpp
+++ b/Source/WebCore/Modules/streams/WritableStreamSink.cpp
@@ -27,6 +27,8 @@
 #include "config.h"
 #include "WritableStreamSink.h"
 
+#include "AbortSignal.h"
+#include "JSAbortSignal.h"
 #include "JSDOMPromiseDeferred.h"
 #include "JSWritableStreamDefaultController.h"
 #include "JSWritableStreamSink.h"
@@ -52,11 +54,24 @@ public:
 
     void errorIfNeeded(JSC::JSGlobalObject&, JSC::JSValue);
     JSWritableStreamDefaultController* NODELETE jsController() { return m_jsController; }
+    RefPtr<AbortSignal> signal() const;
 
 private:
     // The owner of WritableStreamDefaultController is responsible to keep uncollected the JSWritableStreamDefaultController.
     JSWritableStreamDefaultController* m_jsController { nullptr };
 };
+
+RefPtr<AbortSignal> WritableStreamDefaultController::signal() const
+{
+    if (!m_jsController)
+        return nullptr;
+
+    Ref vm = m_jsController->vm();
+    JSC::JSLockHolder lock(vm.get());
+    auto signalValue = m_jsController->getDirect(vm, builtinNames(vm.get()).signalPrivateName());
+    auto* jsSignal = dynamicDowncast<JSAbortSignal>(signalValue);
+    return jsSignal ? RefPtr { &jsSignal->wrapped() } : nullptr;
+}
 
 static bool invokeWritableStreamDefaultControllerFunction(JSC::JSGlobalObject& lexicalGlobalObject, const JSC::Identifier& identifier, const JSC::MarkedArgumentBuffer& arguments)
 {
@@ -87,6 +102,11 @@ void WritableStreamSink::start(std::unique_ptr<WritableStreamDefaultController>&
     m_controller = WTF::move(controller);
 }
 
+RefPtr<AbortSignal> WritableStreamSink::abortSignal() const
+{
+    return m_controller ? m_controller->signal() : nullptr;
+}
+
 void WritableStreamSink::errorIfNeeded(JSC::JSGlobalObject& globalObject, JSC::JSValue error)
 {
     Ref vm = globalObject.vm();
@@ -111,6 +131,11 @@ SimpleWritableStreamSink::SimpleWritableStreamSink(WriteCallback&& writeCallback
 void SimpleWritableStreamSink::write(ScriptExecutionContext& context, JSC::JSValue value, DOMPromiseDeferred<void>&& promise)
 {
     promise.settle(m_writeCallback(context, value));
+}
+
+void SimpleWritableStreamSink::close(JSDOMGlobalObject&, DOMPromiseDeferred<void>&& promise)
+{
+    promise.resolve();
 }
 
 JSC::JSValue JSWritableStreamSink::start(JSC::JSGlobalObject& globalObject, JSC::CallFrame& callFrame)

--- a/Source/WebCore/Modules/streams/WritableStreamSink.h
+++ b/Source/WebCore/Modules/streams/WritableStreamSink.h
@@ -39,6 +39,7 @@ class JSGlobalObject;
 
 namespace WebCore {
 
+class AbortSignal;
 class JSDOMGlobalObject;
 class ScriptExecutionContext;
 template<typename> class ExceptionOr;
@@ -49,15 +50,19 @@ class WritableStreamSink : public RefCounted<WritableStreamSink> {
 public:
     virtual ~WritableStreamSink();
 
-    void start(std::unique_ptr<WritableStreamDefaultController>&&);
+    virtual void start(std::unique_ptr<WritableStreamDefaultController>&&);
     virtual void write(ScriptExecutionContext&, JSC::JSValue, DOMPromiseDeferred<void>&&) = 0;
-    virtual void close(JSDOMGlobalObject&) = 0;
+    virtual void close(JSDOMGlobalObject&, DOMPromiseDeferred<void>&&) = 0;
     virtual void abort(JSDOMGlobalObject&, JSC::JSValue, DOMPromiseDeferred<void>&&);
 
     void errorIfNeeded(JSC::JSGlobalObject&, JSC::JSValue);
 
 protected:
     WritableStreamSink();
+
+    // The AbortSignal owned by the associated WritableStreamDefaultController, if any.
+    // Fired synchronously when the stream is aborted, before the abort algorithm runs.
+    RefPtr<AbortSignal> abortSignal() const;
 
 private:
     std::unique_ptr<WritableStreamDefaultController> m_controller;
@@ -72,7 +77,7 @@ private:
     explicit SimpleWritableStreamSink(WriteCallback&&);
 
     void write(ScriptExecutionContext&, JSC::JSValue, DOMPromiseDeferred<void>&&) final;
-    void close(JSDOMGlobalObject&) final { }
+    void close(JSDOMGlobalObject&, DOMPromiseDeferred<void>&&) final;
 
     WriteCallback m_writeCallback;
 };

--- a/Source/WebCore/Modules/streams/WritableStreamSink.idl
+++ b/Source/WebCore/Modules/streams/WritableStreamSink.idl
@@ -30,7 +30,7 @@
 ] interface WritableStreamSink {
     [Custom] undefined start(WritableStreamDefaultController controller);
     [CallWith=CurrentScriptExecutionContext] Promise<undefined> write(any value);
-    [CallWith=CurrentGlobalObject] undefined close();
+    [CallWith=CurrentGlobalObject] Promise<undefined> close();
     [CallWith=CurrentGlobalObject] Promise<undefined> abort(any reason);
 
     // Place holder to keep the controller linked to the source.

--- a/Source/WebCore/Modules/webtransport/DatagramSink.cpp
+++ b/Source/WebCore/Modules/webtransport/DatagramSink.cpp
@@ -123,4 +123,10 @@ void DatagramSink::write(ScriptExecutionContext& context, JSC::JSValue value, DO
     });
 }
 
+void DatagramSink::close(JSDOMGlobalObject&, DOMPromiseDeferred<void>&& promise)
+{
+    m_isClosed = true;
+    promise.resolve();
+}
+
 }

--- a/Source/WebCore/Modules/webtransport/DatagramSink.h
+++ b/Source/WebCore/Modules/webtransport/DatagramSink.h
@@ -47,7 +47,7 @@ private:
     explicit DatagramSink(WebTransport*);
 
     void write(ScriptExecutionContext&, JSC::JSValue, DOMPromiseDeferred<void>&&) final;
-    void close(JSDOMGlobalObject&) final { m_isClosed = true; }
+    void close(JSDOMGlobalObject&, DOMPromiseDeferred<void>&&) final;
 
     void datagramSent();
     void resolveBufferedDatagramsWithRoom();

--- a/Source/WebCore/Modules/webtransport/WebTransportSendStreamSink.cpp
+++ b/Source/WebCore/Modules/webtransport/WebTransportSendStreamSink.cpp
@@ -26,6 +26,8 @@
 #include "config.h"
 #include "WebTransportSendStreamSink.h"
 
+#include "AbortSignal.h"
+#include "EventLoop.h"
 #include "Exception.h"
 #include "IDLTypes.h"
 #include "JSDOMConvertBufferSource.h"
@@ -50,7 +52,26 @@ WebTransportSendStreamSink::WebTransportSendStreamSink(WebTransport& transport, 
 {
 }
 
-WebTransportSendStreamSink::~WebTransportSendStreamSink() = default;
+WebTransportSendStreamSink::~WebTransportSendStreamSink()
+{
+    if (m_abortSignal && m_abortAlgorithmIdentifier)
+        protect(m_abortSignal)->removeAlgorithm(*m_abortAlgorithmIdentifier);
+}
+
+void WebTransportSendStreamSink::start(std::unique_ptr<WritableStreamDefaultController>&& controller)
+{
+    WritableStreamSink::start(WTF::move(controller));
+
+    // The abort signal fires synchronously during writer.abort(), before the abort() algorithm runs,
+    // so observing it is the only way to cancel an in-flight close().
+    if (RefPtr signal = abortSignal()) {
+        m_abortAlgorithmIdentifier = signal->addAlgorithm([weakThis = WeakPtr { *this }](JSC::JSValue reason) {
+            if (RefPtr protectedThis = weakThis.get())
+                protectedThis->cancel(reason);
+        });
+        m_abortSignal = WTF::move(signal);
+    }
+}
 
 RefPtr<WritableStream> WebTransportSendStreamSink::stream() const
 {
@@ -104,35 +125,76 @@ void WebTransportSendStreamSink::write(ScriptExecutionContext& context, JSC::JSV
     });
 }
 
-void WebTransportSendStreamSink::close(JSDOMGlobalObject&)
+// https://w3c.github.io/webtransport/#webtransportsendstream-close
+void WebTransportSendStreamSink::close(JSDOMGlobalObject& globalObject, DOMPromiseDeferred<void>&& promise)
 {
-    if (m_isClosed)
-        return;
+    if (m_isClosed || m_isCancelled)
+        return promise.reject(Exception { ExceptionCode::InvalidStateError });
     m_isClosed = true;
 
-    if (RefPtr transport = m_transport.get()) {
-        transport->session()->streamSendBytes(m_identifier, { }, true);
-        transport->sendStreamClosed(m_identifier);
-    }
+    RefPtr context = globalObject.scriptExecutionContext();
+    if (!context)
+        return promise.reject(Exception { ExceptionCode::InvalidStateError });
+
+    m_closeDeferred = makeUnique<DOMPromiseDeferred<void>>(WTF::move(promise));
+
+    // Defer the FIN so a racing abort() can suppress it and reset the stream instead.
+    // FIXME: Validate this abort-after-close behavior. https://bugs.webkit.org/show_bug.cgi?id=320232
+    protect(context->eventLoop())->queueTask(TaskSource::Networking, [protectedThis = Ref { *this }, context = Ref { *context }] {
+        protectedThis->sendFin(context.get());
+    });
 }
 
-void WebTransportSendStreamSink::abort(JSDOMGlobalObject&, JSC::JSValue value, DOMPromiseDeferred<void>&& promise)
+void WebTransportSendStreamSink::sendFin(ScriptExecutionContext& context)
 {
-    auto scope = makeScopeExit([&promise] {
-        promise.resolve();
-    });
+    if (m_isCancelled || !m_closeDeferred)
+        return;
 
+    RefPtr transport = m_transport.get();
+    RefPtr session = transport ? transport->session().ptr() : nullptr;
+    if (!transport || !session)
+        return std::exchange(m_closeDeferred, nullptr)->reject(Exception { ExceptionCode::InvalidStateError });
+
+    transport->sendStreamClosed(m_identifier);
+    context.enqueueTaskWhenSettled(session->streamSendBytes(m_identifier, { }, true), TaskSource::Networking, [protectedThis = Ref { *this }] (auto&& exception) mutable {
+        auto deferred = std::exchange(protectedThis->m_closeDeferred, nullptr);
+        if (!deferred)
+            return;
+        if (!exception)
+            return deferred->reject(Exception { ExceptionCode::NetworkError });
+        if (*exception)
+            return deferred->reject(WTF::move(**exception));
+        deferred->resolve();
+    });
+}
+
+void WebTransportSendStreamSink::abort(JSDOMGlobalObject&, JSC::JSValue reason, DOMPromiseDeferred<void>&& promise)
+{
+    cancel(reason);
+    promise.resolve();
+}
+
+void WebTransportSendStreamSink::cancel(JSC::JSValue reason)
+{
     if (m_isCancelled)
         return;
     m_isCancelled = true;
 
+    // Reject an in-flight close() so its promise rejects rather than resolving after the FIN.
+    if (auto deferred = std::exchange(m_closeDeferred, nullptr)) {
+        deferred->rejectWithCallback([reason](JSDOMGlobalObject&) {
+            return reason;
+        });
+    }
+
     RefPtr transport = m_transport.get();
     if (!transport)
         return;
+
     transport->sendStreamClosed(m_identifier);
 
     std::optional<uint64_t> errorCode;
-    if (auto* jsWebTransportError = dynamicDowncast<JSWebTransportError>(value)) {
+    if (auto* jsWebTransportError = dynamicDowncast<JSWebTransportError>(reason)) {
         auto& webTransportError = jsWebTransportError->wrapped();
         if (auto webTransportErrorCode = webTransportError.streamErrorCode())
             errorCode = static_cast<uint64_t>(*webTransportErrorCode);

--- a/Source/WebCore/Modules/webtransport/WebTransportSendStreamSink.h
+++ b/Source/WebCore/Modules/webtransport/WebTransportSendStreamSink.h
@@ -35,10 +35,11 @@ namespace WebCore {
 struct WebTransportStreamIdentifierType;
 using WebTransportStreamIdentifier = ObjectIdentifier<WebTransportStreamIdentifierType>;
 
+class AbortSignal;
 class WebTransport;
 class WritableStream;
 
-class WebTransportSendStreamSink : public WritableStreamSink {
+class WebTransportSendStreamSink : public WritableStreamSink, public CanMakeWeakPtr<WebTransportSendStreamSink> {
 public:
     static Ref<WebTransportSendStreamSink> create(WebTransport& transport, WebTransportStreamIdentifier identifier) { return adoptRef(*new WebTransportSendStreamSink(transport, identifier)); }
     ~WebTransportSendStreamSink();
@@ -51,13 +52,20 @@ public:
 private:
     WEBCORE_EXPORT WebTransportSendStreamSink(WebTransport&, WebTransportStreamIdentifier);
 
+    void start(std::unique_ptr<WritableStreamDefaultController>&&) final;
     void write(ScriptExecutionContext&, JSC::JSValue, DOMPromiseDeferred<void>&&) final;
-    void close(JSDOMGlobalObject&) final;
+    void close(JSDOMGlobalObject&, DOMPromiseDeferred<void>&&) final;
     void abort(JSDOMGlobalObject&, JSC::JSValue, DOMPromiseDeferred<void>&&) final;
+
+    void sendFin(ScriptExecutionContext&);
+    void cancel(JSC::JSValue reason);
 
     const ThreadSafeWeakPtr<WebTransport> m_transport;
     const WebTransportStreamIdentifier m_identifier;
     WeakPtr<WritableStream> m_stream;
+    std::unique_ptr<DOMPromiseDeferred<void>> m_closeDeferred;
+    RefPtr<AbortSignal> m_abortSignal;
+    std::optional<uint32_t> m_abortAlgorithmIdentifier;
     bool m_isClosed { false };
     bool m_isCancelled { false };
 };


### PR DESCRIPTION
#### 54cffb8bc0c7ceaf24819e9a75806301f7baf2f3
<pre>
[WebTransport] WPT failure: Close and abort unidirectional stream
<a href="https://bugs.webkit.org/show_bug.cgi?id=320102">https://bugs.webkit.org/show_bug.cgi?id=320102</a>
<a href="https://rdar.apple.com/167645473">rdar://167645473</a>

Reviewed by Youenn Fablet.

The WPT test streams-close.https.any &quot;Close and abort unidirectional stream&quot;
writes a chunk, calls writer.close() and then immediately writer.abort(e), and
expects close_promise, writer.closed, and abort_promise to all reject with e.
WebTransportSendStreamSink::close() was synchronous (the internal
WritableStreamSink.idl declared `undefined close()`), so the WritableStream
close algorithm resolved immediately and the subsequent abort() could not
preempt the in-flight close; close_promise resolved instead of rejecting.

Make the internal WritableStreamSink close() asynchronous (return
Promise&lt;undefined&gt;) and have WebTransportSendStreamSink observe the
WritableStreamDefaultController&apos;s abort signal, which fires synchronously during
writer.abort(). When an abort races an in-flight close(), the pending close is
rejected with the abort reason and the stream is reset (RESET_STREAM) rather
than sending FIN, matching the spec discussion at
whatwg/streams#1203.

The stream reset is delivered after the already-buffered chunk, so the server
may observe it later than the WPT test&apos;s fixed 10ms delay allows. Update the WPT
test to poll the server for the stream close info (query_stream_close_info)
instead of a single fixed delay; this test change is being upstreamed as
web-platform-tests/wpt#61525. Un-skip streams-close.https.any, which was
previously skipped for an internal streams-hang timeout.

Whether a synchronous abort() should take precedence over an in-flight close()
like this is still under discussion (whatwg/streams#1203);
the code carries a FIXME and <a href="https://bugs.webkit.org/show_bug.cgi?id=320232">https://bugs.webkit.org/show_bug.cgi?id=320232</a>
tracks validating the approach.

Original PR by Basuke Suzuki.  I just rebased it and undid the test changes.

* LayoutTests/imported/w3c/web-platform-tests/webtransport/streams-close.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webtransport/streams-close.https.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webtransport/streams-close.https.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webtransport/streams-close.https.any.worker-expected.txt:
* Source/WebCore/Modules/filesystem/FileSystemWritableFileStreamSink.cpp:
(WebCore::FileSystemWritableFileStreamSink::close):
* Source/WebCore/Modules/filesystem/FileSystemWritableFileStreamSink.h:
* Source/WebCore/Modules/mediastream/VideoTrackGenerator.cpp:
(WebCore::VideoTrackGenerator::Sink::close):
(WebCore::VideoTrackGenerator::Sink::abort):
* Source/WebCore/Modules/mediastream/VideoTrackGenerator.h:
* Source/WebCore/Modules/streams/StreamTransferUtilities.cpp:
* Source/WebCore/Modules/streams/WritableStreamSink.cpp:
(WebCore::WritableStreamDefaultController::signal const):
(WebCore::WritableStreamSink::abortSignal const):
(WebCore::SimpleWritableStreamSink::close):
* Source/WebCore/Modules/streams/WritableStreamSink.h:
(): Deleted.
* Source/WebCore/Modules/streams/WritableStreamSink.idl:
* Source/WebCore/Modules/webtransport/DatagramSink.cpp:
(WebCore::DatagramSink::close):
* Source/WebCore/Modules/webtransport/DatagramSink.h:
* Source/WebCore/Modules/webtransport/WebTransportSendStreamSink.cpp:
(WebCore::WebTransportSendStreamSink::~WebTransportSendStreamSink):
(WebCore::WebTransportSendStreamSink::start):
(WebCore::WebTransportSendStreamSink::close):
(WebCore::WebTransportSendStreamSink::sendFin):
(WebCore::WebTransportSendStreamSink::abort):
(WebCore::WebTransportSendStreamSink::cancel):
* Source/WebCore/Modules/webtransport/WebTransportSendStreamSink.h:

Canonical link: <a href="https://commits.webkit.org/318102@main">https://commits.webkit.org/318102@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7ee13bb1d318529fa3dabc193c24404b548c312d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177321 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51259 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/45053 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186924 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140568 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f85ddfe7-a689-4ccb-b885-1eeb31d84029) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179184 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52551 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50968 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/138186 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140568 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7864bf5a-9d44-419a-b1a4-1997d2862008) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180277 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41683 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/158945 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118651 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/091c464f-bae4-4f91-8bdd-0247765891fe) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/40344 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/38726 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150752 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/38442 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35392 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/43044 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/42960 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189353 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50925 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/158479 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/147276 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51608 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/35069 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147066 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26894 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41787 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123823 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118161 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50116 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/13420 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49512 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49752 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49574 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->