### PR TITLE
"Continue with Google" sign-in redirects to blank page

### DIFF
--- a/Source/WebKit/WebProcess/WebCoreSupport/WebResourceLoadObserver.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebResourceLoadObserver.cpp
@@ -397,6 +397,22 @@ void WebResourceLoadObserver::logUserInteractionWithReducedTimeResolution(const 
             RefPtr openerDocument = opener->document();
             if (RefPtr openerPage = openerDocument ? openerDocument->page() : nullptr)
                 requestStorageAccessUnderOpener(topFrameDomain, Ref { *WebPage::fromCorePage(*openerPage) }, *openerDocument);
+        } else if (frame && frame->opener()) {
+            if (RefPtr openerCorePage = frame->opener()->page()) {
+                RefPtr openerWebPage = WebPage::fromCorePage(*openerCorePage);
+                RefPtr webPage = WebPage::fromCorePage(*protect(protect(mainFrameDocument)->page()));
+                if (webPage && openerWebPage) {
+                    if (auto openerURL = webPage->mainFrameOpenerURL(); !openerURL.isEmpty()) {
+                        RegistrableDomain openerDomain { openerURL };
+                        if (topFrameDomain != openerDomain && !mainFrameDocument->hasRequestedPageSpecificStorageAccessWithUserInteraction(topFrameDomain)) {
+                            openerWebPage->addDomainWithPageLevelStorageAccess(openerDomain, topFrameDomain);
+                            Ref { WebProcess::singleton().ensureNetworkProcessConnection().connection() }->send(
+                                Messages::NetworkConnectionToWebProcess::RequestStorageAccessUnderOpener(topFrameDomain, openerWebPage->identifier(), openerDomain), 0);
+                            mainFrameDocument->setHasRequestedPageSpecificStorageAccessWithUserInteraction(topFrameDomain);
+                        }
+                    }
+                }
+            }
         }
     } else {
         LOG_ONCE(SiteIsolation, "Unable to request storage access under opener when logging user interation without access to the main frame document ");

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
@@ -8092,6 +8092,123 @@ TEST(SiteIsolation, SharedProcessWithUserInteractionOverride)
     });
 }
 
+TEST(SiteIsolation, StorageAccessUnderOpenerWithRemoteFrameOpener)
+{
+    // This test verifies that when Site Isolation is enabled and a popup
+    // triggers user interaction, a cross-origin iframe (in a different
+    // WebProcess) can access its unpartitioned cookies.
+
+    auto iframeHTML = "<script>"
+        "window.addEventListener('message', function(e) {"
+        "    e.source.postMessage(document.cookie, '*');"
+        "});"
+        "</script>"_s;
+
+    auto popupHTML = "popup content"_s;
+
+    auto mainHTML = "<iframe src='https://webkit.org/iframe'></iframe>"
+        "<script>"
+        "window.addEventListener('message', function(e) {"
+        "    document.title = e.data;"
+        "});"
+        "</script>"_s;
+
+    HTTPServer server({
+        { "/main"_s, { mainHTML } },
+        { "/iframe"_s, { iframeHTML } },
+        { "/popup"_s, { { { "Set-Cookie"_s, "auth=loggedin; path=/; SameSite=None; Secure"_s } }, popupHTML } },
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    NSURL *dataStoreRoot = [NSURL fileURLWithPath:[NSTemporaryDirectory() stringByAppendingPathComponent:@"StorageAccessUnderOpenerDataStore"] isDirectory:YES];
+    NSURL *itpRoot = [NSURL fileURLWithPath:[NSTemporaryDirectory() stringByAppendingPathComponent:@"StorageAccessUnderOpenerITP"] isDirectory:YES];
+    auto defaultFileManager = [NSFileManager defaultManager];
+    [defaultFileManager removeItemAtPath:dataStoreRoot.path error:nil];
+    [defaultFileManager removeItemAtPath:itpRoot.path error:nil];
+    [defaultFileManager createDirectoryAtURL:dataStoreRoot withIntermediateDirectories:YES attributes:nil error:nil];
+    [defaultFileManager createDirectoryAtURL:itpRoot withIntermediateDirectories:YES attributes:nil error:nil];
+
+    NSURL *itpDatabaseFile = [itpRoot URLByAppendingPathComponent:@"observations.db"];
+    NSURL *sourceFile = [NSBundle.test_resourcesBundle URLForResource:@"basicITPDatabase" withExtension:@"db"];
+    EXPECT_TRUE([defaultFileManager fileExistsAtPath:sourceFile.path]);
+    [defaultFileManager copyItemAtPath:sourceFile.path toPath:itpDatabaseFile.path error:nil];
+    EXPECT_TRUE([defaultFileManager fileExistsAtPath:itpDatabaseFile.path]);
+
+    // Mark webkit.org as prevalent so its third-party cookies are blocked by ITP.
+    auto database = makeUniqueRef<WebCore::SQLiteDatabase>();
+    EXPECT_TRUE(database->open(itpDatabaseFile.path));
+    EXPECT_TRUE(database->executeCommand("UPDATE ObservedDomains SET isPrevalent = 1 WHERE registrableDomain = 'webkit.org'"_s));
+    database->close();
+
+    RetainPtr dataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initWithDirectory:dataStoreRoot]);
+    dataStoreConfiguration.get()._resourceLoadStatisticsDirectory = itpRoot;
+    [dataStoreConfiguration setHTTPSProxy:[NSURL URLWithString:[NSString stringWithFormat:@"https://127.0.0.1:%d/", server.port()]]];
+
+    RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:dataStoreConfiguration.get()]);
+    [dataStore _setResourceLoadStatisticsEnabled:YES];
+    [dataStore _setResourceLoadStatisticsDebugMode:YES];
+
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
+    [configuration setWebsiteDataStore:dataStore.get()];
+    enableSiteIsolation(configuration.get());
+
+    __block RetainPtr<TestWKWebView> popupWebView;
+
+    RetainPtr openerNavDelegate = adoptNS([TestNavigationDelegate new]);
+    [openerNavDelegate allowAnyTLSCertificate];
+
+    RetainPtr popupNavDelegate = adoptNS([TestNavigationDelegate new]);
+    [popupNavDelegate allowAnyTLSCertificate];
+
+    RetainPtr uiDelegate = adoptNS([TestUIDelegate new]);
+    uiDelegate.get().createWebViewWithConfiguration = ^(WKWebViewConfiguration *config, WKNavigationAction *action, WKWindowFeatures *features) {
+        enableSiteIsolation(config);
+        popupWebView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400) configuration:config]);
+        popupWebView.get().navigationDelegate = popupNavDelegate.get();
+        return popupWebView.get();
+    };
+
+    RetainPtr openerWebView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    openerWebView.get().navigationDelegate = openerNavDelegate.get();
+    openerWebView.get().UIDelegate = uiDelegate.get();
+    openerWebView.get().configuration.preferences.javaScriptCanOpenWindowsAutomatically = YES;
+
+    [openerWebView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/main"]]];
+    [openerNavDelegate waitForDidFinishNavigation];
+
+    // Wait for the cross-origin iframe to load in its own process.
+    while (![[openerWebView firstChildFrame].securityOrigin.host isEqualToString:@"webkit.org"])
+        Util::spinRunLoop();
+
+    // Verify that webkit.org cookies are blocked as third-party under example.com.
+    NSString *cookieBefore = [openerWebView stringByEvaluatingJavaScript:@"document.cookie" inFrame:[openerWebView firstChildFrame]];
+    EXPECT_WK_STREQ(cookieBefore, "");
+
+    // Open a popup to webkit.org which sets a cookie in first-party context.
+    [openerWebView evaluateJavaScript:@"window.open('https://webkit.org/popup')" completionHandler:nil];
+    [popupNavDelegate waitForDidFinishNavigation];
+
+    // The popup is in a different process from the opener (Site Isolation).
+    // The opener is a RemoteFrame from the popup's perspective.
+    EXPECT_NE([openerWebView _webProcessIdentifier], [popupWebView _webProcessIdentifier]);
+
+    NSString *cookieInPopup = [popupWebView stringByEvaluatingJavaScript:@"document.cookie"];
+    EXPECT_WK_STREQ(cookieInPopup, "auth=loggedin");
+
+    // Simulate user interaction in the popup.
+    [popupWebView sendClicksAtPoint:NSMakePoint(50, 50) numberOfClicks:1];
+    [popupWebView waitForPendingMouseEvents];
+
+    // Poll until the iframe can read its unpartitioned cookie.
+    NSString *cookieAfter = @"";
+    while (true) {
+        cookieAfter = [openerWebView stringByEvaluatingJavaScript:@"document.cookie" inFrame:[openerWebView firstChildFrame]];
+        if ([cookieAfter length] > 0)
+            break;
+        Util::runFor(0.1_s);
+    }
+    EXPECT_WK_STREQ(cookieAfter, "auth=loggedin");
+}
+
 #endif
 
 static auto advanceFocusAcrossFramesMainFrame = R"FOCUSRESOURCE(


### PR DESCRIPTION
#### 4412374ea0fcf2daa2efa5e75455b98a85bcef66
<pre>
&quot;Continue with Google&quot; sign-in redirects to blank page
<a href="https://bugs.webkit.org/show_bug.cgi?id=320487">https://bugs.webkit.org/show_bug.cgi?id=320487</a>
<a href="https://rdar.apple.com/168244132">rdar://168244132</a>

Reviewed by Sihui Liu.

With Site Isolation enabled, when a popup triggers user interaction,
requestStorageAccessUnderOpener failed because the opener is a
RemoteFrame, so the existing LocalFrame downcast returned null.

In WebResourceLoadObserver, detect when the opener is a RemoteFrame
and send RequestStorageAccessUnderOpener directly to the
NetworkProcess using the opener URL from WebPage creation parameters.

(WebKit::WebResourceLoadObserver::logUserInteractionWithReducedTimeResolution):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm:
(TEST):

Canonical link: <a href="https://commits.webkit.org/318314@main">https://commits.webkit.org/318314@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/867ada7edde440d22fe0250bd2e80b33aa2d753c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177912 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51850 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45644 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187522 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/141159 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/dc1c0ff3-d7f8-4f4d-81c6-7bae4b5485b5) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179775 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53143 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51559 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138677 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/141159 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d350c9e7-5828-47b4-9552-638355d03898) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180868 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42210 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159422 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119140 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/cb7a50d5-8622-481b-ba81-f521228402a0) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40873 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39232 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151278 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38916 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35983 "Built successfully") | | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44442 "Found 1 new failure in wasm/WasmConstExprGenerator.cpp") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43468 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189951 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51517 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147806 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52199 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35545 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147587 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26982 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42299 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124451 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118886 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50707 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13896 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50103 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50343 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50165 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->