### PR TITLE
Web Inspector: reset frame navigation event timestamps when initializing

### DIFF
--- a/LayoutTests/inspector/timeline/timeline-recording-autocapture-expected.txt
+++ b/LayoutTests/inspector/timeline/timeline-recording-autocapture-expected.txt
@@ -6,6 +6,8 @@ Tests for auto-capture timeline recording.
 Loaded
 PASS: TimelineManager should not be capturing.
 Reload
+PASS: The first reload should have a DOMContentLoaded timestamp.
+PASS: The first reload should have a load timestamp.
 PASS: TimelineManager should be capturing after reload with auto-capture enabled.
 PASS: TimelineRecording should be capturing.
 Stop
@@ -16,6 +18,10 @@ PASS: TimelineRecording should not be capturing.
 Start
 PASS: TimelineManager should be capturing.
 Reload
+PASS: A new navigation should clear the previous DOMContentLoaded timestamp.
+PASS: A new navigation should clear the previous load timestamp.
+PASS: The second reload should have a DOMContentLoaded timestamp.
+PASS: The second reload should have a load timestamp.
 PASS: TimelineManager should still be capturing after reload.
 PASS: TimelineManager active recording should not have changed.
 PASS: Auto-capture should not have stopped the active recording.

--- a/LayoutTests/inspector/timeline/timeline-recording-autocapture.html
+++ b/LayoutTests/inspector/timeline/timeline-recording-autocapture.html
@@ -18,6 +18,18 @@ function test()
         });
     }
 
+    function awaitTimelineMarker(recording, markerType) {
+        return new Promise((resolve) => {
+            let listener = recording.addEventListener(WI.TimelineRecording.Event.MarkerAdded, (event) => {
+                if (event.data.marker.type !== markerType)
+                    return;
+
+                recording.removeEventListener(WI.TimelineRecording.Event.MarkerAdded, listener);
+                resolve();
+            });
+        });
+    }
+
     suite.addTestCase({
         name: "Timeline.AutoCapture",
         description: "Verify that a page reload triggers auto-capture of a timeline recording.",
@@ -33,10 +45,13 @@ function test()
             InspectorTest.log("Reload");
             await Promise.all([
                 InspectorTest.awaitEvent(FrontendTestHarness.Event.TestPageDidLoad),
-                InspectorTest.reloadPage(),
                 awaitCapturingState(WI.TimelineManager.CapturingState.Active),
+                awaitTimelineMarker(recording, WI.TimelineMarker.Type.LoadEvent),
+                InspectorTest.reloadPage(),
             ]);
 
+            InspectorTest.expectFalse(isNaN(WI.networkManager.mainFrame.domContentReadyEventTimestamp), "The first reload should have a DOMContentLoaded timestamp.");
+            InspectorTest.expectFalse(isNaN(WI.networkManager.mainFrame.loadEventTimestamp), "The first reload should have a load timestamp.");
             InspectorTest.expectTrue(WI.timelineManager.isCapturing(), "TimelineManager should be capturing after reload with auto-capture enabled.");
             InspectorTest.expectTrue(recording.capturing, "TimelineRecording should be capturing.");
 
@@ -71,13 +86,25 @@ function test()
             });
 
             InspectorTest.log("Reload");
+            let mainFrame = WI.networkManager.mainFrame;
+            let mainResourceDidChangePromise = new Promise((resolve) => {
+                mainFrame.singleFireEventListener(WI.Frame.Event.MainResourceDidChange, () => {
+                    InspectorTest.expectTrue(isNaN(mainFrame.domContentReadyEventTimestamp), "A new navigation should clear the previous DOMContentLoaded timestamp.");
+                    InspectorTest.expectTrue(isNaN(mainFrame.loadEventTimestamp), "A new navigation should clear the previous load timestamp.");
+                    resolve();
+                });
+            });
             await Promise.all([
                 InspectorTest.awaitEvent(FrontendTestHarness.Event.TestPageDidLoad),
+                mainResourceDidChangePromise,
+                awaitTimelineMarker(recording, WI.TimelineMarker.Type.LoadEvent),
                 InspectorTest.reloadPage(),
             ]);
 
             WI.timelineManager.removeEventListener(WI.TimelineManager.Event.CapturingStateChanged, autoCaptureListener);
 
+            InspectorTest.expectFalse(isNaN(mainFrame.domContentReadyEventTimestamp), "The second reload should have a DOMContentLoaded timestamp.");
+            InspectorTest.expectFalse(isNaN(mainFrame.loadEventTimestamp), "The second reload should have a load timestamp.");
             InspectorTest.expectTrue(WI.timelineManager.isCapturing(), "TimelineManager should still be capturing after reload.");
             InspectorTest.expectEqual(WI.timelineManager.activeRecording, recording, "TimelineManager active recording should not have changed.");
             InspectorTest.expectFalse(autoCaptureDidFire, "Auto-capture should not have stopped the active recording.");

--- a/Source/WebInspectorUI/UserInterface/Models/Frame.js
+++ b/Source/WebInspectorUI/UserInterface/Models/Frame.js
@@ -76,6 +76,9 @@ WI.Frame = class Frame extends WI.Object
         this._mainResource = mainResource;
         this._mainResource._parentFrame = this;
 
+        this._domContentReadyEventTimestamp = NaN;
+        this._loadEventTimestamp = NaN;
+
         if (oldMainResource && this._mainResource !== oldMainResource)
             this._disassociateWithResource(oldMainResource);
 


### PR DESCRIPTION
#### 48da841046f62198c2898d6900f14cb787a97076
<pre>
Web Inspector: reset frame navigation event timestamps when initializing
<a href="https://bugs.webkit.org/show_bug.cgi?id=320523">https://bugs.webkit.org/show_bug.cgi?id=320523</a>

Reviewed by Qianlang Chen.

Speculative fix for a potential race when exporting HAR and/or auto-stopping timeline recordings.

* Source/WebInspectorUI/UserInterface/Models/Frame.js:
(WI.Frame.prototype.initialize):
Clear the previous navigation&apos;s `DOMContentLoaded` and load event timestamps when a frame is initialized with a new main resource.

* LayoutTests/inspector/timeline/timeline-recording-autocapture.html:
* LayoutTests/inspector/timeline/timeline-recording-autocapture-expected.txt:

Canonical link: <a href="https://commits.webkit.org/318213@main">https://commits.webkit.org/318213@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/366a5fd3dec21a6c97339f10730ed73f4d35d722

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177616 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51554 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45348 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187220 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140863 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179479 "Build is in progress. Recent messages:") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52846 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51263 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138441 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140863 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180572 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41949 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159174 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118905 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40610 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/38976 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151017 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38670 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35687 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/43339 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/43211 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189649 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51221 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/158705 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147537 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39638 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51903 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/35298 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147328 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42047 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124118 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118531 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50411 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13647 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49807 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50047 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49869 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->