### PR TITLE
[libpas] Add evicted, read-faulted backing coverage to AllocationZeroingTests

### DIFF
--- a/Source/bmalloc/libpas/src/test/AllocationZeroingTests.cpp
+++ b/Source/bmalloc/libpas/src/test/AllocationZeroingTests.cpp
@@ -33,6 +33,9 @@
 #include <algorithm>
 #include <cstdint>
 #include <vector>
+#if !PAS_OS(WINDOWS)
+#include <sys/mman.h>
+#endif
 
 #if PAS_ENABLE_BMALLOC
 
@@ -781,6 +784,108 @@ void testFragmentationReuseWithScavenge()
     runFragmentationReuse(Reuse::WithScavenge);
 }
 
+// Evict the page-aligned interior of [begin, end) so the pages must be faulted back
+// in. Returns false where that cannot be done, in which case the rounds degenerate
+// into plain re-reads and the test still checks zeroing, just over a narrower set of
+// page states. MADV_PAGEOUT is unavailable on platforms whose headers do not define
+// it, and on Darwin is additionally compiled out of kernels built without
+// MACH_ASSERT, where madvise() fails at runtime.
+bool evictRange(uintptr_t alignedBegin, uintptr_t alignedEnd)
+{
+    if (alignedEnd <= alignedBegin)
+        return false;
+#if defined(MADV_PAGEOUT)
+    return !madvise(reinterpret_cast<void*>(alignedBegin), alignedEnd - alignedBegin, MADV_PAGEOUT);
+#else
+    return false;
+#endif
+}
+
+void readFaultRange(uintptr_t alignedBegin, uintptr_t alignedEnd, size_t pageSize)
+{
+    volatile uint8_t sink = 0;
+    for (uintptr_t page = alignedBegin; page < alignedEnd; page += pageSize)
+        sink = static_cast<uint8_t>(sink ^ *reinterpret_cast<volatile uint8_t*>(page));
+    (void)sink;
+}
+
+// Zeroing must be correct over backing that has been evicted and read-faulted
+// repeatedly, not just over resident-dirty or decommitted pages -- which is all the
+// other tests here produce. Pages that come back from a read fault can be left in
+// states those tests never reach, and the kernel is free to account for them
+// differently depending on how often that has happened, so vary the round count.
+void zeroingReuseAfterEvictionRounds(size_t size, FaultOrder order, unsigned rounds, bool& evictionWorked)
+{
+    void* first = allocateZeroed(HeapVariant::Untagged, AlignmentApi::Plain, size, bmallocMinAlign);
+    if (!first)
+        reportParameters(HeapVariant::Untagged, AlignmentApi::Plain, size, bmallocMinAlign, "fresh");
+    CHECK(first);
+    checkIsZeroed(first, size, HeapVariant::Untagged, AlignmentApi::Plain, bmallocMinAlign, "fresh");
+
+    dirtyBuffer(first, size);
+
+    // Only the page-aligned interior is eligible; madvise requires page-aligned
+    // bounds, and the zeroed path memsets the unaligned head/tail slivers anyway.
+    size_t pageSize = pas_page_malloc_alignment();
+    uintptr_t begin = reinterpret_cast<uintptr_t>(first);
+    uintptr_t alignedBegin = pas_round_up_to_power_of_2(begin, pageSize);
+    uintptr_t alignedEnd = pas_round_down_to_power_of_2(begin + size, pageSize);
+
+    for (unsigned round = 0; round < rounds; ++round) {
+        if (evictRange(alignedBegin, alignedEnd))
+            evictionWorked = true;
+        readFaultRange(alignedBegin, alignedEnd, pageSize);
+    }
+
+    deallocateVariant(HeapVariant::Untagged, first);
+
+    void* second = allocateZeroed(HeapVariant::Untagged, AlignmentApi::Plain, size, bmallocMinAlign);
+    if (!second)
+        reportParameters(HeapVariant::Untagged, AlignmentApi::Plain, size, bmallocMinAlign, "reused");
+    CHECK(second);
+    if (second != first) {
+        std::cout << "Note: reuse returned a different region for size " << size
+                  << " (rounds=" << rounds << "); evicted-backing reuse not exercised." << std::endl;
+    }
+    checkIsZeroed(second, size, HeapVariant::Untagged, AlignmentApi::Plain, bmallocMinAlign, "reused", order);
+
+    deallocateVariant(HeapVariant::Untagged, second);
+}
+
+// Cross the fault orders with a randomized number of evict/read-fault rounds, at
+// the threshold and a multi-megabyte size. Untagged/plain only, as with the other
+// VA-path runs: the behaviour under test is variant- and alignment-independent.
+void testZeroingReuseAfterEvictionRounds()
+{
+    constexpr unsigned minEvictionRounds = 1;
+    constexpr unsigned maxEvictionRounds = 10;
+
+    constexpr size_t multiMegabyteSize = static_cast<size_t>(4) << 20;
+    static_assert(multiMegabyteSize >= vaZeroThreshold,
+                  "evicted-reuse sample should stay on the VA-zeroing path");
+
+    pas_scavenger_suspend();
+
+    static constexpr FaultOrder orders[] = {
+        FaultOrder::Ascending, FaultOrder::Descending, FaultOrder::Shuffled,
+    };
+    static constexpr size_t sizes[] = { vaZeroThreshold, multiMegabyteSize };
+
+    bool evictionWorked = false;
+    for (size_t size : sizes) {
+        for (FaultOrder order : orders) {
+            unsigned rounds = minEvictionRounds
+                + deterministicRandomNumber(maxEvictionRounds - minEvictionRounds + 1);
+            zeroingReuseAfterEvictionRounds(size, order, rounds, evictionWorked);
+        }
+    }
+
+    if (!evictionWorked) {
+        std::cout << "Note: could not evict; pages were only re-read, so this run covers a "
+                  << "narrower set of page states." << std::endl;
+    }
+}
+
 } // anonymous namespace
 
 #endif // PAS_ENABLE_BMALLOC
@@ -800,5 +905,6 @@ void addAllocationZeroingTests()
     ADD_TEST(testLargeZeroingFaultOrder());
     ADD_TEST(testFragmentationReuse());
     ADD_TEST(testFragmentationReuseWithScavenge());
+    ADD_TEST(testZeroingReuseAfterEvictionRounds());
 #endif // PAS_ENABLE_BMALLOC
 }


### PR DESCRIPTION
#### d18773ec666ea2bd59f8411c3bcd8d832998dad2
<pre>
[libpas] Add evicted, read-faulted backing coverage to AllocationZeroingTests
<a href="https://bugs.webkit.org/show_bug.cgi?id=320470">https://bugs.webkit.org/show_bug.cgi?id=320470</a>
<a href="https://rdar.apple.com/183437138">rdar://183437138</a>

Reviewed by Keith Miller.

The tests here dirty a region and free it, so the zeroed path only ever runs
over pages that are resident-dirty or decommitted, never over pages brought
back by a read fault.

Add a case that puts a large region through a randomized number of
evict/read-fault rounds before freeing it, then reallocates the same size and
verifies the reused region reads zero, across all three first-fault orders.
Eviction uses madvise(MADV_PAGEOUT) where available; where it is not, the
rounds degenerate into plain re-reads, which the test reports.

* Source/bmalloc/libpas/src/test/AllocationZeroingTests.cpp:
(addAllocationZeroingTests):

Canonical link: <a href="https://commits.webkit.org/318093@main">https://commits.webkit.org/318093@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/990f106488e44bcba4273b5d9a86a2246691e3c0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177266 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51204 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44998 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186869 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140502 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bf76326a-56d2-4fe7-9657-0574e237c50a) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52496 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50892 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138129 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140502 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a0193a90-9bef-4e97-b507-da360d31f37c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180222 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41636 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158902 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118594 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e85f62cb-f28c-4d9c-b94a-ea308e86fe04) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40296 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38675 "Passed tests") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/251/builds/563 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/7402 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150705 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38400 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35337 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/38537 "Built successfully and passed tests") | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/42889 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189297 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50870 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147223 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51553 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/35026 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147015 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26890 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41750 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118102 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50061 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13378 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49457 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49697 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49519 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->