### PR TITLE
Add HTMLMediaElement.removeTextTrack()

### DIFF
--- a/LayoutTests/media/track/track-remove-text-track-expected.txt
+++ b/LayoutTests/media/track/track-remove-text-track-expected.txt
@@ -1,0 +1,21 @@
+Tests HTMLMediaElement.removeTextTrack().
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS video.textTracks.length is 1
+PASS video.removeTextTrack(addedTrack) is undefined
+PASS video.textTracks.length is 0
+PASS video.removeTextTrack(addedTrack) threw exception NotFoundError: The object can not be found here..
+PASS video.textTracks.length is 1
+PASS video.removeTextTrack(trackElement.track) threw exception NotFoundError: The object can not be found here..
+PASS video.textTracks.length is 1
+PASS video.removeTextTrack(otherTrack) threw exception NotFoundError: The object can not be found here..
+PASS otherVideo.textTracks.length is 1
+PASS removeEvent instanceof TrackEvent is true
+PASS removeEvent.target is video.textTracks
+PASS removeEvent.track is addedTrack
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/media/track/track-remove-text-track.html
+++ b/LayoutTests/media/track/track-remove-text-track.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="../../resources/js-test.js"></script>
+<script>
+description("Tests HTMLMediaElement.removeTextTrack().");
+
+jsTestIsAsync = true;
+
+var video = document.createElement('video');
+
+// A track added via addTextTrack() can be removed with removeTextTrack(), which synchronously
+// removes it from textTracks and asynchronously fires a 'removetrack' event at the media
+// element's TextTrackList.
+var removeEvent = null;
+var addedTrack = video.addTextTrack('captions', 'Captions', 'en');
+video.textTracks.onremovetrack = function(event) {
+    removeEvent = event;
+    shouldBeTrue("removeEvent instanceof TrackEvent");
+    shouldBe("removeEvent.target", "video.textTracks");
+    shouldBe("removeEvent.track", "addedTrack");
+    finishJSTest();
+};
+shouldBe("video.textTracks.length", "1");
+shouldBe("video.removeTextTrack(addedTrack)", "undefined");
+shouldBe("video.textTracks.length", "0");
+
+// Removing it again should throw NotFoundError, since it is no longer in the list of text tracks.
+shouldThrowErrorName("video.removeTextTrack(addedTrack)", "NotFoundError");
+
+// A <track> element's corresponding TextTrack was not added via addTextTrack(), and so cannot be
+// removed with removeTextTrack().
+var trackElement = document.createElement('track');
+trackElement.kind = 'subtitles';
+video.appendChild(trackElement);
+shouldBe("video.textTracks.length", "1");
+shouldThrowErrorName("video.removeTextTrack(trackElement.track)", "NotFoundError");
+shouldBe("video.textTracks.length", "1");
+
+// A TextTrack belonging to a different media element cannot be removed.
+var otherVideo = document.createElement('video');
+var otherTrack = otherVideo.addTextTrack('subtitles');
+shouldThrowErrorName("video.removeTextTrack(otherTrack)", "NotFoundError");
+shouldBe("otherVideo.textTracks.length", "1");
+</script>
+</body>
+</html>

--- a/Source/WebCore/Modules/mediasource/MediaSource.cpp
+++ b/Source/WebCore/Modules/mediasource/MediaSource.cpp
@@ -951,7 +951,7 @@ void MediaSource::removeSourceBufferWithOptionalDestruction(SourceBuffer& buffer
                 // cancelable, and that uses the TrackEvent interface, at the HTMLMediaElement textTracks list.
                 if (isMainThread()) {
                     ensureWeakOnHTMLMediaElementContext([track = track](HTMLMediaElement& mediaElement) mutable {
-                        mediaElement.removeTextTrack(WTF::move(track));
+                        mediaElement.removeTextTrack(WTF::move(track), HTMLMediaElement::ScheduleEvent::Yes);
                     });
                 } else {
                     ensureWeakOnHTMLMediaElementContext([trackID = track->trackId()](auto& mediaElement) mutable {

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -2754,7 +2754,7 @@ void HTMLMediaElement::textTrackLanguageChanged(TextTrack& track)
 void HTMLMediaElement::willRemoveTextTrack(TextTrack& track)
 {
     if (track.trackType() == TextTrack::InBand)
-        removeTextTrack(track);
+        removeTextTrack(track, ScheduleEvent::Yes);
 }
 
 void HTMLMediaElement::videoTrackSelectedChanged(VideoTrack& track)
@@ -5459,10 +5459,10 @@ void HTMLMediaElement::removeAudioTrack(TrackID trackID)
         removeAudioTrack(downcast<AudioTrack>(*track));
 }
 
-void HTMLMediaElement::removeTextTrack(TextTrack& track, bool scheduleEvent)
+bool HTMLMediaElement::removeTextTrack(TextTrack& track, ScheduleEvent scheduleEvent)
 {
     if (!m_textTracks || !m_textTracks->contains(track))
-        return;
+        return false;
 
     if (m_findCaptionTrack == &track) {
         m_findCaptionTrack = nullptr;
@@ -5474,10 +5474,11 @@ void HTMLMediaElement::removeTextTrack(TextTrack& track, bool scheduleEvent)
         textTrackRemoveCues(track, *cues);
     track.clearClient(*this);
     if (m_textTracks)
-        m_textTracks->remove(track, scheduleEvent);
+        m_textTracks->remove(track, scheduleEvent == ScheduleEvent::Yes);
+    return true;
 }
 
-void HTMLMediaElement::removeTextTrack(TrackID trackID, bool scheduleEvent)
+void HTMLMediaElement::removeTextTrack(TrackID trackID, ScheduleEvent scheduleEvent)
 {
     if (!m_textTracks)
         return;
@@ -5512,7 +5513,7 @@ void HTMLMediaElement::forgetResourceSpecificTracks()
         for (int i = m_textTracks->length() - 1; i >= 0; --i) {
             Ref track = *m_textTracks->item(i);
             if (track->trackType() == TextTrack::InBand)
-                removeTextTrack(track, false);
+                removeTextTrack(track, ScheduleEvent::No);
         }
     }
 
@@ -5560,6 +5561,17 @@ ExceptionOr<Ref<TextTrack>> HTMLMediaElement::addTextTrack(const AtomString& kin
     track->setMode(TextTrack::Mode::Hidden);
 
     return track;
+}
+
+ExceptionOr<void> HTMLMediaElement::removeTextTrack(TextTrack& track)
+{
+    if (track.trackType() != TextTrack::AddTrack)
+        return Exception { ExceptionCode::NotFoundError };
+
+    if (!removeTextTrack(track, ScheduleEvent::Yes))
+        return Exception { ExceptionCode::NotFoundError };
+
+    return { };
 }
 
 AudioTrackList& HTMLMediaElement::ensureAudioTracks()
@@ -5624,7 +5636,7 @@ void HTMLMediaElement::didRemoveTextTrack(HTMLTrackElement& trackElement)
     // When a track element's parent element changes and the old parent was a media element,
     // then the user agent must remove the track element's corresponding text track from the
     // media element's list of text tracks.
-    removeTextTrack(textTrack);
+    removeTextTrack(textTrack, ScheduleEvent::Yes);
 
     m_textTracksWhenResourceSelectionBegan.removeFirst(textTrack.ptr());
 }

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -395,6 +395,7 @@ public:
     bool shouldForceControlsDisplay() const;
 
     ExceptionOr<Ref<TextTrack>> addTextTrack(const AtomString& kind, const AtomString& label, const AtomString& language);
+    ExceptionOr<void> removeTextTrack(TextTrack&);
 
     AudioTrackList& ensureAudioTracks();
     TextTrackList& ensureTextTracks();
@@ -410,8 +411,9 @@ public:
     void addVideoTrack(Ref<VideoTrack>&&);
     void removeAudioTrack(AudioTrack&);
     void removeAudioTrack(TrackID);
-    void removeTextTrack(TextTrack&, bool scheduleEvent = true);
-    void removeTextTrack(TrackID, bool scheduleEvent = true);
+    enum class ScheduleEvent : bool { No, Yes };
+    bool removeTextTrack(TextTrack&, ScheduleEvent);
+    void removeTextTrack(TrackID, ScheduleEvent = ScheduleEvent::Yes);
     void removeVideoTrack(VideoTrack&);
     void removeVideoTrack(TrackID);
     void forgetResourceSpecificTracks();

--- a/Source/WebCore/html/HTMLMediaElement.idl
+++ b/Source/WebCore/html/HTMLMediaElement.idl
@@ -119,6 +119,7 @@ typedef (
 
     // tracks
     TextTrack addTextTrack([AtomString] DOMString kind, optional [AtomString] DOMString label = "", optional [AtomString] DOMString language = "");
+    undefined removeTextTrack(TextTrack track);
     [SameObject, ImplementedAs=ensureAudioTracks] readonly attribute AudioTrackList audioTracks;
     [SameObject, ImplementedAs=ensureTextTracks] readonly attribute TextTrackList textTracks;
     [SameObject, ImplementedAs=ensureVideoTracks] readonly attribute VideoTrackList videoTracks;


### PR DESCRIPTION
#### c45604eac6d555f26647dc2eb9d0d190a75d24f8
<pre>
Add HTMLMediaElement.removeTextTrack()
<a href="https://bugs.webkit.org/show_bug.cgi?id=320404">https://bugs.webkit.org/show_bug.cgi?id=320404</a>
<a href="https://rdar.apple.com/183365541">rdar://183365541</a>

Reviewed by Jean-Yves Avenard.

Add removeTextTrack() to the HTMLMediaElement API, which takes as an
argument a track element that was added via HTMLMediaElement.addTextTrack().
It throws an exception if the media element does not contain that text track,
or if the track is a type other than AddTrack (meaning it was not added via
addTextTrack()).

Change the existing removeTextTrack(TextTrack&amp; track, bool scheduleEvent) to
return a bool indicating whether it succeeded at removing the track. Also
remove the default value for scheduleEvent, since it would otherwise be
ambiguous with the new single-argument overload.

Added new test: media/track/track-remove-text-track.html

* LayoutTests/media/track/track-remove-text-track-expected.txt: Added.
* LayoutTests/media/track/track-remove-text-track.html: Added.
* Source/WebCore/Modules/mediasource/MediaSource.cpp:
(WebCore::MediaSource::removeSourceBufferWithOptionalDestruction):
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::removeTextTrack):
(WebCore::HTMLMediaElement::willRemoveTextTrack):
(WebCore::HTMLMediaElement::didRemoveTextTrack):
(WebCore::HTMLMediaElement::forgetResourceSpecificTracks):
* Source/WebCore/html/HTMLMediaElement.h:
* Source/WebCore/html/HTMLMediaElement.idl:

Canonical link: <a href="https://commits.webkit.org/318250@main">https://commits.webkit.org/318250@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/77c9040b7bc00030b75f1574dfa332b184cf9d2f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177659 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51597 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45391 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187266 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140906 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/af1c9c0f-0275-4e79-87fb-b875b0137df9) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179522 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52889 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51306 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138475 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140906 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180615 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41984 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159212 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118939 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40645 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39014 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151052 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38708 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35730 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/43382 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43249 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189694 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51264 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/158743 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147578 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51946 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35336 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147368 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26951 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42082 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124161 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118574 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50454 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13685 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49850 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50090 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49912 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->