### PR TITLE
Wgsl misscompilation `error: no member named 'xyz' in 'PackedVec3<float>'` (320443)

### DIFF
--- a/Source/WebGPU/WGSL/GlobalVariableRewriter.cpp
+++ b/Source/WebGPU/WGSL/GlobalVariableRewriter.cpp
@@ -594,8 +594,14 @@ Packing RewriteGlobalVariables::getPacking(AST::IndexAccessExpression& expressio
         baseType = pointerType->element;
     if (std::holds_alternative<Types::Vector>(*baseType))
         return Packing::Unpacked;
-    if (std::holds_alternative<Types::Matrix>(*baseType))
+    if (auto* matrixType = std::get_if<Types::Matrix>(baseType)) {
+        // Indexing a packed matrix (rows == 3) yields a PackedVec3 column,
+        // which still needs to be unpacked before it can be swizzled or used
+        // as a vec3. See Type::packing().
+        if (matrixType->rows == 3)
+            return Packing::PackedVec3;
         return Packing::Unpacked;
+    }
     ASSERT(std::holds_alternative<Types::Array>(*baseType));
     auto& arrayType = std::get<Types::Array>(*baseType);
     return packingForType(arrayType.element);

--- a/Tools/TestWebKitAPI/Tests/WGSL/MetalCompilationTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WGSL/MetalCompilationTests.mm
@@ -676,6 +676,17 @@ TEST_F(WGSLMetalCompilationTests, Packing)
         check("global\\d+\\[0\\] = __pack\\(local\\d+\\[0\\]\\);"_s),
         check("global\\d+\\[__wgslMin\\(unsigned\\(global\\d+\\), \\(2u - 1u\\)\\)\\] = __pack\\(local\\d+\\[__wgslMin\\(unsigned\\(global\\d+\\), \\(2u - 1u\\)\\)\\]\\);"_s));
 
+    // Indexing a packed matrix (rows == 3) yields a PackedVec3 column, which
+    // must be unpacked before it can be swizzled or used as a vec3.
+    testCompilation(prologue(makeString(
+        "@group(0) @binding(9) var<storage, read_write> m43: mat4x3<f32>;"_s,
+        fn(
+            "t.v3f = m43[1].xyz;"
+            "t.v3f = m43[1];"
+            "t.v3f.x = m43[1].x;"_s))),
+        check("__unpack\\(global\\d+\\.columns\\[__wgslMin\\(unsigned\\(1\\), \\(4u - 1u\\)\\)\\]\\)\\.xyz"_s),
+        check("__unpack\\(global\\d+\\.columns\\[__wgslMin\\(unsigned\\(1\\), \\(4u - 1u\\)\\)\\]\\)"_s));
+
     // Test binary operations
     testCompilation(prologue(fn("t.v2f.x = 2 * t1.v2f.x;"_s)), check("global\\d+\\.field\\d\\.x = \\(2. \\* global\\d+\\.field\\d\\.x\\);"_s));
     testCompilation(prologue(fn("t.v3f.x = 2 * t1.v3f.x;"_s)), check("global\\d+\\.field\\d\\.x = \\(2. \\* global\\d+\\.field\\d\\.x\\);"_s));


### PR DESCRIPTION
#### 4bd6398850757a1e38bc2ecb584bf15d88b38c41
<pre>
Wgsl misscompilation `error: no member named &apos;xyz&apos; in &apos;PackedVec3&lt;float&gt;&apos;` (320443)
<a href="https://bugs.webkit.org/show_bug.cgi?id=320443">https://bugs.webkit.org/show_bug.cgi?id=320443</a>
<a href="https://rdar.apple.com/183426431">rdar://183426431</a>

Reviewed by Tadeu Zagallo.

Indexing a packed matrix yields a packed vector, but we were
assuming it would yield an unpacked vector resulting in compilation
errors.

Test: Tools/TestWebKitAPI/Tests/WGSL/MetalCompilationTests.mm

* Source/WebGPU/WGSL/GlobalVariableRewriter.cpp:
(WGSL::RewriteGlobalVariables::getPacking):
* Tools/TestWebKitAPI/Tests/WGSL/MetalCompilationTests.mm:
(TestWGSLAPI::TEST_F(WGSLMetalCompilationTests, Packing)):

Canonical link: <a href="https://commits.webkit.org/318098@main">https://commits.webkit.org/318098@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ef7631822c36834dcee773e3c89ce71332d3c4b4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177239 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51177 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44971 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186842 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140475 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2dbd8821-6ee0-4bb1-b84f-05b122066c09) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179102 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52469 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50863 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138111 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140475 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/deb2daca-fb36-4685-9848-75e2d02e8f7c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180195 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41613 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158915 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118576 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40273 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38650 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150682 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38372 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35310 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42962 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42864 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189269 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50843 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147200 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39567 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51526 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/35039 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146992 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41717 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123741 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118067 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50031 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13350 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49430 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49669 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49491 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->