### PR TITLE
[css-link-params] Support setting link parameters via URL fragment identifiers

### DIFF
--- a/LayoutTests/svg/css-link-params/fragment-directive-multiple-params-expected.html
+++ b/LayoutTests/svg/css-link-params/fragment-directive-multiple-params-expected.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<img src="resources/circle-green-blue-stroke.svg">

--- a/LayoutTests/svg/css-link-params/fragment-directive-multiple-params.html
+++ b/LayoutTests/svg/css-link-params/fragment-directive-multiple-params.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ CSSLinkParametersEnabled=true ] -->
+<meta charset="utf-8">
+<title>CSS Link Parameters: multiple parameters are separated by an ampersand</title>
+<link rel="help" href="https://drafts.csswg.org/css-link-params/#url-frag">
+<link rel="match" href="fragment-directive-multiple-params-expected.html">
+<img src="resources/circle-with-parameters.svg#:~:param(--color,green)&param(--stroke,blue)">

--- a/LayoutTests/svg/css-link-params/fragment-directive-param-expected.html
+++ b/LayoutTests/svg/css-link-params/fragment-directive-param-expected.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<img src="resources/circle-green.svg">

--- a/LayoutTests/svg/css-link-params/fragment-directive-param.html
+++ b/LayoutTests/svg/css-link-params/fragment-directive-param.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ CSSLinkParametersEnabled=true ] -->
+<meta charset="utf-8">
+<title>CSS Link Parameters: a parameter in the fragment directive is read by env()</title>
+<link rel="help" href="https://drafts.csswg.org/css-link-params/#url-frag">
+<link rel="match" href="fragment-directive-param-expected.html">
+<img src="resources/circle-with-parameters.svg#:~:param(--color,green)">

--- a/LayoutTests/svg/css-link-params/no-params-expected.html
+++ b/LayoutTests/svg/css-link-params/no-params-expected.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<img src="resources/circle-black.svg">

--- a/LayoutTests/svg/css-link-params/no-params.html
+++ b/LayoutTests/svg/css-link-params/no-params.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ CSSLinkParametersEnabled=true ] -->
+<meta charset="utf-8">
+<title>CSS Link Parameters: env() falls back when no parameter is set</title>
+<link rel="help" href="https://drafts.csswg.org/css-link-params/#url-frag">
+<link rel="match" href="no-params-expected.html">
+<img src="resources/circle-with-parameters.svg">

--- a/LayoutTests/svg/css-link-params/resources/circle-black.svg
+++ b/LayoutTests/svg/css-link-params/resources/circle-black.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <circle cx="50" cy="50" r="48" fill="black" stroke-width="4"/>
+</svg>

--- a/LayoutTests/svg/css-link-params/resources/circle-green-blue-stroke.svg
+++ b/LayoutTests/svg/css-link-params/resources/circle-green-blue-stroke.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <circle cx="50" cy="50" r="48" fill="green" stroke="blue" stroke-width="4"/>
+</svg>

--- a/LayoutTests/svg/css-link-params/resources/circle-green.svg
+++ b/LayoutTests/svg/css-link-params/resources/circle-green.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <circle cx="50" cy="50" r="48" fill="green" stroke-width="4"/>
+</svg>

--- a/LayoutTests/svg/css-link-params/resources/circle-with-parameters.svg
+++ b/LayoutTests/svg/css-link-params/resources/circle-with-parameters.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <circle cx="50" cy="50" r="48" fill="env(--color, black)" stroke="env(--stroke)" stroke-width="4"/>
+</svg>

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -1385,6 +1385,20 @@ CSSLineFitEdgeEnabled:
     WebCore:
       default: false
 
+CSSLinkParametersEnabled:
+  type: bool
+  status: unstable
+  category: css
+  humanReadableName: "CSS Linked Parameters"
+  humanReadableDescription: "Enable passing CSS link parameters to linked resources"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 CSSMarkerContentEnabled:
   type: bool
   status: stable

--- a/Source/WebCore/SaferCPPExpectations/NoDeleteCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/NoDeleteCheckerExpectations
@@ -1,6 +1,6 @@
 css/CSSComputedStyleDeclaration.cpp
 css/CSSPropertyInitialValues.cpp
-css/DOMMatrixReadOnly.cpp
+[ iOS ] css/DOMMatrixReadOnly.cpp
 css/StyleSheetList.cpp
 css/parser/CSSPropertyParserConsumer+String.cpp
 css/values/color/CSSKeywordColor.cpp

--- a/Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
@@ -9,7 +9,7 @@ css/CSSStyleProperties.h
 css/CSSValueList.h
 css/SelectorChecker.h
 css/SelectorFilter.h
-css/ShorthandSerializer.cpp
+[ iOS ] css/ShorthandSerializer.cpp
 css/StyleProperties.h
 css/StyleRuleImport.h
 css/StyleSheetContents.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -953,6 +953,7 @@ css/CSSKeyframesRule.cpp
 css/CSSLayerBlockRule.cpp
 css/CSSLayerStatementRule.cpp
 css/CSSLightDarkImageValue.cpp
+css/CSSLinkParameters.cpp
 css/CSSMarkup.cpp
 css/CSSMaskBorderOutsetValue.cpp
 css/CSSMaskBorderRepeatValue.cpp

--- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
+++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
@@ -17106,6 +17106,8 @@
 		9DAC7C561AF2CB6400437C44 /* StyleContentAlignmentData.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StyleContentAlignmentData.h; sourceTree = "<group>"; };
 		9E114EAF2FF41ACE007BD399 /* IsolatedSVGDocumentContext.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = IsolatedSVGDocumentContext.h; sourceTree = "<group>"; };
 		9E114EB02FF41AF3007BD399 /* IsolatedSVGDocumentContext.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = IsolatedSVGDocumentContext.cpp; sourceTree = "<group>"; };
+		9E15480D3018F28A001E28C6 /* CSSLinkParameters.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CSSLinkParameters.h; sourceTree = "<group>"; };
+		9E15480E3018F28A001E28C6 /* CSSLinkParameters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = CSSLinkParameters.cpp; sourceTree = "<group>"; };
 		9E3E301A4FF9CC03FB16C8B2 /* UnifiedSource18-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource18-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
 		9E47A8222F01986A00D57716 /* FEMorphologyCoreImageApplier.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FEMorphologyCoreImageApplier.h; sourceTree = "<group>"; };
 		9E47A8242F0198AA00D57716 /* FEMorphologyCoreImageApplier.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = FEMorphologyCoreImageApplier.mm; sourceTree = "<group>"; };
@@ -41938,6 +41940,8 @@
 				E4FFCEBA2760AC0100A68B03 /* CSSLayerStatementRule.idl */,
 				4958FE602FCABB9F008AF649 /* CSSLightDarkImageValue.cpp */,
 				4958FE5F2FCABB9F008AF649 /* CSSLightDarkImageValue.h */,
+				9E15480E3018F28A001E28C6 /* CSSLinkParameters.cpp */,
+				9E15480D3018F28A001E28C6 /* CSSLinkParameters.h */,
 				946D37471D6D060C0077084F /* CSSMarkup.cpp */,
 				946D37481D6D060C0077084F /* CSSMarkup.h */,
 				BC0D73392FB657F600952D29 /* CSSMaskBorderOutsetValue.cpp */,

--- a/Source/WebCore/css/CSSLinkParameters.cpp
+++ b/Source/WebCore/css/CSSLinkParameters.cpp
@@ -1,0 +1,142 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "CSSLinkParameters.h"
+
+#include "CSSParserToken.h"
+#include "CSSParserTokenRange.h"
+#include "CSSPropertyParser.h"
+#include "CSSTokenizer.h"
+#include "CSSVariableData.h"
+#include <pal/text/TextEncoding.h>
+#include <wtf/URL.h>
+
+namespace WebCore {
+
+// FIXME: `param` is not yet a CSS value keyword, so it cannot be matched with
+// CSSParserToken::functionId(). Compare the function name directly until the
+// url() modifier form needs the keyword too.
+static bool isParamFunction(const CSSParserToken& token)
+{
+    return token.type() == FunctionToken && equalLettersIgnoringASCIICase(token.value(), "param"_s);
+}
+
+// <param()> = param( <dashed-ident> , <declaration-value>? )
+// https://drafts.csswg.org/css-link-params/#funcdef-param
+static std::optional<CSSLinkParameter> consumeParamFunction(CSSParserTokenRange& range)
+{
+    auto block = range.consumeBlock();
+    block.consumeWhitespace();
+
+    auto& nameToken = block.consumeIncludingWhitespace();
+    if (nameToken.type() != IdentToken || !isCustomPropertyName(nameToken.value()))
+        return { };
+
+    auto name = nameToken.value().toAtomString();
+
+    // The value is optional; an omitted value is an empty value.
+    if (block.atEnd())
+        return CSSLinkParameter { WTF::move(name), CSSVariableData::create(block) };
+
+    if (block.consume().type() != CommaToken)
+        return { };
+    block.consumeWhitespace();
+
+    return CSSLinkParameter { WTF::move(name), CSSVariableData::create(block) };
+}
+
+// Link parameters are carried in the fragment directive, so that they are delimited
+// from any other fragment identifier the resource is also addressed by.
+// https://wicg.github.io/scroll-to-text-fragment/#fragmentdirective
+static String linkParameterDirective(const URL& url)
+{
+    if (!url.hasFragmentIdentifier())
+        return { };
+
+    auto urlWithoutDirective = url;
+    return urlWithoutDirective.consumeFragmentDirective();
+}
+
+CSSLinkParameterList parseLinkParametersFromFragment(const URL& url)
+{
+    auto directive = linkParameterDirective(url);
+    if (directive.isEmpty())
+        return { };
+
+    // The directive arrives percent-encoded; `param(--color, green)` contains a
+    // space that must be decoded before the value can be tokenized.
+    auto decoded = PAL::decodeURLEscapeSequences(directive);
+
+    auto tokenizer = CSSTokenizer::tryCreate(decoded);
+    if (!tokenizer)
+        return { };
+
+    auto range = tokenizer->tokenRange();
+    range.consumeWhitespace();
+
+    // Multiple parameters are joined with "&".
+    CSSLinkParameterList parameters;
+    while (!range.atEnd()) {
+        if (!isParamFunction(range.peek()))
+            return { };
+
+        auto parameter = consumeParamFunction(range);
+        if (!parameter)
+            return { };
+
+        // A later duplicate wins over an earlier one.
+        parameters.removeAllMatching([&](auto& existing) {
+            return existing.name == parameter->name;
+        });
+        parameters.append(WTF::move(*parameter));
+
+        range.consumeWhitespace();
+        if (range.atEnd())
+            break;
+
+        auto& separator = range.consume();
+        if (separator.type() != DelimiterToken || separator.delimiter() != '&')
+            return { };
+        range.consumeWhitespace();
+    }
+
+    return parameters;
+}
+
+bool linkParameterListsAreEqual(const CSSLinkParameterList& a, const CSSLinkParameterList& b)
+{
+    if (a.size() != b.size())
+        return false;
+
+    for (size_t i = 0; i < a.size(); ++i) {
+        if (a[i].name != b[i].name || a[i].value.get() != b[i].value.get())
+            return false;
+    }
+
+    return true;
+}
+
+} // namespace WebCore

--- a/Source/WebCore/css/CSSLinkParameters.h
+++ b/Source/WebCore/css/CSSLinkParameters.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/Ref.h>
+#include <wtf/Vector.h>
+#include <wtf/text/AtomString.h>
+
+namespace WTF {
+class URL;
+}
+
+namespace WebCore {
+
+class CSSVariableData;
+
+// https://drafts.csswg.org/css-link-params/#link-parameter
+// A link parameter pairs a <dashed-ident> name with a <declaration-value>.
+struct CSSLinkParameter {
+    AtomString name;
+    Ref<CSSVariableData> value;
+};
+
+using CSSLinkParameterList = Vector<CSSLinkParameter>;
+
+// Parses link parameters out of a URL's fragment directive, e.g.
+// "image.svg#:~:param(--color,green)&param(--bg,white)".
+// https://drafts.csswg.org/css-link-params/#url-frag
+CSSLinkParameterList parseLinkParametersFromFragment(const WTF::URL&);
+
+bool linkParameterListsAreEqual(const CSSLinkParameterList&, const CSSLinkParameterList&);
+
+} // namespace WebCore

--- a/Source/WebCore/dom/ConstantPropertyMap.cpp
+++ b/Source/WebCore/dom/ConstantPropertyMap.cpp
@@ -28,6 +28,7 @@
 #include "ConstantPropertyMap.h"
 
 #include "CSSCustomPropertyValue.h"
+#include "CSSLinkParameters.h"
 #include "CSSParserTokenRange.h"
 #include "CSSVariableData.h"
 #include "DocumentPage.h"
@@ -166,6 +167,25 @@ void ConstantPropertyMap::didChangeFullscreenInsets()
 void ConstantPropertyMap::setFullscreenAutoHideDuration(Seconds duration)
 {
     setValueForProperty(ConstantProperty::FullscreenAutoHideDuration, variableDataForPositiveDuration(duration));
+    protect(m_document)->invalidateMatchedPropertiesCacheAndForceStyleRecalc();
+}
+
+void ConstantPropertyMap::setLinkParameters(const CSSLinkParameterList& parameters)
+{
+    if (linkParameterListsAreEqual(parameters, m_linkParameters))
+        return;
+
+    if (!m_values)
+        buildValues();
+
+    for (auto& parameter : m_linkParameters)
+        m_values->remove(parameter.name);
+
+    for (auto& parameter : parameters)
+        m_values->set(parameter.name, Style::CustomProperty::createForVariableData(parameter.name, parameter.value.copyRef()));
+
+    m_linkParameters = parameters;
+
     protect(m_document)->invalidateMatchedPropertiesCacheAndForceStyleRecalc();
 }
 

--- a/Source/WebCore/dom/ConstantPropertyMap.h
+++ b/Source/WebCore/dom/ConstantPropertyMap.h
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include "CSSLinkParameters.h"
 #include <wtf/HashMap.h>
 #include <wtf/Ref.h>
 #include <wtf/Seconds.h>
@@ -68,6 +69,9 @@ public:
     void didChangeFullscreenInsets();
     void setFullscreenAutoHideDuration(Seconds);
 
+    // Replaces the document's link parameters, leaving user-agent constants intact.
+    void setLinkParameters(const CSSLinkParameterList&);
+
 private:
     void buildValues();
 
@@ -79,6 +83,8 @@ private:
 
 
     std::optional<Values> m_values;
+
+    CSSLinkParameterList m_linkParameters;
 
     WeakRef<Document, WeakPtrImplWithEventTargetData> m_document;
 };

--- a/Source/WebCore/svg/graphics/SVGImage.cpp
+++ b/Source/WebCore/svg/graphics/SVGImage.cpp
@@ -28,8 +28,10 @@
 #include "config.h"
 #include "SVGImage.h"
 
+#include "CSSLinkParameters.h"
 #include "Chrome.h"
 #include "CommonVM.h"
+#include "ConstantPropertyMap.h"
 #include "ContainerNodeInlines.h"
 #include "DOMParser.h"
 #include "DocumentInlines.h"
@@ -217,6 +219,25 @@ IntSize SVGImage::containerSize() const
         return IntSize(300, 150);
 
     return IntSize(currentSize);
+}
+
+void SVGImage::applyLinkParametersFromFragment(const URL& initialFragmentURL)
+{
+    if (!m_page)
+        return;
+
+    RefPtr localMainFrame = m_page->localMainFrame();
+    if (!localMainFrame)
+        return;
+
+    RefPtr document = localMainFrame->document();
+    if (!document)
+        return;
+
+    if (!document->settings().cssLinkParametersEnabled())
+        return;
+
+    document->constantProperties().setLinkParameters(parseLinkParametersFromFragment(initialFragmentURL));
 }
 
 ImageDrawResult SVGImage::drawForContainer(GraphicsContext& context, const FloatSize containerSize, float containerZoom, const URL& initialFragmentURL, const FloatRect& dstRect, const FloatRect& srcRect, ImagePaintingOptions options)
@@ -554,6 +575,7 @@ EncodedDataStatus SVGImage::dataChanged(bool allDataReceived)
                 m_page->settings().setLayerBasedSVGEngineEnabled(parentSettings->layerBasedSVGEngineEnabled());
                 m_page->settings().fontGenericFamilies() = parentSettings->fontGenericFamilies();
                 m_page->settings().setCSSDPropertyEnabled(parentSettings->cssDPropertyEnabled());
+                m_page->settings().setCSSLinkParametersEnabled(parentSettings->cssLinkParametersEnabled());
                 m_page->settings().setDownloadableBinaryFontTrustedTypes(parentSettings->downloadableBinaryFontTrustedTypes());
             }
             protect(m_page)->setUseColorAppearance(observer->useSystemDarkAppearance(), false);

--- a/Source/WebCore/svg/graphics/SVGImage.h
+++ b/Source/WebCore/svg/graphics/SVGImage.h
@@ -110,6 +110,7 @@ private:
     void startAnimationTimerFired();
 
     WEBCORE_EXPORT explicit SVGImage(ImageObserver*);
+    void applyLinkParametersFromFragment(const URL&);
     ImageDrawResult draw(GraphicsContext&, const FloatRect& destination, const FloatRect& source, ImagePaintingOptions = { }) final;
     ImageDrawResult drawForContainer(GraphicsContext&, const FloatSize containerSize, float containerZoom, const URL& initialFragmentURL, const FloatRect& dstRect, const FloatRect& srcRect, ImagePaintingOptions = { });
     void drawPatternForContainer(GraphicsContext&, const FloatSize& containerSize, float containerZoom, const URL& initialFragmentURL, const FloatRect& srcRect, const AffineTransform&, const FloatPoint& phase, const FloatSize& spacing, const FloatRect&, ImagePaintingOptions = { });

--- a/Source/WebCore/svg/graphics/SVGImageForContainer.cpp
+++ b/Source/WebCore/svg/graphics/SVGImageForContainer.cpp
@@ -34,6 +34,8 @@ SVGImageForContainer::SVGImageForContainer(SVGImage* image, const FloatSize& con
     , m_containerZoom(containerZoom)
     , m_initialFragmentURL(initialFragmentURL)
 {
+    if (RefPtr protectedImage = m_image.get())
+        protectedImage->applyLinkParametersFromFragment(m_initialFragmentURL);
 }
 
 FloatSize SVGImageForContainer::size(ImageOrientation) const


### PR DESCRIPTION
#### 0983dea961bc
<pre>
[css-link-params] Support setting link parameters via URL fragment identifiers
<a href="https://bugs.webkit.org/show_bug.cgi?id=320466">https://bugs.webkit.org/show_bug.cgi?id=320466</a>
<a href="https://rdar.apple.com/183435739">rdar://183435739</a>

Reviewed by NOBODY (OOPS!).

An SVG referenced as an image cannot be styled by the referencing document, so a
templated icon needs a separate copy per color. CSS Linked Parameters lets the
reference pass named values into the resource, which reads them with env():

&lt;!-- icon.svg --&gt;
&lt;circle fill=&quot;env(--color, black)&quot;/&gt;

&lt;!-- referencing document; renders a green circle --&gt;
&lt;img src=&quot;icon.svg#:~:param(--color,green)&quot;&gt;

The working group resolved param() fragments with the :~: directive in
w3c/csswg-drafts#14235

This is the URL fragment form only. The link-parameters CSS property and the
param() url() modifier are not implemented yet.

* LayoutTests/svg/css-link-params/fragment-directive-multiple-params-expected.html: Added.
* LayoutTests/svg/css-link-params/fragment-directive-multiple-params.html: Added.
* LayoutTests/svg/css-link-params/fragment-directive-param-expected.html: Added.
* LayoutTests/svg/css-link-params/fragment-directive-param.html: Added.
* LayoutTests/svg/css-link-params/no-params-expected.html: Added.
* LayoutTests/svg/css-link-params/no-params.html: Added.
* LayoutTests/svg/css-link-params/resources/circle-black.svg: Added.
* LayoutTests/svg/css-link-params/resources/circle-green-blue-stroke.svg: Added.
* LayoutTests/svg/css-link-params/resources/circle-green.svg: Added.
* LayoutTests/svg/css-link-params/resources/circle-with-parameters.svg: Added.
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/css/CSSLinkParameters.cpp: Added.
(WebCore::isParamFunction):
(WebCore::consumeParamFunction):
(WebCore::linkParameterDirective):
(WebCore::parseLinkParametersFromFragment):
(WebCore::linkParameterListsAreEqual):
* Source/WebCore/css/CSSLinkParameters.h: Copied from Source/WebCore/dom/ConstantPropertyMap.h.
* Source/WebCore/dom/ConstantPropertyMap.cpp:
(WebCore::ConstantPropertyMap::setLinkParameters):
* Source/WebCore/dom/ConstantPropertyMap.h:
* Source/WebCore/svg/graphics/SVGImage.cpp:
(WebCore::SVGImage::applyLinkParametersFromFragment):
(WebCore::SVGImage::dataChanged):
* Source/WebCore/svg/graphics/SVGImage.h:
* Source/WebCore/svg/graphics/SVGImageForContainer.cpp:
(WebCore::SVGImageForContainer::SVGImageForContainer):
* Source/WebCore/SaferCPPExpectations/NoDeleteCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0983dea961bcc363eb70585f60f23096afb7c574

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178883 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52822 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46617 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188500 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/143192 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b419cae9-9da1-47f2-821d-b17eb877daaa) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/180746 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54115 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52532 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139500 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96716 "2 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/12791060-7a1e-4327-ba12-5ec778112c0c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181840 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43064 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160226 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119944 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8574d59b-f973-4b79-9068-343b34ebbbe3) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41735 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40080 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/1922 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/8711 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152134 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39729 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/19 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/40157 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45428 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44326 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190929 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52492 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/159743 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148691 "") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53172 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36353 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148444 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43137 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125442 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/120154 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51690 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14707 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51075 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51316 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51136 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->