### PR TITLE
Queue multiple JS dialog requests in the UI process (possible with site isolation enabled)

### DIFF
--- a/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
@@ -378,35 +378,22 @@ void WebPageProxy::beginSafeBrowsingCheck(const URL& url, API::Navigation& navig
 }
 
 #if HAVE(SAFE_BROWSING)
-void WebPageProxy::deferModalUntilSafeBrowsingCompletes(CompletionHandler<void(bool)>&& handler)
-{
-    ASSERT(isMainRunLoop());
-    ASSERT(handler);
-
-    if (!m_isSafeBrowsingCheckInProgress)
-        return handler(true);
-    m_deferredModalHandlers.append(WTF::move(handler));
-}
-
 void WebPageProxy::completeSafeBrowsingCheckForModals(bool userProceeded)
 {
     ASSERT(isMainRunLoop());
 
     m_isSafeBrowsingCheckInProgress = false;
 
-    auto& handlers = m_deferredModalHandlers;
-    if (handlers.isEmpty())
-        return;
-
-    for (auto& handler : std::exchange(handlers, { }))
-        handler(userProceeded);
+    if (userProceeded)
+        runNextModalJavaScriptDialogIfNeeded();
+    else
+        purgeQueuedModalDialogs();
 }
 
 void WebPageProxy::drainDeferredModalsForNewNavigation()
 {
     ASSERT(isMainRunLoop());
-    for (auto& handler : std::exchange(m_deferredModalHandlers, { }))
-        handler(false);
+    purgeQueuedModalDialogs();
 
     if (m_isSafeBrowsingCheckInProgress) {
         m_isSafeBrowsingCheckInProgress = false;

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -8157,10 +8157,7 @@ void WebPageProxy::didStartProvisionalLoadForFrameShared(Ref<WebProcessProxy>&& 
         m_pageLoadTimingPendingCommit = makeUnique<WebPageLoadTiming>(timestamp);
         m_generatePageLoadTimingTimer.stop();
 
-#if HAVE(SAFE_BROWSING)
-        for (auto& handler : std::exchange(m_deferredModalHandlers, { }))
-            handler(false);
-#endif
+        purgeQueuedModalDialogs();
     }
 
     // If a provisional load has since been started in another process, ignore this message.
@@ -10927,19 +10924,49 @@ void WebPageProxy::closePage()
     m_uiClient->close(this);
 }
 
-void WebPageProxy::runModalJavaScriptDialog(RefPtr<WebFrameProxy>&& frame, FrameInfoData&& frameInfo, String&& message, CompletionHandler<void(WebPageProxy&, WebFrameProxy* frame, FrameInfoData&& frameInfo, String&& message2, CompletionHandler<void()>&&)>&& runDialogCallback)
+void WebPageProxy::runModalJavaScriptDialog(RefPtr<WebFrameProxy>&& frame, FrameInfoData&& frameInfo, String&& message, CompletionHandler<void(WebPageProxy&, WebFrameProxy* frame, FrameInfoData&& frameInfo, String&& message2, CompletionHandler<void()>&&, DialogDisposition)>&& runDialogCallback)
 {
-    protect(pageClient())->runModalJavaScriptDialog([weakThis = WeakPtr { *this }, frameInfo = WTF::move(frameInfo), frame = WTF::move(frame), message = WTF::move(message), runDialogCallback = WTF::move(runDialogCallback)]() mutable {
-        RefPtr protectedThis { weakThis.get() };
+    m_queuedModalDialogs.append([weakThis = WeakPtr { *this }, frame = WTF::move(frame), frameInfo = WTF::move(frameInfo), message = WTF::move(message), runDialogCallback = WTF::move(runDialogCallback)](DialogDisposition disposition) mutable {
+        RefPtr protectedThis = weakThis.get();
         if (!protectedThis)
             return;
-
-        protectedThis->m_isRunningModalJavaScriptDialog = true;
-        runDialogCallback(*protectedThis, frame.get(), WTF::move(frameInfo), WTF::move(message), [weakThis = WTF::move(weakThis)]() mutable {
-            if (RefPtr protectedThis = weakThis.get())
+        if (disposition == DialogDisposition::Cancel) {
+            runDialogCallback(*protectedThis, frame.get(), WTF::move(frameInfo), WTF::move(message), [] { }, DialogDisposition::Cancel);
+            return;
+        }
+        protect(protectedThis->pageClient())->runModalJavaScriptDialog([weakThis = WTF::move(weakThis), frame = WTF::move(frame), frameInfo = WTF::move(frameInfo), message = WTF::move(message), runDialogCallback = WTF::move(runDialogCallback)]() mutable {
+            RefPtr protectedThis = weakThis.get();
+            if (!protectedThis)
+                return;
+            runDialogCallback(*protectedThis, frame.get(), WTF::move(frameInfo), WTF::move(message), [weakThis = WTF::move(weakThis)]() mutable {
+                RefPtr protectedThis = weakThis.get();
+                if (!protectedThis)
+                    return;
                 protectedThis->m_isRunningModalJavaScriptDialog = false;
+                protectedThis->runNextModalJavaScriptDialogIfNeeded();
+            }, DialogDisposition::Show);
         });
     });
+    runNextModalJavaScriptDialogIfNeeded();
+}
+
+void WebPageProxy::runNextModalJavaScriptDialogIfNeeded()
+{
+#if HAVE(SAFE_BROWSING)
+    if (m_isSafeBrowsingCheckInProgress)
+        return;
+#endif
+    if (m_isRunningModalJavaScriptDialog || m_queuedModalDialogs.isEmpty())
+        return;
+
+    m_isRunningModalJavaScriptDialog = true;
+    m_queuedModalDialogs.takeFirst()(DialogDisposition::Show);
+}
+
+void WebPageProxy::purgeQueuedModalDialogs()
+{
+    for (auto& dialog : std::exchange(m_queuedModalDialogs, { }))
+        dialog(DialogDisposition::Cancel);
 }
 
 void WebPageProxy::runJavaScriptAlert(IPC::Connection& connection, FrameIdentifier frameID, FrameInfoData&& frameInfo, String&& message, CompletionHandler<void()>&& reply)
@@ -10960,24 +10987,16 @@ void WebPageProxy::runJavaScriptAlert(IPC::Connection& connection, FrameIdentifi
             automationSession->willShowJavaScriptDialog(*this, message, std::nullopt);
     }
 
-    auto showModal = [protectedThis = Ref { *this }](RefPtr<WebFrameProxy>&& frame, FrameInfoData&& frameInfo, String&& message, CompletionHandler<void()>&& reply) mutable {
-        protectedThis->runModalJavaScriptDialog(WTF::move(frame), WTF::move(frameInfo), WTF::move(message), [reply = WTF::move(reply)](WebPageProxy& page, WebFrameProxy* frame, FrameInfoData&& frameInfo, String&& message, CompletionHandler<void()>&& completion) mutable {
-            page.m_uiClient->runJavaScriptAlert(page, WTF::move(message), frame, WTF::move(frameInfo), [reply = WTF::move(reply), completion = WTF::move(completion)]() mutable {
-                reply();
-                completion();
-            });
+    runModalJavaScriptDialog(WTF::move(frame), WTF::move(frameInfo), WTF::move(message), [reply = WTF::move(reply)](WebPageProxy& page, WebFrameProxy* frame, FrameInfoData&& frameInfo, String&& message, CompletionHandler<void()>&& completion, DialogDisposition disposition) mutable {
+        if (disposition == DialogDisposition::Cancel) {
+            reply();
+            return completion();
+        }
+        page.m_uiClient->runJavaScriptAlert(page, WTF::move(message), frame, WTF::move(frameInfo), [reply = WTF::move(reply), completion = WTF::move(completion)]() mutable {
+            reply();
+            completion();
         });
-    };
-
-#if HAVE(SAFE_BROWSING)
-    deferModalUntilSafeBrowsingCompletes([protectedThis = Ref { *this }, frame = WTF::move(frame), frameInfo = WTF::move(frameInfo), message = WTF::move(message), reply = WTF::move(reply), showModal = WTF::move(showModal)](bool shouldShow) mutable {
-        if (!shouldShow)
-            return reply();
-        showModal(WTF::move(frame), WTF::move(frameInfo), WTF::move(message), WTF::move(reply));
     });
-#else
-    showModal(WTF::move(frame), WTF::move(frameInfo), WTF::move(message), WTF::move(reply));
-#endif
 }
 
 void WebPageProxy::runJavaScriptConfirm(IPC::Connection& connection, FrameIdentifier frameID, FrameInfoData&& frameInfo, String&& message, CompletionHandler<void(bool)>&& reply)
@@ -10998,24 +11017,16 @@ void WebPageProxy::runJavaScriptConfirm(IPC::Connection& connection, FrameIdenti
             automationSession->willShowJavaScriptDialog(*this, message, std::nullopt);
     }
 
-    auto showModal = [protectedThis = Ref { *this }](RefPtr<WebFrameProxy>&& frame, FrameInfoData&& frameInfo, String&& message, CompletionHandler<void(bool)>&& reply) mutable {
-        protectedThis->runModalJavaScriptDialog(WTF::move(frame), WTF::move(frameInfo), WTF::move(message), [reply = WTF::move(reply)](WebPageProxy& page, WebFrameProxy* frame, FrameInfoData&& frameInfo, String&& message, CompletionHandler<void()>&& completion) mutable {
-            page.m_uiClient->runJavaScriptConfirm(page, WTF::move(message), frame, WTF::move(frameInfo), [reply = WTF::move(reply), completion = WTF::move(completion)](bool result) mutable {
-                reply(result);
-                completion();
-            });
+    runModalJavaScriptDialog(WTF::move(frame), WTF::move(frameInfo), WTF::move(message), [reply = WTF::move(reply)](WebPageProxy& page, WebFrameProxy* frame, FrameInfoData&& frameInfo, String&& message, CompletionHandler<void()>&& completion, DialogDisposition disposition) mutable {
+        if (disposition == DialogDisposition::Cancel) {
+            reply(false);
+            return completion();
+        }
+        page.m_uiClient->runJavaScriptConfirm(page, WTF::move(message), frame, WTF::move(frameInfo), [reply = WTF::move(reply), completion = WTF::move(completion)](bool result) mutable {
+            reply(result);
+            completion();
         });
-    };
-
-#if HAVE(SAFE_BROWSING)
-    deferModalUntilSafeBrowsingCompletes([protectedThis = Ref { *this }, frame = WTF::move(frame), frameInfo = WTF::move(frameInfo), message = WTF::move(message), reply = WTF::move(reply), showModal = WTF::move(showModal)](bool shouldShow) mutable {
-        if (!shouldShow)
-            return reply(false);
-        showModal(WTF::move(frame), WTF::move(frameInfo), WTF::move(message), WTF::move(reply));
     });
-#else
-    showModal(WTF::move(frame), WTF::move(frameInfo), WTF::move(message), WTF::move(reply));
-#endif
 }
 
 void WebPageProxy::runJavaScriptPrompt(IPC::Connection& connection, FrameIdentifier frameID, FrameInfoData&& frameInfo, String&& message, String&& defaultValue, CompletionHandler<void(const String&)>&& reply)
@@ -11036,24 +11047,16 @@ void WebPageProxy::runJavaScriptPrompt(IPC::Connection& connection, FrameIdentif
             automationSession->willShowJavaScriptDialog(*this, message, defaultValue);
     }
 
-    auto showModal = [protectedThis = Ref { *this }](RefPtr<WebFrameProxy>&& frame, FrameInfoData&& frameInfo, String&& message, String&& defaultValue, CompletionHandler<void(const String&)>&& reply) mutable {
-        protectedThis->runModalJavaScriptDialog(WTF::move(frame), WTF::move(frameInfo), WTF::move(message), [reply = WTF::move(reply), defaultValue = WTF::move(defaultValue)](WebPageProxy& page, WebFrameProxy* frame, FrameInfoData&& frameInfo, String&& message, CompletionHandler<void()>&& completion) mutable {
-            page.m_uiClient->runJavaScriptPrompt(page, WTF::move(message), WTF::move(defaultValue), frame, WTF::move(frameInfo), [reply = WTF::move(reply), completion = WTF::move(completion)](auto& result) mutable {
-                reply(result);
-                completion();
-            });
+    runModalJavaScriptDialog(WTF::move(frame), WTF::move(frameInfo), WTF::move(message), [reply = WTF::move(reply), defaultValue = WTF::move(defaultValue)](WebPageProxy& page, WebFrameProxy* frame, FrameInfoData&& frameInfo, String&& message, CompletionHandler<void()>&& completion, DialogDisposition disposition) mutable {
+        if (disposition == DialogDisposition::Cancel) {
+            reply({ });
+            return completion();
+        }
+        page.m_uiClient->runJavaScriptPrompt(page, WTF::move(message), WTF::move(defaultValue), frame, WTF::move(frameInfo), [reply = WTF::move(reply), completion = WTF::move(completion)](auto& result) mutable {
+            reply(result);
+            completion();
         });
-    };
-
-#if HAVE(SAFE_BROWSING)
-    deferModalUntilSafeBrowsingCompletes([protectedThis = Ref { *this }, frame = WTF::move(frame), frameInfo = WTF::move(frameInfo), message = WTF::move(message), defaultValue = WTF::move(defaultValue), reply = WTF::move(reply), showModal = WTF::move(showModal)](bool shouldShow) mutable {
-        if (!shouldShow)
-            return reply({ });
-        showModal(WTF::move(frame), WTF::move(frameInfo), WTF::move(message), WTF::move(defaultValue), WTF::move(reply));
     });
-#else
-    showModal(WTF::move(frame), WTF::move(frameInfo), WTF::move(message), WTF::move(defaultValue), WTF::move(reply));
-#endif
 }
 
 void WebPageProxy::setStatusText(const String& text)

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -3160,7 +3160,6 @@ private:
     void decidePolicyForResponse(IPC::Connection&, FrameInfoData&&, std::optional<WebCore::NavigationIdentifier>, const WebCore::ResourceResponse&, const WebCore::ResourceRequest&, bool canShowMIMEType, String&& downloadAttribute, bool isShowingInitialAboutBlank, WebCore::CrossOriginOpenerPolicyValue activeDocumentCOOPValue, CompletionHandler<void(PolicyDecision&&)>&&);
     void beginSafeBrowsingCheck(const URL&, API::Navigation&, bool forMainFrameNavigation);
     void showBrowsingWarning(RefPtr<WebKit::BrowsingWarning>&&);
-    void deferModalUntilSafeBrowsingCompletes(CompletionHandler<void(bool shouldShow)>&&);
     void completeSafeBrowsingCheckForModals(bool userProceeded);
     void drainDeferredModalsForNewNavigation();
 
@@ -3610,7 +3609,10 @@ private:
 
     void didUpdateEditorState(const EditorState& oldEditorState, const EditorState& newEditorState);
 
-    void runModalJavaScriptDialog(RefPtr<WebFrameProxy>&&, FrameInfoData&&, String&& message, CompletionHandler<void(WebPageProxy&, WebFrameProxy*, FrameInfoData&&, String&&, CompletionHandler<void()>&&)>&&);
+    enum class DialogDisposition : bool { Show, Cancel };
+    void runModalJavaScriptDialog(RefPtr<WebFrameProxy>&&, FrameInfoData&&, String&& message, CompletionHandler<void(WebPageProxy&, WebFrameProxy*, FrameInfoData&&, String&&, CompletionHandler<void()>&&, DialogDisposition)>&&);
+    void runNextModalJavaScriptDialogIfNeeded();
+    void purgeQueuedModalDialogs();
 
 #if ENABLE(IMAGE_ANALYSIS) && PLATFORM(MAC)
     void showImageInQuickLookPreviewPanel(WebCore::ShareableBitmap& imageBitmap, const String& tooltip, const URL& imageURL, QuickLookPreviewActivity);
@@ -4259,10 +4261,10 @@ private:
 
     bool m_lastNavigationWasAppInitiated { true };
     bool m_isRunningModalJavaScriptDialog { false };
+    Deque<Function<void(DialogDisposition)>> m_queuedModalDialogs;
     bool m_isSuspended { false };
 
 #if HAVE(SAFE_BROWSING)
-    Vector<CompletionHandler<void(bool)>> m_deferredModalHandlers;
     bool m_isSafeBrowsingCheckInProgress { false };
     std::optional<WebCore::NavigationIdentifier> m_safeBrowsingWarningShownForNavigation;
     std::optional<WebCore::NavigationIdentifier> m_committedMainFrameNavigationID;

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
@@ -1623,6 +1623,123 @@ TEST(SiteIsolation, MainFrameHeartbeatContinuesWhileCrossSiteIframeDialogShown)
         heldCompletion();
 }
 
+// With site isolation, a single WKWebView can have more than one WebContent process at once hosting it.
+// Each of those processes can make a JS dialog request to the UI process simultaneously.
+// As far as WKWebView API is concerned, the client would only expect to see one dialog at a time.
+// This test verifies that WebKit queues the requests and sends them to the API client serially.
+TEST(SiteIsolation, SimultaneousDialogsFromMultipleCrossOriginFrames)
+{
+    HTTPServer server({
+        { "/example"_s, { "<iframe src='https://webkit.org/webkit'></iframe>"
+            "<iframe src='https://apple.com/apple'></iframe>"
+            "<script>setTimeout(() => alert('example dialog'), 0)</script>"_s } },
+        { "/webkit"_s, { "<script>alert('webkit dialog')</script>"_s } },
+        { "/apple"_s, { "<script>alert('apple dialog')</script>"_s } },
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto [webView, navigationDelegate] = siteIsolatedViewAndDelegate(server);
+
+    // The three frames each request a dialog at roughly the same time, but WebKit must deliver
+    // them to the client one at a time: the next dialog should only appear after the previous
+    // one's completion handler has been called.
+    __block unsigned outstandingDialogs = 0;
+    __block unsigned totalDialogs = 0;
+    __block bool sawMoreThanOneAtOnce = false;
+    __block BlockPtr<void()> pendingCompletion;
+    RetainPtr receivedHosts = adoptNS([NSMutableSet new]);
+    RetainPtr uiDelegate = adoptNS([TestUIDelegate new]);
+    uiDelegate.get().runJavaScriptAlertPanelWithMessage = ^(WKWebView *, NSString *message, WKFrameInfo *frameInfo, void (^completionHandler)(void)) {
+        [receivedHosts addObject:frameInfo.securityOrigin.host];
+        totalDialogs++;
+        if (++outstandingDialogs > 1)
+            sawMoreThanOneAtOnce = true;
+        // Hold this dialog open; the test's run loop will release it, and only then should the
+        // next queued dialog be delivered.
+        pendingCompletion = makeBlockPtr(completionHandler);
+    };
+    webView.get().UIDelegate = uiDelegate.get();
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/example"]]];
+
+    // Release dialogs one at a time until all three have been delivered serially.
+    for (unsigned attempt = 0; attempt < 100 && totalDialogs < 3; ++attempt) {
+        TestWebKitAPI::Util::runFor(Seconds(0.05));
+        if (pendingCompletion) {
+            auto completion = std::exchange(pendingCompletion, nullptr);
+            --outstandingDialogs;
+            completion();
+        }
+    }
+
+    EXPECT_EQ(totalDialogs, 3u);
+    EXPECT_FALSE(sawMoreThanOneAtOnce);
+    EXPECT_TRUE([receivedHosts containsObject:@"example.com"]);
+    EXPECT_TRUE([receivedHosts containsObject:@"webkit.org"]);
+    EXPECT_TRUE([receivedHosts containsObject:@"apple.com"]);
+
+    if (pendingCompletion) {
+        auto completion = std::exchange(pendingCompletion, nullptr);
+        completion();
+    }
+}
+
+// Has two cross-origin iframes request a modal dialog, then navigates the main frame while one
+// of those requests is still queued. Makes sure the still-queued request cancels cleanly.
+TEST(SiteIsolation, QueuedDialogPurgedByMainFrameNavigation)
+{
+    HTTPServer server({
+        { "/example"_s, { "<iframe src='https://webkit.org/webkit'></iframe>"
+            "<iframe src='https://apple.com/apple'></iframe>"_s } },
+        { "/webkit"_s, { "<script>alert('webkit dialog')</script>"_s } },
+        { "/apple"_s, { "<script>alert('apple dialog')</script>"_s } },
+        { "/next"_s, { "<p>next</p>"_s } },
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto [webView, navigationDelegate] = siteIsolatedViewAndDelegate(server);
+
+    __block unsigned totalDialogs = 0;
+    __block BlockPtr<void()> firstCompletion;
+    RetainPtr uiDelegate = adoptNS([TestUIDelegate new]);
+    uiDelegate.get().runJavaScriptAlertPanelWithMessage = ^(WKWebView *, NSString *message, WKFrameInfo *frameInfo, void (^completionHandler)(void)) {
+        if (!totalDialogs++) {
+            // Hold the first dialog open so the second stays queued in the UI process.
+            firstCompletion = makeBlockPtr(completionHandler);
+            return;
+        }
+        // Reaching here means a queued dialog was delivered after the navigation, which is the bug.
+        completionHandler();
+    };
+    webView.get().UIDelegate = uiDelegate.get();
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/example"]]];
+
+    // Wait for the first dialog to be shown and held.
+    while (!firstCompletion)
+        TestWebKitAPI::Util::runFor(Seconds(0.05));
+
+    // Give the second cross-origin frame time to get its dialog request queued behind the first. It
+    // cannot be shown while the first is held, so a longer wait here is harmless.
+    TestWebKitAPI::Util::runFor(Seconds(0.5));
+
+    // Navigate the main frame and wait for the new provisional load to start, which is where the queue
+    // is purged.
+    __block bool navigationStarted = false;
+    navigationDelegate.get().didStartProvisionalNavigation = ^(WKWebView *, WKNavigation *) {
+        navigationStarted = true;
+    };
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/next"]]];
+    while (!navigationStarted)
+        TestWebKitAPI::Util::runFor(Seconds(0.05));
+
+    // Release the first dialog. If the queued dialog had not been purged, dismissing the first would
+    // let it flow to the API client now.
+    std::exchange(firstCompletion, nullptr)();
+
+    // Let anything still in flight settle, then confirm only the first dialog was ever delivered.
+    TestWebKitAPI::Util::runFor(Seconds(0.5));
+    EXPECT_EQ(totalDialogs, 1u);
+}
+
 TEST(SiteIsolation, GrandchildIframe)
 {
     HTTPServer server({


### PR DESCRIPTION
#### adb057839de955260036324af1343aa8dbb4875d
<pre>
Queue multiple JS dialog requests in the UI process (possible with site isolation enabled)
<a href="https://rdar.apple.com/156027399">rdar://156027399</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=320429">https://bugs.webkit.org/show_bug.cgi?id=320429</a>

Reviewed by Alex Christensen.

With site isolation, a single WKWebView can have multiple web content processes at once.
Each of those processes might be making a request to show a modal JS dialog,
meaning the UI process can receive multiple requests at once.

Before site isolation, a WebKit API client would only ever receive a single JS dialog
request at once for a given WKWebView, but now they might receive more than one at once.

This is a surprising and probably breaking change, and was unintentional. So this patch
teaches the UI process to queue API dialog requests and send them to the client serially.

There was already an instance where we queued &quot;modal dialog requests&quot; - which was while the
web page was waiting on a safe browsing check - and this PR rolls these two queues into one.

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm

* Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm:
(WebKit::WebPageProxy::completeSafeBrowsingCheckForModals):
(WebKit::WebPageProxy::drainDeferredModalsForNewNavigation):
(WebKit::WebPageProxy::deferModalUntilSafeBrowsingCompletes): Deleted.
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::didStartProvisionalLoadForFrameShared):
(WebKit::WebPageProxy::runModalJavaScriptDialog):
(WebKit::WebPageProxy::runNextModalJavaScriptDialogIfNeeded):
(WebKit::WebPageProxy::purgeQueuedModalDialogs):
(WebKit::WebPageProxy::runJavaScriptAlert):
(WebKit::WebPageProxy::runJavaScriptConfirm):
(WebKit::WebPageProxy::runJavaScriptPrompt):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm:
(TestWebKitAPI::TEST(SiteIsolation, SimultaneousDialogsFromMultipleCrossOriginFrames)):
(TestWebKitAPI::TEST(SiteIsolation, QueuedDialogPurgedByMainFrameNavigation)):

Canonical link: <a href="https://commits.webkit.org/318134@main">https://commits.webkit.org/318134@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3a3084ba58f74b9350b8861b5b30c058b54b1968

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177384 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51322 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45116 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186988 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140631 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6a478afb-e900-428d-9e66-8b0e42ba466e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179247 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52614 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51031 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138233 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140631 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f7e5cc78-9a56-42fe-a0c4-641f4081ff49) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180340 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41735 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/158991 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118698 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b52e79b1-ffd8-4e30-bd74-0ff5fa3c1a4f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40397 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/38771 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150804 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38488 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-highlight-api/painting/custom-highlight-dynamic-font-metrics-001.html (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35455 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/43107 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/43005 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189416 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50988 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147328 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39587 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51671 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/35115 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147120 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41841 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123886 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118224 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50179 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13466 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49575 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49815 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49637 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->