### PR TITLE
Null Document dereference in XMLDocumentParser::end() when readystatechange detaches the parser

### DIFF
--- a/LayoutTests/fast/parser/resources/xml-parser-end-detach-frame.xhtml
+++ b/LayoutTests/fast/parser/resources/xml-parser-end-detach-frame.xhtml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml"><body><script>
+// Removing this frame from the parent document detaches this document's XML parser while
+// XMLDocumentParser::end() is still running.
+document.onreadystatechange = function () {
+    parent.postMessage("readystatechange", "*");
+    parent.document.querySelector("iframe").remove();
+};
+</script></body></html>

--- a/LayoutTests/fast/parser/xml-parser-end-detach-crash-frame-removal-expected.txt
+++ b/LayoutTests/fast/parser/xml-parser-end-detach-crash-frame-removal-expected.txt
@@ -1,0 +1,1 @@
+Test passes if it does not crash.

--- a/LayoutTests/fast/parser/xml-parser-end-detach-crash-frame-removal.html
+++ b/LayoutTests/fast/parser/xml-parser-end-detach-crash-frame-removal.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+Test passes if it does not crash.
+<script>
+testRunner?.dumpAsText();
+testRunner?.waitUntilDone();
+onmessage = function () { setTimeout(function () { testRunner?.notifyDone(); }, 0); };
+</script>
+<iframe src="resources/xml-parser-end-detach-frame.xhtml" style="display: none"></iframe>
+</html>

--- a/LayoutTests/fast/parser/xml-parser-end-detach-crash-window-stop-expected.txt
+++ b/LayoutTests/fast/parser/xml-parser-end-detach-crash-window-stop-expected.txt
@@ -1,0 +1,1 @@
+Test passes if it does not crash.

--- a/LayoutTests/fast/parser/xml-parser-end-detach-crash-window-stop.xhtml
+++ b/LayoutTests/fast/parser/xml-parser-end-detach-crash-window-stop.xhtml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml"><body><p>Test passes if it does not crash.</p><script>
+testRunner?.dumpAsText();
+// XMLDocumentParser::end() dispatches readystatechange from setReadyState(). window.stop()
+// calls DocumentParser::finish() re-entrantly, which ends up detaching this parser and
+// nulling out its document, so end() must not keep using document() afterwards.
+document.onreadystatechange = function () { window.stop(); };
+</script></body></html>

--- a/Source/WebCore/xml/parser/XMLDocumentParser.cpp
+++ b/Source/WebCore/xml/parser/XMLDocumentParser.cpp
@@ -208,14 +208,25 @@ void XMLDocumentParser::end()
             return;
     } else {
         updateLeafTextNode();
+
+        // Appending to the leaf text node may have fired mutation events, which can run arbitrary scripts.
+        if (isDetached())
+            return;
         document()->styleScope().didChangeStyleSheetEnvironment();
     }
 
     if (isParsing())
         prepareToStopParsing();
-    protect(document())->setReadyState(Document::ReadyState::Interactive);
+
+    Ref document = *this->document();
+    document->setReadyState(Document::ReadyState::Interactive);
+
+    // Setting the ready state above dispatches readystatechange, which can run arbitrary scripts.
+    if (isDetached())
+        return;
+
     clearCurrentNodeStack();
-    protect(document())->finishedParsing();
+    document->finishedParsing();
 }
 
 void XMLDocumentParser::finish()


### PR DESCRIPTION
#### cee623c24bfce90c11aa34ff96fa5b6dbd884e9b
<pre>
Null Document dereference in XMLDocumentParser::end() when readystatechange detaches the parser
<a href="https://bugs.webkit.org/show_bug.cgi?id=320262">https://bugs.webkit.org/show_bug.cgi?id=320262</a>
<a href="https://rdar.apple.com/183186440">rdar://183186440</a>

Reviewed by David Kilzer.

XMLDocumentParser::end() dispatches readystatechange by calling
Document::setReadyState(Interactive), which can run arbitrary script, and then
kept using document() unconditionally. Script run from that event can detach the
parser -- for example window.stop(), which calls DocumentParser::finish()
re-entrantly and reaches Document::finishedParsing(), or removing the frame the
XML document is loaded in -- after which document() is null and
document()-&gt;finishedParsing() dereferences it. HTMLDocumentParser already
re-checks isDetached() after setting the ready state for this reason; do the
same in XMLDocumentParser::end(), and also re-check after updateLeafTextNode(),
whose mutation events can run script two lines before another use of document().

Bailing out is safe because detach() has already cleared the current node stack.

Tests: fast/parser/xml-parser-end-detach-crash-frame-removal.html
       fast/parser/xml-parser-end-detach-crash-window-stop.xhtml

* LayoutTests/fast/parser/resources/xml-parser-end-detach-frame.xhtml: Added.
(document.onreadystatechange):
* LayoutTests/fast/parser/xml-parser-end-detach-crash-frame-removal-expected.txt: Added.
* LayoutTests/fast/parser/xml-parser-end-detach-crash-frame-removal.html: Added.
* LayoutTests/fast/parser/xml-parser-end-detach-crash-window-stop-expected.txt: Added.
* LayoutTests/fast/parser/xml-parser-end-detach-crash-window-stop.xhtml: Added.
* Source/WebCore/xml/parser/XMLDocumentParser.cpp:
(WebCore::XMLDocumentParser::end):

Canonical link: <a href="https://commits.webkit.org/319245@main">https://commits.webkit.org/319245@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6fb5a823df71d06a4fd5cbeb0449e62cf7a92d20

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180922 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54867 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48665 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191136 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145245 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/68cc6bc3-f22d-4a9a-ad3d-1d779d17c29b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182784 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56165 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54583 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141151 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97847 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d7e81d3c-7375-47d4-9c09-d051e62595dc) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183877 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44817 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161899 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121602 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/677236c5-b4c5-466b-9937-164376e96bcd) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/43490 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41765 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153894 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41426 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2296 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47479 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46020 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193071 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54533 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/161415 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150534 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40278 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55221 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38044 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150252 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44845 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127487 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122879 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53738 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16419 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53120 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53357 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53185 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->