### PR TITLE
Cherry-pick 318055@main (9f0d1487e002). https://bugs.webkit.org/show_bug.cgi?id=320327

### DIFF
--- a/Source/WebCore/platform/audio/gstreamer/AudioDecoderGStreamer.cpp
+++ b/Source/WebCore/platform/audio/gstreamer/AudioDecoderGStreamer.cpp
@@ -78,6 +78,11 @@ private:
 
 void GStreamerAudioDecoder::create(const String& codecName, const Config& config, CreateCallback&& callback, OutputCallback&& outputCallback)
 {
+    if (!ensureGStreamerInitialized()) [[unlikely]] {
+        callback(makeUnexpected("GStreamer initialization failed"_s));
+        return;
+    }
+
     static std::once_flag debugRegisteredFlag;
     std::call_once(debugRegisteredFlag, [] {
         GST_DEBUG_CATEGORY_INIT(webkit_audio_decoder_debug, "webkitaudiodecoder", 0, "WebKit WebCodecs Audio Decoder");

--- a/Source/WebCore/platform/audio/gstreamer/AudioEncoderGStreamer.cpp
+++ b/Source/WebCore/platform/audio/gstreamer/AudioEncoderGStreamer.cpp
@@ -85,6 +85,9 @@ private:
 
 Ref<AudioEncoder::CreatePromise> GStreamerAudioEncoder::create(const String& codecName, const AudioEncoder::Config& config, DescriptionCallback&& descriptionCallback, OutputCallback&& outputCallback)
 {
+    if (!ensureGStreamerInitialized()) [[unlikely]]
+        return CreatePromise::createAndReject("GStreamer initialization failed"_s);
+
     static std::once_flag debugRegisteredFlag;
     std::call_once(debugRegisteredFlag, [] {
         GST_DEBUG_CATEGORY_INIT(webkit_audio_encoder_debug, "webkitaudioencoder", 0, "WebKit WebCodecs Audio Encoder");

--- a/Source/WebCore/platform/graphics/gstreamer/VideoDecoderGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoDecoderGStreamer.cpp
@@ -94,6 +94,11 @@ private:
 
 void GStreamerVideoDecoder::create(const String& codecName, const Config& config, CreateCallback&& callback, OutputCallback&& outputCallback)
 {
+    if (!ensureGStreamerInitialized()) [[unlikely]] {
+        callback(makeUnexpected("GStreamer initialization failed"_s));
+        return;
+    }
+
     static std::once_flag debugRegisteredFlag;
     std::call_once(debugRegisteredFlag, [] {
         GST_DEBUG_CATEGORY_INIT(webkit_video_decoder_debug, "webkitvideodecoder", 0, "WebKit WebCodecs Video Decoder");

--- a/Source/WebCore/platform/graphics/gstreamer/VideoEncoderGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoEncoderGStreamer.cpp
@@ -109,6 +109,9 @@ void GStreamerVideoEncoder::create(const String& codecName, const VideoEncoder::
 
 Expected<Ref<GStreamerVideoEncoder>, String> GStreamerVideoEncoder::create(const String& codecName, const VideoEncoder::Config& config, DescriptionCallback&& descriptionCallback, OutputCallback&& outputCallback)
 {
+    if (!ensureGStreamerInitialized()) [[unlikely]]
+        return makeUnexpected("GStreamer initialization failed"_s);
+
     static std::once_flag debugRegisteredFlag;
     std::call_once(debugRegisteredFlag, [] {
         GST_DEBUG_CATEGORY_INIT(webkit_video_encoder_debug, "webkitvideoencoder", 0, "WebKit WebCodecs Video Encoder");

--- a/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
@@ -438,17 +438,15 @@ std::tuple<GRefPtr<GstCaps>, StreamType, FloatSize> AppendPipeline::parseDemuxer
 
     auto originalMediaType = capsMediaType(demuxerSrcPadCaps);
     auto& gstRegistryScanner = GStreamerRegistryScannerMSE::singleton();
-    if (doCapsHaveType(demuxerSrcPadCaps, GST_TEXT_CAPS_TYPE_PREFIX) || originalMediaType == "application/x-subtitle-vtt"_s || originalMediaType == "closedcaption/x-cea-608") {
+    if (doCapsHaveType(demuxerSrcPadCaps, GST_TEXT_CAPS_TYPE_PREFIX) || originalMediaType == "application/x-subtitle-vtt"_s || originalMediaType == "closedcaption/x-cea-608"_s) {
         streamType = StreamType::Text;
     } else if (!gstRegistryScanner.isCodecSupported(GStreamerRegistryScanner::Configuration::Decoding, originalMediaType.span())) {
         streamType = StreamType::Invalid;
     } else if (doCapsHaveType(demuxerSrcPadCaps, GST_VIDEO_CAPS_TYPE_PREFIX)) {
         presentationSize = getVideoResolutionFromCaps(demuxerSrcPadCaps).value_or(FloatSize());
         streamType = StreamType::Video;
-    } else {
-        if (doCapsHaveType(demuxerSrcPadCaps, GST_AUDIO_CAPS_TYPE_PREFIX))
-            streamType = StreamType::Audio;
-    }
+    } else if (doCapsHaveType(demuxerSrcPadCaps, GST_AUDIO_CAPS_TYPE_PREFIX))
+        streamType = StreamType::Audio;
 
     return { WTF::move(parsedCaps), streamType, WTF::move(presentationSize) };
 }
@@ -574,7 +572,7 @@ void AppendPipeline::appsinkNewSample(const Track& track, GRefPtr<GstSample>&& s
     }
 
     if (hasValidPTS)
-        m_sourceBufferPrivate.didReceiveSample(mediaSample.get());
+        m_sourceBufferPrivate.didReceiveSample(WTF::move(mediaSample));
 }
 
 #ifndef GST_DISABLE_GST_DEBUG
@@ -1089,7 +1087,7 @@ static GRefPtr<GstElement> createOptionalParserForFormat([[maybe_unused]] GstBin
         // Necessary for: metadata filling.
         // Without this parser the codec string set on the corresponding video track will be incomplete.
         elementClass = "vp9parse"_s;
-    } else if (mediaType == "closedcaption/x-cea-608") {
+    } else if (mediaType == "closedcaption/x-cea-608"_s) {
         // Used in converting cea-608 to WebVTT.
         // qtdemux pushes captions in format: s334-1a, while cea608tott expects format: raw.
         elementClass = "ccconverter"_s;
@@ -1119,7 +1117,7 @@ GRefPtr<GstElement> createOptionalEncoderForFormat([[maybe_unused]] GstBin* bin,
     //   - SouceBuffer timestampOffset   (Media Source Extensions, 5.1 Attributes)
     if (mediaType == "text/x-raw"_s)
         elementClass = "webvttenc"_s;
-    else if (mediaType == "closedcaption/x-cea-608")
+    else if (mediaType == "closedcaption/x-cea-608"_s)
         elementClass = "cea608tott"_s;
 
     GST_DEBUG_OBJECT(bin, "Creating %s encoder for stream with caps %" GST_PTR_FORMAT, elementClass.characters(), caps);


### PR DESCRIPTION
#### edeb513a25f2277fa0e151f8857080893571203c
<pre>
Cherry-pick 318055@main (9f0d1487e002). <a href="https://bugs.webkit.org/show_bug.cgi?id=320327">https://bugs.webkit.org/show_bug.cgi?id=320327</a>

    [GStreamer] Any WebCodecs VideoEncoder use crashes WebKitWebProcess (SIGABRT) during webkitvideoencoder element registration
    <a href="https://bugs.webkit.org/show_bug.cgi?id=320327">https://bugs.webkit.org/show_bug.cgi?id=320327</a>

    Reviewed by Xabier Rodriguez-Calvar.

    Make sure GStreamer is initialized before creating WebCodecs backends.

    * Source/WebCore/platform/audio/gstreamer/AudioDecoderGStreamer.cpp:
    (WebCore::GStreamerAudioDecoder::create):
    * Source/WebCore/platform/audio/gstreamer/AudioEncoderGStreamer.cpp:
    (WebCore::GStreamerAudioEncoder::create):
    * Source/WebCore/platform/graphics/gstreamer/VideoDecoderGStreamer.cpp:
    (WebCore::GStreamerVideoDecoder::create):
    * Source/WebCore/platform/graphics/gstreamer/VideoEncoderGStreamer.cpp:
    (WebCore::GStreamerVideoEncoder::create):

    Canonical link: <a href="https://commits.webkit.org/318055@main">https://commits.webkit.org/318055@main</a>

Canonical link: <a href="https://commits.webkit.org/317695.7@webkitglib/2.54">https://commits.webkit.org/317695.7@webkitglib/2.54</a>
</pre>
----------------------------------------------------------------------
#### a133f46c703a75d763d44e0e6eb813b28b8375fb
<pre>
Cherry-pick 317971@main (34b6ff507c28). <a href="https://bugs.webkit.org/show_bug.cgi?id=320170">https://bugs.webkit.org/show_bug.cgi?id=320170</a>

    [GStreamer][MSE] Minor fixes for AppendPipeline
    <a href="https://bugs.webkit.org/show_bug.cgi?id=320170">https://bugs.webkit.org/show_bug.cgi?id=320170</a>

    Reviewed by Xabier Rodriguez-Calvar.

    * Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp:
    (WebCore::AppendPipeline::parseDemuxerSrcPadCaps): Refactor an else clause.
    (WebCore::AppendPipeline::appsinkNewSample): Pass the moved media sample reference to
    didReceiveSample.
    (WebCore::createOptionalParserForFormat): Add string operator for comparison with mediaType CStringView.
    (WebCore::createOptionalEncoderForFormat): Ditto.

    Canonical link: <a href="https://commits.webkit.org/317971@main">https://commits.webkit.org/317971@main</a>

Canonical link: <a href="https://commits.webkit.org/317695.6@webkitglib/2.54">https://commits.webkit.org/317695.6@webkitglib/2.54</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/63a5640ce976580618150f3b9ce5a9cb4cc3c725

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177190 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/51127 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/44922 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186793 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140426 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179053 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/52420 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/50814 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138068 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140426 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180146 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/52420 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/44922 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118533 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/52420 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/50814 "The change is no longer eligible for processing.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/44922 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/52420 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/44922 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35261 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/42911 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/50814 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189219 "Built successfully") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/176593 "Build is in progress. Recent messages:") | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/50794 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/44922 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147156 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/51477 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/44922 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146948 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26871 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/51477 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/123691 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/117998 "The change is no longer eligible for processing.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/49982 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/44922 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/49381 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/49618 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/49442 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->