### PR TITLE
[Scroll snap] css/css-scroll-snap/overscroll-snap.html fails in Safari

### DIFF
--- a/LayoutTests/fast/scrolling/mac/hidpi-overscroll-snap-discrete-scroll-expected.txt
+++ b/LayoutTests/fast/scrolling/mac/hidpi-overscroll-snap-discrete-scroll-expected.txt
@@ -1,0 +1,10 @@
+Tests that we don't scroll back to the top when scrolled to the end of a scroller with a snap port having fractional height, with a single discrete scroll event.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS Math.abs(scroller.scrollTop - (scroller.scrollHeight - scroller.clientHeight)) <= 1 is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/scrolling/mac/hidpi-overscroll-snap-discrete-scroll.html
+++ b/LayoutTests/fast/scrolling/mac/hidpi-overscroll-snap-discrete-scroll.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ] -->
+<html>
+<head>
+<style>
+    body { margin: 0; }
+    #scroller {
+        width: 200px;
+        height: 400px;
+        overflow-y: scroll;
+        scroll-snap-type: y mandatory;
+    }
+    #snap_target {
+        width: 100px;
+        height: 1942.5px;
+        scroll-snap-align: start;
+        background-color: blue;
+    }
+</style>
+<script src="../../../resources/js-test.js"></script>
+<script src="../../../resources/ui-helper.js"></script>
+<script>
+jsTestIsAsync = true;
+var scroller;
+
++description("Tests that we don't scroll back to the top when scrolled to the end of a scroller with a snap port having fractional height, with a single discrete scroll event.");
+
+async function scrollTest()
+{
+    const scrollDistance = scroller.scrollHeight;
+    await UIHelper.statelessMouseWheelScrollAt(100, 200, 0, -scrollDistance);
+    await UIHelper.renderingUpdate();
+
+    shouldBeTrue("Math.abs(scroller.scrollTop - (scroller.scrollHeight - scroller.clientHeight)) <= 1");
+    finishJSTest();
+}
+
+window.addEventListener('load', () => {
+    scroller = document.getElementById('scroller');
+    setTimeout(scrollTest, 0);
+}, false);
+</script>
+</head>
+<body>
+    <div id="scroller"><div id="snap_target"></div></div>
+</body>
+</html>

--- a/LayoutTests/fast/scrolling/mac/overscroll-snap-adjusted-scroll-destination-expected.txt
+++ b/LayoutTests/fast/scrolling/mac/overscroll-snap-adjusted-scroll-destination-expected.txt
@@ -1,0 +1,11 @@
+Tests that we don't scroll back to the top when scrolled to the end of a scroller with a snap port having fractional height.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS maximumScrollOffset > 0 is true
+PASS Math.abs(scroller.scrollTop - maximumScrollOffset) <= 1 is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/scrolling/mac/overscroll-snap-adjusted-scroll-destination.html
+++ b/LayoutTests/fast/scrolling/mac/overscroll-snap-adjusted-scroll-destination.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ] -->
+<html>
+<head>
+<style>
+    body { margin: 0; }
+    #scroller {
+        width: 200px;
+        height: 400px;
+        overflow-y: scroll;
+        scroll-snap-type: y mandatory;
+    }
+    #snap_target {
+        width: 100px;
+        height: 1942.5px;
+        scroll-snap-align: start;
+        background-color: blue;
+    }
+</style>
+<script src="../../../resources/js-test.js"></script>
+<script src="../../../resources/ui-helper.js"></script>
+<script>
+jsTestIsAsync = true;
+var scroller;
+var maximumScrollOffset;
+
+description("Tests that we don't scroll back to the top when scrolled to the end of a scroller with a snap port having fractional height.");
+
+async function scrollTest()
+{
+    if (window.internals)
+        internals.settings.setScrollAnimatorEnabled(false);
+
+    scroller.focus();
+
+    // A clamped programmatic scroll leaves the scroller at its maximum scroll offset.
+    scroller.scrollTop = scroller.scrollHeight;
+    await UIHelper.renderingUpdate();
+    maximumScrollOffset = scroller.scrollTop;
+    shouldBeTrue("maximumScrollOffset > 0");
+
+    await UIHelper.keyboardScroll("downArrow");
+    await UIHelper.renderingUpdate();
+
+    shouldBeTrue("Math.abs(scroller.scrollTop - maximumScrollOffset) <= 1");
+    finishJSTest();
+}
+
+window.addEventListener('load', () => {
+    scroller = document.getElementById('scroller');
+    setTimeout(scrollTest, 0);
+}, false);
+</script>
+</head>
+<body>
+    <div id="scroller" tabindex="0">
+      <div id="snap_target"></div>
+    </div>
+</body>
+</html>

--- a/Source/WebCore/page/scrolling/ScrollSnapOffsetsInfo.cpp
+++ b/Source/WebCore/page/scrolling/ScrollSnapOffsetsInfo.cpp
@@ -55,11 +55,15 @@ bool ScrollSnapOffsetsInfo<UnitType, RectType>::snapOffsetCoversSnapport(const S
 {
     if (!snapOffset.hasSnapAreaLargerThanViewport)
         return false;
+
+    // Tolerance is required because scroll offsets are integral, but snap offsets can be fractional.
+    UnitType tolerance { 0.5f };
     for (auto areaIndex : snapOffset.snapAreaIndices) {
         auto [areaMin, areaMax] = rangeForAxis<UnitType>(snapAreas[areaIndex], axis);
-        if (areaMin <= axisOffset && areaMax >= axisOffset + viewportLength)
+        if (areaMin - tolerance <= axisOffset && areaMax + tolerance >= axisOffset + viewportLength)
             return true;
     }
+
     return false;
 }
 

--- a/Source/WebCore/platform/ScrollSnapAnimatorState.cpp
+++ b/Source/WebCore/platform/ScrollSnapAnimatorState.cpp
@@ -94,6 +94,12 @@ float ScrollSnapAnimatorState::adjustedScrollDestination(ScrollEventAxis axis, F
     if (originalOffset)
         originalOffsetInLayoutUnits = LayoutUnit(*originalOffset / pageScale);
     LayoutSize viewportSize(scrollExtents.viewportSize);
+
+    // Clamp the destination to the reachable scroll range before choosing a snap offset.
+    auto minScrollOffset = valueForAxis(scrollExtents.minimumScrollOffset(), axis);
+    auto maxScrollOffset = valueForAxis(scrollExtents.maximumScrollOffset(), axis);
+    destinationOffset = setValueForAxis(destinationOffset, axis, clampTo<float>(valueForAxis(destinationOffset, axis), minScrollOffset, maxScrollOffset));
+
     LayoutPoint layoutDestinationOffset(destinationOffset.x() / pageScale, destinationOffset.y() / pageScale);
     LayoutUnit offset = snapOffsetInfo().closestSnapOffset(axis, viewportSize, layoutDestinationOffset, velocity, originalOffsetInLayoutUnits, selectionMethod).first;
     return offset * pageScale;
@@ -458,8 +464,17 @@ std::pair<float, std::optional<unsigned>> ScrollSnapAnimatorState::targetOffsetF
         return std::make_pair(clampTo<float>(axis == ScrollEventAxis::Horizontal ? predictedOffset.x() : predictedOffset.y(), minScrollOffset, maxScrollOffset), std::nullopt);
 
     LayoutPoint predictedLayoutOffset(predictedOffset.x() / pageScale, predictedOffset.y() / pageScale);
+
+    // Clamp the predicted destination to the reachable scroll range before choosing a snap offset.
+    auto clampedAxisOffset = clampTo<float>(axis == ScrollEventAxis::Horizontal ? predictedOffset.x() : predictedOffset.y(), minScrollOffset, maxScrollOffset) / pageScale;
+    if (axis == ScrollEventAxis::Horizontal)
+        predictedLayoutOffset.setX(LayoutUnit(clampedAxisOffset));
+    else
+        predictedLayoutOffset.setY(LayoutUnit(clampedAxisOffset));
+
     auto [targetOffset, snapIndex] = m_snapOffsetsInfo.closestSnapOffset(axis, LayoutSize { scrollExtents.viewportSize }, predictedLayoutOffset, initialDelta, LayoutUnit(startOffset / pageScale));
-    return std::make_pair(pageScale * clampTo<float>(float { targetOffset }, minScrollOffset, maxScrollOffset), snapIndex);
+    targetOffset = clampTo<float>(float { targetOffset }, minScrollOffset, maxScrollOffset) * pageScale;
+    return std::make_pair(targetOffset, snapIndex);
 }
 
 TextStream& operator<<(TextStream& ts, const ScrollSnapAnimatorState& state)


### PR DESCRIPTION
#### 1d489b3538d6c3f561e8ceab185be188eab4e3dc
<pre>
[Scroll snap] css/css-scroll-snap/overscroll-snap.html fails in Safari
<a href="https://bugs.webkit.org/show_bug.cgi?id=320405">https://bugs.webkit.org/show_bug.cgi?id=320405</a>
<a href="https://rdar.apple.com/183375912">rdar://183375912</a>

Reviewed by Abrar Rahman Protyasha.

The WPT `css/css-scroll-snap/overscroll-snap.html` has a fractional height scroll snap element
that goes to the end of the scrolling content, which reveals a couple of issues in the scroll
snap code.

First, `snapOffsetCoversSnapport()` needs a bit of tolerance, because in this case the end
snap point is at, say, 20.5px, but the `scrollHeight` is integral and rounded up to 21px,
and we need to not thing we&apos;re outside this snap port, otherwise it triggers scrolling
back to the start.

Second, two places that use the destination scroll offset need to clamp for rubber-banding,
otherwise we again think that the target scroll position is outside the last snap target element,
and scroll to the wrong place.

Tests: fast/scrolling/mac/hidpi-overscroll-snap-discrete-scroll.html
       fast/scrolling/mac/overscroll-snap-adjusted-scroll-destination.html

* LayoutTests/fast/scrolling/mac/hidpi-overscroll-snap-discrete-scroll-expected.txt: Added.
* LayoutTests/fast/scrolling/mac/hidpi-overscroll-snap-discrete-scroll.html: Added.
* LayoutTests/fast/scrolling/mac/overscroll-snap-adjusted-scroll-destination-expected.txt: Added.
* LayoutTests/fast/scrolling/mac/overscroll-snap-adjusted-scroll-destination.html: Added.
* Source/WebCore/page/scrolling/ScrollSnapOffsetsInfo.cpp:
(WebCore::RectType&gt;::snapOffsetCoversSnapport const):
* Source/WebCore/platform/ScrollSnapAnimatorState.cpp:
(WebCore::ScrollSnapAnimatorState::adjustedScrollDestination const):
(WebCore::ScrollSnapAnimatorState::targetOffsetForStartOffset const):

Canonical link: <a href="https://commits.webkit.org/318081@main">https://commits.webkit.org/318081@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/efd31dc4709830ceacd058d959f531c1f88aadea

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177150 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51087 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44882 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186753 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140386 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b93bf3dc-cf49-4fe4-b4fe-245878f69e24) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179013 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52380 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50773 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138032 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140386 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c12c1fbf-698a-4c64-8add-39509b804a0c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180106 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41534 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158793 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118499 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/30c0f47d-fa28-4747-b21c-cf659504f8cb) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40190 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38566 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150600 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38292 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35221 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42866 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42797 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189179 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50754 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/158332 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147116 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39557 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51437 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34916 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146910 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41641 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123651 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117947 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49942 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13272 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49341 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49578 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49402 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->