### PR TITLE
Implement fetch upload backpressure

### DIFF
--- a/LayoutTests/http/wpt/service-workers/upload-stream-backpressure-worker.js
+++ b/LayoutTests/http/wpt/service-workers/upload-stream-backpressure-worker.js
@@ -1,0 +1,33 @@
+let waitingToRead = null;
+
+addEventListener("fetch", (event) => {
+    const url = new URL(event.request.url);
+
+    if (url.searchParams.get("release") === "1") {
+        if (waitingToRead) {
+            waitingToRead.resolve();
+            waitingToRead = null;
+        }
+        event.respondWith(new Response("released"));
+        return;
+    }
+
+    if (!url.pathname.endsWith("backpressure-endpoint"))
+        return;
+
+    event.respondWith((async () => {
+        await new Promise((resolve) => { waitingToRead = { resolve }; });
+
+        const reader = event.request.body.getReader();
+        let total = 0;
+        while (true) {
+            const { value, done } = await reader.read();
+            if (done)
+                break;
+            total += value.byteLength;
+        }
+        return new Response(String(total), {
+            headers: { "Content-Type": "text/plain" },
+        });
+    })());
+});

--- a/LayoutTests/http/wpt/service-workers/upload-stream-backpressure.https-expected.txt
+++ b/LayoutTests/http/wpt/service-workers/upload-stream-backpressure.https-expected.txt
@@ -1,0 +1,6 @@
+
+
+PASS Setup: register service worker
+PASS Backpressure pauses the ReadableStream pull() and resumes once the service worker consumes the body
+PASS Cleanup: unregister service worker
+

--- a/LayoutTests/http/wpt/service-workers/upload-stream-backpressure.https.html
+++ b/LayoutTests/http/wpt/service-workers/upload-stream-backpressure.https.html
@@ -1,0 +1,126 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Upload stream backpressure releases when a service worker consumes the body</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<script>
+const scope = "resources";
+const endpoint = "resources/backpressure-endpoint";
+const releaseUrl = "resources/backpressure-endpoint?release=1";
+const CHUNK_SIZE = 16 * 1024;   // 16 KB per pull
+const MAX_TOTAL   = 4 * 1024 * 1024; // 4 MB safety cap
+let activeWorker;
+let controlledFrame;
+
+function withIframe(url) {
+    return new Promise((resolve) => {
+        const iframe = document.createElement("iframe");
+        iframe.src = url;
+        iframe.onload = () => resolve(iframe);
+        document.body.appendChild(iframe);
+    });
+}
+
+function makeCountedStream(counters) {
+    const chunk = new Uint8Array(CHUNK_SIZE);
+    for (let i = 0; i < CHUNK_SIZE; ++i)
+        chunk[i] = i & 0xff;
+    return new ReadableStream({
+        pull(controller) {
+            if (counters.bytesEnqueued >= MAX_TOTAL) {
+                controller.close();
+                return;
+            }
+            counters.pullCount += 1;
+            counters.bytesEnqueued += CHUNK_SIZE;
+            counters.lastPullTime = performance.now();
+            controller.enqueue(chunk);
+        },
+    });
+}
+
+promise_test(async () => {
+    const registration = await navigator.serviceWorker.register("upload-stream-backpressure-worker.js", { scope });
+    activeWorker = registration.active || registration.installing;
+    if (activeWorker.state !== "activated") {
+        await new Promise(resolve => {
+            activeWorker.addEventListener("statechange", () => {
+                if (activeWorker.state === "activated") resolve();
+            });
+        });
+    }
+    controlledFrame = await withIframe("resources/empty.html");
+}, "Setup: register service worker");
+
+promise_test(async () => {
+    const counters = { pullCount: 0, bytesEnqueued: 0, lastPullTime: 0 };
+    const stream = makeCountedStream(counters);
+
+    const responsePromise = controlledFrame.contentWindow.fetch(endpoint, {
+        method: "POST",
+        body: stream,
+        duplex: "half",
+    });
+
+    // Phase 1a: wait for pull() to actually start firing.
+    const startDeadline = performance.now() + 3000;
+    while (counters.pullCount === 0 && performance.now() < startDeadline)
+        await new Promise(r => step_timeout(r, 25));
+    assert_greater_than(counters.pullCount, 0, "pull() must fire at least once");
+
+    // Phase 1b: wait for pull() to stabilize — i.e., the same count observed
+    // twice in a row across a short window. That's the signal that backpressure
+    // has kicked in and the ReadableStream is no longer being pulled.
+    const STABILITY_POLL_MS = 50;
+    const STABILITY_HITS_REQUIRED = 4; // ~200ms of no-change
+    const stabilizeDeadline = performance.now() + 5000;
+    let stableHits = 0;
+    let lastCount = counters.pullCount;
+    while (stableHits < STABILITY_HITS_REQUIRED && performance.now() < stabilizeDeadline) {
+        await new Promise(r => step_timeout(r, STABILITY_POLL_MS));
+        if (counters.pullCount === lastCount)
+            stableHits++;
+        else {
+            stableHits = 0;
+            lastCount = counters.pullCount;
+        }
+    }
+    assert_equals(stableHits, STABILITY_HITS_REQUIRED,
+        `pull() count never stabilized (last=${lastCount}, current=${counters.pullCount})`);
+
+    const pullsAfterFill = counters.pullCount;
+    const bytesAfterFill = counters.bytesEnqueued;
+
+    // The amount pulled before backpressure should be close to the sink threshold (64KB)
+    // + the loader in-flight allowance. Upper-bound guards against runaway pulls.
+    assert_less_than(bytesAfterFill, 2 * 1024 * 1024,
+        `pulled bytes before backpressure must be bounded (${bytesAfterFill})`);
+
+    // Phase 2: tell the SW to release. pull() should resume once the network
+    // process starts forwarding to the SW.
+    await controlledFrame.contentWindow.fetch(releaseUrl);
+
+    const resumeDeadline = performance.now() + 5000;
+    while (counters.pullCount === pullsAfterFill && performance.now() < resumeDeadline)
+        await new Promise(r => step_timeout(r, 25));
+    assert_greater_than(counters.pullCount, pullsAfterFill,
+        "pull() must resume once the service worker starts reading the body");
+
+    const response = await responsePromise;
+    assert_true(response.ok, "network response ok");
+    const totalReceived = parseInt(await response.text(), 10);
+    assert_equals(totalReceived, counters.bytesEnqueued, "server saw exactly the bytes the stream enqueued");
+}, "Backpressure pauses the ReadableStream pull() and resumes once the service worker consumes the body");
+
+promise_test(async () => {
+    if (activeWorker) {
+        const registration = await navigator.serviceWorker.getRegistration(scope);
+        await registration?.unregister();
+    }
+}, "Cleanup: unregister service worker");
+</script>
+</body>
+</html>

--- a/Source/WebCore/Modules/fetch/FetchBody.cpp
+++ b/Source/WebCore/Modules/fetch/FetchBody.cpp
@@ -302,6 +302,7 @@ Ref<ReadableStreamToSharedBufferSink> FetchBody::startPendingStreamUpload(Script
     Ref state = PendingStreamState::create();
     m_pendingStreamState = state.copyRef();
 
+    static constexpr size_t desiredBufferingSize = 64 * 1024;
     Ref sink = ReadableStreamToSharedBufferSink::create([state](auto&& result) mutable {
         WTF::switchOn(result,
             [&](std::nullptr_t) { state->endStream(); },
@@ -309,6 +310,13 @@ Ref<ReadableStreamToSharedBufferSink> FetchBody::startPendingStreamUpload(Script
             [&](JSC::JSValue) { state->errorStream(-1); },
             [&](Exception&) { state->errorStream(-1); }
         );
+    }, desiredBufferingSize);
+
+    state->setQueueDrainedHandler([weakSink = WeakPtr { sink.get() }, identifier = context.identifier()] {
+        ScriptExecutionContext::postTaskTo(identifier, [weakSink](auto&) {
+            if (RefPtr sink = weakSink)
+                sink->resumeReading();
+        });
     });
     state->setCancelCallback([weakSink = WeakPtr { sink }, contextIdentifier = context.identifier()] {
         ScriptExecutionContext::postTaskTo(contextIdentifier, [weakSink](auto& context) {

--- a/Source/WebCore/Modules/streams/ReadableStreamToSharedBufferSink.cpp
+++ b/Source/WebCore/Modules/streams/ReadableStreamToSharedBufferSink.cpp
@@ -106,8 +106,9 @@ private:
     WeakPtr<ScriptExecutionContext> m_context;
 };
 
-ReadableStreamToSharedBufferSink::ReadableStreamToSharedBufferSink(Callback&& callback)
+ReadableStreamToSharedBufferSink::ReadableStreamToSharedBufferSink(Callback&& callback, std::optional<size_t> backpressureThreshold)
     : m_callback { WTF::move(callback) }
+    , m_backpressureThreshold { backpressureThreshold }
 {
 }
 
@@ -139,8 +140,23 @@ void ReadableStreamToSharedBufferSink::enqueue(const Ref<JSC::Uint8Array>& buffe
     if (buffer->byteLength()) {
         if (m_callback)
             m_callback(buffer->span());
+        m_dataStored += buffer->byteLength();
     }
 
+    if (m_backpressureThreshold && m_dataStored >= *m_backpressureThreshold)
+        return;
+
+    scheduleKeepReading();
+}
+
+void ReadableStreamToSharedBufferSink::resumeReading()
+{
+    m_dataStored = 0;
+    scheduleKeepReading();
+}
+
+void ReadableStreamToSharedBufferSink::scheduleKeepReading()
+{
     RefPtr context = m_readRequest ? m_readRequest->context() : nullptr;
     if (!context)
         return;

--- a/Source/WebCore/Modules/streams/ReadableStreamToSharedBufferSink.h
+++ b/Source/WebCore/Modules/streams/ReadableStreamToSharedBufferSink.h
@@ -46,7 +46,8 @@ class ReadableStreamToSharedBufferSink final : public RefCountedAndCanMakeWeakPt
 public:
     using Result = Variant<std::nullptr_t, std::span<const uint8_t>, JSC::JSValue, Exception>;
     using Callback = Function<void(Result&&)>;
-    static Ref<ReadableStreamToSharedBufferSink> create(Callback&& callback) { return adoptRef(*new ReadableStreamToSharedBufferSink(WTF::move(callback))); }
+
+    static Ref<ReadableStreamToSharedBufferSink> create(Callback&& callback, std::optional<size_t> backpressureThreshold = std::nullopt) { return adoptRef(*new ReadableStreamToSharedBufferSink(WTF::move(callback), backpressureThreshold)); }
     ~ReadableStreamToSharedBufferSink();
 
     void pipeFrom(ReadableStream&);
@@ -54,8 +55,10 @@ public:
     bool hasCallback() const { return !!m_callback; }
     void cancel(JSDOMGlobalObject&, JSC::JSValue);
 
+    void resumeReading();
+
 private:
-    explicit ReadableStreamToSharedBufferSink(Callback&&);
+    ReadableStreamToSharedBufferSink(Callback&&, std::optional<size_t> backpressureThreshold);
 
     friend class SinkReadRequest;
     void enqueue(const Ref<JSC::Uint8Array>&);
@@ -64,10 +67,13 @@ private:
     void error(JSC::JSValue);
 
     void keepReading();
+    void scheduleKeepReading();
 
     Callback m_callback;
     RefPtr<ReadableStreamDefaultReader> m_reader;
     RefPtr<SinkReadRequest> m_readRequest;
+    size_t m_dataStored { 0 };
+    const std::optional<size_t> m_backpressureThreshold;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/network/PendingStreamState.cpp
+++ b/Source/WebCore/platform/network/PendingStreamState.cpp
@@ -29,6 +29,7 @@
 #include "Logging.h"
 #include "SharedBuffer.h"
 #include <wtf/Locker.h>
+#include <wtf/Scope.h>
 #include <wtf/StdLibExtras.h>
 
 namespace WebCore {
@@ -74,10 +75,28 @@ void PendingStreamState::invokeHandlerIfNeeded(NOESCAPE const std::function<RefP
         handler->invoke();
 }
 
+template<typename Result>
+Result PendingStreamState::invokeDrainedHandlerIfNeeded(NOESCAPE const std::function<Result(RefPtr<CallbackHandler>&)>& function)
+{
+    RefPtr<CallbackHandler> handler;
+    auto result = function(handler);
+    if (handler) {
+#if ASSERT_ENABLED
+        m_isInvokingQueueDrainedHandler = true;
+        auto scope = makeScopeExit([&] {
+            m_isInvokingQueueDrainedHandler = false;
+        });
+#endif
+        handler->invoke();
+    }
+    return result;
+}
+
 void PendingStreamState::appendData(Ref<SharedBuffer>&& buffer)
 {
     invokeHandlerIfNeeded([&] -> RefPtr<CallbackHandler> {
         Locker locker { m_lock };
+        ASSERT(!m_isInvokingQueueDrainedHandler);
         if (m_ended || m_errorCode)
             return nullptr;
         m_chunks.append(WTF::move(buffer));
@@ -89,6 +108,7 @@ void PendingStreamState::endStream()
 {
     invokeHandlerIfNeeded([&] -> RefPtr<CallbackHandler> {
         Locker locker { m_lock };
+        ASSERT(!m_isInvokingQueueDrainedHandler);
         if (m_ended || m_errorCode)
             return nullptr;
         m_ended = true;
@@ -100,6 +120,7 @@ void PendingStreamState::errorStream(int errorCode)
 {
     invokeHandlerIfNeeded([&] -> RefPtr<CallbackHandler> {
         Locker locker { m_lock };
+        ASSERT(!m_isInvokingQueueDrainedHandler);
         if (m_ended || m_errorCode)
             return nullptr;
         m_errorCode = errorCode ? errorCode : -1;
@@ -118,6 +139,7 @@ void PendingStreamState::setDataAvailableHandler(Function<void()>&& handler)
     invokeHandlerIfNeeded([&] -> RefPtr<CallbackHandler> {
         Locker locker { m_lock };
         ASSERT(!m_dataAvailableHandler);
+        ASSERT(!m_isInvokingQueueDrainedHandler);
         RELEASE_LOG_ERROR_IF(m_dataAvailableHandler, Network, "Trying to get upload stream data twice");
         m_dataAvailableHandler = CallbackHandler::create(WTF::move(handler));
         if (!m_chunks.isEmpty() || m_ended || m_errorCode)
@@ -132,6 +154,17 @@ void PendingStreamState::clearDataAvailableHandler()
     m_dataAvailableHandler = nullptr;
 }
 
+void PendingStreamState::setQueueDrainedHandler(Function<void()>&& handler)
+{
+    Locker locker { m_lock };
+    if (!handler) {
+        m_queueDrainedHandler = nullptr;
+        return;
+    }
+    ASSERT(!m_queueDrainedHandler);
+    m_queueDrainedHandler = CallbackHandler::create(WTF::move(handler));
+}
+
 PendingStreamState::HTTPVersion PendingStreamState::currentHTTPVersion()
 {
     Locker locker { m_lock };
@@ -140,39 +173,49 @@ PendingStreamState::HTTPVersion PendingStreamState::currentHTTPVersion()
     return m_httpVersionProbe();
 }
 
-Expected<std::pair<size_t, bool>, int> PendingStreamState::readInto(std::span<uint8_t> outBuffer)
+PendingStreamState::ReadResult PendingStreamState::readInto(std::span<uint8_t> outBuffer)
 {
-    Locker locker { m_lock };
+    return invokeDrainedHandlerIfNeeded<ReadResult>([&](auto& drainedHandler) -> ReadResult {
+        Locker locker { m_lock };
+        ASSERT(!m_isInvokingQueueDrainedHandler);
 
-    if (m_errorCode)
-        return makeUnexpected(m_errorCode);
+        if (m_errorCode)
+            return makeUnexpected(m_errorCode);
 
-    size_t written = 0;
-    while (written < outBuffer.size() && !m_chunks.isEmpty()) {
-        auto chunkSpan = protect(m_chunks.first())->span();
-        size_t available = chunkSpan.size() - m_frontChunkOffset;
-        size_t remaining = outBuffer.size() - written;
-        size_t toCopy = std::min(available, remaining);
-        memcpySpan(outBuffer.subspan(written, toCopy), chunkSpan.subspan(m_frontChunkOffset, toCopy));
-        written += toCopy;
-        m_frontChunkOffset += toCopy;
-        if (m_frontChunkOffset >= chunkSpan.size()) {
-            m_chunks.removeFirst();
-            m_frontChunkOffset = 0;
+        size_t written = 0;
+        while (written < outBuffer.size() && !m_chunks.isEmpty()) {
+            auto chunkSpan = protect(m_chunks.first())->span();
+            size_t available = chunkSpan.size() - m_frontChunkOffset;
+            size_t remaining = outBuffer.size() - written;
+            size_t toCopy = std::min(available, remaining);
+            memcpySpan(outBuffer.subspan(written, toCopy), chunkSpan.subspan(m_frontChunkOffset, toCopy));
+            written += toCopy;
+            m_frontChunkOffset += toCopy;
+            if (m_frontChunkOffset >= chunkSpan.size()) {
+                m_chunks.removeFirst();
+                m_frontChunkOffset = 0;
+            }
         }
-    }
 
-    return std::make_pair(written, m_chunks.isEmpty() && m_ended);
+        if (m_chunks.isEmpty())
+            drainedHandler = m_queueDrainedHandler;
+        return std::make_pair(written, m_chunks.isEmpty() && m_ended);
+    });
 }
 
-Expected<std::pair<Deque<Ref<SharedBuffer>>, bool>, int> PendingStreamState::takeAvailableChunks()
+PendingStreamState::TakeResult PendingStreamState::takeAvailableChunks()
 {
-    Locker locker { m_lock };
-    ASSERT(!m_frontChunkOffset);
-    if (m_errorCode)
-        return makeUnexpected(m_errorCode);
+    return invokeDrainedHandlerIfNeeded<TakeResult>([&](auto& drainedHandler) -> TakeResult {
+        Locker locker { m_lock };
+        ASSERT(!m_frontChunkOffset);
+        ASSERT(!m_isInvokingQueueDrainedHandler);
 
-    return std::make_pair(WTF::move(m_chunks), m_ended);
+        if (m_errorCode)
+            return makeUnexpected(m_errorCode);
+
+        drainedHandler = m_queueDrainedHandler;
+        return std::make_pair(std::exchange(m_chunks, { }), m_ended);
+    });
 }
 
 bool PendingStreamState::hasReadyData()

--- a/Source/WebCore/platform/network/PendingStreamState.h
+++ b/Source/WebCore/platform/network/PendingStreamState.h
@@ -58,12 +58,15 @@ public:
     // FIXME: Provide meaningful PendingStreamState errors.
     WEBCORE_EXPORT void errorStream(int errorCode);
     WEBCORE_EXPORT void setCancelCallback(Function<void()>&&);
+    WEBCORE_EXPORT void setQueueDrainedHandler(Function<void()>&&);
 
     // Data consumer API
     WEBCORE_EXPORT void setDataAvailableHandler(Function<void()>&&);
     WEBCORE_EXPORT void clearDataAvailableHandler();
-    Expected<std::pair<size_t, bool>, int> readInto(std::span<uint8_t>);
-    WEBCORE_EXPORT Expected<std::pair<Deque<Ref<SharedBuffer>>, bool>, int> takeAvailableChunks();
+    using ReadResult = Expected<std::pair<size_t, bool>, int>;
+    ReadResult readInto(std::span<uint8_t>);
+    using TakeResult = Expected<std::pair<Deque<Ref<SharedBuffer>>, bool>, int>;
+    WEBCORE_EXPORT TakeResult takeAvailableChunks();
     bool hasReadyData();
     WEBCORE_EXPORT void cancel();
 
@@ -78,6 +81,8 @@ private:
     PendingStreamState();
 
     static void invokeHandlerIfNeeded(NOESCAPE const std::function<RefPtr<CallbackHandler>()>&);
+    template<typename Result>
+    Result invokeDrainedHandlerIfNeeded(NOESCAPE const std::function<Result(RefPtr<CallbackHandler>&)>&);
 
     Lock m_lock;
     Deque<Ref<SharedBuffer>> m_chunks WTF_GUARDED_BY_LOCK(m_lock);
@@ -86,8 +91,12 @@ private:
     int m_errorCode WTF_GUARDED_BY_LOCK(m_lock) { 0 };
     RefPtr<CallbackHandler> m_dataAvailableHandler WTF_GUARDED_BY_LOCK(m_lock);
     RefPtr<CallbackHandler> m_cancelHandler WTF_GUARDED_BY_LOCK(m_lock);
+    RefPtr<CallbackHandler> m_queueDrainedHandler WTF_GUARDED_BY_LOCK(m_lock);
     HTTPVersionProbe m_httpVersionProbe WTF_GUARDED_BY_LOCK(m_lock);
     Markable<FetchIdentifier> m_serviceWorkerFetchIdentifier;
+#if ASSERT_ENABLED
+    std::atomic<bool> m_isInvokingQueueDrainedHandler { false };
+#endif
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/network/cf/FormDataStreamCFNet.mm
+++ b/Source/WebCore/platform/network/cf/FormDataStreamCFNet.mm
@@ -389,6 +389,7 @@ struct PendingStreamFields {
     Ref<PendingStreamState> state;
     WeakObjCPtr<NSInputStream> formStream;
     std::optional<bool> isHTTP2OrLater;
+    bool isOpened { false };
 };
 
 static void* pendingStreamCreate(CFReadStreamRef stream, void* context)

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.cpp
@@ -37,6 +37,7 @@
 #include "ServiceWorkerFetchTask.h"
 #include "ServiceWorkerFetchTaskMessages.h"
 #include "SharedBufferReference.h"
+#include "WebResourceLoaderMessages.h"
 #include "WebSWContextManagerConnectionMessages.h"
 #include "WebSWServerConnection.h"
 #include <WebCore/NotificationData.h>
@@ -418,6 +419,8 @@ void WebSWServerToContextConnection::startPendingStreamUploadForwarding(WebCore:
     }
 
     m_requestPendingStreamStates.add(fetchIdentifier, *state);
+
+    loader->connectionToWebProcess().connection().send(Messages::WebResourceLoader::ServiceWorkerPendingStreamForwardingNeedData { }, loader->coreIdentifier());
 
     state->setDataAvailableHandler([weakThis = WeakPtr { *this }, fetchIdentifier] {
         if (RefPtr protectedThis = weakThis)

--- a/Source/WebKit/WebProcess/Network/WebResourceLoader.cpp
+++ b/Source/WebKit/WebProcess/Network/WebResourceLoader.cpp
@@ -96,28 +96,50 @@ void WebResourceLoader::initPendingStreamState()
         return;
     state->setDataAvailableHandler([weakThis = WeakPtr { *this }] {
         ensureOnMainThread([weakThis] {
-            RefPtr protectedThis = weakThis.get();
-            if (!protectedThis || !protectedThis->m_pendingStreamState)
-                return;
-
-            auto result = protect(protectedThis->m_pendingStreamState)->takeAvailableChunks();
-
-            if (!result) {
-                protectedThis->send(Messages::NetworkResourceLoader::PendingStreamError { });
-                protectedThis->m_pendingStreamState = nullptr;
-                return;
-            }
-
-            for (Ref chunk : result->first)
-                protectedThis->send(Messages::NetworkResourceLoader::PendingStreamAppendData { IPC::SharedBufferReference(WTF::move(chunk)) });
-
-            if (!result->second)
-                return;
-
-            protectedThis->send(Messages::NetworkResourceLoader::PendingStreamEnd { });
-            protectedThis->m_pendingStreamState = nullptr;
+            if (RefPtr protectedThis = weakThis.get())
+                protectedThis->drainPendingStreamIfPossible();
         });
     });
+}
+
+static constexpr uint64_t kMaxInFlightBytes = 64 * 1024;
+
+void WebResourceLoader::drainPendingStreamIfPossible()
+{
+    if (!m_isServiceWorkerPendingStreamForwarding) {
+        if (m_pendingStreamBytesForwardedToNetworkProcess >= m_pendingStreamBytesSentByNetwork + kMaxInFlightBytes)
+            return;
+    }
+
+    RefPtr state = m_pendingStreamState;
+    if (!state)
+        return;
+
+    auto result = state->takeAvailableChunks();
+
+    if (!result) {
+        send(Messages::NetworkResourceLoader::PendingStreamError { });
+        m_pendingStreamState = nullptr;
+        return;
+    }
+
+    for (Ref chunk : result->first) {
+        m_pendingStreamBytesForwardedToNetworkProcess += chunk->size();
+        send(Messages::NetworkResourceLoader::PendingStreamAppendData { IPC::SharedBufferReference(WTF::move(chunk)) });
+    }
+
+    if (!result->second)
+        return;
+
+    send(Messages::NetworkResourceLoader::PendingStreamEnd { });
+    m_pendingStreamState = nullptr;
+}
+
+void WebResourceLoader::serviceWorkerPendingStreamForwardingNeedData()
+{
+    // FIXME: We should implement backpressure for service worker stream uploads as well.
+    m_isServiceWorkerPendingStreamForwarding = true;
+    drainPendingStreamIfPossible();
 }
 
 WebResourceLoader::~WebResourceLoader() = default;
@@ -188,6 +210,11 @@ void WebResourceLoader::willSendRequest(ResourceRequest&& proposedRequest, IPC::
 
 void WebResourceLoader::didSendData(uint64_t bytesSent, uint64_t totalBytesToBeSent)
 {
+    ASSERT(bytesSent >= m_pendingStreamBytesSentByNetwork);
+    if (bytesSent > m_pendingStreamBytesSentByNetwork) {
+        m_pendingStreamBytesSentByNetwork = bytesSent;
+        drainPendingStreamIfPossible();
+    }
     protect(resourceLoader())->didSendData(bytesSent, totalBytesToBeSent);
 }
 

--- a/Source/WebKit/WebProcess/Network/WebResourceLoader.h
+++ b/Source/WebKit/WebProcess/Network/WebResourceLoader.h
@@ -98,11 +98,14 @@ private:
     void serviceWorkerDidNotHandle();
     void updateResultingClientIdentifier(WTF::UUID currentIdentifier, WTF::UUID newIdentifier);
     void cancelPendingStreamUpload();
+    void serviceWorkerPendingStreamForwardingNeedData();
 
     void didBlockAuthenticationChallenge();
     void setServiceWorkerTimingInfo(ServiceWorkerTimingInfo&& info) { m_serviceWorkerTimingInfo = WTF::move(info); }
 
     void stopLoadingAfterXFrameOptionsOrContentSecurityPolicyDenied(const WebCore::ResourceResponse&);
+
+    void drainPendingStreamIfPossible();
 
     WebCore::MainFrameMainResource mainFrameMainResource() const;
     
@@ -121,6 +124,9 @@ private:
     const std::optional<TrackingParameters> m_trackingParameters;
     WebResourceInterceptController m_interceptController;
     RefPtr<WebCore::PendingStreamState> m_pendingStreamState;
+    uint64_t m_pendingStreamBytesForwardedToNetworkProcess { 0 };
+    uint64_t m_pendingStreamBytesSentByNetwork { 0 };
+    bool m_isServiceWorkerPendingStreamForwarding { false };
     size_t m_numBytesReceived { 0 };
     size_t m_bytesTransferredOverNetwork { 0 };
 

--- a/Source/WebKit/WebProcess/Network/WebResourceLoader.messages.in
+++ b/Source/WebKit/WebProcess/Network/WebResourceLoader.messages.in
@@ -36,6 +36,7 @@ messages -> WebResourceLoader {
     ServiceWorkerDidNotHandle()
     UpdateResultingClientIdentifier(WTF::UUID currentIdentifier, WTF::UUID newIdentifier);
     CancelPendingStreamUpload()
+    ServiceWorkerPendingStreamForwardingNeedData()
     DidBlockAuthenticationChallenge()
 
     StopLoadingAfterXFrameOptionsOrContentSecurityPolicyDenied(WebCore::ResourceResponse response)


### PR DESCRIPTION
#### 5e1804eb373e303a701daf25b01d0133c157542b
<pre>
Implement fetch upload backpressure
<a href="https://bugs.webkit.org/show_bug.cgi?id=320436">https://bugs.webkit.org/show_bug.cgi?id=320436</a>
<a href="https://rdar.apple.com/problem/183400867">rdar://problem/183400867</a>

Reviewed by Alex Christensen.

To implement backpressure, we do the following:
- ReadableStreamToSharedBufferSink is taking an optional max buffered size parameter. When reported size is above a threshold, it stops reading the readable stream.
- ReadableStreamToSharedBufferSink is registering a drained buffer to the PendingStreamState it is sharing with WebResourceLoader. Whenever it sees that more data is needed, it restarts reading.
- WebResourceLoader is getting data from ReadableStreamToSharedBufferSink via its PendingStreamState. After having sent some data (256ko), it waits for network process to notify whether it should send more. Network process does notify via two mechanisms:
  1. Either service worker is reading the body and upload streaming is forwarded to service worker. In that case, backpressure is removed and all data goes to the service worker.
  2. Or the upload is going to the network via NetworkResourceLoader/FormDataStreamCFNet, in which case the network process is sending back to web process the bytes that have been sent.

Covered by newly added test.

* LayoutTests/http/wpt/service-workers/upload-stream-backpressure-worker.js: Added.
(event.url.searchParams):
(event.event.respondWith.async await):
(event.event.respondWith):
* LayoutTests/http/wpt/service-workers/upload-stream-backpressure.https-expected.txt: Added.
* LayoutTests/http/wpt/service-workers/upload-stream-backpressure.https.html: Added.
* Source/WebCore/Modules/fetch/FetchBody.cpp:
(WebCore::FetchBody::startPendingStreamUpload):
* Source/WebCore/Modules/streams/ReadableStreamToSharedBufferSink.cpp:
(WebCore::ReadableStreamToSharedBufferSink::ReadableStreamToSharedBufferSink):
(WebCore::ReadableStreamToSharedBufferSink::enqueue):
(WebCore::ReadableStreamToSharedBufferSink::resumeReading):
(WebCore::ReadableStreamToSharedBufferSink::scheduleKeepReading):
* Source/WebCore/Modules/streams/ReadableStreamToSharedBufferSink.h:
* Source/WebCore/platform/network/PendingStreamState.cpp:
(WebCore::PendingStreamState::appendData):
(WebCore::PendingStreamState::endStream):
(WebCore::PendingStreamState::errorStream):
(WebCore::PendingStreamState::setDataAvailableHandler):
(WebCore::PendingStreamState::setQueueDrainedHandler):
(WebCore::PendingStreamState::read):
(WebCore::PendingStreamState::takeNextChunk):
* Source/WebCore/platform/network/PendingStreamState.h:
(WebCore::PendingStreamState::WTF_GUARDED_BY_LOCK):
* Source/WebCore/platform/network/cf/FormDataStreamCFNet.mm:
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.cpp:
(WebKit::WebSWServerToContextConnection::startPendingStreamUploadForwarding):
* Source/WebKit/WebProcess/Network/WebResourceLoader.cpp:
(WebKit::WebResourceLoader::initPendingStreamState):
(WebKit::WebResourceLoader::drainPendingStreamIfPossible):
(WebKit::WebResourceLoader::serviceWorkerPendingStreamForwardingStarted):
(WebKit::WebResourceLoader::didSendData):
* Source/WebKit/WebProcess/Network/WebResourceLoader.h:
* Source/WebKit/WebProcess/Network/WebResourceLoader.messages.in:

Canonical link: <a href="https://commits.webkit.org/318236@main">https://commits.webkit.org/318236@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a413b4d47990dd8d782f70845c1f79f95707ae35

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177501 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51439 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45233 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187105 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140748 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e3dc2b0d-911e-40aa-8b72-d05a1fa06ebb) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179364 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52731 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51148 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138342 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140748 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1abd7f5b-8aea-4548-9a1f-54681208e6e5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180457 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41845 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159090 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118807 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/52958708-bb28-47e8-8723-c75b743cbe2d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40506 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38880 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150913 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38587 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35572 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/43224 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43114 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189533 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51106 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/158624 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147438 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39657 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51788 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35215 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147230 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41946 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124003 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118398 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50296 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13566 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49692 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49932 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49754 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->