### PR TITLE
Remove incorrect NODELETE annotations from Source/WebCore/css

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/NoDeleteCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/NoDeleteCheckerExpectations
@@ -1,9 +1,4 @@
-css/CSSComputedStyleDeclaration.cpp
-css/CSSPropertyInitialValues.cpp
 css/DOMMatrixReadOnly.cpp
-css/StyleSheetList.cpp
-css/parser/CSSPropertyParserConsumer+String.cpp
-css/values/color/CSSKeywordColor.cpp
 dom/Document.cpp
 dom/FragmentDirectiveRangeFinder.cpp
 dom/UserGestureIndicator.cpp

--- a/Source/WebCore/css/CSSComputedStyleDeclaration.h
+++ b/Source/WebCore/css/CSSComputedStyleDeclaration.h
@@ -65,12 +65,12 @@ private:
     String NODELETE getPropertyPriority(const String& propertyName) final;
     String NODELETE getPropertyShorthand(const String& propertyName) final;
     bool NODELETE isPropertyImplicit(const String& propertyName) final;
-    ExceptionOr<void> NODELETE setProperty(const String& propertyName, const String& value, const String& priority) final;
+    ExceptionOr<void> setProperty(const String& propertyName, const String& value, const String& priority) final;
     ExceptionOr<String> removeProperty(const String& propertyName) final;
     String NODELETE cssText() const final;
-    ExceptionOr<void> NODELETE setCssText(const String&) final;
+    ExceptionOr<void> setCssText(const String&) final;
     String getPropertyValueInternal(CSSPropertyID) final;
-    ExceptionOr<void> NODELETE setPropertyInternal(CSSPropertyID, const String& value, IsImportant) final;
+    ExceptionOr<void> setPropertyInternal(CSSPropertyID, const String& value, IsImportant) final;
     Ref<MutableStyleProperties> copyProperties() const final;
 
     Element& element() const { return m_element; }

--- a/Source/WebCore/css/CSSPropertyInitialValues.cpp
+++ b/Source/WebCore/css/CSSPropertyInitialValues.cpp
@@ -55,7 +55,8 @@ static bool NODELETE isValueIDPair(const CSSValue& value, CSSValueID valueID)
     return value.isPair() && isValueID(value.first(), valueID) && isValueID(value.second(), valueID);
 }
 
-static bool NODELETE isNumber(const CSSPrimitiveValue& value, CSSPrimitiveValue::Raw number)
+// FIXME: SUPPRESS_NODELETE shouldn't be necessary.
+SUPPRESS_NODELETE static bool NODELETE isNumber(const CSSPrimitiveValue& value, CSSPrimitiveValue::Raw number)
 {
     return WTF::switchOn(value,
         [&](const CSSPrimitiveValue::Calc&) {
@@ -67,8 +68,9 @@ static bool NODELETE isNumber(const CSSPrimitiveValue& value, CSSPrimitiveValue:
     );
 }
 
+// FIXME: SUPPRESS_NODELETE shouldn't be necessary.
 template<auto unit>
-static bool NODELETE isNumber(const CSSPrimitiveValue& value, CSS::ValueLiteral<unit> literal)
+SUPPRESS_NODELETE static bool NODELETE isNumber(const CSSPrimitiveValue& value, CSS::ValueLiteral<unit> literal)
 {
     return WTF::switchOn(value,
         [&](const CSSPrimitiveValue::Calc&) {

--- a/Source/WebCore/css/DOMMatrixReadOnly.h
+++ b/Source/WebCore/css/DOMMatrixReadOnly.h
@@ -124,7 +124,7 @@ public:
 
     const TransformationMatrix& transformationMatrix() const LIFETIME_BOUND { return m_matrix; }
     
-    Ref<DOMMatrix> NODELETE cloneAsDOMMatrix() const;
+    Ref<DOMMatrix> cloneAsDOMMatrix() const;
 
 protected:
     DOMMatrixReadOnly() = default;

--- a/Source/WebCore/css/SelectorChecker.cpp
+++ b/Source/WebCore/css/SelectorChecker.cpp
@@ -309,7 +309,7 @@ inline static bool hasScrollbarPseudoElement(EnumSet<PseudoElementType> collecte
     return collectedPseudoElements.contains(PseudoElementType::WebKitResizer);
 }
 
-static SelectorChecker::LocalContext NODELETE localContextForParent(const SelectorChecker::LocalContext& context)
+static SelectorChecker::LocalContext localContextForParent(const SelectorChecker::LocalContext& context)
 {
     SelectorChecker::LocalContext updatedContext(context);
     // Disable :visited matching when we see the first link.

--- a/Source/WebCore/css/StyleSheetList.h
+++ b/Source/WebCore/css/StyleSheetList.h
@@ -47,7 +47,7 @@ public:
 
     CSSStyleSheet* namedItem(const AtomString&) const;
     bool isSupportedPropertyName(const AtomString&) const;
-    Vector<AtomString> NODELETE supportedPropertyNames();
+    Vector<AtomString> supportedPropertyNames();
 
     Node* NODELETE ownerNode() const;
 

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+String.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+String.h
@@ -41,7 +41,7 @@ namespace CSSPropertyParserHelpers {
 // https://drafts.csswg.org/css-values/#strings
 
 StringView NODELETE consumeStringRaw(CSSParserTokenRange&);
-std::optional<CSS::String> NODELETE consumeUnresolvedString(CSSParserTokenRange&);
+std::optional<CSS::String> consumeUnresolvedString(CSSParserTokenRange&);
 RefPtr<CSSValue> consumeString(CSSParserTokenRange&);
 
 } // namespace CSSPropertyParserHelpers

--- a/Source/WebCore/css/values/color/CSSKeywordColor.cpp
+++ b/Source/WebCore/css/values/color/CSSKeywordColor.cpp
@@ -72,7 +72,7 @@ bool isSystemColorKeyword(CSSValueID id)
     return (id >= CSSValueCanvas && id <= CSSValueInternalDocumentTextColor) || isDeprecatedSystemColorKeyword(id);
 }
 
-bool isDeprecatedSystemColorKeyword(CSSValueID id)
+SUPPRESS_NODELETE bool isDeprecatedSystemColorKeyword(CSSValueID id)
 {
     if (id == CSSValueText)
 #if PLATFORM(COCOA)


### PR DESCRIPTION
#### 65b1821f100eb623205ecb3f59b961307f97dca8
<pre>
Remove incorrect NODELETE annotations from Source/WebCore/css
<a href="https://bugs.webkit.org/show_bug.cgi?id=320518">https://bugs.webkit.org/show_bug.cgi?id=320518</a>

Reviewed by Geoffrey Garen.

Removed NODELETE annotations from a bunch of functions in Source/WebCore/css.

* Source/WebCore/SaferCPPExpectations/NoDeleteCheckerExpectations:
* Source/WebCore/css/CSSComputedStyleDeclaration.h:
* Source/WebCore/css/CSSPropertyInitialValues.cpp:
(WebCore::isNumber):
* Source/WebCore/css/DOMMatrixReadOnly.h:
* Source/WebCore/css/SelectorChecker.cpp:
(WebCore::localContextForParent):
* Source/WebCore/css/StyleSheetList.h:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+String.h:
* Source/WebCore/css/values/color/CSSKeywordColor.cpp:
(WebCore::CSS::isDeprecatedSystemColorKeyword):

Canonical link: <a href="https://commits.webkit.org/318810@main">https://commits.webkit.org/318810@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2d99694db495886a185773c2c8a55e717d5b7176

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179429 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53368 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47165 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189261 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/143738 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6a7a31f9-24f6-423b-af57-f8ebceac71b3) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181292 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54662 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53078 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139924 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/143738 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7b309953-2287-4447-82db-f8c2af4c9c09) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182386 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43531 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160671 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120376 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3a698557-0062-4dc1-8fd4-b0ae9d92d084) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/42201 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40532 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152601 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/40176 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/714 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45974 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44779 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191479 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53038 "Built successfully") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/149183 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53719 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/36806 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148926 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27239 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43596 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125991 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/120886 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52236 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15166 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51621 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51862 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51682 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->