### PR TITLE
Web Inspector: replace stale execution contexts when their identifiers change

### DIFF
--- a/LayoutTests/inspector/runtime/frame-execution-context-after-navigation-expected.txt
+++ b/LayoutTests/inspector/runtime/frame-execution-context-after-navigation-expected.txt
@@ -1,0 +1,15 @@
+
+Tests that navigating a frame replaces its page execution context.
+
+
+== Running test suite: Frame.ExecutionContextAfterNavigation
+-- Running test case: Frame.ExecutionContextAfterNavigation.ReplacePreviousContext
+PASS: The test page should have one subframe.
+PASS: The subframe should have an initial page execution context.
+PASS: Evaluation should use the initial page execution context.
+PASS: The navigated frame should have a new execution context identifier.
+PASS: The new execution context should become the page execution context.
+PASS: The previous execution context should no longer belong to the frame.
+PASS: The new execution context should belong to the frame.
+PASS: Evaluation should use the new page execution context.
+

--- a/LayoutTests/inspector/runtime/frame-execution-context-after-navigation.html
+++ b/LayoutTests/inspector/runtime/frame-execution-context-after-navigation.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../http/tests/inspector/resources/inspector-test.js"></script>
+<script>
+var passphrase = "main-frame";
+
+function navigateSubframe() {
+    document.getElementById("subframe").src = "resources/frame-execution-context.html?after-navigation";
+}
+
+function test()
+{
+    let suite = InspectorTest.createAsyncSuite("Frame.ExecutionContextAfterNavigation");
+
+    function evaluatePassphrase() {
+        return new Promise((resolve, reject) => {
+            WI.runtimeManager.evaluateInInspectedWindow("passphrase", {objectGroup: "test"}, (remoteObject, wasThrown) => {
+                if (!remoteObject || wasThrown) {
+                    reject(new Error("Failed to evaluate the passphrase in the selected execution context."));
+                    return;
+                }
+
+                resolve(remoteObject.value);
+            });
+        });
+    }
+
+    suite.addTestCase({
+        name: "Frame.ExecutionContextAfterNavigation.ReplacePreviousContext",
+        description: "Navigating a frame should replace its previous page execution context.",
+        async test() {
+            let mainFrame = WI.networkManager.mainFrame;
+            let subframes = WI.networkManager.frames.filter((frame) => frame !== mainFrame);
+            InspectorTest.expectEqual(subframes.length, 1, "The test page should have one subframe.");
+
+            let subframe = subframes[0];
+            let previousExecutionContext = subframe.pageExecutionContext;
+            InspectorTest.expectNotNull(previousExecutionContext, "The subframe should have an initial page execution context.");
+
+            WI.runtimeManager.activeExecutionContext = previousExecutionContext;
+            InspectorTest.expectEqual(await evaluatePassphrase(), "before-navigation", "Evaluation should use the initial page execution context.");
+
+            let executionContextAddedPromise = new Promise((resolve) => {
+                let listener = subframe.addEventListener(WI.Frame.Event.ExecutionContextAdded, (event) => {
+                    let {context} = event.data;
+                    if (context.type !== WI.ExecutionContext.Type.Normal || context.id === previousExecutionContext.id)
+                        return;
+
+                    subframe.removeEventListener(WI.Frame.Event.ExecutionContextAdded, listener);
+                    resolve(context);
+                });
+            });
+
+            let [, newExecutionContext] = await Promise.all([
+                subframe.awaitEvent(WI.Frame.Event.MainResourceDidChange),
+                executionContextAddedPromise,
+                InspectorTest.evaluateInPage(`navigateSubframe()`),
+            ]);
+
+            InspectorTest.expectNotEqual(newExecutionContext.id, previousExecutionContext.id, "The navigated frame should have a new execution context identifier.");
+            InspectorTest.expectEqual(subframe.pageExecutionContext, newExecutionContext, "The new execution context should become the page execution context.");
+            InspectorTest.expectFalse(subframe.executionContextList.contexts.includes(previousExecutionContext), "The previous execution context should no longer belong to the frame.");
+            InspectorTest.expectTrue(subframe.executionContextList.contexts.includes(newExecutionContext), "The new execution context should belong to the frame.");
+
+            WI.runtimeManager.activeExecutionContext = newExecutionContext;
+            InspectorTest.expectEqual(await evaluatePassphrase(), "after-navigation", "Evaluation should use the new page execution context.");
+        }
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+</head>
+<body onload="runTest()">
+<iframe id="subframe" src="resources/frame-execution-context.html"></iframe>
+<p>Tests that navigating a frame replaces its page execution context.</p>
+</body>
+</html>
+

--- a/LayoutTests/inspector/runtime/resources/frame-execution-context.html
+++ b/LayoutTests/inspector/runtime/resources/frame-execution-context.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script>
+var passphrase = location.search ? "after-navigation" : "before-navigation";
+</script>
+</head>
+<body></body>
+</html>

--- a/Source/WebInspectorUI/UserInterface/Models/Frame.js
+++ b/Source/WebInspectorUI/UserInterface/Models/Frame.js
@@ -232,6 +232,10 @@ WI.Frame = class Frame extends WI.Object
 
     addExecutionContext(context)
     {
+        let pageExecutionContext = this._executionContextList.pageExecutionContext;
+        if (context.type === WI.ExecutionContext.Type.Normal && pageExecutionContext && context.id !== pageExecutionContext.id)
+            this.clearExecutionContexts();
+
         this._executionContextList.add(context);
 
         this.dispatchEventToListeners(WI.Frame.Event.ExecutionContextAdded, {context});


### PR DESCRIPTION
#### d6752fc2981b0d3bbb4b1081fb5b257aca8a54fb
<pre>
Web Inspector: replace stale execution contexts when their identifiers change
<a href="https://bugs.webkit.org/show_bug.cgi?id=320522">https://bugs.webkit.org/show_bug.cgi?id=320522</a>

Reviewed by Simon Fraser.

* Source/WebInspectorUI/UserInterface/Models/Frame.js:
(WI.Frame.prototype.addExecutionContext):
Clear existing execution contexts before adding a new `Normal` execution context with a different identifier so stale page and isolated contexts are not retained.

* LayoutTests/inspector/runtime/resources/frame-execution-context.html: Added.
* LayoutTests/inspector/runtime/frame-execution-context-after-navigation.html: Added.
* LayoutTests/inspector/runtime/frame-execution-context-after-navigation-expected.txt: Added.

Canonical link: <a href="https://commits.webkit.org/318356@main">https://commits.webkit.org/318356@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/be53290c9a9c88abb5b339227c50f93653a16bbd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177425 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51363 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45157 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187029 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140672 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52655 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51072 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138271 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140672 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180381 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41773 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159018 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118736 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40435 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38810 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150842 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38515 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35496 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/43148 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43044 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189457 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51030 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/158552 "") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147368 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39730 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51712 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35142 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147160 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41874 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123927 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118280 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50220 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13493 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49616 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49856 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49678 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->