### PR TITLE
Web Inspector: restore a selected details sidebar panel when it becomes available again

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/ContentBrowserTabContentView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/ContentBrowserTabContentView.js
@@ -156,7 +156,7 @@ WI.ContentBrowserTabContentView = class ContentBrowserTabContentView extends WI.
     showDetailsSidebarPanels()
     {
         if (!this.isAttached)
-            return;
+            return null;
 
         var currentRepresentedObjects = this._contentBrowser.currentRepresentedObjects;
         var wasSidebarEmpty = !WI.detailsSidebar.sidebarPanels.length;
@@ -206,9 +206,11 @@ WI.ContentBrowserTabContentView = class ContentBrowserTabContentView extends WI.
         this._ignoreDetailsSidebarPanelSelectedEvent = false;
 
         if (!this.detailsSidebarPanels.length)
-            return;
+            return null;
 
         this._showDetailsSidebarItem.enabled = WI.detailsSidebar.sidebarPanels.length;
+
+        return sidebarPanelToSelect;
     }
 
     showRepresentedObject(representedObject, cookie)

--- a/Source/WebInspectorUI/UserInterface/Views/SourcesTabContentView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/SourcesTabContentView.js
@@ -80,9 +80,14 @@ WI.SourcesTabContentView = class SourcesTabContentView extends WI.ContentBrowser
 
     showDetailsSidebarPanels()
     {
-        super.showDetailsSidebarPanels();
+        let sidebarPanelToSelect = super.showDetailsSidebarPanels();
 
         if (!this._showScopeChainDetailsSidebarPanel)
+            return;
+
+        this._showScopeChainDetailsSidebarPanel = false;
+
+        if (sidebarPanelToSelect)
             return;
 
         let scopeChainDetailsSidebarPanel = this.detailsSidebarPanels.find((item) => item instanceof WI.ScopeChainDetailsSidebarPanel);
@@ -91,8 +96,6 @@ WI.SourcesTabContentView = class SourcesTabContentView extends WI.ContentBrowser
 
         WI.detailsSidebar.selectedSidebarPanel = scopeChainDetailsSidebarPanel;
         WI.detailsSidebar.collapsed = false;
-
-        this._showScopeChainDetailsSidebarPanel = false;
     }
 
     showScopeChainDetailsSidebarPanel()


### PR DESCRIPTION
#### 637f1f985e4cd3a8eadbb0d29821876bf1656339
<pre>
Web Inspector: restore a selected details sidebar panel when it becomes available again
<a href="https://bugs.webkit.org/show_bug.cgi?id=320525">https://bugs.webkit.org/show_bug.cgi?id=320525</a>

Reviewed by Simon Fraser.

When a `WI.DetailsSidebarPanel` cannot inspect the current represented object(s), it is removed and the first available other `WI.DetailsSidebarPanel` is shown instead.

Currently, the selection setting will keep the unavailable `WI.DetailsSidebarPanel` as the last user choice.

However, the Sources Tab automatically selects the &quot;Scope Chain&quot; panel when pausing, which always replaces it.

* Source/WebInspectorUI/UserInterface/Views/ContentBrowserTabContentView.js:
(WI.ContentBrowserTabContentView.prototype.showDetailsSidebarPanels):
* Source/WebInspectorUI/UserInterface/Views/SourcesTabContentView.js:
(WI.SourcesTabContentView.prototype.showDetailsSidebarPanels):
Let any restored `WI.DetailsSidebarPanel` override the automatic &quot;Scope Chain&quot; panel selection.
Note that if the developer selects a different `WI.DetailsSidebarPanel` then that will be respected.

Canonical link: <a href="https://commits.webkit.org/318353@main">https://commits.webkit.org/318353@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/115dbaaece64c23b25c8fa595c803f2abb1abd69

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177418 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51356 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45150 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187022 "Hash 115dbaae for PR 70413 does not build (failure)") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140665 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52648 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51065 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/187022 "Hash 115dbaae for PR 70413 does not build (failure)") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140665 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180374 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41765 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159016 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/187022 "Hash 115dbaae for PR 70413 does not build (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40427 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38803 "Passed tests") | [❌ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/5/builds/187022 "Hash 115dbaae for PR 70413 does not build (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150834 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38513 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35489 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/43141 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43037 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189450 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51023 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147361 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39733 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51705 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35140 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147153 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41867 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123920 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118260 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50213 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13491 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49609 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49849 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49671 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->