### PR TITLE
[JSC] Fix JSON stringify regression due to toJSON check

### DIFF
--- a/JSTests/stress/json-stringify-enumerable-to-json.js
+++ b/JSTests/stress/json-stringify-enumerable-to-json.js
@@ -1,0 +1,71 @@
+function shouldBe(actual, expected)
+{
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+function shouldThrow(func, errorType)
+{
+    let error;
+    try {
+        func();
+    } catch (e) {
+        error = e;
+    }
+    if (!(error instanceof errorType))
+        throw new Error(`bad error: ${String(error)}`);
+}
+
+// FastStringifier's property loop only tests for toJSON on the DontEnum branch, since that
+// branch is the one that would otherwise skip the entry. An enumerable own toJSON needs no
+// such test: a callable one fails the fast path when its value is appended, and a
+// non-callable one is serialized as an ordinary property, which is what the loop does.
+// These cases cover that reasoning; the expectations match V8.
+
+// An enumerable own callable toJSON is invoked.
+{
+    shouldBe(JSON.stringify({ a: 1, toJSON() { return 'method'; } }), '"method"');
+    shouldBe(JSON.stringify({ a: 1, toJSON: () => 'arrow' }), '"arrow"');
+    shouldBe(JSON.stringify({ a: 1, toJSON: function () { return { b: 2 }; } }), '{"b":2}');
+    shouldBe(JSON.stringify({ a: 1, toJSON: function (key) { return key; } }), '""');
+    shouldBe(JSON.stringify({ key: { a: 1, toJSON: function (key) { return key; } } }), '{"key":"key"}');
+    shouldBe(JSON.stringify({ nested: { a: 1, toJSON() { return 42; } } }), '{"nested":42}');
+    shouldBe(JSON.stringify([{ a: 1, toJSON() { return [1]; } }]), '[[1]]');
+    shouldBe(JSON.stringify({ a: 1, toJSON: (function () { }).bind(null) }), undefined);
+    shouldBe(JSON.stringify({ a: 1, toJSON: new Proxy(function () { return 'proxy'; }, { }) }), '"proxy"');
+    shouldBe(JSON.stringify({ a: 1, toJSON: function* () { } }), '{}');
+    shouldThrow(() => JSON.stringify({ a: 1, toJSON: class C { } }), TypeError);
+}
+
+// An enumerable own non-callable toJSON is serialized as an ordinary property.
+{
+    shouldBe(JSON.stringify({ a: 1, toJSON: 42 }), '{"a":1,"toJSON":42}');
+    shouldBe(JSON.stringify({ a: 1, toJSON: 'str' }), '{"a":1,"toJSON":"str"}');
+    shouldBe(JSON.stringify({ a: 1, toJSON: true }), '{"a":1,"toJSON":true}');
+    shouldBe(JSON.stringify({ a: 1, toJSON: null }), '{"a":1,"toJSON":null}');
+    shouldBe(JSON.stringify({ a: 1, toJSON: undefined }), '{"a":1}');
+    shouldBe(JSON.stringify({ a: 1, toJSON: { b: 2 } }), '{"a":1,"toJSON":{"b":2}}');
+    shouldBe(JSON.stringify({ a: 1, toJSON: [1, 2] }), '{"a":1,"toJSON":[1,2]}');
+    shouldBe(JSON.stringify({ toJSON: 'only' }), '{"toJSON":"only"}');
+}
+
+// The fast path and the general stringifier must agree, with and without a gap.
+{
+    let values = [
+        { a: 1, toJSON() { return 'method'; } },
+        { a: 1, toJSON: 42 },
+        { a: 1, toJSON: { nested: 1 } },
+        { a: 1, b: 2, c: 3, toJSON: 7 },
+        { toJSON: undefined, a: 1 },
+        { toJSON: 'only' },
+    ];
+    for (let value of values) {
+        for (let space of [undefined, 2, '\t'])
+            shouldBe(JSON.stringify(value, null, space), JSON.stringify(value, (key, x) => x, space));
+    }
+}
+
+for (let i = 0; i < testLoopCount; ++i) {
+    shouldBe(JSON.stringify({ a: 1, toJSON() { return 'hot'; } }), '"hot"');
+    shouldBe(JSON.stringify({ a: 1, toJSON: 42 }), '{"a":1,"toJSON":42}');
+}

--- a/Source/JavaScriptCore/runtime/JSONObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSONObject.cpp
@@ -1461,14 +1461,19 @@ void FastStringifier<CharType, bufferMode>::append(JSValue value)
             ++m_depth;
         const unsigned newLineAndIndent = hasGap == HasGap::Yes ? newLineAndIndentSize() : 0;
         structure.forEachProperty(m_vm, [&](const auto& entry) -> bool {
-            // https://tc39.es/ecma262/#sec-serializejsonproperty
-            // Step 2.a's GetV finds an own toJSON regardless of enumerability.
-            if (entry.key() == m_vm.propertyNames->toJSON) [[unlikely]] {
-                recordFailure("object has toJSON"_s);
-                return false;
-            }
-            if (entry.attributes() & PropertyAttribute::DontEnum)
+            if (entry.attributes() & PropertyAttribute::DontEnum) [[unlikely]] {
+                // https://tc39.es/ecma262/#sec-serializejsonproperty
+                // Step 2.a's GetV finds an own toJSON regardless of enumerability, so a
+                // non-enumerable one still applies even though this loop skips the entry.
+                // An enumerable toJSON needs no check.
+                // 1. If it is callable, appending its value below fails the fast path.
+                // 2. If it is not callable the spec serializes it as an ordinary property.
+                if (entry.key() == m_vm.propertyNames->toJSON) [[unlikely]] {
+                    recordFailure("object has non-enumerable toJSON"_s);
+                    return false;
+                }
                 return true;
+            }
             auto& name = *entry.key();
             if (name.isSymbol()) [[unlikely]] {
                 recordFailure("symbol"_s);


### PR DESCRIPTION
#### 9f9370cc729f0e035aa09416b3ca84e6ac8a69c5
<pre>
[JSC] Fix JSON stringify regression due to toJSON check
<a href="https://bugs.webkit.org/show_bug.cgi?id=320437">https://bugs.webkit.org/show_bug.cgi?id=320437</a>
<a href="https://rdar.apple.com/183400665">rdar://183400665</a>

Reviewed by Sosuke Suzuki.

316941@main becomes performance regression in JSON.stringify because we
insert toJSON name check in the one of the hottest loop listing
properties. But we do not need this check for enumerable properties.
When it is enumerable, we check this field later anyway, and we fail if
it is callable one and otherwise it is just handled as a normal object.
So we only need to check this name when a property is non-enumerable.
This patch fixes it by moving the check to make this loop fast.

Test: JSTests/stress/json-stringify-enumerable-to-json.js

* JSTests/stress/json-stringify-enumerable-to-json.js: Added.
(shouldBe):
(shouldThrow):
(shouldBe.JSON.stringify.toJSON):
(shouldBe.JSON.stringify.key.toJSON):
(shouldBe.JSON.stringify.nested.toJSON):
(shouldBe.JSON.stringify.toJSON.new.Proxy):
(shouldThrow.JSON.stringify.toJSON):
(shouldThrow.JSON.stringify):
(i.shouldBe.JSON.stringify.toJSON):
* Source/JavaScriptCore/runtime/JSONObject.cpp:
(JSC::bufferMode&gt;::append):

Canonical link: <a href="https://commits.webkit.org/318072@main">https://commits.webkit.org/318072@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d1b1cb7f3a0b2b2c5d2ec5069d5ac6a993c02ef7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177177 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51114 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44909 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186780 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140413 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c7f5af62-7ac5-41a7-977e-0a43ebbcbd49) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52407 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50800 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138052 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140413 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5c9a7da2-ffec-42b2-9d2c-701e48beb32e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180133 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41560 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158816 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118519 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a5727da1-cad8-4327-8234-c3c48efb8671) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40216 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38598 "Passed tests") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/251/builds/488 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/7320 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150627 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38315 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35248 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/38448 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42896 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/42819 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189206 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50781 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147138 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51464 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34944 "Found 2 new test failures: pageoverlay/overlay-small-frame-mouse-events.html pageoverlay/overlay-small-frame-paints.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146932 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26877 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41663 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123678 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117982 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49969 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13295 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49368 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49605 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49429 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->