### PR TITLE
BlockGroup-wrapped WebM Blocks get compounding presentation times

### DIFF
--- a/LayoutTests/media/media-source/media-source-real-webm-blockgroup-presentation-times-expected.txt
+++ b/LayoutTests/media/media-source/media-source-real-webm-blockgroup-presentation-times-expected.txt
@@ -1,0 +1,15 @@
+
+EVENT(sourceopen)
+EVENT(updateend)
+EVENT(updateend)
+EXPECTED (simpleBlockBuffered.length == '1') OK
+EXPECTED (simpleBlockBuffered.start(0) == '0') OK
+EXPECTED (simpleBlockBuffered.end(0) == '1') OK
+EVENT(sourceopen)
+EVENT(updateend)
+EVENT(updateend)
+EXPECTED (blockGroupBuffered.length == '1') OK
+EXPECTED (blockGroupBuffered.start(0) == '0') OK
+EXPECTED (blockGroupBuffered.end(0) == '1') OK
+END OF TEST
+

--- a/LayoutTests/media/media-source/media-source-real-webm-blockgroup-presentation-times.html
+++ b/LayoutTests/media/media-source/media-source-real-webm-blockgroup-presentation-times.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>media-source-real-webm-blockgroup-presentation-times</title>
+    <script src="webm-generator.js"></script>
+    <script src="../video-test.js"></script>
+    <script>
+    // Tests that a Block wrapped in a BlockGroup gets the same presentation time
+    // as the equivalent bare SimpleBlock.
+    //
+    // WebMParser accumulates each consumed frame's duration so that laced frames
+    // sharing a single Matroska timecode are spaced apart correctly. That
+    // accumulator was reset around SimpleBlock but not around a Block inside a
+    // BlockGroup, so each BlockGroup-wrapped block's presentation time was pushed
+    // out by the total duration of every block before it. With 20ms Opus packets
+    // the error compounds one packet duration per block, so 50 contiguous packets
+    // spanned two seconds instead of one.
+    // See: https://bugs.webkit.org/show_bug.cgi?id=297781
+
+    // Opus packet duration in ms. Must match the codec frame duration emitted by
+    // the generator, otherwise the samples aren't contiguous to begin with.
+    const SAMPLE_DURATION = 20;
+    const SAMPLE_COUNT = 50; // Exactly one second of audio.
+
+    var simpleBlockBuffered;
+    var blockGroupBuffered;
+
+    async function appendOpusPackets(useSimpleBlock) {
+        var source = new MediaSource();
+        video.src = URL.createObjectURL(source);
+        await waitFor(source, 'sourceopen');
+
+        var sourceBuffer = source.addSourceBuffer(WebM.AUDIO_TYPE);
+
+        sourceBuffer.appendBuffer(WebM.initSegment({
+            tracks: [{ id: 1, type: 'audio' }]
+        }));
+        await waitFor(sourceBuffer, 'updateend');
+
+        sourceBuffer.appendBuffer(WebM.mediaSegment({
+            simpleBlock: useSimpleBlock,
+            tracks: [{
+                id: 1, type: 'audio', baseDecodeTime: 0,
+                samples: new Array(SAMPLE_COUNT).fill({ duration: SAMPLE_DURATION, isSync: true }),
+            }]
+        }));
+        await waitFor(sourceBuffer, 'updateend');
+
+        return sourceBuffer.buffered;
+    }
+
+    async function runTest() {
+        findMediaElement();
+
+        if (!MediaSource.isTypeSupported(WebM.AUDIO_TYPE)) {
+            consoleWrite('SKIPPED: ' + WebM.AUDIO_TYPE + ' is not supported');
+            return;
+        }
+
+        // Baseline: bare SimpleBlocks, which always reset the accumulator.
+        simpleBlockBuffered = await appendOpusPackets(true);
+        testExpected('simpleBlockBuffered.length', 1);
+        testExpectedEqualWithTolerance('simpleBlockBuffered.start(0)', 0, 0.01);
+        testExpectedEqualWithTolerance('simpleBlockBuffered.end(0)', 1, 0.05);
+
+        // The same packets carried in BlockGroups must land on the same timeline.
+        blockGroupBuffered = await appendOpusPackets(false);
+        testExpected('blockGroupBuffered.length', 1);
+        testExpectedEqualWithTolerance('blockGroupBuffered.start(0)', 0, 0.01);
+        testExpectedEqualWithTolerance('blockGroupBuffered.end(0)', 1, 0.05);
+    }
+
+    window.addEventListener('load', event => {
+        runTest().then(endTest).catch(failTest);
+    });
+    </script>
+</head>
+<body>
+    <video></video>
+</body>
+</html>

--- a/LayoutTests/media/media-source/webm-generator.js
+++ b/LayoutTests/media/media-source/webm-generator.js
@@ -299,19 +299,29 @@ const WebM = (function() {
     }
 
     // ========================================================================
-    // Media Segment Builders (Cluster + BlockGroup)
+    // Media Segment Builders (Cluster + SimpleBlock/BlockGroup)
     // ========================================================================
 
-    function blockGroup(trackNumber, relativeTimecode, isKeyframe, duration, frameData) {
-        // Block payload: trackNumber(VINT) + timecode(int16 BE) + flags(byte) + frame
+    // Block/SimpleBlock payload: trackNumber(VINT) + timecode(int16 BE) + flags(byte) + frame
+    function blockPayload(trackNumber, relativeTimecode, flagBits, frameData) {
         const trackVint = new Uint8Array([0x80 | trackNumber]);
         const tc = new Uint8Array(2);
         new DataView(tc.buffer).setInt16(0, relativeTimecode, false);
-        const flags = new Uint8Array([0x00]); // Block flags (no lacing)
-        const blockPayload = concat(trackVint, tc, flags, frameData);
+        return concat(trackVint, tc, new Uint8Array([flagBits]), frameData);
+    }
+
+    // A bare SimpleBlock. Unlike Block, the keyframe bit lives in the block's own
+    // flags byte, and there is nowhere to carry an explicit BlockDuration.
+    function simpleBlock(trackNumber, relativeTimecode, isKeyframe, frameData) {
+        return ebmlElement(ID.SimpleBlock,
+            blockPayload(trackNumber, relativeTimecode, isKeyframe ? 0x80 : 0x00, frameData));
+    }
+
+    function blockGroup(trackNumber, relativeTimecode, isKeyframe, duration, frameData) {
+        const payload = blockPayload(trackNumber, relativeTimecode, 0x00, frameData); // no lacing
 
         const children = [
-            ebmlElement(ID.Block, blockPayload),
+            ebmlElement(ID.Block, payload),
             ebmlUint(ID.BlockDuration, duration),
         ];
 
@@ -359,6 +369,8 @@ const WebM = (function() {
         // Each frame gets an explicit BlockDuration so parsers don't need
         // to infer duration from timecode gaps.
         //
+        // options.simpleBlock - Emit bare SimpleBlock elements instead of
+        //                       BlockGroup(Block + BlockDuration) (optional).
         // options.tracks[] - Array of track data:
         //   .id              - Track number (must match init segment)
         //   .type            - 'video' or 'audio'
@@ -370,6 +382,9 @@ const WebM = (function() {
         mediaSegment(options) {
             const tracks = options.tracks;
             const clusterTimecode = (tracks[0] && tracks[0].baseDecodeTime) || 0;
+            const encodeBlock = options.simpleBlock
+                ? (b => simpleBlock(b.trackId, b.relativeTime, b.isSync, b.data))
+                : (b => blockGroup(b.trackId, b.relativeTime, b.isSync, b.duration, b.data));
 
             // Block relative timecodes are int16 (max 32767). If cumulative
             // durations exceed this, we must split into multiple clusters.
@@ -387,8 +402,7 @@ const WebM = (function() {
                     if (relativeTime > MAX_RELATIVE_TC && currentBlocks.length > 0) {
                         clusters.push(ebmlMasterUnknownSize(ID.Cluster,
                             ebmlUint(ID.Timecode, currentClusterBase),
-                            ...currentBlocks.map(b =>
-                                blockGroup(b.trackId, b.relativeTime, b.isSync, b.duration, b.data))
+                            ...currentBlocks.map(encodeBlock)
                         ));
                         currentClusterBase += relativeTime;
                         relativeTime = 0;
@@ -414,8 +428,7 @@ const WebM = (function() {
             if (currentBlocks.length > 0) {
                 clusters.push(ebmlMasterUnknownSize(ID.Cluster,
                     ebmlUint(ID.Timecode, currentClusterBase),
-                    ...currentBlocks.map(b =>
-                        blockGroup(b.trackId, b.relativeTime, b.isSync, b.duration, b.data))
+                    ...currentBlocks.map(encodeBlock)
                 ));
             }
 

--- a/Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.cpp
@@ -859,6 +859,7 @@ webm::Status WebMParser::OnBlockBegin(const ElementMetadata&, const Block& block
     *action = Action::kRead;
 
     m_currentBlock = std::make_optional<BlockVariant>(Block(block));
+    m_currentDuration = MediaTime::zeroTime();
 
     return Status(Status::kOkCompleted);
 }
@@ -866,6 +867,7 @@ webm::Status WebMParser::OnBlockBegin(const ElementMetadata&, const Block& block
 webm::Status WebMParser::OnBlockEnd(const ElementMetadata&, const Block&)
 {
     m_currentBlock = std::nullopt;
+    m_currentDuration = MediaTime::zeroTime();
 
     return Status(Status::kOkCompleted);
 }


### PR DESCRIPTION
#### 97b38365f939f8106f648fa6182b8de823bb83a6
<pre>
BlockGroup-wrapped WebM Blocks get compounding presentation times
<a href="https://bugs.webkit.org/show_bug.cgi?id=297781">https://bugs.webkit.org/show_bug.cgi?id=297781</a>
<a href="https://rdar.apple.com/problem/158943997">rdar://problem/158943997</a>

Reviewed by Jean-Yves Avenard.

WebMParser::m_currentDuration accumulates the duration of each frame consumed
within a single Block, so that laced frames sharing one Matroska timecode are
spaced out correctly. WebMParser::OnSimpleBlockBegin() and OnSimpleBlockEnd()
reset it to zero, but OnBlockBegin() and OnBlockEnd() did not, so for Blocks
carried inside a BlockGroup the accumulated duration was never cleared and
leaked into the next block&apos;s presentation time in OnFrame(), which computes
MediaTime(block-&gt;timecode + m_currentTimecode, m_timescale) + m_currentDuration.

The error compounds: with 20ms Opus packets, 50 back-to-back frames covering one
second of audio were timestamped 0, 0.04, 0.08, ... 1.96, so the track spanned
two seconds instead of one and every frame after the first was out of sync.

Reset m_currentDuration in OnBlockBegin() and OnBlockEnd(), mirroring the
SimpleBlock path. Only audio tracks are affected, since only
AudioTrackData::consumeFrameData() returns a frame duration for OnFrame() to
accumulate; VideoTrackData::consumeFrameData() returns a webm::Status.

Added a layout test that appends the same 50 Opus packets twice through the
synthesized WebM generator, once as bare SimpleBlocks and once wrapped in
BlockGroups, and checks that both produce the same one-second buffered range.
Taught webm-generator.js to emit SimpleBlock so the unaffected path can serve
as the baseline; it previously only ever emitted BlockGroup(Block).

* LayoutTests/media/media-source/media-source-real-webm-blockgroup-presentation-times-expected.txt: Added.
* LayoutTests/media/media-source/media-source-real-webm-blockgroup-presentation-times.html: Added.
* LayoutTests/media/media-source/webm-generator.js:
* Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.cpp:
(WebCore::WebMParser::OnBlockBegin):
(WebCore::WebMParser::OnBlockEnd):

Canonical link: <a href="https://commits.webkit.org/319281@main">https://commits.webkit.org/319281@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6ff0aafffaa5134274697b1550da070c02a65450

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180192 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54137 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47935 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190403 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144510 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4d479f5e-4f8b-4e23-9541-9a20f1817670) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182054 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55435 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53853 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140534 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/97333 "4 flakes 7 failures") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e8e87745-b6df-4f59-a753-6c7f672df036) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183147 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44193 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161318 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120986 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6670d6a7-4096-4b45-adb9-638c8d6b1d34) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42865 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41171 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153269 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40847 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1562 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46736 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45424 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192337 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53803 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/160836 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149884 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40304 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54491 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37459 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149611 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44251 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126754 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121890 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53008 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15836 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52390 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52627 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52455 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->