### PR TITLE
EmbeddedPDFHUDSiteIsolation test suite should toggle SiteIsolationSharedProcessEnabled

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/UnifiedPDFTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/UnifiedPDFTests.mm
@@ -760,11 +760,14 @@ UNIFIED_PDF_TEST(PDFHUDMultipleIFrames)
 
 enum class PDFEmbedElement : uint8_t { IFrame, Embed, Object };
 
-class EmbeddedPDFHUDSiteIsolation : public testing::TestWithParam<std::tuple<PDFEmbedElement, bool, bool>> {
+using EmbeddedPDFHUDSiteIsolationParams = std::tuple<PDFEmbedElement, bool, bool, bool>;
+
+class EmbeddedPDFHUDSiteIsolation : public testing::TestWithParam<EmbeddedPDFHUDSiteIsolationParams> {
 public:
     PDFEmbedElement embedElement() const { return std::get<0>(GetParam()); }
     bool crossOrigin() const { return std::get<1>(GetParam()); }
     bool siteIsolationEnabled() const { return std::get<2>(GetParam()); }
+    bool siteIsolationSharedProcessEnabled() const { return std::get<3>(GetParam()); }
 
     String mainHTML() const
     {
@@ -782,7 +785,7 @@ public:
         return { };
     }
 
-    static std::string testNameGenerator(testing::TestParamInfo<std::tuple<PDFEmbedElement, bool, bool>> info)
+    static std::string testNameGenerator(testing::TestParamInfo<EmbeddedPDFHUDSiteIsolationParams> info)
     {
         std::string element = [embedElement = std::get<0>(info.param)] {
             switch (embedElement) {
@@ -798,7 +801,8 @@ public:
         }();
         return element
             + (std::get<1>(info.param) ? "_CrossOrigin" : "_SameOrigin")
-            + (std::get<2>(info.param) ? "_SiteIsolationEnabled" : "_SiteIsolationDisabled");
+            + "_SiteIsolation" + (std::get<2>(info.param) ? "Enabled" : "Disabled")
+            + "_SiteIsolationSharedProcess" + (std::get<3>(info.param) ? "Enabled" : "Disabled");
     }
 };
 
@@ -816,6 +820,8 @@ TEST_P(EmbeddedPDFHUDSiteIsolation, HUDMatchesOffset)
             [[configuration preferences] _setEnabled:YES forFeature:feature];
         else if ([key isEqualToString:@"SiteIsolationEnabled"])
             [[configuration preferences] _setEnabled:siteIsolationEnabled() forFeature:feature];
+        else if ([key isEqualToString:@"SiteIsolationSharedProcessEnabled"])
+            [[configuration preferences] _setEnabled:siteIsolationSharedProcessEnabled() forFeature:feature];
     }
 
     RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
@@ -841,7 +847,7 @@ TEST_P(EmbeddedPDFHUDSiteIsolation, HUDMatchesOffset)
     checkFrame([hud frame], 10, 28, 300, 150);
 }
 
-INSTANTIATE_TEST_SUITE_P(UnifiedPDF, EmbeddedPDFHUDSiteIsolation, testing::Combine(testing::Values(PDFEmbedElement::IFrame, PDFEmbedElement::Embed, PDFEmbedElement::Object), testing::Bool(), testing::Bool()), &EmbeddedPDFHUDSiteIsolation::testNameGenerator);
+INSTANTIATE_TEST_SUITE_P(UnifiedPDF, EmbeddedPDFHUDSiteIsolation, testing::Combine(testing::Values(PDFEmbedElement::IFrame, PDFEmbedElement::Embed, PDFEmbedElement::Object), testing::Bool(), testing::Bool(), testing::Bool()), &EmbeddedPDFHUDSiteIsolation::testNameGenerator);
 
 UNIFIED_PDF_TEST(PDFHUDLoadPDFTypeWithPluginsBlocked)
 {


### PR DESCRIPTION
#### cc692cea334e640a5e5038ecc5c80b052c589141
<pre>
EmbeddedPDFHUDSiteIsolation test suite should toggle SiteIsolationSharedProcessEnabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=320495">https://bugs.webkit.org/show_bug.cgi?id=320495</a>
<a href="https://rdar.apple.com/183460049">rdar://183460049</a>

Reviewed by Sihui Liu.

SiteIsolationSharedProcessEnabled may soon be enabled by default. While
this is a useful performance optimization to complement Site Isolation,
it _may_ mask real issues unique to frames in separate processes, since
there will be more process re-use now.

We should introduce test coverage around this feature, so let&apos;s retrofit
the EmbeddedPDFHUDSiteIsolation suite for that purpose.

* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/UnifiedPDFTests.mm:
(TestWebKitAPI::EmbeddedPDFHUDSiteIsolation::siteIsolationSharedProcessEnabled const):
(TestWebKitAPI::EmbeddedPDFHUDSiteIsolation::testNameGenerator):
(TestWebKitAPI::TEST_P):

Canonical link: <a href="https://commits.webkit.org/318183@main">https://commits.webkit.org/318183@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8cbbac3109b184e8c4584f46810346b920258bb7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177334 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51272 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45066 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186937 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140581 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e1f2eac9-dc7c-4c2b-a2d9-44730edb2e00) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179197 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52564 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50981 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138189 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140581 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/13352966-3e41-43b0-af59-6d3c6edb2971) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180290 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41694 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158952 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118654 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a6917146-977c-4ad4-925a-397372a70623) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40355 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38732 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150763 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38449 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35405 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42966 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189366 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50938 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147285 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51621 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35076 "Too many flaky failures: http/tests/contentextensions/video-element-resource-type.html, http/tests/media/now-playing-info-private-browsing.html, http/tests/misc/resource-timing-navigation-in-restored-iframe-2.html, http/tests/navigation/redirect-to-random-url-versus-memory-cache.html, http/tests/resourceLoadStatistics/only-accept-first-party-cookies-with-third-party-cookie-blocking.html, http/tests/security/contentSecurityPolicy/1.1/scriptnonce-allowed-by-enforced-policy-and-blocked-by-report-policy2.py, http/tests/security/contentSecurityPolicy/policy-does-not-affect-child.html, http/tests/security/mixedContent/secure-redirect-to-insecure-redirect-to-basic-auth-secure-image-UpgradeMixedContent.https.html, http/tests/storageAccess/deny-storage-access-under-opener-if-auto-dismiss-ephemeral.html, http/tests/websocket/tests/hybi/contentextensions/block-worker.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147077 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26930 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41797 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118174 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50129 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13427 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49525 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49765 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49587 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->