### PR TITLE
[css-conditional-5] @container style queries on pseudo-element's host element uses old style data

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/pseudo-elements-005-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/pseudo-elements-005-expected.txt
@@ -1,5 +1,5 @@
 
 PASS ::before pseudo element querying style() of originating element
 PASS ::before pseudo element not matching style()
-FAIL ::before pseudo element matching style() query after class change assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 0, 0)"
+PASS ::before pseudo element matching style() query after class change
 

--- a/Source/WebCore/style/ContainerQueryEvaluator.cpp
+++ b/Source/WebCore/style/ContainerQueryEvaluator.cpp
@@ -68,13 +68,15 @@ bool ContainerQueryEvaluator::evaluate(const CQ::ContainerQuery& containerQuery)
     return false;
 }
 
-static const Style::ComputedStyle* styleForContainer(const Element& container, CQ::ContainerRequirements requirements, const ContainerQueryEvaluationState* evaluationState)
+static CheckedPtr<const ComputedStyle> styleForContainer(const Element& container, CQ::ContainerRequirements requirements, const ContainerQueryEvaluationState* evaluationState)
 {
     // Queries that don't need a size container (style and scroll-state queries) resolve
     // against the container's style, which may not be committed to the render tree yet.
     // Look it up from the currently computed style update instead.
-    if (!requirements.needsSizeContainer() && evaluationState && evaluationState->styleUpdate)
-        return evaluationState->styleUpdate->elementStyle(container);
+    if (!requirements.needsSizeContainer() && evaluationState && evaluationState->newStyleDuringResolutionMap) {
+        if (CheckedPtr newContainerStyle = evaluationState->newStyleDuringResolutionMap->get(container))
+            return newContainerStyle;
+    }
 
     return container.existingComputedStyle();
 }
@@ -105,7 +107,7 @@ auto ContainerQueryEvaluator::featureEvaluationContextForCondition(const CQ::Con
 
     Ref document = element->document();
 
-    CheckedPtr rootStyle = [&] () -> const Style::ComputedStyle* {
+    auto rootStyle = [&] () -> CheckedPtr<const Style::ComputedStyle> {
         RefPtr rootElement = document->documentElement();
         if (!rootElement)
             return nullptr;

--- a/Source/WebCore/style/ContainerQueryEvaluator.h
+++ b/Source/WebCore/style/ContainerQueryEvaluator.h
@@ -28,6 +28,7 @@
 #include "GenericMediaQueryEvaluator.h"
 #include "StyleScopeOrdinal.h"
 #include "StyleUpdate.h"
+#include <wtf/Box.h>
 #include <wtf/Ref.h>
 
 namespace WebCore {
@@ -36,9 +37,18 @@ class Element;
 
 namespace Style {
 
+using NewStyleDuringResolutionMap = WeakHashMap<Element, std::unique_ptr<ComputedStyle>, WeakPtrImplWithEventTargetData>;
+
 struct ContainerQueryEvaluationState {
     Vector<Ref<const Element>> sizeQueryContainers;
-    CheckedPtr<Style::Update> styleUpdate;
+
+    // During style resolution, newly resolved styles aren't committed to the
+    // render tree until the render tree is updated, which occurs after style
+    // resolution. Container style queries rely on fresh style data that was
+    // resolved during style resolution but not committed yet. This map lives
+    // in TreeResolver and is updated with newly resolved styles once they're
+    // produced, so the container query evaluator can use it.
+    Box<NewStyleDuringResolutionMap> newStyleDuringResolutionMap;
 };
 
 class ContainerQueryEvaluator : public MQ::GenericMediaQueryEvaluator<ContainerQueryEvaluator> {

--- a/Source/WebCore/style/StyleTreeResolver.cpp
+++ b/Source/WebCore/style/StyleTreeResolver.cpp
@@ -101,7 +101,7 @@ TreeResolver::~TreeResolver()
     m_document->styleScope().updateAnchorPositioningStateAfterStyleResolution();
 }
 
-TreeResolver::Scope::Scope(Document& document, Update& update)
+TreeResolver::Scope::Scope(Document& document, Box<NewStyleDuringResolutionMap> newStyleDuringResolutionMap)
     : resolver(document.styleScope().resolver())
 {
     document.setIsResolvingTreeStyle(true);
@@ -110,7 +110,7 @@ TreeResolver::Scope::Scope(Document& document, Update& update)
     for (Ref shadowRoot : document.inDocumentShadowRoots())
         const_cast<ShadowRoot&>(shadowRoot.get()).styleScope().resolver();
 
-    selectorMatchingState.containerQueryEvaluationState.styleUpdate = &update;
+    selectorMatchingState.containerQueryEvaluationState.newStyleDuringResolutionMap = WTF::move(newStyleDuringResolutionMap);
 }
 
 TreeResolver::Scope::Scope(ShadowRoot& shadowRoot, Scope& enclosingScope)
@@ -375,6 +375,8 @@ auto TreeResolver::resolveElement(Element& element, const Style::ComputedStyle* 
             descendantsToResolve = DescendantsToResolve::All;
         }
     }
+
+    m_newStyleDuringResolutionMap->add(element, ComputedStyle::clonePtr(*update.style));
 
     auto resolveAndAddPseudoElementStyle = [&](const PseudoElementIdentifier& pseudoElementIdentifier) {
         const Style::ComputedStyle* existingPseudoStyle = existingStyle ? existingStyle->pseudoElementStyle(pseudoElementIdentifier) : nullptr;
@@ -1514,7 +1516,10 @@ std::unique_ptr<Update> TreeResolver::resolve()
 
     if (!m_update)
         m_update = makeUnique<Update>(m_document);
-    m_scopeStack.append(adoptRef(*new Scope(m_document, *m_update)));
+
+    m_newStyleDuringResolutionMap->clear();
+
+    m_scopeStack.append(adoptRef(*new Scope(m_document, m_newStyleDuringResolutionMap)));
     m_parentStack.append(Parent(m_document));
 
     resolveComposedTree();

--- a/Source/WebCore/style/StyleTreeResolver.h
+++ b/Source/WebCore/style/StyleTreeResolver.h
@@ -117,7 +117,7 @@ private:
         RefPtr<ShadowRoot> shadowRoot;
         RefPtr<Scope> enclosingScope;
 
-        Scope(Document&, Update&);
+        Scope(Document&, Box<NewStyleDuringResolutionMap>);
         Scope(ShadowRoot&, Scope& enclosingScope);
         ~Scope();
     };
@@ -254,6 +254,15 @@ private:
     bool m_allAnchorNamesInvalid { false };
 
     std::unique_ptr<Update> m_update;
+
+    // Stores new styles that was produced during style resolution.
+    // This is different then m_update: m_update is updated after styles of
+    // pseudo-elements are resolved. On the other hands, this map is updated
+    // immediately after the (non-pseudo) element style is resolved. This is
+    // threaded to ContainerQueryEvaluator for evaluating style queries. See
+    // ContainerQueryEvaluationState for more details.
+    // NOTE: stored styles do not contain pseudo-element's styles.
+    Box<NewStyleDuringResolutionMap> m_newStyleDuringResolutionMap { Box<NewStyleDuringResolutionMap>::create() };
 };
 
 // Integrate with the HTML5 event loop instead, see EventLoop.cpp and consumers.


### PR DESCRIPTION
#### bd7ffafffdad6b3d68373b526c0939a71313aa67
<pre>
[css-conditional-5] @container style queries on pseudo-element&apos;s host element uses old style data
<a href="https://rdar.apple.com/183158814">rdar://183158814</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=320220">https://bugs.webkit.org/show_bug.cgi?id=320220</a>

Reviewed by Antti Koivisto.

During style resolution, new styles aren&apos;t committed to the render tree right away.
Instead, they&apos;re packaged into a Style::Update, and once style resolution completes,
it&apos;s passed to RenderTreeUpdater to update the styles in the render tree. @container
style queries should be evaluated against the newest style of the container element.
But the queries are evaluated during style resolution, when new styles aren&apos;t committed
to the render tree yet. Hence evaluating against the current (stale) render style might
lead to incorrect results.

ContainerQueryEvaluator has a clever workaround: it has access to the Style::Update
object, so it gets the freshest possible style of a container element from there,
and falls back to the render style if a style isn&apos;t in Update. The Update object is
threaded from TreeResolver -&gt; TreeResolver::Scope -&gt; SelectorMatchingState
-&gt; ContainerQueryEvaluationState -&gt; used by Style::styleForContainer to get the style
for style query evaluation.

However, during style resolution of an element, the timing when the Update object is
updated doesn&apos;t work for @container style queries affecting a pseudo-element.

1) resolve the element&apos;s style
2) resolve its pseudo-elements&apos; styles
  2.1) @container queries are evaluated if a @container rule affects a pseudo-element
3) the element&apos;s and its psuedo-elements&apos; styles are addded to the Update object

When 2.1) runs, @container style queries are evaluated against the container element,
which is the host. But the host&apos;s new style resolved in 1) is not added to the Update
object yet, since it&apos;s only done in 3) after all pseudo-elements&apos; styles are resolved.
Hence ContainerQueryEvaluator will use the (stale) host&apos;s render style.

Since the order can&apos;t be change, this patch fixes the bug by maintaining our own
WeakHashMap to store freshly resolved styles. This way, we control when styles are
added to the hashmap and aren&apos;t dependent on Update. ContainerQueryEvaluator is
changed to use this hashmap, and we thread it from TreeResolver to ContainerQueryEvaluator
the same way the Update object is threaded before.

For memory safety, ref-count the hash map using Box&lt;&gt;, so we can pass its pointers
around without fear of use-after-free.

Test: imported/w3c/web-platform-tests/css/css-conditional/container-queries/pseudo-elements-005.html

* LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/pseudo-elements-005-expected.txt:
* Source/WebCore/style/ContainerQueryEvaluator.cpp:
(WebCore::Style::styleForContainer):
(WebCore::Style::ContainerQueryEvaluator::featureEvaluationContextForCondition const):
* Source/WebCore/style/ContainerQueryEvaluator.h:
* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::Scope::Scope):
(WebCore::Style::TreeResolver::resolveElement):
(WebCore::Style::TreeResolver::resolve):
* Source/WebCore/style/StyleTreeResolver.h:

Canonical link: <a href="https://commits.webkit.org/319186@main">https://commits.webkit.org/319186@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/41d3c9d087acaee26e0744122d8a0b586573214a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180653 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54598 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48396 "Build is in progress. Recent messages:OS: Tahoe (26.5.1), Xcode: 26.5; Checked out pull request; Compiled WebKit (warnings); Compiled WebKit (warnings)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190864 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144975 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5a2bd0f7-8645-4dd7-ae48-fa22974fbc8b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182515 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55896 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54314 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140905 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97622 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b28fe285-f827-4cc4-9be8-235f5887117c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183608 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44580 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161680 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121357 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1fd280cf-4b30-43d8-80d4-a9101ab22516) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/43253 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41535 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153657 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41209 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2025 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47207 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45790 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192800 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54264 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150285 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40241 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54952 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37826 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/held.https.any.sharedworker.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150002 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44618 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127217 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122433 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53469 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16202 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52851 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53088 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52916 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->