### PR TITLE
Unreviewed, address unexpected safer cpp issue on the bot

### DIFF
--- a/Source/WebKit/Shared/LogStream.mm
+++ b/Source/WebKit/Shared/LogStream.mm
@@ -63,7 +63,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 // All LogStreams share a single work queue: the StreamServerConnection for each LogStream is opened on
 // (and thus bound to) this queue, so all of its connection work -- including invalidate() -- must run
 // on it. See rdar://182244946 and the comment in stopListeningForIPC().
-static IPC::StreamConnectionWorkQueue& logWorkQueue()
+static IPC::StreamConnectionWorkQueue& logWorkQueueSingleton()
 {
     static NeverDestroyed<Ref<IPC::StreamConnectionWorkQueue>> queue = IPC::StreamConnectionWorkQueue::create("Log work queue"_s);
     return queue.get();
@@ -104,7 +104,7 @@ void LogStream::stopListeningForIPC()
     // soon as this returns), so capture Ref to both the LogStream and its connection: invalidate()
     // clears the connection's CheckedPtr back to us (the client), so the LogStream must outlive the
     // dispatched teardown.
-    logWorkQueue().dispatch([protectedThis = Ref { *this }, connection = Ref { m_connection }, identifier = m_identifier] {
+    logWorkQueueSingleton().dispatch([protectedThis = Ref { *this }, connection = Ref { m_connection }, identifier = m_identifier] {
         connection->stopReceivingMessages(Messages::LogStream::messageReceiverName(), identifier.toUInt64());
         connection->invalidate();
     });
@@ -162,12 +162,11 @@ RefPtr<LogStream> LogStream::create(AuxiliaryProcessProxy& process, ASCIILiteral
         completionHandler(invalidWakeUpSemaphore, invalidClientWaitSemaphore);
         return nullptr;
     }
-    Ref logQueue = logWorkQueue();
 
     Ref instance = adoptRef(*new LogStream(process, processName, connection.releaseNonNull(), identifier));
-    instance->m_connection->open(instance.get(), logQueue.get());
+    instance->m_connection->open(instance.get(), logWorkQueueSingleton());
     instance->m_connection->startReceivingMessages(instance, Messages::LogStream::messageReceiverName(), identifier.toUInt64());
-    completionHandler(logQueue->wakeUpSemaphore(), instance->m_connection->clientWaitSemaphore());
+    completionHandler(logWorkQueueSingleton().wakeUpSemaphore(), instance->m_connection->clientWaitSemaphore());
     return instance;
 }
 


### PR DESCRIPTION
#### 15bfcabf49a08aaf2f9153a19af394c00aff70a3
<pre>
Unreviewed, address unexpected safer cpp issue on the bot
<a href="https://bugs.webkit.org/show_bug.cgi?id=320426">https://bugs.webkit.org/show_bug.cgi?id=320426</a>

* Source/WebKit/Shared/LogStream.mm:
(WebKit::logWorkQueueSingleton):
(WebKit::LogStream::stopListeningForIPC):
(WebKit::LogStream::create):
(WebKit::logWorkQueue): Deleted.

Canonical link: <a href="https://commits.webkit.org/318044@main">https://commits.webkit.org/318044@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0f517688a5e17b4e7623f01f76c0071582923390

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177137 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51074 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44869 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186740 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140373 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/dfcc3298-f921-4a49-8047-9c1d5fb795eb) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52367 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50760 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138017 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140373 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e56a2c5c-895f-46c6-b5a0-dc124b7243fa) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180093 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41524 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158777 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118484 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e3fda215-f84d-495e-b602-529f7ffbf8f5) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40180 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38553 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150590 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38276 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35208 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42851 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42771 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189166 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50741 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147103 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51424 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/34900 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146897 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26867 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41627 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123638 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117926 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49929 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13256 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49328 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49565 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49389 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->