### PR TITLE
pendingStreamSchedule should not allow to call CFReadStreamSignalEvent before pendingStreamOpen

### DIFF
--- a/Source/WebCore/platform/network/cf/FormDataStreamCFNet.mm
+++ b/Source/WebCore/platform/network/cf/FormDataStreamCFNet.mm
@@ -454,11 +454,20 @@ static Boolean pendingStreamCanRead(CFReadStreamRef, void* context)
 {
     auto* fields = static_cast<PendingStreamFields*>(context);
 
-    if (!fields->isHTTP2OrLater)
-        fields->isHTTP2OrLater = protect(fields->state)->currentHTTPVersion() == PendingStreamState::HTTPVersion::HTTP2OrLater;
+    Ref state = fields->state;
+    if (!fields->isHTTP2OrLater) {
+        fields->isHTTP2OrLater = state->currentHTTPVersion() == PendingStreamState::HTTPVersion::HTTP2OrLater;
+        if (!*fields->isHTTP2OrLater) {
+            // Under HTTP/1 we fail immediately in pendingStreamRead.
+            return true;
+        }
+        state->setDataAvailableHandler([weakStream = fields->formStream] {
+            if (RetainPtr stream = weakStream.get())
+                CFReadStreamSignalEvent(bridge_cast(stream.get()), kCFStreamEventHasBytesAvailable, nullptr);
+        });
+    }
 
-    // Under HTTP/1 we fail immediately in pendingStreamRead.
-    return !*fields->isHTTP2OrLater || protect(fields->state)->hasReadyData();
+    return state->hasReadyData();
 }
 
 static void pendingStreamClose(CFReadStreamRef, void* context)
@@ -473,20 +482,6 @@ static CFTypeRef pendingStreamCopyProperty(CFReadStreamRef, CFStringRef, void*)
     return 0;
 }
 
-static void pendingStreamSchedule(CFReadStreamRef, CFRunLoopRef, CFStringRef, void* context)
-{
-    auto* fields = static_cast<PendingStreamFields*>(context);
-    RetainPtr<CFReadStreamRef> outerStream = fields->cfFormStream();
-    protect(fields->state)->setDataAvailableHandler([outerStream = WTF::move(outerStream)] {
-        if (outerStream)
-            CFReadStreamSignalEvent(outerStream.get(), kCFStreamEventHasBytesAvailable, nullptr);
-    });
-}
-
-static void pendingStreamUnschedule(CFReadStreamRef, CFRunLoopRef, CFStringRef, void*)
-{
-}
-
 RetainPtr<CFReadStreamRef> createHTTPBodyCFReadStream(FormData& formData)
 {
     if (!hasPlatformStrategies() && formData.containsBlobElement())
@@ -499,7 +494,7 @@ RetainPtr<CFReadStreamRef> createHTTPBodyCFReadStream(FormData& formData)
         if (!state)
             return nullptr;
         auto* context = new PendingStreamCreationContext { state.releaseNonNull() };
-        CFReadStreamCallBacksV1 pendingStreamCallBacks = { 1, pendingStreamCreate, pendingStreamFinalize, nullptr, pendingStreamOpen, nullptr, pendingStreamRead, nullptr, pendingStreamCanRead, pendingStreamClose, pendingStreamCopyProperty, nullptr, nullptr, pendingStreamSchedule, pendingStreamUnschedule };
+        CFReadStreamCallBacksV1 pendingStreamCallBacks = { 1, pendingStreamCreate, pendingStreamFinalize, nullptr, pendingStreamOpen, nullptr, pendingStreamRead, nullptr, pendingStreamCanRead, pendingStreamClose, pendingStreamCopyProperty, nullptr, nullptr, nullptr, nullptr };
         return adoptCF(CFReadStreamCreate(nullptr, static_cast<const void*>(&pendingStreamCallBacks), context));
     }
 


### PR DESCRIPTION
#### c9df83b2f0da3b9cbdafc9ac3afc99b0ad728310
<pre>
pendingStreamSchedule should not allow to call CFReadStreamSignalEvent before pendingStreamOpen
<a href="https://rdar.apple.com/183422054">rdar://183422054</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=320454">https://bugs.webkit.org/show_bug.cgi?id=320454</a>

Reviewed by Chris Dumez.

The contract is to call CFReadStreamSignalEvent when the CFReadStream is opened.
But pendingStreamSchedule can be called before pendingStreamOpen.

We are now registering the data available handler (that can call CFReadStreamSignalEvent) in pendingStreamCanRead.
At that point, we know it makes sense to register this handler since CFNetwork is interested in data.

We register the data available handler at the first call of pendingStreamCanRead, based on context isHTTP2OrLater.
We also move the HTTP1.1 check there since it will fail the load immediately afterwards.

* Source/WebCore/platform/network/cf/FormDataStreamCFNet.mm:
(WebCore::pendingStreamOpen):
(WebCore::pendingStreamCanRead):
(WebCore::pendingStreamSchedule):
(WebCore::createHTTPBodyCFReadStream):
(WebCore::pendingStreamUnschedule): Deleted.

Canonical link: <a href="https://commits.webkit.org/318147@main">https://commits.webkit.org/318147@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8727e8e4a944379faeeb521d030ff45c4d04130a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177475 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51413 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45207 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187079 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140722 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/325cdd72-c75c-4f2a-9875-b4506a8bb770) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179338 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52705 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51122 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138317 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140722 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/92028deb-a669-4b41-980d-b5f6d50f6e09) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180431 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41819 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/159067 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118782 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/538470d9-bebb-4edd-ba93-ffb7712662cf) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/40480 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/38857 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/150887 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38564 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35546 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/43198 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/43091 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189507 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51080 "Built successfully") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/147412 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39595 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51762 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/35192 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147204 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41924 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123977 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118344 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50270 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13542 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49666 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49906 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49728 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->