### PR TITLE
Web Inspector: detach child frames without detaching their parent

### DIFF
--- a/LayoutTests/http/tests/inspector/dom/disconnect-dom-tree-after-main-frame-navigation-expected.txt
+++ b/LayoutTests/http/tests/inspector/dom/disconnect-dom-tree-after-main-frame-navigation-expected.txt
@@ -13,6 +13,14 @@ DOMTree instance count: 1
 PASS: There should be four DOMTrees listening to DOMTreeManager events after touching each Frame.
 DOMTree instance count: 4
 
+-- Running test case: CheckFrameTreeAfterChildFrameNavigation
+PASS: The navigated frame should remain attached to the main frame.
+PASS: The main frame should still contain the navigated frame.
+PASS: The navigated frame should no longer contain its previous child.
+PASS: The previous child should be detached.
+PASS: The previous child should no longer contain its child.
+PASS: The previous grandchild should be detached.
+
 -- Running test case: CheckDOMTreeCountAfterReloading
 PASS: There should not be any DOMTrees listening to DOMTreeManager events after a main frame navigation.
 DOMTree instance count: 0

--- a/LayoutTests/http/tests/inspector/dom/disconnect-dom-tree-after-main-frame-navigation.html
+++ b/LayoutTests/http/tests/inspector/dom/disconnect-dom-tree-after-main-frame-navigation.html
@@ -48,6 +48,29 @@ function test()
     });
 
     suite.addTestCase({
+        name: "CheckFrameTreeAfterChildFrameNavigation",
+        description: "Check that navigating a child frame detaches its descendants without detaching the child frame.",
+        async test() {
+            let mainFrame = WI.networkManager.mainFrame;
+            let childFrame = Array.from(mainFrame.childFrameCollection)[0];
+            let grandchildFrame = Array.from(childFrame.childFrameCollection)[0];
+            let greatGrandchildFrame = Array.from(grandchildFrame.childFrameCollection)[0];
+
+            await Promise.all([
+                childFrame.awaitEvent(WI.Frame.Event.MainResourceDidChange),
+                InspectorTest.evaluateInPage(`document.querySelector("iframe").src = "resources/nested-frame-base.html"`),
+            ]);
+
+            InspectorTest.expectEqual(childFrame.parentFrame, mainFrame, "The navigated frame should remain attached to the main frame.");
+            InspectorTest.expectEqual(mainFrame.childFrameForIdentifier(childFrame.id), childFrame, "The main frame should still contain the navigated frame.");
+            InspectorTest.expectEqual(childFrame.childFrameCollection.size, 0, "The navigated frame should no longer contain its previous child.");
+            InspectorTest.expectNull(grandchildFrame.parentFrame, "The previous child should be detached.");
+            InspectorTest.expectEqual(grandchildFrame.childFrameCollection.size, 0, "The previous child should no longer contain its child.");
+            InspectorTest.expectNull(greatGrandchildFrame.parentFrame, "The previous grandchild should be detached.");
+        }
+    });
+
+    suite.addTestCase({
         name: "CheckDOMTreeCountAfterReloading",
         description: "Check that the count of connected DOMTrees is correct after a reload.",
         test(resolve, reject) {

--- a/Source/WebInspectorUI/UserInterface/Models/Frame.js
+++ b/Source/WebInspectorUI/UserInterface/Models/Frame.js
@@ -367,10 +367,10 @@ WI.Frame = class Frame extends WI.Object
 
     removeAllChildFrames()
     {
-        this._detachFromParentFrame();
-
-        for (let childFrame of this._childFrameCollection)
+        for (let childFrame of this._childFrameCollection) {
             childFrame.removeAllChildFrames();
+            childFrame._detachFromParentFrame();
+        }
 
         this._childFrameCollection.clear();
         this._childFrameIdentifierMap.clear();


### PR DESCRIPTION
#### c84fe48195571c4e22feb3fe9684f22b371eb988
<pre>
Web Inspector: detach child frames without detaching their parent
<a href="https://bugs.webkit.org/show_bug.cgi?id=320521">https://bugs.webkit.org/show_bug.cgi?id=320521</a>

Reviewed by Simon Fraser.

* Source/WebInspectorUI/UserInterface/Models/Frame.js:
(WI.Frame.prototype.removeAllChildFrames):
Recursively detach each child frame instead of detaching the frame whose children are being removed.

* LayoutTests/http/tests/inspector/dom/disconnect-dom-tree-after-main-frame-navigation.html:
* LayoutTests/http/tests/inspector/dom/disconnect-dom-tree-after-main-frame-navigation-expected.txt:

Canonical link: <a href="https://commits.webkit.org/318355@main">https://commits.webkit.org/318355@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0dd532dca490e9d74781c7e1146649d345729cad

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177412 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51350 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45144 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187016 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140659 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52642 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51059 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138261 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140659 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180368 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41762 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159008 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118726 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40424 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38797 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150831 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38505 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35483 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/43135 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43031 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189444 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51017 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/158542 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147355 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39729 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51699 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35132 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147147 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41865 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123914 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118254 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50207 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13483 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49603 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49843 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49665 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->