### PR TITLE
[Digital Credentials] Parse OpenID4VP unsigned requests and their DCQL query in the web content process

### DIFF
--- a/LayoutTests/http/wpt/identity/digital-credential-openid4vp-request-parsing-disabled.https-expected.txt
+++ b/LayoutTests/http/wpt/identity/digital-credential-openid4vp-request-parsing-disabled.https-expected.txt
@@ -1,3 +1,4 @@
 
 PASS With the setting disabled, a malformed openid4vp-v1-signed request is skipped, so a valid mdoc request alongside it still passes filtering
+PASS With the setting disabled, a malformed openid4vp-v1-unsigned request is skipped, so a valid mdoc request alongside it still passes filtering
 

--- a/LayoutTests/http/wpt/identity/digital-credential-openid4vp-request-parsing-disabled.https.html
+++ b/LayoutTests/http/wpt/identity/digital-credential-openid4vp-request-parsing-disabled.https.html
@@ -43,4 +43,20 @@
         assert_not_equals(error.name, "TypeError",
             "the unsupported openid4vp-v1-signed request should be skipped, leaving the valid mdoc request");
     }, "With the setting disabled, a malformed openid4vp-v1-signed request is skipped, so a valid mdoc request alongside it still passes filtering");
+
+    promise_test(async (t) => {
+        let error;
+        try {
+            await navigator.credentials.get({
+                digital: { requests: [validMDocRequest, { protocol: "openid4vp-v1-unsigned", data: {} }] },
+                mediation: "required",
+            });
+            assert_unreached("get() should not succeed in the test environment");
+        } catch (e) {
+            error = e;
+        }
+        assert_not_equals(error.name, "TypeError",
+            "the unsupported openid4vp-v1-unsigned request should be skipped, leaving the valid mdoc request");
+    }, "With the setting disabled, a malformed openid4vp-v1-unsigned request is skipped, so a valid mdoc request alongside it still passes filtering");
+
 </script>

--- a/LayoutTests/http/wpt/identity/digital-credential-openid4vp-request-parsing.https-expected.txt
+++ b/LayoutTests/http/wpt/identity/digital-credential-openid4vp-request-parsing.https-expected.txt
@@ -2,4 +2,13 @@
 PASS openid4vp-v1-signed missing the required 'request' member rejects with a TypeError
 PASS openid4vp-v1-multisigned missing the required 'payload'/'signatures' members rejects with a TypeError
 PASS A malformed openid4vp-v1-signed request is parsed and aborts a get() that also contains a valid mdoc request
+PASS A well-formed openid4vp-v1-unsigned request (mso_mdoc credential + claims path) converts successfully
+PASS openid4vp-v1-unsigned missing the required envelope members rejects with a TypeError
+PASS openid4vp-v1-unsigned missing the required 'dcql_query' member rejects with a TypeError
+PASS openid4vp-v1-unsigned with a non-object 'dcql_query' rejects with a TypeError
+PASS openid4vp-v1-unsigned with a non-array 'credentials' rejects with a TypeError
+PASS openid4vp-v1-unsigned with a credential missing the required 'meta' rejects with a TypeError
+PASS openid4vp-v1-unsigned with a boolean DCQL claims-path component rejects with a TypeError
+PASS openid4vp-v1-unsigned with a dc+sd-jwt credential and vct_values meta converts successfully
+PASS openid4vp-v1-unsigned with an unrecognized format captures its meta as a structured JSON value
 

--- a/LayoutTests/http/wpt/identity/digital-credential-openid4vp-request-parsing.https.html
+++ b/LayoutTests/http/wpt/identity/digital-credential-openid4vp-request-parsing.https.html
@@ -1,7 +1,7 @@
 <!-- webkit-test-runner [ DigitalCredentialsOpenID4VPEnabled=true ] -->
 <!DOCTYPE html>
 <meta charset="utf-8" />
-<title>Digital Credentials: OpenID4VP signed/multisigned requests are parsed when enabled.</title>
+<title>Digital Credentials: OpenID4VP unsigned/signed/multisigned requests are parsed when enabled.</title>
 <link rel="help" href="https://w3c-fedid.github.io/digital-credentials/" />
 <link rel="author" href="mailto:pascoe@apple.com">
 <script src="/resources/testdriver.js"></script>
@@ -56,4 +56,90 @@
             mediation: "required",
         }));
     }, "A malformed openid4vp-v1-signed request is parsed and aborts a get() that also contains a valid mdoc request");
+
+    function unsignedData(overrides = {}) {
+        return {
+            response_type: "vp_token",
+            response_mode: "dc_api",
+            nonce: "n-0S6_WzA2Mj",
+            dcql_query: {
+                credentials: [{
+                    id: "my_credential",
+                    format: "mso_mdoc",
+                    meta: { doctype_value: "org.iso.18013.5.1.mDL" },
+                    claims: [{ path: ["org.iso.18013.5.1", "given_name"] }],
+                }],
+            },
+            ...overrides,
+        };
+    }
+
+    async function getUnsignedTypeError(t, data) {
+        return promise_rejects_js(t, TypeError, navigator.credentials.get({
+            digital: { requests: [{ protocol: "openid4vp-v1-unsigned", data }] },
+            mediation: "required",
+        }));
+    }
+
+    async function assertUnsignedParses(data) {
+        let error;
+        try {
+            await navigator.credentials.get({
+                digital: { requests: [{ protocol: "openid4vp-v1-unsigned", data }] },
+                mediation: "required",
+            });
+            assert_unreached("get() should not succeed in the test environment");
+        } catch (e) {
+            error = e;
+        }
+        assert_not_equals(error.name, "TypeError",
+            "a well-formed openid4vp-v1-unsigned request should convert without a TypeError");
+    }
+
+    promise_test(async () => {
+        await assertUnsignedParses(unsignedData());
+    }, "A well-formed openid4vp-v1-unsigned request (mso_mdoc credential + claims path) converts successfully");
+
+    promise_test(async (t) => {
+        await getUnsignedTypeError(t, {});
+    }, "openid4vp-v1-unsigned missing the required envelope members rejects with a TypeError");
+
+    promise_test(async (t) => {
+        const data = unsignedData();
+        delete data.dcql_query;
+        await getUnsignedTypeError(t, data);
+    }, "openid4vp-v1-unsigned missing the required 'dcql_query' member rejects with a TypeError");
+
+    promise_test(async (t) => {
+        await getUnsignedTypeError(t, unsignedData({ dcql_query: 42 }));
+    }, "openid4vp-v1-unsigned with a non-object 'dcql_query' rejects with a TypeError");
+
+    promise_test(async (t) => {
+        await getUnsignedTypeError(t, unsignedData({ dcql_query: { credentials: {} } }));
+    }, "openid4vp-v1-unsigned with a non-array 'credentials' rejects with a TypeError");
+
+    promise_test(async (t) => {
+        await getUnsignedTypeError(t, unsignedData({
+            dcql_query: { credentials: [{ id: "c", format: "mso_mdoc" }] },
+        }));
+    }, "openid4vp-v1-unsigned with a credential missing the required 'meta' rejects with a TypeError");
+
+    promise_test(async (t) => {
+        await getUnsignedTypeError(t, unsignedData({
+            dcql_query: { credentials: [{ id: "c", format: "mso_mdoc", meta: { doctype_value: "org.iso.18013.5.1.mDL" }, claims: [{ path: [true] }] }] },
+        }));
+    }, "openid4vp-v1-unsigned with a boolean DCQL claims-path component rejects with a TypeError");
+
+    promise_test(async () => {
+        await assertUnsignedParses(unsignedData({
+            dcql_query: { credentials: [{ id: "c", format: "dc+sd-jwt", meta: { vct_values: ["https://example.test/vct"] } }] },
+        }));
+    }, "openid4vp-v1-unsigned with a dc+sd-jwt credential and vct_values meta converts successfully");
+
+    promise_test(async () => {
+        await assertUnsignedParses(unsignedData({
+            dcql_query: { credentials: [{ id: "c", format: "custom_format", meta: { nested: { a: 1.5 }, list: [true, "x", null] } }] },
+        }));
+    }, "openid4vp-v1-unsigned with an unrecognized format captures its meta as a structured JSON value");
+
 </script>

--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -456,9 +456,12 @@ set(WebCore_NON_SVG_IDL_FILES
 
     Modules/identity/protocols/ISO18013/MobileDocumentRequest.idl
 
+    Modules/identity/protocols/openid/DCQLMsoMdocMeta.idl
+    Modules/identity/protocols/openid/DCQLSdJwtMeta.idl
     Modules/identity/protocols/openid/OpenID4VPMultisignedRequest.idl
     Modules/identity/protocols/openid/OpenID4VPSignature.idl
     Modules/identity/protocols/openid/OpenID4VPSignedRequest.idl
+    Modules/identity/protocols/openid/OpenID4VPUnsignedRequest.idl
 
     Modules/indexeddb/IDBCursor.idl
     Modules/indexeddb/IDBCursorDirection.idl

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -383,9 +383,12 @@ JS_BINDING_IDLS := \
     $(WebCore)/Modules/identity/DigitalCredentialRequestOptions.idl \
     $(WebCore)/Modules/identity/DigitalCredentialPresentationProtocol.idl \
     $(WebCore)/Modules/identity/protocols/ISO18013/MobileDocumentRequest.idl \
+    $(WebCore)/Modules/identity/protocols/openid/DCQLMsoMdocMeta.idl \
+    $(WebCore)/Modules/identity/protocols/openid/DCQLSdJwtMeta.idl \
     $(WebCore)/Modules/identity/protocols/openid/OpenID4VPMultisignedRequest.idl \
     $(WebCore)/Modules/identity/protocols/openid/OpenID4VPSignature.idl \
     $(WebCore)/Modules/identity/protocols/openid/OpenID4VPSignedRequest.idl \
+    $(WebCore)/Modules/identity/protocols/openid/OpenID4VPUnsignedRequest.idl \
     $(WebCore)/Modules/indexeddb/IDBCursor.idl \
     $(WebCore)/Modules/indexeddb/IDBCursorDirection.idl \
     $(WebCore)/Modules/indexeddb/IDBCursorWithValue.idl \

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -490,9 +490,14 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     Modules/identity/protocols/ISO18013/MobileDocumentRequest.h
     Modules/identity/protocols/ISO18013/ValidatedMobileDocumentRequest.h
 
+    Modules/identity/protocols/openid/DCQLMsoMdocMeta.h
+    Modules/identity/protocols/openid/DCQLQuery.h
+    Modules/identity/protocols/openid/DCQLSdJwtMeta.h
+    Modules/identity/protocols/openid/DCQLValue.h
     Modules/identity/protocols/openid/OpenID4VPMultisignedRequest.h
     Modules/identity/protocols/openid/OpenID4VPSignature.h
     Modules/identity/protocols/openid/OpenID4VPSignedRequest.h
+    Modules/identity/protocols/openid/OpenID4VPUnsignedRequest.h
 
     Modules/indexeddb/IDBActiveDOMObject.h
     Modules/indexeddb/IDBActiveDOMObjectInlines.h
@@ -935,6 +940,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     bindings/js/JSDOMConvertBoolean.h
     bindings/js/JSDOMConvertBufferSource.h
     bindings/js/JSDOMConvertCallbacks.h
+    bindings/js/JSDOMConvertDCQL.h
     bindings/js/JSDOMConvertDate.h
     bindings/js/JSDOMConvertDictionary.h
     bindings/js/JSDOMConvertEnumeration.h

--- a/Source/WebCore/Modules/identity/DigitalCredential.cpp
+++ b/Source/WebCore/Modules/identity/DigitalCredential.cpp
@@ -43,6 +43,7 @@
 #include "JSDOMPromiseDeferred.h"
 #include "JSOpenID4VPMultisignedRequest.h"
 #include "JSOpenID4VPSignedRequest.h"
+#include "JSOpenID4VPUnsignedRequest.h"
 #include "LocalDOMWindow.h"
 #include "LocalFrame.h"
 #include "MediationRequirement.h"
@@ -93,6 +94,8 @@ static std::optional<DigitalCredentialPresentationProtocol> convertProtocolStrin
         return DigitalCredentialPresentationProtocol::OrgIsoMdoc;
 
     if (document.settings().digitalCredentialsOpenID4VPEnabled()) {
+        if (protocolString == "openid4vp-v1-unsigned"_s)
+            return DigitalCredentialPresentationProtocol::Openid4vpV1Unsigned;
         if (protocolString == "openid4vp-v1-signed"_s)
             return DigitalCredentialPresentationProtocol::Openid4vpV1Signed;
         if (protocolString == "openid4vp-v1-multisigned"_s)
@@ -124,6 +127,12 @@ static ExceptionOr<std::optional<UnvalidatedDigitalCredentialRequest>> jsToCrede
             return Exception { ExceptionCode::ExistingExceptionError };
         return std::make_optional<UnvalidatedDigitalCredentialRequest>(result.releaseReturnValue());
     }
+    case Openid4vpV1Unsigned: {
+        auto result = convertDictionary<OpenID4VPUnsignedRequest>(*globalObject, request.data.get());
+        if (result.hasException(scope)) [[unlikely]]
+            return Exception { ExceptionCode::ExistingExceptionError };
+        return std::make_optional<UnvalidatedDigitalCredentialRequest>(result.releaseReturnValue());
+    }
     case Openid4vpV1Signed: {
         auto result = convertDictionary<OpenID4VPSignedRequest>(*globalObject, request.data.get());
         if (result.hasException(scope)) [[unlikely]]
@@ -136,11 +145,10 @@ static ExceptionOr<std::optional<UnvalidatedDigitalCredentialRequest>> jsToCrede
             return Exception { ExceptionCode::ExistingExceptionError };
         return std::make_optional<UnvalidatedDigitalCredentialRequest>(result.releaseReturnValue());
     }
-    default:
-        // FIXME: Handle "openid4vp-v1-unsigned" once DCQL parsing lands (webkit.org/b/320207).
-        ASSERT_NOT_REACHED();
-        return Exception { ExceptionCode::TypeError, "Unsupported protocol."_s };
     }
+
+    ASSERT_NOT_REACHED();
+    return Exception { ExceptionCode::TypeError, "Unsupported protocol."_s };
 }
 
 ExceptionOr<Vector<UnvalidatedDigitalCredentialRequest>> DigitalCredential::convertObjectsToDigitalPresentationRequests(const Document& document, const Vector<DigitalCredentialGetRequest>& requests)

--- a/Source/WebCore/Modules/identity/protocols/openid/DCQLMsoMdocMeta.h
+++ b/Source/WebCore/Modules/identity/protocols/openid/DCQLMsoMdocMeta.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,20 +25,13 @@
 
 #pragma once
 
-#include <WebCore/MobileDocumentRequest.h>
-#include <WebCore/OpenID4VPMultisignedRequest.h>
-#include <WebCore/OpenID4VPSignedRequest.h>
-#include <WebCore/OpenID4VPUnsignedRequest.h>
-#include <wtf/Variant.h>
+#include <optional>
+#include <wtf/text/WTFString.h>
 
 namespace WebCore {
 
-// Every alternative must be IPC-serializable; see WebCoreArgumentCodersAuth.serialization.in.
-using UnvalidatedDigitalCredentialRequest = Variant<
-    MobileDocumentRequest,
-    OpenID4VPUnsignedRequest,
-    OpenID4VPSignedRequest,
-    OpenID4VPMultisignedRequest
->;
+struct DCQLMsoMdocMeta {
+    std::optional<String> doctypeValue;
+};
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/identity/protocols/openid/DCQLMsoMdocMeta.idl
+++ b/Source/WebCore/Modules/identity/protocols/openid/DCQLMsoMdocMeta.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,22 +23,6 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
-
-#include <WebCore/MobileDocumentRequest.h>
-#include <WebCore/OpenID4VPMultisignedRequest.h>
-#include <WebCore/OpenID4VPSignedRequest.h>
-#include <WebCore/OpenID4VPUnsignedRequest.h>
-#include <wtf/Variant.h>
-
-namespace WebCore {
-
-// Every alternative must be IPC-serializable; see WebCoreArgumentCodersAuth.serialization.in.
-using UnvalidatedDigitalCredentialRequest = Variant<
-    MobileDocumentRequest,
-    OpenID4VPUnsignedRequest,
-    OpenID4VPSignedRequest,
-    OpenID4VPMultisignedRequest
->;
-
-} // namespace WebCore
+dictionary DCQLMsoMdocMeta {
+    [ImplementedAs=doctypeValue] DOMString doctype_value;
+};

--- a/Source/WebCore/Modules/identity/protocols/openid/DCQLQuery.h
+++ b/Source/WebCore/Modules/identity/protocols/openid/DCQLQuery.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,20 +25,41 @@
 
 #pragma once
 
-#include <WebCore/MobileDocumentRequest.h>
-#include <WebCore/OpenID4VPMultisignedRequest.h>
-#include <WebCore/OpenID4VPSignedRequest.h>
-#include <WebCore/OpenID4VPUnsignedRequest.h>
+#include <WebCore/DCQLMsoMdocMeta.h>
+#include <WebCore/DCQLSdJwtMeta.h>
+#include <WebCore/DCQLValue.h>
+#include <optional>
 #include <wtf/Variant.h>
+#include <wtf/Vector.h>
+#include <wtf/text/WTFString.h>
 
 namespace WebCore {
 
-// Every alternative must be IPC-serializable; see WebCoreArgumentCodersAuth.serialization.in.
-using UnvalidatedDigitalCredentialRequest = Variant<
-    MobileDocumentRequest,
-    OpenID4VPUnsignedRequest,
-    OpenID4VPSignedRequest,
-    OpenID4VPMultisignedRequest
->;
+using DCQLClaimPathComponent = Variant<String, uint64_t, std::nullptr_t>;
+
+struct DCQLClaimsQuery {
+    std::optional<String> id;
+    Vector<DCQLClaimPathComponent> path;
+};
+
+using DCQLMeta = Variant<DCQLMsoMdocMeta, DCQLSdJwtMeta, DCQLValue>;
+
+struct DCQLCredentialQuery {
+    String id;
+    String format;
+    DCQLMeta meta;
+    Vector<DCQLClaimsQuery> claims;
+    Vector<Vector<String>> claimSets;
+};
+
+struct DCQLCredentialSetQuery {
+    Vector<Vector<String>> options;
+    std::optional<bool> required;
+};
+
+struct DCQLQuery {
+    Vector<DCQLCredentialQuery> credentials;
+    Vector<DCQLCredentialSetQuery> credentialSets;
+};
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/identity/protocols/openid/DCQLSdJwtMeta.h
+++ b/Source/WebCore/Modules/identity/protocols/openid/DCQLSdJwtMeta.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,20 +25,13 @@
 
 #pragma once
 
-#include <WebCore/MobileDocumentRequest.h>
-#include <WebCore/OpenID4VPMultisignedRequest.h>
-#include <WebCore/OpenID4VPSignedRequest.h>
-#include <WebCore/OpenID4VPUnsignedRequest.h>
-#include <wtf/Variant.h>
+#include <wtf/Vector.h>
+#include <wtf/text/WTFString.h>
 
 namespace WebCore {
 
-// Every alternative must be IPC-serializable; see WebCoreArgumentCodersAuth.serialization.in.
-using UnvalidatedDigitalCredentialRequest = Variant<
-    MobileDocumentRequest,
-    OpenID4VPUnsignedRequest,
-    OpenID4VPSignedRequest,
-    OpenID4VPMultisignedRequest
->;
+struct DCQLSdJwtMeta {
+    Vector<String> vctValues;
+};
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/identity/protocols/openid/DCQLSdJwtMeta.idl
+++ b/Source/WebCore/Modules/identity/protocols/openid/DCQLSdJwtMeta.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,22 +23,6 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
-
-#include <WebCore/MobileDocumentRequest.h>
-#include <WebCore/OpenID4VPMultisignedRequest.h>
-#include <WebCore/OpenID4VPSignedRequest.h>
-#include <WebCore/OpenID4VPUnsignedRequest.h>
-#include <wtf/Variant.h>
-
-namespace WebCore {
-
-// Every alternative must be IPC-serializable; see WebCoreArgumentCodersAuth.serialization.in.
-using UnvalidatedDigitalCredentialRequest = Variant<
-    MobileDocumentRequest,
-    OpenID4VPUnsignedRequest,
-    OpenID4VPSignedRequest,
-    OpenID4VPMultisignedRequest
->;
-
-} // namespace WebCore
+dictionary DCQLSdJwtMeta {
+    [ImplementedAs=vctValues] sequence<DOMString> vct_values = [];
+};

--- a/Source/WebCore/Modules/identity/protocols/openid/DCQLValue.h
+++ b/Source/WebCore/Modules/identity/protocols/openid/DCQLValue.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,20 +25,23 @@
 
 #pragma once
 
-#include <WebCore/MobileDocumentRequest.h>
-#include <WebCore/OpenID4VPMultisignedRequest.h>
-#include <WebCore/OpenID4VPSignedRequest.h>
-#include <WebCore/OpenID4VPUnsignedRequest.h>
+#include <wtf/Box.h>
+#include <wtf/HashMap.h>
 #include <wtf/Variant.h>
+#include <wtf/Vector.h>
+#include <wtf/text/WTFString.h>
 
 namespace WebCore {
 
-// Every alternative must be IPC-serializable; see WebCoreArgumentCodersAuth.serialization.in.
-using UnvalidatedDigitalCredentialRequest = Variant<
-    MobileDocumentRequest,
-    OpenID4VPUnsignedRequest,
-    OpenID4VPSignedRequest,
-    OpenID4VPMultisignedRequest
->;
+struct DCQLValue {
+    Variant<
+        std::nullptr_t,
+        bool,
+        double,
+        String,
+        Vector<Box<DCQLValue>>,
+        HashMap<String, Box<DCQLValue>>
+    > value;
+};
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/identity/protocols/openid/OpenID4VPUnsignedRequest.h
+++ b/Source/WebCore/Modules/identity/protocols/openid/OpenID4VPUnsignedRequest.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,20 +25,16 @@
 
 #pragma once
 
-#include <WebCore/MobileDocumentRequest.h>
-#include <WebCore/OpenID4VPMultisignedRequest.h>
-#include <WebCore/OpenID4VPSignedRequest.h>
-#include <WebCore/OpenID4VPUnsignedRequest.h>
-#include <wtf/Variant.h>
+#include <WebCore/DCQLQuery.h>
+#include <wtf/text/WTFString.h>
 
 namespace WebCore {
 
-// Every alternative must be IPC-serializable; see WebCoreArgumentCodersAuth.serialization.in.
-using UnvalidatedDigitalCredentialRequest = Variant<
-    MobileDocumentRequest,
-    OpenID4VPUnsignedRequest,
-    OpenID4VPSignedRequest,
-    OpenID4VPMultisignedRequest
->;
+struct OpenID4VPUnsignedRequest {
+    String responseType;
+    String responseMode;
+    String nonce;
+    DCQLQuery dcqlQuery;
+};
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/identity/protocols/openid/OpenID4VPUnsignedRequest.idl
+++ b/Source/WebCore/Modules/identity/protocols/openid/OpenID4VPUnsignedRequest.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,22 +23,11 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
-
-#include <WebCore/MobileDocumentRequest.h>
-#include <WebCore/OpenID4VPMultisignedRequest.h>
-#include <WebCore/OpenID4VPSignedRequest.h>
-#include <WebCore/OpenID4VPUnsignedRequest.h>
-#include <wtf/Variant.h>
-
-namespace WebCore {
-
-// Every alternative must be IPC-serializable; see WebCoreArgumentCodersAuth.serialization.in.
-using UnvalidatedDigitalCredentialRequest = Variant<
-    MobileDocumentRequest,
-    OpenID4VPUnsignedRequest,
-    OpenID4VPSignedRequest,
-    OpenID4VPMultisignedRequest
->;
-
-} // namespace WebCore
+// FIXME: client_metadata, transaction_data, and verifier_info are not parsed yet.
+// https://bugs.webkit.org/show_bug.cgi?id=320482
+dictionary OpenID4VPUnsignedRequest {
+    [ImplementedAs=responseType] required DOMString response_type;
+    [ImplementedAs=responseMode] required DOMString response_mode;
+    required DOMString nonce;
+    [ImplementedAs=dcqlQuery] required [OverrideIDLType=IDLDCQLQuery] object dcql_query;
+};

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -706,6 +706,7 @@ bindings/js/JSDOMConstructorWithDocument.cpp
 bindings/js/JSDOMConvertAny.cpp
 bindings/js/JSDOMConvertBoolean.cpp
 bindings/js/JSDOMConvertBufferSource.cpp
+bindings/js/JSDOMConvertDCQL.cpp
 bindings/js/JSDOMConvertDate.cpp
 bindings/js/JSDOMConvertNumbers.cpp
 bindings/js/JSDOMConvertStrings.cpp
@@ -4108,6 +4109,8 @@ JSCustomElementRegistry.cpp
 JSCustomEvent.cpp
 JSCustomStateSet.cpp
 JSCustomXPathNSResolver.cpp
+JSDCQLMsoMdocMeta.cpp
+JSDCQLSdJwtMeta.cpp
 JSDOMAudioSession.cpp
 JSDOMCSSCustomPropertyDescriptor.cpp
 JSDOMCSSNamespace.cpp
@@ -4707,6 +4710,7 @@ JSOffscreenCanvasRenderingContext2D.cpp
 JSOpenID4VPMultisignedRequest.cpp
 JSOpenID4VPSignature.cpp
 JSOpenID4VPSignedRequest.cpp
+JSOpenID4VPUnsignedRequest.cpp
 JSOptionalEffectTiming.cpp
 JSOpusEncoderConfig.cpp
 JSOrigin.cpp

--- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
+++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
@@ -3303,6 +3303,12 @@
 		7C8E34C41E4A33B00054CE23 /* JSDOMConvertUnion.h in Headers */ = {isa = PBXBuildFile; fileRef = 7C8E34A91E4A338E0054CE23 /* JSDOMConvertUnion.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		7C8E34C51E4A33B00054CE23 /* JSDOMConvertVariadic.h in Headers */ = {isa = PBXBuildFile; fileRef = 7C8E34AA1E4A338E0054CE23 /* JSDOMConvertVariadic.h */; };
 		7C8E34C61E4A33B00054CE23 /* JSDOMConvertWebGL.h in Headers */ = {isa = PBXBuildFile; fileRef = 7C8E34AB1E4A338E0054CE23 /* JSDOMConvertWebGL.h */; };
+		E8E7BE000000000000000002 /* DCQLMsoMdocMeta.h in Headers */ = {isa = PBXBuildFile; fileRef = E8E7BE000000000000000001 /* DCQLMsoMdocMeta.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		E8E7BE000000000000000005 /* DCQLQuery.h in Headers */ = {isa = PBXBuildFile; fileRef = E8E7BE000000000000000004 /* DCQLQuery.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		E8E7BE20000000000000000B /* DCQLValue.h in Headers */ = {isa = PBXBuildFile; fileRef = E8E7BE20000000000000000A /* DCQLValue.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		E8E7BE000000000000000007 /* DCQLSdJwtMeta.h in Headers */ = {isa = PBXBuildFile; fileRef = E8E7BE000000000000000006 /* DCQLSdJwtMeta.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		E8E7BE00000000000000000A /* OpenID4VPUnsignedRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = E8E7BE000000000000000009 /* OpenID4VPUnsignedRequest.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		E8E7BE00000000000000000E /* JSDOMConvertDCQL.h in Headers */ = {isa = PBXBuildFile; fileRef = E8E7BE00000000000000000D /* JSDOMConvertDCQL.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		7C8E34C71E4A33B00054CE23 /* JSDOMConvertXPathNSResolver.h in Headers */ = {isa = PBXBuildFile; fileRef = 7C8E34AC1E4A338E0054CE23 /* JSDOMConvertXPathNSResolver.h */; };
 		7C93F34A1AA6BA5E00A98BAB /* CompiledContentExtension.h in Headers */ = {isa = PBXBuildFile; fileRef = 7C93F3481AA6BA5E00A98BAB /* CompiledContentExtension.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		7C93F34E1AA6BF0700A98BAB /* ContentExtensionCompiler.h in Headers */ = {isa = PBXBuildFile; fileRef = 7C93F34C1AA6BF0700A98BAB /* ContentExtensionCompiler.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -15314,6 +15320,16 @@
 		7CAC6AE8247F082000E61D59 /* ColorMatrix.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ColorMatrix.h; sourceTree = "<group>"; };
 		7CAC6AEC247F1C5100E61D59 /* ColorComponents.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ColorComponents.h; sourceTree = "<group>"; };
 		7CBA5BA61F0B4BDE0034D745 /* JSDOMConvertWebGL.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = JSDOMConvertWebGL.cpp; sourceTree = "<group>"; };
+		E8E7BE000000000000000001 /* DCQLMsoMdocMeta.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DCQLMsoMdocMeta.h; sourceTree = "<group>"; };
+		E8E7BE000000000000000003 /* DCQLMsoMdocMeta.idl */ = {isa = PBXFileReference; lastKnownFileType = text; path = DCQLMsoMdocMeta.idl; sourceTree = "<group>"; };
+		E8E7BE000000000000000004 /* DCQLQuery.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DCQLQuery.h; sourceTree = "<group>"; };
+		E8E7BE20000000000000000A /* DCQLValue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DCQLValue.h; sourceTree = "<group>"; };
+		E8E7BE000000000000000006 /* DCQLSdJwtMeta.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DCQLSdJwtMeta.h; sourceTree = "<group>"; };
+		E8E7BE000000000000000008 /* DCQLSdJwtMeta.idl */ = {isa = PBXFileReference; lastKnownFileType = text; path = DCQLSdJwtMeta.idl; sourceTree = "<group>"; };
+		E8E7BE000000000000000009 /* OpenID4VPUnsignedRequest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OpenID4VPUnsignedRequest.h; sourceTree = "<group>"; };
+		E8E7BE00000000000000000B /* OpenID4VPUnsignedRequest.idl */ = {isa = PBXFileReference; lastKnownFileType = text; path = OpenID4VPUnsignedRequest.idl; sourceTree = "<group>"; };
+		E8E7BE00000000000000000C /* JSDOMConvertDCQL.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = JSDOMConvertDCQL.cpp; sourceTree = "<group>"; };
+		E8E7BE00000000000000000D /* JSDOMConvertDCQL.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSDOMConvertDCQL.h; sourceTree = "<group>"; };
 		7CBBBCC41F560567005EFAAC /* DOMMatrix2DInit.idl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = DOMMatrix2DInit.idl; sourceTree = "<group>"; };
 		7CBBBCC61F560568005EFAAC /* DOMMatrix2DInit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DOMMatrix2DInit.h; sourceTree = "<group>"; };
 		7CBBBCC81F5617C0005EFAAC /* JSDOMMatrix2DInit.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = JSDOMMatrix2DInit.cpp; sourceTree = "<group>"; };
@@ -32530,6 +32546,8 @@
 				7C8E34961E4A338E0054CE23 /* JSDOMConvertCallbacks.h */,
 				7C8E34971E4A338E0054CE23 /* JSDOMConvertDate.cpp */,
 				7C8E34981E4A338E0054CE23 /* JSDOMConvertDate.h */,
+				E8E7BE00000000000000000C /* JSDOMConvertDCQL.cpp */,
+				E8E7BE00000000000000000D /* JSDOMConvertDCQL.h */,
 				7C8E34991E4A338E0054CE23 /* JSDOMConvertDictionary.h */,
 				7C8E349A1E4A338E0054CE23 /* JSDOMConvertEnumeration.h */,
 				7C8E349B1E4A338E0054CE23 /* JSDOMConvertEventListener.h */,
@@ -41591,12 +41609,20 @@
 		E8E7BDE12D94D12A0000A163 /* openid */ = {
 			isa = PBXGroup;
 			children = (
+				E8E7BE000000000000000001 /* DCQLMsoMdocMeta.h */,
+				E8E7BE000000000000000003 /* DCQLMsoMdocMeta.idl */,
+				E8E7BE000000000000000004 /* DCQLQuery.h */,
+				E8E7BE20000000000000000A /* DCQLValue.h */,
+				E8E7BE000000000000000006 /* DCQLSdJwtMeta.h */,
+				E8E7BE000000000000000008 /* DCQLSdJwtMeta.idl */,
 				745C1E395EA6A30D6AE53DCB /* OpenID4VPMultisignedRequest.h */,
 				10DCBDE288D8DF09E9DE8095 /* OpenID4VPMultisignedRequest.idl */,
 				166FD29091573AE0071CC010 /* OpenID4VPSignature.h */,
 				DA1F1A26CC1A22F7F9E51921 /* OpenID4VPSignature.idl */,
 				24318795E4EEC2337746A550 /* OpenID4VPSignedRequest.h */,
 				99AC31211F38CFD6F2485E92 /* OpenID4VPSignedRequest.idl */,
+				E8E7BE000000000000000009 /* OpenID4VPUnsignedRequest.h */,
+				E8E7BE00000000000000000B /* OpenID4VPUnsignedRequest.idl */,
 			);
 			path = openid;
 			sourceTree = "<group>";
@@ -45102,6 +45128,10 @@
 				F55B3DBA1251F12D003EF269 /* DateTimeLocalInputType.h in Headers */,
 				E5F06AEB24D49BF700BBC4F8 /* DateTimeNumericFieldElement.h in Headers */,
 				E5F06AEF24D4A63700BBC4F8 /* DateTimeSymbolicFieldElement.h in Headers */,
+				E8E7BE000000000000000002 /* DCQLMsoMdocMeta.h in Headers */,
+				E8E7BE000000000000000005 /* DCQLQuery.h in Headers */,
+				E8E7BE20000000000000000B /* DCQLValue.h in Headers */,
+				E8E7BE000000000000000007 /* DCQLSdJwtMeta.h in Headers */,
 				BC4A532D256056D50028C592 /* DebugOverlayRegions.h in Headers */,
 				0F6A12BE1A00923700C6DE72 /* DebugPageOverlays.h in Headers */,
 				45FEA5D0156DDE8C00654101 /* Decimal.h in Headers */,
@@ -46446,6 +46476,7 @@
 				7C8E34B01E4A33AF0054CE23 /* JSDOMConvertBufferSource.h in Headers */,
 				7C8E34B11E4A33B00054CE23 /* JSDOMConvertCallbacks.h in Headers */,
 				7C8E34B31E4A33B00054CE23 /* JSDOMConvertDate.h in Headers */,
+				E8E7BE00000000000000000E /* JSDOMConvertDCQL.h in Headers */,
 				7C8E34B41E4A33B00054CE23 /* JSDOMConvertDictionary.h in Headers */,
 				7C8E34B51E4A33B00054CE23 /* JSDOMConvertEnumeration.h in Headers */,
 				7C8E34B61E4A33B00054CE23 /* JSDOMConvertEventListener.h in Headers */,
@@ -47710,6 +47741,7 @@
 				EB08054AAEA4BB58328F5762 /* OpenID4VPMultisignedRequest.h in Headers */,
 				599DD0B0C2E2D658258CFA9A /* OpenID4VPSignature.h in Headers */,
 				34B3726E71963DE8E6D0A99B /* OpenID4VPSignedRequest.h in Headers */,
+				E8E7BE00000000000000000A /* OpenID4VPUnsignedRequest.h in Headers */,
 				B2D3DA650D006CD600EF6F3A /* OpenTypeCG.h in Headers */,
 				B2D3DA650D006CD600EF6F27 /* OpenTypeMathData.h in Headers */,
 				B2D3EA650D006CD600EF6F28 /* OpenTypeTypes.h in Headers */,

--- a/Source/WebCore/bindings/js/JSDOMConvertDCQL.cpp
+++ b/Source/WebCore/bindings/js/JSDOMConvertDCQL.cpp
@@ -1,0 +1,371 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "JSDOMConvertDCQL.h"
+
+#include "JSDCQLMsoMdocMeta.h"
+#include "JSDCQLSdJwtMeta.h"
+#include "JSDOMConvertDictionary.h"
+#include "JSDOMConvertStrings.h"
+#include "JSDOMExceptionHandling.h"
+#include "JSDOMGlobalObject.h"
+#include <JavaScriptCore/Error.h>
+#include <JavaScriptCore/JSArray.h>
+#include <JavaScriptCore/JSCInlines.h>
+#include <JavaScriptCore/JSGlobalObject.h>
+#include <JavaScriptCore/JSObject.h>
+#include <JavaScriptCore/PropertyNameArray.h>
+#include <cmath>
+#include <wtf/Box.h>
+#include <wtf/JSONValues.h>
+#include <wtf/text/WTFString.h>
+
+namespace WebCore {
+
+using namespace JSC;
+
+static constexpr double maxSafeInteger = 9007199254740991.0;
+
+static std::optional<String> stringFromValue(JSGlobalObject& globalObject, ThrowScope& scope, JSValue value)
+{
+    if (!value.isString()) {
+        throwTypeError(&globalObject, scope);
+        return std::nullopt;
+    }
+    auto result = convert<IDLDOMString>(globalObject, value);
+    if (result.hasException(scope)) [[unlikely]]
+        return std::nullopt;
+    return result.releaseReturnValue();
+}
+
+static std::optional<String> stringProperty(JSGlobalObject& globalObject, ThrowScope& scope, JSObject& object, ASCIILiteral key)
+{
+    auto value = object.get(&globalObject, Identifier::fromString(globalObject.vm(), key));
+    RETURN_IF_EXCEPTION(scope, std::nullopt);
+    return stringFromValue(globalObject, scope, value);
+}
+
+static std::optional<JSValue> property(JSGlobalObject& globalObject, ThrowScope& scope, JSObject& object, ASCIILiteral key)
+{
+    auto value = object.get(&globalObject, Identifier::fromString(globalObject.vm(), key));
+    RETURN_IF_EXCEPTION(scope, std::nullopt);
+    return value;
+}
+
+template<typename Element, typename ParseElement>
+static std::optional<Vector<Element>> parseArray(JSGlobalObject& globalObject, ThrowScope& scope, JSValue value, NOESCAPE ParseElement&& parseElement)
+{
+    if (!isJSArray(value)) {
+        throwTypeError(&globalObject, scope);
+        return std::nullopt;
+    }
+    auto& array = *asArray(value);
+    unsigned length = array.length();
+    Vector<Element> result;
+    for (unsigned i = 0; i < length; ++i) {
+        auto element = array.getIndex(&globalObject, i);
+        RETURN_IF_EXCEPTION(scope, std::nullopt);
+        auto parsed = parseElement(element);
+        if (!parsed)
+            return std::nullopt;
+        result.append(WTF::move(*parsed));
+    }
+    return result;
+}
+
+static bool parseOptionalBoolean(JSGlobalObject& globalObject, ThrowScope& scope, JSObject& object, ASCIILiteral key, std::optional<bool>& result)
+{
+    auto value = property(globalObject, scope, object, key);
+    if (!value)
+        return false;
+    if (value->isUndefinedOrNull())
+        return true;
+    if (!value->isBoolean()) {
+        throwTypeError(&globalObject, scope);
+        return false;
+    }
+    result = value->asBoolean();
+    return true;
+}
+
+template<typename Container, typename ParseValue>
+static bool parseOptionalMember(JSGlobalObject& globalObject, ThrowScope& scope, JSObject& object, ASCIILiteral key, Container& result, NOESCAPE ParseValue&& parseValue)
+{
+    auto value = property(globalObject, scope, object, key);
+    if (!value)
+        return false;
+    if (value->isUndefinedOrNull())
+        return true;
+    auto parsed = parseValue(*value);
+    if (!parsed)
+        return false;
+    result = WTF::move(*parsed);
+    return true;
+}
+
+static std::optional<DCQLValue> jsToDCQLValue(JSGlobalObject& globalObject, ThrowScope& scope, JSValue value, unsigned depth)
+{
+    if (!depth) {
+        throwTypeError(&globalObject, scope);
+        return std::nullopt;
+    }
+
+    if (value.isUndefinedOrNull())
+        return DCQLValue { nullptr };
+    if (value.isBoolean())
+        return DCQLValue { value.asBoolean() };
+    if (value.isNumber())
+        return DCQLValue { value.asNumber() };
+    if (value.isString()) {
+        auto string = stringFromValue(globalObject, scope, value);
+        if (!string)
+            return std::nullopt;
+        return DCQLValue { WTF::move(*string) };
+    }
+
+    VM& vm = globalObject.vm();
+    if (isJSArray(value)) {
+        auto elements = parseArray<Box<DCQLValue>>(globalObject, scope, value, [&](JSValue element) -> std::optional<Box<DCQLValue>> {
+            auto parsed = jsToDCQLValue(globalObject, scope, element, depth - 1);
+            if (!parsed)
+                return std::nullopt;
+            return Box<DCQLValue>::create(WTF::move(*parsed));
+        });
+        if (!elements)
+            return std::nullopt;
+        return DCQLValue { WTF::move(*elements) };
+    }
+
+    if (value.isObject()) {
+        auto& object = *value.getObject();
+        PropertyNameArrayBuilder propertyNames(vm, PropertyNameMode::Strings, PrivateSymbolMode::Exclude);
+        object.methodTable()->getOwnPropertyNames(&object, &globalObject, propertyNames, DontEnumPropertiesMode::Exclude);
+        RETURN_IF_EXCEPTION(scope, std::nullopt);
+        HashMap<String, Box<DCQLValue>> map;
+        for (auto& name : propertyNames) {
+            auto propertyValue = object.get(&globalObject, name);
+            RETURN_IF_EXCEPTION(scope, std::nullopt);
+            auto parsed = jsToDCQLValue(globalObject, scope, propertyValue, depth - 1);
+            if (!parsed)
+                return std::nullopt;
+            map.set(name.string(), Box<DCQLValue>::create(WTF::move(*parsed)));
+        }
+        return DCQLValue { WTF::move(map) };
+    }
+
+    // Symbols and other exotic values have no JSON representation.
+    throwTypeError(&globalObject, scope);
+    return std::nullopt;
+}
+
+static std::optional<DCQLMeta> parseMeta(JSGlobalObject& globalObject, ThrowScope& scope, JSObject& credential, const String& format)
+{
+    VM& vm = globalObject.vm();
+    auto metaValue = credential.get(&globalObject, Identifier::fromString(vm, "meta"_s));
+    RETURN_IF_EXCEPTION(scope, std::nullopt);
+
+    // meta is REQUIRED by OpenID4VP, though it may be an empty object.
+    if (!metaValue.isObject()) {
+        throwTypeError(&globalObject, scope);
+        return std::nullopt;
+    }
+
+    if (format == "mso_mdoc"_s) {
+        auto result = convertDictionary<DCQLMsoMdocMeta>(globalObject, metaValue);
+        if (result.hasException(scope)) [[unlikely]]
+            return std::nullopt;
+        return DCQLMeta { result.releaseReturnValue() };
+    }
+
+    if (format == "dc+sd-jwt"_s) {
+        auto result = convertDictionary<DCQLSdJwtMeta>(globalObject, metaValue);
+        if (result.hasException(scope)) [[unlikely]]
+            return std::nullopt;
+        return DCQLMeta { result.releaseReturnValue() };
+    }
+
+    auto any = jsToDCQLValue(globalObject, scope, metaValue, JSON::Value::maxDepth);
+    if (!any)
+        return std::nullopt;
+    return DCQLMeta { WTF::move(*any) };
+}
+
+static std::optional<DCQLClaimPathComponent> parsePathComponent(JSGlobalObject& globalObject, ThrowScope& scope, JSValue value)
+{
+    if (value.isNull())
+        return DCQLClaimPathComponent { nullptr };
+    if (value.isString()) {
+        auto string = stringFromValue(globalObject, scope, value);
+        if (!string)
+            return std::nullopt;
+        return DCQLClaimPathComponent { WTF::move(*string) };
+    }
+    if (value.isNumber()) {
+        double number = value.asNumber();
+        if (!std::isfinite(number) || std::trunc(number) != number || number < 0 || number > maxSafeInteger) {
+            throwTypeError(&globalObject, scope);
+            return std::nullopt;
+        }
+        return DCQLClaimPathComponent { static_cast<uint64_t>(number) };
+    }
+    throwTypeError(&globalObject, scope);
+    return std::nullopt;
+}
+
+static std::optional<DCQLClaimsQuery> parseClaimsQuery(JSGlobalObject& globalObject, ThrowScope& scope, JSValue value)
+{
+    if (!value.isObject()) {
+        throwTypeError(&globalObject, scope);
+        return std::nullopt;
+    }
+    auto& claim = *value.getObject();
+    VM& vm = globalObject.vm();
+    DCQLClaimsQuery result;
+
+    auto idValue = claim.get(&globalObject, Identifier::fromString(vm, "id"_s));
+    RETURN_IF_EXCEPTION(scope, std::nullopt);
+    if (!idValue.isUndefinedOrNull()) {
+        auto id = stringFromValue(globalObject, scope, idValue);
+        if (!id)
+            return std::nullopt;
+        result.id = WTF::move(*id);
+    }
+
+    auto pathValue = claim.get(&globalObject, Identifier::fromString(vm, "path"_s));
+    RETURN_IF_EXCEPTION(scope, std::nullopt);
+    auto path = parseArray<DCQLClaimPathComponent>(globalObject, scope, pathValue, [&](JSValue component) {
+        return parsePathComponent(globalObject, scope, component);
+    });
+    if (!path)
+        return std::nullopt;
+    result.path = WTF::move(*path);
+    return result;
+}
+
+static std::optional<Vector<Vector<String>>> parseIdentifierListArray(JSGlobalObject& globalObject, ThrowScope& scope, JSValue value)
+{
+    return parseArray<Vector<String>>(globalObject, scope, value, [&](JSValue inner) {
+        return parseArray<String>(globalObject, scope, inner, [&](JSValue element) {
+            return stringFromValue(globalObject, scope, element);
+        });
+    });
+}
+
+static std::optional<DCQLCredentialQuery> parseCredentialQuery(JSGlobalObject& globalObject, ThrowScope& scope, JSValue value)
+{
+    if (!value.isObject()) {
+        throwTypeError(&globalObject, scope);
+        return std::nullopt;
+    }
+    auto& credential = *value.getObject();
+    DCQLCredentialQuery result;
+
+    auto id = stringProperty(globalObject, scope, credential, "id"_s);
+    if (!id)
+        return std::nullopt;
+    result.id = WTF::move(*id);
+
+    auto format = stringProperty(globalObject, scope, credential, "format"_s);
+    if (!format)
+        return std::nullopt;
+    result.format = WTF::move(*format);
+
+    auto meta = parseMeta(globalObject, scope, credential, result.format);
+    if (!meta)
+        return std::nullopt;
+    result.meta = WTF::move(*meta);
+
+    if (!parseOptionalMember(globalObject, scope, credential, "claims"_s, result.claims, [&](JSValue claimsValue) {
+        return parseArray<DCQLClaimsQuery>(globalObject, scope, claimsValue, [&](JSValue claimValue) {
+            return parseClaimsQuery(globalObject, scope, claimValue);
+        });
+    }))
+        return std::nullopt;
+
+    if (!parseOptionalMember(globalObject, scope, credential, "claim_sets"_s, result.claimSets, [&](JSValue claimSetsValue) {
+        return parseIdentifierListArray(globalObject, scope, claimSetsValue);
+    }))
+        return std::nullopt;
+
+    return result;
+}
+
+static std::optional<DCQLCredentialSetQuery> parseCredentialSetQuery(JSGlobalObject& globalObject, ThrowScope& scope, JSValue value)
+{
+    if (!value.isObject()) {
+        throwTypeError(&globalObject, scope);
+        return std::nullopt;
+    }
+    auto& set = *value.getObject();
+    VM& vm = globalObject.vm();
+    DCQLCredentialSetQuery result;
+
+    auto optionsValue = set.get(&globalObject, Identifier::fromString(vm, "options"_s));
+    RETURN_IF_EXCEPTION(scope, std::nullopt);
+    auto options = parseIdentifierListArray(globalObject, scope, optionsValue);
+    if (!options)
+        return std::nullopt;
+    result.options = WTF::move(*options);
+
+    if (!parseOptionalBoolean(globalObject, scope, set, "required"_s, result.required))
+        return std::nullopt;
+
+    return result;
+}
+
+ConversionResult<IDLDCQLQuery> Converter<IDLDCQLQuery>::convert(JSGlobalObject& globalObject, JSValue value)
+{
+    VM& vm = globalObject.vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    auto* queryObject = value.getObject();
+    if (!queryObject) {
+        throwTypeError(&globalObject, scope);
+        return ConversionResultException { };
+    }
+
+    DCQLQuery result;
+
+    auto credentialsValue = queryObject->get(&globalObject, Identifier::fromString(vm, "credentials"_s));
+    RETURN_IF_EXCEPTION(scope, ConversionResultException { });
+    auto credentials = parseArray<DCQLCredentialQuery>(globalObject, scope, credentialsValue, [&](JSValue credentialValue) {
+        return parseCredentialQuery(globalObject, scope, credentialValue);
+    });
+    if (!credentials)
+        return ConversionResultException { };
+    result.credentials = WTF::move(*credentials);
+
+    if (!parseOptionalMember(globalObject, scope, *queryObject, "credential_sets"_s, result.credentialSets, [&](JSValue credentialSetsValue) {
+        return parseArray<DCQLCredentialSetQuery>(globalObject, scope, credentialSetsValue, [&](JSValue setValue) {
+            return parseCredentialSetQuery(globalObject, scope, setValue);
+        });
+    }))
+        return ConversionResultException { };
+
+    return result;
+}
+
+} // namespace WebCore

--- a/Source/WebCore/bindings/js/JSDOMConvertDCQL.h
+++ b/Source/WebCore/bindings/js/JSDOMConvertDCQL.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,20 +25,21 @@
 
 #pragma once
 
-#include <WebCore/MobileDocumentRequest.h>
-#include <WebCore/OpenID4VPMultisignedRequest.h>
-#include <WebCore/OpenID4VPSignedRequest.h>
-#include <WebCore/OpenID4VPUnsignedRequest.h>
-#include <wtf/Variant.h>
+#include <WebCore/DCQLQuery.h>
+#include <WebCore/IDLTypes.h>
+#include <WebCore/JSDOMConvertBase.h>
 
 namespace WebCore {
 
-// Every alternative must be IPC-serializable; see WebCoreArgumentCodersAuth.serialization.in.
-using UnvalidatedDigitalCredentialRequest = Variant<
-    MobileDocumentRequest,
-    OpenID4VPUnsignedRequest,
-    OpenID4VPSignedRequest,
-    OpenID4VPMultisignedRequest
->;
+// Custom inbound IDL type for the DCQL query object, used as
+// [OverrideIDLType=IDLDCQLQuery] on OpenID4VPUnsignedRequest so the whole subtree is parsed by
+// one converter that can dispatch each credential's meta on its sibling format.
+struct IDLDCQLQuery : IDLType<DCQLQuery> { };
+
+template<> struct Converter<IDLDCQLQuery> : DefaultConverter<IDLDCQLQuery> {
+    using ReturnType = DCQLQuery;
+
+    static ConversionResult<IDLDCQLQuery> convert(JSC::JSGlobalObject&, JSC::JSValue);
+};
 
 } // namespace WebCore

--- a/Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
+++ b/Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
@@ -594,6 +594,11 @@ sub AddToIncludesForIDLType
             AddToIncludes("JSDOMConvertWebGL.h", $includesRef, $conditional);
             return;
         }
+
+        if ($overrideTypeName eq "IDLDCQLQuery") {
+            AddToIncludes("JSDOMConvertDCQL.h", $includesRef, $conditional);
+            return;
+        }
     }
 
     if ($type->name eq "undefined") {

--- a/Source/WebKit/Shared/WebCoreArgumentCodersAuth.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCodersAuth.serialization.in
@@ -354,8 +354,59 @@ struct WebCore::OpenID4VPMultisignedRequest {
     Vector<WebCore::OpenID4VPSignature> signatures;
 };
 
+header: <WebCore/DCQLMsoMdocMeta.h>
+[Nested] struct WebCore::DCQLMsoMdocMeta {
+    std::optional<String> doctypeValue;
+};
+
+header: <WebCore/DCQLSdJwtMeta.h>
+[Nested] struct WebCore::DCQLSdJwtMeta {
+    Vector<String> vctValues;
+};
+
+header: <WebCore/DCQLValue.h>
+[Nested] struct WebCore::DCQLValue {
+    Variant<std::nullptr_t, bool, double, String, Vector<Box<WebCore::DCQLValue>>, HashMap<String, Box<WebCore::DCQLValue>>> value;
+};
+
+header: <WebCore/DCQLQuery.h>
+using WebCore::DCQLClaimPathComponent = Variant<String, uint64_t, std::nullptr_t>;
+
+using WebCore::DCQLMeta = Variant<WebCore::DCQLMsoMdocMeta, WebCore::DCQLSdJwtMeta, WebCore::DCQLValue>;
+
+[Nested] struct WebCore::DCQLClaimsQuery {
+    std::optional<String> id;
+    Vector<WebCore::DCQLClaimPathComponent> path;
+};
+
+[Nested] struct WebCore::DCQLCredentialQuery {
+    String id;
+    String format;
+    WebCore::DCQLMeta meta;
+    Vector<WebCore::DCQLClaimsQuery> claims;
+    Vector<Vector<String>> claimSets;
+};
+
+[Nested] struct WebCore::DCQLCredentialSetQuery {
+    Vector<Vector<String>> options;
+    std::optional<bool> required;
+};
+
+[Nested] struct WebCore::DCQLQuery {
+    Vector<WebCore::DCQLCredentialQuery> credentials;
+    Vector<WebCore::DCQLCredentialSetQuery> credentialSets;
+};
+
+header: <WebCore/OpenID4VPUnsignedRequest.h>
+struct WebCore::OpenID4VPUnsignedRequest {
+    String responseType;
+    String responseMode;
+    String nonce;
+    WebCore::DCQLQuery dcqlQuery;
+};
+
 header: <WebCore/UnvalidatedDigitalCredentialRequest.h>
-using WebCore::UnvalidatedDigitalCredentialRequest = Variant<WebCore::MobileDocumentRequest, WebCore::OpenID4VPSignedRequest, WebCore::OpenID4VPMultisignedRequest>;
+using WebCore::UnvalidatedDigitalCredentialRequest = Variant<WebCore::MobileDocumentRequest, WebCore::OpenID4VPUnsignedRequest, WebCore::OpenID4VPSignedRequest, WebCore::OpenID4VPMultisignedRequest>;
 
 header: <WebCore/DigitalCredentialsRequestData.h>
 [AdditionalEncoder=StreamConnectionEncoder] struct WebCore::DigitalCredentialsSecurityOriginData {

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -380,7 +380,8 @@ using RawDigitalCredentialsWithRequestInfo = Vector<String>;
 struct MobileDocumentRequest;
 struct OpenID4VPMultisignedRequest;
 struct OpenID4VPSignedRequest;
-using UnvalidatedDigitalCredentialRequest = Variant<MobileDocumentRequest, OpenID4VPSignedRequest, OpenID4VPMultisignedRequest>;
+struct OpenID4VPUnsignedRequest;
+using UnvalidatedDigitalCredentialRequest = Variant<MobileDocumentRequest, OpenID4VPUnsignedRequest, OpenID4VPSignedRequest, OpenID4VPMultisignedRequest>;
 using DigitalCredentialsRequestData = Variant<
     WebCore::DigitalCredentialsMobileDocumentRequestData
 #if ENABLE(ISO18013_DOCUMENT_REQUEST_INFO)


### PR DESCRIPTION
#### ee23a78b5e203428f3b73ccd2cf5b269948cc6e6
<pre>
[Digital Credentials] Parse OpenID4VP unsigned requests and their DCQL query in the web content process
<a href="https://bugs.webkit.org/show_bug.cgi?id=320475">https://bugs.webkit.org/show_bug.cgi?id=320475</a>
<a href="https://rdar.apple.com/problem/183443425">rdar://problem/183443425</a>

Reviewed by NOBODY (OOPS!).

DCQL can&apos;t be expressed as a static WebIDL dictionary. credentials[].meta is
polymorphic on the sibling credentials[].format, and claims[].path elements are a
string | non-negative-integer | null union that WebIDL only expresses coercively,
turning true into &quot;true&quot; where the spec requires an error.

This patch parses the whole dcql_query subtree with one custom converter,
IDLDCQLQuery, wired via [OverrideIDLType] on the envelope&apos;s dcql_query member so it
sees format and meta together. Known formats parse into typed dictionaries via
convertDictionary(); an unrecognized format is captured as a DCQLValue rather than
re-stringified. CodeGeneratorJS.pm learns the one type name so the converter&apos;s
header reaches the generated bindings.

Parse-only. Value policy and signature verification come in follow-up patches.
Only the parameters the DCQL query needs are parsed; client_metadata,
transaction_data, and verifier_info are not yet plumbed through
(<a href="https://bugs.webkit.org/show_bug.cgi?id=320482).">https://bugs.webkit.org/show_bug.cgi?id=320482).</a>

* Source/WebCore/CMakeLists.txt:
* Source/WebCore/DerivedSources.make:
* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/Modules/identity/DigitalCredential.cpp:
(WebCore::convertProtocolString):
(WebCore::jsToCredentialRequest):
* Source/WebCore/Modules/identity/protocols/UnvalidatedDigitalCredentialRequest.h:
* Source/WebCore/Modules/identity/protocols/openid/DCQLMsoMdocMeta.h: Added.
* Source/WebCore/Modules/identity/protocols/openid/DCQLMsoMdocMeta.idl: Added.
* Source/WebCore/Modules/identity/protocols/openid/DCQLQuery.h: Added.
* Source/WebCore/Modules/identity/protocols/openid/DCQLValue.h: Added.
* Source/WebCore/Modules/identity/protocols/openid/DCQLSdJwtMeta.h: Added.
* Source/WebCore/Modules/identity/protocols/openid/DCQLSdJwtMeta.idl: Added.
* Source/WebCore/Modules/identity/protocols/openid/OpenID4VPUnsignedRequest.h: Added.
* Source/WebCore/Modules/identity/protocols/openid/OpenID4VPUnsignedRequest.idl: Added.
* Source/WebCore/bindings/js/JSDOMConvertDCQL.h: Added.
* Source/WebCore/bindings/js/JSDOMConvertDCQL.cpp: Added.
(WebCore::Converter&lt;IDLDCQLQuery&gt;::convert):
* Source/WebCore/bindings/scripts/CodeGeneratorJS.pm:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebKit/Shared/WebCoreArgumentCodersAuth.serialization.in:
* Source/WebKit/UIProcess/WebPageProxy.h:
* LayoutTests/http/wpt/identity/digital-credential-openid4vp-request-parsing.https.html:
* LayoutTests/http/wpt/identity/digital-credential-openid4vp-request-parsing.https-expected.txt:
* LayoutTests/http/wpt/identity/digital-credential-openid4vp-request-parsing-disabled.https.html:
* LayoutTests/http/wpt/identity/digital-credential-openid4vp-request-parsing-disabled.https-expected.txt:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ee23a78b5e203428f3b73ccd2cf5b269948cc6e6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177301 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51239 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45033 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186904 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140548 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e994d85a-789f-4091-9c4b-856b9cb33c2b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179164 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52531 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50928 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138165 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140548 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bd2970c5-4ecc-4a0e-88fc-a8d7f0bb00fe) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180257 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41661 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158938 "Found 1 new API test failure: TestWebKitAPI.SiteIsolation.CrossProcessHistoryTraversalSameFrameBackTwice (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118630 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7823c14a-825d-4207-bc27-ef66ca7cacde) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40322 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38707 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150730 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38435 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35372 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/43024 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42921 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189333 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50905 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/158472 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147254 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51588 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35062 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147045 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41776 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123803 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118137 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50096 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13413 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49492 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49732 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49554 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->