### PR TITLE
libWebKitSwift.dylib is not loaded in some configurations

### DIFF
--- a/Source/WebKit/GPUProcess/mac/com.apple.WebKit.GPUProcess.sb.in
+++ b/Source/WebKit/GPUProcess/mac/com.apple.WebKit.GPUProcess.sb.in
@@ -68,11 +68,10 @@
     "IOAudioSelectorControl"
     "IOMobileFramebufferShim"))
 
-#if !RC_XBS
 ;; Allow development dylibs to be loaded
-(allow file-read* file-map-executable
-    (literal (string-append (param "WEBKIT2_FRAMEWORK_DIR") "/libWebKitSwift.dylib")))
-#endif
+(when (equal? (param "WK_FRAMEWORKS_ARE_RELOCATED") "YES")
+    (allow file-read* file-map-executable
+        (literal (string-append (param "WEBKIT2_FRAMEWORK_DIR") "/libWebKitSwift.dylib"))))
 
 (allow file-map-executable (subpath
     "/System/Library/Components"

--- a/Source/WebKit/Shared/mac/AuxiliaryProcessMac.mm
+++ b/Source/WebKit/Shared/mac/AuxiliaryProcessMac.mm
@@ -664,10 +664,17 @@ static void populateSandboxInitializationParameters(SandboxInitializationParamet
     }
 
     String bundlePath = webKit2BundleSingleton().bundlePath;
-    if (!bundlePath.startsWith("/System/Library/Frameworks"_s))
+    // A WebKit framework installed outside /System/Library/Frameworks (e.g. relocated into an
+    // app bundle by a spade Performance build, or a development install) is not covered by the
+    // system-framework or Cryptex file-map-executable sandbox grants, so the soft-linked
+    // libWebKitSwift.dylib cannot be mapped. Signal this relocated case to the sandbox so it can
+    // allow mapping that one dylib; shipping root and Cryptex installs are unaffected.
+    bool isRelocatedFramework = !bundlePath.startsWith("/System/Library/Frameworks"_s);
+    if (isRelocatedFramework)
         bundlePath = webKit2BundleSingleton().bundlePath.stringByDeletingLastPathComponent;
 
     sandboxParameters.addPathParameter("WEBKIT2_FRAMEWORK_DIR"_s, bundlePath.utf8().data());
+    sandboxParameters.addParameter("WK_FRAMEWORKS_ARE_RELOCATED"_s, isRelocatedFramework ? "YES"_span : "NO"_span);
     sandboxParameters.addConfDirectoryParameter("DARWIN_USER_TEMP_DIR"_s, _CS_DARWIN_USER_TEMP_DIR);
     sandboxParameters.addConfDirectoryParameter("DARWIN_USER_CACHE_DIR"_s, _CS_DARWIN_USER_CACHE_DIR);
 

--- a/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
+++ b/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
@@ -64,11 +64,10 @@
 
 (allow fs-quota-get)
 
-#if !RC_XBS
 ;; Allow development dylibs to be loaded
-(allow file-read* file-map-executable
-    (literal (string-append (param "WEBKIT2_FRAMEWORK_DIR") "/libWebKitSwift.dylib")))
-#endif
+(when (equal? (param "WK_FRAMEWORKS_ARE_RELOCATED") "YES")
+    (allow file-read* file-map-executable
+        (literal (string-append (param "WEBKIT2_FRAMEWORK_DIR") "/libWebKitSwift.dylib"))))
 
 #if HAVE(SANDBOX_STATE_FLAGS)
 (with-filter (require-not (webcontent-process-launched))

--- a/Source/WebKit/WebProcess/com.apple.WebProcess.x86.sb.in
+++ b/Source/WebKit/WebProcess/com.apple.WebProcess.x86.sb.in
@@ -62,11 +62,10 @@
 
 (allow fs-quota-get)
 
-#if !RC_XBS
 ;; Allow development dylibs to be loaded
-(allow file-read* file-map-executable
-    (literal (string-append (param "WEBKIT2_FRAMEWORK_DIR") "/libWebKitSwift.dylib")))
-#endif
+(when (equal? (param "WK_FRAMEWORKS_ARE_RELOCATED") "YES")
+    (allow file-read* file-map-executable
+        (literal (string-append (param "WEBKIT2_FRAMEWORK_DIR") "/libWebKitSwift.dylib"))))
 
 #if HAVE(SANDBOX_STATE_FLAGS)
 (with-filter (require-not (webcontent-process-launched))


### PR DESCRIPTION
#### 52773b38d5deafc9f5be68897872b8cbcfdb4bfd
<pre>
libWebKitSwift.dylib is not loaded in some configurations
<a href="https://bugs.webkit.org/show_bug.cgi?id=320478">https://bugs.webkit.org/show_bug.cgi?id=320478</a>
<a href="https://rdar.apple.com/183094727">rdar://183094727</a>

Reviewed by Per Arne Vollan.

The fix added to 307679@main supports loading libWebKitSwift.dylib
at runtime from local builds, but not from downloaded bundles
which also have their frameworks relocated.

Adjust 307679@main to support downloaded app bundles.

* Source/WebKit/GPUProcess/mac/com.apple.WebKit.GPUProcess.sb.in:
* Source/WebKit/Shared/mac/AuxiliaryProcessMac.mm:
(WebKit::populateSandboxInitializationParameters):
* Source/WebKit/WebProcess/com.apple.WebProcess.sb.in:
* Source/WebKit/WebProcess/com.apple.WebProcess.x86.sb.in:

Canonical link: <a href="https://commits.webkit.org/318266@main">https://commits.webkit.org/318266@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/25a4782ab9a3989aaa85d4e75f41ca84250fedbf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177548 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51486 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45280 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187152 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140795 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8639057e-0b6f-4a49-9879-d0759890f732) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52778 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51195 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138376 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140795 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2cd3924f-d44d-4162-b898-5af26624ef3e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180504 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41884 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159123 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118841 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/01ef2383-20a4-47b1-870b-aa9d7e9c2348) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40545 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38914 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150952 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38618 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35619 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/43271 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43148 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189580 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51153 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147477 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39675 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51835 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35247 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147269 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41978 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124050 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118462 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50343 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13597 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49739 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49979 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49801 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->