### PR TITLE
Implement moving steps for source and img elements

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6142,7 +6142,6 @@ imported/w3c/web-platform-tests/trusted-types/should-trusted-type-policy-creatio
 webkit.org/b/281223 imported/w3c/web-platform-tests/dom/nodes/moveBefore/focus-preserve-render.html [ Skip ]
 webkit.org/b/281223 imported/w3c/web-platform-tests/dom/nodes/moveBefore/moveBefore-option-recalc-style.html [ Skip ]
 webkit.org/b/281223 imported/w3c/web-platform-tests/dom/nodes/moveBefore/select-option-optgroup.html [ Skip ]
-webkit.org/b/281223 imported/w3c/web-platform-tests/dom/nodes/moveBefore/relevant-mutations.html [ Skip ]
 
 # Flaky crash.
 webkit.org/b/315031 imported/w3c/web-platform-tests/dom/nodes/moveBefore/throws-exception.html [ Skip ]

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/relevant-mutations-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/relevant-mutations-expected.txt
@@ -1,7 +1,4 @@
 
-
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT Moving <source> out of <picture> triggers a relevant mutation on sibling <img> Test timed out
-NOTRUN Moving <img> into a <picture> triggers a relevant mutation on the <img>, loading <source>
+PASS Moving <source> out of <picture> triggers a relevant mutation on sibling <img>
+PASS Moving <img> into a <picture> triggers a relevant mutation on the <img>, loading <source>
 

--- a/Source/WebCore/html/HTMLImageElement.cpp
+++ b/Source/WebCore/html/HTMLImageElement.cpp
@@ -631,6 +631,22 @@ void HTMLImageElement::removingSteps(RemovalType removalType, ContainerNode& old
     FormAssociatedElement::elementRemovedFromAncestor(*this, removalType);
 }
 
+void HTMLImageElement::movingSteps(bool isSubtreeRoot, ContainerNode& oldParent)
+{
+    HTMLElement::movingSteps(isSubtreeRoot, oldParent);
+
+    if (!isSubtreeRoot)
+        return;
+
+    if (RefPtr parentPicture = dynamicDowncast<HTMLPictureElement>(parentElement())) {
+        setPictureElement(parentPicture.get());
+        selectImageSource(RelevantMutation::Yes);
+    } else if (RefPtr oldParentPicture = dynamicDowncast<HTMLPictureElement>(oldParent)) {
+        setPictureElement(nullptr);
+        selectImageSource(RelevantMutation::Yes);
+    }
+}
+
 HTMLPictureElement* HTMLImageElement::pictureElement() const
 {
     return m_pictureElement.get();

--- a/Source/WebCore/html/HTMLImageElement.h
+++ b/Source/WebCore/html/HTMLImageElement.h
@@ -218,6 +218,7 @@ private:
 
     NeedsPostConnectionSteps insertionSteps(InsertionType, ContainerNode&) override;
     void removingSteps(RemovalType, ContainerNode&) override;
+    void movingSteps(bool isSubtreeRoot, ContainerNode&) override;
 
     bool NODELETE isFormListedElement() const final { return false; }
     FormAssociatedElement* NODELETE asFormAssociatedElement() final { return this; }

--- a/Source/WebCore/html/HTMLSourceElement.cpp
+++ b/Source/WebCore/html/HTMLSourceElement.cpp
@@ -124,6 +124,34 @@ void HTMLSourceElement::removingSteps(RemovalType removalType, ContainerNode& ol
     }
 }
 
+void HTMLSourceElement::movingSteps(bool isSubtreeRoot, ContainerNode& oldParent)
+{
+    HTMLElement::movingSteps(isSubtreeRoot, oldParent);
+
+    if (!isSubtreeRoot)
+        return;
+
+    RefPtr oldParentPicture = dynamicDowncast<HTMLPictureElement>(oldParent);
+    RefPtr parentPicture = dynamicDowncast<HTMLPictureElement>(parentElement());
+
+    m_shouldCallSourcesChanged = false;
+    if (parentPicture) {
+        m_shouldCallSourcesChanged = true;
+        for (const Node* node = previousSibling(); node; node = node->previousSibling()) {
+            if (is<HTMLImageElement>(*node)) {
+                m_shouldCallSourcesChanged = false;
+                break;
+            }
+        }
+    }
+
+    if (oldParentPicture)
+        oldParentPicture->sourcesChanged();
+
+    if (parentPicture && parentPicture != oldParentPicture && m_shouldCallSourcesChanged)
+        parentPicture->sourcesChanged();
+}
+
 void HTMLSourceElement::didMoveToNewDocument(Document& oldDocument, Document& newDocument)
 {
     HTMLElement::didMoveToNewDocument(oldDocument, newDocument);

--- a/Source/WebCore/html/HTMLSourceElement.h
+++ b/Source/WebCore/html/HTMLSourceElement.h
@@ -60,6 +60,7 @@ private:
     
     NeedsPostConnectionSteps insertionSteps(InsertionType, ContainerNode&) final;
     void removingSteps(RemovalType, ContainerNode&) final;
+    void movingSteps(bool isSubtreeRoot, ContainerNode&) final;
     void didMoveToNewDocument(Document& oldDocument, Document& newDocument) final;
 
     bool NODELETE isURLAttribute(const Attribute&) const final;


### PR DESCRIPTION
#### 84e2011fd5d2387195b07cee41dac1022e5873f5
<pre>
Implement moving steps for source and img elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=320462">https://bugs.webkit.org/show_bug.cgi?id=320462</a>

Reviewed by Ryosuke Niwa.

Implements the moving steps for source and img elements to handle when they&apos;re moved inside of or out of a picture element.

This now passes the relevant-mutations.html WPT.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/relevant-mutations-expected.txt:
* Source/WebCore/html/HTMLImageElement.cpp:
(WebCore::HTMLImageElement::movingSteps):
* Source/WebCore/html/HTMLImageElement.h:
* Source/WebCore/html/HTMLSourceElement.cpp:
(WebCore::HTMLSourceElement::movingSteps):
* Source/WebCore/html/HTMLSourceElement.h:

Canonical link: <a href="https://commits.webkit.org/318725@main">https://commits.webkit.org/318725@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0256192c68f7bf7530c9db3412613050133c3b81

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179147 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53086 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46881 "Build is in progress. Recent messages:OS: Tahoe (26.5.1), Xcode: 26.5; Checked out pull request; Compiled WebKit (warnings); Compiled WebKit (warnings)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188978 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/143456 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181010 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54379 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52796 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139702 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/143456 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182104 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43300 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160457 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120149 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/41971 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40309 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152371 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39961 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/284 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45692 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44555 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191196 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52756 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/159974 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148939 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39961 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53436 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36587 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148685 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43367 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125707 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/120548 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51954 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14940 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51339 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51580 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51400 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->