### PR TITLE
Unreviewed, address unexpected safer cpp issue on the bot

### DIFF
--- a/Source/WebKit/NetworkProcess/webtransport/cocoa/NetworkTransportSessionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/webtransport/cocoa/NetworkTransportSessionCocoa.mm
@@ -376,7 +376,9 @@ void NetworkTransportSession::initialize(CompletionHandler<void(std::optional<We
             }
             return creationCompletionHandler(std::nullopt);
         case nw_connection_group_state_cancelled:
-            return;
+            // A group cancelled before it became ready must still resolve the completion
+            // handler, otherwise the captured one-shot CompletionHandler is destroyed uncalled.
+            return creationCompletionHandler(std::nullopt);
         }
         RELEASE_ASSERT_NOT_REACHED();
     }).get());

--- a/Source/WebKit/NetworkProcess/webtransport/cocoa/NetworkTransportStreamCocoa.mm
+++ b/Source/WebKit/NetworkProcess/webtransport/cocoa/NetworkTransportStreamCocoa.mm
@@ -61,7 +61,12 @@ void NetworkTransportStream::start(NetworkTransportStreamReadyHandler&& readyHan
         case nw_connection_state_invalid:
         case nw_connection_state_waiting:
         case nw_connection_state_preparing:
+            return;
         case nw_connection_state_cancelled:
+            // A connection cancelled before it became ready must still resolve the ready
+            // handler, otherwise the captured one-shot CompletionHandler is destroyed uncalled.
+            if (readyHandler)
+                readyHandler(std::nullopt);
             return;
         case nw_connection_state_ready: {
             if (!protectedThis)

--- a/Source/WebKit/Shared/LogStream.mm
+++ b/Source/WebKit/Shared/LogStream.mm
@@ -63,7 +63,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 // All LogStreams share a single work queue: the StreamServerConnection for each LogStream is opened on
 // (and thus bound to) this queue, so all of its connection work -- including invalidate() -- must run
 // on it. See rdar://182244946 and the comment in stopListeningForIPC().
-static IPC::StreamConnectionWorkQueue& logWorkQueue()
+static IPC::StreamConnectionWorkQueue& logWorkQueueSingleton()
 {
     static NeverDestroyed<Ref<IPC::StreamConnectionWorkQueue>> queue = IPC::StreamConnectionWorkQueue::create("Log work queue"_s);
     return queue.get();
@@ -104,7 +104,7 @@ void LogStream::stopListeningForIPC()
     // soon as this returns), so capture Ref to both the LogStream and its connection: invalidate()
     // clears the connection's CheckedPtr back to us (the client), so the LogStream must outlive the
     // dispatched teardown.
-    logWorkQueue().dispatch([protectedThis = Ref { *this }, connection = Ref { m_connection }, identifier = m_identifier] {
+    logWorkQueueSingleton().dispatch([protectedThis = Ref { *this }, connection = Ref { m_connection }, identifier = m_identifier] {
         connection->stopReceivingMessages(Messages::LogStream::messageReceiverName(), identifier.toUInt64());
         connection->invalidate();
     });
@@ -162,12 +162,11 @@ RefPtr<LogStream> LogStream::create(AuxiliaryProcessProxy& process, ASCIILiteral
         completionHandler(invalidWakeUpSemaphore, invalidClientWaitSemaphore);
         return nullptr;
     }
-    Ref logQueue = logWorkQueue();
 
     Ref instance = adoptRef(*new LogStream(process, processName, connection.releaseNonNull(), identifier));
-    instance->m_connection->open(instance.get(), logQueue.get());
+    instance->m_connection->open(instance.get(), logWorkQueueSingleton());
     instance->m_connection->startReceivingMessages(instance, Messages::LogStream::messageReceiverName(), identifier.toUInt64());
-    completionHandler(logQueue->wakeUpSemaphore(), instance->m_connection->clientWaitSemaphore());
+    completionHandler(logWorkQueueSingleton()->wakeUpSemaphore(), instance->m_connection->clientWaitSemaphore());
     return instance;
 }
 


### PR DESCRIPTION
#### 45368a6495c4e3d922fea4afbb8b64941ab70c67
<pre>
Unreviewed, address unexpected safer cpp issue on the bot
<a href="https://bugs.webkit.org/show_bug.cgi?id=320426">https://bugs.webkit.org/show_bug.cgi?id=320426</a>

* Source/WebKit/Shared/LogStream.mm:
(WebKit::logWorkQueueSingleton):
(WebKit::LogStream::stopListeningForIPC):
(WebKit::LogStream::create):
(WebKit::logWorkQueue): Deleted.
</pre>
----------------------------------------------------------------------
#### cf3b21ada8145db466cb83530850712795b3ab3c
<pre>
WebTransport: resolve pending promise when a connection or group is cancelled before becoming ready
<a href="https://bugs.webkit.org/show_bug.cgi?id=320424">https://bugs.webkit.org/show_bug.cgi?id=320424</a>

Reviewed by NOBODY (OOPS!).

The Network.framework state-changed handlers for a WebTransport stream connection and
for the session&apos;s connection group treated the terminal nw_connection_state_cancelled /
nw_connection_group_state_cancelled transition as a silent return, without invoking the
one-shot CompletionHandler they had captured.

When a session or stream is cancelled before it ever reaches the ready state -- e.g. the
page calls WebTransport.close() (or creates then tears down a stream) while the QUIC
connection is still being established -- terminate() cancels the underlying nw_connection /
nw_connection_group, the cancelled state is delivered, and the captured handler is never
called. When Network.framework later releases the block, the CompletionHandler is destroyed
uncalled: an assertion failure in debug builds, and in release builds a never-settled IPC
async reply, leaving the corresponding JS promise (WebTransport.ready,
createBidirectionalStream()) pending until the whole connection is torn down.

Handle the cancelled transition the same way the datagram connection already does: resolve
the handler with a failure result. NetworkTransportStream::start calls readyHandler(nullopt)
when it is still pending (guarded like the existing failed branch, since cancelled can also
fire after ready/failed during normal teardown), which also covers the createStream reply
captured inside that handler. NetworkTransportSession::initialize calls
creationCompletionHandler(nullopt), which already self-guards against being called twice.

* Source/WebKit/NetworkProcess/webtransport/cocoa/NetworkTransportSessionCocoa.mm:
(WebKit::NetworkTransportSession::initialize):
* Source/WebKit/NetworkProcess/webtransport/cocoa/NetworkTransportStreamCocoa.mm:
(WebKit::NetworkTransportStream::start):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/45368a6495c4e3d922fea4afbb8b64941ab70c67

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177134 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51071 "Hash 45368a64 for PR 70315 does not build (failure)") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/44866 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186737 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140370 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52364 "Hash 45368a64 for PR 70315 does not build (failure)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50757 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/138015 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140370 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180090 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/52364 "Hash 45368a64 for PR 70315 does not build (failure)") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/44866 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/118482 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/52364 "Hash 45368a64 for PR 70315 does not build (failure)") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/38551 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/44866 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/52364 "Hash 45368a64 for PR 70315 does not build (failure)") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/44866 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35205 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/42848 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/42769 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189163 "Built successfully") | | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50738 "Hash 45368a64 for PR 70315 does not build (failure)") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/44866 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/147101 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51421 "Hash 45368a64 for PR 70315 does not build (failure)") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/44866 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/146895 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/160/builds/51421 "Hash 45368a64 for PR 70315 does not build (failure)") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/123635 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117922 "Built successfully") | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49926 "Hash 45368a64 for PR 70315 does not build (failure)") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/44866 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49325 "Hash 45368a64 for PR 70315 does not build (failure)") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/49562 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49386 "Hash 45368a64 for PR 70315 does not build (failure)") | | | | 
<!--EWS-Status-Bubble-End-->