### PR TITLE
Web Inspector: overlay label ellipsis truncation is O(length²)

### DIFF
--- a/Source/WebCore/inspector/InspectorOverlayLabel.cpp
+++ b/Source/WebCore/inspector/InspectorOverlayLabel.cpp
@@ -241,15 +241,33 @@ Path InspectorOverlayLabel::draw(GraphicsContext& context, float maximumLineWidt
             auto textRun = TextRun(text);
             float textWidth = font.width(textRun);
 
-            // FIXME: This looks very inefficient.
             if (maximumLineWidth && currentLineWidth + textWidth + (labelPadding * 2) > maximumLineWidth) {
-                text = makeString(text, ellipsis);
-                while (currentLineWidth + textWidth + (labelPadding * 2) > maximumLineWidth && text.length() > 1) {
-                    // Remove the second from last character (the character before the ellipsis) and remeasure.
-                    text = makeStringByRemoving(text, text.length() - 2, 1);
-                    textRun = TextRun(text);
-                    textWidth = font.width(textRun);
+                // Binary search for the longest prefix of `text` that, with an ellipsis appended, fits within
+                // maximumLineWidth. Each candidate is remeasured before being accepted, so the result never
+                // overflows even if width isn't strictly monotonic in prefix length.
+                auto widthWithEllipsis = [&](unsigned prefixLength) {
+                    textRun = TextRun(makeString(StringView(text).left(prefixLength), ellipsis));
+                    return font.width(textRun);
+                };
+
+                unsigned bestPrefixLength = 0;
+                unsigned low = 0;
+                unsigned high = text.length();
+                while (low <= high) {
+                    unsigned mid = low + (high - low) / 2;
+                    if (currentLineWidth + widthWithEllipsis(mid) + (labelPadding * 2) <= maximumLineWidth) {
+                        bestPrefixLength = mid;
+                        low = mid + 1;
+                    } else {
+                        if (!mid)
+                            break;
+                        high = mid - 1;
+                    }
                 }
+
+                text = makeString(StringView(text).left(bestPrefixLength), ellipsis);
+                textRun = TextRun(text);
+                textWidth = font.width(textRun);
             }
 
             computedContentRuns.append({ textRun, content.textColor, content.decoration, startsNewLine, textWidth });


### PR DESCRIPTION
#### 3e8ef0e63a8d240db1aac3024dc81a4ab1b709c6
<pre>
Web Inspector: overlay label ellipsis truncation is O(length&#178;)
<a href="https://bugs.webkit.org/show_bug.cgi?id=320434">https://bugs.webkit.org/show_bug.cgi?id=320434</a>
<a href="https://rdar.apple.com/183397793">rdar://183397793</a>

Reviewed by NOBODY (OOPS!).

InspectorOverlayLabel::draw() truncated overlong label text by removing one
character at a time and remeasuring the whole string with FontCascade::width()
after each removal, an O(length) loop where each iteration itself does
O(length) work, i.e. O(length^2) overall for a single label line.

Replace this with a binary search over the truncation prefix length. This
assumes width is roughly monotonic in prefix length, which kerning/ligatures
and RTL/bidi shaping can violate in principle; each candidate is still
remeasured directly before being accepted, so the result can never overflow
the available width, only potentially truncate a character or two more than
the strict optimum in those rare cases. Visually-correct bidi truncation would
require truncating already-shaped, bidi-resolved runs in visual order (as
line layout does for text-overflow: ellipsis), which is out of scope for this
standalone debug label text. Number of measurements drops from O(length) to
O(log length).

* Source/WebCore/inspector/InspectorOverlayLabel.cpp:
(WebCore::InspectorOverlayLabel::draw):
</pre>

---
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3e8ef0e63a8d240db1aac3024dc81a4ab1b709c6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177171 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51108 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44903 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186774 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/140407 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7b13a3c9-5527-4242-9ca7-737cc9f23bd4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179034 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52401 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50794 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138046 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96289 "1 flakes 2 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1a38bff6-558c-4e0c-b0fa-647a4740a0b4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180127 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/41554 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158812 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118513 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3560fdc5-1250-48a0-b10d-a498fcf8d205) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/40210 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38596 "Passed tests") | | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/150623 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38311 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35242 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42889 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/42815 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189200 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50775 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147134 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51458 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34940 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146928 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41661 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123672 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117971 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49963 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13291 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Checked out pull request; Uploaded test results") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49362 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49599 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49423 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->