### PR TITLE
[WKCI] filter-test-logs prints nothing when the command dies before producing any recognizable output

### DIFF
--- a/Tools/CISupport/Shared/steps.py
+++ b/Tools/CISupport/Shared/steps.py
@@ -56,6 +56,9 @@ class ShellMixin(object):
         return self.getProperty('platform', '*') in self.WINDOWS_SHELL_PLATFORMS
 
     def shell_command(self, command, pipefail=True):
+        # Give filter-test-logs time to report its buffered output before forcing termination.
+        if 'filter-test-logs' in command and self.sigtermTime is None:
+            self.sigtermTime = 10
         if pipefail:
             # -o pipefail is new in POSIX 2024, and on systems using `dash` to provide
             # `sh` (e.g., Debian and Ubuntu) this is unsupported, as it is currently

--- a/Tools/CISupport/Shared/steps_unittest.py
+++ b/Tools/CISupport/Shared/steps_unittest.py
@@ -51,6 +51,26 @@ def expectedFailure(f):
     return f
 
 
+class TestShellMixin(unittest.TestCase):
+    def setUp(self):
+        self.mixin = ShellMixin()
+        self.mixin.sigtermTime = None
+        self.mixin.getProperty = lambda name, default=None: default
+
+    def test_filter_test_logs_sets_sigterm_time(self):
+        self.mixin.shell_command('run-tests 2>&1 | Tools/Scripts/filter-test-logs layout')
+        self.assertEqual(self.mixin.sigtermTime, 10)
+
+    def test_filter_test_logs_preserves_sigterm_time(self):
+        self.mixin.sigtermTime = 20
+        self.mixin.shell_command('run-tests 2>&1 | Tools/Scripts/filter-test-logs layout')
+        self.assertEqual(self.mixin.sigtermTime, 20)
+
+    def test_other_command_does_not_set_sigterm_time(self):
+        self.mixin.shell_command('run-tests')
+        self.assertIsNone(self.mixin.sigtermTime)
+
+
 class ExpectMasterShellCommand(object):
     def __init__(self, command, workdir=None, env=None, usePTY=0):
         self.args = command

--- a/Tools/Scripts/filter-test-logs
+++ b/Tools/Scripts/filter-test-logs
@@ -24,9 +24,12 @@
 
 import os
 import argparse
+import atexit
+import collections
 import datetime
 import sys
 import re
+import signal
 import time
 
 # This prints the progress every interval_seconds to avoid that the step gets killed
@@ -104,20 +107,49 @@ def filter_logs(filter_type, log_file_name):
     always_print = config.get('always_print', lambda line: False)
     log_file = os.path.abspath(f'{log_file_name}')
     keep_alive_stdout = KeepAliveStdoutProgress()
+    # keep the last 50 lines printed to report those if something unexpected happens.
+    tail = collections.deque(maxlen=50)
+    printed_anything = False
+    reached_end_of_stdin = False
+    ready_to_read = False
+
+    @atexit.register
+    def maybe_report_tail_log_or_output_issues():
+        if not ready_to_read:
+            print('filter-test-logs: exited before it could start reading the piped command output.')
+            return
+        if not reached_end_of_stdin:
+            print('\nfilter-test-logs: killed or crashed before the piped command finished printing.')
+        if printed_anything:
+            return
+        if not tail:
+            print('filter-test-logs: the piped command produced no output at all.')
+            return
+        print(f'filter-test-logs: no {filter_type} results found in the piped command output, so the command '
+              f'likely failed before finishing. Last {len(tail)} line{"s" if len(tail) > 1 else ""} received:')
+        for line in tail:
+            print(line, end='')
+    # Ensure running the atexit handler also on SIGTERM
+    signal.signal(signal.SIGTERM, lambda signum, frame: sys.exit(128 + signum))
 
     with open(log_file, 'w', buffering=1, errors='backslashreplace') as f:
+        ready_to_read = True
         print_all_lines = False
         for line in sys.stdin:
+            tail.append(line)
             f.write(line)
             if print_all_lines:
                 print(line, end='')
             elif start_printing(line):
                 print_all_lines = True
+                printed_anything = True
                 print(line, end='')
             elif always_print(line):
+                printed_anything = True
                 print(line, end='')
             else:
                 keep_alive_stdout.maybe_update_progress()
+        reached_end_of_stdin = True
 
 
 def main():


### PR DESCRIPTION
#### fc59a1a2548f9883c098cb03b2c8209cf0c60879
<pre>
[WKCI] filter-test-logs prints nothing when the command dies before producing any recognizable output
<a href="https://bugs.webkit.org/show_bug.cgi?id=320451">https://bugs.webkit.org/show_bug.cgi?id=320451</a>

Reviewed by NOBODY (OOPS!).

Remember up to the last 50 lines printed by the piped command, and print those
at exit if the filter didn&apos;t recognized any line (therefore it was silent).
Print also information about any issue found when receiving the input from the
piped command.

This should help to better identify issues on the CI when a test runner crashes
or gives any error that is unexpected. Previously that info would be only sent
to the logs.txt file that sometimes fails to upload when the step fails, or if
the buildbot step is not configured to upload the logs.txt file, or for some
reason there is any issue creating the log file.

And for the steps on buildbot that run with this filter script change the default
stopping method, so buildbot first sends a SIGTERM 10 seconds before the SIGKILL,
giving the script enough time to finish and report.

* Tools/CISupport/Shared/steps.py:
(ShellMixin.shell_command):
* Tools/CISupport/Shared/steps_unittest.py:
(TestShellMixin):
(TestShellMixin.setUp):
(TestShellMixin.test_filter_test_logs_sets_sigterm_time):
(TestShellMixin.test_filter_test_logs_preserves_sigterm_time):
(TestShellMixin.test_other_command_does_not_set_sigterm_time):
* Tools/Scripts/filter-test-logs:
(filter_logs):
(filter_logs.maybe_report_tail_log_or_output_issues):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fc59a1a2548f9883c098cb03b2c8209cf0c60879

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177283 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51221 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45015 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186886 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/140528 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179146 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52513 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50909 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138145 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96302 "2 flakes 3 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180239 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41654 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158906 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118610 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40315 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38690 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150723 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38404 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35354 "Built successfully") | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42904 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189315 "Built successfully") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/176686 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50887 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147235 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51570 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35030 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147027 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41752 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118119 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50078 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13382 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49474 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49714 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49536 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->