### PR TITLE
[JSC] Add fast operation for Array#shift

### DIFF
--- a/JSTests/stress/array-shift-intrinsic.js
+++ b/JSTests/stress/array-shift-intrinsic.js
@@ -52,7 +52,7 @@ noInline(drain);
     }
 })();
 
-// Multi-element Int32: drains via slow path (operationArrayShift).
+// Multi-element Int32: drains via the element-move path (operationArrayShiftElements).
 (function () {
     for (var i = 0; i < testLoopCount; ++i) {
         var results = drain([1, 2, 3, 4, 5]);
@@ -65,7 +65,7 @@ noInline(drain);
     }
 })();
 
-// Multi-element Double: drains via slow path.
+// Multi-element Double: drains via the element-move path.
 (function () {
     for (var i = 0; i < testLoopCount; ++i) {
         var results = drain([1.5, 2.5, 3.5, 4.5]);
@@ -77,7 +77,7 @@ noInline(drain);
     }
 })();
 
-// Multi-element Contiguous: drains via slow path.
+// Multi-element Contiguous: drains via the element-move path.
 (function () {
     for (var i = 0; i < testLoopCount; ++i) {
         var results = drain(["a", "b", "c"]);
@@ -132,6 +132,272 @@ noInline(drain);
     }
 })();
 
+// Length >= 2 with a hole at index 0: the element-move operation must bail to the
+// generic path (it returns the empty value without mutating the array).
+(function () {
+    for (var i = 0; i < testLoopCount; ++i) {
+        var array = [1, 2, 3];
+        delete array[0];
+        shouldBe(array.length, 3);
+        shouldBe(shiftOnce(array), undefined);
+        shouldBe(array.length, 2);
+        shouldBe(array[0], 2);
+        shouldBe(array[1], 3);
+    }
+})();
+
+// Length >= 2 with a hole in the middle: the hole moves down like any other value.
+(function () {
+    for (var i = 0; i < testLoopCount; ++i) {
+        var array = [1, 2, 3];
+        delete array[1];
+        shouldBe(shiftOnce(array), 1);
+        shouldBe(array.length, 2);
+        shouldBe(0 in array, false);
+        shouldBe(array[0], undefined);
+        shouldBe(array[1], 3);
+    }
+})();
+
+// Length == 128 (JSArray::shiftThreshold) takes the element-move path; length == 129
+// takes the generic path. Both must produce the same result.
+(function () {
+    for (var i = 0; i < testLoopCount; ++i) {
+        var a128 = [];
+        for (var j = 0; j < 128; ++j)
+            a128.push(j);
+        shouldBe(shiftOnce(a128), 0);
+        shouldBe(a128.length, 127);
+        shouldBe(a128[0], 1);
+        shouldBe(a128[126], 127);
+
+        var a129 = [];
+        for (var j = 0; j < 129; ++j)
+            a129.push(j);
+        shouldBe(shiftOnce(a129), 0);
+        shouldBe(a129.length, 128);
+        shouldBe(a129[0], 1);
+        shouldBe(a129[127], 128);
+    }
+})();
+
+// Same boundary with Contiguous (string) elements.
+(function () {
+    for (var i = 0; i < testLoopCount; ++i) {
+        var a128 = [];
+        for (var j = 0; j < 128; ++j)
+            a128.push("v" + j);
+        shouldBe(shiftOnce(a128), "v0");
+        shouldBe(a128.length, 127);
+        shouldBe(a128[0], "v1");
+        shouldBe(a128[126], "v127");
+
+        var a129 = [];
+        for (var j = 0; j < 129; ++j)
+            a129.push("v" + j);
+        shouldBe(shiftOnce(a129), "v0");
+        shouldBe(a129.length, 128);
+        shouldBe(a129[0], "v1");
+        shouldBe(a129[127], "v128");
+    }
+})();
+
+// Arrays whose structure is no longer primordial still take the intrinsic: the
+// element-move path is disabled for them, but the length 0 and length 1 paths move
+// no elements and stay inlined, and every length must still shift correctly.
+(function () {
+    function shiftNonOriginal(array) {
+        return array.shift();
+    }
+    noInline(shiftNonOriginal);
+
+    for (var i = 0; i < testLoopCount; ++i) {
+        var empty = [];
+        empty.extra = 1;
+        shouldBe(shiftNonOriginal(empty), undefined);
+        shouldBe(empty.length, 0);
+
+        var one = [7];
+        one.extra = 1;
+        shouldBe(shiftNonOriginal(one), 7);
+        shouldBe(one.length, 0);
+
+        var many = [1, 2, 3];
+        many.extra = 1;
+        shouldBe(shiftNonOriginal(many), 1);
+        shouldBe(many.length, 2);
+        shouldBe(many[0], 2);
+        shouldBe(many[1], 3);
+    }
+})();
+
+// Same, on an Array subclass, which also has a non-primordial structure.
+(function () {
+    class MyArray extends Array { }
+
+    function shiftSubclass(array) {
+        return array.shift();
+    }
+    noInline(shiftSubclass);
+
+    for (var i = 0; i < testLoopCount; ++i) {
+        var array = new MyArray();
+        array.push(1, 2, 3);
+        shouldBe(shiftSubclass(array), 1);
+        shouldBe(array.length, 2);
+        shouldBe(array[0], 2);
+        shouldBe(array[1], 3);
+        shouldBe(shiftSubclass(array), 2);
+        shouldBe(shiftSubclass(array), 3);
+        shouldBe(shiftSubclass(array), undefined);
+        shouldBe(array.length, 0);
+    }
+})();
+
+// Element-move boundaries around JSArray::shiftThreshold (128), which is the
+// largest length the intrinsic moves elements for. Assert every slot, not just
+// the returned value, for Int32, Double and Contiguous elements.
+(function () {
+    function checkShift(length, makeElement) {
+        var array = [];
+        for (var j = 0; j < length; ++j)
+            array.push(makeElement(j));
+
+        shouldBe(shiftOnce(array), makeElement(0));
+        shouldBe(array.length, length - 1);
+        for (var j = 0; j < length - 1; ++j)
+            shouldBe(array[j], makeElement(j + 1));
+        shouldBe(array[length - 1], undefined);
+    }
+
+    var int32Element = function (j) { return j + 1; };
+    var doubleElement = function (j) { return j + 0.5; };
+    var stringElement = function (j) { return "v" + j; };
+
+    for (var i = 0; i < testLoopCount; ++i) {
+        for (var length of [2, 3, 4, 5, 127, 128, 129]) {
+            checkShift(length, int32Element);
+            checkShift(length, doubleElement);
+            checkShift(length, stringElement);
+        }
+    }
+})();
+
+// Double arrays cannot tell a hole from a stored NaN: both read back as PNaN, so
+// the element move bails on either and lets the generic path decide. A hole must
+// shift in undefined, a real NaN must shift out NaN, and both must leave the
+// remaining elements correct. Values that are easy to corrupt in a raw double
+// move (-0, the infinities) must survive with their bit patterns intact.
+(function () {
+    for (var i = 0; i < testLoopCount; ++i) {
+        var hole = [1.5, 2.5, 3.5, 4.5];
+        delete hole[0];
+        shouldBe(shiftOnce(hole), undefined);
+        shouldBe(hole.length, 3);
+        shouldBe(hole[0], 2.5);
+        shouldBe(hole[2], 4.5);
+
+        var nan = [NaN, 2.5, 3.5, 4.5];
+        var shifted = shiftOnce(nan);
+        shouldBe(shifted !== shifted, true);
+        shouldBe(nan.length, 3);
+        shouldBe(nan[0], 2.5);
+        shouldBe(nan[2], 4.5);
+
+        var nanInMiddle = [1.5, NaN, 3.5, 4.5];
+        shouldBe(shiftOnce(nanInMiddle), 1.5);
+        shouldBe(nanInMiddle[0] !== nanInMiddle[0], true);
+        shouldBe(nanInMiddle[1], 3.5);
+
+        var signedZero = [1.5, -0, 2.5, 3.5];
+        shouldBe(shiftOnce(signedZero), 1.5);
+        shouldBe(1 / signedZero[0], -Infinity);
+
+        var infinities = [1.5, Infinity, -Infinity, 2.5];
+        shouldBe(shiftOnce(infinities), 1.5);
+        shouldBe(infinities[0], Infinity);
+        shouldBe(infinities[1], -Infinity);
+    }
+})();
+
+// A hole at slot 0 must leave the array unmutated before the generic path takes
+// over: the element move reports the hole without touching the elements.
+(function () {
+    for (var i = 0; i < testLoopCount; ++i) {
+        for (var length of [2, 3, 5, 128]) {
+            var array = [];
+            for (var j = 0; j < length; ++j)
+                array.push(j + 1);
+            delete array[0];
+
+            shouldBe(shiftOnce(array), undefined);
+            shouldBe(array.length, length - 1);
+            for (var j = 0; j < length - 1; ++j)
+                shouldBe(array[j], j + 2);
+        }
+    }
+})();
+
+// Draining walks one array down through every length, so a single call site sees
+// the element move, then the length 1 case, then the length 0 case.
+(function () {
+    for (var i = 0; i < testLoopCount; ++i) {
+        var array = [];
+        for (var j = 0; j < 20; ++j)
+            array.push("d" + j);
+
+        for (var j = 0; j < 20; ++j) {
+            shouldBe(array.length, 20 - j);
+            shouldBe(shiftOnce(array), "d" + j);
+        }
+        shouldBe(array.length, 0);
+        shouldBe(shiftOnce(array), undefined);
+    }
+})();
+
+// Shifting a Contiguous array moves cell references down into slots the
+// concurrent marker may already have scanned, which is why the element move ends
+// with a write barrier on the array. Shift cells while allocating and collecting,
+// keeping the moved-down cells reachable only through the array.
+(function () {
+    function shiftCells(array) {
+        return array.shift();
+    }
+    noInline(shiftCells);
+
+    for (var i = 0; i < 100; ++i) {
+        var array = [];
+        for (var j = 0; j < 64; ++j)
+            array.push({ index: j, payload: "p" + j });
+
+        // Promote the array out of eden so it can be scanned before we mutate it.
+        gc();
+
+        for (var j = 0; j < 32; ++j) {
+            var shifted = shiftCells(array);
+            shouldBe(shifted.index, j);
+
+            // Allocate to drive the collector forward while the array holds the
+            // moved-down cells.
+            for (var k = 0; k < 100; ++k)
+                new Object();
+            if (!(j % 8))
+                edenGC();
+
+            // Every surviving cell must still be intact and correctly ordered.
+            shouldBe(array.length, 63 - j);
+            shouldBe(array[0].index, j + 1);
+            shouldBe(array[0].payload, "p" + (j + 1));
+            shouldBe(array[array.length - 1].index, 63);
+        }
+    }
+})();
+
+// Everything below pollutes Array.prototype with an indexed property, which
+// permanently invalidates the arrayPrototypeChainIsSane watchpoint for the rest of
+// this VM: deleting the property again does not re-arm it. Any test that needs the
+// intrinsic's element-move path must run before this point.
+
 // With Array.prototype[0] set, a length-1 hole array must shift to the
 // prototype value. The intrinsic's slow path (operationArrayShift) reads
 // through the prototype chain via getIndex.
@@ -152,5 +418,31 @@ noInline(drain);
         shouldBe(array.length, 0);
     } finally {
         delete Array.prototype[0];
+    }
+})();
+
+// Polluting Array.prototype with an indexed property invalidates the
+// arrayPrototypeChainIsSane watchpoint. Compiled code must fall back to the
+// generic path, where a hole reads through the prototype chain.
+(function () {
+    function shiftIsolated(array) {
+        return array.shift();
+    }
+    noInline(shiftIsolated);
+
+    for (var i = 0; i < testLoopCount; ++i)
+        shiftIsolated([i, i + 1, i + 2]);
+
+    Array.prototype[1] = "proto-one";
+    try {
+        var array = [10, 20, 30];
+        delete array[1];
+        shouldBe(array.length, 3);
+        shouldBe(shiftIsolated(array), 10);
+        shouldBe(array.length, 2);
+        shouldBe(array[0], "proto-one");
+        shouldBe(array[1], 30);
+    } finally {
+        delete Array.prototype[1];
     }
 })();

--- a/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
@@ -1836,6 +1836,19 @@ private:
         case ArrayShift: {
             blessArrayOperation(node->child1(), Edge(), node->child2());
             fixEdge<KnownCellUse>(node->child1());
+
+            // The element-move path moves elements without consulting the prototype, which is
+            // valid only when the structure speculation pins the array prototype and the prototype
+            // chain is known to be sane. Without InBoundsSaneChain the backends emit only the
+            // length 0 and length 1 paths, which never look at the prototype, and route everything
+            // else to operationArrayShift, which does its own prototype check.
+            //
+            // setSaneChainIfPossible() is not usable here: it also clears NodeMustGenerate, which
+            // is only sound for pure loads. ArrayShift mutates the array, so it must stay
+            // must-generate even when its result is unused.
+            ArrayMode arrayMode = node->arrayMode();
+            if (arrayMode.isJSArrayWithOriginalStructure() && watchSaneChain(node))
+                node->setArrayMode(arrayMode.withSpeculation(Array::InBoundsSaneChain));
             break;
         }
 

--- a/Source/JavaScriptCore/dfg/DFGOperations.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOperations.cpp
@@ -48,6 +48,7 @@
 #include "FTLForOSREntryJITCode.h"
 #include "FTLOSREntry.h"
 #include "FrameTracers.h"
+#include "GCMemoryOperations.h"
 #include "HasOwnPropertyCache.h"
 #include "Interpreter.h"
 #include "InterpreterInlines.h"
@@ -1346,6 +1347,102 @@ JSC_DEFINE_JIT_OPERATION(operationArrayShift, EncodedJSValue, (JSGlobalObject* g
     scope.release();
     setLength(globalObject, vm, array, length - 1);
     OPERATION_RETURN(scope, JSValue::encode(front));
+}
+
+// Preconditions shared by the operationArrayShiftElements* family, which the JIT caller and the
+// array mode speculation together guarantee.
+static ALWAYS_INLINE void assertArrayShiftElementsPreconditions(JSArray* array, unsigned length)
+{
+    UNUSED_PARAM(array);
+    UNUSED_PARAM(length);
+    ASSERT(length >= 2 && length <= JSArray::shiftThreshold);
+    // JSArray::fastShift starts with ensureWritable(vm). We can skip that because
+    // ArrayMode::fromObserved forces Array::Convert whenever a CopyOnWrite mode was observed for a
+    // write, so checkArray has already arrayified the butterfly. indexingType() masks off the
+    // CopyOnWrite bit and so cannot catch a violation on its own: writing into a shared
+    // JSImmutableButterfly would silently corrupt every array sharing it.
+    ASSERT(!isCopyOnWrite(array->indexingMode()));
+    // fastShift also checks holesMustForwardToPrototype() before moving anything. We can skip that
+    // because the ArrayShift case in FixupPhase only marks the array mode sane chain once the
+    // structure speculation pins the array prototype and the arrayPrototypeChainIsSane watchpoint
+    // is registered, which is exactly when that check returns false.
+    ASSERT(!array->holesMustForwardToPrototype());
+}
+
+// Element-move core of fastShift for small non-CopyOnWrite arrays whose prototype chain is known to
+// be sane. There is one entry point per indexing type because the caller speculates on the array
+// mode and so knows statically which one applies. Each returns the empty value without mutating the
+// array when element 0 cannot be handled here, so the caller can fall back to the generic shift
+// path. The caller guarantees 2 <= length <= JSArray::shiftThreshold.
+JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationArrayShiftElementsInt32, EncodedJSValue, (VM* vmPointer, JSArray* array))
+{
+    VM& vm = *vmPointer;
+    CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
+    JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
+
+    ASSERT(array->indexingType() == ArrayWithInt32);
+    Butterfly* butterfly = array->butterfly();
+    unsigned length = butterfly->publicLength();
+    assertArrayShiftElementsPreconditions(array, length);
+
+    JSValue result = butterfly->contiguous().at(array, 0).get();
+    if (!result) [[unlikely]]
+        return JSValue::encode(JSValue());
+
+    unsigned moveCount = length - 1;
+    // Int32 elements are not cells, so this needs neither gcSafeMemmove nor a write barrier.
+    memmove(butterfly->contiguous().data(), butterfly->contiguous().data() + 1, sizeof(JSValue) * moveCount);
+    butterfly->contiguous().at(array, moveCount).clear();
+    butterfly->setPublicLength(moveCount);
+    return JSValue::encode(result);
+}
+
+JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationArrayShiftElementsContiguous, EncodedJSValue, (VM* vmPointer, JSArray* array))
+{
+    VM& vm = *vmPointer;
+    CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
+    JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
+
+    ASSERT(array->indexingType() == ArrayWithContiguous);
+    Butterfly* butterfly = array->butterfly();
+    unsigned length = butterfly->publicLength();
+    assertArrayShiftElementsPreconditions(array, length);
+
+    JSValue result = butterfly->contiguous().at(array, 0).get();
+    if (!result) [[unlikely]]
+        return JSValue::encode(JSValue());
+
+    unsigned moveCount = length - 1;
+    gcSafeMemmove(butterfly->contiguous().data(), butterfly->contiguous().data() + 1, sizeof(JSValue) * moveCount);
+    butterfly->contiguous().at(array, moveCount).clear();
+    butterfly->setPublicLength(moveCount);
+    vm.writeBarrier(array);
+    return JSValue::encode(result);
+}
+
+JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationArrayShiftElementsDouble, EncodedJSValue, (VM* vmPointer, JSArray* array))
+{
+    VM& vm = *vmPointer;
+    CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
+    JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
+
+    ASSERT(array->indexingType() == ArrayWithDouble);
+    Butterfly* butterfly = array->butterfly();
+    unsigned length = butterfly->publicLength();
+    assertArrayShiftElementsPreconditions(array, length);
+
+    double result = butterfly->contiguousDouble().at(array, 0);
+    // A hole reads back as PNaN and is indistinguishable from a real NaN element, so both bail to
+    // the generic path, which sorts out which one it was.
+    if (result != result) [[unlikely]]
+        return JSValue::encode(JSValue());
+
+    unsigned moveCount = length - 1;
+    // Doubles are not cells, so this needs neither gcSafeMemmove nor a write barrier.
+    memmove(butterfly->contiguousDouble().data(), butterfly->contiguousDouble().data() + 1, sizeof(double) * moveCount);
+    butterfly->contiguousDouble().at(array, moveCount) = PNaN;
+    butterfly->setPublicLength(moveCount);
+    return JSValue::encode(JSValue(JSValue::EncodeAsDouble, result));
 }
 
 static ALWAYS_INLINE JSValue arrayUnshiftSingleImpl(JSGlobalObject* globalObject, VM& vm, JSArray* array, JSValue value)

--- a/Source/JavaScriptCore/dfg/DFGOperations.h
+++ b/Source/JavaScriptCore/dfg/DFGOperations.h
@@ -225,6 +225,9 @@ JSC_DECLARE_JIT_OPERATION(operationArrayPushDoubleMultiple, EncodedJSValue, (JSG
 JSC_DECLARE_JIT_OPERATION(operationArrayPop, EncodedJSValue, (JSGlobalObject*, JSArray*));
 JSC_DECLARE_JIT_OPERATION(operationArrayPopAndRecoverLength, EncodedJSValue, (JSGlobalObject*, JSArray*));
 JSC_DECLARE_JIT_OPERATION(operationArrayShift, EncodedJSValue, (JSGlobalObject*, JSArray*));
+JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationArrayShiftElementsInt32, EncodedJSValue, (VM*, JSArray*));
+JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationArrayShiftElementsContiguous, EncodedJSValue, (VM*, JSArray*));
+JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationArrayShiftElementsDouble, EncodedJSValue, (VM*, JSArray*));
 JSC_DECLARE_JIT_OPERATION(operationArrayUnshift, EncodedJSValue, (JSGlobalObject*, JSArray*, EncodedJSValue));
 JSC_DECLARE_JIT_OPERATION(operationArrayUnshiftDouble, EncodedJSValue, (JSGlobalObject*, JSArray*, double));
 JSC_DECLARE_JIT_OPERATION(operationArrayUnshiftMultiple, EncodedJSValue, (JSGlobalObject*, JSArray*, EncodedJSValue* buffer, int32_t elementCount));

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
@@ -41,6 +41,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 #include "DateInstance.h"
 #include "HasOwnPropertyCache.h"
 #include "IteratorOperations.h"
+#include "JSArray.h"
 #include "JSMap.h"
 #include "JSMapIterator.h"
 #include "JSPromise.h"
@@ -4507,64 +4508,80 @@ void SpeculativeJIT::compile(Node* node)
     case ArrayShift: {
         ASSERT(node->arrayMode().isJSArray());
 
+        Array::Type arrayType = node->arrayMode().type();
+        auto shiftElementsOperation = [&] {
+            switch (arrayType) {
+            case Array::Int32:
+                return operationArrayShiftElementsInt32;
+            case Array::Contiguous:
+                return operationArrayShiftElementsContiguous;
+            case Array::Double:
+                return operationArrayShiftElementsDouble;
+            default:
+                DFG_CRASH(m_graph, node, "Bad array mode");
+                return operationArrayShiftElementsInt32;
+            }
+        }();
+        bool isDouble = arrayType == Array::Double;
+
         SpeculateCellOperand base(this, node->child1());
         StorageOperand storage(this, node->child2());
         GPRTemporary value(this);
         GPRTemporary storageLength(this);
+        std::optional<FPRTemporary> temp;
 
         GPRReg baseGPR = base.gpr();
         GPRReg storageGPR = storage.gpr();
         GPRReg valueGPR = value.gpr();
         GPRReg storageLengthGPR = storageLength.gpr();
-
-        switch (node->arrayMode().type()) {
-        case Array::Int32:
-        case Array::Contiguous: {
-            JumpList slowCases;
-            load32(Address(storageGPR, Butterfly::offsetOfPublicLength()), storageLengthGPR);
-            Jump undefinedCase = branchTest32(Zero, storageLengthGPR);
-            slowCases.append(branch32(NotEqual, storageLengthGPR, TrustedImm32(1)));
-
-            load64(Address(storageGPR), valueGPR);
-            slowCases.append(branchIfEmpty(valueGPR));
-
-            storeTrustedValue(JSValue(), Address(storageGPR));
-            store32(TrustedImm32(0), Address(storageGPR, Butterfly::offsetOfPublicLength()));
-
-            addSlowPathGenerator(slowPathMove(undefinedCase, this, TrustedImm64(JSValue::encode(jsUndefined())), valueGPR));
-            addSlowPathGenerator(slowPathCall(slowCases, this, operationArrayShift, valueGPR, LinkableConstant::globalObject(*this, node), baseGPR));
-
-            jsValueResult(valueGPR, node);
-            break;
+        FPRReg tempFPR = InvalidFPRReg;
+        if (isDouble) {
+            temp.emplace(this);
+            tempFPR = temp->fpr();
         }
 
-        case Array::Double: {
-            FPRTemporary temp(this);
-            FPRReg tempFPR = temp.fpr();
+        JumpList slowCases;
+        JumpList doneCases;
+        load32(Address(storageGPR, Butterfly::offsetOfPublicLength()), storageLengthGPR);
+        auto undefinedCase = branchTest32(Zero, storageLengthGPR);
+        auto notOneCase = branch32(NotEqual, storageLengthGPR, TrustedImm32(1));
 
-            JumpList slowCases;
-            load32(Address(storageGPR, Butterfly::offsetOfPublicLength()), storageLengthGPR);
-            Jump undefinedCase = branchTest32(Zero, storageLengthGPR);
-            slowCases.append(branch32(NotEqual, storageLengthGPR, TrustedImm32(1)));
-
+        // length == 1, fully inlined. It moves no elements, so it needs no guarantee about the
+        // prototype chain.
+        if (isDouble) {
             loadDouble(Address(storageGPR), tempFPR);
             slowCases.append(branchIfNaN(tempFPR));
             boxDouble(tempFPR, valueGPR);
-
             store64(TrustedImm64(std::bit_cast<int64_t>(PNaN)), Address(storageGPR));
-            store32(TrustedImm32(0), Address(storageGPR, Butterfly::offsetOfPublicLength()));
-
-            addSlowPathGenerator(slowPathMove(undefinedCase, this, TrustedImm64(JSValue::encode(jsUndefined())), valueGPR));
-            addSlowPathGenerator(slowPathCall(slowCases, this, operationArrayShift, valueGPR, LinkableConstant::globalObject(*this, node), baseGPR));
-
-            jsValueResult(valueGPR, node);
-            break;
+        } else {
+            load64(Address(storageGPR), valueGPR);
+            slowCases.append(branchIfEmpty(valueGPR));
+            storeTrustedValue(JSValue(), Address(storageGPR));
         }
+        store32(TrustedImm32(0), Address(storageGPR, Butterfly::offsetOfPublicLength()));
 
-        default:
-            DFG_CRASH(m_graph, node, "Bad array mode");
-            break;
-        }
+        if (node->arrayMode().isInBoundsSaneChain()) {
+            doneCases.append(jump());
+            // 2 <= length <= JSArray::shiftThreshold. FixupPhase only marks the array mode sane
+            // chain when the elements can be moved without re-checking the prototype chain. This
+            // is the case the node exists to speed up, so the call stays inline rather than going
+            // out of line through a slow path generator.
+            notOneCase.link(this);
+            slowCases.append(branch32(Above, storageLengthGPR, TrustedImm32(JSArray::shiftThreshold)));
+            silentSpillAllRegisters(valueGPR);
+            callOperationWithoutExceptionCheck(shiftElementsOperation, valueGPR, TrustedImmPtr(&vm()), baseGPR);
+            silentFillAllRegisters();
+
+            // The operation returns the empty value when it cannot handle element 0, so fall back to the generic shift then.
+            slowCases.append(branchIfEmpty(valueGPR));
+        } else
+            slowCases.append(notOneCase);
+
+        addSlowPathGenerator(slowPathMove(undefinedCase, this, TrustedImm64(JSValue::encode(jsUndefined())), valueGPR));
+        addSlowPathGenerator(slowPathCall(slowCases, this, operationArrayShift, valueGPR, LinkableConstant::globalObject(*this, node), baseGPR));
+
+        doneCases.link(this);
+        jsValueResult(valueGPR, node);
         break;
     }
 

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -80,6 +80,7 @@
 #include "JITRightShiftGenerator.h"
 #include "JITSubGenerator.h"
 #include "JITThunks.h"
+#include "JSArray.h"
 #include "JSArrayIterator.h"
 #include "JSAsyncFromSyncIterator.h"
 #include "JSAsyncFunction.h"
@@ -9092,76 +9093,73 @@ IGNORE_CLANG_WARNINGS_END
 
     void compileArrayShift()
     {
-        // Inlined code handles length = 0 and length = 1 case. Otherwise, calling operation.
         JSGlobalObject* globalObject = m_graph.globalObjectFor(m_origin.semantic);
         LValue base = lowCell(m_node->child1());
         LValue storage = lowStorage(m_node->child2());
 
         switch (m_node->arrayMode().type()) {
         case Array::Int32:
+        case Array::Double:
         case Array::Contiguous: {
             IndexedAbstractHeap& heap = m_heaps.forArrayType(m_node->arrayMode().type());
+            bool isDouble = m_node->arrayMode().type() == Array::Double;
+            bool canShiftElements = m_node->arrayMode().isInBoundsSaneChain();
+            auto shiftElementsOperation = [&] {
+                switch (m_node->arrayMode().type()) {
+                case Array::Int32:
+                    return operationArrayShiftElementsInt32;
+                case Array::Contiguous:
+                    return operationArrayShiftElementsContiguous;
+                default:
+                    ASSERT(m_node->arrayMode().type() == Array::Double);
+                    return operationArrayShiftElementsDouble;
+                }
+            }();
 
             LBasicBlock checkLengthOne = m_out.newBlock();
+            LBasicBlock checkSmallShift = canShiftElements ? m_out.newBlock() : nullptr;
+            LBasicBlock shiftElementsCase = canShiftElements ? m_out.newBlock() : nullptr;
             LBasicBlock loadCase = m_out.newBlock();
             LBasicBlock fastDone = m_out.newBlock();
             LBasicBlock slowCase = m_out.newBlock();
             LBasicBlock continuation = m_out.newBlock();
 
+            // Where length != 1 goes: the element-move path when we are allowed to use it,
+            // otherwise straight to the generic shift.
+            LBasicBlock notLengthOneCase = canShiftElements ? checkSmallShift : slowCase;
+
             LValue prevLength = m_out.load32(storage, m_heaps.Butterfly_publicLength);
 
-            Vector<ValueFromBlock, 3> results;
+            Vector<ValueFromBlock, 4> results;
             results.append(m_out.anchor(m_out.constInt64(JSValue::encode(jsUndefined()))));
             m_out.branch(m_out.isZero32(prevLength), rarely(continuation), usually(checkLengthOne));
 
-            LBasicBlock lastNext = m_out.appendTo(checkLengthOne, loadCase);
-            m_out.branch(m_out.equal(prevLength, m_out.int32One), usually(loadCase), rarely(slowCase));
+            LBasicBlock lastNext = m_out.appendTo(checkLengthOne, notLengthOneCase);
+            // Moving elements is the case this node exists to speed up, so it is the likely one.
+            m_out.branch(m_out.equal(prevLength, m_out.int32One), rarely(loadCase), usually(notLengthOneCase));
 
+            if (canShiftElements) {
+                m_out.appendTo(checkSmallShift, shiftElementsCase);
+                m_out.branch(m_out.above(prevLength, m_out.constInt32(JSArray::shiftThreshold)), rarely(slowCase), usually(shiftElementsCase));
+
+                m_out.appendTo(shiftElementsCase, loadCase);
+                LValue shiftResult = vmCall(Int64, shiftElementsOperation, m_vmValue, base);
+                // The operation returns the empty value when it cannot handle element 0.
+                results.append(m_out.anchor(shiftResult));
+                m_out.branch(m_out.notZero64(shiftResult), usually(continuation), rarely(slowCase));
+            }
+
+            // length == 1. This moves no elements, so it needs no prototype chain guarantee.
             m_out.appendTo(loadCase, fastDone);
             TypedPointer pointer = m_out.baseIndex(heap, storage, m_out.intPtrZero);
-            LValue result = m_out.load64(pointer);
-            m_out.branch(m_out.notZero64(result), usually(fastDone), rarely(slowCase));
+            LValue loadedValue = isDouble ? m_out.loadDouble(pointer) : m_out.load64(pointer);
+            LValue isUsable = isDouble ? m_out.doubleEqual(loadedValue, loadedValue) : m_out.notZero64(loadedValue);
+            m_out.branch(isUsable, usually(fastDone), rarely(slowCase));
 
             m_out.appendTo(fastDone, slowCase);
-            m_out.store64(m_out.constInt64(JSValue::encode(JSValue())), pointer);
+            m_out.store64(m_out.constInt64(isDouble ? std::bit_cast<int64_t>(PNaN) : static_cast<int64_t>(JSValue::encode(JSValue()))), pointer);
             m_out.store32(m_out.int32Zero, storage, m_heaps.Butterfly_publicLength);
-            results.append(m_out.anchor(result));
-            m_out.jump(continuation);
-
-            m_out.appendTo(slowCase, continuation);
-            results.append(m_out.anchor(vmCall(Int64, operationArrayShift, weakPointer(globalObject), base)));
-            m_out.jump(continuation);
-
-            m_out.appendTo(continuation, lastNext);
-            setJSValue(m_out.phi(Int64, results));
-            return;
-        }
-
-        case Array::Double: {
-            LBasicBlock checkLengthOne = m_out.newBlock();
-            LBasicBlock loadCase = m_out.newBlock();
-            LBasicBlock fastDone = m_out.newBlock();
-            LBasicBlock slowCase = m_out.newBlock();
-            LBasicBlock continuation = m_out.newBlock();
-
-            LValue prevLength = m_out.load32(storage, m_heaps.Butterfly_publicLength);
-
-            Vector<ValueFromBlock, 3> results;
-            results.append(m_out.anchor(m_out.constInt64(JSValue::encode(jsUndefined()))));
-            m_out.branch(m_out.isZero32(prevLength), rarely(continuation), usually(checkLengthOne));
-
-            LBasicBlock lastNext = m_out.appendTo(checkLengthOne, loadCase);
-            m_out.branch(m_out.equal(prevLength, m_out.int32One), usually(loadCase), rarely(slowCase));
-
-            m_out.appendTo(loadCase, fastDone);
-            TypedPointer pointer = m_out.baseIndex(m_heaps.indexedDoubleProperties, storage, m_out.intPtrZero);
-            LValue resultDouble = m_out.loadDouble(pointer);
-            m_out.branch(m_out.doubleEqual(resultDouble, resultDouble), usually(fastDone), rarely(slowCase));
-
-            m_out.appendTo(fastDone, slowCase);
-            m_out.store64(m_out.constInt64(std::bit_cast<int64_t>(PNaN)), pointer);
-            m_out.store32(m_out.int32Zero, storage, m_heaps.Butterfly_publicLength);
-            results.append(m_out.anchor(boxDouble(resultDouble)));
+            results.append(m_out.anchor(isDouble ? boxDouble(loadedValue) : loadedValue));
             m_out.jump(continuation);
 
             m_out.appendTo(slowCase, continuation);

--- a/Source/JavaScriptCore/runtime/JSArray.cpp
+++ b/Source/JavaScriptCore/runtime/JSArray.cpp
@@ -1418,8 +1418,6 @@ JSValue JSArray::fastShift(VM& vm)
     Butterfly* butterfly = this->butterfly();
     auto indexingType = this->indexingType();
 
-    constexpr unsigned shiftThreshold = 128;
-
     switch (indexingType) {
     case ArrayClass:
         return jsUndefined();
@@ -1669,7 +1667,7 @@ bool JSArray::shiftCountWithArrayStorage(VM& vm, unsigned startIndex, unsigned c
     return true;
 }
 
-bool JSArray::shiftCountWithAnyIndexingType(JSGlobalObject* globalObject, unsigned& startIndex, unsigned count, unsigned shiftThreshold)
+bool JSArray::shiftCountWithAnyIndexingType(JSGlobalObject* globalObject, unsigned& startIndex, unsigned count, unsigned shiftArrayStorageThreshold)
 {
     VM& vm = globalObject->vm();
     RELEASE_ASSERT(count > 0);
@@ -1694,7 +1692,7 @@ bool JSArray::shiftCountWithAnyIndexingType(JSGlobalObject* globalObject, unsign
         
         // We may have to walk the entire array to do the shift. We're willing to do
         // so only if it's not horribly slow.
-        if (oldLength - (startIndex + count) >= MIN_SPARSE_ARRAY_INDEX || oldLength > shiftThreshold)
+        if (oldLength - (startIndex + count) >= MIN_SPARSE_ARRAY_INDEX || oldLength > shiftArrayStorageThreshold)
             return shiftCountWithArrayStorage(vm, startIndex, count, ensureArrayStorage(vm));
 
         // Storing to a hole is fine since we're still having a good time. But reading from a hole
@@ -1739,7 +1737,7 @@ bool JSArray::shiftCountWithAnyIndexingType(JSGlobalObject* globalObject, unsign
         
         // We may have to walk the entire array to do the shift. We're willing to do
         // so only if it's not horribly slow.
-        if (oldLength - (startIndex + count) >= MIN_SPARSE_ARRAY_INDEX || oldLength > shiftThreshold)
+        if (oldLength - (startIndex + count) >= MIN_SPARSE_ARRAY_INDEX || oldLength > shiftArrayStorageThreshold)
             return shiftCountWithArrayStorage(vm, startIndex, count, ensureArrayStorage(vm));
 
         // Storing to a hole is fine since we're still having a good time. But reading from a hole 

--- a/Source/JavaScriptCore/runtime/JSArray.h
+++ b/Source/JavaScriptCore/runtime/JSArray.h
@@ -108,6 +108,8 @@ public:
     JS_EXPORT_PRIVATE JSValue pop(JSGlobalObject*);
     JSValue fastShift(VM&);
 
+    static constexpr unsigned shiftThreshold = 128;
+
     static JSArray* fastSlice(JSGlobalObject*, JSObject* source, uint64_t startIndex, uint64_t count);
 
     bool holesMustForwardToPrototype() const;
@@ -151,10 +153,8 @@ public:
     template<ShiftCountMode shiftCountMode>
     bool shiftCount(JSGlobalObject* globalObject, unsigned& startIndex, unsigned count)
     {
-        constexpr unsigned shiftThreashold = 128;
-        UNUSED_VARIABLE(shiftThreashold);
         if constexpr (shiftCountMode == ShiftCountForShift)
-            return shiftCountWithAnyIndexingType(globalObject, startIndex, count, shiftThreashold);
+            return shiftCountWithAnyIndexingType(globalObject, startIndex, count, shiftThreshold);
         else if constexpr (shiftCountMode == ShiftCountForSplice)
             return shiftCountWithAnyIndexingType(globalObject, startIndex, count, UINT32_MAX);
         RELEASE_ASSERT_NOT_REACHED();


### PR DESCRIPTION
#### 960adeccefcd5f0320489e46f1aa4af764983853
<pre>
[JSC] Add fast operation for Array#shift
<a href="https://bugs.webkit.org/show_bug.cgi?id=320484">https://bugs.webkit.org/show_bug.cgi?id=320484</a>
<a href="https://rdar.apple.com/183450092">rdar://183450092</a>

Reviewed by Yijia Huang.

This patch adds optimized code for Array#shift by leveraging ArrayMode-based speculation.

1. We are already emitting Write based ArrayMode in DFGByteCodeParser.
   So blessArrayOperation can ensure that this is not CoW array
   (otherwise, we convert them).
2. Based on that, we further speculate InBoundsSaneChain status, which
   subscribes a watchpoint.
3. With (2), we no longer need to care about holes. They should just go
   to all the [[Prototype]] and getting undefined without side-effect.
   This makes Array#shift operation simpler by just moving elements.
4. DFG and FTL supports 0, 1, &lt;= 128 elements cases efficiently. 0 And 1
   are handled inline, and small array shift is handled in exremely
   optimized operation (I tried doing this inline and it had negative
   effect rather).

* JSTests/stress/array-shift-intrinsic.js:
(shiftNonOriginal):
(MyArray):
(shiftSubclass):
(checkShift):
(int32Element):
(doubleElement):
(stringElement):
(shiftCells):
(shiftIsolated):
* Source/JavaScriptCore/dfg/DFGFixupPhase.cpp:
(JSC::DFG::FixupPhase::fixupNode):
* Source/JavaScriptCore/dfg/DFGOperations.cpp:
(JSC::DFG::assertArrayShiftElementsPreconditions):
(JSC::DFG::JSC_DEFINE_NOEXCEPT_JIT_OPERATION):
* Source/JavaScriptCore/dfg/DFGOperations.h:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp:
(JSC::DFG::SpeculativeJIT::compile):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileArrayShift):
* Source/JavaScriptCore/runtime/JSArray.cpp:
(JSC::JSArray::fastShift):
(JSC::JSArray::shiftCountWithAnyIndexingType):
* Source/JavaScriptCore/runtime/JSArray.h:
(JSC::JSArray::shiftCount):

Canonical link: <a href="https://commits.webkit.org/318132@main">https://commits.webkit.org/318132@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/04ed5737bbbe4ef67284417f03075d2c23a2101c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177299 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51237 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45031 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186902 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140546 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fa71c686-6e8b-419b-a42d-1e3767652953) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52529 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50926 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138175 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140546 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/729f1745-1f24-4855-a648-936eaead35df) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180255 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41668 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158933 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118640 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d1efee1c-29ab-4d92-85b6-587fc3e99ec4) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40329 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38706 "Passed tests") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/251/builds/609 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/7432 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150737 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38430 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35370 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/38570 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/43022 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42920 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189331 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50903 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147252 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51586 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35057 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147044 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26904 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41773 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123801 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118135 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50094 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13408 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49490 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49730 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49552 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->