### PR TITLE
AX: SelectedTextChanged should report the stitch representative, not a stitched-away text member

### DIFF
--- a/LayoutTests/accessibility/mac/text-stitching-selection-notification-element-expected.txt
+++ b/LayoutTests/accessibility/mac/text-stitching-selection-notification-element-expected.txt
@@ -1,0 +1,10 @@
+This test ensures that when the caret moves (via the accessibility selection API) into a stitched-away text run, the AXSelectedTextChanged notification reports the stitch-group representative, which is present in the tree, rather than the removed member. Otherwise an assistive technology client can be handed an element that is absent from its parent's children, which may cause navigation problems.
+
+PASS: webArea.addNotificationListener(notificationCallback) === true
+PASS: changeElement.role.includes('AXStaticText') === true
+PASS: changeElement.stringValue.includes('and then some more text') === true
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Hello World and then some more text.

--- a/LayoutTests/accessibility/mac/text-stitching-selection-notification-element.html
+++ b/LayoutTests/accessibility/mac/text-stitching-selection-notification-element.html
@@ -1,0 +1,50 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN"><!-- webkit-test-runner [ AccessibilityTextStitchingEnabled=true ] -->
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+
+<p>Hello <b>World</b> and then some more text.</p>
+
+<script>
+var output = "This test ensures that when the caret moves (via the accessibility selection API) into a stitched-away text run, the AXSelectedTextChanged notification reports the stitch-group representative, which is present in the tree, rather than the removed member. Otherwise an assistive technology client can be handed an element that is absent from its parent's children, which may cause navigation problems.\n\n";
+
+var webArea;
+var changeElement;
+
+function notificationCallback(notification, userInfo) {
+    if (notification != "AXSelectedTextChanged" || !userInfo)
+        return;
+
+    changeElement = userInfo["AXTextChangeElement"];
+    if (!changeElement)
+        return;
+
+    // The caret was set inside the stitched-away "World" member. The reported change element must
+    // be the stitch-group representative, whose value spans the whole run ("Hello World and then
+    // some more text."), not the "World" member alone (which stitching removed from its parent's
+    // exposed children).
+    output += expect("changeElement.role.includes('AXStaticText')", "true");
+    output += expect("changeElement.stringValue.includes('and then some more text')", "true");
+
+    webArea.removeNotificationListener();
+    debug(output);
+    finishJSTest();
+}
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+    accessibilityController.enableEnhancedAccessibility(true);
+
+    webArea = accessibilityController.rootElement.childAtIndex(0);
+    output += expect("webArea.addNotificationListener(notificationCallback)", "true");
+
+    // Move the caret into the stitched-away "World" run ("Hello Wo|rld ...", index 8).
+    var marker = webArea.textMarkerForIndex(8);
+    webArea.setSelectedTextMarkerRange(webArea.textMarkerRangeForMarkers(marker, marker));
+}
+</script>
+</body>
+</html>

--- a/Source/WebCore/accessibility/AXCoreObject.cpp
+++ b/Source/WebCore/accessibility/AXCoreObject.cpp
@@ -414,6 +414,19 @@ size_t AXCoreObject::stitchedUnignoredChildrenCount()
     return stitchedUnignoredChildren().size();
 }
 
+RefPtr<AXCoreObject> AXCoreObject::stitchRepresentativeOrSelf()
+{
+    std::optional<AXID> representativeID = stitchedIntoID();
+    if (!representativeID || *representativeID == objectID())
+        return this;
+    // The AXTextMarker is not a text position here (offset 0 is unused); it is the idiomatic way to
+    // resolve an { treeID, AXID } pair to its object on whichever tree we are on, dispatching to the
+    // isolated tree off the main thread or the main-thread cache on it.
+    if (RefPtr representative = AXTextMarker { treeID(), *representativeID, 0 }.object())
+        return representative;
+    return this;
+}
+
 AXCoreObject::AccessibilityChildrenVector AXCoreObject::crossFrameUnignoredChildrenInRange(size_t start, size_t maxCount)
 {
     auto children = crossFrameUnignoredChildren();

--- a/Source/WebCore/accessibility/AXCoreObject.h
+++ b/Source/WebCore/accessibility/AXCoreObject.h
@@ -1186,6 +1186,12 @@ public:
         return std::nullopt;
     }
 
+    // Resolves this object to its stitch-group representative when it has been stitched away
+    // (i.e. removed from its parent's exposed children); otherwise returns this object. AT-facing
+    // APIs that hand a single object to the client should route through this so a stitched-away
+    // member is never exposed as an element that is absent from the tree.
+    RefPtr<AXCoreObject> stitchRepresentativeOrSelf();
+
     // When ENABLE(INCLUDE_IGNORED_IN_CORE_AX_TREE) is true, this returns IDs of ignored children.
     // When it is not, it returns IDs of unignored children. After ENABLE(INCLUDE_IGNORED_IN_CORE_AX_TREE)
     // is the default, we should rename this function to childrenIDsIncludingIgnored, as that is what all

--- a/Source/WebCore/accessibility/mac/AXObjectCacheMac.mm
+++ b/Source/WebCore/accessibility/mac/AXObjectCacheMac.mm
@@ -526,6 +526,13 @@ void AXObjectCache::postTextSelectionChangePlatformNotification(AccessibilityObj
 
     processQueuedIsolatedNodeUpdates();
 
+    // If the selection landed on a stitched-away text run, report the change on the stitch-group
+    // representative (the element actually exposed in the tree) rather than the removed member,
+    // so the SelectedTextChanged notification that VoiceOver uses to move focus during caret
+    // navigation targets an element present in its parent's children. Mirrors the
+    // AXUIElementForTextMarker redirect.
+    axObject = downcast<AccessibilityObject>(axObject->stitchRepresentativeOrSelf());
+
     auto intent = inferDirectionFromIntent(*axObject, originalIntent, selection);
 
     auto userInfo = adoptNS([[NSMutableDictionary alloc] initWithCapacity:5]);

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
@@ -3671,10 +3671,7 @@ static id handleUIElementForTextMarkerAttribute(WebAccessibilityObjectWrapper*, 
     if (!object)
         return nil;
 
-    if (std::optional<AXID> representativeID = object->stitchedIntoID(); representativeID && *representativeID != object->objectID()) {
-        if (RefPtr representative = AXTextMarker { object->treeID(), *representativeID, 0 }.object())
-            object = WTF::move(representative);
-    }
+    object = object->stitchRepresentativeOrSelf();
 
     RetainPtr wrapper = object->wrapper();
     if (!wrapper)


### PR DESCRIPTION
#### 0c6fba63ba28ce7dcb2cc90e9afe32acbb488043
<pre>
AX: SelectedTextChanged should report the stitch representative, not a stitched-away text member
<a href="https://bugs.webkit.org/show_bug.cgi?id=320427">https://bugs.webkit.org/show_bug.cgi?id=320427</a>
&lt;<a href="https://rdar.apple.com/problem/183385743">rdar://problem/183385743</a>&gt;

Reviewed by Tyler Wilcock.

Accessibility text stitching combines a paragraph&apos;s inline text runs into a single
representative AXStaticText and removes the individual (stitched-away) runs from their
parent&apos;s exposed children (see childrenAfterStitching in AXCoreObject.cpp). Because those
members are no longer present in their parent&apos;s children, any AT-facing API that hands a
single object back to the client must resolve a stitched-away member to its representative;
otherwise it exposes an element that cannot be found in the tree it is supposedly part of.

309924@main added that resolution for the NSAccessibilityUIElementForTextMarker path
(handleUIElementForTextMarkerAttribute), but the SelectedTextChanged notification posted by
postTextSelectionChangePlatformNotification still targeted the stitched-away member. That
notification is the one an assistive client such as VoiceOver uses to follow the caret while
the user reads a read-only web document line by line with the arrow keys (for example, an
HTML mail message body). When the caret lands inside a stitched-away run, the client is handed
the member object that stitching removed from its parent&apos;s children. On the next
layout-changed notification VoiceOver re-validates that its focused element is still among its
parent&apos;s children, does not find it, concludes the focused element has been removed, and
re-homes focus to the web area, re-announcing the entire message from the beginning. The
AXUIElementForTextMarker fix did not cover this case because the element the client caches for
the caret comes from the selection-change notification, not from resolving a text marker.

This patch factors the &quot;resolve a stitched-away object to its representative&quot; step into a
single shared helper, AXCoreObject::stitchRepresentativeOrSelf(), and routes both AT-facing
single-object paths through it:

    1. handleUIElementForTextMarkerAttribute now calls the helper, replacing the inline
       resolution added in 309924@main.
    2. postTextSelectionChangePlatformNotification calls the helper before building and posting
       the notification, so the change element (NSAccessibilityTextChangeElement) and the
       object the notification is posted on are the exposed representative.

The helper resolves the representative tree-agnostically via
AXTextMarker { treeID(), representativeID, 0 }.object(), and returns the object itself when it
is not stitched away, so it is a no-op for non-stitched content and behaves correctly on both
the main-thread and the isolated tree. Stitching&apos;s presentation is unchanged: the individual
members are still removed from their parent&apos;s children, and only the single object handed to
the assistive client for the caret&apos;s position is corrected to the representative that is
actually present in the tree. The selected-text-marker range carried in the notification is
still computed from the live selection, so the reported caret range is unaffected.

The new test moves the caret into a stitched-away run of a read-only paragraph using the
accessibility selection API and verifies that the SelectedTextChanged change element is the
representative, whose value spans the whole run, rather than the individual member.

Test: accessibility/mac/text-stitching-selection-notification-element.html

* LayoutTests/accessibility/mac/text-stitching-selection-notification-element-expected.txt: Added.
* LayoutTests/accessibility/mac/text-stitching-selection-notification-element.html: Added.
* Source/WebCore/accessibility/AXCoreObject.cpp:
(WebCore::AXCoreObject::stitchRepresentativeOrSelf):
* Source/WebCore/accessibility/AXCoreObject.h:
* Source/WebCore/accessibility/mac/AXObjectCacheMac.mm:
(WebCore::AXObjectCache::postTextSelectionChangePlatformNotification):
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm:
(handleUIElementForTextMarkerAttribute):

Canonical link: <a href="https://commits.webkit.org/318112@main">https://commits.webkit.org/318112@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bb8a26bcf49dd65f4d339971aa3652d9667c17d5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177223 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51161 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44955 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186826 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140459 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e490443f-4f4f-4368-a580-ef31280648f5) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179086 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52453 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50847 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138096 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140459 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d76ab804-ece4-4ff0-b9ed-4548cb833c12) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180179 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41602 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158862 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118561 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40262 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38639 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150671 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38360 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35294 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42946 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42853 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189253 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50827 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/158397 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147186 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39575 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51510 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34986 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146978 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41705 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123725 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118047 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50015 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13338 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49414 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49653 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49475 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->