### PR TITLE
Fix safer C++ failures in Source/WebCore/layout/flex

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/NoDeleteCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/NoDeleteCheckerExpectations
@@ -20,7 +20,6 @@ html/HTMLFormControlsCollection.cpp
 html/HTMLTableElement.cpp
 html/HTMLTableRowsCollection.cpp
 [ macOS ] inspector/InspectorFrontendHost.cpp
-layout/formattingContexts/flex/FlexFormattingContext.cpp
 layout/formattingContexts/inline/InlineLineBuilder.cpp
 layout/formattingContexts/inline/InlineTextItem.cpp
 loader/EmptyClients.cpp
@@ -33,7 +32,6 @@ page/LocalFrameView.cpp
 page/scrolling/ScrollingStateNode.cpp
 page/text-extraction/TextExtraction.cpp
 platform/sql/SQLiteStatementAutoResetScope.cpp
-rendering/RenderBox.cpp
 rendering/RenderGeometryMap.cpp
 rendering/RenderObject.cpp
 rendering/StyledMarkedText.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -164,8 +164,6 @@ layout/formattingContexts/block/BlockFormattingContext.cpp
 layout/formattingContexts/block/BlockFormattingQuirks.cpp
 layout/formattingContexts/block/PrecomputedBlockMarginCollapse.cpp
 layout/formattingContexts/block/tablewrapper/TableWrapperBlockFormattingContext.cpp
-layout/formattingContexts/flex/FlexFormattingContext.cpp
-layout/formattingContexts/flex/FlexFormattingUtils.cpp
 layout/formattingContexts/inline/AbstractLineBuilder.cpp
 layout/formattingContexts/inline/InlineContentAligner.cpp
 layout/formattingContexts/inline/InlineContentBreaker.cpp
@@ -196,7 +194,6 @@ layout/formattingContexts/table/TableLayout.cpp
 layout/integration/LayoutIntegrationBoxGeometryUpdater.cpp
 layout/integration/LayoutIntegrationBoxTreeUpdater.cpp
 layout/integration/LayoutIntegrationFormattingContextLayout.cpp
-layout/integration/flex/FlexIntegrationUtils.cpp
 layout/integration/flex/LayoutIntegrationFlexLayout.cpp
 layout/integration/inline/InlineIteratorBox.cpp
 layout/integration/inline/InlineIteratorBoxModernPath.h

--- a/Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
@@ -29,7 +29,6 @@ inspector/InspectorOverlay.cpp
 inspector/agents/InspectorCSSAgent.cpp
 inspector/agents/InspectorDOMAgent.cpp
 layout/formattingContexts/FormattingGeometry.cpp
-layout/formattingContexts/flex/FlexFormattingUtils.cpp
 layout/formattingContexts/inline/InlineLineBoxBuilder.cpp
 layout/formattingContexts/inline/InlineLineBuilder.cpp
 layout/formattingContexts/inline/InlineQuirks.cpp
@@ -40,8 +39,6 @@ layout/formattingContexts/table/TableFormattingContext.cpp
 layout/formattingContexts/table/TableLayout.cpp
 layout/integration/LayoutIntegrationBoxGeometryUpdater.cpp
 layout/integration/LayoutIntegrationBoxTreeUpdater.cpp
-layout/integration/flex/FlexIntegrationUtils.cpp
-layout/integration/flex/LayoutIntegrationFlexLayout.cpp
 loader/cache/CachedSVGFont.cpp
 [ iOS ] page/DOMTimer.cpp
 page/DragController.cpp

--- a/Source/WebCore/layout/formattingContexts/flex/FlexFormattingContext.cpp
+++ b/Source/WebCore/layout/formattingContexts/flex/FlexFormattingContext.cpp
@@ -1294,12 +1294,14 @@ LayoutUnit FlexLayoutItem::logicalHeight() const
 
 LayoutUnit FlexLayoutItem::borderAndPaddingLogicalHeight() const
 {
-    return renderer->borderAndPaddingLogicalHeight();
+    CheckedRef flexItem = renderer;
+    return flexItem->borderAndPaddingLogicalHeight();
 }
 
 LayoutSize FlexLayoutItem::intrinsicSize() const
 {
-    return renderer->intrinsicSize();
+    CheckedRef flexItem = renderer;
+    return flexItem->intrinsicSize();
 }
 
 #if ASSERT_ENABLED

--- a/Source/WebCore/layout/formattingContexts/flex/FlexFormattingContext.h
+++ b/Source/WebCore/layout/formattingContexts/flex/FlexFormattingContext.h
@@ -54,8 +54,8 @@ public:
     // The item's current, laid-out geometry.
     LayoutUnit NODELETE logicalWidth() const;
     LayoutUnit NODELETE logicalHeight() const;
-    LayoutUnit NODELETE borderAndPaddingLogicalHeight() const;
-    LayoutSize NODELETE intrinsicSize() const;
+    LayoutUnit borderAndPaddingLogicalHeight() const;
+    LayoutSize intrinsicSize() const;
 #if ASSERT_ENABLED
     bool needsLayout() const;
 #endif

--- a/Source/WebCore/layout/formattingContexts/flex/FlexFormattingUtils.cpp
+++ b/Source/WebCore/layout/formattingContexts/flex/FlexFormattingUtils.cpp
@@ -351,18 +351,19 @@ bool FlexFormattingUtils::willStretchFlexItem(const RenderFlexibleBox& flexBox, 
     if (isHorizontalFlow(flexBox) == (BoxAxis::Horizontal == physicalAxis))
         return false;
 
-    auto& itemStyle = flexItem.style();
+    CheckedRef itemStyle = flexItem.style();
     bool isVerticalCrossAxis = physicalAxis == BoxAxis::Vertical;
-    auto& crossSize = isVerticalCrossAxis ? itemStyle.height() : itemStyle.width();
+    auto& crossSize = isVerticalCrossAxis ? itemStyle->height() : itemStyle->width();
 
     if (!crossSize.isStretch()) {
-        if (!itemStyle.alignSelf().resolve(&flexBox.style()).isStretchy(mode == StretchingMode::Explicit ? ItemPosition::Normal : ItemPosition::Stretch))
+        CheckedRef containerStyle = flexBox.style();
+        if (!itemStyle->alignSelf().resolve(containerStyle.ptr()).isStretchy(mode == StretchingMode::Explicit ? ItemPosition::Normal : ItemPosition::Stretch))
             return false;
         if (!crossSize.isAuto())
             return false;
     }
 
-    return isVerticalCrossAxis ? !itemStyle.marginTop().isAuto() && !itemStyle.marginBottom().isAuto() : !itemStyle.marginLeft().isAuto() && !itemStyle.marginRight().isAuto();
+    return isVerticalCrossAxis ? !itemStyle->marginTop().isAuto() && !itemStyle->marginBottom().isAuto() : !itemStyle->marginLeft().isAuto() && !itemStyle->marginRight().isAuto();
 }
 
 // Whether any in-flow item is a stretched aspect-ratio item, i.e. one whose cross size the container supplies and

--- a/Source/WebCore/layout/integration/flex/FlexIntegrationUtils.cpp
+++ b/Source/WebCore/layout/integration/flex/FlexIntegrationUtils.cpp
@@ -62,11 +62,11 @@ FlexLayoutState& FlexIntegrationUtils::flexLayoutState() const
 
 void FlexIntegrationUtils::applyStretchedLogicalHeightToFlexItem(const FlexLayoutItem& flexLayoutItem, LayoutUnit blockSize)
 {
-    auto& renderer = flexLayoutItem.renderer.get();
+    CheckedRef renderer = flexLayoutItem.renderer;
     // We cache the child's content logical height to avoid it being reset to the stretched height.
     // FIXME: This is fragile. RenderBoxes should be smart enough to determine their content logical height
     // correctly even when there's an overrideHeight.
-    auto canSetFlexItemContentLogicalHeight = !is<RenderReplaced>(renderer) && !renderer.shouldComputeLogicalHeightFromAspectRatio();
+    auto canSetFlexItemContentLogicalHeight = !is<RenderReplaced>(renderer) && !renderer->shouldComputeLogicalHeightFromAspectRatio();
     if (!canSetFlexItemContentLogicalHeight) {
         dirtyPercentHeightDescendantsWithinFlexItem(renderer);
         layoutFlexItemForStretchedCrossSize(flexLayoutItem, blockSize, LogicalBoxAxis::Block);
@@ -81,13 +81,13 @@ void FlexIntegrationUtils::applyStretchedLogicalHeightToFlexItem(const FlexLayou
 
 void FlexIntegrationUtils::layoutFlexItemForStretchedCrossSize(const FlexLayoutItem& flexLayoutItem, LayoutUnit crossSize, LogicalBoxAxis crossAxis)
 {
-    auto& renderer = flexLayoutItem.renderer.get();
+    CheckedRef renderer = flexLayoutItem.renderer;
     if (crossAxis == LogicalBoxAxis::Block)
-        renderer.setOverridingBorderBoxLogicalHeight(crossSize);
+        renderer->setOverridingBorderBoxLogicalHeight(crossSize);
     else
-        renderer.setOverridingBorderBoxLogicalWidth(crossSize);
-    renderer.setChildNeedsLayout(MarkingBehavior::MarkOnlyThis);
-    renderer.layoutIfNeeded();
+        renderer->setOverridingBorderBoxLogicalWidth(crossSize);
+    renderer->setChildNeedsLayout(MarkingBehavior::MarkOnlyThis);
+    renderer->layoutIfNeeded();
 }
 
 void FlexIntegrationUtils::resetAutoMarginsAndLogicalTopInCrossAxis(RenderBox& flexItem)
@@ -112,11 +112,11 @@ void FlexIntegrationUtils::resetAutoMarginsAndLogicalTopInCrossAxis(RenderBox& f
 
 void FlexIntegrationUtils::layoutFlexItemWithMainSize(FlexLayoutItem& flexLayoutItem, LayoutUnit mainSize)
 {
-    auto& flexItem = flexLayoutItem.renderer.get();
+    CheckedRef flexItem = flexLayoutItem.renderer;
 
-    FlexFormattingUtils::mainAxisIsFlexItemInlineAxis(flexItem) ? flexItem.setOverridingBorderBoxLogicalWidth(mainSize + flexItem.borderAndPaddingLogicalWidth())
-        : flexItem.setOverridingBorderBoxLogicalHeight(mainSize + flexItem.borderAndPaddingLogicalHeight());
-    auto mainAxisContentExtentIncludingScrollbar = FlexFormattingUtils::isHorizontalFlow(flexBox()) ? flexItem.contentBoxWidth() + flexItem.verticalScrollbarWidth() : flexItem.contentBoxHeight() + flexItem.horizontalScrollbarHeight();
+    FlexFormattingUtils::mainAxisIsFlexItemInlineAxis(flexItem) ? flexItem->setOverridingBorderBoxLogicalWidth(mainSize + flexItem->borderAndPaddingLogicalWidth())
+        : flexItem->setOverridingBorderBoxLogicalHeight(mainSize + flexItem->borderAndPaddingLogicalHeight());
+    auto mainAxisContentExtentIncludingScrollbar = FlexFormattingUtils::isHorizontalFlow(flexBox()) ? flexItem->contentBoxWidth() + flexItem->verticalScrollbarWidth() : flexItem->contentBoxHeight() + flexItem->horizontalScrollbarHeight();
     auto mainSizeIsUnchanged = mainSize == mainAxisContentExtentIncludingScrollbar;
 
     if (mainSizeIsUnchanged) {
@@ -128,7 +128,7 @@ void FlexIntegrationUtils::layoutFlexItemWithMainSize(FlexLayoutItem& flexLayout
     auto shouldMarkFlexItemForLayout = [&] {
         // FIXME: Technically percentage height objects only need a relayout if their percentage isn't going to be turned into
         // an auto value. Add a method to determine this, so that we can avoid the relayout.
-        if (flexItem.hasRelativeLogicalHeight())
+        if (flexItem->hasRelativeLogicalHeight())
             return true;
         if (flexLayoutItem.shouldInvalidateChildContent && !flexLayoutState().hasFlexItemCompletedLayout(flexItem))
             return true;
@@ -145,18 +145,18 @@ void FlexIntegrationUtils::layoutFlexItemWithMainSize(FlexLayoutItem& flexLayout
     };
 
     if (shouldMarkFlexItemForLayout())
-        flexItem.setChildNeedsLayout(MarkingBehavior::MarkOnlyThis);
+        flexItem->setChildNeedsLayout(MarkingBehavior::MarkOnlyThis);
     else
-        flexItem.markForPaginationRelayoutIfNeeded();
+        flexItem->markForPaginationRelayoutIfNeeded();
 
-    if (flexItem.needsLayout()) {
-        flexItem.layoutIfNeeded();
+    if (flexItem->needsLayout()) {
+        flexItem->layoutIfNeeded();
         flexLayoutState().setFlexItemHasCompletedLayout(flexItem);
     }
 
-    if (!flexLayoutItem.everHadLayout && flexItem.checkForRepaintDuringLayout()) {
-        flexItem.repaint();
-        flexItem.repaintOverhangingFloats(true);
+    if (!flexLayoutItem.everHadLayout && flexItem->checkForRepaintDuringLayout()) {
+        flexItem->repaint();
+        flexItem->repaintOverhangingFloats(true);
     }
 }
 
@@ -186,19 +186,19 @@ void FlexIntegrationUtils::setFlexItemGeometry(const FlexLayoutItem& flexLayoutI
 
 void FlexIntegrationUtils::updateAutoMarginsInMainAxis(const FlexLayoutItem& flexLayoutItem, LayoutUnit autoMarginOffset)
 {
-    auto& flexItem = flexLayoutItem.renderer.get();
+    CheckedRef flexItem = flexLayoutItem.renderer;
     ASSERT(autoMarginOffset >= 0_lu);
 
     if (FlexFormattingUtils::isHorizontalFlow(flexBox())) {
-        if (flexItem.style().marginLeft().isAuto())
-            flexItem.setMarginLeft(autoMarginOffset);
-        if (flexItem.style().marginRight().isAuto())
-            flexItem.setMarginRight(autoMarginOffset);
+        if (flexItem->style().marginLeft().isAuto())
+            flexItem->setMarginLeft(autoMarginOffset);
+        if (flexItem->style().marginRight().isAuto())
+            flexItem->setMarginRight(autoMarginOffset);
     } else {
-        if (flexItem.style().marginTop().isAuto())
-            flexItem.setMarginTop(autoMarginOffset);
-        if (flexItem.style().marginBottom().isAuto())
-            flexItem.setMarginBottom(autoMarginOffset);
+        if (flexItem->style().marginTop().isAuto())
+            flexItem->setMarginTop(autoMarginOffset);
+        if (flexItem->style().marginBottom().isAuto())
+            flexItem->setMarginBottom(autoMarginOffset);
     }
 }
 
@@ -206,33 +206,33 @@ bool FlexIntegrationUtils::updateAutoMarginsInCrossAxis(const FlexLayoutItem& fl
 {
     // 9.6. (#13) Resolve cross-axis auto margins: if both cross-axis margins are auto, split the free space
     // between them; if only one is auto, give it all the free space so the item's outer cross size fills the line.
-    auto& flexItem = flexLayoutItem.renderer.get();
-    ASSERT(!flexItem.isOutOfFlowPositioned());
+    CheckedRef flexItem = flexLayoutItem.renderer;
+    ASSERT(!flexItem->isOutOfFlowPositioned());
     ASSERT(availableAlignmentSpace >= 0_lu);
 
     bool isHorizontal = FlexFormattingUtils::isHorizontalFlow(flexBox());
-    auto& style = flexLayoutItem.style();
-    auto& topOrLeft = isHorizontal ? style.marginTop() : style.marginLeft();
-    auto& bottomOrRight = isHorizontal ? style.marginBottom() : style.marginRight();
+    CheckedRef style = flexLayoutItem.style();
+    auto& topOrLeft = isHorizontal ? style->marginTop() : style->marginLeft();
+    auto& bottomOrRight = isHorizontal ? style->marginBottom() : style->marginRight();
     if (topOrLeft.isAuto() && bottomOrRight.isAuto()) {
         crossOffset += availableAlignmentSpace / 2;
         if (isHorizontal) {
-            flexItem.setMarginTop(availableAlignmentSpace / 2);
-            flexItem.setMarginBottom(availableAlignmentSpace / 2);
+            flexItem->setMarginTop(availableAlignmentSpace / 2);
+            flexItem->setMarginBottom(availableAlignmentSpace / 2);
         } else {
-            flexItem.setMarginLeft(availableAlignmentSpace / 2);
-            flexItem.setMarginRight(availableAlignmentSpace / 2);
+            flexItem->setMarginLeft(availableAlignmentSpace / 2);
+            flexItem->setMarginRight(availableAlignmentSpace / 2);
         }
         return true;
     }
     bool shouldAdjustTopOrLeft = true;
-    if (FlexFormattingUtils::isColumnFlow(flexBox()) && flexItem.writingMode().isInlineFlipped()) {
+    if (FlexFormattingUtils::isColumnFlow(flexBox()) && flexItem->writingMode().isInlineFlipped()) {
         // For column flows, only make this adjustment if topOrLeft corresponds to
         // the "before" margin, so that the rtl-column flip in computeFlexItemRects
         // will do the right thing.
         shouldAdjustTopOrLeft = false;
     }
-    if (!FlexFormattingUtils::isColumnFlow(flexBox()) && flexItem.writingMode().isBlockFlipped()) {
+    if (!FlexFormattingUtils::isColumnFlow(flexBox()) && flexItem->writingMode().isBlockFlipped()) {
         // If we are a flipped writing mode, we need to adjust the opposite side.
         // This is only needed for row flows because this only affects the
         // block-direction axis.
@@ -244,9 +244,9 @@ bool FlexIntegrationUtils::updateAutoMarginsInCrossAxis(const FlexLayoutItem& fl
             crossOffset += availableAlignmentSpace;
 
         if (isHorizontal)
-            flexItem.setMarginTop(availableAlignmentSpace);
+            flexItem->setMarginTop(availableAlignmentSpace);
         else
-            flexItem.setMarginLeft(availableAlignmentSpace);
+            flexItem->setMarginLeft(availableAlignmentSpace);
         return true;
     }
 
@@ -255,9 +255,9 @@ bool FlexIntegrationUtils::updateAutoMarginsInCrossAxis(const FlexLayoutItem& fl
             crossOffset += availableAlignmentSpace;
 
         if (isHorizontal)
-            flexItem.setMarginBottom(availableAlignmentSpace);
+            flexItem->setMarginBottom(availableAlignmentSpace);
         else
-            flexItem.setMarginRight(availableAlignmentSpace);
+            flexItem->setMarginRight(availableAlignmentSpace);
         return true;
     }
     return false;
@@ -265,14 +265,15 @@ bool FlexIntegrationUtils::updateAutoMarginsInCrossAxis(const FlexLayoutItem& fl
 
 void FlexIntegrationUtils::setFlexItemOverridingBorderBoxLogicalHeight(const FlexLayoutItem& flexLayoutItem, LayoutUnit blockSize)
 {
-    flexLayoutItem.renderer->setOverridingBorderBoxLogicalHeight(blockSize);
+    CheckedRef flexItem = flexLayoutItem.renderer;
+    flexItem->setOverridingBorderBoxLogicalHeight(blockSize);
 }
 
 void FlexIntegrationUtils::invalidateFlexItemContentLogicalWidthsIfNeeded(const FlexLayoutItem& flexLayoutItem)
 {
-    auto& flexItem = flexLayoutItem.renderer.get();
-    if (flexItem.shouldInvalidateContentWidths())
-        flexItem.invalidateContentLogicalWidths(MarkingBehavior::MarkOnlyThis);
+    CheckedRef flexItem = flexLayoutItem.renderer;
+    if (flexItem->shouldInvalidateContentWidths())
+        flexItem->invalidateContentLogicalWidths(MarkingBehavior::MarkOnlyThis);
 }
 
 void FlexIntegrationUtils::setTrimmedMarginForChild(const FlexLayoutItem& flexLayoutItem, Style::MarginTrimSide side)
@@ -282,10 +283,10 @@ void FlexIntegrationUtils::setTrimmedMarginForChild(const FlexLayoutItem& flexLa
 
 void FlexIntegrationUtils::trimMainAxisMarginStart(FlexLayoutItem& flexLayoutItem)
 {
-    auto& renderer = flexLayoutItem.renderer.get();
+    CheckedRef renderer = flexLayoutItem.renderer;
     auto horizontalFlow = FlexFormattingUtils::isHorizontalFlow(flexBox());
     auto containerWritingMode = flexBox().style().writingMode();
-    flexLayoutItem.mainAxisMargin -= horizontalFlow ? renderer.marginStart(containerWritingMode) : renderer.marginBefore(containerWritingMode);
+    flexLayoutItem.mainAxisMargin -= horizontalFlow ? renderer->marginStart(containerWritingMode) : renderer->marginBefore(containerWritingMode);
     if (horizontalFlow)
         setTrimmedMarginForChild(flexLayoutItem, Style::MarginTrimSide::InlineStart);
     else
@@ -337,8 +338,8 @@ void FlexIntegrationUtils::dirtyPercentHeightDescendantsWithinFlexItem(RenderBox
     CheckedPtr flexItemBlockFlow = dynamicDowncast<RenderBlockFlow>(flexItem);
     if (!flexItemBlockFlow)
         return;
-    for (auto& descendant : *flexBox().percentHeightDescendants()) {
-        if (descendant.parent() == &flexBox())
+    for (CheckedRef descendant : *flexBox().percentHeightDescendants()) {
+        if (descendant->parent() == &flexBox())
             continue;
         if (flexItemBlockFlow->isContainingBlockAncestorFor(descendant))
             flexItemBlockFlow->dirtyForLayoutFromPercentageHeightDescendant(descendant);
@@ -358,7 +359,7 @@ bool FlexIntegrationUtils::flexItemHasPercentHeightDescendants(const RenderBox& 
     // addPercentHeightDescendant() is never called for them. This means that this method would always wrongly
     // return false for a child of a <button> with a percentage height.
     if (flexBox().hasPercentHeightDescendants()) {
-        for (auto& descendant : *flexBox().percentHeightDescendants()) {
+        for (CheckedRef descendant : *flexBox().percentHeightDescendants()) {
             if (renderBlock->isContainingBlockAncestorFor(descendant))
                 return true;
         }
@@ -371,9 +372,9 @@ bool FlexIntegrationUtils::flexItemHasPercentHeightDescendants(const RenderBox& 
     if (!percentHeightDescendants)
         return false;
 
-    for (auto& descendant : *percentHeightDescendants) {
+    for (CheckedRef descendant : *percentHeightDescendants) {
         bool hasOutOfFlowAncestor = false;
-        for (auto* ancestor = descendant.containingBlock(); ancestor && ancestor != renderBlock.get(); ancestor = ancestor->containingBlock()) {
+        for (CheckedPtr ancestor = descendant->containingBlock(); ancestor && ancestor != renderBlock.get(); ancestor = ancestor->containingBlock()) {
             if (ancestor->isOutOfFlowPositioned()) {
                 hasOutOfFlowAncestor = true;
                 break;
@@ -392,21 +393,21 @@ bool FlexIntegrationUtils::flexItemHasPercentHeightDescendants(const FlexLayoutI
 
 LayoutUnit FlexIntegrationUtils::flexItemContentLogicalHeight(const FlexLayoutItem& flexLayoutItem) const
 {
-    auto& renderer = flexLayoutItem.renderer.get();
+    CheckedRef renderer = flexLayoutItem.renderer;
     if (CheckedPtr renderReplaced = dynamicDowncast<RenderReplaced>(renderer))
         return renderReplaced->intrinsicLogicalHeight();
 
     if (auto logicalHeight = m_flexItemContentCache.contentLogicalHeight(renderer))
         return *logicalHeight;
 
-    return renderer.contentBoxLogicalHeight();
+    return renderer->contentBoxLogicalHeight();
 }
 
 LayoutUnit FlexIntegrationUtils::computeBlockAxisContentSizeForFlexItem(const FlexLayoutItem& flexLayoutItem)
 {
-    auto& renderer = flexLayoutItem.renderer.get();
+    CheckedRef renderer = flexLayoutItem.renderer;
     // Reuse the size cached in a previous layout while the item stays clean.
-    if (!renderer.needsLayout()) {
+    if (!renderer->needsLayout()) {
         if (auto cachedBlockAxisContentSize = m_flexItemContentCache.blockAxisSize(renderer))
             return *cachedBlockAxisContentSize;
     }
@@ -415,15 +416,15 @@ LayoutUnit FlexIntegrationUtils::computeBlockAxisContentSizeForFlexItem(const Fl
     // where we want percentages to be treated as auto. For flex-basis itself, this is not a problem because
     // by definition we have an indefinite flex basis here and thus percentages should not resolve.
     auto percentResolveDisableScope = FlexPercentResolveDisabler { flexBox().view().frameView().layoutContext(), renderer };
-    renderer.setChildNeedsLayout(MarkingBehavior::MarkOnlyThis);
-    renderer.layoutIfNeeded();
+    renderer->setChildNeedsLayout(MarkingBehavior::MarkOnlyThis);
+    renderer->layoutIfNeeded();
     flexLayoutState().setFlexItemHasCompletedLayout(renderer);
 
     auto blockAxisContentSize = [&] {
         auto flexBasis = FlexFormattingUtils::flexBasisForFlexItem(renderer);
         if (flexBasis.isPercentOrCalculated() && !flexBox().flexLayout().flexItemMainSizeIsDefinite(renderer, flexBasis))
-            return flexItemContentLogicalHeight(flexLayoutItem) + renderer.scrollbarLogicalHeight();
-        return renderer.logicalHeight() - renderer.borderAndPaddingLogicalHeight();
+            return flexItemContentLogicalHeight(flexLayoutItem) + renderer->scrollbarLogicalHeight();
+        return renderer->logicalHeight() - renderer->borderAndPaddingLogicalHeight();
     }();
 
     // Cache it so a later layout can skip re-laying-out this item while it stays clean, and record that we laid it out this iteration.
@@ -523,11 +524,11 @@ template std::optional<LayoutUnit> FlexIntegrationUtils::computeMainAxisExtentFo
 // cross-size override (the scope invalidates the item's preferred widths so they recompute with it in place).
 LayoutUnit FlexIntegrationUtils::maxContentMainAxisExtentForFlexItem(const FlexLayoutItem& flexLayoutItem)
 {
-    auto& flexItem = flexLayoutItem.renderer.get();
+    CheckedRef flexItem = flexLayoutItem.renderer;
     auto definiteCrossSizeScope = FlexItemDefiniteCrossSizeScope { flexItem, FlexItemDefiniteCrossSizeScope::InvalidateContentWidths::Yes };
     auto intrinsicWidthComputationScope = FlexItemIntrinsicWidthComputationScope { flexItem };
-    auto mainAxisBorderAndPadding = FlexFormattingUtils::isHorizontalFlow(flexBox()) ? flexItem.horizontalBorderAndPaddingExtent() : flexItem.verticalBorderAndPaddingExtent();
-    return flexItem.maxContentLogicalWidthContribution() - mainAxisBorderAndPadding;
+    auto mainAxisBorderAndPadding = FlexFormattingUtils::isHorizontalFlow(flexBox()) ? flexItem->horizontalBorderAndPaddingExtent() : flexItem->verticalBorderAndPaddingExtent();
+    return flexItem->maxContentLogicalWidthContribution() - mainAxisBorderAndPadding;
 }
 
 // The item's raw min-content main-axis contribution (border/padding included), measured under the cross-size override
@@ -536,36 +537,37 @@ LayoutUnit FlexIntegrationUtils::minContentMainAxisContributionForFlexItem(const
 {
     auto definiteCrossSizeScope = FlexItemDefiniteCrossSizeScope { flexLayoutItem.renderer.get(), FlexItemDefiniteCrossSizeScope::InvalidateContentWidths::Yes };
     auto intrinsicWidthComputationScope = FlexItemIntrinsicWidthComputationScope { flexLayoutItem.renderer.get() };
-    return flexLayoutItem.renderer->minContentLogicalWidthContribution();
+    CheckedRef flexItem = flexLayoutItem.renderer;
+    return flexItem->minContentLogicalWidthContribution();
 }
 
 LayoutUnit FlexIntegrationUtils::flexItemIntrinsicLogicalHeight(const FlexLayoutItem& flexLayoutItem, bool needToStretchLogicalHeight) const
 {
-    auto& flexItem = flexLayoutItem.renderer.get();
+    CheckedRef flexItem = flexLayoutItem.renderer;
     // This should only be called if the logical height is the cross size.
     ASSERT(flexLayoutItem.mainAxisIsInlineAxis);
     if (needToStretchLogicalHeight) {
         auto flexItemContentHeight = flexItemContentLogicalHeight(flexLayoutItem);
-        auto flexItemLogicalHeight = flexItemContentHeight + flexItem.scrollbarLogicalHeight() + flexItem.borderAndPaddingLogicalHeight();
-        return flexItem.constrainLogicalHeightByMinMax(flexItemLogicalHeight, flexItemContentHeight);
+        auto flexItemLogicalHeight = flexItemContentHeight + flexItem->scrollbarLogicalHeight() + flexItem->borderAndPaddingLogicalHeight();
+        return flexItem->constrainLogicalHeightByMinMax(flexItemLogicalHeight, flexItemContentHeight);
     }
-    return flexItem.logicalHeight();
+    return flexItem->logicalHeight();
 }
 
 LayoutUnit FlexIntegrationUtils::flexItemIntrinsicLogicalWidth(const FlexLayoutItem& flexLayoutItem, bool crossSizeIsDefinite)
 {
-    auto& flexItem = flexLayoutItem.renderer.get();
+    CheckedRef flexItem = flexLayoutItem.renderer;
     // This should only be called if the logical width is the cross size.
     ASSERT(!flexLayoutItem.mainAxisIsInlineAxis);
     if (crossSizeIsDefinite)
-        return flexItem.logicalWidth();
+        return flexItem->logicalWidth();
 
     // computeLogicalWidth returns the overriding width as-is for a flex item, so clear it to get the width the
     // item computes from its own style.
     // FIXME: Check whether an overriding inline size can actually be set on an orthogonal flex item at this point
     // (nothing in this layout pass appears to set one) and remove this if it cannot.
-    auto previousOverridingBorderBoxLogicalWidth = flexItem.overridingBorderBoxLogicalWidth();
-    flexItem.clearOverridingBorderBoxLogicalWidth();
+    auto previousOverridingBorderBoxLogicalWidth = flexItem->overridingBorderBoxLogicalWidth();
+    flexItem->clearOverridingBorderBoxLogicalWidth();
 
     RenderBox::LogicalExtentComputedValues values;
     {
@@ -573,27 +575,30 @@ LayoutUnit FlexIntegrationUtils::flexItemIntrinsicLogicalWidth(const FlexLayoutI
         // minContentMainAxisContributionForFlexItem: a percentage resolved against this item while measuring it
         // answers from the item's cross-size definiteness, not from how far the flex algorithm has got.
         auto intrinsicWidthComputationScope = FlexItemIntrinsicWidthComputationScope { flexItem };
-        flexItem.computeLogicalWidth(values);
+        flexItem->computeLogicalWidth(values);
     }
 
     if (previousOverridingBorderBoxLogicalWidth)
-        flexItem.setOverridingBorderBoxLogicalWidth(*previousOverridingBorderBoxLogicalWidth);
+        flexItem->setOverridingBorderBoxLogicalWidth(*previousOverridingBorderBoxLogicalWidth);
     return values.extent;
 }
 
 LayoutUnit FlexIntegrationUtils::constrainFlexItemLogicalHeightByMinMax(const FlexLayoutItem& flexLayoutItem, LayoutUnit logicalHeight, std::optional<LayoutUnit> intrinsicContentHeight) const
 {
-    return flexLayoutItem.renderer->constrainLogicalHeightByMinMax(logicalHeight, intrinsicContentHeight);
+    CheckedRef flexItem = flexLayoutItem.renderer;
+    return flexItem->constrainLogicalHeightByMinMax(logicalHeight, intrinsicContentHeight);
 }
 
 LayoutUnit FlexIntegrationUtils::constrainFlexItemLogicalWidthByMinMax(const FlexLayoutItem& flexLayoutItem, LayoutUnit logicalWidth, LayoutUnit availableWidth) const
 {
-    return flexLayoutItem.renderer->constrainLogicalWidthByMinMax(logicalWidth, availableWidth, flexBox());
+    CheckedRef flexItem = flexLayoutItem.renderer;
+    return flexItem->constrainLogicalWidthByMinMax(logicalWidth, availableWidth, flexBox());
 }
 
 template<typename SizeType> std::optional<LayoutUnit> FlexIntegrationUtils::computePercentageLogicalHeightForFlexItem(const FlexLayoutItem& flexLayoutItem, const SizeType& size) const
 {
-    return flexLayoutItem.renderer->computePercentageLogicalHeight(size);
+    CheckedRef flexItem = flexLayoutItem.renderer;
+    return flexItem->computePercentageLogicalHeight(size);
 }
 
 // Explicit instantiations for the SizeTypes FlexFormattingContext resolves through the integration from a separate translation unit.
@@ -604,7 +609,8 @@ template std::optional<LayoutUnit> FlexIntegrationUtils::computePercentageLogica
 
 template<typename SizeType> std::optional<LayoutUnit> FlexIntegrationUtils::computeLogicalHeightUsingForFlexItem(const FlexLayoutItem& flexLayoutItem, const SizeType& size) const
 {
-    return flexLayoutItem.renderer->computeLogicalHeightUsing(size, std::nullopt);
+    CheckedRef flexItem = flexLayoutItem.renderer;
+    return flexItem->computeLogicalHeightUsing(size, std::nullopt);
 }
 
 template std::optional<LayoutUnit> FlexIntegrationUtils::computeLogicalHeightUsingForFlexItem<Style::PreferredSize>(const FlexLayoutItem&, const Style::PreferredSize&) const;
@@ -613,7 +619,8 @@ template std::optional<LayoutUnit> FlexIntegrationUtils::computeLogicalHeightUsi
 
 template<typename SizeType> LayoutUnit FlexIntegrationUtils::computeLogicalWidthUsingForFlexItem(const FlexLayoutItem& flexLayoutItem, const SizeType& size, LayoutUnit availableWidth) const
 {
-    return flexLayoutItem.renderer->computeLogicalWidthUsing(size, availableWidth, flexBox());
+    CheckedRef flexItem = flexLayoutItem.renderer;
+    return flexItem->computeLogicalWidthUsing(size, availableWidth, flexBox());
 }
 
 template LayoutUnit FlexIntegrationUtils::computeLogicalWidthUsingForFlexItem<Style::PreferredSize>(const FlexLayoutItem&, const Style::PreferredSize&, LayoutUnit) const;

--- a/Source/WebCore/layout/integration/flex/LayoutIntegrationFlexLayout.cpp
+++ b/Source/WebCore/layout/integration/flex/LayoutIntegrationFlexLayout.cpp
@@ -163,9 +163,9 @@ FlexLayoutState::MarginTrimItems FlexLayout::marginTrimItemsBeforeFlexLayout() c
     // flex algorithm below gets this right; the container's intrinsic width, which this feeds, does not.
     auto marginTrimItems = FlexLayoutState::MarginTrimItems { };
     auto isRowsFlexbox = FlexFormattingUtils::isHorizontalFlow(flexBox());
-    if (auto flexItem = flexBox().firstInFlowChildBox(); flexItem && marginTrim.contains(Style::MarginTrimSide::InlineStart))
+    if (CheckedPtr flexItem = flexBox().firstInFlowChildBox(); flexItem && marginTrim.contains(Style::MarginTrimSide::InlineStart))
         isRowsFlexbox ? marginTrimItems.itemsAtFlexLineStart.add(*flexItem) : marginTrimItems.itemsOnFirstFlexLine.add(*flexItem);
-    if (auto flexItem = flexBox().lastInFlowChildBox(); flexItem && marginTrim.contains(Style::MarginTrimSide::InlineEnd))
+    if (CheckedPtr flexItem = flexBox().lastInFlowChildBox(); flexItem && marginTrim.contains(Style::MarginTrimSide::InlineEnd))
         isRowsFlexbox ? marginTrimItems.itemsAtFlexLineEnd.add(*flexItem) : marginTrimItems.itemsOnLastFlexLine.add(*flexItem);
     return marginTrimItems;
 }

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -661,7 +661,7 @@ bool RenderBox::shouldResetLogicalHeightBeforeLayout() const
     // A flex item resets its logical height while its container is stretching items along the cross axis, so the
     // stretch relayout starts from a clean height. This runs inside the item's own layout, after its LayoutRepainter
     // has captured the pre-stretch bounds, so repaint stays minimal (see webkit.org/b/204380).
-    CheckedPtr flexBoxParent = dynamicDowncast<RenderFlexibleBox>(parent());
+    auto* flexBoxParent = dynamicDowncast<RenderFlexibleBox>(parent());
     return flexBoxParent && flexBoxParent->isInCrossAxisStretchLayout();
 }
 

--- a/Source/WebCore/rendering/RenderFlexibleBox.h
+++ b/Source/WebCore/rendering/RenderFlexibleBox.h
@@ -86,8 +86,8 @@ public:
     // Returns true if the position changed. In that case, the flexItem will have to be laid out again.
     bool setStaticPositionForPositionedLayout(const RenderBox&);
 
-    bool isComputingFlexBaseSizes() const;
-    bool isInCrossAxisStretchLayout() const;
+    bool NODELETE isComputingFlexBaseSizes() const;
+    bool NODELETE isInCrossAxisStretchLayout() const;
 
 protected:
     std::pair<LayoutUnit, LayoutUnit> computeIntrinsicLogicalWidths() const override;


### PR DESCRIPTION
#### b205d90d7bc65ae3d7fe4050d437d3da81ef2129
<pre>
Fix safer C++ failures in Source/WebCore/layout/flex
<a href="https://bugs.webkit.org/show_bug.cgi?id=320469">https://bugs.webkit.org/show_bug.cgi?id=320469</a>
&lt;<a href="https://rdar.apple.com/problem/183436566">rdar://problem/183436566</a>&gt;

Reviewed by Antti Koivisto.

* Source/WebCore/SaferCPPExpectations/NoDeleteCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations:
* Source/WebCore/layout/formattingContexts/flex/FlexFormattingContext.cpp:
(WebCore::FlexLayoutItem::borderAndPaddingLogicalHeight const):
(WebCore::FlexLayoutItem::intrinsicSize const):
* Source/WebCore/layout/formattingContexts/flex/FlexFormattingContext.h:
* Source/WebCore/layout/formattingContexts/flex/FlexFormattingUtils.cpp:
(WebCore::FlexFormattingUtils::willStretchFlexItem):
* Source/WebCore/layout/integration/flex/FlexIntegrationUtils.cpp:
(WebCore::LayoutIntegration::FlexIntegrationUtils::applyStretchedLogicalHeightToFlexItem):
(WebCore::LayoutIntegration::FlexIntegrationUtils::layoutFlexItemForStretchedCrossSize):
(WebCore::LayoutIntegration::FlexIntegrationUtils::layoutFlexItemWithMainSize):
(WebCore::LayoutIntegration::FlexIntegrationUtils::updateAutoMarginsInMainAxis):
(WebCore::LayoutIntegration::FlexIntegrationUtils::updateAutoMarginsInCrossAxis):
(WebCore::LayoutIntegration::FlexIntegrationUtils::setFlexItemOverridingBorderBoxLogicalHeight):
(WebCore::LayoutIntegration::FlexIntegrationUtils::invalidateFlexItemContentLogicalWidthsIfNeeded):
(WebCore::LayoutIntegration::FlexIntegrationUtils::trimMainAxisMarginStart):
(WebCore::LayoutIntegration::FlexIntegrationUtils::dirtyPercentHeightDescendantsWithinFlexItem):
(WebCore::LayoutIntegration::FlexIntegrationUtils::flexItemHasPercentHeightDescendants const):
(WebCore::LayoutIntegration::FlexIntegrationUtils::flexItemContentLogicalHeight const):
(WebCore::LayoutIntegration::FlexIntegrationUtils::computeBlockAxisContentSizeForFlexItem):
(WebCore::LayoutIntegration::FlexIntegrationUtils::maxContentMainAxisExtentForFlexItem):
(WebCore::LayoutIntegration::FlexIntegrationUtils::minContentMainAxisContributionForFlexItem):
(WebCore::LayoutIntegration::FlexIntegrationUtils::flexItemIntrinsicLogicalHeight const):
(WebCore::LayoutIntegration::FlexIntegrationUtils::flexItemIntrinsicLogicalWidth):
(WebCore::LayoutIntegration::FlexIntegrationUtils::constrainFlexItemLogicalHeightByMinMax const):
(WebCore::LayoutIntegration::FlexIntegrationUtils::constrainFlexItemLogicalWidthByMinMax const):
(WebCore::LayoutIntegration::FlexIntegrationUtils::computePercentageLogicalHeightForFlexItem const):
(WebCore::LayoutIntegration::FlexIntegrationUtils::computeLogicalHeightUsingForFlexItem const):
(WebCore::LayoutIntegration::FlexIntegrationUtils::computeLogicalWidthUsingForFlexItem const):
* Source/WebCore/layout/integration/flex/LayoutIntegrationFlexLayout.cpp:
(WebCore::LayoutIntegration::FlexLayout::marginTrimItemsBeforeFlexLayout const):
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::shouldResetLogicalHeightBeforeLayout const):
* Source/WebCore/rendering/RenderFlexibleBox.h:

Canonical link: <a href="https://commits.webkit.org/318088@main">https://commits.webkit.org/318088@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9e83a11f1c50caabe39b813920ce8ae8e48f9d59

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177265 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51203 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44997 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186868 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140501 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0435838d-fde1-4bb4-9650-3620247e5885) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179128 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52495 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50891 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138133 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140501 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f14a9724-259d-4346-8d8b-db9812d73bfa) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180221 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41644 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158900 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118598 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4b8a888c-2af0-44c2-ad01-a2af75894be6) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40304 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38674 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150713 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38398 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35336 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42988 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/42888 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189296 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50869 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147222 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39561 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51552 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/35024 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147014 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41737 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123767 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118101 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50060 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13376 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49456 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49696 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49518 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->