### PR TITLE
[ANGLE] Correctly rewrite nested interpolateAtOffset offsets

### DIFF
--- a/Source/ThirdParty/ANGLE/src/compiler/translator/tree_ops/msl/RewriteInterpolants.cpp
+++ b/Source/ThirdParty/ANGLE/src/compiler/translator/tree_ops/msl/RewriteInterpolants.cpp
@@ -110,7 +110,8 @@ class FindInterpolantsTraverser : public TIntermTraverser
             TIntermTyped *correctedOffset = TIntermAggregate::CreateFunctionCall(
                 *getFlipFunction(), new TIntermSequence{offsetNode});
 
-            queueReplacementWithParent(node, offsetNode, correctedOffset, OriginalNode::IS_DROPPED);
+            queueReplacementWithParent(node, offsetNode, correctedOffset,
+                                       OriginalNode::BECOMES_CHILD);
         }
 
         return true;

--- a/Source/ThirdParty/ANGLE/src/compiler/translator/tree_ops/spirv/RewriteInterpolateAtOffset.cpp
+++ b/Source/ThirdParty/ANGLE/src/compiler/translator/tree_ops/spirv/RewriteInterpolateAtOffset.cpp
@@ -88,7 +88,7 @@ bool Traverser::visitAggregate(Visit visit, TIntermAggregate *node)
     correctedOffset->setLine(offsetNode->getLine());
 
     // Replace the offset by the rotated one.
-    queueReplacementWithParent(node, offsetNode, correctedOffset, OriginalNode::IS_DROPPED);
+    queueReplacementWithParent(node, offsetNode, correctedOffset, OriginalNode::BECOMES_CHILD);
 
     return true;
 }

--- a/Source/ThirdParty/ANGLE/src/tests/gl_tests/ShaderMultisampleInterpolation.cpp
+++ b/Source/ThirdParty/ANGLE/src/tests/gl_tests/ShaderMultisampleInterpolation.cpp
@@ -445,6 +445,52 @@ void main()
     ANGLE_GL_PROGRAM(program, kVS, kFS);
 }
 
+// Test that nested interpolateAtOffset calls (the offset argument is itself an interpolateAtOffset)
+// compile and draw correctly.
+TEST_P(SampleMultisampleInterpolationTest, CompileNestedInterpolateAtOffset)
+{
+    ANGLE_SKIP_TEST_IF(!EnsureGLExtensionEnabled("GL_OES_shader_multisample_interpolation"));
+
+    constexpr char kVS[] = R"(#version 300 es
+in vec4 a_position;
+out vec2 interpolant;
+
+void main()
+{
+    gl_Position = a_position;
+    // Keep the interpolant constant across the primitive: interpolateAtOffset samples at an
+    // implementation-defined location, so a constant keeps the drawn result the same everywhere.
+    // 0.5 also keeps the nested call's result within the valid offset range.
+    interpolant = vec2(0.0, 0.5);
+})";
+
+    constexpr char kFS[] = R"(#version 300 es
+#extension GL_OES_shader_multisample_interpolation : require
+
+precision highp float;
+
+in vec2 interpolant;
+
+out vec4 color;
+
+void main()
+{
+    // The offset (second) argument of the outer interpolateAtOffset is itself an
+    // interpolateAtOffset call.
+    color = vec4(interpolateAtOffset(interpolant, interpolateAtOffset(interpolant, vec2(0.5))),
+                 0.0, 1.0);
+})";
+
+    ANGLE_GL_PROGRAM(program, kVS, kFS);
+
+    // Draw and verify: with a constant interpolant of (0.0, 0.5), both interpolateAtOffset calls
+    // return it, so the fragment output is vec4(0.0, 0.5, 0.0, 1.0). 0.5 becomes 127 or 128 after
+    // unorm8 conversion, so allow an off-by-one.
+    drawQuad(program, "a_position", 0.0f);
+    ASSERT_GL_NO_ERROR();
+    EXPECT_PIXEL_COLOR_NEAR(0, 0, GLColor(0, 128, 0, 255), 1);
+}
+
 class SampleMultisampleInterpolationTest31 : public SampleMultisampleInterpolationTest
 {};
 


### PR DESCRIPTION
#### 746d4c43e40a9cc16381da0caf3d4b3f44712215
<pre>
[ANGLE] Correctly rewrite nested interpolateAtOffset offsets
<a href="https://bugs.webkit.org/show_bug.cgi?id=320515">https://bugs.webkit.org/show_bug.cgi?id=320515</a>
<a href="https://rdar.apple.com/180731415">rdar://180731415</a>

Reviewed by Dan Glastonbury.

Compiling a fragment shader that nests one interpolateAtOffset inside another
call&apos;s offset argument crashes in the Metal backend. The offset rewrite wraps
each offset in a helper that adjusts it for Metal and passes the original offset
into that helper as a child. It incorrectly queues the replacement with
OriginalNode::IS_DROPPED, telling the tree updater the original is gone. For
nested calls the inner call is both a replaced node and the parent of its own
replacement, so the updater points the inner replacement at the wrapper, cannot
find the offset there, and fails an assertion.

Fix by queuing the replacement with OriginalNode::BECOMES_CHILD, which matches
what actually happens since the offset is reused inside the wrapper. The updater
then leaves the inner call&apos;s parent alone and both offsets are rewritten
correctly.

Vulkan (SPIR-V) backend has same bug in its own interpolateAtOffset offset rewrite
so fix here too to keep it intact when the change is upstreamed.

* Source/ThirdParty/ANGLE/src/compiler/translator/tree_ops/msl/RewriteInterpolants.cpp:
* Source/ThirdParty/ANGLE/src/tests/gl_tests/ShaderMultisampleInterpolation.cpp:
* Source/ThirdParty/ANGLE/src/compiler/translator/tree_ops/spirv/RewriteInterpolateAtOffset.cpp:

Canonical link: <a href="https://commits.webkit.org/318205@main">https://commits.webkit.org/318205@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/16ba0ec93ba62293a1d37fc364590c0181908b4a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177561 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51499 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45293 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187165 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140808 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/163033fb-e350-4163-8574-a4ac263d4190) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52791 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51208 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138390 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140808 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f90caec8-16cd-426a-a729-be4a94872a73) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180517 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41892 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159135 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118855 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/45f20251-3571-4a75-aca0-00ffc8a10439) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40553 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38928 "Passed tests") | | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/7632 "Build is in progress. Recent messages:") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150960 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38630 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35632 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43162 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189593 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51166 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147488 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39631 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51848 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35259 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147285 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41990 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118475 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50356 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13609 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49752 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49992 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49814 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->