### PR TITLE
[ModelProcess] Prepare the RealityKit hierarchy to support multiple entities with global transforms

### DIFF
--- a/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.h
+++ b/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.h
@@ -198,6 +198,10 @@ private:
     void notifyModelPlayerOfEntityTransformChange();
     void applyDefaultIBL();
     void updateForCurrentStageMode();
+#if HAVE(CORE_RE)
+    void ensurePortalEntityHierarchy();
+    void parentToContainer(WKRKEntity *);
+#endif
     std::optional<WebCore::LayerHostingContextIdentifier> layerHostingContextIdentifier();
     int entityMemoryLimit(bool) const;
 
@@ -215,6 +219,7 @@ private:
     REPtr<RESceneRef> m_scene;
     REPtr<REEntityRef> m_hostingEntity;
     REPtr<REEntityRef> m_containerEntity;
+    RetainPtr<WKRKEntity> m_containerEntityWrapper;
 #endif
     RetainPtr<WKModelProcessModelPlayerProxyObjCAdapter> m_objCAdapter;
 

--- a/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm
+++ b/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm
@@ -632,10 +632,23 @@ void ModelProcessModelPlayerProxy::notifyModelPlayerOfEntityTransformChange()
 
 void ModelProcessModelPlayerProxy::updateTransform()
 {
-    if (!m_modelRKEntity || !m_layer)
+    if (!m_layer)
+        return;
+
+#if HAVE(CORE_RE)
+    if (!m_containerEntityWrapper)
+        return;
+
+    // The container owns the global transforms (stagemode, portal-transform) and the model sits beneath with only its original scale applied.
+    [m_containerEntityWrapper setTransform:WKEntityTransform({ m_transformSRT.scale, m_transformSRT.rotation, m_transformSRT.translation })];
+    if (m_modelRKEntity)
+        [m_modelRKEntity setTransform:WKEntityTransform({ m_originalEntityScale, simd_quaternion(0, simd_make_float3(1, 0, 0)), simd_make_float3(0, 0, 0) })];
+#else
+    if (!m_modelRKEntity)
         return;
 
     [m_modelRKEntity setTransform:WKEntityTransform({ m_transformSRT.scale * m_originalEntityScale, m_transformSRT.rotation, m_transformSRT.translation })];
+#endif
 }
 
 void ModelProcessModelPlayerProxy::updateTransformAfterLayout()
@@ -728,35 +741,10 @@ void ModelProcessModelPlayerProxy::didFinishLoading(WebCore::REModelLoader& load
     m_originalBoundingBoxCenter = [m_modelRKEntity boundingBoxCenter] * m_originalEntityScale;
 
 #if HAVE(CORE_RE)
-    m_hostingEntity = adoptRE(REEntityCreate());
-    REEntitySetName(m_hostingEntity.get(), "WebKit:EntityWithRootComponent");
+    ensurePortalEntityHierarchy();
 
-    REPtr<REComponentRef> layerComponent = adoptRE(RECALayerServiceCreateRootComponent(webDefaultLayerService(), CALayerGetContext(m_layer.get()), m_hostingEntity.get(), nil));
-    RESceneAddEntity(m_scene.get(), m_hostingEntity.get());
-
-    CALayer *contextEntityLayer = RECALayerClientComponentGetCALayer(layerComponent.get());
-    [contextEntityLayer setSeparatedState:kCALayerSeparatedStateTracked];
-
-    RECALayerClientComponentSetShouldSyncToRemotes(layerComponent.get(), true);
-
-    auto clientComponent = RECALayerGetCALayerClientComponent(m_layer.get());
-    auto clientComponentEntity = REComponentGetEntity(clientComponent);
-    REEntitySetName(clientComponentEntity, "WebKit:ClientComponentEntity");
-    if (canLoadWithRealityKit)
-        [model->rootRKEntity() setName:@"WebKit:ModelRootEntity"];
-    else
-        REEntitySetName(model->rootEntity(), "WebKit:ModelRootEntity");
-
-    if (canLoadWithRealityKit)
-        [model->rootRKEntity() setParentCoreEntity:clientComponentEntity preservingWorldTransform:NO];
-    else {
-        REEntitySetParent(model->rootEntity(), clientComponentEntity);
-    }
-
-    m_stageModeInteractionDriver = adoptNS([allocWKStageModeInteractionDriverInstance() initWithModel:m_modelRKEntity.get() container:clientComponentEntity delegate:m_objCAdapter.get()]);
-
-    REEntitySubtreeAddNetworkComponentRecursive([m_stageModeInteractionDriver interactionContainerRef]);
-    RENetworkMarkEntityMetadataDirty([m_stageModeInteractionDriver interactionContainerRef]);
+    [m_modelRKEntity setName:@"WebKit:ModelRootEntity"];
+    parentToContainer(m_modelRKEntity.get());
 
     applyStageModeOperationToDriver();
 
@@ -1193,7 +1181,11 @@ void ModelProcessModelPlayerProxy::updateForCurrentStageMode()
 {
     if (m_stageModeOperation != WebCore::StageModeOperation::None) {
         computeTransform(false);
+#if HAVE(CORE_RE)
+        [m_containerEntityWrapper recenterEntityAtTransform:WKEntityTransform({ m_transformSRT.scale, m_transformSRT.rotation, m_transformSRT.translation })];
+#else
         [m_modelRKEntity recenterEntityAtTransform:WKEntityTransform({ m_transformSRT.scale * m_originalEntityScale, m_transformSRT.rotation, m_transformSRT.translation })];
+#endif
         updateTransformSRT();
     }
 
@@ -1217,12 +1209,27 @@ void ModelProcessModelPlayerProxy::setStageMode(WebCore::StageModeOperation stag
 
 void ModelProcessModelPlayerProxy::updateTransformSRT()
 {
+#if HAVE(CORE_RE)
+    if (!m_containerEntityWrapper)
+        return;
+
+    WKEntityTransform containerTransform = [m_containerEntityWrapper transform];
+    m_transformSRT = RESRT {
+        .scale = containerTransform.scale,
+        .rotation = containerTransform.rotation,
+        .translation = containerTransform.translation
+    };
+#else
+    if (!m_modelRKEntity)
+        return;
+
     WKEntityTransform entityTransform = [m_modelRKEntity transform];
     m_transformSRT = RESRT {
         .scale = entityTransform.scale / m_originalEntityScale,
         .rotation = entityTransform.rotation,
         .translation = entityTransform.translation
     };
+#endif
 
     notifyModelPlayerOfEntityTransformChange();
 }
@@ -1244,6 +1251,62 @@ void ModelProcessModelPlayerProxy::applyStageModeOperationToDriver()
 }
 #endif // HAVE(CORE_RE)
 
+#if HAVE(CORE_RE)
+void ModelProcessModelPlayerProxy::ensurePortalEntityHierarchy()
+{
+    if (m_hostingEntity && m_containerEntity)
+        return;
+
+    if (!m_hostingEntity) {
+        m_hostingEntity = adoptRE(REEntityCreate());
+        REEntitySetName(m_hostingEntity.get(), "WebKit:EntityWithRootComponent");
+
+        REPtr<REComponentRef> layerComponent = adoptRE(RECALayerServiceCreateRootComponent(webDefaultLayerService(), CALayerGetContext(m_layer.get()), m_hostingEntity.get(), nil));
+        RESceneAddEntity(m_scene.get(), m_hostingEntity.get());
+
+        CALayer *contextEntityLayer = RECALayerClientComponentGetCALayer(layerComponent.get());
+        [contextEntityLayer setSeparatedState:kCALayerSeparatedStateTracked];
+
+        RECALayerClientComponentSetShouldSyncToRemotes(layerComponent.get(), true);
+    }
+
+    auto clientComponent = RECALayerGetCALayerClientComponent(m_layer.get());
+    auto clientComponentEntity = REComponentGetEntity(clientComponent);
+    REEntitySetName(clientComponentEntity, "WebKit:ClientComponentEntity");
+
+    if (!m_containerEntity) {
+        m_containerEntity = adoptRE(REEntityCreate());
+        REEntitySetName(m_containerEntity.get(), "WebKit:PortalContainer");
+        REEntitySetParent(m_containerEntity.get(), clientComponentEntity);
+
+        m_containerEntityWrapper = adoptNS([allocWKRKEntityInstance() initWithCoreEntity:m_containerEntity.get()]);
+        [m_containerEntityWrapper setTransform:WKEntityTransform({
+            .scale = simd_make_float3(1, 1, 1),
+            .rotation = simd_quaternion(0, simd_make_float3(1, 0, 0)),
+            .translation = simd_make_float3(0, 0, 0)
+        })];
+
+        REEntitySubtreeAddNetworkComponentRecursive(m_containerEntity.get());
+        RENetworkMarkEntityMetadataDirty(m_containerEntity.get());
+
+        // StageMode operates on the whole portal.
+        m_stageModeInteractionDriver = adoptNS([allocWKStageModeInteractionDriverInstance()
+            initWithModel:m_containerEntityWrapper.get()
+            container:clientComponentEntity
+            delegate:m_objCAdapter.get()]);
+
+        REEntitySubtreeAddNetworkComponentRecursive([m_stageModeInteractionDriver interactionContainerRef]);
+        RENetworkMarkEntityMetadataDirty([m_stageModeInteractionDriver interactionContainerRef]);
+    }
+}
+
+void ModelProcessModelPlayerProxy::parentToContainer(WKRKEntity *childEntity)
+{
+    [childEntity setParentCoreEntity:m_containerEntity.get() preservingWorldTransform:NO];
+    [childEntity setReferenceEntity:m_containerEntityWrapper.get()];
+}
+#endif // HAVE(CORE_RE)
+
 void ModelProcessModelPlayerProxy::applyDefaultIBL()
 {
     [m_modelRKEntity applyDefaultIBL];
@@ -1258,9 +1321,15 @@ void ModelProcessModelPlayerProxy::teardownEntity()
         m_loader = nullptr;
     }
 #if HAVE(CORE_RE)
+    if (m_containerEntity.get())
+        REEntityRemoveFromSceneOrParent(m_containerEntity.get());
+    m_containerEntity = nullptr;
+    m_containerEntityWrapper = nil;
+
     if (m_hostingEntity.get())
         REEntityRemoveFromSceneOrParent(m_hostingEntity.get());
     m_hostingEntity = nullptr;
+
     [m_stageModeInteractionDriver removeInteractionContainerFromSceneOrParent];
     m_stageModeInteractionDriver = nil;
 #endif

--- a/Source/WebKit/WebKitSwift/RealityKit/WKRKEntity.h
+++ b/Source/WebKit/WebKitSwift/RealityKit/WKRKEntity.h
@@ -63,6 +63,7 @@ NS_SWIFT_UI_ACTOR
 @property (nonatomic, readonly) float boundingRadius;
 @property (nonatomic, readonly) simd_float3 interactionPivotPoint;
 @property (nonatomic) WKEntityTransform transform;
+@property (nonatomic, weak) WKRKEntity * _Nullable referenceEntity;
 @property (nonatomic) float opacity;
 @property (nonatomic, readonly) NSTimeInterval duration;
 @property (nonatomic) BOOL loop;

--- a/Source/WebKit/WebKitSwift/RealityKit/WKRKEntity.swift
+++ b/Source/WebKit/WebKitSwift/RealityKit/WKRKEntity.swift
@@ -167,18 +167,17 @@ extension WKRKEntity {
         entity.visualBounds(relativeTo: entity)
     }
 
+    @objc(referenceEntity)
+    weak var reference: WKRKEntity?
+
     var transform: WKEntityTransform {
         get {
-            let transform = Transform(matrix: entity.transformMatrix(relativeTo: nil))
+            let transform = Transform(matrix: entity.transformMatrix(relativeTo: reference?.entity))
             return WKEntityTransform(scale: transform.scale, rotation: transform.rotation, translation: transform.translation)
         }
         set {
-            var adjustedTransform = Transform(scale: newValue.scale, rotation: newValue.rotation, translation: newValue.translation)
-            if let container = entity.parent {
-                adjustedTransform = container.convert(transform: adjustedTransform, from: nil)
-            }
-
-            entity.transform = adjustedTransform
+            let newTransform = Transform(scale: newValue.scale, rotation: newValue.rotation, translation: newValue.translation)
+            entity.setTransformMatrix(newTransform.matrix, relativeTo: reference?.entity)
         }
     }
 


### PR DESCRIPTION
#### ed12ae04be1437210d092774dd2033e051e15be3
<pre>
[ModelProcess] Prepare the RealityKit hierarchy to support multiple entities with global transforms
<a href="https://bugs.webkit.org/show_bug.cgi?id=320458">https://bugs.webkit.org/show_bug.cgi?id=320458</a>
&lt;<a href="https://rdar.apple.com/182292365">rdar://182292365</a>&gt;

Reviewed by Mike Wyrzykowski.

Introduce a top-level wrapper that owns the global transforms: auto-fit,
stagemode, and in the future `portal-transform` / `portal-action`.

* Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.h:
* Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm:
(WebKit::ModelProcessModelPlayerProxy::updateTransform):
(WebKit::ModelProcessModelPlayerProxy::didFinishLoading):
(WebKit::ModelProcessModelPlayerProxy::updateForCurrentStageMode):
(WebKit::ModelProcessModelPlayerProxy::updateTransformSRT):
(WebKit::ModelProcessModelPlayerProxy::ensurePortalEntityHierarchy):
(WebKit::ModelProcessModelPlayerProxy::parentToContainer):
(WebKit::ModelProcessModelPlayerProxy::teardownEntity):
Add a wrapper entity that will contain multiple models.

* Source/WebKit/WebKitSwift/RealityKit/WKRKEntity.h:
* Source/WebKit/WebKitSwift/RealityKit/WKRKEntity.swift:
(WKRKEntity.reference):
(WKRKEntity.transform):
Clean-up a previous work-around making all transforms apply in world
space now that we have some hierarchy.

Canonical link: <a href="https://commits.webkit.org/318249@main">https://commits.webkit.org/318249@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/406b4099dc85a5f9d206023413040e85cc8f9826

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177752 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51690 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45484 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187361 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140999 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52982 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51399 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138550 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140999 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180708 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42073 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/159294 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119013 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40735 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/39098 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151141 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38790 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35823 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/43475 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/43333 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189789 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51357 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147667 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39665 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52039 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/35418 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147453 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42166 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124254 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118711 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50547 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13767 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49943 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50183 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50005 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->