### PR TITLE
Catch mismatched pixelFormats in ImageData JS constructor

### DIFF
--- a/LayoutTests/fast/canvas/hdr/float16-canvas-imagedata-large-unaccelerated-expected.txt
+++ b/LayoutTests/fast/canvas/hdr/float16-canvas-imagedata-large-unaccelerated-expected.txt
@@ -133,6 +133,8 @@ PASS gotten_imageData_float16.data.length is expected_imageData_float16.data.len
 PASS gotten_imageData_float16.data.byteLength is expected_imageData_float16.data.byteLength
 PASS context.createImageData(1, 1, { pixelFormat: "foo" }) threw exception TypeError: Type error.
 PASS context.getImageData(0, 0, 1, 1, { pixelFormat: "foo" }) threw exception TypeError: Type error.
+PASS new ImageData(new Uint8ClampedArray(4), 1, 1, { colorSpace: "srgb", pixelFormat: "rgba-float16" }) threw exception InvalidStateError: Mismatched pixel formats in data and settings.
+PASS new ImageData(new Float16Array(4), 1, 1, { colorSpace: "srgb", pixelFormat: "rgba-unorm8" }) threw exception InvalidStateError: Mismatched pixel formats in data and settings.
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/canvas/hdr/float16-canvas-imagedata-small-accelerated-display-p3-expected.txt
+++ b/LayoutTests/fast/canvas/hdr/float16-canvas-imagedata-small-accelerated-display-p3-expected.txt
@@ -133,6 +133,8 @@ PASS gotten_imageData_float16.data.length is expected_imageData_float16.data.len
 PASS gotten_imageData_float16.data.byteLength is expected_imageData_float16.data.byteLength
 PASS context.createImageData(1, 1, { pixelFormat: "foo" }) threw exception TypeError: Type error.
 PASS context.getImageData(0, 0, 1, 1, { pixelFormat: "foo" }) threw exception TypeError: Type error.
+PASS new ImageData(new Uint8ClampedArray(4), 1, 1, { colorSpace: "display-p3", pixelFormat: "rgba-float16" }) threw exception InvalidStateError: Mismatched pixel formats in data and settings.
+PASS new ImageData(new Float16Array(4), 1, 1, { colorSpace: "display-p3", pixelFormat: "rgba-unorm8" }) threw exception InvalidStateError: Mismatched pixel formats in data and settings.
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/canvas/hdr/float16-canvas-imagedata-small-accelerated-display-p3-linear-expected.txt
+++ b/LayoutTests/fast/canvas/hdr/float16-canvas-imagedata-small-accelerated-display-p3-linear-expected.txt
@@ -133,6 +133,8 @@ PASS gotten_imageData_float16.data.length is expected_imageData_float16.data.len
 PASS gotten_imageData_float16.data.byteLength is expected_imageData_float16.data.byteLength
 PASS context.createImageData(1, 1, { pixelFormat: "foo" }) threw exception TypeError: Type error.
 PASS context.getImageData(0, 0, 1, 1, { pixelFormat: "foo" }) threw exception TypeError: Type error.
+PASS new ImageData(new Uint8ClampedArray(4), 1, 1, { colorSpace: "display-p3-linear", pixelFormat: "rgba-float16" }) threw exception InvalidStateError: Mismatched pixel formats in data and settings.
+PASS new ImageData(new Float16Array(4), 1, 1, { colorSpace: "display-p3-linear", pixelFormat: "rgba-unorm8" }) threw exception InvalidStateError: Mismatched pixel formats in data and settings.
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/canvas/hdr/float16-canvas-imagedata-small-accelerated-expected.txt
+++ b/LayoutTests/fast/canvas/hdr/float16-canvas-imagedata-small-accelerated-expected.txt
@@ -133,6 +133,8 @@ PASS gotten_imageData_float16.data.length is expected_imageData_float16.data.len
 PASS gotten_imageData_float16.data.byteLength is expected_imageData_float16.data.byteLength
 PASS context.createImageData(1, 1, { pixelFormat: "foo" }) threw exception TypeError: Type error.
 PASS context.getImageData(0, 0, 1, 1, { pixelFormat: "foo" }) threw exception TypeError: Type error.
+PASS new ImageData(new Uint8ClampedArray(4), 1, 1, { colorSpace: "srgb", pixelFormat: "rgba-float16" }) threw exception InvalidStateError: Mismatched pixel formats in data and settings.
+PASS new ImageData(new Float16Array(4), 1, 1, { colorSpace: "srgb", pixelFormat: "rgba-unorm8" }) threw exception InvalidStateError: Mismatched pixel formats in data and settings.
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/canvas/hdr/float16-canvas-imagedata-small-accelerated-srgb-linear-expected.txt
+++ b/LayoutTests/fast/canvas/hdr/float16-canvas-imagedata-small-accelerated-srgb-linear-expected.txt
@@ -133,6 +133,8 @@ PASS gotten_imageData_float16.data.length is expected_imageData_float16.data.len
 PASS gotten_imageData_float16.data.byteLength is expected_imageData_float16.data.byteLength
 PASS context.createImageData(1, 1, { pixelFormat: "foo" }) threw exception TypeError: Type error.
 PASS context.getImageData(0, 0, 1, 1, { pixelFormat: "foo" }) threw exception TypeError: Type error.
+PASS new ImageData(new Uint8ClampedArray(4), 1, 1, { colorSpace: "srgb-linear", pixelFormat: "rgba-float16" }) threw exception InvalidStateError: Mismatched pixel formats in data and settings.
+PASS new ImageData(new Float16Array(4), 1, 1, { colorSpace: "srgb-linear", pixelFormat: "rgba-unorm8" }) threw exception InvalidStateError: Mismatched pixel formats in data and settings.
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/canvas/hdr/float16-canvas-imagedata.js
+++ b/LayoutTests/fast/canvas/hdr/float16-canvas-imagedata.js
@@ -217,3 +217,5 @@ areEqualImageData('gotten_imageData_float16', 'expected_imageData_float16', floa
 
 shouldThrowErrorName(`context.createImageData(1, 1, { pixelFormat: "foo" })`, "TypeError")
 shouldThrowErrorName(`context.getImageData(0, 0, 1, 1, { pixelFormat: "foo" })`, "TypeError")
+shouldThrowErrorName(`new ImageData(new Uint8ClampedArray(4), 1, 1, { colorSpace: "${canvas.dataset.colorSpace}", pixelFormat: "rgba-float16" })`, "InvalidStateError")
+shouldThrowErrorName(`new ImageData(new Float16Array(4), 1, 1, { colorSpace: "${canvas.dataset.colorSpace}", pixelFormat: "rgba-unorm8" })`, "InvalidStateError")

--- a/Source/WebCore/html/ImageData.cpp
+++ b/Source/WebCore/html/ImageData.cpp
@@ -150,6 +150,9 @@ ExceptionOr<Ref<ImageData>> ImageData::create(ImageDataArray&& array, unsigned s
     if (sh && sh.value() != height)
         return Exception { ExceptionCode::IndexSizeError, "sh value is not equal to height"_s };
 
+    if (settings && settings->pixelFormat != array.pixelFormat())
+        return Exception { ExceptionCode::InvalidStateError, "Mismatched pixel formats in data and settings"_s };
+
     IntSize size(sw, height.value());
     auto dataSize = computeDataSize(size, computePixelFormat(settings));
     if (dataSize.hasOverflowed() || dataSize != length)


### PR DESCRIPTION
#### e9fc18b84ae2af773b28216685002cd3fdfa092a
<pre>
Catch mismatched pixelFormats in ImageData JS constructor
<a href="https://bugs.webkit.org/show_bug.cgi?id=320519">https://bugs.webkit.org/show_bug.cgi?id=320519</a>
<a href="https://rdar.apple.com/183483114">rdar://183483114</a>

Reviewed by Mike Wyrzykowski.

As per <a href="https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#initialize-an-imagedata-object">https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#initialize-an-imagedata-object</a>
1.1: If settings[&quot;pixelFormat&quot;] equals &quot;rgba-unorm8&quot; and source is not a
     Uint8ClampedArray, then throw an &quot;InvalidStateError&quot; DOMException.
1.2: If settings[&quot;pixelFormat&quot;] is &quot;rgba-float16&quot; and source is not a
     Float16Array, then throw an &quot;InvalidStateError&quot; DOMException.

* LayoutTests/fast/canvas/hdr/float16-canvas-imagedata-large-unaccelerated-expected.txt:
* LayoutTests/fast/canvas/hdr/float16-canvas-imagedata-small-accelerated-display-p3-expected.txt:
* LayoutTests/fast/canvas/hdr/float16-canvas-imagedata-small-accelerated-display-p3-linear-expected.txt:
* LayoutTests/fast/canvas/hdr/float16-canvas-imagedata-small-accelerated-expected.txt:
* LayoutTests/fast/canvas/hdr/float16-canvas-imagedata-small-accelerated-srgb-linear-expected.txt:
* LayoutTests/fast/canvas/hdr/float16-canvas-imagedata.js:
* Source/WebCore/html/ImageData.cpp:
(WebCore::ImageData::create):

Canonical link: <a href="https://commits.webkit.org/318195@main">https://commits.webkit.org/318195@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4be0489c00e6b79cb1ff9610da229a178293efc0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177407 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51345 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45139 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187011 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140654 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/36bef7db-8af0-4bc9-9e9f-cdaaa5ffaef0) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179270 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52637 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51054 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138255 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140654 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/80561cff-49bc-4a43-adcc-5f797b9759bd) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180363 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41756 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159002 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118720 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/02984948-e5fe-4552-99d7-19237cfbdaf9) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40418 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38795 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150825 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38499 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35478 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/43130 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43029 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189439 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51012 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147350 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39623 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51694 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35126 "Found 1 new test failure: fast/mediastream/video-rotation-gpu-process-crash.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147142 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41859 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123909 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118249 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50202 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13477 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49598 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49838 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49660 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->