### PR TITLE
Stream IPC message receivers can dispatch synchronous messages to Swift

### DIFF
--- a/Source/WebKit/Platform/IPC/HandleMessage.h
+++ b/Source/WebKit/Platform/IPC/HandleMessage.h
@@ -514,11 +514,14 @@ void handleMessageSynchronous(StreamServerConnection& connection, Decoder& decod
     using CompletionHandlerType = typename ValidationType::CompletionHandlerType;
 
     logMessage(connection, MessageType::name(), object, *arguments);
+    auto completionHandler = ValidationType::wrapCompletionHandler(CompletionHandlerType(
+    [syncRequestID = decoder.syncRequestID(), connection = protect(connection)] (auto&&... args) mutable {
+        logReply(connection, MessageType::name(), args...);
+        connection->sendSyncReply<MessageType>(syncRequestID, std::forward<decltype(args)>(args)...);
+    }));
+
     callMemberFunction(object, function, WTF::move(*arguments),
-        CompletionHandlerType([syncRequestID = decoder.syncRequestID(), connection = protect(connection)] (auto&&... args) mutable {
-            logReply(connection, MessageType::name(), args...);
-            connection->sendSyncReply<MessageType>(syncRequestID, std::forward<decltype(args)>(args)...);
-        }));
+        ValidationType::unwrapCompletionHandler(std::forward<decltype(completionHandler)>(completionHandler)));
 }
 
 template<typename MessageType, typename C, typename T, typename U, typename MF>

--- a/Source/WebKit/Scripts/webkit/tests/MessageArgumentDescriptions.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/MessageArgumentDescriptions.cpp
@@ -289,6 +289,8 @@ std::optional<JSC::JSValue> jsValueForArguments(JSC::JSGlobalObject* globalObjec
         return jsValueForDecodedMessage<MessageName::TestWithStreamServerConnectionHandle_SendStreamServerConnection>(globalObject, decoder);
     case MessageName::TestWithStreamSwift_SendString:
         return jsValueForDecodedMessage<MessageName::TestWithStreamSwift_SendString>(globalObject, decoder);
+    case MessageName::TestWithStreamSwift_SendStringSync:
+        return jsValueForDecodedMessage<MessageName::TestWithStreamSwift_SendStringSync>(globalObject, decoder);
     case MessageName::TestWithSuperclass_LoadURL:
         return jsValueForDecodedMessage<MessageName::TestWithSuperclass_LoadURL>(globalObject, decoder);
 #if ENABLE(TEST_FEATURE)
@@ -432,6 +434,8 @@ std::optional<JSC::JSValue> jsValueForReplyArguments(JSC::JSGlobalObject* global
     case MessageName::TestWithStream_SendAndReceiveMachSendRight:
         return jsValueForDecodedMessageReply<MessageName::TestWithStream_SendAndReceiveMachSendRight>(globalObject, decoder);
 #endif
+    case MessageName::TestWithStreamSwift_SendStringSync:
+        return jsValueForDecodedMessageReply<MessageName::TestWithStreamSwift_SendStringSync>(globalObject, decoder);
 #if ENABLE(TEST_FEATURE)
     case MessageName::TestWithSuperclass_TestAsyncMessage:
         return jsValueForDecodedMessageReply<MessageName::TestWithSuperclass_TestAsyncMessage>(globalObject, decoder);
@@ -1071,6 +1075,10 @@ std::optional<Vector<ArgumentDescription>> messageArgumentDescriptions(MessageNa
         return Vector<ArgumentDescription> {
             { "url"_s, "String"_s },
         };
+    case MessageName::TestWithStreamSwift_SendStringSync:
+        return Vector<ArgumentDescription> {
+            { "url"_s, "String"_s },
+        };
     case MessageName::TestWithSuperclass_LoadURL:
         return Vector<ArgumentDescription> {
             { "url"_s, "String"_s },
@@ -1314,6 +1322,10 @@ std::optional<Vector<ArgumentDescription>> messageReplyArgumentDescriptions(Mess
             { "r1"_s, "MachSendRight"_s },
         };
 #endif
+    case MessageName::TestWithStreamSwift_SendStringSync:
+        return Vector<ArgumentDescription> {
+            { "returnValue"_s, "int64_t"_s },
+        };
 #if ENABLE(TEST_FEATURE)
     case MessageName::TestWithSuperclass_TestAsyncMessage:
         return Vector<ArgumentDescription> {

--- a/Source/WebKit/Scripts/webkit/tests/MessageNames.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/MessageNames.cpp
@@ -195,6 +195,7 @@ const MessageDescriptionsArray messageDescriptions {
     MessageDescription { "SyncMessageReply"_s, ReceiverName::IPC, false, false, false, ProcessName::Unknown, ProcessName::Unknown },
     MessageDescription { "TestWithLegacyReceiver_GetPluginProcessConnection"_s, ReceiverName::TestWithLegacyReceiver, true, false, false, ProcessName::Unknown, ProcessName::Unknown },
     MessageDescription { "TestWithLegacyReceiver_TestMultipleAttributes"_s, ReceiverName::TestWithLegacyReceiver, true, false, false, ProcessName::Unknown, ProcessName::Unknown },
+    MessageDescription { "TestWithStreamSwift_SendStringSync"_s, ReceiverName::TestWithStreamSwift, true, false, false, ProcessName::Unknown, ProcessName::Unknown },
 #if PLATFORM(COCOA)
     MessageDescription { "TestWithStream_ReceiveMachSendRight"_s, ReceiverName::TestWithStream, true, false, false, ProcessName::Unknown, ProcessName::Unknown },
     MessageDescription { "TestWithStream_SendAndReceiveMachSendRight"_s, ReceiverName::TestWithStream, true, false, false, ProcessName::Unknown, ProcessName::Unknown },

--- a/Source/WebKit/Scripts/webkit/tests/MessageNames.h
+++ b/Source/WebKit/Scripts/webkit/tests/MessageNames.h
@@ -244,6 +244,7 @@ enum class MessageName : uint16_t {
     LastAsynchronous = FirstSynchronous - 1,
     TestWithLegacyReceiver_GetPluginProcessConnection,
     TestWithLegacyReceiver_TestMultipleAttributes,
+    TestWithStreamSwift_SendStringSync,
 #if PLATFORM(COCOA)
     TestWithStream_ReceiveMachSendRight,
     TestWithStream_SendAndReceiveMachSendRight,

--- a/Source/WebKit/Scripts/webkit/tests/TestWithStreamSwift.messages.in
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithStreamSwift.messages.in
@@ -28,4 +28,5 @@
 ]
 messages -> TestWithStreamSwift Stream {
     void SendString(String url)
+    void SendStringSync(String url) -> (int64_t returnValue) Synchronous
 }

--- a/Source/WebKit/Scripts/webkit/tests/TestWithStreamSwiftMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithStreamSwiftMessageReceiver.cpp
@@ -47,6 +47,10 @@ void TestWithStreamSwiftMessageForwarder::didReceiveStreamMessage(IPC::StreamSer
         IPC::handleMessage<Messages::TestWithStreamSwift::SendString>(connection, decoder, target.get(), &TestWithStreamSwift::sendString);
         return;
     }
+    if (decoder.messageName() == Messages::TestWithStreamSwift::SendStringSync::name()) {
+        IPC::handleMessageSynchronous<Messages::TestWithStreamSwift::SendStringSync>(connection, decoder, target.get(), &TestWithStreamSwift::sendStringSync);
+        return;
+    }
     RELEASE_LOG_ERROR(IPC, "Unhandled stream message %s to %" PRIu64, IPC::description(decoder.messageName()).characters(), decoder.destinationID());
     decoder.markInvalid();
 }
@@ -84,6 +88,14 @@ namespace IPC {
 template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithStreamSwift_SendString>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
 {
     return jsValueForDecodedArguments<Messages::TestWithStreamSwift::SendString::Arguments>(globalObject, decoder);
+}
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithStreamSwift_SendStringSync>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+{
+    return jsValueForDecodedArguments<Messages::TestWithStreamSwift::SendStringSync::Arguments>(globalObject, decoder);
+}
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessageReply<MessageName::TestWithStreamSwift_SendStringSync>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+{
+    return jsValueForDecodedArguments<Messages::TestWithStreamSwift::SendStringSync::ReplyArguments>(globalObject, decoder);
 }
 
 }

--- a/Source/WebKit/Scripts/webkit/tests/TestWithStreamSwiftMessages.h
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithStreamSwiftMessages.h
@@ -96,12 +96,43 @@ private:
     const String& m_url;
 };
 
+class SendStringSync {
+public:
+    using Arguments = std::tuple<String>;
+
+    static IPC::MessageName name() { return IPC::MessageName::TestWithStreamSwift_SendStringSync; }
+    static constexpr bool isSync = true;
+    static constexpr bool canDispatchOutOfOrder = false;
+    static constexpr bool replyCanDispatchOutOfOrder = false;
+    static constexpr bool deferSendingIfSuspended = false;
+    static constexpr bool isStreamEncodable = true;
+    static constexpr bool isReplyStreamEncodable = true;
+    static constexpr bool isStreamBatched = false;
+
+    static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;
+    using ReplyArguments = std::tuple<int64_t>;
+    using Reply = CompletionHandler<void(int64_t)>;
+    explicit SendStringSync(const String& url)
+        : m_url(url)
+    {
+    }
+
+    template<typename Encoder>
+    void encode(Encoder& encoder)
+    {
+        encoder << m_url;
+    }
+
+private:
+    const String& m_url;
+};
+
 } // namespace TestWithStreamSwift
 } // namespace Messages
 
 namespace CompletionHandlers {
 namespace TestWithStreamSwift {
-
+using SendStringSyncCompletionHandler = WTF::RefCountable<Messages::TestWithStreamSwift::SendStringSync::Reply>;
 } // namespace TestWithStreamSwift
 } // namespace CompletionHandlers
 


### PR DESCRIPTION
#### 578b578ca162593e05818162b33ff99dd3975952
<pre>
Stream IPC message receivers can dispatch synchronous messages to Swift

<a href="https://bugs.webkit.org/show_bug.cgi?id=320481">https://bugs.webkit.org/show_bug.cgi?id=320481</a>
<a href="https://rdar.apple.com/183448505">rdar://183448505</a>

Reviewed by Mike Wyrzykowski.

Stream IPC message receivers can now be implemented in Swift, but a
synchronous message on such a receiver does not build. IPC::handleMessageSynchronous
constructs the reply completion handler itself, and its StreamServerConnection
overload builds a bare CompletionHandler rather than routing it through
MethodSignatureValidation::wrapCompletionHandler, unlike the Connection overload
and handleMessageAsync. A Swift handler takes its completion handler as a
WTF::RefCountable&lt;CompletionHandler&lt;...&gt;&gt;*, because a CompletionHandler is not
itself reference counted and Swift needs an ARC-managed reference to keep it
alive until the reply is sent, so a Swift receiver with a Synchronous message
cannot be dispatched.

Wrap and unwrap the completion handler in the stream overload exactly as the
non-stream overload does. For C++ receivers wrapCompletionHandler and
unwrapCompletionHandler are std::identity, so existing stream receivers are
unaffected. This is a prerequisite for moving RemoteMesh, whose
PaintCurrentFrameToImageBuffer message is synchronous, to Swift.

Adds a Synchronous message to the TestWithStreamSwift fixture in
messages_unittest.py, giving the stream Swift receiver combination codegen
coverage. The generated output is the same either way, so the fixture does not
exercise the fix itself; that is covered when a Swift stream receiver is first
compiled.

* Source/WebKit/Platform/IPC/HandleMessage.h:
(IPC::handleMessageSynchronous):
* Source/WebKit/Scripts/webkit/tests/MessageArgumentDescriptions.cpp:
* Source/WebKit/Scripts/webkit/tests/MessageNames.cpp:
* Source/WebKit/Scripts/webkit/tests/MessageNames.h:
* Source/WebKit/Scripts/webkit/tests/TestWithStreamSwift.messages.in:
* Source/WebKit/Scripts/webkit/tests/TestWithStreamSwiftMessageReceiver.cpp:
* Source/WebKit/Scripts/webkit/tests/TestWithStreamSwiftMessages.h:

Canonical link: <a href="https://commits.webkit.org/318141@main">https://commits.webkit.org/318141@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ca2e91b2c370c9575512596c1edc36071027e829

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177296 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51234 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45028 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186899 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140543 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9f5e3bb1-ba04-4aae-99ab-b3a5e8e581e2) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52526 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50923 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138156 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140543 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7b82d3c0-81c4-4f8b-958b-e23cb3b7ab50) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180252 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41659 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158925 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118621 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/11aeabe3-4d47-4d74-9130-69d750ba93fc) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/176619 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40320 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38701 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150728 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38422 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35367 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/43019 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42915 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189328 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50900 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147250 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39592 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51583 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35049 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147042 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41768 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123798 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118132 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50091 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13400 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49487 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49727 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49549 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->