### PR TITLE
MiniBrowser doesn't respect window.open window features (part 1: size and location)

### DIFF
--- a/Tools/MiniBrowser/mac/WK2BrowserWindowController.h
+++ b/Tools/MiniBrowser/mac/WK2BrowserWindowController.h
@@ -31,5 +31,6 @@
 @property (readonly) WKWebView *webView;
 
 - (instancetype)initWithConfiguration:(WKWebViewConfiguration *)configuration;
+- (instancetype)initWithConfiguration:(WKWebViewConfiguration *)configuration windowFeatures:(WKWindowFeatures *)windowFeatures;
 
 @end

--- a/Tools/MiniBrowser/mac/WK2BrowserWindowController.m
+++ b/Tools/MiniBrowser/mac/WK2BrowserWindowController.m
@@ -103,6 +103,7 @@ static const int testFooterBannerHeight = 58;
 
 @implementation WK2BrowserWindowController {
     WKWebViewConfiguration *_configuration;
+    WKWindowFeatures *_windowFeatures;
     WKWebView *_webView;
     BOOL _zoomTextOnly;
     BOOL _isPrivateBrowsingWindow;
@@ -198,10 +199,16 @@ static const int testFooterBannerHeight = 58;
 
 - (instancetype)initWithConfiguration:(WKWebViewConfiguration *)configuration
 {
+    return [self initWithConfiguration:configuration windowFeatures:nil];
+}
+
+- (instancetype)initWithConfiguration:(WKWebViewConfiguration *)configuration windowFeatures:(WKWindowFeatures *)windowFeatures
+{
     if (!(self = [super initWithWindowNibName:@"BrowserWindow"]))
         return nil;
 
     _configuration = [configuration copy];
+    _windowFeatures = windowFeatures;
     _isPrivateBrowsingWindow = !_configuration.websiteDataStore.isPersistent;
 
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(userAgentDidChange:) name:kUserAgentChangedNotificationName object:nil];
@@ -225,6 +232,47 @@ static const int testFooterBannerHeight = 58;
     [progressIndicator unbind:NSValueBinding];
 }
 
+static NSRect frameForWindowFeatures(WKWindowFeatures *features, NSWindow *window)
+{
+    NSRect contentRect = [window contentRectForFrameRect:window.frame];
+
+    // The web view insets its viewport underneath the titlebar and toolbar, so that inset has to be
+    // added back on to give the page the size it asked for.
+    CGFloat viewportInset = NSHeight(window.contentView.frame) - NSHeight(window.contentLayoutRect);
+
+    if (features.width.doubleValue > 0)
+        contentRect.size.width = features.width.doubleValue;
+    if (features.height.doubleValue > 0)
+        contentRect.size.height = features.height.doubleValue + viewportInset;
+
+    NSRect frameRect = [window frameRectForContentRect:contentRect];
+
+    if (features.x)
+        frameRect.origin.x = features.x.doubleValue;
+
+    if (features.y)
+        frameRect.origin.y = NSMaxY(NSScreen.screens.firstObject.frame) - features.y.doubleValue - NSHeight(frameRect);
+    else
+        frameRect.origin.y = NSMaxY(window.frame) - NSHeight(frameRect);
+
+    return [window constrainFrameRect:frameRect toScreen:nil];
+}
+
+- (void)applyWindowFeatures
+{
+    if (!_windowFeatures.x && !_windowFeatures.y && !_windowFeatures.width && !_windowFeatures.height)
+        return;
+
+    NSWindow *window = self.window;
+
+    // For windows that are opened with specific geometry, ignore AppKit's frame autosaving (and don't contribute to it).
+    self.windowFrameAutosaveName = @"";
+    window.tabbingMode = NSWindowTabbingModeDisallowed;
+
+    [window layoutIfNeeded];
+    [window setFrame:frameForWindowFeatures(_windowFeatures, window) display:NO];
+}
+
 - (void)windowDidLoad
 {
     [super windowDidLoad];
@@ -232,6 +280,8 @@ static const int testFooterBannerHeight = 58;
     // Private windows get separate identifier so they can't merge with regular windows
     if (_isPrivateBrowsingWindow)
         self.window.tabbingIdentifier = @"MiniBrowserPrivateWindow";
+
+    [self applyWindowFeatures];
 }
 
 - (void)userAgentDidChange:(NSNotification *)notification
@@ -756,9 +806,9 @@ static BOOL areEssentiallyEqual(double a, double b)
 
 - (nullable WKWebView *)webView:(WKWebView *)webView createWebViewWithConfiguration:(WKWebViewConfiguration *)configuration forNavigationAction:(WKNavigationAction *)navigationAction windowFeatures:(WKWindowFeatures *)windowFeatures
 {
-    WK2BrowserWindowController *controller = [[WK2BrowserWindowController alloc] initWithConfiguration:configuration];
+    WK2BrowserWindowController *controller = [[WK2BrowserWindowController alloc] initWithConfiguration:configuration windowFeatures:windowFeatures];
     [controller.window makeKeyAndOrderFront:self];
-    
+
     [[[NSApplication sharedApplication] browserAppDelegate] didCreateBrowserWindowController:controller];
 
     return controller->_webView;


### PR DESCRIPTION
#### c05f55c26706e9397a2289a8f06810a6eeffff79
<pre>
MiniBrowser doesn&apos;t respect window.open window features (part 1: size and location)
<a href="https://bugs.webkit.org/show_bug.cgi?id=320468">https://bugs.webkit.org/show_bug.cgi?id=320468</a>

Reviewed by Wenson Hsieh, Pascoe, Richard Robinson, and Abrar Rahman Protyasha.

Add support for x/y/width/height window features to MiniBrowser.
Don&apos;t save the custom sizes in AppKit frame autosaving mechanism,
and don&apos;t let them join with the main window.

* Tools/MiniBrowser/mac/WK2BrowserWindowController.h:
* Tools/MiniBrowser/mac/WK2BrowserWindowController.m:
(-[WK2BrowserWindowController initWithConfiguration:]):
(-[WK2BrowserWindowController initWithConfiguration:windowFeatures:]):
(frameForWindowFeatures):
(-[WK2BrowserWindowController applyWindowFeatures]):
(-[WK2BrowserWindowController windowDidLoad]):
(-[WK2BrowserWindowController webView:createWebViewWithConfiguration:forNavigationAction:windowFeatures:]):

Canonical link: <a href="https://commits.webkit.org/318139@main">https://commits.webkit.org/318139@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6c847023a78b92f18fcd9b847fccf3e99997ea15

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177259 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51197 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44991 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186862 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140495 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b26db317-9e5f-4262-8094-3c61fe191c48) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179122 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52489 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50885 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138132 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140495 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/219ceef4-721d-488e-93bb-ee45bdf45e13) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180215 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41632 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158893 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118597 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b74cc630-ce7e-4fa6-a335-655277ceee06) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40292 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38668 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150701 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38391 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35330 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42882 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189290 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50863 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147218 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39591 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51546 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35017 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147010 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41734 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118095 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50053 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13369 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49450 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49690 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49512 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->