### PR TITLE
REGRESSION(317233@main): REGRESSION(317226@main): [GLIB] API test names reported in --json-output don't match the names reported to results.webkit.org

### DIFF
--- a/Tools/Scripts/webkitpy/api_tests/glib_api_test_runner_unittest.py
+++ b/Tools/Scripts/webkitpy/api_tests/glib_api_test_runner_unittest.py
@@ -1,0 +1,143 @@
+# Copyright (C) 2026 Igalia S.L.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""Unit tests for Tools/glib/api_test_runner.py."""
+
+import os
+import sys
+import tempfile
+import unittest
+
+tools_directory = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..'))
+sys.path.insert(0, os.path.join(tools_directory, 'glib'))
+sys.path.insert(0, os.path.join(tools_directory, 'jhbuild'))
+
+from api_test_runner import TestRunner  # noqa: E402
+
+
+class StubTestRunner(TestRunner):
+    def __init__(self, base_directory, tests=None):
+        self._base_directory = base_directory
+        self._initial_test_list = tests or []
+
+    def _test_programs_base_dir(self):
+        return self._base_directory
+
+    def is_google_test(self, test_program):
+        return os.path.basename(test_program) == "TestWTF"
+
+
+class GLibAPITestRunnerTest(unittest.TestCase):
+    def setUp(self):
+        self._temporary_directory = tempfile.TemporaryDirectory()
+        self._base_directory = self._temporary_directory.name
+        self._wpe_directory = os.path.join(self._base_directory, "WPE")
+        self._gtk_directory = os.path.join(self._base_directory, "WebKitGTK")
+        os.mkdir(self._wpe_directory)
+        os.mkdir(self._gtk_directory)
+        self._glib_test = self._create_executable(self._wpe_directory, "TestDownloads")
+        self._gtk_test = self._create_executable(self._gtk_directory, "TestWebKitWebView")
+        self._google_test = self._create_executable(self._base_directory, "TestWTF")
+
+    def tearDown(self):
+        self._temporary_directory.cleanup()
+
+    def _create_executable(self, directory, name):
+        path = os.path.join(directory, name)
+        with open(path, "w"):
+            pass
+        os.chmod(path, 0o755)
+        return path
+
+    def test_resolves_bare_and_prefixed_binary_names(self):
+        runner = StubTestRunner(self._base_directory)
+
+        self.assertEqual(self._glib_test, runner._resolve_test_program("TestDownloads"))
+        self.assertEqual(self._glib_test, runner._resolve_test_program("WPE/TestDownloads"))
+        self.assertEqual(self._gtk_test, runner._resolve_test_program("TestWebKitWebView"))
+        self.assertEqual(self._gtk_test, runner._resolve_test_program("WebKitGTK/TestWebKitWebView"))
+        self.assertEqual(self._google_test, runner._resolve_test_program("TestWTF"))
+
+    def test_canonical_and_prefixed_names_select_the_same_glib_subtest(self):
+        subtest = "/webkit/Downloads/download"
+        for requested_name in (
+            f"TestDownloads:{subtest}",
+            f"WPE/TestDownloads:{subtest}",
+        ):
+            with self.subTest(requested_name=requested_name):
+                runner = StubTestRunner(self._base_directory, [requested_name])
+                self.assertEqual([self._glib_test], runner._get_tests([requested_name]))
+                self.assertEqual([subtest], runner._getsubtests_to_run_for_test(self._glib_test))
+
+    def test_canonical_google_test_name_resolves_and_selects_only_its_test_case(self):
+        requested_name = "TestWTF.WTF_GUniquePtr.Basic"
+        runner = StubTestRunner(self._base_directory, [requested_name])
+
+        self.assertEqual([self._google_test], runner._get_tests([requested_name]))
+        self.assertEqual(["WTF_GUniquePtr.Basic"], runner._getsubtests_to_run_for_test(self._google_test))
+
+    def test_multiple_subtests_are_preserved(self):
+        requested_names = [
+            "TestDownloads:/webkit/Downloads/first",
+            "TestDownloads:/webkit/Downloads/second",
+        ]
+        runner = StubTestRunner(self._base_directory, requested_names)
+
+        self.assertEqual([self._glib_test], runner._get_tests(requested_names))
+        self.assertEqual([
+            "/webkit/Downloads/first",
+            "/webkit/Downloads/second",
+        ], runner._getsubtests_to_run_for_test(self._glib_test))
+
+    def test_uploaded_names_can_be_passed_back_to_the_runner(self):
+        test_cases = (
+            (self._glib_test, "/webkit/Downloads/download", "TestDownloads:/webkit/Downloads/download"),
+            (self._gtk_test, "/webkit/WebKitWebView/title", "TestWebKitWebView:/webkit/WebKitWebView/title"),
+            (self._google_test, "WTF_GUniquePtr.Basic", "TestWTF.WTF_GUniquePtr.Basic"),
+        )
+        for test_program, test_case, expected_name in test_cases:
+            with self.subTest(test_program=test_program):
+                runner = StubTestRunner(self._base_directory)
+                uploaded_name = runner._get_test_name_for_upload(test_program, test_case)
+                runner._initial_test_list = [uploaded_name]
+
+                self.assertEqual(expected_name, uploaded_name)
+                self.assertEqual([test_program], runner._get_tests([uploaded_name]))
+                self.assertEqual([test_case], runner._getsubtests_to_run_for_test(test_program))
+
+    def test_json_output_uses_uploaded_test_names(self):
+        runner = StubTestRunner(self._base_directory)
+
+        self.assertEqual([
+            {"name": "TestDownloads:/webkit/Downloads/download", "output": None},
+            {"name": "TestWebKitWebView:/webkit/WebKitWebView/title", "output": None},
+            {"name": "TestWTF.WTF_GUniquePtr.Basic", "output": None},
+        ], runner._generate_test_list_for_json_output({
+            self._glib_test: ["/webkit/Downloads/download"],
+            self._gtk_test: ["/webkit/WebKitWebView/title"],
+            self._google_test: ["WTF_GUniquePtr.Basic"],
+        }))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Tools/glib/api_test_runner.py
+++ b/Tools/glib/api_test_runner.py
@@ -113,12 +113,25 @@ class TestRunner(object):
         test_dir_prefix_len = len(self._test_programs_base_dir()) + 1
         return (path[test_dir_prefix_len:] for path in test_paths)
 
+    def _resolve_test_program(self, test):
+        # Test binaries to run can be specified by the bare name or by using a path to the binary (relative or full)
+        if os.path.exists(test):
+            return test
+        base_dir = self._test_programs_base_dir()
+        candidate = os.path.join(base_dir, test)
+        if os.path.exists(candidate):
+            return candidate
+        if os.sep not in test and os.path.isdir(base_dir):
+            for entry in sorted(os.listdir(base_dir)):
+                nested = os.path.join(base_dir, entry, test)
+                if os.path.isfile(nested) and os.access(nested, os.X_OK):
+                    return nested
+        return candidate
+
     def _get_tests(self, requested_test_list):
         tests = []
         for test in requested_test_list:
-            test = self._binary_and_subtest(test)[0]
-            if not os.path.exists(test):
-                test = os.path.join(self._test_programs_base_dir(), test)
+            test = self._resolve_test_program(self._binary_and_subtest(test)[0])
             if os.path.isdir(test):
                 tests.extend(self._get_tests_from_dir(test))
             elif os.path.isfile(test) and os.access(test, os.X_OK):
@@ -367,6 +380,16 @@ class TestRunner(object):
         separator = '.' if self.is_google_test(test_path) else ':'
         return f'{short_name}{separator}{test_case}'
 
+    def _generate_test_list_for_json_output(self, tests):
+        test_list = []
+        for test in tests:
+            for test_case in tests[test]:
+                # Report the same name used for results.webkit.org, so that consumers of this
+                # file (the EWS) can look the test up there and pass it back on the command line.
+                # FIXME: get output from failed tests
+                test_list.append({"name": self._get_test_name_for_upload(test, test_case), "output": None})
+        return test_list
+
     def _binary_and_subtest(self, test_name):
         # Accept both the "<binary>:<subtest>" (GLib) and "<binary>.<case>"
         # (Google Test) forms. Split the dotted form only when the bare name is
@@ -378,12 +401,17 @@ class TestRunner(object):
             return tuple(test_name.split('.', 1))
         return test_name, None
 
+    def _canonical_binary_name(self, test_name):
+        # Drop the base directory and any port-specific subdirectory so that the prefixed
+        # ("WPE/TestDownloads") and bare ("TestDownloads") spellings compare equal.
+        return os.path.basename(self._get_test_short_name(test_name))
+
     def _getsubtests_to_run_for_test(self, requested_test_name):
         subtests_to_run = []
-        requested_test_name = self._get_test_short_name(requested_test_name)
+        requested_test_name = self._canonical_binary_name(requested_test_name)
         for test_name in self._initial_test_list:
             test_name, subtest_name = self._binary_and_subtest(test_name)
-            if requested_test_name == self._get_test_short_name(test_name):
+            if requested_test_name == self._canonical_binary_name(test_name):
                 if subtest_name:
                     subtests_to_run.append(subtest_name)
                 else:
@@ -518,21 +546,11 @@ class TestRunner(object):
         report(timed_out_tests, "timeouts", self._test_programs_base_dir())
         report(passed_tests, "passes", self._test_programs_base_dir())
 
-        def generate_test_list_for_json_output(tests):
-            test_list = []
-            for test in tests:
-                base_name = self._get_test_short_name(test)
-                for test_case in tests[test]:
-                    test_name = "%s:%s" % (base_name, test_case)
-                    # FIXME: get output from failed tests
-                    test_list.append({"name": test_name, "output": None})
-            return test_list
-
         if self._options.json_output:
             result_dictionary = {}
-            result_dictionary['Failed'] = generate_test_list_for_json_output(failed_tests)
-            result_dictionary['Crashed'] = generate_test_list_for_json_output(crashed_tests)
-            result_dictionary['Timedout'] = generate_test_list_for_json_output(timed_out_tests)
+            result_dictionary['Failed'] = self._generate_test_list_for_json_output(failed_tests)
+            result_dictionary['Crashed'] = self._generate_test_list_for_json_output(crashed_tests)
+            result_dictionary['Timedout'] = self._generate_test_list_for_json_output(timed_out_tests)
             self._port.host.filesystem.write_text_file(self._options.json_output, json.dumps(result_dictionary, indent=4))
 
         if self._options.report_urls:


### PR DESCRIPTION
#### da58bb4f55b16310af446902cf4d58e7f97fcf74
<pre>
REGRESSION(317233@main): REGRESSION(317226@main): [GLIB] API test names reported in --json-output don&apos;t match the names reported to results.webkit.org
<a href="https://bugs.webkit.org/show_bug.cgi?id=320499">https://bugs.webkit.org/show_bug.cgi?id=320499</a>

Reviewed by Carlos Garcia Campos.

317226@main removed the port subdirectory from being part of the name uploaded
to results.webkit.org, and 317233@main made Google Test cases use a dot like
the Mac ports do. However, neither updated --json-output, which still uses the
old names.

This causes problems on the EWS for API tests on GTK and WPE, when there are
failures on a run it tries to consult resuls.webkit.org to see if the failure
is pre-existent but for that query it uses the test names as reported in the
json file, and those names don&apos;t match anymore.

Fix that by ensuring that the names used for the tests stay consistent both in
--json-output as well as on the names used for the upload to results.webkit.org

When running tests accept as argument for the test to run both a binary path (full
or relative) on the command line as well as the bare name with the port subdirectory
removed. So the previous naming still works to specify tests to run even when the
name of the tests reported uses the bare name everywhere now.

Also added unit tests to verify this works as expected and doesn&apos;t regress,
including also round trip testing from the canonical names written to --json-output
back to the command-line runner.

* Tools/Scripts/webkitpy/api_tests/glib_api_test_runner_unittest.py: Added.
(StubTestRunner):
(StubTestRunner.__init__):
(StubTestRunner._test_programs_base_dir):
(StubTestRunner.is_google_test):
(GLibAPITestRunnerTest):
(GLibAPITestRunnerTest.setUp):
(GLibAPITestRunnerTest.tearDown):
(GLibAPITestRunnerTest._create_executable):
(GLibAPITestRunnerTest.test_resolves_bare_and_prefixed_binary_names):
(GLibAPITestRunnerTest.test_canonical_and_prefixed_names_select_the_same_glib_subtest):
(GLibAPITestRunnerTest.test_canonical_google_test_name_resolves_and_selects_only_its_test_case):
(GLibAPITestRunnerTest.test_multiple_subtests_are_preserved):
(GLibAPITestRunnerTest.test_uploaded_names_can_be_passed_back_to_the_runner):
(GLibAPITestRunnerTest.test_json_output_uses_uploaded_test_names):
* Tools/glib/api_test_runner.py:
(TestRunner._resolve_test_program): Added.
(TestRunner._get_tests):
(TestRunner._generate_test_list_for_json_output): Added.
(TestRunner._canonical_binary_name): Added.
(TestRunner._getsubtests_to_run_for_test):
(TestRunner.run_tests):
(TestRunner.run_tests.generate_test_list_for_json_output): Deleted.

Canonical link: <a href="https://commits.webkit.org/318146@main">https://commits.webkit.org/318146@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8ae42d5102e16c4aafeb14d7f78bc4b07d5b3c3f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177361 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51299 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45093 "Build is in progress. Recent messages:OS: Tahoe (26.5.1), Xcode: 26.5; Checked out pull request; Compiled WebKit (warnings); Compiled WebKit (warnings)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186964 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140608 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179224 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52591 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51008 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138218 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140608 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180317 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41716 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158969 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118683 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/176684 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40378 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38752 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150785 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38466 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35432 "Built successfully") | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42986 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189393 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50965 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147312 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51648 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35093 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/held.https.any.sharedworker.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147104 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26913 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41821 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118201 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50156 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13444 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49552 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49792 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49614 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->