### PR TITLE
[GFC] Resolve negative grid lines against the explicit grid track count

### DIFF
--- a/Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.cpp
@@ -60,6 +60,13 @@ UnplacedGridItems GridFormattingContext::constructUnplacedGridItems() const
         int order;
     };
 
+    // Negative line placements are resolved against the explicit grid track count, which can still
+    // produce a negative line when the placement counts past the start edge of the explicit grid.
+    // Those are normalized by shifting every line forward by the magnitude of the most-negative
+    // resolved line, so e.g. with 3 explicit columns a column-start of -5 resolves to line -1,
+    // which shifts all column lines forward by 1 and maps to matrix column 0.
+    auto explicitColumnCount = m_gridBox->style().gridTemplateColumns().sizes.size();
+    auto explicitRowCount = m_gridBox->style().gridTemplateRows().sizes.size();
     int minimumColumnLine = 0;
     int minimumRowLine = 0;
     Vector<GridItem> gridItems;
@@ -68,11 +75,11 @@ UnplacedGridItems GridFormattingContext::constructUnplacedGridItems() const
             continue;
 
         CheckedRef gridItemStyle = gridItem->style();
-        if (auto columnRange = UnplacedGridItem::resolveDefinitePosition(gridItemStyle->gridItemColumnStart(), gridItemStyle->gridItemColumnEnd())) {
+        if (auto columnRange = UnplacedGridItem::resolveDefinitePosition(gridItemStyle->gridItemColumnStart(), gridItemStyle->gridItemColumnEnd(), explicitColumnCount)) {
             auto [startLine, endLine] = *columnRange;
             minimumColumnLine = std::min({ minimumColumnLine, startLine, endLine });
         }
-        if (auto rowRange = UnplacedGridItem::resolveDefinitePosition(gridItemStyle->gridItemRowStart(), gridItemStyle->gridItemRowEnd())) {
+        if (auto rowRange = UnplacedGridItem::resolveDefinitePosition(gridItemStyle->gridItemRowStart(), gridItemStyle->gridItemRowEnd(), explicitRowCount)) {
             auto [startLine, endLine] = *rowRange;
             minimumRowLine = std::min({ minimumRowLine, startLine, endLine });
         }
@@ -100,6 +107,8 @@ UnplacedGridItems GridFormattingContext::constructUnplacedGridItems() const
             gridItemColumnEnd,
             gridItemRowStart,
             gridItemRowEnd,
+            explicitColumnCount,
+            explicitRowCount,
             columnNegativeLineOffset,
             rowNegativeLineOffset
         };

--- a/Source/WebCore/layout/formattingContexts/grid/UnplacedGridItem.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/UnplacedGridItem.cpp
@@ -32,20 +32,30 @@
 namespace WebCore {
 namespace Layout {
 
-// Convert a 1-indexed explicit CSS grid line into a 0-indexed grid line. For example
-// grid-column-start: 1 maps to 0. https://www.w3.org/TR/css-grid-1/#line-placement
-static int explicitLineToIndex(const Style::GridPosition& position)
+// Convert a 1-indexed explicit CSS grid line into a 0-indexed grid line.
+// https://www.w3.org/TR/css-grid-1/#line-placement
+//
+// Positive lines count forward from the start of the explicit grid: grid-column-start: 1 maps to 0.
+// Negative lines count backward from the *end* of the explicit grid: grid-column-start: -1 maps to
+// the last line (explicitTrackCount). The mapping is a single linear formula that stays correct as
+// a negative line counts past the start edge into the leading implicit grid, producing a negative
+// index. For example, with 3 explicit columns (lines 0..3):
+//     -1 -> 3 (last line), -4 -> 0 (first line), -5 -> -1, -6 -> -2 (two lines before the start).
+// A negative index is not a valid matrix position on its own; GridFormattingContext computes the
+// most-negative line across all items and shifts every line forward by that magnitude (the
+// negative-line offset) so, e.g., -2 above maps to matrix column 0. See GridPosition::create().
+static int explicitLineToIndex(const Style::GridPosition& position, size_t explicitTrackCount)
 {
     ASSERT(position.isExplicit());
     auto line = position.explicitPosition();
     // A value of zero makes the declaration invalid.
     ASSERT(line);
-    return line > 0 ? line - 1 : line;
+    return line > 0 ? line - 1 : static_cast<int>(explicitTrackCount) + 1 + line;
 }
 
-UnplacedGridItem::GridPosition UnplacedGridItem::GridPosition::create(const Style::GridPosition& start, const Style::GridPosition& end, size_t negativeLineOffset)
+UnplacedGridItem::GridPosition UnplacedGridItem::GridPosition::create(const Style::GridPosition& start, const Style::GridPosition& end, size_t explicitTrackCount, size_t negativeLineOffset)
 {
-    auto explicitRange = UnplacedGridItem::resolveDefinitePosition(start, end);
+    auto explicitRange = UnplacedGridItem::resolveDefinitePosition(start, end, explicitTrackCount);
     if (!explicitRange) {
         // An axis with no explicit line is auto-positioned; carry the span forward for the
         // placement algorithm to resolve.
@@ -73,7 +83,7 @@ UnplacedGridItem::GridPosition UnplacedGridItem::GridPosition::create(const Styl
     return DefinitePosition { static_cast<size_t>(startLine), static_cast<size_t>(endLine) };
 }
 
-std::optional<std::pair<int, int>> UnplacedGridItem::resolveDefinitePosition(const Style::GridPosition& start, const Style::GridPosition& end)
+std::optional<std::pair<int, int>> UnplacedGridItem::resolveDefinitePosition(const Style::GridPosition& start, const Style::GridPosition& end, size_t explicitTrackCount)
 {
     // An axis is only definite when one of its edges references an explicit line. Anything
     // else (auto/auto, span/auto, auto/span) is auto-positioned and has no explicit line range.
@@ -83,20 +93,20 @@ std::optional<std::pair<int, int>> UnplacedGridItem::resolveDefinitePosition(con
     int startLine = 0;
     int endLine = 0;
     if (start.isExplicit() && end.isExplicit()) {
-        startLine = explicitLineToIndex(start);
-        endLine = explicitLineToIndex(end);
+        startLine = explicitLineToIndex(start, explicitTrackCount);
+        endLine = explicitLineToIndex(end, explicitTrackCount);
     } else if (start.isExplicit() && end.isSpan()) {
-        startLine = explicitLineToIndex(start);
+        startLine = explicitLineToIndex(start, explicitTrackCount);
         endLine = startLine + end.spanPosition();
     } else if (start.isSpan() && end.isExplicit()) {
-        endLine = explicitLineToIndex(end);
+        endLine = explicitLineToIndex(end, explicitTrackCount);
         startLine = endLine - static_cast<int>(start.spanPosition());
     } else if (start.isExplicit() && end.isAuto()) {
-        startLine = explicitLineToIndex(start);
+        startLine = explicitLineToIndex(start, explicitTrackCount);
         endLine = startLine + 1;
     } else {
         ASSERT(start.isAuto() && end.isExplicit());
-        endLine = explicitLineToIndex(end);
+        endLine = explicitLineToIndex(end, explicitTrackCount);
         startLine = endLine - 1;
     }
 
@@ -111,17 +121,18 @@ size_t UnplacedGridItem::GridPosition::span() const
 }
 
 UnplacedGridItem::UnplacedGridItem(const ElementBox& layoutBox, Style::GridPosition columnStart, Style::GridPosition columnEnd,
-    Style::GridPosition rowStart, Style::GridPosition rowEnd, size_t columnNegativeLineOffset, size_t rowNegativeLineOffset)
+    Style::GridPosition rowStart, Style::GridPosition rowEnd, size_t explicitColumnCount, size_t explicitRowCount,
+    size_t columnNegativeLineOffset, size_t rowNegativeLineOffset)
     : m_layoutBox(layoutBox)
-    , m_columnPosition(GridPosition::create(columnStart, columnEnd, columnNegativeLineOffset))
-    , m_rowPosition(GridPosition::create(rowStart, rowEnd, rowNegativeLineOffset))
+    , m_columnPosition(GridPosition::create(columnStart, columnEnd, explicitColumnCount, columnNegativeLineOffset))
+    , m_rowPosition(GridPosition::create(rowStart, rowEnd, explicitRowCount, rowNegativeLineOffset))
 {
 }
 
 UnplacedGridItem::UnplacedGridItem(WTF::HashTableEmptyValueType)
     : m_layoutBox(WTF::HashTableEmptyValue)
-    , m_columnPosition(GridPosition::create(Style::ComputedStyle::initialGridItemColumnStart(), Style::ComputedStyle::initialGridItemColumnEnd(), 0))
-    , m_rowPosition(GridPosition::create(Style::ComputedStyle::initialGridItemRowStart(), Style::ComputedStyle::initialGridItemRowEnd(), 0))
+    , m_columnPosition(GridPosition::create(Style::ComputedStyle::initialGridItemColumnStart(), Style::ComputedStyle::initialGridItemColumnEnd(), 0, 0))
+    , m_rowPosition(GridPosition::create(Style::ComputedStyle::initialGridItemRowStart(), Style::ComputedStyle::initialGridItemRowEnd(), 0, 0))
 {
 }
 

--- a/Source/WebCore/layout/formattingContexts/grid/UnplacedGridItem.h
+++ b/Source/WebCore/layout/formattingContexts/grid/UnplacedGridItem.h
@@ -59,7 +59,11 @@ private:
 
     class GridPosition {
     public:
-        static GridPosition create(const Style::GridPosition& start, const Style::GridPosition& end, size_t negativeLineOffset);
+        // explicitTrackCount is the number of explicit tracks in the axis, used to resolve negative
+        // lines against the end of the explicit grid. The negative-line offset then shifts negative
+        // resolved lines forward so the range maps to non-negative matrix indices. See
+        // UnplacedGridItem::resolveDefinitePosition().
+        static GridPosition create(const Style::GridPosition& start, const Style::GridPosition& end, size_t explicitTrackCount, size_t negativeLineOffset);
 
         bool isDefinite() const { return std::holds_alternative<DefinitePosition>(m_position); }
         bool isAuto() const { return std::holds_alternative<AutoPosition>(m_position); }
@@ -82,7 +86,7 @@ private:
     };
 
 public:
-    UnplacedGridItem(const ElementBox&, Style::GridPosition columnStart, Style::GridPosition columnEnd, Style::GridPosition rowStart, Style::GridPosition rowEnd, size_t columnNegativeLineOffset, size_t rowNegativeLineOffset);
+    UnplacedGridItem(const ElementBox&, Style::GridPosition columnStart, Style::GridPosition columnEnd, Style::GridPosition rowStart, Style::GridPosition rowEnd, size_t explicitColumnCount, size_t explicitRowCount, size_t columnNegativeLineOffset, size_t rowNegativeLineOffset);
     UnplacedGridItem(WTF::HashTableEmptyValueType);
 
     bool operator==(const UnplacedGridItem& other) const;
@@ -101,10 +105,12 @@ public:
     std::pair<size_t, size_t> definiteRowStartEnd() const;
     std::pair<size_t, size_t> definiteColumnStartEnd() const;
 
-    // Resolves the raw (pre-normalization) 0-based explicit line range [start, end) for an axis, or
-    // std::nullopt when the axis is auto-positioned. Lines may be negative for negative line
-    // placements; the negative-line offset is applied later in GridPosition::create().
-    static std::optional<std::pair<int, int>> resolveDefinitePosition(const Style::GridPosition& start, const Style::GridPosition& end);
+    // Resolves the 0-based explicit line range [start, end) for an axis, or std::nullopt when the
+    // axis is auto-positioned. explicitTrackCount is used to resolve negative lines against the end
+    // of the explicit grid; the resolved lines may still be negative for negative line placements
+    // that count past the start edge, and the negative-line offset is applied later in
+    // GridPosition::create().
+    static std::optional<std::pair<int, int>> resolveDefinitePosition(const Style::GridPosition& start, const Style::GridPosition& end, size_t explicitTrackCount);
 
 private:
     CheckedRef<const ElementBox> m_layoutBox;


### PR DESCRIPTION
#### 385c9c629c84a067b47ed966c0d3d96e50819349
<pre>
[GFC] Resolve negative grid lines against the explicit grid track count
<a href="https://bugs.webkit.org/show_bug.cgi?id=320511">https://bugs.webkit.org/show_bug.cgi?id=320511</a>
<a href="https://rdar.apple.com/problem/183473145">rdar://problem/183473145</a>

Reviewed by Alan Baradlay.

A negative grid line counts backward from the end edge of the explicit grid: for
a grid with N explicit tracks, -1 is the last line and -(N+1) is the first line,
with more-negative values counting past the start edge into the leading implicit
grid. Previously explicitLineToIndex() passed negative lines through unchanged
(e.g. -1 stayed -1), which is not quite how they are supposed to get
resolved.

To fix this we can just thread in the number of explicit tracks through
the code that computes the UnplacedGridItem&apos;s GridPosition so that it
takes the number of explicit tracks into account. For example, if you
have three expliti columns with lines L1 L2 L3 L4, then -1 will map to
L4 and -5 will map to the first implicit track that is created right
before the first explicit one.

* Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.cpp:
(WebCore::Layout::GridFormattingContext::constructUnplacedGridItems const):
* Source/WebCore/layout/formattingContexts/grid/UnplacedGridItem.cpp:
(WebCore::Layout::explicitLineToIndex):
This is what does the mapping as described above. This means that this
may still return a negative number for those lines that are part of the
implicit grid that is part of the beginning. That is ok though since
those will be translated and be relative to the implicit grid when we
actually create the GridPosition itself.

(WebCore::Layout::UnplacedGridItem::GridPosition::create):
This is where the line numbers will get transformed to be relative to
the implicit grid. So here -5 from the example above would be fed in as
-1 but then transformed into 0 since it is the first line in the
implicit grid.

(WebCore::Layout::UnplacedGridItem::resolveDefinitePosition):
Plumb the number of explicit tracks to explicitLineToIndex so that the
values take them into consideration like described above in the
explanation of the function.

Canonical link: <a href="https://commits.webkit.org/318175@main">https://commits.webkit.org/318175@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a0f5b9fcc1ac41f2e56c9523856ece5f9e637c40

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177387 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51325 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45119 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186991 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140634 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d7708c97-afea-4283-87eb-a34ebf0f93e4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179250 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52617 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51034 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138234 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140634 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/98fefd3d-0d04-4530-9e2c-dae72005be34) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180343 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41743 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158987 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118699 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d06cbbd5-424f-4f0a-8ae0-47383a3d4db0) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40405 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38777 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150812 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38484 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35458 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/43110 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43011 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189419 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50992 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147332 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39612 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51674 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35111 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147124 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41846 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123889 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118227 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50182 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13462 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49578 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49818 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49640 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->