### PR TITLE
Compute minimum content size for break-spaces text without running line layout

### DIFF
--- a/Source/WebCore/layout/formattingContexts/inline/InlineContentBreaker.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineContentBreaker.cpp
@@ -893,46 +893,6 @@ InlineContentBreaker::OverflowingTextContent InlineContentBreaker::processOverfl
     return { overflowingRunIndex };
 }
 
-EnumSet<InlineContentBreaker::WordBreakRule> InlineContentBreaker::wordBreakBehavior(const Style::ComputedStyle& style, bool hasWrapOpportunityAtPreviousPosition) const
-{
-    // Disregard any prohibition against line breaks mandated by the word-break property.
-    // The different wrapping opportunities must not be prioritized.
-    // Note hyphenation is not applied.
-    if (style.lineBreak() == LineBreak::Anywhere)
-        return { WordBreakRule::AtArbitraryPosition };
-
-    // Breaking is allowed within “words”.
-    if (style.wordBreak() == WordBreak::BreakAll)
-        return { WordBreakRule::AtArbitraryPositionWithinWords };
-
-    auto includeHyphenationIfAllowed = [&](std::optional<InlineContentBreaker::WordBreakRule> wordBreakRule) -> EnumSet<InlineContentBreaker::WordBreakRule> {
-        auto hyphenationIsAllowed = !m_hyphenationIsDisabled && style.hyphens() == Hyphens::Auto && canHyphenate(Style::toPlatform(style.computedLocale()));
-        if (hyphenationIsAllowed) {
-            if (wordBreakRule)
-                return { *wordBreakRule, WordBreakRule::AtHyphenationOpportunities };
-            return { WordBreakRule::AtHyphenationOpportunities };
-        }
-        if (wordBreakRule)
-            return *wordBreakRule;
-        return { };
-    };
-
-    // For compatibility with legacy content, the word-break property also supports a deprecated break-word keyword.
-    // When specified, this has the same effect as word-break: normal and overflow-wrap: anywhere, regardless of the actual value of the overflow-wrap property.
-    if (style.wordBreak() == WordBreak::BreakWord && !hasWrapOpportunityAtPreviousPosition)
-        return includeHyphenationIfAllowed(WordBreakRule::AtArbitraryPosition);
-    // OverflowWrap::BreakWord/Anywhere An otherwise unbreakable sequence of characters may be broken at an arbitrary point if there are no otherwise-acceptable break points in the line.
-    // Note that this applies to content where CSS properties (e.g. WordBreak::KeepAll) make it unbreakable. 
-    // Soft wrap opportunities introduced by overflow-wrap/word-wrap: break-word are not considered when calculating min-content intrinsic sizes.
-    auto overflowWrapBreakWordIsApplicable = !isMinimumInIntrinsicWidthMode();
-    if (((overflowWrapBreakWordIsApplicable && style.overflowWrap() == OverflowWrap::BreakWord) || style.overflowWrap() == OverflowWrap::Anywhere) && !hasWrapOpportunityAtPreviousPosition)
-        return includeHyphenationIfAllowed(WordBreakRule::AtArbitraryPosition);
-    // Breaking is forbidden within “words”.
-    if (style.wordBreak() == WordBreak::KeepAll)
-        return { };
-    return includeHyphenationIfAllowed({ });
-}
-
 void InlineContentBreaker::ContinuousContent::setTrailingSoftHyphenWidth(InlineLayoutUnit hyphenWidth)
 {
     m_logicalWidth += hyphenWidth;

--- a/Source/WebCore/layout/formattingContexts/inline/InlineContentBreaker.h
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineContentBreaker.h
@@ -27,6 +27,7 @@
 
 #include <WebCore/FormattingConstraints.h>
 #include <WebCore/LayoutUnits.h>
+#include <WebCore/TextUtil.h>
 
 namespace WebCore {
 
@@ -186,12 +187,13 @@ private:
     std::optional<OverflowingTextContent::BreakingPosition> tryBreakingNextOverflowingRuns(const LineStatus&, const ContinuousContent::RunList&, size_t overflowingRunIndex, InlineLayoutUnit nonOverflowingContentWidth) const;
     std::optional<OverflowingTextContent::BreakingPosition> tryHyphenationAcrossOverflowingInlineTextItems(const LineStatus&, const ContinuousContent::RunList&, size_t overflowingRunIndex) const;
 
-    enum class WordBreakRule : uint8_t {
-        AtArbitraryPositionWithinWords,
-        AtArbitraryPosition,
-        AtHyphenationOpportunities
-    };
-    EnumSet<WordBreakRule> wordBreakBehavior(const Style::ComputedStyle&, bool hasWrapOpportunityAtPreviousPosition) const;
+    using WordBreakRule = TextUtil::WordBreakRule;
+    EnumSet<WordBreakRule> wordBreakBehavior(const Style::ComputedStyle& style, bool hasWrapOpportunityAtPreviousPosition) const
+    {
+        return TextUtil::wordBreakBehavior(style, hasWrapOpportunityAtPreviousPosition,
+            m_isMinimumInIntrinsicWidthMode ? TextUtil::IsMinimumInIntrinsicWidthMode::Yes : TextUtil::IsMinimumInIntrinsicWidthMode::No,
+            m_hyphenationIsDisabled ? TextUtil::HyphenationIsDisabled::Yes : TextUtil::HyphenationIsDisabled::No);
+    }
     bool isMinimumInIntrinsicWidthMode() const { return m_isMinimumInIntrinsicWidthMode; }
 
 private:

--- a/Source/WebCore/layout/formattingContexts/inline/IntrinsicWidthHandler.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/IntrinsicWidthHandler.cpp
@@ -150,11 +150,78 @@ IntrinsicWidthHandler::IntrinsicWidthHandler(InlineFormattingContext& inlineForm
     initializeRangeAndTextOnlyBuilderEligibility();
 }
 
-InlineLayoutUnit IntrinsicWidthHandler::minimumContentSize()
-{
-    if (isContentEligibleForNonLineBuilderMinimumWidth(formattingContextRoot(), m_inlineItems, m_mayUseSimplifiedTextOnlyInlineLayoutInRange))
-        return simplifiedMinimumWidth(formattingContextRoot());
+struct ContentWidthBetweenLineBreaks {
+    InlineLayoutUnit maximum { };
+    InlineLayoutUnit current { };
+};
 
+std::optional<InlineLayoutUnit> IntrinsicWidthHandler::minimumContentSizeForBreakSpaces()
+{
+    if (!m_mayUseSimplifiedTextOnlyInlineLayoutInRange)
+        return { };
+
+    auto& lineBuilderRoot = this->lineBuilderRoot();
+    auto& lineBuilderRootStyle = lineBuilderRoot.style();
+    auto isEligibleForBreakSpacesFastPath = [&] {
+        if (lineBuilderRootStyle.whiteSpaceCollapse() != WhiteSpaceCollapse::BreakSpaces)
+            return false;
+        if (&lineBuilderRootStyle != &lineBuilderRoot.firstLineStyle())
+            return false;
+        if (!TextUtil::isWrappingAllowed(lineBuilderRootStyle))
+            return false;
+        if (m_inlineItemRange.isEmpty())
+            return false;
+        if (!TextUtil::wordBreakBehavior(lineBuilderRootStyle, false, TextUtil::IsMinimumInIntrinsicWidthMode::Yes, TextUtil::HyphenationIsDisabled::No).isEmpty())
+            return false;
+        return true;
+    };
+
+    if (!isEligibleForBreakSpacesFastPath())
+        return { };
+
+    auto& inlineItemList = this->inlineItemList();
+
+    auto maximumUnbreakableWidth = InlineLayoutUnit { };
+    auto currentUnbreakableWidth = InlineLayoutUnit { };
+    auto contentWidthBetweenLineBreaks = ContentWidthBetweenLineBreaks { };
+    auto layoutRange = m_inlineItemRange;
+
+    auto recordUnbreakableWidth = [](auto& currentUnbreakableWidth, auto& maximumUnbreakableWidth, auto& contentWidthBetweenLineBreaks) {
+        maximumUnbreakableWidth = std::max(maximumUnbreakableWidth, currentUnbreakableWidth);
+        contentWidthBetweenLineBreaks.current += currentUnbreakableWidth;
+        currentUnbreakableWidth = { };
+    };
+
+    for (size_t index = layoutRange.startIndex(); index < layoutRange.endIndex(); ++index) {
+        auto& inlineItem = inlineItemList[index];
+        if (inlineItem.isLineBreak()) {
+            recordUnbreakableWidth(currentUnbreakableWidth, maximumUnbreakableWidth, contentWidthBetweenLineBreaks);
+            contentWidthBetweenLineBreaks.maximum = std::max(contentWidthBetweenLineBreaks.maximum, contentWidthBetweenLineBreaks.current);
+            contentWidthBetweenLineBreaks.current = { };
+            continue;
+        }
+
+        auto& inlineTextItem = downcast<InlineTextItem>(inlineItem);
+        auto width = inlineTextItem.width();
+        if (!width)
+            width = TextOnlySimpleLineBuilder::measuredInlineTextItem(inlineTextItem, lineBuilderRootStyle, currentUnbreakableWidth);
+
+        bool isAtSoftWrapOpportunityOrContentEnd = TextOnlySimpleLineBuilder::isAtSoftWrapOpportunityOrContentEnd(inlineTextItem, inlineItemList, index + 1, layoutRange, lineBuilderRootStyle);
+        if (inlineTextItem.hasTrailingSoftHyphen() && isAtSoftWrapOpportunityOrContentEnd && !TextOnlySimpleLineBuilder::isAtContentEnd(inlineItemList, index + 1, layoutRange))
+            *width += TextUtil::hyphenWidth(lineBuilderRootStyle);
+
+        currentUnbreakableWidth += *width;
+        if (isAtSoftWrapOpportunityOrContentEnd)
+            recordUnbreakableWidth(currentUnbreakableWidth, maximumUnbreakableWidth, contentWidthBetweenLineBreaks);
+    }
+    // Summing the widths of unbreakable InlineItems between forced breaks is the unwrapped width, so this is a max-content value.
+    // maximumContentSize() returns it instead of running its own line layout.
+    m_maximumContentWidthBetweenLineBreaks = std::max(contentWidthBetweenLineBreaks.current, contentWidthBetweenLineBreaks.maximum);
+    return maximumUnbreakableWidth;
+}
+
+InlineLayoutUnit IntrinsicWidthHandler::lineBuilderMinimumContentSize()
+{
     if (m_mayUseSimplifiedTextOnlyInlineLayoutInRange) {
         auto simplifiedLineBuilder = TextOnlySimpleLineBuilder { formattingContext(), lineBuilderRoot(), { }, inlineItemList() };
         return computedIntrinsicWidthForConstraint(IntrinsicWidthMode::Minimum, simplifiedLineBuilder, MayCacheLayoutResult::No);
@@ -162,6 +229,30 @@ InlineLayoutUnit IntrinsicWidthHandler::minimumContentSize()
 
     auto lineBuilder = LineBuilder { formattingContext(), { }, inlineItemList() };
     return computedIntrinsicWidthForConstraint(IntrinsicWidthMode::Minimum, lineBuilder, MayCacheLayoutResult::No);
+}
+
+InlineLayoutUnit IntrinsicWidthHandler::minimumContentSize()
+{
+    if (isContentEligibleForNonLineBuilderMinimumWidth(formattingContextRoot(), m_inlineItems, m_mayUseSimplifiedTextOnlyInlineLayoutInRange))
+        return simplifiedMinimumWidth(formattingContextRoot());
+
+    if (auto minimumContentSize = minimumContentSizeForBreakSpaces()) {
+#ifndef NDEBUG
+        {
+            auto nonLineBuilderContentWidthBetweenLineBreaks = m_maximumContentWidthBetweenLineBreaks;
+            auto lineBuilderContentSize = lineBuilderMinimumContentSize();
+            ASSERT(ceiledLayoutUnit(*minimumContentSize) == ceiledLayoutUnit(lineBuilderContentSize));
+            ASSERT(m_maximumContentWidthBetweenLineBreaks && nonLineBuilderContentWidthBetweenLineBreaks);
+            ASSERT(std::abs(*m_maximumContentWidthBetweenLineBreaks - *nonLineBuilderContentWidthBetweenLineBreaks) < 1);
+            // computedIntrinsicWidthForConstraint overwrote the member. Restore the fast path's value so maximumContentSize()
+            // returns the same value in debug as it would in release.
+            m_maximumContentWidthBetweenLineBreaks = nonLineBuilderContentWidthBetweenLineBreaks;
+        }
+#endif
+        return *minimumContentSize;
+    }
+
+    return lineBuilderMinimumContentSize();
 }
 
 InlineLayoutUnit IntrinsicWidthHandler::maximumContentSize()
@@ -198,10 +289,6 @@ InlineLayoutUnit IntrinsicWidthHandler::computedIntrinsicWidthForConstraint(Intr
 
     auto availableWidth = intrinsicWidthMode == IntrinsicWidthMode::Maximum ? maxInlineLayoutUnit() : 0.f;
     auto maximumContentWidth = InlineLayoutUnit { };
-    struct ContentWidthBetweenLineBreaks {
-        InlineLayoutUnit maximum { };
-        InlineLayoutUnit current { };
-    };
     auto contentWidthBetweenLineBreaks = ContentWidthBetweenLineBreaks { };
     auto previousLineEnd = std::optional<InlineItemPosition> { };
     auto previousLine = std::optional<PreviousLine> { };

--- a/Source/WebCore/layout/formattingContexts/inline/IntrinsicWidthHandler.h
+++ b/Source/WebCore/layout/formattingContexts/inline/IntrinsicWidthHandler.h
@@ -47,6 +47,8 @@ private:
     enum class MayCacheLayoutResult : bool { No, Yes };
     InlineLayoutUnit computedIntrinsicWidthForConstraint(IntrinsicWidthMode, AbstractLineBuilder&, MayCacheLayoutResult = MayCacheLayoutResult::No);
     InlineLayoutUnit simplifiedMinimumWidth(const ElementBox& root) const;
+    std::optional<InlineLayoutUnit> minimumContentSizeForBreakSpaces();
+    InlineLayoutUnit lineBuilderMinimumContentSize();
     InlineLayoutUnit simplifiedMaximumWidth(MayCacheLayoutResult = MayCacheLayoutResult::No);
 
     InlineFormattingContext& NODELETE formattingContext() LIFETIME_BOUND;

--- a/Source/WebCore/layout/formattingContexts/inline/TextOnlySimpleLineBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/TextOnlySimpleLineBuilder.cpp
@@ -54,7 +54,7 @@ struct CandidateTextContent {
     InlineLayoutUnit logicalWidth { 0.f };
 };
 
-static inline InlineLayoutUnit measuredInlineTextItem(const InlineTextItem& inlineTextItem, const Style::ComputedStyle& style, InlineLayoutUnit contentLogicalLeft)
+InlineLayoutUnit TextOnlySimpleLineBuilder::measuredInlineTextItem(const InlineTextItem& inlineTextItem, const Style::ComputedStyle& style, InlineLayoutUnit contentLogicalLeft)
 {
     ASSERT(!inlineTextItem.width());
     if (!inlineTextItem.isWhitespace() || InlineTextItem::shouldPreserveSpacesAndTabs(inlineTextItem))
@@ -195,26 +195,31 @@ std::optional<LineLayoutResult> TextOnlySimpleLineBuilder::placeSingleCharacterC
     };
 }
 
+bool TextOnlySimpleLineBuilder::isAtContentEnd(std::span<const InlineItem> inlineItemList, size_t nextItemIndex, const InlineItemRange& layoutRange)
+{
+    return nextItemIndex >= layoutRange.endIndex() || inlineItemList[nextItemIndex].isLineBreak();
+}
+
+bool TextOnlySimpleLineBuilder::isAtSoftWrapOpportunityOrContentEnd(const InlineTextItem& inlineTextItem, std::span<const InlineItem> inlineItemList, size_t nextItemIndex, const InlineItemRange& layoutRange, const Style::ComputedStyle& rootStyle)
+{
+    if (inlineTextItem.isWhitespace())
+        return true;
+    if (isAtContentEnd(inlineItemList, nextItemIndex, layoutRange))
+        return true;
+    auto& nextInlineTextItem = downcast<InlineTextItem>(inlineItemList[nextItemIndex]);
+    if (nextInlineTextItem.isWhitespace())
+        return rootStyle.whiteSpaceCollapse() != WhiteSpaceCollapse::BreakSpaces && rootStyle.lineBreak() != LineBreak::AfterWhiteSpace;
+    return &inlineTextItem.inlineTextBox() == &nextInlineTextItem.inlineTextBox() || TextUtil::mayBreakInBetween(inlineTextItem, nextInlineTextItem);
+}
+
 InlineItemPosition TextOnlySimpleLineBuilder::placeInlineTextContent(const Style::ComputedStyle& rootStyle, const InlineItemRange& layoutRange)
 {
-    auto hasWrapOpportunityBeforeWhitespace = rootStyle.whiteSpaceCollapse() != WhiteSpaceCollapse::BreakSpaces && rootStyle.lineBreak() != LineBreak::AfterWhiteSpace;
     size_t placedInlineItemCount = 0;
 
     auto result = TextOnlyLineBreakResult { };
     auto candidateContent = CandidateTextContent { layoutRange.startIndex(), layoutRange.startIndex(), { } };
 
     auto nextItemIndex = layoutRange.startIndex();
-    auto isAtSoftWrapOpportunityOrContentEnd = [&](auto& inlineTextItem) {
-        if (inlineTextItem.isWhitespace())
-            return true;
-        if (nextItemIndex >= layoutRange.endIndex() || m_inlineItemList[nextItemIndex].isLineBreak())
-            return true;
-        auto& nextInlineTextItem = downcast<InlineTextItem>(m_inlineItemList[nextItemIndex]);
-        if (nextInlineTextItem.isWhitespace())
-            return hasWrapOpportunityBeforeWhitespace;
-        return &inlineTextItem.inlineTextBox() == &nextInlineTextItem.inlineTextBox() || TextUtil::mayBreakInBetween(inlineTextItem, nextInlineTextItem);
-    };
-
     auto processCandidateContent = [&] {
         result = commitCandidateContent(rootStyle, candidateContent, layoutRange);
         placedInlineItemCount = !result.isRevert ? placedInlineItemCount + result.committedCount : result.committedCount;
@@ -227,7 +232,7 @@ InlineItemPosition TextOnlySimpleLineBuilder::placeInlineTextContent(const Style
     if (m_partialLeadingTextItem) {
         candidateContent.append({ });
         ++nextItemIndex;
-        if (isAtSoftWrapOpportunityOrContentEnd(*m_partialLeadingTextItem))
+        if (isAtSoftWrapOpportunityOrContentEnd(*m_partialLeadingTextItem, m_inlineItemList, nextItemIndex, layoutRange, rootStyle))
             isEndOfLine = processCandidateContent();
     }
 
@@ -242,7 +247,7 @@ InlineItemPosition TextOnlySimpleLineBuilder::placeInlineTextContent(const Style
                 return measuredInlineTextItem(*inlineTextItem, rootStyle, m_line.contentLogicalRight() + candidateContent.logicalWidth);
             };
             candidateContent.append(contentWidth());
-            if (isAtSoftWrapOpportunityOrContentEnd(*inlineTextItem))
+            if (isAtSoftWrapOpportunityOrContentEnd(*inlineTextItem, m_inlineItemList, nextItemIndex, layoutRange, rootStyle))
                 isEndOfLine = processCandidateContent();
             continue;
         }

--- a/Source/WebCore/layout/formattingContexts/inline/TextOnlySimpleLineBuilder.h
+++ b/Source/WebCore/layout/formattingContexts/inline/TextOnlySimpleLineBuilder.h
@@ -45,6 +45,10 @@ public:
     static bool isEligibleForSimplifiedInlineLayoutByStyle(const Box&);
     static bool isEligibleForSimplifiedDisplayBuild(const ElementBox& rootBlockContainer);
 
+    static bool isAtContentEnd(std::span<const InlineItem>, size_t nextItemIndex, const InlineItemRange&);
+    static bool isAtSoftWrapOpportunityOrContentEnd(const InlineTextItem&, std::span<const InlineItem>, size_t nextItemIndex, const InlineItemRange&, const Style::ComputedStyle& rootStyle);
+    static InlineLayoutUnit measuredInlineTextItem(const InlineTextItem&, const Style::ComputedStyle&, InlineLayoutUnit contentLogicalLeft);
+
 private:
     InlineItemPosition placeInlineTextContent(const Style::ComputedStyle&, const InlineItemRange&);
     InlineItemPosition placeNonWrappingInlineTextContent(const Style::ComputedStyle&, const InlineItemRange&);

--- a/Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp
@@ -32,6 +32,7 @@
 #include "FontCascadeFonts.h"
 #include "FontCascadeInlines.h"
 #include "FontInlines.h"
+#include "Hyphenation.h"
 #include "InlineLineTypes.h"
 #include "InlineTextItem.h"
 #include "Latin1TextIterator.h"
@@ -443,6 +444,46 @@ bool TextUtil::isWrappingAllowed(const Style::ComputedStyle& style)
 {
     // https://www.w3.org/TR/css-text-4/#text-wrap
     return style.textWrapMode() != TextWrapMode::NoWrap;
+}
+
+EnumSet<TextUtil::WordBreakRule> TextUtil::wordBreakBehavior(const Style::ComputedStyle& style, bool hasWrapOpportunityAtPreviousPosition, IsMinimumInIntrinsicWidthMode isMinimumInIntrinsicWidthMode, HyphenationIsDisabled hyphenationIsDisabled)
+{
+    // Disregard any prohibition against line breaks mandated by the word-break property.
+    // The different wrapping opportunities must not be prioritized.
+    // Note hyphenation is not applied.
+    if (style.lineBreak() == LineBreak::Anywhere)
+        return { WordBreakRule::AtArbitraryPosition };
+
+    // Breaking is allowed within “words”.
+    if (style.wordBreak() == WordBreak::BreakAll)
+        return { WordBreakRule::AtArbitraryPositionWithinWords };
+
+    auto includeHyphenationIfAllowed = [&](std::optional<WordBreakRule> wordBreakRule) -> EnumSet<WordBreakRule> {
+        auto hyphenationIsAllowed = hyphenationIsDisabled == HyphenationIsDisabled::No && style.hyphens() == Hyphens::Auto && canHyphenate(Style::toPlatform(style.computedLocale()));
+        if (hyphenationIsAllowed) {
+            if (wordBreakRule)
+                return { *wordBreakRule, WordBreakRule::AtHyphenationOpportunities };
+            return { WordBreakRule::AtHyphenationOpportunities };
+        }
+        if (wordBreakRule)
+            return *wordBreakRule;
+        return { };
+    };
+
+    // For compatibility with legacy content, the word-break property also supports a deprecated break-word keyword.
+    // When specified, this has the same effect as word-break: normal and overflow-wrap: anywhere, regardless of the actual value of the overflow-wrap property.
+    if (style.wordBreak() == WordBreak::BreakWord && !hasWrapOpportunityAtPreviousPosition)
+        return includeHyphenationIfAllowed(WordBreakRule::AtArbitraryPosition);
+    // OverflowWrap::BreakWord/Anywhere An otherwise unbreakable sequence of characters may be broken at an arbitrary point if there are no otherwise-acceptable break points in the line.
+    // Note that this applies to content where CSS properties (e.g. WordBreak::KeepAll) make it unbreakable.
+    // Soft wrap opportunities introduced by overflow-wrap/word-wrap: break-word are not considered when calculating min-content intrinsic sizes.
+    auto overflowWrapBreakWordIsApplicable = isMinimumInIntrinsicWidthMode == IsMinimumInIntrinsicWidthMode::No;
+    if (((overflowWrapBreakWordIsApplicable && style.overflowWrap() == OverflowWrap::BreakWord) || style.overflowWrap() == OverflowWrap::Anywhere) && !hasWrapOpportunityAtPreviousPosition)
+        return includeHyphenationIfAllowed(WordBreakRule::AtArbitraryPosition);
+    // Breaking is forbidden within “words”.
+    if (style.wordBreak() == WordBreak::KeepAll)
+        return { };
+    return includeHyphenationIfAllowed({ });
 }
 
 bool TextUtil::shouldTrailingWhitespaceHang(const Style::ComputedStyle& style)

--- a/Source/WebCore/layout/formattingContexts/inline/text/TextUtil.h
+++ b/Source/WebCore/layout/formattingContexts/inline/text/TextUtil.h
@@ -30,6 +30,7 @@
 #include <WebCore/InlineLine.h>
 #include <WebCore/LayoutUnits.h>
 #include <WebCore/TextSpacing.h>
+#include <wtf/EnumSet.h>
 #include <wtf/Range.h>
 #include <wtf/WeakHashSet.h>
 #include <wtf/text/TextBreakIterator.h>
@@ -56,6 +57,15 @@ class InlineTextItem;
 
 class TextUtil {
 public:
+    enum class WordBreakRule : uint8_t {
+        AtArbitraryPositionWithinWords,
+        AtArbitraryPosition,
+        AtHyphenationOpportunities
+    };
+    enum class IsMinimumInIntrinsicWidthMode : bool { No, Yes };
+    enum class HyphenationIsDisabled : bool { No, Yes };
+    static EnumSet<WordBreakRule> wordBreakBehavior(const Style::ComputedStyle&, bool hasWrapOpportunityAtPreviousPosition, IsMinimumInIntrinsicWidthMode, HyphenationIsDisabled);
+
     enum class UseTrailingWhitespaceMeasuringOptimization : bool { No, Yes };
     static InlineLayoutUnit width(const InlineTextItem&, const FontCascade&, InlineLayoutUnit contentLogicalLeft);
     static InlineLayoutUnit width(const InlineTextItem&, const FontCascade&, unsigned from, unsigned to, InlineLayoutUnit contentLogicalLeft, UseTrailingWhitespaceMeasuringOptimization = UseTrailingWhitespaceMeasuringOptimization::Yes, TextSpacing::SpacingState spacingState = { }, GlyphOverflow* = nullptr);


### PR DESCRIPTION
#### 3e4e20f5b35f660ea1e3442dfcf8f7cd4724b9ec
<pre>
Compute minimum content size for break-spaces text without running line layout
<a href="https://bugs.webkit.org/show_bug.cgi?id=320489">https://bugs.webkit.org/show_bug.cgi?id=320489</a>
<a href="https://rdar.apple.com/183456012">rdar://183456012</a>

Reviewed by Alan Baradlay.

The minimum content size of an inline formatting context is the width of its widest
unbreakable piece of content, which for ordinary text is the widest word. We obtained it
by running a real line layout with an available width of zero, which forces one line per
unbreakable piece, so the line builder ran once per word and each call produced a full
line layout result the loop reduced to a width. Maximum content size goes through that
same loop with an infinite available width and lays out one line per forced break. The
cost difference between the two is therefore the number of lines laid out, and profiling
shows the minimum costing much more than the maximum.

We can skip the layout because at an available width of zero the line builder puts exactly
one unbreakable piece on each line, so the width the loop reads off the line is just that
piece&apos;s width. Building the inline item list already split the text at each position the
line break iterator reported and stored a width on each item, where it can. A piece&apos;s
width is the sum of its item widths, so laying out a line to obtain it is unnecessary.

Scope this optimization to content whose root style has white-space: break-spaces.
break-spaces keeps every space, so a piece is a word plus the space after it. It also
preserves spaces and tabs, which leaves no item fully trimmable so a line has nothing to
trim, and trailing whitespace only hangs under &apos;preserve&apos;, so it has nothing to hang
either. With both of those empty the width a line arrives at is the sum of the item widths
it was handed.

Add a fast path that traverses the inline item list, summing item widths and closing a
piece at each wrap opportunity. The fast path is only worth trusting if it agrees with the
line builder, so it calls the same wrap opportunity test the builder uses.
Early return from this optimization if it is possible we can break within an
item.

* Source/WebCore/layout/formattingContexts/inline/InlineContentBreaker.cpp:
(WebCore::Layout::InlineContentBreaker::wordBreakBehavior const): Deleted.
* Source/WebCore/layout/formattingContexts/inline/InlineContentBreaker.h:
(WebCore::Layout::InlineContentBreaker::wordBreakBehavior const):
* Source/WebCore/layout/formattingContexts/inline/IntrinsicWidthHandler.cpp:
(WebCore::Layout::IntrinsicWidthHandler::minimumContentSizeForBreakSpaces):
(WebCore::Layout::IntrinsicWidthHandler::lineBuilderMinimumContentSize):
(WebCore::Layout::IntrinsicWidthHandler::minimumContentSize):
(WebCore::Layout::IntrinsicWidthHandler::computedIntrinsicWidthForConstraint):
* Source/WebCore/layout/formattingContexts/inline/IntrinsicWidthHandler.h:
* Source/WebCore/layout/formattingContexts/inline/TextOnlySimpleLineBuilder.cpp:
(WebCore::Layout::TextOnlySimpleLineBuilder::measuredInlineTextItem):
(WebCore::Layout::TextOnlySimpleLineBuilder::isAtContentEnd):
(WebCore::Layout::TextOnlySimpleLineBuilder::isAtSoftWrapOpportunityOrContentEnd):
(WebCore::Layout::TextOnlySimpleLineBuilder::placeInlineTextContent):
(WebCore::Layout::measuredInlineTextItem): Deleted.
* Source/WebCore/layout/formattingContexts/inline/TextOnlySimpleLineBuilder.h:
* Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp:
(WebCore::Layout::TextUtil::wordBreakBehavior):
* Source/WebCore/layout/formattingContexts/inline/text/TextUtil.h:

Canonical link: <a href="https://commits.webkit.org/318914@main">https://commits.webkit.org/318914@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0d79acb34ccef53a503dcc9eec7e51c7f8a99c59

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179763 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53702 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47501 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189595 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144074 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/568e3782-c82e-4c7e-8fc4-89d25f94db9d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181626 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54996 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53414 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140219 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97041 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0bf23573-258a-44d2-9b6a-865f1f8cf1c9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182720 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43827 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160955 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120670 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e5c5eeb1-4a61-4f59-97a6-3d60564cfbf9) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42497 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40815 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152898 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40522 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1049 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46308 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45064 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191817 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53372 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149497 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40064 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54053 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37093 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149235 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43886 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126325 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121350 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52570 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15465 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51955 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52196 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52016 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->