### PR TITLE
Find in Page can’t find any matches for a video’s captions when turned off

### DIFF
--- a/LayoutTests/media/track/text-track-find-preferred-language-expected.txt
+++ b/LayoutTests/media/track/text-track-find-preferred-language-expected.txt
@@ -1,0 +1,51 @@
+Tests that with captions off, Find searches the caption track for the highest-priority preferred language, shows it while searching, and restores it to off when Find is cleared.
+
+
+** English preferred: Find searches the English track, shows it, and restores it when cleared.
+RUN(englishMatches = internals.findCueMatches('banana', []).length)
+EXPECTED (englishMatches == '2') OK
+EXPECTED (englishTrack.mode == 'showing') OK
+EXPECTED (englishTrack.mode == 'disabled') OK
+
+** Spanish preferred: Find searches the Spanish track, shows it, and restores it when cleared.
+RUN(spanishMatches = internals.findCueMatches('banana', []).length)
+EXPECTED (spanishMatches == '4') OK
+EXPECTED (spanishTrack.mode == 'showing') OK
+EXPECTED (spanishTrack.mode == 'disabled') OK
+
+** French most preferred of the three: Find searches the highest-priority track, shows it, and restores it when cleared.
+RUN(frenchMatches = internals.findCueMatches('banana', []).length)
+EXPECTED (frenchMatches == '6') OK
+EXPECTED (frenchTrack.mode == 'showing') OK
+EXPECTED (frenchTrack.mode == 'disabled') OK
+
+** Upgrading the preferred language between searches swaps to the better track and restores the previous one.
+RUN(upgradeEnglishMatches = internals.findCueMatches('banana', []).length)
+EXPECTED (upgradeEnglishMatches == '2') OK
+EXPECTED (englishTrack.mode == 'showing') OK
+RUN(upgradeFrenchMatches = internals.findCueMatches('banana', []).length)
+EXPECTED (upgradeFrenchMatches == '6') OK
+EXPECTED (frenchTrack.mode == 'showing') OK
+EXPECTED (englishTrack.mode == 'disabled') OK
+EXPECTED (frenchTrack.mode == 'disabled') OK
+
+** With no preferred language present and no default track, Find promotes nothing and reports no matches.
+RUN(noPreferredMatches = internals.findCueMatches('banana', []).length)
+EXPECTED (noPreferredMatches == '0') OK
+EXPECTED (englishTrack.mode == 'disabled') OK
+EXPECTED (spanishTrack.mode == 'disabled') OK
+EXPECTED (frenchTrack.mode == 'disabled') OK
+
+** A captions-kind track is searchable, not just subtitles.
+RUN(germanCaptionsMatches = internals.findCueMatches('banana', []).length)
+EXPECTED (germanCaptionsMatches == '3') OK
+EXPECTED (germanCaptionsTrack.mode == 'showing') OK
+EXPECTED (germanCaptionsTrack.mode == 'disabled') OK
+
+** A track the user turned on is searched as-is, even when another language is preferred.
+RUN(userShownMatches = internals.findCueMatches('banana', []).length)
+EXPECTED (userShownMatches == '4') OK
+EXPECTED (englishTrack.mode == 'disabled') OK
+EXPECTED (spanishTrack.mode == 'showing') OK
+END OF TEST
+

--- a/LayoutTests/media/track/text-track-find-preferred-language.html
+++ b/LayoutTests/media/track/text-track-find-preferred-language.html
@@ -1,0 +1,108 @@
+<!-- webkit-test-runner [ FindInVideoEnabled=true ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+<script src=../video-test.js></script>
+<script>
+function addOffTrack(language, label, matchCount, kind = 'subtitles')
+{
+    let track = video.addTextTrack(kind, label, language);
+    for (let i = 1; i <= matchCount; ++i)
+        track.addCue(new VTTCue(i, i + 1, 'banana ' + i));
+    track.mode = 'disabled';
+    return track;
+}
+
+async function runTest()
+{
+    if (!window.internals) {
+        failTest('This test requires window.internals.');
+        return;
+    }
+
+    findMediaElement();
+    if (video.readyState < HTMLMediaElement.HAVE_METADATA)
+        await new Promise(resolve => video.addEventListener('loadedmetadata', resolve, { once: true }));
+
+    // Three subtitle tracks, different languages, each with a distinct number of matches, all off.
+    englishTrack = addOffTrack('en', 'English', 2);
+    spanishTrack = addOffTrack('es', 'Spanish', 4);
+    frenchTrack = addOffTrack('fr', 'French', 6);
+
+    consoleWrite('** English preferred: Find searches the English track, shows it, and restores it when cleared.');
+    internals.setUserPreferredLanguages(['en']);
+    run("englishMatches = internals.findCueMatches('banana', []).length");
+    testExpected('englishMatches', 2);
+    testExpected("englishTrack.mode", 'showing');
+    internals.clearFindCaptionTracks();
+    testExpected("englishTrack.mode", 'disabled');
+
+    consoleWrite('<br>** Spanish preferred: Find searches the Spanish track, shows it, and restores it when cleared.');
+    internals.setUserPreferredLanguages(['es']);
+    run("spanishMatches = internals.findCueMatches('banana', []).length");
+    testExpected('spanishMatches', 4);
+    testExpected("spanishTrack.mode", 'showing');
+    internals.clearFindCaptionTracks();
+    testExpected("spanishTrack.mode", 'disabled');
+
+    consoleWrite('<br>** French most preferred of the three: Find searches the highest-priority track, shows it, and restores it when cleared.');
+    internals.setUserPreferredLanguages(['fr', 'en', 'es']);
+    run("frenchMatches = internals.findCueMatches('banana', []).length");
+    testExpected('frenchMatches', 6);
+    testExpected("frenchTrack.mode", 'showing');
+    internals.clearFindCaptionTracks();
+    testExpected("frenchTrack.mode", 'disabled');
+
+    consoleWrite('<br>** Upgrading the preferred language between searches swaps to the better track and restores the previous one.');
+    internals.setUserPreferredLanguages(['en']);
+    run("upgradeEnglishMatches = internals.findCueMatches('banana', []).length");
+    testExpected('upgradeEnglishMatches', 2);
+    testExpected("englishTrack.mode", 'showing');
+    internals.setUserPreferredLanguages(['fr']);
+    run("upgradeFrenchMatches = internals.findCueMatches('banana', []).length");
+    testExpected('upgradeFrenchMatches', 6);
+    testExpected("frenchTrack.mode", 'showing');
+    testExpected("englishTrack.mode", 'disabled');
+    internals.clearFindCaptionTracks();
+    testExpected("frenchTrack.mode", 'disabled');
+
+    consoleWrite('<br>** With no preferred language present and no default track, Find promotes nothing and reports no matches.');
+    internals.setUserPreferredLanguages(['ja']);
+    run("noPreferredMatches = internals.findCueMatches('banana', []).length");
+    testExpected('noPreferredMatches', 0);
+    testExpected("englishTrack.mode", 'disabled');
+    testExpected("spanishTrack.mode", 'disabled');
+    testExpected("frenchTrack.mode", 'disabled');
+
+    consoleWrite('<br>** A captions-kind track is searchable, not just subtitles.');
+    germanCaptionsTrack = addOffTrack('de', 'German', 3, 'captions');
+    internals.setUserPreferredLanguages(['de']);
+    run("germanCaptionsMatches = internals.findCueMatches('banana', []).length");
+    testExpected('germanCaptionsMatches', 3);
+    testExpected("germanCaptionsTrack.mode", 'showing');
+    internals.clearFindCaptionTracks();
+    testExpected("germanCaptionsTrack.mode", 'disabled');
+
+    consoleWrite('<br>** A track the user turned on is searched as-is, even when another language is preferred.');
+    internals.setUserPreferredLanguages(['en']);
+    spanishTrack.mode = 'showing';
+    run("userShownMatches = internals.findCueMatches('banana', []).length");
+    testExpected('userShownMatches', 4);
+    testExpected("englishTrack.mode", 'disabled');
+    internals.clearFindCaptionTracks();
+    testExpected("spanishTrack.mode", 'showing');
+
+    endTest();
+}
+
+setCaptionDisplayMode('ForcedOnly');
+</script>
+</head>
+<body onload="runTest()">
+<p>Tests that with captions off, Find searches the caption track for the highest-priority preferred language, shows it while searching, and restores it to off when Find is cleared.</p>
+<video controls>
+    <source src="../content/long-test.mp4" type="video/mp4">
+</video>
+</body>
+</html>

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -2684,59 +2684,9 @@ Vector<CueMatch> Document::findCueMatches(const String& target, FindOptions opti
         return is_lt(treeOrder<ComposedTree>(a.get(), b.get()));
     });
 
-    // FIXME: Decisions still need to be made on whether we should only include videos that are paused, that have been interacted with, etc.
     for (Ref element : elements) {
-        size_t firstMatchForElement = results.size();
-
-        RefPtr tracks = element->textTracks();
-        if (!tracks)
-            continue;
-        MediaTime duration = element->durationMediaTime();
-        for (unsigned i = 0; i < tracks->length(); ++i) {
-            RefPtr track = tracks->item(i);
-            if (!track)
-                continue;
-            if (track->mode() != TextTrack::Mode::Showing)
-                continue;
-            // Only search tracks whose cues carry text the user reads or hears, skip chapters and metadata tracks.
-            switch (track->kind()) {
-            case TextTrack::Kind::Subtitles:
-            case TextTrack::Kind::Captions:
-            case TextTrack::Kind::Descriptions:
-                break;
-            default:
-                continue;
-            }
-            RefPtr cues = track->cues();
-            if (!cues)
-                continue;
-
-            for (unsigned j = 0; j < cues->length(); ++j) {
-                RefPtr cue = cues->item(j);
-                // Only VTTCue carries searchable caption text.
-                RefPtr vttCue = dynamicDowncast<VTTCue>(cue.get());
-                if (!vttCue)
-                    continue;
-                if (duration.isValid() && vttCue->startMediaTime() >= duration)
-                    break;
-                RefPtr cueAsHTML = vttCue->getCueAsHTML();
-                if (cueAsHTML && containsPlainText(cueAsHTML->textContent(), target, options))
-                    results.append({ element.get(), vttCue->startMediaTime() });
-            }
-        }
-
-        // One element can carry several active text tracks (captions, subtitles, etc.), so sort by cue time.
-        std::ranges::stable_sort(results.mutableSubspan(firstMatchForElement), [](auto& a, auto& b) {
-            return a.seekTime < b.seekTime;
-        });
-
-        // Collapse cues that share a start time
-        MediaTime previousSeekTime = MediaTime::invalidTime();
-        results.removeAllMatching([&previousSeekTime](auto& match) {
-            bool isDuplicate = match.seekTime == previousSeekTime;
-            previousSeekTime = match.seekTime;
-            return isDuplicate;
-        }, firstMatchForElement);
+        for (auto& seekTime : element->findCueMatches(target, options))
+            results.append({ element.get(), seekTime });
     }
 
     return results;

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -138,6 +138,7 @@
 #include "ShadowRoot.h"
 #include "SleepDisabler.h"
 #include "SpeechSynthesis.h"
+#include "TextIterator.h"
 #include "TextTrackCueList.h"
 #include "TextTrackList.h"
 #include "TextTrackRepresentation.h"
@@ -145,6 +146,7 @@
 #include "TimeRanges.h"
 #include "UserContentController.h"
 #include "UserGestureIndicator.h"
+#include "VTTCue.h"
 #include "VideoPlaybackQuality.h"
 #include "VideoTrack.h"
 #include "VideoTrackConfiguration.h"
@@ -5461,6 +5463,11 @@ void HTMLMediaElement::removeTextTrack(TextTrack& track, bool scheduleEvent)
     if (!m_textTracks || !m_textTracks->contains(track))
         return;
 
+    if (m_findCaptionTrack == &track) {
+        m_findCaptionTrack = nullptr;
+        m_findCaptionTrackPreviousMode = std::nullopt;
+    }
+
     TrackDisplayUpdateScope scope { *this };
     if (RefPtr cues = track.cues())
         textTrackRemoveCues(track, *cues);
@@ -5901,6 +5908,135 @@ void HTMLMediaElement::configureTextTracks()
     m_processingPreferenceChange = false;
 
     configureTextTrackDisplay();
+}
+
+static bool isSubtitleOrCaptionTrackKind(TextTrack::Kind kind)
+{
+    return kind == TextTrack::Kind::Subtitles || kind == TextTrack::Kind::Captions;
+}
+
+bool HTMLMediaElement::hasShowingFindSearchableTextTrackExcept(const TextTrack* except) const
+{
+    if (!m_textTracks)
+        return false;
+    for (unsigned i = 0; i < m_textTracks->length(); ++i) {
+        RefPtr track = m_textTracks->item(i);
+        if (!track || track.get() == except)
+            continue;
+        if (track->mode() == TextTrack::Mode::Showing && isSubtitleOrCaptionTrackKind(track->kind()))
+            return true;
+    }
+    return false;
+}
+
+RefPtr<TextTrack> HTMLMediaElement::bestFindCaptionTrack() const
+{
+    if (!m_textTracks)
+        return nullptr;
+
+    RefPtr page = document().page();
+    RefPtr captionPreferences = page ? &protect(page->group())->ensureCaptionPreferences() : nullptr;
+    auto preferredLanguages = captionPreferences ? captionPreferences->preferredLanguages() : Vector<String> { };
+
+    RefPtr<TextTrack> bestLanguageMatch;
+    int bestLanguageScore = 0;
+    RefPtr<TextTrack> defaultTrack;
+
+    for (unsigned i = 0; i < m_textTracks->length(); ++i) {
+        RefPtr track = m_textTracks->item(i);
+        if (!track)
+            continue;
+        if (!isSubtitleOrCaptionTrackKind(track->kind()))
+            continue;
+        if (track->containsOnlyForcedSubtitles() || !track->isMainProgramContent())
+            continue;
+
+        if (!defaultTrack && track->isDefault())
+            defaultTrack = track;
+
+        if (captionPreferences) {
+            int languageScore = captionPreferences->textTrackLanguageSelectionScore(*track, preferredLanguages);
+            if (languageScore > bestLanguageScore) {
+                bestLanguageScore = languageScore;
+                bestLanguageMatch = track;
+            }
+        }
+    }
+
+    if (bestLanguageMatch)
+        return bestLanguageMatch;
+    return defaultTrack;
+}
+
+void HTMLMediaElement::updateFindCaptionTrack()
+{
+    RefPtr best = hasShowingFindSearchableTextTrackExcept(m_findCaptionTrack.get()) ? nullptr : bestFindCaptionTrack();
+    if (m_findCaptionTrack == best)
+        return;
+
+    if (RefPtr previous = m_findCaptionTrack; previous && m_findCaptionTrackPreviousMode && previous->mode() == TextTrack::Mode::Showing)
+        previous->setMode(*m_findCaptionTrackPreviousMode);
+    m_findCaptionTrackPreviousMode = std::nullopt;
+
+    m_findCaptionTrack = best;
+    if (best) {
+        m_findCaptionTrackPreviousMode = best->mode();
+        best->setMode(TextTrack::Mode::Showing);
+    }
+}
+
+void HTMLMediaElement::clearFindCaptionTrack()
+{
+    if (RefPtr findCaptionTrack = m_findCaptionTrack; findCaptionTrack && m_findCaptionTrackPreviousMode && findCaptionTrack->mode() == TextTrack::Mode::Showing)
+        findCaptionTrack->setMode(*m_findCaptionTrackPreviousMode);
+    m_findCaptionTrack = nullptr;
+    m_findCaptionTrackPreviousMode = std::nullopt;
+}
+
+Vector<MediaTime> HTMLMediaElement::findCueMatches(const String& target, FindOptions options)
+{
+    if (!document().settings().findInVideoEnabled())
+        return { };
+
+    updateFindCaptionTrack();
+
+    Vector<MediaTime> matches;
+    if (RefPtr tracks = m_textTracks) {
+        MediaTime duration = durationMediaTime();
+        for (unsigned i = 0; i < tracks->length(); ++i) {
+            RefPtr track = tracks->item(i);
+            if (!track || track->mode() != TextTrack::Mode::Showing)
+                continue;
+            if (!isSubtitleOrCaptionTrackKind(track->kind()))
+                continue;
+            RefPtr cues = track->cues();
+            if (!cues)
+                continue;
+            for (unsigned j = 0; j < cues->length(); ++j) {
+                RefPtr vttCue = dynamicDowncast<VTTCue>(cues->item(j));
+                if (!vttCue)
+                    continue;
+                if (duration.isValid() && vttCue->startMediaTime() >= duration)
+                    break;
+                RefPtr cueAsHTML = vttCue->getCueAsHTML();
+                if (cueAsHTML && containsPlainText(cueAsHTML->textContent(), target, options))
+                    matches.append(vttCue->startMediaTime());
+            }
+        }
+    }
+
+    std::ranges::stable_sort(matches, [](auto& a, auto& b) {
+        return a < b;
+    });
+
+    MediaTime previousTime = MediaTime::invalidTime();
+    matches.removeAllMatching([&previousTime](auto& time) {
+        bool isDuplicate = time == previousTime;
+        previousTime = time;
+        return isDuplicate;
+    });
+
+    return matches;
 }
 
 bool HTMLMediaElement::havePotentialSourceChild()

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -34,6 +34,7 @@
 #include <WebCore/AudioTrackClient.h>
 #include <WebCore/AutoplayEvent.h>
 #include <WebCore/CaptionUserPreferences.h>
+#include <WebCore/FindOptions.h>
 #include <WebCore/HTMLElement.h>
 #include <WebCore/HTMLMediaElementEnums.h>
 #include <WebCore/HTMLMediaElementIdentifier.h>
@@ -45,6 +46,7 @@
 #include <WebCore/MediaUniqueIdentifier.h>
 #include <WebCore/MessageTargetForTesting.h>
 #include <WebCore/PlatformDynamicRangeLimit.h>
+#include <WebCore/TextTrack.h>
 #include <WebCore/TextTrackClient.h>
 #include <WebCore/URLKeepingBlobAlive.h>
 #include <WebCore/VideoTrackClient.h>
@@ -416,6 +418,9 @@ public:
     void closeCaptionTracksChanged();
     void notifyMediaPlayerOfTextTrackChanges();
 
+    Vector<MediaTime> findCueMatches(const String& target, FindOptions);
+    void clearFindCaptionTrack();
+
     virtual void didAddTextTrack(HTMLTrackElement&);
     virtual void didRemoveTextTrack(HTMLTrackElement&);
 
@@ -435,6 +440,10 @@ public:
     void configureTextTracks();
     void configureTextTrackGroup(const TrackGroup&);
     void configureMetadataTextTrackGroup(const TrackGroup&);
+
+    void updateFindCaptionTrack();
+    bool hasShowingFindSearchableTextTrackExcept(const TextTrack*) const;
+    RefPtr<TextTrack> bestFindCaptionTrack() const;
 
     void setSelectedTextTrack(TextTrack*);
 
@@ -1397,6 +1406,9 @@ private:
 
     struct CueData;
     std::unique_ptr<CueData> m_cueData;
+
+    RefPtr<TextTrack> m_findCaptionTrack;
+    std::optional<TextTrack::Mode> m_findCaptionTrackPreviousMode;
 
     int m_ignoreTrackDisplayUpdate { 0 };
 

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -1312,6 +1312,13 @@ Vector<CueMatch> Page::findCueMatches(const String& target, FindOptions options)
 
     return results;
 }
+
+void Page::clearFindCaptionTracks()
+{
+    forEachMediaElement([](HTMLMediaElement& element) {
+        element.clearFindCaptionTrack();
+    });
+}
 #endif // ENABLE(VIDEO)
 
 std::optional<SimpleRange> Page::rangeOfString(const String& target, const std::optional<SimpleRange>& referenceRange, FindOptions options)

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -591,6 +591,7 @@ public:
 
 #if ENABLE(VIDEO)
     WEBCORE_EXPORT Vector<CueMatch> findCueMatches(const String&, FindOptions);
+    WEBCORE_EXPORT void clearFindCaptionTracks();
 #endif
 
 #if PLATFORM(COCOA)

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -3399,6 +3399,12 @@ ExceptionOr<Vector<double>> Internals::findCueMatches(const String& text, const 
         return match.seekTime.toDouble();
     });
 }
+
+void Internals::clearFindCaptionTracks()
+{
+    if (RefPtr document = contextDocument(); document && document->page())
+        document->page()->clearFindCaptionTracks();
+}
 #endif
 
 unsigned Internals::numberOfIDBTransactions() const

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -542,6 +542,7 @@ public:
     void setCachedFindMatchBufferLimitForTesting(unsigned maximumRunCount);
 #if ENABLE(VIDEO)
     ExceptionOr<Vector<double>> findCueMatches(const String&, const Vector<String>& findOptions);
+    void clearFindCaptionTracks();
 #endif
 
     unsigned numberOfScrollableAreas();

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -675,6 +675,7 @@ enum ContentsFormat {
     unsigned long countFindMatches(DOMString text, sequence<DOMString> findOptions);
     undefined setCachedFindMatchBufferLimitForTesting(unsigned long maximumRunCount);
     [Conditional=VIDEO] sequence<unrestricted double> findCueMatches(DOMString text, sequence<DOMString> findOptions);
+    [Conditional=VIDEO] undefined clearFindCaptionTracks();
 
     DOMString autofillFieldName(Element formControlElement);
     boolean isSpellcheckDisabledExceptTextReplacement(HTMLInputElement inputElement);

--- a/Source/WebKit/WebProcess/WebPage/FindController.cpp
+++ b/Source/WebKit/WebProcess/WebPage/FindController.cpp
@@ -725,6 +725,9 @@ void FindController::hideFindUI()
 {
     m_findMatches.clear();
     m_lastFoundRange = std::nullopt;
+#if ENABLE(VIDEO)
+    protect(protect(m_webPage.get())->corePage())->clearFindCaptionTracks();
+#endif
     if (RefPtr findPageOverlay = m_findPageOverlay.get())
         m_webPage->corePage()->pageOverlayController().uninstallPageOverlay(*findPageOverlay, PageOverlay::FadeMode::Fade);
 

--- a/Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.cpp
@@ -374,6 +374,9 @@ void WebFoundTextRangeController::clearAllDecoratedFoundText()
     RefPtr corePage = protect(m_webPage.get())->corePage();
     corePage->unmarkAllTextMatches();
     corePage->removeAllActiveTextMatches();
+#if ENABLE(VIDEO)
+    corePage->clearFindCaptionTracks();
+#endif
 
     m_highlightedRange = { };
     m_textIndicator = nullptr;


### PR DESCRIPTION
#### a82cb239707d0b8c17f94d92c1dab4f0b83fefd4
<pre>
Find in Page can’t find any matches for a video’s captions when turned off
<a href="https://bugs.webkit.org/show_bug.cgi?id=320455">https://bugs.webkit.org/show_bug.cgi?id=320455</a>
<a href="https://rdar.apple.com/183422611">rdar://183422611</a>

Reviewed by Eric Carlson.

Find in Page only searched caption tracks that were already showing,so
a word spoken in a video wasn&apos;t findable unless the user first turned captions on.
Now the cue search lives on HTMLMediaElement.

When a find query runs and no caption or subtitle track is showing,
the element shows the best one, ranked by the user&apos;s preferred caption
languages and then the author&apos;s default track, so its cues can be searched.
The track&apos;s previous mode is restored when Find is dismissed. If a track
is already showing, that one is searched instead.

Adds a layout test that, with captions off, searches across three preferred
languages and confirms Find shows the highest-priority track while searching and
restores it to off when cleared. It also confirms a track the user already has
showing is searched as-is and left untouched.

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::findCueMatches):
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::removeTextTrack):
(WebCore::isSubtitleOrCaptionTrackKind):
(WebCore::HTMLMediaElement::hasShowingFindSearchableTextTrackExcept const):
(WebCore::HTMLMediaElement::bestFindCaptionTrack const):
(WebCore::HTMLMediaElement::updateFindCaptionTrack):
(WebCore::HTMLMediaElement::clearFindCaptionTrack):
(WebCore::HTMLMediaElement::findCueMatches):
* Source/WebCore/html/HTMLMediaElement.h:
* Source/WebCore/page/Page.cpp:
(WebCore::Page::clearFindCaptionTracks):
* Source/WebCore/page/Page.h:
* Source/WebKit/WebProcess/WebPage/FindController.cpp:
(WebKit::FindController::hideFindUI):
* Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.cpp:
(WebKit::WebFoundTextRangeController::clearAllDecoratedFoundText):
* LayoutTests/media/track/text-track-find-preferred-language-expected.txt: Added.
* LayoutTests/media/track/text-track-find-preferred-language.html: Added.
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::clearFindCaptionTracks):
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:

Canonical link: <a href="https://commits.webkit.org/318159@main">https://commits.webkit.org/318159@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ef96ba99948684f7bad2db7816e33ba41203aec0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177428 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51366 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45160 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187032 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140675 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179291 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52658 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51075 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138281 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140675 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180384 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41777 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159027 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118746 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40439 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38813 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150846 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38524 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35499 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/43151 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/43047 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189460 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51033 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/158561 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147375 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39605 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51715 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35151 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147167 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41880 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123930 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/118283 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50223 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13502 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49619 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49859 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49681 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->