### PR TITLE
Subframe is missing from the back/forward list when its src changes before the first load commits

### DIFF
--- a/LayoutTests/fast/history/back-to-discarded-page-loads-subframe-history-url-expected.txt
+++ b/LayoutTests/fast/history/back-to-discarded-page-loads-subframe-history-url-expected.txt
@@ -1,0 +1,6 @@
+
+
+============== Back Forward List ==============
+curr->  (file test):fast/history/back-to-discarded-page-loads-subframe-history-url.html
+            (file test):fast/history/resources/discarded-page-subframe-blue.html (in frame "theSubframe")
+===============================================

--- a/LayoutTests/fast/history/back-to-discarded-page-loads-subframe-history-url.html
+++ b/LayoutTests/fast/history/back-to-discarded-page-loads-subframe-history-url.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.dumpBackForwardList();
+    testRunner.waitUntilDone();
+}
+</script>
+</head>
+<body>
+<iframe id="frame" name="theSubframe" src="resources/discarded-page-subframe-red.html"></iframe>
+<script>
+const frame = document.getElementById("frame");
+frame.src = "resources/discarded-page-subframe-red.html";
+
+window.addEventListener("load", function () {
+    frame.onload = function () {
+        frame.onload = null;
+        if (window.testRunner)
+            testRunner.notifyDone();
+    };
+    frame.src = "resources/discarded-page-subframe-blue.html";
+});
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/history/resources/discarded-page-subframe-blue.html
+++ b/LayoutTests/fast/history/resources/discarded-page-subframe-blue.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html>
+<html>
+<body style="background: blue">blue</body>
+</html>

--- a/LayoutTests/fast/history/resources/discarded-page-subframe-red.html
+++ b/LayoutTests/fast/history/resources/discarded-page-subframe-red.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html>
+<html>
+<body style="background: red">red</body>
+</html>

--- a/LayoutTests/http/tests/navigation/multiple-back-forward-entries-expected.txt
+++ b/LayoutTests/http/tests/navigation/multiple-back-forward-entries-expected.txt
@@ -3,4 +3,5 @@ This test creates an iFrame via document.write(), then immediately changes the s
 
 ============== Back Forward List ==============
 curr->  http://127.0.0.1:8000/navigation/multiple-back-forward-entries.html
+            http://127.0.0.1:8000/navigation/resources/slow-resource.pl?delay=250 (in frame "<!--frame1-->")
 ===============================================

--- a/Source/WebCore/loader/HistoryController.cpp
+++ b/Source/WebCore/loader/HistoryController.cpp
@@ -610,35 +610,42 @@ void HistoryController::updateForRedirectWithLockedBackForwardList()
     bool canRecordHistory = canRecordHistoryForFrame(m_frame);
     auto historyURL = documentLoader ? documentLoader->urlForHistory() : URL { };
 
+    auto createChildItemInParent = [&] {
+        RefPtr page = m_frame->page();
+        RefPtr parentFrame = dynamicDowncast<LocalFrame>(m_frame->tree().parent());
+        if (!page || !parentFrame)
+            return;
+        RefPtr parentCurrentItem = parentFrame->loader().history().currentItem();
+        if (!parentCurrentItem)
+            return;
+        Ref item = createItem(page->historyItemClient(), parentCurrentItem->itemID());
+        parentCurrentItem->setChildItem(item.copyRef());
+        protect(page->backForward())->setChildItem(parentCurrentItem->frameItemID(), WTF::move(item));
+    };
+
     if (documentLoader && documentLoader->isClientRedirect()) {
-        if (!m_currentItem && m_frame->isMainFrame()) {
-            if (!historyURL.isEmpty()) {
-                updateBackForwardListClippedAtTarget(true);
-                if (canRecordHistory) {
-                    Ref frameLoader = m_frame->loader();
-                    protect(frameLoader->client())->updateGlobalHistory();
-                    documentLoader->setDidCreateGlobalHistoryEntry(true);
-                    if (documentLoader->unreachableURL().isEmpty())
-                        protect(frameLoader->client())->updateGlobalHistoryRedirectLinks();
+        if (!m_currentItem) {
+            if (m_frame->isMainFrame()) {
+                if (!historyURL.isEmpty()) {
+                    updateBackForwardListClippedAtTarget(true);
+                    if (canRecordHistory) {
+                        Ref frameLoader = m_frame->loader();
+                        protect(frameLoader->client())->updateGlobalHistory();
+                        documentLoader->setDidCreateGlobalHistoryEntry(true);
+                        if (documentLoader->unreachableURL().isEmpty())
+                            protect(frameLoader->client())->updateGlobalHistoryRedirectLinks();
+                    }
                 }
-            }
+            } else
+                createChildItemInParent();
         }
         // The client redirect replaces the current history item.
         if (RefPtr page = m_frame->page()) {
             auto scope = protect(page->historyItemClient())->ignoreChangesForScopeDuringRedirect(m_frame);
             updateCurrentItem();
         }
-    } else {
-        RefPtr page = m_frame->page();
-        RefPtr parentFrame = dynamicDowncast<LocalFrame>(m_frame->tree().parent());
-        if (page && parentFrame) {
-            if (RefPtr parentCurrentItem = parentFrame->loader().history().currentItem()) {
-                Ref item = createItem(page->historyItemClient(), parentCurrentItem->itemID());
-                parentCurrentItem->setChildItem(item.copyRef());
-                protect(page->backForward())->setChildItem(parentCurrentItem->frameItemID(), WTF::move(item));
-            }
-        }
-    }
+    } else
+        createChildItemInParent();
 
     if (!historyURL.isEmpty() && canRecordHistory) {
         Ref frame = m_frame.get();


### PR DESCRIPTION
#### 992b7aefb22245f7431f27e06ff84aab288da8c6
<pre>
Subframe is missing from the back/forward list when its src changes before the first load commits
<a href="https://bugs.webkit.org/show_bug.cgi?id=320488">https://bugs.webkit.org/show_bug.cgi?id=320488</a>
<a href="https://rdar.apple.com/149977268">rdar://149977268</a>

Reviewed by NOBODY (OOPS!).

When a subframe&apos;s src changes before its initial load has created a history item,
HistoryController::updateForRedirectWithLockedBackForwardList() took a path that skipped creating a
child item in the parent&apos;s current item. With no child item recorded, going back to a page discarded
from the back/forward cache reloaded the subframe&apos;s original markup src instead of its history URL.

Hoist the child-item creation into a lambda and run it on that path too.

Test: fast/history/back-to-discarded-page-loads-subframe-history-url.html

* LayoutTests/fast/history/back-to-discarded-page-loads-subframe-history-url-expected.txt: Added.
* LayoutTests/fast/history/back-to-discarded-page-loads-subframe-history-url.html: Added.
* LayoutTests/fast/history/resources/discarded-page-subframe-blue.html: Added.
* LayoutTests/fast/history/resources/discarded-page-subframe-red.html: Added.
* LayoutTests/http/tests/navigation/multiple-back-forward-entries-expected.txt:
* Source/WebCore/loader/HistoryController.cpp:
(WebCore::HistoryController::updateForRedirectWithLockedBackForwardList):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/992b7aefb22245f7431f27e06ff84aab288da8c6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177314 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51252 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45046 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186917 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/140561 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c19d4287-528d-45be-b611-75e8b89932d6) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179177 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52544 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50941 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138182 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96305 "1 flakes 2 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3aa9473e-3627-40d3-b3ad-f87d47b0136b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180270 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41682 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158935 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118647 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e690a6eb-eeff-4424-baf2-972eff46fd59) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40343 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38721 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150751 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38432 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35385 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/43037 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42936 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189346 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50918 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/158469 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147267 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51601 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35059 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147058 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41784 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123816 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118152 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50109 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13410 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49505 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49745 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49567 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->