### PR TITLE
[libpas] Fix frequent-scavenging test scopes decommitting almost nothing

### DIFF
--- a/Source/bmalloc/libpas/src/test/IsoHeapChaosTests.cpp
+++ b/Source/bmalloc/libpas/src/test/IsoHeapChaosTests.cpp
@@ -1338,7 +1338,7 @@ void addIsoTests()
                 "frequent-scavenging",
                 [] () {
                     pas_scavenger_period_in_milliseconds = 1.;
-                    pas_scavenger_max_epoch_delta = -1ll * 1000ll * 1000ll;
+                    pas_scavenger_max_epoch_delta = 0;
                 });
 
             addSpotTests(false);
@@ -1441,7 +1441,7 @@ void addAllTests()
                 "frequent-scavenging",
                 [] () {
                     pas_scavenger_period_in_milliseconds = 1.;
-                    pas_scavenger_max_epoch_delta = -1ll * 1000ll * 1000ll;
+                    pas_scavenger_max_epoch_delta = 0;
                 });
 
             addSpotTests(false);
@@ -1481,7 +1481,7 @@ void addAllTests()
                 "frequent-scavenging",
                 [] () {
                     pas_scavenger_period_in_milliseconds = 1.;
-                    pas_scavenger_max_epoch_delta = -1ll * 1000ll * 1000ll;
+                    pas_scavenger_max_epoch_delta = 0;
                 });
 
             addSpotTests(false);

--- a/Source/bmalloc/libpas/src/test/ScavengerExternalWorkTests.cpp
+++ b/Source/bmalloc/libpas/src/test/ScavengerExternalWorkTests.cpp
@@ -91,7 +91,7 @@ void addScavengerExternalWorkTests()
             "frequent-scavenging",
             [] () {
                 pas_scavenger_period_in_milliseconds = 1.;
-                pas_scavenger_max_epoch_delta = -1ll * 1000ll * 1000ll;
+                pas_scavenger_max_epoch_delta = 0;
             });
         ADD_TEST(testCallbacksAreCalledWhenExpected(50, 50));
     }


### PR DESCRIPTION
#### f01297663d405f5f74796bde25933ff9230d560e
<pre>
[libpas] Fix frequent-scavenging test scopes decommitting almost nothing
<a href="https://bugs.webkit.org/show_bug.cgi?id=320506">https://bugs.webkit.org/show_bug.cgi?id=320506</a>
<a href="https://rdar.apple.com/183470095">rdar://183470095</a>

Reviewed by Yusuke Suzuki.

pas_scavenger_max_epoch_delta is unsigned, so assigning it a negative value
wraps to near 2^64. The scavenger&apos;s epoch subtraction then underflows and
clamps max_epoch to PAS_EPOCH_MIN, which admits almost no pages -- the opposite
of the intended aggressive decommit. Use 0, which yields max_epoch equal to the
current epoch so every page qualifies, and which EpochIsCounter in TestHarness
already uses for the same purpose. Four scopes across two test files had the
negative value; none remains in the tree.

Verified with temporary logging in the scavenger, sampling one in 200 passes over
a full run of the affected scopes:

                   overflow   passes blocked by max_epoch   bytes decommitted
  negative delta       yes              87%                      162 MB
  delta = 0            no               20%                     3214 MB

frequent-scavenging 49/49, ScavengerExternalWork 2/2, testAllocationChaos
252/252, AllocationZeroing 14/14.

* Source/bmalloc/libpas/src/test/IsoHeapChaosTests.cpp:
(std::addIsoTests):
(std::addAllTests):
* Source/bmalloc/libpas/src/test/ScavengerExternalWorkTests.cpp:
(addScavengerExternalWorkTests):

Canonical link: <a href="https://commits.webkit.org/318111@main">https://commits.webkit.org/318111@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9a88635a84a9a006e2ce8775928f2649b0626aea

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177375 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51313 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/45107 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/186979 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140622 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52605 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51022 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/186979 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140622 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180331 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/41726 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/45107 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/186979 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/40388 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/38765 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/186979 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/45107 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/150795 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/45107 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35446 "Built successfully") | | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/38646 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/42999 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189407 "Built successfully") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/50979 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/45107 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/147321 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51662 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/45107 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/147113 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26897 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41829 "Passed tests") | | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/118215 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50170 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/45107 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/49566 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/49806 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/49628 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->