### PR TITLE
Web Inspector: allow response end times without request timing data

### DIFF
--- a/LayoutTests/http/tests/site-isolation/inspector/network/resource-timing-cross-origin-page-navigation-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/inspector/network/resource-timing-cross-origin-page-navigation-expected.txt
@@ -1,0 +1,10 @@
+Tests resource timing for a cross-origin page navigation under site isolation.
+
+
+== Running test suite: SiteIsolation.ResourceTiming.CrossOriginPageNavigation
+-- Running test case: SiteIsolation.ResourceTiming.CrossOriginPageNavigation.MissingRequestTiming
+PASS: A resource should finish with a response end time when request timing data is unavailable.
+PASS: Start time should be unavailable.
+PASS: Request start time should be unavailable.
+PASS: Response end time should remain available.
+

--- a/LayoutTests/http/tests/site-isolation/inspector/network/resource-timing-cross-origin-page-navigation.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/network/resource-timing-cross-origin-page-navigation.html
@@ -1,0 +1,47 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<script src="../../../inspector/resources/inspector-test.js"></script>
+<script>
+function navigateCrossOrigin() {
+    location.hostname = location.hostname === "127.0.0.1" ? "localhost" : "127.0.0.1";
+}
+
+function test()
+{
+    let suite = InspectorTest.createAsyncSuite("SiteIsolation.ResourceTiming.CrossOriginPageNavigation");
+
+    suite.addTestCase({
+        name: "SiteIsolation.ResourceTiming.CrossOriginPageNavigation.MissingRequestTiming",
+        description: "Resources loaded by a provisional frame target may finish without request timing data.",
+        async test() {
+            let finishedTimingData = [];
+            let listener = WI.Resource.addEventListener(WI.Resource.Event.LoadingDidFinish, (event) => {
+                let timingData = event.target.timingData;
+                if (timingData)
+                    finishedTimingData.push(timingData);
+            });
+
+            let pageLoadedPromise = InspectorTest.awaitEvent(FrontendTestHarness.Event.TestPageDidLoad);
+            InspectorTest.deferOutputUntilTestPageIsReloaded();
+            InspectorTest.evaluateInPage(`navigateCrossOrigin()`);
+            await pageLoadedPromise;
+
+            WI.Resource.removeEventListener(WI.Resource.Event.LoadingDidFinish, listener);
+
+            let timingData = finishedTimingData.find((item) => isNaN(item.startTime) && isNaN(item.requestStart) && !isNaN(item.responseEnd));
+            InspectorTest.expectThat(!!timingData, "A resource should finish with a response end time when request timing data is unavailable.");
+            if (!timingData)
+                return;
+
+            InspectorTest.expectTrue(isNaN(timingData.startTime), "Start time should be unavailable.");
+            InspectorTest.expectTrue(isNaN(timingData.requestStart), "Request start time should be unavailable.");
+            InspectorTest.expectFalse(isNaN(timingData.responseEnd), "Response end time should remain available.");
+        }
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+<body onload="runTest()">
+<p>Tests resource timing for a cross-origin page navigation under site isolation.</p>
+</body>
+

--- a/Source/WebInspectorUI/UserInterface/Models/ResourceTimingData.js
+++ b/Source/WebInspectorUI/UserInterface/Models/ResourceTimingData.js
@@ -116,8 +116,8 @@ WI.ResourceTimingData = class ResourceTimingData
     markResponseEndTime(responseEnd)
     {
         console.assert(typeof responseEnd === "number");
-        console.assert(isNaN(responseEnd) || responseEnd >= this.startTime, "responseEnd time should be greater than the start time", this.startTime, responseEnd);
-        console.assert(isNaN(responseEnd) || responseEnd >= this.requestStart, "responseEnd time should be greater than the request time", this.requestStart, responseEnd);
+        console.assert(isNaN(responseEnd) || isNaN(this.startTime) || responseEnd >= this.startTime, "responseEnd time should be greater than the start time", this.startTime, responseEnd);
+        console.assert(isNaN(responseEnd) || isNaN(this.requestStart) || responseEnd >= this.requestStart, "responseEnd time should be greater than the request time", this.requestStart, responseEnd);
         this._responseEnd = responseEnd;
     }
 };


### PR DESCRIPTION
#### 63e12069ffa22b8572ce5a5526c8f4ff0a3fba98
<pre>
Web Inspector: allow response end times without request timing data
<a href="https://bugs.webkit.org/show_bug.cgi?id=320524">https://bugs.webkit.org/show_bug.cgi?id=320524</a>

Reviewed by Simon Fraser.

* Source/WebInspectorUI/UserInterface/Models/ResourceTimingData.js:
(WI.ResourceTimingData.prototype.markResponseEndTime):
Resources loaded by a provisional frame target can finish with a valid `responseEnd` while `startTime` and `requestStart` are unavailable.
Treat those missing values as unknown when checking `responseEnd`.

* LayoutTests/http/tests/site-isolation/inspector/network/resource-timing-cross-origin-page-navigation.html: Added.
* LayoutTests/http/tests/site-isolation/inspector/network/resource-timing-cross-origin-page-navigation-expected.txt: Added.

Canonical link: <a href="https://commits.webkit.org/318360@main">https://commits.webkit.org/318360@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ce0182352cdd96dd8796510cc36397848f479f7f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177416 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51354 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45148 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187020 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140663 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52646 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51063 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138264 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140663 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180372 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41764 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159011 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118729 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40426 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38800 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150833 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38508 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-highlight-api/painting/custom-highlight-dynamic-font-metrics-001.html (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35487 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/43139 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43034 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189448 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51021 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/158545 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147358 "Found 1 new test failure: fast/flexbox/002.html (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39732 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51703 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35135 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147150 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41873 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123918 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118258 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50211 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13486 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49607 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49847 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49669 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->