### PR TITLE
Add the Local Network Access check algorithm

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -422,6 +422,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     Modules/fetch/FetchRequestMode.h
     Modules/fetch/FetchResponse.h
     Modules/fetch/IPAddressSpace.h
+    Modules/fetch/LocalNetworkAccess.h
     Modules/fetch/RequestPriority.h
 
     Modules/filesystem/FileSystemDirectoryHandle.h

--- a/Source/WebCore/Modules/fetch/LocalNetworkAccess.cpp
+++ b/Source/WebCore/Modules/fetch/LocalNetworkAccess.cpp
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "LocalNetworkAccess.h"
+
+#include "IPAddressSpace.h"
+#include "ResourceRequest.h"
+#include "SecurityOrigin.h"
+#include "SecurityOriginData.h"
+
+namespace WebCore {
+
+std::optional<ResourceError> performLocalNetworkAccessCheck(const ResourceRequest& request, IPAddressSpace connectionAddressSpace, IPAddressSpace clientPolicyContainerAddressSpace, bool clientIsSecureContext, const SecurityOriginData& clientOrigin, NOESCAPE const LocalNetworkAccessPermissionCheckFunction& permissionCheck)
+{
+    if (shouldTreatAsPotentiallyTrustworthy(request.url()) && SecurityOriginData::fromURL(request.url()) == clientOrigin)
+        return std::nullopt;
+
+    if (connectionAddressSpace != IPAddressSpace::Unknown) {
+        if (request.targetAddressSpace() != IPAddressSpace::Public && request.targetAddressSpace() != connectionAddressSpace) {
+            return ResourceError { "WebKitErrorDomain"_s, 0, request.url(),
+                "Local Network Access: connection's resolved address space does not match the request's declared targetAddressSpace"_s,
+                ResourceError::Type::AccessControl };
+        }
+
+        if (!isLessPublicThan(connectionAddressSpace, clientPolicyContainerAddressSpace))
+            return std::nullopt;
+    }
+
+    auto error = ResourceError { "WebKitErrorDomain"_s, 0, request.url(),
+        "Local Network Access: connection to a less public address space than the requesting document was blocked"_s,
+        ResourceError::Type::AccessControl };
+
+    if (!clientIsSecureContext)
+        return error;
+
+    // FIXME: Per the spec, the permission check should be keyed on a PermissionName ("local-network" or
+    // "loopback-network" depending on connectionAddressSpace) looked up through PermissionController, not
+    // this bespoke callback. This stub exists because no such permission names are wired up yet.
+    switch (permissionCheck(clientOrigin, connectionAddressSpace)) {
+    case PermissionState::Granted:
+        return std::nullopt;
+    case PermissionState::Denied:
+    case PermissionState::Prompt:
+        return error;
+    }
+    return error;
+}
+
+} // namespace WebCore

--- a/Source/WebCore/Modules/fetch/LocalNetworkAccess.h
+++ b/Source/WebCore/Modules/fetch/LocalNetworkAccess.h
@@ -25,53 +25,20 @@
 
 #pragma once
 
-#include <wtf/HashFunctions.h>
-#include <wtf/HashTraits.h>
+#include <WebCore/PermissionState.h>
+#include <WebCore/ResourceError.h>
+#include <optional>
+#include <wtf/Forward.h>
+#include <wtf/Function.h>
 
 namespace WebCore {
 
-class IPAddress;
+enum class IPAddressSpace : uint8_t;
+class ResourceRequest;
+class SecurityOriginData;
 
-class Site;
+using LocalNetworkAccessPermissionCheckFunction = Function<PermissionState(const SecurityOriginData& clientOrigin, IPAddressSpace connectionAddressSpace)>;
 
-enum class IPAddressSpace : uint8_t {
-    Public,
-    Local,
-    Loopback,
-    Unknown
-};
-
-constexpr uint8_t publicnessRank(IPAddressSpace space)
-{
-    switch (space) {
-    case IPAddressSpace::Loopback:
-        return 0;
-    case IPAddressSpace::Local:
-        return 1;
-    case IPAddressSpace::Public:
-        return 2;
-    case IPAddressSpace::Unknown:
-        return 0;
-    }
-    return 2;
-}
-
-inline bool isLessPublicThan(IPAddressSpace a, IPAddressSpace b)
-{
-    return publicnessRank(a) < publicnessRank(b);
-}
-
-WEBCORE_EXPORT IPAddressSpace determineIPAddressSpace(const WTF::URL&);
-WEBCORE_EXPORT IPAddressSpace determineIPAddressSpace(const Site&);
-
-WEBCORE_EXPORT IPAddressSpace classifyIPAddressSpace(const IPAddress&);
+WEBCORE_EXPORT std::optional<ResourceError> performLocalNetworkAccessCheck(const ResourceRequest&, IPAddressSpace connectionAddressSpace, IPAddressSpace clientPolicyContainerAddressSpace, bool clientIsSecureContext, const SecurityOriginData& clientOrigin, NOESCAPE const LocalNetworkAccessPermissionCheckFunction&);
 
 } // namespace WebCore
-
-namespace WTF {
-
-template<> struct DefaultHash<WebCore::IPAddressSpace> : IntHash<WebCore::IPAddressSpace> { };
-template<> struct HashTraits<WebCore::IPAddressSpace> : StrongEnumHashTraits<WebCore::IPAddressSpace> { };
-
-} // namespace WTF
-

--- a/Source/WebCore/Modules/indexeddb/shared/IDBRequestData.h
+++ b/Source/WebCore/Modules/indexeddb/shared/IDBRequestData.h
@@ -57,7 +57,7 @@ public:
 
     enum IsolatedCopyTag { IsolatedCopy };
     IDBRequestData(const IDBRequestData&, IsolatedCopyTag);
-    WEBCORE_EXPORT IDBRequestData NODELETE isolatedCopy() const;
+    WEBCORE_EXPORT IDBRequestData isolatedCopy() const;
 
     IDBConnectionIdentifier NODELETE serverConnectionIdentifier() const;
     WEBCORE_EXPORT IDBResourceIdentifier NODELETE requestIdentifier() const;

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -136,6 +136,7 @@ Modules/fetch/FetchRequest.cpp @cost:3
 Modules/fetch/FetchResponse.cpp @cost:4
 Modules/fetch/FormDataConsumer.cpp
 Modules/fetch/IPAddressSpace.cpp
+Modules/fetch/LocalNetworkAccess.cpp
 Modules/fetch/WindowOrWorkerGlobalScopeFetch.cpp @cost:3
 Modules/filesystem/FileSystemDirectoryHandle.cpp
 Modules/filesystem/FileSystemFileHandle.cpp

--- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
+++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
@@ -1380,6 +1380,7 @@
 		3BB6B81122A7D313003A2A69 /* TabSize.h in Headers */ = {isa = PBXBuildFile; fileRef = 3BB6B80F22A7D311003A2A69 /* TabSize.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		3C244FEAA375AC633F88BE6F /* RenderLayerModelObject.h in Headers */ = {isa = PBXBuildFile; fileRef = 3C244FE4A375AC633F88BE6F /* RenderLayerModelObject.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		3C8D24EE2E25CF1A00D2A929 /* IPAddressSpace.h in Headers */ = {isa = PBXBuildFile; fileRef = 3C8D24ED2E25CF1A00D2A929 /* IPAddressSpace.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		58E9CA87641E10563C3CE61C /* LocalNetworkAccess.h in Headers */ = {isa = PBXBuildFile; fileRef = DAE4358201103A6E524EB9AE /* LocalNetworkAccess.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		3D42BC4514B0E28F44D62E77 /* UnifiedSource51-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6D90699809046B96AE290168 /* UnifiedSource51-header-RenderStyleGetters.cpp */; };
 		3D4E6A98F12B0C85A2C173D6 /* RenderLayerSVGAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 2C7B5F48E0A31D9467FB8C52 /* RenderLayerSVGAdditions.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		3F42B31D1881191B00278AAC /* WebVideoFullscreenControllerAVKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 3F42B31B1881191B00278AAC /* WebVideoFullscreenControllerAVKit.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -10904,6 +10905,8 @@
 		3C6A595F2E4E5D5300A908CC /* IPAddressSpace.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = IPAddressSpace.cpp; sourceTree = "<group>"; };
 		3C8D24ED2E25CF1A00D2A929 /* IPAddressSpace.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = IPAddressSpace.h; sourceTree = "<group>"; };
 		3CE7C6702E270278005CDFD8 /* IPAddressSpace.idl */ = {isa = PBXFileReference; lastKnownFileType = text; path = IPAddressSpace.idl; sourceTree = "<group>"; };
+		DAE4358201103A6E524EB9AE /* LocalNetworkAccess.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = LocalNetworkAccess.h; sourceTree = "<group>"; };
+		DAD333D76403A91488F601D7 /* LocalNetworkAccess.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = LocalNetworkAccess.cpp; sourceTree = "<group>"; };
 		3DCCA4B4BF1CEDC0C5E7B3BB /* Airplay.svg */ = {isa = PBXFileReference; lastKnownFileType = text; path = Airplay.svg; sourceTree = "<group>"; };
 		3EB98985C78E4C2A4C58889D /* UnifiedSource61-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource61-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
 		3F3BB5821E709EE400C701F2 /* CoreAudioCaptureSource.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CoreAudioCaptureSource.cpp; sourceTree = "<group>"; };
@@ -27939,6 +27942,8 @@
 				3C6A595F2E4E5D5300A908CC /* IPAddressSpace.cpp */,
 				3C8D24ED2E25CF1A00D2A929 /* IPAddressSpace.h */,
 				3CE7C6702E270278005CDFD8 /* IPAddressSpace.idl */,
+				DAD333D76403A91488F601D7 /* LocalNetworkAccess.cpp */,
+				DAE4358201103A6E524EB9AE /* LocalNetworkAccess.h */,
 				44CF5098299B906F0038D284 /* RequestPriority.h */,
 				44CF5097299B90600038D284 /* RequestPriority.idl */,
 				7C2E0BD125106AC4005F3C87 /* WindowOrWorkerGlobalScope+Fetch.idl */,
@@ -47301,6 +47306,7 @@
 				E35B907F23F60A50000011FF /* LocalizedDeviceModel.h in Headers */,
 				935207BE09BD410A00F2038D /* LocalizedStrings.h in Headers */,
 				550A0BCC085F6039007353D7 /* LocalNameWithNamespace.h in Headers */,
+				58E9CA87641E10563C3CE61C /* LocalNetworkAccess.h in Headers */,
 				41FCD6BB23CE027700C62567 /* LocalSampleBufferDisplayLayer.h in Headers */,
 				BCE1C41B0D982980003B02F2 /* Location.h in Headers */,
 				E3C788EE2D035C9500D6C13D /* LogClient.h in Headers */,

--- a/Tools/TestWebKitAPI/CMakeLists.txt
+++ b/Tools/TestWebKitAPI/CMakeLists.txt
@@ -243,6 +243,7 @@ if (ENABLE_WEBCORE)
         Tests/WebCore/KeyedCoding.cpp
         Tests/WebCore/LayoutRoundedRectTests.cpp
         Tests/WebCore/LayoutUnitTests.cpp
+        Tests/WebCore/LocalNetworkAccess.cpp
         Tests/WebCore/MIMESniffer.cpp
         Tests/WebCore/MIMETypeRegistry.cpp
         Tests/WebCore/MediaConstraintsTests.cpp

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -772,6 +772,7 @@
 				WebCore/KeyedCoding.cpp,
 				WebCore/LayoutRoundedRectTests.cpp,
 				WebCore/LayoutUnitTests.cpp,
+				WebCore/LocalNetworkAccess.cpp,
 				WebCore/Logging.cpp,
 				WebCore/LoginStatus.cpp,
 				WebCore/MarkedText.cpp,

--- a/Tools/TestWebKitAPI/Tests/WebCore/LocalNetworkAccess.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/LocalNetworkAccess.cpp
@@ -1,0 +1,201 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#include <WebCore/IPAddressSpace.h>
+#include <WebCore/LocalNetworkAccess.h>
+#include <WebCore/PermissionState.h>
+#include <WebCore/ResourceRequest.h>
+#include <WebCore/SecurityOriginData.h>
+
+namespace TestWebKitAPI {
+
+using namespace WebCore;
+
+static LocalNetworkAccessPermissionCheckFunction permissionCheckReturning(PermissionState decision)
+{
+    return [decision](const SecurityOriginData&, IPAddressSpace) {
+        return decision;
+    };
+}
+
+TEST(LocalNetworkAccess, SameOriginTrustworthyExemption)
+{
+    ResourceRequest request { URL { "https://example.com/"_s } };
+    auto clientOrigin = SecurityOriginData::fromURL(URL { "https://example.com/"_s });
+
+    auto error = performLocalNetworkAccessCheck(request, IPAddressSpace::Loopback, IPAddressSpace::Public, true, clientOrigin, permissionCheckReturning(PermissionState::Denied));
+    EXPECT_FALSE(error.has_value());
+}
+
+TEST(LocalNetworkAccess, SameOriginButNotTrustworthyIsNotExempt)
+{
+    ResourceRequest request { URL { "http://example.com/"_s } };
+    auto clientOrigin = SecurityOriginData::fromURL(URL { "http://example.com/"_s });
+
+    auto error = performLocalNetworkAccessCheck(request, IPAddressSpace::Loopback, IPAddressSpace::Public, true, clientOrigin, permissionCheckReturning(PermissionState::Denied));
+    ASSERT_TRUE(error.has_value());
+    EXPECT_TRUE(error->isAccessControl());
+}
+
+TEST(LocalNetworkAccess, CrossOriginIsNotExempt)
+{
+    ResourceRequest request { URL { "https://example.com/"_s } };
+    auto clientOrigin = SecurityOriginData::fromURL(URL { "https://other.com/"_s });
+
+    auto error = performLocalNetworkAccessCheck(request, IPAddressSpace::Loopback, IPAddressSpace::Public, true, clientOrigin, permissionCheckReturning(PermissionState::Denied));
+    ASSERT_TRUE(error.has_value());
+    EXPECT_TRUE(error->isAccessControl());
+}
+
+TEST(LocalNetworkAccess, MatchingTargetAddressSpaceStillRequiresPermission)
+{
+    ResourceRequest request { URL { "https://example.com/"_s } };
+    request.setTargetAddressSpace(IPAddressSpace::Loopback);
+    auto clientOrigin = SecurityOriginData::fromURL(URL { "https://other.com/"_s });
+
+    auto error = performLocalNetworkAccessCheck(request, IPAddressSpace::Loopback, IPAddressSpace::Public, true, clientOrigin, permissionCheckReturning(PermissionState::Denied));
+    ASSERT_TRUE(error.has_value());
+    EXPECT_TRUE(error->isAccessControl());
+}
+
+TEST(LocalNetworkAccess, MatchingTargetAddressSpaceAllowedWithGrant)
+{
+    ResourceRequest request { URL { "https://example.com/"_s } };
+    request.setTargetAddressSpace(IPAddressSpace::Loopback);
+    auto clientOrigin = SecurityOriginData::fromURL(URL { "https://other.com/"_s });
+
+    auto error = performLocalNetworkAccessCheck(request, IPAddressSpace::Loopback, IPAddressSpace::Public, true, clientOrigin, permissionCheckReturning(PermissionState::Granted));
+    EXPECT_FALSE(error.has_value());
+}
+
+TEST(LocalNetworkAccess, MismatchedTargetAddressSpaceIsBlocked)
+{
+    ResourceRequest request { URL { "https://example.com/"_s } };
+    request.setTargetAddressSpace(IPAddressSpace::Local);
+    auto clientOrigin = SecurityOriginData::fromURL(URL { "https://other.com/"_s });
+
+    auto error = performLocalNetworkAccessCheck(request, IPAddressSpace::Loopback, IPAddressSpace::Public, false, clientOrigin, permissionCheckReturning(PermissionState::Granted));
+    ASSERT_TRUE(error.has_value());
+    EXPECT_TRUE(error->isAccessControl());
+}
+
+TEST(LocalNetworkAccess, MorePublicConnectionIsAllowed)
+{
+    ResourceRequest request { URL { "https://example.com/"_s } };
+    auto clientOrigin = SecurityOriginData::fromURL(URL { "https://other.com/"_s });
+
+    auto error = performLocalNetworkAccessCheck(request, IPAddressSpace::Public, IPAddressSpace::Public, true, clientOrigin, permissionCheckReturning(PermissionState::Denied));
+    EXPECT_FALSE(error.has_value());
+}
+
+TEST(LocalNetworkAccess, LoopbackToLoopbackIsAllowedWithoutExplicitTargetAddressSpace)
+{
+    ResourceRequest request { URL { "https://example.com/"_s } };
+    auto clientOrigin = SecurityOriginData::fromURL(URL { "https://other.com/"_s });
+
+    auto error = performLocalNetworkAccessCheck(request, IPAddressSpace::Loopback, IPAddressSpace::Loopback, true, clientOrigin, permissionCheckReturning(PermissionState::Denied));
+    EXPECT_FALSE(error.has_value());
+}
+
+TEST(LocalNetworkAccess, NonSecureContextIsBlockedWithoutConsultingPermissionStub)
+{
+    ResourceRequest request { URL { "https://example.com/"_s } };
+    auto clientOrigin = SecurityOriginData::fromURL(URL { "https://other.com/"_s });
+
+    auto error = performLocalNetworkAccessCheck(request, IPAddressSpace::Loopback, IPAddressSpace::Public, false, clientOrigin, permissionCheckReturning(PermissionState::Granted));
+    ASSERT_TRUE(error.has_value());
+    EXPECT_TRUE(error->isAccessControl());
+}
+
+TEST(LocalNetworkAccess, SecureContextGrantedByPermissionStub)
+{
+    ResourceRequest request { URL { "https://example.com/"_s } };
+    auto clientOrigin = SecurityOriginData::fromURL(URL { "https://other.com/"_s });
+
+    auto error = performLocalNetworkAccessCheck(request, IPAddressSpace::Loopback, IPAddressSpace::Public, true, clientOrigin, permissionCheckReturning(PermissionState::Granted));
+    EXPECT_FALSE(error.has_value());
+}
+
+TEST(LocalNetworkAccess, SecureContextDeniedByPermissionStub)
+{
+    ResourceRequest request { URL { "https://example.com/"_s } };
+    auto clientOrigin = SecurityOriginData::fromURL(URL { "https://other.com/"_s });
+
+    auto error = performLocalNetworkAccessCheck(request, IPAddressSpace::Loopback, IPAddressSpace::Public, true, clientOrigin, permissionCheckReturning(PermissionState::Denied));
+    ASSERT_TRUE(error.has_value());
+    EXPECT_TRUE(error->isAccessControl());
+}
+
+TEST(LocalNetworkAccess, SecureContextPromptIsTreatedAsDenied)
+{
+    ResourceRequest request { URL { "https://example.com/"_s } };
+    auto clientOrigin = SecurityOriginData::fromURL(URL { "https://other.com/"_s });
+
+    auto error = performLocalNetworkAccessCheck(request, IPAddressSpace::Loopback, IPAddressSpace::Public, true, clientOrigin, permissionCheckReturning(PermissionState::Prompt));
+    ASSERT_TRUE(error.has_value());
+    EXPECT_TRUE(error->isAccessControl());
+}
+
+TEST(LocalNetworkAccess, UndeterminedConnectionSpaceInNonSecureContextIsBlocked)
+{
+    ResourceRequest request { URL { "https://example.com/"_s } };
+    auto clientOrigin = SecurityOriginData::fromURL(URL { "https://other.com/"_s });
+
+    auto error = performLocalNetworkAccessCheck(request, IPAddressSpace::Unknown, IPAddressSpace::Public, false, clientOrigin, permissionCheckReturning(PermissionState::Granted));
+    ASSERT_TRUE(error.has_value());
+    EXPECT_TRUE(error->isAccessControl());
+}
+
+TEST(LocalNetworkAccess, UndeterminedConnectionSpaceIsBlockedByDefaultPermission)
+{
+    ResourceRequest request { URL { "https://example.com/"_s } };
+    auto clientOrigin = SecurityOriginData::fromURL(URL { "https://other.com/"_s });
+
+    auto error = performLocalNetworkAccessCheck(request, IPAddressSpace::Unknown, IPAddressSpace::Public, true, clientOrigin, permissionCheckReturning(PermissionState::Denied));
+    ASSERT_TRUE(error.has_value());
+    EXPECT_TRUE(error->isAccessControl());
+}
+
+TEST(LocalNetworkAccess, UndeterminedConnectionSpaceCanStillBeGranted)
+{
+    ResourceRequest request { URL { "https://example.com/"_s } };
+    auto clientOrigin = SecurityOriginData::fromURL(URL { "https://other.com/"_s });
+
+    auto error = performLocalNetworkAccessCheck(request, IPAddressSpace::Unknown, IPAddressSpace::Public, true, clientOrigin, permissionCheckReturning(PermissionState::Granted));
+    EXPECT_FALSE(error.has_value());
+}
+
+TEST(LocalNetworkAccess, UndeterminedConnectionSpaceStillHonorsSameOriginTrustworthyExemption)
+{
+    ResourceRequest request { URL { "https://example.com/"_s } };
+    auto clientOrigin = SecurityOriginData::fromURL(URL { "https://example.com/"_s });
+
+    auto error = performLocalNetworkAccessCheck(request, IPAddressSpace::Unknown, IPAddressSpace::Public, true, clientOrigin, permissionCheckReturning(PermissionState::Denied));
+    EXPECT_FALSE(error.has_value());
+}
+
+} // namespace TestWebKitAPI


### PR DESCRIPTION
#### 8fd2cf727f53a99f2cd45d8d23858ce45d6d4ff1
<pre>
Add the Local Network Access check algorithm
<a href="https://bugs.webkit.org/show_bug.cgi?id=319907">https://bugs.webkit.org/show_bug.cgi?id=319907</a>
<a href="https://rdar.apple.com/182830329">rdar://182830329</a>

Reviewed by NOBODY (OOPS!).

Adds WebCore::performLocalNetworkAccessCheck(), implementing the algorithm from the WICG Local
Network Access spec (<a href="https://wicg.github.io/local-network-access/#fetching)">https://wicg.github.io/local-network-access/#fetching)</a>: a same-origin/trustworthy
exemption, a targetAddressSpace mismatch check, a publicness comparison via isLessPublicThan(), and a
fail-closed result for non-secure contexts.

The permission decision is not looked up directly. WebCore can&apos;t link against a NetworkProcess-resident
permission store, and no native Local Network Access prompt exists yet, so the function takes the
decision as a NOESCAPE callback returning WebCore::PermissionState (the existing Permissions API
decision type, rather than a bespoke duplicate). This keeps the algorithm a pure, self-contained
function: the caller supplies the lookup, and this patch&apos;s unit tests supply it directly. The
NetworkProcess-side permission store, its test-only IPC plumbing, and the enforcement call sites that
consume this function all land in the follow-up patch for bug 319908, which is what makes the check
observable to a browser user.

Also drops an incorrect NODELETE annotation on IDBRequestData::isolatedCopy() const, caught by
mac/ios-safer-cpp EWS and unrelated to the above.

* Source/WebCore/Headers.cmake:
* Source/WebCore/Modules/fetch/IPAddressSpace.h:
* Source/WebCore/Modules/fetch/LocalNetworkAccess.cpp: Added.
(WebCore::performLocalNetworkAccessCheck):
* Source/WebCore/Modules/fetch/LocalNetworkAccess.h: Added.
* Source/WebCore/Modules/indexeddb/shared/IDBRequestData.h:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/CMakeLists.txt:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebCore/LocalNetworkAccess.cpp: Added.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8fd2cf727f53a99f2cd45d8d23858ce45d6d4ff1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178059 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; check-webkit-style") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51997 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45792 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187672 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/141306 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179922 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53291 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51706 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138806 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96403 "1 flakes 4 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181016 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42346 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159555 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119262 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41012 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39363 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151412 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39053 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36130 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44596 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43606 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190099 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51665 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147940 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52347 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35678 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147716 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42427 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124610 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119080 "Build is in progress. Recent messages:Printed configuration; Checked out pull request") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50865 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14025 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50250 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50490 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50312 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->