### PR TITLE
Add a "pid=" label and stagger frame process indicators by nesting depth

### DIFF
--- a/Source/WebCore/platform/graphics/GraphicsLayer.h
+++ b/Source/WebCore/platform/graphics/GraphicsLayer.h
@@ -436,8 +436,9 @@ public:
     virtual void setShowRepaintCounter(bool show) { m_showRepaintCounter = show; }
     bool isShowingRepaintCounter() const { return m_showRepaintCounter; }
 
-    virtual void setShowFrameProcessBorders(bool show) { m_showFrameProcessBorders = show; }
+    virtual void setShowFrameProcessBorders(bool show, unsigned frameDepth = 0) { m_showFrameProcessBorders = show; m_frameProcessIndicatorDepth = frameDepth; }
     bool isShowingFrameProcessBorders() const { return m_showFrameProcessBorders; }
+    unsigned frameProcessIndicatorDepth() const { return m_frameProcessIndicatorDepth; }
 
     // FIXME: this is really a paint count.
     int repaintCount() const { return m_repaintCount; }
@@ -672,7 +673,7 @@ protected:
 #endif
 
     int m_repaintCount { 0 };
-
+    unsigned m_frameProcessIndicatorDepth { 0 };
     Vector<Ref<GraphicsLayer>> m_children;
     WeakPtr<GraphicsLayer> m_parent;
 

--- a/Source/WebCore/platform/graphics/ca/FrameProcessIndicators.cpp
+++ b/Source/WebCore/platform/graphics/ca/FrameProcessIndicators.cpp
@@ -36,19 +36,21 @@
 #include "TextRun.h"
 #include <wtf/ProcessID.h>
 #include <wtf/TZoneMallocInlines.h>
+#include <wtf/text/MakeString.h>
 
 namespace WebCore {
 
 static constexpr float padding = 3;
 static constexpr float fontSize = 12;
 static constexpr float borderWidth = 4;
+static constexpr float depthStaggerStep = 12;
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(FrameProcessIndicators);
 
 FrameProcessIndicators::FrameProcessIndicators(GraphicsLayerCA& graphicsLayer)
     : m_graphicsLayer(graphicsLayer)
     , m_backgroundColor(borderColor())
-    , m_text(String::number(getCurrentProcessID()))
+    , m_text(makeString("pid="_s, getCurrentProcessID()))
     , m_borderLayer(graphicsLayer.createPlatformCALayer(PlatformCALayer::LayerType::LayerTypeLayer, nullptr))
     , m_indicatorLayer(graphicsLayer.createPlatformCALayer(PlatformCALayer::LayerType::LayerTypeWebLayer, this))
 {
@@ -84,7 +86,11 @@ void FrameProcessIndicators::updateGeometry(const FloatRect& bounds)
     auto location = bounds.location();
     m_borderLayer->setPosition(location);
     m_borderLayer->setBounds({ { }, bounds.size() });
-    m_indicatorLayer->setPosition({ bounds.maxX() - m_indicatorLayer->bounds().width(), location.y(), 1 });
+
+    // Stagger indicators by frame nesting depth so co-located frames (e.g. a mainframe and an
+    // iframe both anchored at the page origin) don't draw their labels directly on top of each other.
+    float stagger = m_graphicsLayer ? m_graphicsLayer->frameProcessIndicatorDepth() * depthStaggerStep : 0;
+    m_indicatorLayer->setPosition({ location.x() + stagger, location.y() + stagger, 1 });
 }
 
 void FrameProcessIndicators::updateContentsScale(float contentsScale)

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
@@ -4481,12 +4481,12 @@ void GraphicsLayerCA::setShowRepaintCounter(bool showCounter)
     noteLayerPropertyChanged(DebugIndicatorsChanged);
 }
 
-void GraphicsLayerCA::setShowFrameProcessBorders(bool showBorders)
+void GraphicsLayerCA::setShowFrameProcessBorders(bool showBorders, unsigned frameDepth)
 {
-    if (showBorders == m_showFrameProcessBorders)
+    if (showBorders == m_showFrameProcessBorders && frameDepth == m_frameProcessIndicatorDepth)
         return;
 
-    GraphicsLayer::setShowFrameProcessBorders(showBorders);
+    GraphicsLayer::setShowFrameProcessBorders(showBorders, frameDepth);
     noteLayerPropertyChanged(DebugIndicatorsChanged);
 }
 

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h
@@ -200,7 +200,7 @@ public:
 
     WEBCORE_EXPORT void setDebugBackgroundColor(const Color&) override;
     WEBCORE_EXPORT void setDebugBorder(const Color&, float borderWidth) override;
-    WEBCORE_EXPORT void setShowFrameProcessBorders(bool) override;
+    WEBCORE_EXPORT void setShowFrameProcessBorders(bool, unsigned frameDepth = 0) override;
 
     WEBCORE_EXPORT void setCustomAppearance(CustomAppearance) override;
 

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -591,7 +591,11 @@ void RenderLayerBacking::updateDebugIndicators(bool showBorder, bool showRepaint
 
     if (m_childContainmentLayer) {
         m_childContainmentLayer->setShowDebugBorder(showBorder);
-        m_childContainmentLayer->setShowFrameProcessBorders(renderer().settings().showFrameProcessBorders() && m_owningLayer.isRenderViewLayer());
+        bool showFrameProcessBorders = renderer().settings().showFrameProcessBorders() && m_owningLayer.isRenderViewLayer();
+        // depth() is 1-based and counts through cross-process ancestor frames, so subtract 1 to keep the
+        // mainframe's indicator unstaggered while nested frames offset further with each level of nesting.
+        unsigned frameNestingDepth = showFrameProcessBorders ? renderer().frame().tree().depth() - 1 : 0;
+        m_childContainmentLayer->setShowFrameProcessBorders(showFrameProcessBorders, frameNestingDepth);
     }
 
     if (m_backgroundLayer) {


### PR DESCRIPTION
#### 0c06c1222be25577be16cd332872ce568942f9db
<pre>
Add a &quot;pid=&quot; label and stagger frame process indicators by nesting depth
<a href="https://bugs.webkit.org/show_bug.cgi?id=320471">https://bugs.webkit.org/show_bug.cgi?id=320471</a>
<a href="https://rdar.apple.com/183439648">rdar://183439648</a>

Reviewed by Per Arne Vollan.

Follow-up to the frame process indicator overlay (bug 320012). Two changes to make the
per-frame process ID overlay more usable when debugging site isolation:

- Prefix the label text with &quot;pid=&quot; so the number is unambiguous at a glance.
- Offset each indicator by its frame&apos;s nesting depth in the (cross-process) frame tree, so
  frames that share an origin on screen (e.g. a mainframe and an iframe both anchored at the
  page origin) don&apos;t draw their labels directly on top of each other. The mainframe&apos;s label is
  unstaggered; each level of nesting shifts the label further down and to the right.

* Source/WebCore/platform/graphics/GraphicsLayer.h:
(WebCore::GraphicsLayer::setShowFrameProcessBorders):
(WebCore::GraphicsLayer::frameProcessIndicatorDepth const):
* Source/WebCore/platform/graphics/ca/FrameProcessIndicators.cpp:
(WebCore::FrameProcessIndicators::FrameProcessIndicators):
(WebCore::FrameProcessIndicators::updateGeometry):
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp:
(WebCore::GraphicsLayerCA::ensureStructuralLayer):
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h:
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::updateDebugIndicators):

Canonical link: <a href="https://commits.webkit.org/318572@main">https://commits.webkit.org/318572@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/50b2f44656bdcaa7779e9b2009fd020221922e03

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177270 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51208 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45002 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186873 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/140506 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/09e86400-cc51-4d2f-95f9-67fb7756aba6) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179133 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52500 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50896 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138138 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96300 "2 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/aa2cbd6f-f8e9-491d-87b8-f8c8374b77d9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180226 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41637 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158898 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118603 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fe407607-e86b-4958-a0c6-d1f6d5f3cfd4) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40297 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38677 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150706 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38396 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35341 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42993 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42891 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189302 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50874 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147226 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39869 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51557 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35022 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147018 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41743 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123772 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118106 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50065 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13374 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49461 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49701 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49523 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->