### PR TITLE
Web Inspector: SelectionController tree comparator is O(n² log n) due to repeated children.indexOf() per comparison

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Controllers/SelectionController.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/SelectionController.js
@@ -52,7 +52,22 @@ WI.SelectionController = class SelectionController extends WI.Object
 
     static createTreeComparator(itemForRepresentedObject)
     {
-        return (a, b) => {
+        // Within a single sort the tree is not mutated, so each item's index in
+        // its parent's children list is stable. Memoize it so the comparator
+        // stays O(1) per compare instead of doing two linear children.indexOf()
+        // lookups on every comparison. The cache must be reset before each sort
+        // (see comparator.reset) because the tree can change between sorts.
+        let indexInParentCache = new Map;
+        let indexInParent = (item) => {
+            let index = indexInParentCache.get(item);
+            if (index === undefined) {
+                index = item.parent.children.indexOf(item);
+                indexInParentCache.set(item, index);
+            }
+            return index;
+        };
+
+        let comparator = (a, b) => {
             a = itemForRepresentedObject(a);
             b = itemForRepresentedObject(b);
             if (!a || !b)
@@ -65,9 +80,7 @@ WI.SelectionController = class SelectionController extends WI.Object
                 return level;
             };
 
-            let compareSiblings = (s, t) => {
-                return s.parent.children.indexOf(s) - s.parent.children.indexOf(t);
-            };
+            let compareSiblings = (s, t) => indexInParent(s) - indexInParent(t);
 
             if (a.parent === b.parent)
                 return compareSiblings(a, b);
@@ -95,6 +108,10 @@ WI.SelectionController = class SelectionController extends WI.Object
             console.assert(a.parent === b.parent, "Missing common ancestor.", a, b);
             return compareSiblings(a, b);
         };
+
+        comparator.reset = () => indexInParentCache.clear();
+
+        return comparator;
     }
 
     static createListComparator(indexForRepresentedObject)
@@ -240,6 +257,7 @@ WI.SelectionController = class SelectionController extends WI.Object
 
         let operation = this._allowsMultipleSelection ? WI.SelectionController.Operation.Extend : WI.SelectionController.Operation.Direct;
 
+        this._comparator.reset?.();
         let orderedSelection = Array.from(this._selectedItems).sort(this._comparator);
 
         // Try selecting the item preceding the selection.
@@ -346,6 +364,7 @@ WI.SelectionController = class SelectionController extends WI.Object
         // selected range and add the new range between the anchor and clicked item.
 
         let sortItemPair = (a, b) => {
+            this._comparator.reset?.();
             return [a, b].sort(this._comparator);
         };
 


### PR DESCRIPTION
#### 6fae2f080f3dfff4a7fda807a4ab0d6e07a55108
<pre>
Web Inspector: SelectionController tree comparator is O(n² log n) due to repeated children.indexOf() per comparison
<a href="https://bugs.webkit.org/show_bug.cgi?id=320440">https://bugs.webkit.org/show_bug.cgi?id=320440</a>
<a href="https://rdar.apple.com/183404025">rdar://183404025</a>

Reviewed by NOBODY (OOPS!).

The comparator returned by SelectionController.createTreeComparator()
resolved each sibling&apos;s position with parent.children.indexOf(), and did
so twice per comparison. Since the comparator is fed to Array.prototype.sort(),
sorting a selection of n items invoked it O(n log n) times, and every
invocation was O(k) in the sibling-list length k. For a flat list where the
selection spans all siblings (k == n) this degenerates to ~O(n² log n),
which can cause a noticeable delay when reordering large selections.

This path is used by TreeOutline (e.g. DOMTreeOutline) and DataGrid (e.g. the
Timeline and Heap grids); Table uses createListComparator and is unaffected.

Memoize each item&apos;s index within its parent&apos;s children for the duration of a
single sort. The tree is not mutated during a synchronous sort, so cached
indices are exact; the cache is reset before each sort because the tree can
change between sorts. This makes each comparison O(1) after the first touch of
an item, lowering the sort to O(n·k + n log n). The parent-chain walk for
cross-level comparisons is unchanged.

* UserInterface/Controllers/SelectionController.js:
(WI.SelectionController.createTreeComparator): Cache index-in-parent lookups
and expose a reset() on the returned comparator to clear the cache per sort.
(WI.SelectionController.prototype.removeSelectedItems): Reset the comparator
cache before sorting the selection.
(WI.SelectionController.prototype._addRangeToSelection.sortItemPair): Ditto.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6fae2f080f3dfff4a7fda807a4ab0d6e07a55108

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177182 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51119 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44914 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186785 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/140418 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1c95b390-465b-4ec5-b0b9-f16fcb005912) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52412 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50961 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138056 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96293 "2 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0fa0dd1d-b7a3-46ba-a984-a33f33893120) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180138 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41564 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158823 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118523 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e410b442-f774-4a40-aefb-575244d674cb) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40220 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38600 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150631 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38322 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35253 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42901 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42952 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189211 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50786 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147143 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51469 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34951 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146937 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41667 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123683 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117988 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49974 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13302 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49373 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49610 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49434 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->