### PR TITLE
[Site Isolation] Add TextStream logging support to generated ProcessSyncData types

### DIFF
--- a/Source/WebCore/Scripts/generate-process-sync-data.py
+++ b/Source/WebCore/Scripts/generate-process-sync-data.py
@@ -294,6 +294,11 @@ def generate_synched_data_header(prefix, variant_sorted_synched_datas, sync_data
     for header in headers:
         result.append('#include %s' % header)
 
+    result.append('')
+    result.append('namespace WTF {')
+    result.append('class TextStream;')
+    result.append('}')
+
     result.append(_synced_data_header_midfix.format(prefix=prefix))
 
     for data in sync_data_sorted_synched_datas:
@@ -329,6 +334,10 @@ def generate_synched_data_header(prefix, variant_sorted_synched_datas, sync_data
 
     result.append(generate_process_sync_data_header(prefix, variant_sorted_synched_datas, sync_data_sorted_synched_datas))
 
+    result.append('WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const %sSyncData&);' % prefix)
+    result.append('WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const %sSyncSerializationData&);' % prefix)
+    result.append('')
+
     result.append('} // namespace WebCore')
     result.append('')
 
@@ -340,6 +349,7 @@ _synched_data_impl_prefix = """
 #include "data_type_name.h"
 
 #include <wtf/EnumTraits.h>
+#include <wtf/text/TextStream.h>
 
 namespace WebCore {{
 
@@ -416,6 +426,43 @@ def generate_synched_data_impl(prefix, synched_datas):
     result.append('{')
     result.append('}')
     result.append('')
+
+    result.append('WTF::TextStream& operator<<(WTF::TextStream& ts, const data_type_name& data)')
+    result.append('{')
+    result.append('    WTF::TextStream::GroupScope scope(ts);')
+    result.append('    ts << "data_type_name"_s;')
+    for data in synched_datas:
+        if data.conditional is not None:
+            result.append('#if %s' % data.conditional)
+        lowercase_name = data.name[0].lower() + data.name[1:]
+        result.append('    ts.dumpProperty("%s"_s, ValueOrEllipsis(data.%s));' % (lowercase_name, lowercase_name))
+        if data.conditional is not None:
+            result.append('#endif')
+    result.append('    return ts;')
+    result.append('}')
+    result.append('')
+
+    result.append('WTF::TextStream& operator<<(WTF::TextStream& ts, const %sSyncSerializationData& data)' % prefix)
+    result.append('{')
+    result.append('    WTF::TextStream::GroupScope scope(ts);')
+    result.append('    ts << "%sSyncSerializationData"_s;' % prefix)
+    result.append('    switch (static_cast<%sSyncDataType>(data.value.index())) {' % prefix)
+    for data in synched_datas:
+        if data.conditional is not None:
+            result.append('#if %s' % data.conditional)
+        lowercase_name = data.name[0].lower() + data.name[1:]
+        result.append('    case %sSyncDataType::%s:' % (prefix, data.name))
+        result.append('        ts.dumpProperty("%s"_s, ValueOrEllipsis(std::get<std::to_underlying(%sSyncDataType::%s)>(data.value)));' % (lowercase_name, prefix, data.name))
+        result.append('        break;')
+        if data.conditional is not None:
+            result.append('#endif')
+    result.append('    default:')
+    result.append('        RELEASE_ASSERT_NOT_REACHED();')
+    result.append('    }')
+    result.append('    return ts;')
+    result.append('}')
+    result.append('')
+
     result.append('} // namespace WebCore')
     result.append('')
 

--- a/Source/WebCore/Scripts/tests/TestSyncClient.cpp
+++ b/Source/WebCore/Scripts/tests/TestSyncClient.cpp
@@ -34,40 +34,28 @@ namespace WebCore {
 #if ENABLE(DOM_AUDIO_SESSION)
 void TestSyncClient::broadcastAudioSessionTypeToOtherProcesses(const WebCore::DOMAudioSessionType& data)
 {
-    TestSyncDataVariant dataVariant;
-    dataVariant.emplace<std::to_underlying(TestSyncDataType::AudioSessionType)>(data);
-    broadcastTestSyncDataToOtherProcesses({ TestSyncDataType::AudioSessionType, WTF::move(dataVariant) });
+    broadcastTestSyncDataToOtherProcesses({ TestSyncDataVariant { WTF::InPlaceIndex<std::to_underlying(TestSyncDataType::AudioSessionType)>, data } });
 }
 #endif
 void TestSyncClient::broadcastMainFrameURLChangeToOtherProcesses(const URL& data)
 {
-    TestSyncDataVariant dataVariant;
-    dataVariant.emplace<std::to_underlying(TestSyncDataType::MainFrameURLChange)>(data);
-    broadcastTestSyncDataToOtherProcesses({ TestSyncDataType::MainFrameURLChange, WTF::move(dataVariant) });
+    broadcastTestSyncDataToOtherProcesses({ TestSyncDataVariant { WTF::InPlaceIndex<std::to_underlying(TestSyncDataType::MainFrameURLChange)>, data } });
 }
 void TestSyncClient::broadcastIsAutofocusProcessedToOtherProcesses(const bool& data)
 {
-    TestSyncDataVariant dataVariant;
-    dataVariant.emplace<std::to_underlying(TestSyncDataType::IsAutofocusProcessed)>(data);
-    broadcastTestSyncDataToOtherProcesses({ TestSyncDataType::IsAutofocusProcessed, WTF::move(dataVariant) });
+    broadcastTestSyncDataToOtherProcesses({ TestSyncDataVariant { WTF::InPlaceIndex<std::to_underlying(TestSyncDataType::IsAutofocusProcessed)>, data } });
 }
 void TestSyncClient::broadcastUserDidInteractWithPageToOtherProcesses(const bool& data)
 {
-    TestSyncDataVariant dataVariant;
-    dataVariant.emplace<std::to_underlying(TestSyncDataType::UserDidInteractWithPage)>(data);
-    broadcastTestSyncDataToOtherProcesses({ TestSyncDataType::UserDidInteractWithPage, WTF::move(dataVariant) });
+    broadcastTestSyncDataToOtherProcesses({ TestSyncDataVariant { WTF::InPlaceIndex<std::to_underlying(TestSyncDataType::UserDidInteractWithPage)>, data } });
 }
 void TestSyncClient::broadcastAnotherOneToOtherProcesses(const StringifyThis& data)
 {
-    TestSyncDataVariant dataVariant;
-    dataVariant.emplace<std::to_underlying(TestSyncDataType::AnotherOne)>(data);
-    broadcastTestSyncDataToOtherProcesses({ TestSyncDataType::AnotherOne, WTF::move(dataVariant) });
+    broadcastTestSyncDataToOtherProcesses({ TestSyncDataVariant { WTF::InPlaceIndex<std::to_underlying(TestSyncDataType::AnotherOne)>, data } });
 }
 void TestSyncClient::broadcastMultipleHeadersToOtherProcesses(const HashSet<URL>& data)
 {
-    TestSyncDataVariant dataVariant;
-    dataVariant.emplace<std::to_underlying(TestSyncDataType::MultipleHeaders)>(data);
-    broadcastTestSyncDataToOtherProcesses({ TestSyncDataType::MultipleHeaders, WTF::move(dataVariant) });
+    broadcastTestSyncDataToOtherProcesses({ TestSyncDataVariant { WTF::InPlaceIndex<std::to_underlying(TestSyncDataType::MultipleHeaders)>, data } });
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Scripts/tests/TestSyncData.cpp
+++ b/Source/WebCore/Scripts/tests/TestSyncData.cpp
@@ -27,12 +27,13 @@
 #include "TestSyncData.h"
 
 #include <wtf/EnumTraits.h>
+#include <wtf/text/TextStream.h>
 
 namespace WebCore {
 
 void TestSyncData::update(const TestSyncSerializationData& data)
 {
-    switch (data.type) {
+    switch (static_cast<TestSyncDataType>(data.value.index())) {
     case TestSyncDataType::MainFrameURLChange:
         mainFrameURLChange = std::get<std::to_underlying(TestSyncDataType::MainFrameURLChange)>(data.value);
         break;
@@ -77,6 +78,52 @@ TestSyncData::TestSyncData(
 #endif
     , multipleHeaders(multipleHeaders)
 {
+}
+
+WTF::TextStream& operator<<(WTF::TextStream& ts, const TestSyncData& data)
+{
+    WTF::TextStream::GroupScope scope(ts);
+    ts << "TestSyncData"_s;
+    ts.dumpProperty("mainFrameURLChange"_s, ValueOrEllipsis(data.mainFrameURLChange));
+    ts.dumpProperty("isAutofocusProcessed"_s, ValueOrEllipsis(data.isAutofocusProcessed));
+    ts.dumpProperty("userDidInteractWithPage"_s, ValueOrEllipsis(data.userDidInteractWithPage));
+    ts.dumpProperty("anotherOne"_s, ValueOrEllipsis(data.anotherOne));
+#if ENABLE(DOM_AUDIO_SESSION)
+    ts.dumpProperty("audioSessionType"_s, ValueOrEllipsis(data.audioSessionType));
+#endif
+    ts.dumpProperty("multipleHeaders"_s, ValueOrEllipsis(data.multipleHeaders));
+    return ts;
+}
+
+WTF::TextStream& operator<<(WTF::TextStream& ts, const TestSyncSerializationData& data)
+{
+    WTF::TextStream::GroupScope scope(ts);
+    ts << "TestSyncSerializationData"_s;
+    switch (static_cast<TestSyncDataType>(data.value.index())) {
+    case TestSyncDataType::MainFrameURLChange:
+        ts.dumpProperty("mainFrameURLChange"_s, ValueOrEllipsis(std::get<std::to_underlying(TestSyncDataType::MainFrameURLChange)>(data.value)));
+        break;
+    case TestSyncDataType::IsAutofocusProcessed:
+        ts.dumpProperty("isAutofocusProcessed"_s, ValueOrEllipsis(std::get<std::to_underlying(TestSyncDataType::IsAutofocusProcessed)>(data.value)));
+        break;
+    case TestSyncDataType::UserDidInteractWithPage:
+        ts.dumpProperty("userDidInteractWithPage"_s, ValueOrEllipsis(std::get<std::to_underlying(TestSyncDataType::UserDidInteractWithPage)>(data.value)));
+        break;
+    case TestSyncDataType::AnotherOne:
+        ts.dumpProperty("anotherOne"_s, ValueOrEllipsis(std::get<std::to_underlying(TestSyncDataType::AnotherOne)>(data.value)));
+        break;
+#if ENABLE(DOM_AUDIO_SESSION)
+    case TestSyncDataType::AudioSessionType:
+        ts.dumpProperty("audioSessionType"_s, ValueOrEllipsis(std::get<std::to_underlying(TestSyncDataType::AudioSessionType)>(data.value)));
+        break;
+#endif
+    case TestSyncDataType::MultipleHeaders:
+        ts.dumpProperty("multipleHeaders"_s, ValueOrEllipsis(std::get<std::to_underlying(TestSyncDataType::MultipleHeaders)>(data.value)));
+        break;
+    default:
+        RELEASE_ASSERT_NOT_REACHED();
+    }
+    return ts;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Scripts/tests/TestSyncData.h
+++ b/Source/WebCore/Scripts/tests/TestSyncData.h
@@ -33,6 +33,10 @@
 #include <wtf/HashSet.h>
 #include <wtf/URL.h>
 
+namespace WTF {
+class TextStream;
+}
+
 namespace WebCore {
 
 struct TestSyncSerializationData;
@@ -46,16 +50,16 @@ public:
         return adoptRef(*new TestSyncData(std::forward<Args>(args)...));
     }
     static Ref<TestSyncData> create() { return adoptRef(*new TestSyncData); }
-    void update(const TestSyncSerializationData&);
+    WEBCORE_EXPORT void update(const TestSyncSerializationData&);
 
-    URL mainFrameURLChange = { };
-    bool isAutofocusProcessed = { };
-    bool userDidInteractWithPage = { };
-    StringifyThis anotherOne = { };
+    URL mainFrameURLChange { };
+    bool isAutofocusProcessed { };
+    bool userDidInteractWithPage { };
+    StringifyThis anotherOne { };
 #if ENABLE(DOM_AUDIO_SESSION)
-    WebCore::DOMAudioSessionType audioSessionType = { };
+    WebCore::DOMAudioSessionType audioSessionType { };
 #endif
-    HashSet<URL> multipleHeaders = { };
+    HashSet<URL> multipleHeaders { };
 
 private:
     TestSyncData() = default;
@@ -107,9 +111,11 @@ using TestSyncDataVariant = Variant<
 >;
 
 struct TestSyncSerializationData {
-    TestSyncDataType type;
     TestSyncDataVariant value;
 };
 
+
+WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const TestSyncData&);
+WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const TestSyncSerializationData&);
 
 } // namespace WebCore

--- a/Source/WebCore/Scripts/tests/TestSyncData.serialization.in
+++ b/Source/WebCore/Scripts/tests/TestSyncData.serialization.in
@@ -36,17 +36,6 @@ header: <WebCore/TestSyncData.h>
     HashSet<URL> multipleHeaders;
 };
 
-enum class WebCore::TestSyncDataType : uint8_t {
-#if ENABLE(DOM_AUDIO_SESSION)
-    AudioSessionType,
-#endif
-    MainFrameURLChange,
-    IsAutofocusProcessed,
-    UserDidInteractWithPage,
-    AnotherOne,
-    MultipleHeaders,
-};
- 
 #if !ENABLE(DOM_AUDIO_SESSION)
 using WebCore::DOMAudioSessionType = bool;
 #endif
@@ -54,6 +43,5 @@ using WebCore::DOMAudioSessionType = bool;
 using WebCore::TestSyncDataVariant = Variant<WebCore::DOMAudioSessionType, URL, bool, bool, StringifyThis, HashSet<URL>>;
 
 [CustomHeader] struct WebCore::TestSyncSerializationData {
-    WebCore::TestSyncDataType type;
     WebCore::TestSyncDataVariant value;
 };


### PR DESCRIPTION
#### a98133faac84549c8d12241d36ec2ec759f631b6
<pre>
[Site Isolation] Add TextStream logging support to generated ProcessSyncData types
<a href="https://bugs.webkit.org/show_bug.cgi?id=320517">https://bugs.webkit.org/show_bug.cgi?id=320517</a>
<a href="https://rdar.apple.com/183482026">rdar://183482026</a>

Reviewed by Brady Eidson.

Sometimes it&apos;s desirable to log said data close to their IPC
send/receive methods, where they are usually bundled as ProcessSyncData
types. As such, this patch teaches generate-process-sync-data.py to
create TextStream operator&lt;&lt; overloads for said types.

We also regenerate the TestSyncData output, which had drifted from the
generator after 312295@main and 316357@main; each of those commits
altered the script without regenerating these baselines.

* Source/WebCore/Scripts/generate-process-sync-data.py:
(generate_synched_data_header):
(generate_synched_data_header.TextStream):
(generate_synched_data_impl):
* Source/WebCore/Scripts/tests/TestSyncClient.cpp:
(WebCore::TestSyncClient::broadcastAudioSessionTypeToOtherProcesses):
(WebCore::TestSyncClient::broadcastMainFrameURLChangeToOtherProcesses):
(WebCore::TestSyncClient::broadcastIsAutofocusProcessedToOtherProcesses):
(WebCore::TestSyncClient::broadcastUserDidInteractWithPageToOtherProcesses):
(WebCore::TestSyncClient::broadcastAnotherOneToOtherProcesses):
(WebCore::TestSyncClient::broadcastMultipleHeadersToOtherProcesses):
* Source/WebCore/Scripts/tests/TestSyncData.cpp:
(WebCore::TestSyncData::update):
(WebCore::operator&lt;&lt;):
* Source/WebCore/Scripts/tests/TestSyncData.h:
* Source/WebCore/Scripts/tests/TestSyncData.serialization.in:

Canonical link: <a href="https://commits.webkit.org/318182@main">https://commits.webkit.org/318182@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4023360648260ffc60715c632cddf981866a4ffe

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177405 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51343 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45137 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187009 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140652 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0f830565-04b9-4fde-8c21-0944580a7679) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179268 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52635 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51052 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138254 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140652 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/79df0483-a021-412c-aa43-a6dcc8c4a390) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180361 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41754 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159012 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118719 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/525f1092-6019-47a0-ac69-425448a322f7) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40416 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38792 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150823 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38509 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-highlight-api/painting/custom-highlight-dynamic-font-metrics-001.html (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35476 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/43128 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43026 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189437 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51010 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147348 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51692 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35136 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147140 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26929 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41863 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123907 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118245 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50200 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13487 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49596 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49836 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49658 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->