### PR TITLE
[WebTransport] createBidirectionalStream and createUnidirectionalStream before WebTransport.ready should fail if the server closes the connection

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/close.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/close.https.any-expected.txt
@@ -8,7 +8,7 @@ PASS server initiated closure with code and reason
 PASS server initiated connection closure
 PASS opening unidirectional stream before ready
 PASS opening bidirectional stream before ready
-FAIL server initiated closure while opening unidirectional stream before ready assert_unreached: Should have rejected: undefined Reached unreachable code
-FAIL server initiated closure while opening bidirectional stream before ready assert_unreached: Should have rejected: undefined Reached unreachable code
+PASS server initiated closure while opening unidirectional stream before ready
+PASS server initiated closure while opening bidirectional stream before ready
 PASS reading closed property after close should work
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/close.https.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/close.https.any.serviceworker-expected.txt
@@ -8,7 +8,7 @@ PASS server initiated closure with code and reason
 PASS server initiated connection closure
 PASS opening unidirectional stream before ready
 PASS opening bidirectional stream before ready
-FAIL server initiated closure while opening unidirectional stream before ready assert_unreached: Should have rejected: undefined Reached unreachable code
-FAIL server initiated closure while opening bidirectional stream before ready assert_unreached: Should have rejected: undefined Reached unreachable code
+PASS server initiated closure while opening unidirectional stream before ready
+PASS server initiated closure while opening bidirectional stream before ready
 PASS reading closed property after close should work
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/close.https.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/close.https.any.sharedworker-expected.txt
@@ -8,7 +8,7 @@ PASS server initiated closure with code and reason
 PASS server initiated connection closure
 PASS opening unidirectional stream before ready
 PASS opening bidirectional stream before ready
-FAIL server initiated closure while opening unidirectional stream before ready assert_unreached: Should have rejected: undefined Reached unreachable code
-FAIL server initiated closure while opening bidirectional stream before ready assert_unreached: Should have rejected: undefined Reached unreachable code
+PASS server initiated closure while opening unidirectional stream before ready
+PASS server initiated closure while opening bidirectional stream before ready
 PASS reading closed property after close should work
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/close.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/close.https.any.worker-expected.txt
@@ -8,7 +8,7 @@ PASS server initiated closure with code and reason
 PASS server initiated connection closure
 PASS opening unidirectional stream before ready
 PASS opening bidirectional stream before ready
-FAIL server initiated closure while opening unidirectional stream before ready assert_unreached: Should have rejected: undefined Reached unreachable code
-FAIL server initiated closure while opening bidirectional stream before ready assert_unreached: Should have rejected: undefined Reached unreachable code
+PASS server initiated closure while opening unidirectional stream before ready
+PASS server initiated closure while opening bidirectional stream before ready
 PASS reading closed property after close should work
 

--- a/Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.cpp
+++ b/Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.cpp
@@ -46,6 +46,8 @@ NetworkTransportSession::~NetworkTransportSession()
 {
     for (auto&& statsRequest : std::exchange(m_statsRequestsBeforeInitialization, { }))
         statsRequest(std::nullopt);
+    for (auto&& streamRequest : std::exchange(m_streamRequestsBeforeInitialization, { }))
+        streamRequest.completionHandler(std::nullopt);
 }
 
 IPC::Connection* NetworkTransportSession::messageSenderConnection() const
@@ -217,7 +219,7 @@ void NetworkTransportSession::getStats(CompletionHandler<void(std::optional<WebC
     });
 }
 
-void NetworkTransportSession::completeStatsRequestsAfterInitialization(std::optional<Seconds> initializationTime)
+void NetworkTransportSession::completeRequestsAfterInitialization(std::optional<Seconds> initializationTime)
 {
     ASSERT(!m_initializationTime);
     ASSERT(m_initializationState == InitializationState::Waiting);
@@ -225,12 +227,16 @@ void NetworkTransportSession::completeStatsRequestsAfterInitialization(std::opti
         m_initializationState = InitializationState::Failed;
         for (auto&& statsRequest : std::exchange(m_statsRequestsBeforeInitialization, { }))
             statsRequest(std::nullopt);
+        for (auto&& streamRequest : std::exchange(m_streamRequestsBeforeInitialization, { }))
+            streamRequest.completionHandler(std::nullopt);
         return;
     }
     m_initializationState = InitializationState::Succeeded;
     m_initializationTime = *initializationTime;
     for (auto&& statsRequest : std::exchange(m_statsRequestsBeforeInitialization, { }))
         getStats(WTF::move(statsRequest));
+    for (auto&& streamRequest : std::exchange(m_streamRequestsBeforeInitialization, { }))
+        createStream(streamRequest.streamType, WTF::move(streamRequest.completionHandler));
 }
 
 #if !HAVE(WEBTRANSPORT)

--- a/Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.h
+++ b/Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.h
@@ -30,6 +30,7 @@
 #include "WebPageProxyIdentifier.h"
 #include <WebCore/ProcessQualified.h>
 #include <WebCore/WebTransportOptions.h>
+#include <wtf/CompletionHandler.h>
 #include <wtf/Identified.h>
 #include <wtf/RefCounted.h>
 #include <wtf/TZoneMalloc.h>
@@ -132,7 +133,7 @@ private:
     void setupDatagramConnection(CompletionHandler<void(std::optional<WebCore::WebTransportConnectionInfo>&&)>&&);
     void receiveDatagramLoop();
     void createStream(NetworkTransportStreamType, CompletionHandler<void(std::optional<WebCore::WebTransportStreamIdentifier>)>&&);
-    void completeStatsRequestsAfterInitialization(std::optional<Seconds>);
+    void completeRequestsAfterInitialization(std::optional<Seconds>);
 
     HashMap<WebCore::WebTransportStreamIdentifier, Ref<NetworkTransportStream>> m_streams;
     WeakPtr<NetworkConnectionToWebProcess> m_connectionToWebProcess;
@@ -140,6 +141,13 @@ private:
     const WebCore::WebTransportOptions m_options;
     HashMap<WebCore::WebTransportSendGroupIdentifier, uint64_t> m_datagramBytesSent;
     uint64_t m_datagramBytesReceived { 0 };
+
+    struct StreamRequestBeforeInitialization {
+        NetworkTransportStreamType streamType;
+        CompletionHandler<void(std::optional<WebCore::WebTransportStreamIdentifier>)> completionHandler;
+    };
+    Vector<StreamRequestBeforeInitialization> m_streamRequestsBeforeInitialization;
+    Vector<CompletionHandler<void(std::optional<WebCore::WebTransportConnectionStats>&&)>> m_statsRequestsBeforeInitialization;
 
     uint64_t m_bytesSentOnClosedStreams { 0 };
     uint64_t m_bytesReceivedOnClosedStreams { 0 };
@@ -149,7 +157,6 @@ private:
         Succeeded,
         Failed
     } m_initializationState { InitializationState::Waiting };
-    Vector<CompletionHandler<void(std::optional<WebCore::WebTransportConnectionStats>&&)>> m_statsRequestsBeforeInitialization;
 
 #if PLATFORM(COCOA)
     const RetainPtr<nw_connection_group_t> m_connectionGroup;

--- a/Source/WebKit/NetworkProcess/webtransport/cocoa/NetworkTransportSessionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/webtransport/cocoa/NetworkTransportSessionCocoa.mm
@@ -300,7 +300,7 @@ void NetworkTransportSession::initialize(CompletionHandler<void(std::optional<We
         if (!completionHandler)
             return;
         if (RefPtr strongThis = weakThis.get())
-            strongThis->completeStatsRequestsAfterInitialization(connectionInfo ? std::optional(MonotonicTime::now() - initializationStartTime) : std::nullopt);
+            strongThis->completeRequestsAfterInitialization(connectionInfo ? std::optional(MonotonicTime::now() - initializationStartTime) : std::nullopt);
         return completionHandler(WTF::move(connectionInfo));
     };
 
@@ -481,6 +481,16 @@ void NetworkTransportSession::setupConnectionHandler()
 
 void NetworkTransportSession::createStream(NetworkTransportStreamType streamType, CompletionHandler<void(std::optional<WebCore::WebTransportStreamIdentifier>)>&& completionHandler)
 {
+    switch (m_initializationState) {
+    case InitializationState::Waiting:
+        m_streamRequestsBeforeInitialization.append({ streamType, WTF::move(completionHandler) });
+        return;
+    case InitializationState::Failed:
+        return completionHandler(std::nullopt);
+    case InitializationState::Succeeded:
+        break;
+    }
+
     ASSERT(streamType != NetworkTransportStreamType::IncomingUnidirectional);
     RetainPtr webtransportOptions = adoptNS(nw_webtransport_create_options());
     if (!webtransportOptions) {


### PR DESCRIPTION
#### b89af4901547b62428e87ff6335cba0d7308a851
<pre>
[WebTransport] createBidirectionalStream and createUnidirectionalStream before WebTransport.ready should fail if the server closes the connection
<a href="https://bugs.webkit.org/show_bug.cgi?id=320510">https://bugs.webkit.org/show_bug.cgi?id=320510</a>
<a href="https://rdar.apple.com/183471508">rdar://183471508</a>

Reviewed by Chris Dumez.

Like getStats requests, createStream requests need to wait until the session has been initialized
either successfully or unsuccessfully before completing.

* LayoutTests/imported/w3c/web-platform-tests/webtransport/close.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webtransport/close.https.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webtransport/close.https.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webtransport/close.https.any.worker-expected.txt:
* Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.cpp:
(WebKit::NetworkTransportSession::~NetworkTransportSession):
(WebKit::NetworkTransportSession::completeRequestsAfterInitialization):
(WebKit::NetworkTransportSession::completeStatsRequestsAfterInitialization): Deleted.
* Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.h:
* Source/WebKit/NetworkProcess/webtransport/cocoa/NetworkTransportSessionCocoa.mm:
(WebKit::NetworkTransportSession::initialize):
(WebKit::NetworkTransportSession::createStream):

Canonical link: <a href="https://commits.webkit.org/318172@main">https://commits.webkit.org/318172@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ea2ae67abb4c949fad1699b730e4351ef9c313f7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177531 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/51469 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/45263 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/187135 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140778 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/52761 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/51178 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/187135 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140778 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180487 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/52761 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/45263 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/187135 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/52761 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/51178 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/187135 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/45263 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/52761 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/45263 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/35602 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/43254 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/51178 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/189563 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/51136 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/45263 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/189563 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/51818 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/45263 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/189563 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26926 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/51818 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124033 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/118445 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/50326 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/45263 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/49722 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/49962 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/49784 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->