### PR TITLE
[macOS 27] Momentum scrolling should not trigger NSRefreshController

### DIFF
--- a/Source/WebKit/Platform/spi/mac/AppKitSPI.h
+++ b/Source/WebKit/Platform/spi/mac/AppKitSPI.h
@@ -303,6 +303,9 @@ NS_HEADER_AUDIT_END(nullability, sendability)
 
 - (void)applyWithVerticalInset:(CGFloat)verticalInset animated:(BOOL)animated completion:(void (^ _Nullable)(void))completion;
 - (void)removeWithVerticalInset:(CGFloat)verticalInset animated:(BOOL)animated completion:(void (^ _Nullable)(void))completion;
+
+@optional
+@property (nonatomic, readonly) BOOL refreshControlHostIsTracking;
 @end
 
 #endif

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView+RefreshControl.swift
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView+RefreshControl.swift
@@ -79,6 +79,13 @@ extension WKWebView: AppKit.NSRefreshControlHosting {
             height: bounds.height - insets.top - insets.bottom
         )
     }
+
+    // Protocol conformance.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
+    @objc(refreshControlHostIsTracking)
+    public var refreshControlHostIsTracking: Bool {
+        _refreshControlHostIsTracking
+    }
 }
 
 #endif // HAVE_NSREFRESHCONTROLLER

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -4102,6 +4102,11 @@ struct WKWebViewData {
     return _impl->topScrollStretchForRefreshController();
 }
 
+- (BOOL)_refreshControlHostIsTracking
+{
+    return _impl->refreshControllerIsTracking();
+}
+
 #endif
 
 #endif // PLATFORM(MAC)

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -761,6 +761,7 @@ struct LiveResizeSnapshotState {
 
 #if HAVE(NSREFRESHCONTROLLER)
 @property (nonatomic, readonly) CGFloat _refreshControlVisibleHeight;
+@property (nonatomic, readonly) BOOL _refreshControlHostIsTracking;
 #endif
 #endif // PLATFORM(MAC)
 

--- a/Source/WebKit/UIProcess/API/mac/WKWebViewPrivateForTestingMac.h
+++ b/Source/WebKit/UIProcess/API/mac/WKWebViewPrivateForTestingMac.h
@@ -63,6 +63,10 @@
 
 @property (nonatomic, readonly) CGFloat _fullScreenTitlebarOverlayHeightForTesting;
 
+// The value NSRefreshControl reads through the NSRefreshControlHosting protocol to decide
+// whether a pull may commit to a refresh. False during momentum so a flick cannot refresh.
+@property (nonatomic, readonly) BOOL _refreshControlHostIsTrackingForTesting;
+
 - (BOOL)isPointInScrollbar:(NSPoint)locationInView;
 
 @end

--- a/Source/WebKit/UIProcess/API/mac/WKWebViewTestingMac.mm
+++ b/Source/WebKit/UIProcess/API/mac/WKWebViewTestingMac.mm
@@ -158,6 +158,15 @@
     return _impl->isPointInScrollbar(locationInView);
 }
 
+- (BOOL)_refreshControlHostIsTrackingForTesting
+{
+#if HAVE(NSREFRESHCONTROLLER)
+    return _impl->refreshControllerIsTracking();
+#else
+    return NO;
+#endif
+}
+
 @end
 
 #endif // PLATFORM(MAC)

--- a/Source/WebKit/UIProcess/mac/WKAppKitGestureController.mm
+++ b/Source/WebKit/UIProcess/mac/WKAppKitGestureController.mm
@@ -1514,6 +1514,11 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
         return toRawPlatformDelta(initialMomentumDelta);
     }());
 
+#if HAVE(NSREFRESHCONTROLLER)
+    // The refresh controller should not track synthetic momentum scrolling.
+    viewImpl->clearRefreshControllerTracking();
+#endif
+
     page->handleNativeWheelEvent(nativeMomentumEvent);
     _isMomentumActive = true;
 

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.h
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.h
@@ -898,6 +898,8 @@ public:
     void applyRefreshControllerHeight(CGFloat, bool);
     CGFloat topScrollStretchForRefreshController() const;
     CGFloat refreshControllerSnappingThreshold() const;
+    bool refreshControllerIsTracking() const { return m_refreshControllerIsTracking; }
+    void clearRefreshControllerTracking() { m_refreshControllerIsTracking = false; }
     void updateRefreshControllerForWheelEvent(NSEvent *);
     void updateRefreshControllerForPanGesture(NSGestureRecognizerState);
     void updateRefreshControllerFrame();
@@ -1239,6 +1241,7 @@ private:
     RetainPtr<CAShapeLayer> m_refreshControllerMask;
     CGFloat m_topScrollStretchForRefreshController { 0 };
     bool m_canShowRefreshController { false };
+    bool m_refreshControllerIsTracking { false };
     bool m_suppressRefreshControllerUpdates { false };
     CGFloat m_cachedTopScrollStretch { 0 };
 #endif

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -8259,6 +8259,7 @@ void WebViewImpl::setRefreshController(NSRefreshController *refreshController)
     if (m_refreshController) {
         [[m_refreshController refreshControl] removeFromSuperview];
         m_topScrollStretchForRefreshController = 0;
+        m_refreshControllerIsTracking = false;
         m_refreshControllerMask = nil;
         m_suppressRefreshControllerUpdates = false;
     }
@@ -8378,6 +8379,28 @@ void WebViewImpl::updateRefreshControllerForWheelEvent(NSEvent *event)
         m_canShowRefreshController = pageIsScrolledToTop();
         m_suppressRefreshControllerUpdates = false;
     }
+
+    // Prevent momentum scrolls from triggering the refresh control. Only an active,
+    // ongoing scroll should trigger the control.
+    auto shouldTrackEventForRefreshControl = [](NSEvent *event, bool wasTracking) {
+        if (event.momentumPhase != NSEventPhaseNone)
+            return false;
+
+        switch (event.phase) {
+        case NSEventPhaseBegan:
+        case NSEventPhaseChanged:
+        case NSEventPhaseNone:
+        case NSEventPhaseStationary:
+            return true;
+        case NSEventPhaseCancelled:
+        case NSEventPhaseEnded:
+            return false;
+        case NSEventPhaseMayBegin:
+            return wasTracking;
+        }
+        return false;
+    };
+    m_refreshControllerIsTracking = shouldTrackEventForRefreshControl(event, m_refreshControllerIsTracking);
 }
 
 #if HAVE(APPKIT_GESTURES_SUPPORT)
@@ -8392,6 +8415,23 @@ void WebViewImpl::updateRefreshControllerForPanGesture(NSGestureRecognizerState 
         m_canShowRefreshController = pageIsScrolledToTop();
         m_suppressRefreshControllerUpdates = false;
     }
+
+    // Prevent momentum scrolls from triggering the refresh control. Only an active,
+    // ongoing scroll should trigger the control.
+    auto shouldTrackEventForRefreshControl = [](NSGestureRecognizerState state, bool wasTracking) {
+        switch (state) {
+        case NSGestureRecognizerStateBegan:
+        case NSGestureRecognizerStateChanged:
+            return true;
+        case NSGestureRecognizerStateCancelled:
+        case NSGestureRecognizerStateEnded:
+        case NSGestureRecognizerStateFailed:
+            return false;
+        case NSGestureRecognizerStatePossible:
+            return wasTracking;
+        }
+    };
+    m_refreshControllerIsTracking = shouldTrackEventForRefreshControl(state, m_refreshControllerIsTracking);
 }
 #endif
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/NSRefreshControllerTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/NSRefreshControllerTests.mm
@@ -33,6 +33,7 @@
 #import "Helpers/cocoa/TestWKWebView.h"
 #import "Helpers/mac/AppKitSPI.h"
 #import <WebKit/WKWebViewPrivate.h>
+#import <WebKit/WKWebViewPrivateForTestingMac.h>
 #import <wtf/RetainPtr.h>
 
 @interface TestRefreshControllerTarget : NSObject
@@ -53,17 +54,43 @@
 
 namespace TestWebKitAPI {
 
+// Real momentum events carry a momentum phase and no scroll phase.
+static constexpr auto noScrollPhase = static_cast<CGScrollPhase>(0);
+
+static constexpr auto maximumPullIterations = 200;
+
 static void pullDownAndWaitForRefresh(TestWKWebView *webView, NSRefreshController *refreshController)
 {
     auto eventLocation = NSMakePoint(NSMidX([webView bounds]), NSMidY([webView bounds]));
     [webView wheelEventAtPoint:eventLocation wheelDelta:CGSizeMake(0, 1) phase:kCGScrollPhaseBegan momentumPhase:kCGMomentumScrollPhaseNone];
 
-    for (int i = 0; i < 200 && ![refreshController isRefreshing]; ++i) {
+    for (int i = 0; i < maximumPullIterations && ![refreshController isRefreshing]; ++i) {
         [webView wheelEventAtPoint:eventLocation wheelDelta:CGSizeMake(0, 100) phase:kCGScrollPhaseChanged momentumPhase:kCGMomentumScrollPhaseNone];
         [webView waitForNextPresentationUpdate];
     }
 
     [webView wheelEventAtPoint:eventLocation wheelDelta:CGSizeMake(0, 0) phase:kCGScrollPhaseEnded momentumPhase:kCGMomentumScrollPhaseNone];
+    [webView waitForNextPresentationUpdate];
+}
+
+static void flickDownAndCoastWithMomentum(TestWKWebView *webView, NSRefreshController *refreshController)
+{
+    auto eventLocation = NSMakePoint(NSMidX([webView bounds]), NSMidY([webView bounds]));
+
+    [webView wheelEventAtPoint:eventLocation wheelDelta:CGSizeMake(0, 1) phase:kCGScrollPhaseBegan momentumPhase:kCGMomentumScrollPhaseNone];
+    [webView waitForNextPresentationUpdate];
+    [webView wheelEventAtPoint:eventLocation wheelDelta:CGSizeMake(0, 0) phase:kCGScrollPhaseEnded momentumPhase:kCGMomentumScrollPhaseNone];
+    [webView waitForNextPresentationUpdate];
+
+    [webView wheelEventAtPoint:eventLocation wheelDelta:CGSizeMake(0, 100) phase:noScrollPhase momentumPhase:kCGMomentumScrollPhaseBegin];
+    [webView waitForNextPresentationUpdate];
+
+    for (int i = 0; i < maximumPullIterations && ![refreshController isRefreshing]; ++i) {
+        [webView wheelEventAtPoint:eventLocation wheelDelta:CGSizeMake(0, 100) phase:noScrollPhase momentumPhase:kCGMomentumScrollPhaseContinue];
+        [webView waitForNextPresentationUpdate];
+    }
+
+    [webView wheelEventAtPoint:eventLocation wheelDelta:CGSizeMake(0, 0) phase:noScrollPhase momentumPhase:kCGMomentumScrollPhaseEnd];
     [webView waitForNextPresentationUpdate];
 }
 
@@ -131,6 +158,65 @@ TEST_F(NSRefreshControllerTests, DoesNotRefireDuringSettleAtSmallWindowHeight)
     Util::runFor(1_s);
     EXPECT_EQ([target activationCount], 1U);
     EXPECT_FALSE([refreshController isRefreshing]);
+}
+
+TEST_F(NSRefreshControllerTests, MomentumScrollDoesNotTriggerRefresh)
+{
+    setUpWithWindowHeight(600);
+
+    [webView synchronouslyLoadHTMLString:@"<body style='height: 2000px;'></body>"];
+    [webView waitForNextPresentationUpdate];
+
+    flickDownAndCoastWithMomentum(webView, refreshController.get());
+
+    EXPECT_EQ([target activationCount], 0U);
+    EXPECT_FALSE([refreshController isRefreshing]);
+}
+
+TEST_F(NSRefreshControllerTests, HostIsNotTrackingDuringMomentumScroll)
+{
+    setUpWithWindowHeight(600);
+
+    [webView synchronouslyLoadHTMLString:@"<body style='height: 2000px;'></body>"];
+    [webView waitForNextPresentationUpdate];
+
+    auto eventLocation = NSMakePoint(NSMidX([webView bounds]), NSMidY([webView bounds]));
+
+    EXPECT_FALSE([webView _refreshControlHostIsTrackingForTesting]);
+
+    [webView wheelEventAtPoint:eventLocation wheelDelta:CGSizeMake(0, 1) phase:kCGScrollPhaseBegan momentumPhase:kCGMomentumScrollPhaseNone];
+    EXPECT_TRUE([webView _refreshControlHostIsTrackingForTesting]);
+
+    [webView wheelEventAtPoint:eventLocation wheelDelta:CGSizeMake(0, 100) phase:kCGScrollPhaseChanged momentumPhase:kCGMomentumScrollPhaseNone];
+    EXPECT_TRUE([webView _refreshControlHostIsTrackingForTesting]);
+
+    [webView wheelEventAtPoint:eventLocation wheelDelta:CGSizeMake(0, 0) phase:kCGScrollPhaseEnded momentumPhase:kCGMomentumScrollPhaseNone];
+    EXPECT_FALSE([webView _refreshControlHostIsTrackingForTesting]);
+
+    [webView wheelEventAtPoint:eventLocation wheelDelta:CGSizeMake(0, 100) phase:noScrollPhase momentumPhase:kCGMomentumScrollPhaseBegin];
+    EXPECT_FALSE([webView _refreshControlHostIsTrackingForTesting]);
+
+    [webView wheelEventAtPoint:eventLocation wheelDelta:CGSizeMake(0, 100) phase:noScrollPhase momentumPhase:kCGMomentumScrollPhaseContinue];
+    EXPECT_FALSE([webView _refreshControlHostIsTrackingForTesting]);
+
+    [webView wheelEventAtPoint:eventLocation wheelDelta:CGSizeMake(0, 0) phase:noScrollPhase momentumPhase:kCGMomentumScrollPhaseEnd];
+    EXPECT_FALSE([webView _refreshControlHostIsTrackingForTesting]);
+}
+
+TEST_F(NSRefreshControllerTests, HostIsTrackingForLegacyMouseWheelScroll)
+{
+    setUpWithWindowHeight(600);
+
+    [webView synchronouslyLoadHTMLString:@"<body style='height: 2000px;'></body>"];
+    [webView waitForNextPresentationUpdate];
+
+    auto eventLocation = NSMakePoint(NSMidX([webView bounds]), NSMidY([webView bounds]));
+
+    // A classic mouse wheel sends no phase and no momentum. Such an event carries no way
+    // to distinguish it from a deliberate pull, so it must still count as tracking;
+    // otherwise pull-to-refresh would be impossible with a mouse.
+    [webView wheelEventAtPoint:eventLocation wheelDelta:CGSizeMake(0, 100) phase:noScrollPhase momentumPhase:kCGMomentumScrollPhaseNone];
+    EXPECT_TRUE([webView _refreshControlHostIsTrackingForTesting]);
 }
 
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### 4f227986989fbd30f5b12752fe4928b250b81a4b
<pre>
[macOS 27] Momentum scrolling should not trigger NSRefreshController
<a href="https://bugs.webkit.org/show_bug.cgi?id=320448">https://bugs.webkit.org/show_bug.cgi?id=320448</a>
<a href="https://rdar.apple.com/182688886">rdar://182688886</a>

Reviewed by Abrar Rahman Protyasha.

Adopt `NSRefreshControlHosting` property `refreshControlHostIsTracking` so that
we can prevent momentum scrolling from triggering refresh controllers by setting
the property to false during momentum scrolls.

Tests:
NSRefreshControllerTests.MomentumScrollDoesNotTriggerRefresh
NSRefreshControllerTests.HostIsNotTrackingDuringMomentumScroll
NSRefreshControllerTests.HostIsTrackingForLegacyMouseWheelScroll

* Source/WebKit/Platform/spi/mac/AppKitSPI.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView+RefreshControl.swift:
(WKWebView.refreshControlHostIsTracking):
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _refreshControlHostIsTracking]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:
* Source/WebKit/UIProcess/mac/WKAppKitGestureController.mm:
(-[WKAppKitGestureController startMomentumIfNeededForGesture:]):
* Source/WebKit/UIProcess/mac/WebViewImpl.h:
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::setRefreshController):
(WebKit::WebViewImpl::updateRefreshControllerForWheelEvent):
(WebKit::WebViewImpl::updateRefreshControllerForPanGesture):
* Source/WebKit/UIProcess/API/mac/WKWebViewPrivateForTestingMac.h:
* Source/WebKit/UIProcess/API/mac/WKWebViewTestingMac.mm:
(-[WKWebView _refreshControlHostIsTrackingForTesting]):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/NSRefreshControllerTests.mm:
(TestWebKitAPI::pullDownAndWaitForRefresh):
(TestWebKitAPI::flickDownAndCoastWithMomentum):
(TestWebKitAPI::TEST_F(NSRefreshControllerTests, MomentumScrollDoesNotTriggerRefresh)):
(TestWebKitAPI::TEST_F(NSRefreshControllerTests, HostIsNotTrackingDuringMomentumScroll)):
(TestWebKitAPI::TEST_F(NSRefreshControllerTests, HostIsTrackingForLegacyMouseWheelScroll)):

Canonical link: <a href="https://commits.webkit.org/318106@main">https://commits.webkit.org/318106@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2ff3345d74c37f39b57b85108371cec354adbfad

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177295 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51233 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45027 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186898 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140542 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/868b182c-d8a0-4dec-8f7f-4dd2650cb806) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179158 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52525 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50922 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138153 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140542 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f550b6fe-d601-4de2-8b72-384338ed64f3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180251 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41667 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158924 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118618 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/119ec660-c873-4fba-bf40-2885fbfa66b9) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40328 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38702 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150736 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38421 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35366 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/43018 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/42916 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189327 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50899 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147246 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39571 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51582 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/35048 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147038 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41761 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123797 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118131 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50090 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13399 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49486 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49726 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49548 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->