### PR TITLE
WebAVSampleBufferListener should assert the main thread when accessing _client in ensureOnMainThread blocks

### DIFF
--- a/Source/WebCore/platform/graphics/avfoundation/WebAVSampleBufferListener.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/WebAVSampleBufferListener.mm
@@ -172,6 +172,7 @@ static bool isSampleBufferVideoRenderer(id object)
             RetainPtr renderer = (WebSampleBufferVideoRendering *)object;
 
             ensureOnMainThread([self, protectedSelf = RetainPtr { self }, renderer = WTF::move(renderer), error = WTF::move(error)] {
+                assertIsMainThread();
                 ASSERT(_videoRenderers.contains(renderer.get()));
                 if (RefPtr client = _client.get())
                     client->videoRendererDidReceiveError(renderer.get(), error.get());
@@ -183,6 +184,7 @@ static bool isSampleBufferVideoRenderer(id object)
             RetainPtr renderer = (AVSampleBufferAudioRenderer *)object;
 
             ensureOnMainThread([self, protectedSelf = RetainPtr { self }, renderer = WTF::move(renderer), error = WTF::move(error)] {
+                assertIsMainThread();
                 ASSERT(_audioRenderers.contains(renderer.get()));
                 if (RefPtr client = _client.get())
                     client->audioRendererDidReceiveError(renderer.get(), error.get());
@@ -199,6 +201,7 @@ static bool isSampleBufferVideoRenderer(id object)
         BOOL isObscured = [[change valueForKey:NSKeyValueChangeNewKey] boolValue];
 
         ensureOnMainThread([self, protectedSelf = RetainPtr { self }, renderer = WTF::move(renderer), isObscured] {
+            assertIsMainThread();
             ASSERT(_videoRenderers.contains(renderer.get()));
             if (RefPtr client = _client.get())
                 client->outputObscuredDueToInsufficientExternalProtectionChanged(isObscured);
@@ -215,6 +218,7 @@ static bool isSampleBufferVideoRenderer(id object)
     RetainPtr error = dynamic_objc_cast<NSError>([retainPtr(notification.userInfo) valueForKey:AVSampleBufferDisplayLayerFailedToDecodeNotificationErrorKey]);
 
     ensureOnMainThread([self, protectedSelf = RetainPtr { self }, renderer = WTF::move(renderer), error = WTF::move(error)] {
+        assertIsMainThread();
         if (!_videoRenderers.contains(renderer.get()))
             return;
         if (RefPtr client = _client.get())
@@ -228,6 +232,7 @@ static bool isSampleBufferVideoRenderer(id object)
     BOOL requiresFlush = [renderer requiresFlushToResumeDecoding];
 
     ensureOnMainThread([self, protectedSelf = RetainPtr { self }, renderer = WTF::move(renderer), requiresFlush] {
+        assertIsMainThread();
         if (!_videoRenderers.contains(renderer.get()))
             return;
         if (RefPtr client = _client.get())
@@ -244,6 +249,7 @@ static bool isSampleBufferVideoRenderer(id object)
     BOOL isReadyForDisplay = [layer isReadyForDisplay];
 
     ensureOnMainThread([self, protectedSelf = RetainPtr { self }, layer = WTF::move(layer), isReadyForDisplay] {
+        assertIsMainThread();
         if (!_videoRenderers.contains(layer.get()))
             return;
         if (RefPtr client = _client.get())
@@ -257,6 +263,7 @@ static bool isSampleBufferVideoRenderer(id object)
     CMTime flushTime = [[retainPtr(notification.userInfo) valueForKey:AVSampleBufferAudioRendererFlushTimeKey] CMTimeValue];
 
     ensureOnMainThread([self, protectedSelf = RetainPtr { self }, renderer = WTF::move(renderer), flushTime] {
+        assertIsMainThread();
         if (!_audioRenderers.contains(renderer.get()))
             return;
         if (RefPtr client = _client.get())


### PR DESCRIPTION
#### 6f1dd314cc55b8f8a74253ea88f0dd77b4fedfc1
<pre>
WebAVSampleBufferListener should assert the main thread when accessing _client in ensureOnMainThread blocks
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=320431">https://bugs.webkit.org/show_bug.cgi?id=320431</a>&gt;
&lt;<a href="https://rdar.apple.com/183392744">rdar://183392744</a>&gt;

Reviewed by Eric Carlson.

Assert the main thread at the top of each `ensureOnMainThread()` block
in `WebAVSampleBufferListenerPrivate` that reads the `_client` instance
variable.  `_client` is annotated
`WTF_GUARDED_BY_CAPABILITY(mainThread)`, and although every reader
reaches it through `ensureOnMainThread()`, the thread-safety analyzer
cannot infer that the dispatched block body runs on the main thread.
`assertIsMainThread()` supplies the missing main-thread capability so
`-Wthread-safety-analysis` can prove the guarded access is well-formed.

No new tests since no change in behavior.

* Source/WebCore/platform/graphics/avfoundation/WebAVSampleBufferListener.mm:
(-[WebAVSampleBufferListenerPrivate observeValueForKeyPath:ofObject:change:context:]):
(-[WebAVSampleBufferListenerPrivate layerFailedToDecode:]):
(-[WebAVSampleBufferListenerPrivate layerRequiresFlushToResumeDecodingChanged:]):
(-[WebAVSampleBufferListenerPrivate layerReadyForDisplayChanged:]):
(-[WebAVSampleBufferListenerPrivate audioRendererWasAutomaticallyFlushed:]):

Canonical link: <a href="https://commits.webkit.org/319012@main">https://commits.webkit.org/319012@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5d231d78726ec12bfcd2d1b35cd16dc1b83b4378

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177165 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51102 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44897 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186768 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/140401 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0db1bb5a-01a7-43ff-919a-b34f5caa7cca) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179028 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52395 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50912 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138038 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96288 "1 flakes 3 failures") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5308ae84-a35e-46ec-8611-eebf16de5f4c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180121 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41544 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158803 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118505 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f241290d-173f-4c01-b202-b3bc4fe51e43) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40200 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38689 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150610 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38302 "Passed tests") | [⏳ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/GTK-GTK3-GCC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42883 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42903 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189194 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50769 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147126 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51452 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34931 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/held.https.any.sharedworker.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146920 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27358 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41652 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123666 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117962 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49957 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13282 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49356 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49593 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49417 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->