### PR TITLE
[GFC] Resolve limited min-content contributions for auto-min tracks under a min-/max-content constraint

### DIFF
--- a/LayoutTests/fast/grid/grid-auto-min-track-under-min-content-constraint-expected.txt
+++ b/LayoutTests/fast/grid/grid-auto-min-track-under-min-content-constraint-expected.txt
@@ -1,0 +1,3 @@
+An auto track sized under a min-content constraint takes the maximum of its items' min-content contributions.
+
+PASS

--- a/LayoutTests/fast/grid/grid-auto-min-track-under-min-content-constraint.html
+++ b/LayoutTests/fast/grid/grid-auto-min-track-under-min-content-constraint.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Grid: auto-min track base size under a min-content constraint</title>
+<link rel="help" href="https://www.w3.org/TR/css-grid-2/#algo-single-span-items">
+<script src="../../resources/check-layout.js"></script>
+<style>
+.grid {
+    display: grid;
+    width: min-content;
+    justify-items: normal;
+    grid-template-columns: auto;
+    grid-template-rows: auto auto;
+}
+.wideContent {
+    width: 100px;
+    height: 20px;
+}
+.narrowContent {
+    width: 60px;
+    height: 20px;
+}
+</style>
+<body onload="checkLayout('.grid')">
+<p>An auto track sized under a min-content constraint takes the maximum of its items' min-content contributions.</p>
+<div class="grid" data-expected-width="100">
+    <div class="item"><div class="wideContent"></div></div>
+    <div class="item"><div class="narrowContent"></div></div>
+</div>
+</body>

--- a/Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.cpp
@@ -319,13 +319,25 @@ static void sizeTracksToFitNonSpanningItems(const ResolveIntrinsicTrackSizesCont
                 return std::max({ }, std::ranges::max(itemContributions));
             },
             [&](const CSS::Keyword::Auto&) -> LayoutUnit {
-                // If the track has an auto min track sizing function and the grid container
-                // is being sized under a min-/max-content constraint, set the track’s base
-                // size to the maximum of its items’ limited min-content
-                // contributions, floored at zero.
+                // If the track has an auto min track sizing function and the grid container is
+                // being sized under a min-/max-content constraint, its base size should be the
+                // maximum of its items’ limited min-content contributions, floored at zero.
                 if (isSizedUnderMinOrMaxContentConstraint(resolveIntrinsicTrackSizesContext.axisConstraint)) {
-                    notImplemented();
-                    return { };
+                    // The limited min-/max-content contribution of an item is (for this purpose) its min-/max-content contribution (accordingly),
+                    auto minContentSizeContributions = minContentContributions(trackSizingItems, singleSpanningItemsIndexes, gridItemSizingFunctions);
+
+                    // limited by the max track sizing function (which could be the argument to a fit-content() track sizing function) if that is fixed
+                    auto fixedMaxTrackSizingFunctionSums = singleSpanningItemsIndexes.map([&](size_t gridItemIndex) {
+                        return fixedMaxTrackSizingFunctionSum(trackSizingItems[gridItemIndex].spannedLines, unsizedTracks);
+                    });
+
+                    // and ultimately floored by its minimum contribution.
+                    auto itemMinimumContributions = minimumContributions(trackSizingItems, singleSpanningItemsIndexes, gridItemSizingFunctions, resolveIntrinsicTrackSizesContext.trackSizingFunctionsList);
+
+                    auto limitedContributions = limitedContentContributions(minContentSizeContributions, fixedMaxTrackSizingFunctionSums, itemMinimumContributions);
+                    if (limitedContributions.isEmpty())
+                        return { };
+                    return std::max({ }, std::ranges::max(limitedContributions));
                 }
                 // Otherwise, set the track’s base size to the maximum of its items’ minimum
                 // contributions, floored at zero.


### PR DESCRIPTION
#### 293d26c84bad0bfd15fb7028aa9377ba88455103
<pre>
[GFC] Resolve limited min-content contributions for auto-min tracks under a min-/max-content constraint
<a href="https://bugs.webkit.org/show_bug.cgi?id=320486">https://bugs.webkit.org/show_bug.cgi?id=320486</a>
<a href="https://rdar.apple.com/183452829">rdar://183452829</a>

Reviewed by Sammy Gill.

Implements the auto-minimum case of the single-span intrinsic track sizing step
(CSS Grid 1 §11.5.2): under a min-/max-content constraint, an auto-min track&apos;s
base size is the maximum of its items&apos; limited min-content contributions,
floored at zero, rather than their plain minimum contributions.

* Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.cpp:
(WebCore::Layout::sizeTracksToFitNonSpanningItems):
* LayoutTests/fast/grid/grid-auto-min-track-under-min-content-constraint-expected.txt: Added.
* LayoutTests/fast/grid/grid-auto-min-track-under-min-content-constraint.html: Added.

Canonical link: <a href="https://commits.webkit.org/318125@main">https://commits.webkit.org/318125@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e220a6590e80365a3da43aaf6df20e79632e1b32

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177327 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51265 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45059 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186930 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140574 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/06d8d90c-b370-4add-be44-e2b3941c4ea3) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179190 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52557 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50974 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138185 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140574 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6aaf2345-ff86-4a3d-a506-4074b76d2415) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180283 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41684 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158947 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118650 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40345 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38729 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/619 "Build is in progress. Recent messages:") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150753 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38444 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35398 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/43050 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/42963 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189359 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50931 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/158481 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147279 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39582 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51614 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35071 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147076 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41789 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123829 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118167 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50122 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13422 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49518 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49758 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49580 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->