### PR TITLE
AdaptiveStringSearcher good-suffix shift table is one element too small

### DIFF
--- a/Source/WTF/wtf/text/AdaptiveStringSearcher.h
+++ b/Source/WTF/wtf/text/AdaptiveStringSearcher.h
@@ -97,14 +97,36 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 class AdaptiveStringSearcherTables {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED(AdaptiveStringSearcherTables);
 public:
-    int* badCharShiftTable() LIFETIME_BOUND { return m_badCharShiftTable.data(); }
-    int* goodSuffixShiftTable() LIFETIME_BOUND { return m_goodSuffixShiftTable.data(); }
-    int* suffixTable() LIFETIME_BOUND { return m_suffixTable.data(); }
+    static constexpr size_t badCharShiftTableSize = AdaptiveStringSearcherBase::ucharAlphabetSize;
+    static constexpr size_t shiftTableSize = AdaptiveStringSearcherBase::bmMaxShift + 1;
+
+    std::span<int, badCharShiftTableSize> badCharShiftTable() LIFETIME_BOUND { return m_badCharShiftTable; }
+    std::span<int, shiftTableSize> goodSuffixShiftTable() LIFETIME_BOUND { return m_goodSuffixShiftTable; }
+    std::span<int, shiftTableSize> suffixTable() LIFETIME_BOUND { return m_suffixTable; }
 
 private:
-    std::array<int, AdaptiveStringSearcherBase::ucharAlphabetSize> m_badCharShiftTable { };
-    std::array<int, AdaptiveStringSearcherBase::bmMaxShift> m_goodSuffixShiftTable { };
-    std::array<int, AdaptiveStringSearcherBase::bmMaxShift + 1> m_suffixTable { };
+    std::array<int, badCharShiftTableSize> m_badCharShiftTable { };
+    std::array<int, shiftTableSize> m_goodSuffixShiftTable { };
+    std::array<int, shiftTableSize> m_suffixTable { };
+};
+
+// Maps pattern indices in [start, patternLength] onto a shift table that only covers the last
+// bmMaxShift + 1 positions of the pattern. Unlike a biased pointer, both ends are bounds-checked
+// against the physical table, and the check is against a compile-time constant extent.
+class BiasedShiftTable {
+public:
+    using Table = std::span<int, AdaptiveStringSearcherTables::shiftTableSize>;
+
+    BiasedShiftTable(Table table, int start)
+        : m_table(table)
+        , m_start(start)
+    { }
+
+    int& operator[](int patternIndex) const { return m_table[static_cast<size_t>(patternIndex - m_start)]; }
+
+private:
+    Table m_table;
+    int m_start;
 };
 
 template <typename PatternChar, typename SubjectChar>
@@ -168,23 +190,22 @@ private:
 
     void populateBoyerMooreTable();
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-    static inline int charOccurrence(int* badCharOccurrence, SubjectChar charCode)
+    // The index is always reduced into [0, ucharAlphabetSize) so that the bounds check against the
+    // table's constant extent folds away.
+    static inline int charOccurrence(std::span<const int, AdaptiveStringSearcherTables::badCharShiftTableSize> badCharOccurrence, SubjectChar charCode)
     {
         if constexpr (sizeof(SubjectChar) == 1)
-            return badCharOccurrence[static_cast<int>(charCode)];
+            return badCharOccurrence[static_cast<uint8_t>(charCode)];
 
         if constexpr (sizeof(PatternChar) == 1) {
             if (exceedsOneByte(charCode))
                 return -1;
-            return badCharOccurrence[static_cast<unsigned>(charCode)];
+            return badCharOccurrence[static_cast<uint8_t>(charCode)];
         }
         // Both pattern and subject are UC16. Reduce character to equivalence
         // class.
-        int equivClass = charCode % ucharAlphabetSize;
-        return badCharOccurrence[equivClass];
+        return badCharOccurrence[static_cast<uint16_t>(charCode) % ucharAlphabetSize];
     }
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
     // The following tables are shared by all searches.
     // TODO(lrn): Introduce a way for a pattern to keep its tables
@@ -193,26 +214,14 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     // Store for the BoyerMoore(Horspool) bad char shift table.
     // Return a table covering the last bmMaxShift+1 positions of
     // pattern.
-    int* badCharTable() LIFETIME_BOUND { return m_tables.badCharShiftTable(); }
+    std::span<int, AdaptiveStringSearcherTables::badCharShiftTableSize> badCharTable() LIFETIME_BOUND { return m_tables.badCharShiftTable(); }
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-    // Store for the BoyerMoore good suffix shift table.
-    int* goodSuffixShiftTable()
-    {
-        // Return biased pointer that maps the range  [m_start..m_pattern.size()
-        // to the kGoodSuffixShiftTable array.
-        return m_tables.goodSuffixShiftTable() - m_start;
-    }
+    // Store for the BoyerMoore good suffix shift table, indexed by pattern index.
+    BiasedShiftTable goodSuffixShiftTable() { return { m_tables.goodSuffixShiftTable(), m_start }; }
 
     // Table used temporarily while building the BoyerMoore good suffix
     // shift table.
-    int* suffixTable()
-    {
-        // Return biased pointer that maps the range  [m_start..m_pattern.size()
-        // to the kSuffixTable array.
-        return m_tables.suffixTable() - m_start;
-    }
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+    BiasedShiftTable suffixTable() { return { m_tables.suffixTable(), m_start }; }
 
     AdaptiveStringSearcherTables& m_tables;
     // The pattern to search for.
@@ -379,8 +388,8 @@ int AdaptiveStringSearcher<PatternChar, SubjectChar>::boyerMooreSearch(AdaptiveS
     // Only preprocess at most bmMaxShift last characters of pattern.
     int start = search.m_start;
 
-    int* badCharOccurrence = search.badCharTable();
-    int* goodSuffixShift = search.goodSuffixShiftTable();
+    auto badCharOccurrence = search.badCharTable();
+    auto goodSuffixShift = search.goodSuffixShiftTable();
 
     PatternChar lastChar = patternPtr[patternLength - 1];
     int index = startIndex;
@@ -427,8 +436,8 @@ void AdaptiveStringSearcher<PatternChar, SubjectChar>::populateBoyerMooreTable()
 
     // Biased tables so that we can use pattern indices as table indices,
     // even if we only cover the part of the pattern from offset start.
-    int* shiftTable = goodSuffixShiftTable();
-    int* suffixTable = this->suffixTable();
+    auto shiftTable = goodSuffixShiftTable();
+    auto suffixTable = this->suffixTable();
 
     // Initialize table.
     for (int i = start; i < patternLength; i++)
@@ -487,7 +496,7 @@ int AdaptiveStringSearcher<PatternChar, SubjectChar>::boyerMooreHorspoolSearch(A
     const auto* patternPtr = pattern.data();
     int subjectLength = subject.size();
     int patternLength = pattern.size();
-    int* charOccurrences = search.badCharTable();
+    auto charOccurrences = search.badCharTable();
     int badness = -patternLength;
 
     // How bad we are doing without a good-suffix table.
@@ -532,20 +541,16 @@ void AdaptiveStringSearcher<PatternChar, SubjectChar>::populateBoyerMooreHorspoo
 {
     int patternLength = m_pattern.size();
 
-    int* badCharOccurrence = badCharTable();
+    auto badCharOccurrence = badCharTable();
+    static_assert(alphabetSize() == AdaptiveStringSearcherTables::badCharShiftTableSize);
 
     // Only preprocess at most bmMaxShift last characters of pattern.
     int start = m_start;
     // Run forwards to populate badCharTable, so that *last* instance
     // of character equivalence class is the one registered.
     // Notice: Doesn't include the last character.
-    int tableSize = alphabetSize();
-    if (!start) // All patterns less than bmMaxShift in length.
-        memset(badCharOccurrence, -1, tableSize * sizeof(*badCharOccurrence));
-    else {
-        for (int i = 0; i < tableSize; i++)
-            badCharOccurrence[i] = start - 1;
-    }
+    std::ranges::fill(badCharOccurrence, start - 1); // -1 for all patterns shorter than bmMaxShift.
+
     const auto* patternPtr = m_pattern.data();
     for (int i = start; i < patternLength - 1; i++) {
         PatternChar c = patternPtr[i];


### PR DESCRIPTION
#### 5590f2e70615e4b6f6a7187dbdaddf5c7b98520f
<pre>
AdaptiveStringSearcher good-suffix shift table is one element too small
<a href="https://bugs.webkit.org/show_bug.cgi?id=320520">https://bugs.webkit.org/show_bug.cgi?id=320520</a>

Reviewed by Darin Adler.

The Boyer-Moore good-suffix shift table (m_goodSuffixShiftTable) was sized
bmMaxShift, but it is indexed by pattern index over the range
[m_start, patternLength], i.e. up to and including patternLength. When a
needle&apos;s length is exactly bmMaxShift (250), populateBoyerMooreTable() writes
to index patternLength, which is one past the end of the table.

The out-of-bounds access was masked because the tables were handed around as
raw int* and the good-suffix / suffix tables were accessed through a biased
pointer (table - m_start), so nothing bounds-checked the index against the
physical array.

Fix the size (bmMaxShift + 1) and, to make this class of bug fail loudly
rather than silently write in the wrong place, replace the raw table pointers
with std::span:

  - AdaptiveStringSearcherTables now vends fixed-extent std::span accessors
    instead of int*, so every access is bounds-checked against a compile-time
    constant extent (a hard trap under hardened libc++).
  - Introduce BiasedShiftTable, which maps pattern indices in
    [m_start, patternLength] onto the shift table while bounds-checking both
    ends against the physical table, replacing the previous biased raw pointer.
  - charOccurrence() takes a fixed-extent span and reduces the index into
    [0, ucharAlphabetSize) via uint8_t / uint16_t casts so the bounds check
    folds away.
  - Replace the manual memset/loop that initializes the bad-char table with
    std::ranges::fill.

This change tested as performance neutral on Speedometer and JetStream.

* Source/WTF/wtf/text/AdaptiveStringSearcher.h:
(WTF::BiasedShiftTable::BiasedShiftTable):
(WTF::BiasedShiftTable::operator[] const):
(WTF::AdaptiveStringSearcher::charOccurrence):
(WTF::AdaptiveStringSearcher::goodSuffixShiftTable):
(WTF::AdaptiveStringSearcher::suffixTable):
(WTF::SubjectChar&gt;::boyerMooreSearch):
(WTF::SubjectChar&gt;::populateBoyerMooreTable):
(WTF::SubjectChar&gt;::boyerMooreHorspoolSearch):
(WTF::SubjectChar&gt;::populateBoyerMooreHorspoolTable):

Canonical link: <a href="https://commits.webkit.org/318198@main">https://commits.webkit.org/318198@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d078c69a06c6d52107e7ff0816b14c4adfad5e68

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177409 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51347 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45141 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187013 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140656 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1518cc4f-57f3-4f64-af6b-c47ea36ab702) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52639 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51056 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138267 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140656 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e633b487-5d2c-40a7-9569-e5da3802c213) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180365 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41763 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159017 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118732 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e48df313-f1b4-43f1-bd38-15d0972233d7) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40425 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38801 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/701 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/7516 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150832 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38514 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35480 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/38680 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/43132 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43035 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189441 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51014 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147359 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39625 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51696 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35141 "344 new passes 16 flakes 5 failures") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147151 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41869 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123911 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118251 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50204 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13492 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49600 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49840 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49662 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->