### PR TITLE
[JSC] Use codeForEval before ToString in Function constructor

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-function-constructor-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-function-constructor-expected.txt
@@ -60,8 +60,8 @@ PASS AsyncFunction constructor with mixed plain and trusted strings, mask #14
 PASS GeneratorFunction constructor with mixed plain and trusted strings, mask #14
 PASS AsyncGeneratorFunction constructor with mixed plain and trusted strings, mask #14
 PASS Function constructor with mixed plain and trusted strings, mask #15
-FAIL Function constructor with trusted strings, and a forged toString() for the one at index 0 Refused to evaluate a string as JavaScript because this document requires a 'Trusted Type' assignment.
-FAIL Function constructor with trusted strings, and a forged toString() for the one at index 1 Refused to evaluate a string as JavaScript because this document requires a 'Trusted Type' assignment.
-FAIL Function constructor with trusted strings, and a forged toString() for the one at index 2 Refused to evaluate a string as JavaScript because this document requires a 'Trusted Type' assignment.
-FAIL Function constructor with trusted strings, and a forged toString() for the one at index 3 Refused to evaluate a string as JavaScript because this document requires a 'Trusted Type' assignment.
+PASS Function constructor with trusted strings, and a forged toString() for the one at index 0
+PASS Function constructor with trusted strings, and a forged toString() for the one at index 1
+PASS Function constructor with trusted strings, and a forged toString() for the one at index 2
+PASS Function constructor with trusted strings, and a forged toString() for the one at index 3
 

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-function-constructor-untrusted-arguments-and-applying-default-policy-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-function-constructor-untrusted-arguments-and-applying-default-policy-expected.txt
@@ -7,8 +7,8 @@ PASS plain string at index 0 (default policy leaving the function text unchanged
 PASS plain string at index 1 (default policy leaving the function text unchanged).
 PASS plain string at index 2 (default policy leaving the function text unchanged).
 PASS plain string at index 3 (default policy leaving the function text unchanged).
-FAIL TrustedScript with forged toString() at index 0 (default policy not invoked). assert_equals: toString() should never be called on a TrustedScript argument expected 0 but got 2
-FAIL TrustedScript with forged toString() at index 1 (default policy not invoked). assert_equals: toString() should never be called on a TrustedScript argument expected 0 but got 2
-FAIL TrustedScript with forged toString() at index 2 (default policy not invoked). assert_equals: toString() should never be called on a TrustedScript argument expected 0 but got 2
-FAIL TrustedScript with forged toString() at index 3 (default policy not invoked). assert_equals: toString() should never be called on a TrustedScript argument expected 0 but got 2
+PASS TrustedScript with forged toString() at index 0 (default policy not invoked).
+PASS TrustedScript with forged toString() at index 1 (default policy not invoked).
+PASS TrustedScript with forged toString() at index 2 (default policy not invoked).
+PASS TrustedScript with forged toString() at index 3 (default policy not invoked).
 

--- a/LayoutTests/js/dom/eval-exception-check-expected.txt
+++ b/LayoutTests/js/dom/eval-exception-check-expected.txt
@@ -1,0 +1,10 @@
+Tests that eval() returns a non-trusted, non-string object unchanged without ever calling toString() on it, per the Dynamic Code Brand Checks proposal (HostGetCodeForEval step 3c: if codeForEval() does not return a String, the object is returned unchanged, and ToString() is never called). Unlike new Function(), eval() has no ToString() fallback for object arguments, so there is no reachable exception-check gap to test here.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS eval(untrustedObject) === untrustedObject is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/js/dom/eval-exception-check.html
+++ b/LayoutTests/js/dom/eval-exception-check.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html><!-- webkit-test-runner [ jscOptions=--validateExceptionChecks=true ] -->
+<html>
+<head>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+<script>
+// See https://tc39.es/proposal-dynamic-code-brand-checks/#sec-performeval
+description("Tests that eval() returns a non-trusted, non-string object unchanged without ever calling toString() on it, per the Dynamic Code Brand Checks proposal (HostGetCodeForEval step 3c: if codeForEval() does not return a String, the object is returned unchanged, and ToString() is never called). Unlike new Function(), eval() has no ToString() fallback for object arguments, so there is no reachable exception-check gap to test here.");
+
+// codeForEval() returns null for untrustedObject, and per step 3c eval() returns
+// the object unchanged instead of falling back to toString() (unlike
+// new Function()). toString() intentionally throws here; if eval() incorrectly
+// called it, this test would fail with that exception instead of passing.
+const untrustedObject = { toString() { throw new Error("toString() should never be called"); } };
+
+shouldBeTrue("eval(untrustedObject) === untrustedObject");
+</script>
+</body>
+</html>

--- a/LayoutTests/js/dom/function-constructor-exception-check-expected.txt
+++ b/LayoutTests/js/dom/function-constructor-exception-check-expected.txt
@@ -1,0 +1,10 @@
+Tests that new Function() correctly propagates an exception thrown by an object's toString() when that object is not a trusted type, per the Dynamic Code Brand Checks proposal. codeForEval() returns null for a non-trusted object, so the code falls back to calling toString() on it, which throws here.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS function() { new Function(untrustedObject, "return 1"); } threw exception Error: Intentional test exception.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/js/dom/function-constructor-exception-check.html
+++ b/LayoutTests/js/dom/function-constructor-exception-check.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html><!-- webkit-test-runner [ jscOptions=--validateExceptionChecks=true ] -->
+<html>
+<head>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+<script>
+// See https://tc39.es/proposal-dynamic-code-brand-checks/#sec-createdynamicfunction
+description("Tests that new Function() correctly propagates an exception thrown by an object's toString() when that object is not a trusted type, per the Dynamic Code Brand Checks proposal. codeForEval() returns null for a non-trusted object, so the code falls back to calling toString() on it, which throws here.");
+
+// codeForEval() returns null for untrustedObject (it is not a real TrustedScript),
+// so execution falls through to the toString() fallback below, where the exception
+// is actually thrown and caught. This exercises the pre-existing exception check
+// after that fallback call, not the defensive check added directly after
+// codeForEval() itself. WebCore's codeForEval() implementation never throws,
+// so that check has no reachable test case.
+const untrustedObject = { toString() { throw new Error("Intentional test exception"); } };
+
+shouldThrow(function() { new Function(untrustedObject, "return 1"); }, "'Error: Intentional test exception'");
+</script>
+</body>
+</html>

--- a/Source/JavaScriptCore/interpreter/Interpreter.cpp
+++ b/Source/JavaScriptCore/interpreter/Interpreter.cpp
@@ -147,7 +147,7 @@ JSValue eval(CallFrame* callFrame, JSValue thisValue, JSScope* callerScopeChain,
     }
 
     if (globalObject->trustedTypesEnforcement() != TrustedTypesEnforcement::None && !isTrusted) [[unlikely]] {
-        bool canCompileStrings = globalObject->globalObjectMethodTable()->canCompileStrings(globalObject, CompilationType::DirectEval, programString->value(globalObject).data, *vm.emptyList);
+        bool canCompileStrings = globalObject->globalObjectMethodTable()->canCompileStrings(globalObject, CompilationType::DirectEval, programString->value(globalObject).data);
         RETURN_IF_EXCEPTION(scope, { });
         if (!canCompileStrings) [[unlikely]] {
             throwException(globalObject, scope, createEvalError(globalObject, "Refused to evaluate a string as JavaScript because this document requires a 'Trusted Type' assignment."_s));

--- a/Source/JavaScriptCore/runtime/FunctionConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/FunctionConstructor.cpp
@@ -83,6 +83,24 @@ ASCIILiteral functionConstructorPrefix(FunctionConstructionMode functionConstruc
     return ASCIILiteral { };
 }
 
+// Dynamic Code Brand Checks Proposal
+// https://tc39.es/proposal-dynamic-code-brand-checks/#sec-hostgetcodeforeval
+//
+// For object-typed arguments, ask the host for code via codeForEval()
+// before falling back to ToString().
+static String codeForEvalOrToString(JSGlobalObject* globalObject, JSValue value, ThrowScope& scope)
+{
+    if (value.isObject()) [[unlikely]] {
+        String code = globalObject->globalObjectMethodTable()->codeForEval(globalObject, value);
+        RETURN_IF_EXCEPTION(scope, { });
+        if (!code.isNull())
+            return code;
+    }
+    String result = value.toWTFString(globalObject);
+    RETURN_IF_EXCEPTION(scope, { });
+    return result;
+}
+
 static String stringifyFunction(JSGlobalObject* globalObject, const ArgList& args, const Identifier& functionName, FunctionConstructionMode functionConstructionMode, ThrowScope& scope, std::optional<int>& functionConstructorParametersEndPosition)
 {
     ASCIILiteral prefix = functionConstructorPrefix(functionConstructionMode);
@@ -98,7 +116,7 @@ static String stringifyFunction(JSGlobalObject* globalObject, const ArgList& arg
         if (arg0.isString()) [[likely]]
             program = tryMakeString(prefix, functionName.string(), "(\n) {\n"_s, asString(arg0), "\n}"_s);
         else {
-            auto body = arg0.toWTFString(globalObject);
+            String body = codeForEvalOrToString(globalObject, arg0, scope);
             RETURN_IF_EXCEPTION(scope, { });
             program = tryMakeString(prefix, functionName.string(), "(\n) {\n"_s, body, "\n}"_s);
         }
@@ -116,10 +134,12 @@ static String stringifyFunction(JSGlobalObject* globalObject, const ArgList& arg
             arg0Length = asString(arg0)->length();
             program = tryMakeString(prefix, functionName.string(), "("_s, asString(arg0), "\n) {\n"_s, asString(arg1), "\n}"_s);
         } else {
-            auto arg = arg0.toWTFString(globalObject);
+            String arg = codeForEvalOrToString(globalObject, arg0, scope);
             RETURN_IF_EXCEPTION(scope, { });
-            auto body = arg1.toWTFString(globalObject);
+
+            String body = codeForEvalOrToString(globalObject, arg1, scope);
             RETURN_IF_EXCEPTION(scope, { });
+
             arg0Length = arg.length();
             program = tryMakeString(prefix, functionName.string(), "("_s, arg, "\n) {\n"_s, body, "\n}"_s);
         }
@@ -133,17 +153,13 @@ static String stringifyFunction(JSGlobalObject* globalObject, const ArgList& arg
         StringBuilder builder(OverflowPolicy::RecordOverflow);
         builder.append(prefix, functionName.string(), '(');
 
-        auto* jsString = args.at(0).toString(globalObject);
+        auto arg0Str = codeForEvalOrToString(globalObject, args.at(0), scope);
         RETURN_IF_EXCEPTION(scope, { });
-        auto view = jsString->view(globalObject);
-        RETURN_IF_EXCEPTION(scope, { });
-        builder.append(view.data);
+        builder.append(arg0Str);
         for (size_t i = 1; !builder.hasOverflowed() && i < args.size() - 1; i++) {
-            auto* jsString = args.at(i).toString(globalObject);
+            auto argStr = codeForEvalOrToString(globalObject, args.at(i), scope);
             RETURN_IF_EXCEPTION(scope, { });
-            auto view = jsString->view(globalObject);
-            RETURN_IF_EXCEPTION(scope, { });
-            builder.append(',', view.data);
+            builder.append(',', argStr);
         }
         if (builder.hasOverflowed()) [[unlikely]] {
             throwOutOfMemoryError(globalObject, scope);
@@ -152,11 +168,9 @@ static String stringifyFunction(JSGlobalObject* globalObject, const ArgList& arg
 
         functionConstructorParametersEndPosition = builder.length() + "\n)"_s.length();
 
-        auto* bodyString = args.at(args.size() - 1).toString(globalObject);
+        auto bodyStr = codeForEvalOrToString(globalObject, args.at(args.size() - 1), scope);
         RETURN_IF_EXCEPTION(scope, { });
-        auto body = bodyString->view(globalObject);
-        RETURN_IF_EXCEPTION(scope, { });
-        builder.append("\n) {\n"_s, body.data, "\n}"_s);
+        builder.append("\n) {\n"_s, bodyStr, "\n}"_s);
         if (builder.hasOverflowed()) [[unlikely]] {
             throwOutOfMemoryError(globalObject, scope);
             return { };
@@ -178,18 +192,24 @@ JSObject* constructFunction(JSGlobalObject* globalObject, const ArgList& args, c
 
     if (globalObject->trustedTypesEnforcement() != TrustedTypesEnforcement::None) [[unlikely]] {
         bool isTrusted = true;
-        auto* structure = globalObject->trustedScriptStructure();
         for (size_t i = 0; i < args.size(); i++) {
             auto arg = args.at(i);
 
-            if (!arg.isObject() || structure != asObject(arg)->structure()) {
+            if (!arg.isObject()) {
+                isTrusted = false;
+                break;
+            }
+
+            String codeForEval = globalObject->globalObjectMethodTable()->codeForEval(globalObject, arg);
+            RETURN_IF_EXCEPTION(scope, { });
+            if (codeForEval.isNull()) {
                 isTrusted = false;
                 break;
             }
         }
 
         if (!isTrusted) {
-            bool canCompileStrings = globalObject->globalObjectMethodTable()->canCompileStrings(globalObject, CompilationType::Function, code, args);
+            bool canCompileStrings = globalObject->globalObjectMethodTable()->canCompileStrings(globalObject, CompilationType::Function, code);
             RETURN_IF_EXCEPTION(scope, { });
             if (!canCompileStrings) {
                 throwException(globalObject, scope, createEvalError(globalObject, "Refused to evaluate a string as JavaScript because this document requires a 'Trusted Type' assignment."_s));

--- a/Source/JavaScriptCore/runtime/GlobalObjectMethodTable.h
+++ b/Source/JavaScriptCore/runtime/GlobalObjectMethodTable.h
@@ -85,7 +85,7 @@ struct GlobalObjectMethodTable {
 #endif
     JSGlobalObject* (*deriveShadowRealmGlobalObject)(JSGlobalObject*);
     String (*codeForEval)(JSGlobalObject*, JSValue);
-    bool (*canCompileStrings)(JSGlobalObject*, CompilationType, String, const ArgList&);
+    bool (*canCompileStrings)(JSGlobalObject*, CompilationType, String);
     Structure* (*trustedScriptStructure)(JSGlobalObject*);
 };
 

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.h
@@ -1120,7 +1120,7 @@ public:
     static ScriptExecutionStatus scriptExecutionStatus(JSGlobalObject*, JSObject*) { return ScriptExecutionStatus::Running; }
     static void reportViolationForUnsafeEval(JSGlobalObject*, const String&) { }
     static String codeForEval(JSGlobalObject*, JSValue) { return nullString(); }
-    static bool canCompileStrings(JSGlobalObject*, CompilationType, String, const ArgList&) { return true; }
+    static bool canCompileStrings(JSGlobalObject*, CompilationType, String) { return true; }
     static Structure* trustedScriptStructure(JSGlobalObject*) { return nullptr; }
 
     inline JSObject* arrayBufferPrototype(ArrayBufferSharingMode) const;

--- a/Source/JavaScriptCore/runtime/JSGlobalObjectFunctions.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObjectFunctions.cpp
@@ -479,7 +479,7 @@ JSC_DEFINE_HOST_FUNCTION(globalFuncEval, (JSGlobalObject* globalObject, CallFram
         return JSValue::encode(x);
 
     if (globalObject->trustedTypesEnforcement() != TrustedTypesEnforcement::None && !isTrusted) {
-        bool canCompileStrings = globalObject->globalObjectMethodTable()->canCompileStrings(globalObject, CompilationType::IndirectEval, programSource, *vm.emptyList);
+        bool canCompileStrings = globalObject->globalObjectMethodTable()->canCompileStrings(globalObject, CompilationType::IndirectEval, programSource);
         RETURN_IF_EXCEPTION(scope, { });
         if (!canCompileStrings) {
             throwException(globalObject, scope, createEvalError(globalObject, "Refused to evaluate a string as JavaScript because this document requires a 'Trusted Type' assignment."_s));

--- a/Source/WebCore/bindings/js/JSDOMGlobalObject.cpp
+++ b/Source/WebCore/bindings/js/JSDOMGlobalObject.cpp
@@ -411,7 +411,7 @@ String JSDOMGlobalObject::codeForEval(JSGlobalObject* globalObject, JSValue valu
     return String();
 }
 
-bool JSDOMGlobalObject::canCompileStrings(JSGlobalObject* globalObject, CompilationType compilationType, String codeString, const ArgList& args)
+bool JSDOMGlobalObject::canCompileStrings(JSGlobalObject* globalObject, CompilationType compilationType, String codeString)
 {
     VM& vm = globalObject->vm();
     auto throwScope = DECLARE_THROW_SCOPE(vm);
@@ -419,7 +419,7 @@ bool JSDOMGlobalObject::canCompileStrings(JSGlobalObject* globalObject, Compilat
     auto& thisObject = *downcast<JSDOMGlobalObject>(globalObject);
     CheckedPtr scriptExecutionContext = thisObject.scriptExecutionContext();
 
-    auto result = canCompile(*scriptExecutionContext, compilationType, codeString, args);
+    auto result = canCompile(*scriptExecutionContext, compilationType, codeString);
 
     if (result.hasException()) {
         // https://w3c.github.io/webappsec-csp/#can-compile-strings

--- a/Source/WebCore/bindings/js/JSDOMGlobalObject.h
+++ b/Source/WebCore/bindings/js/JSDOMGlobalObject.h
@@ -90,7 +90,7 @@ public:
     ScriptExecutionContext* scriptExecutionContext() const;
 
     static String codeForEval(JSC::JSGlobalObject*, JSC::JSValue);
-    static bool canCompileStrings(JSC::JSGlobalObject*, JSC::CompilationType, String, const JSC::ArgList&);
+    static bool canCompileStrings(JSC::JSGlobalObject*, JSC::CompilationType, String);
     static JSC::Structure* trustedScriptStructure(JSC::JSGlobalObject*);
 
     // Make binding code generation easier.

--- a/Source/WebCore/dom/TrustedType.cpp
+++ b/Source/WebCore/dom/TrustedType.cpp
@@ -309,37 +309,8 @@ ExceptionOr<String> requireTrustedTypesForPreNavigationCheckPasses(ScriptExecuti
     return String(urlString);
 }
 
-ExceptionOr<bool> canCompile(ScriptExecutionContext& scriptExecutionContext, JSC::CompilationType compilationType, String codeString, const JSC::ArgList& args)
+ExceptionOr<bool> canCompile(ScriptExecutionContext& scriptExecutionContext, JSC::CompilationType compilationType, String codeString)
 {
-    if (compilationType == CompilationType::Function) {
-        VM& vm = scriptExecutionContext.vm();
-        auto scope = DECLARE_THROW_SCOPE(vm);
-
-        bool isTrusted = true;
-
-        for (size_t i = 0; i < args.size(); i++) {
-            auto arg = args.at(i);
-            if (!arg.isObject()) {
-                isTrusted = false;
-                break;
-            }
-            if (RefPtr trustedScript = JSTrustedScript::toWrapped(vm, arg)) {
-                auto argString = arg.toWTFString(scriptExecutionContext.globalObject());
-                RETURN_IF_EXCEPTION(scope, Exception { ExceptionCode::ExistingExceptionError });
-                if (trustedScript->toString() != argString) {
-                    isTrusted = false;
-                    break;
-                }
-            } else {
-                isTrusted = false;
-                break;
-            }
-        }
-
-        if (isTrusted)
-            return true;
-    }
-
     auto sink = compilationType == CompilationType::Function ? "Function"_s : "eval"_s;
 
     auto stringValueHolder = trustedTypeCompliantString(TrustedType::TrustedScript, scriptExecutionContext, codeString, sink);

--- a/Source/WebCore/dom/TrustedType.h
+++ b/Source/WebCore/dom/TrustedType.h
@@ -76,7 +76,7 @@ ExceptionOr<String> trustedTypeCompliantString(ScriptExecutionContext&, Variant<
 
 WEBCORE_EXPORT AttributeTypeAndSink trustedTypeForAttribute(const String& elementName, const String& attributeName, const String& elementNamespace, const String& attributeNamespace);
 
-ExceptionOr<bool> canCompile(ScriptExecutionContext&, JSC::CompilationType, String codeString, const JSC::ArgList& args);
+ExceptionOr<bool> canCompile(ScriptExecutionContext&, JSC::CompilationType, String codeString);
 
 bool isEventHandlerAttribute(const QualifiedName& attributeName);
 


### PR DESCRIPTION
#### 9e26c002a8ef409ec399c7107f10eeb44ad54c1a
<pre>
[JSC] Use codeForEval before ToString in Function constructor
<a href="https://bugs.webkit.org/show_bug.cgi?id=319409">https://bugs.webkit.org/show_bug.cgi?id=319409</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=320529">https://bugs.webkit.org/show_bug.cgi?id=320529</a>

Reviewed by NOBODY (OOPS!).

Update Dynamic Code Brand Checks in JSC by calling host&apos;s codeForEval() before ToString()
for Function constructor arguments.
This fixes the TrustedScript forged toString() WPT tests that were previously failing.

* LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-function-constructor-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-function-constructor-untrusted-arguments-and-applying-default-policy-expected.txt:
* Source/JavaScriptCore/runtime/FunctionConstructor.cpp:
(JSC::stringifyFunction):
* Source/WebCore/dom/TrustedType.cpp:
(WebCore::canCompile):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1040d23c3f733f77ae26c6bc81b188a34498c7b6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182766 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56687 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50495 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192980 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147054 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184628 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58028 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56422 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142652 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99040 "4 flakes 5 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185721 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46362 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163407 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123081 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45055 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43304 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/5051 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/11877 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155443 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42938 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4154 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/44035 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49327 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47568 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194923 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56357 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/162901 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152094 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57061 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39549 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151793 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46362 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129329 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/125362 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55569 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17933 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54941 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55179 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55007 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->