### PR TITLE
[GTK][WPE] Skia compositor: remove effectiveLayerRect()

### DIFF
--- a/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp
@@ -91,10 +91,10 @@ void SkiaCompositingLayer::invalidate()
 // size to decide what to damage, and what it has to damage is what the layer is about to paint.
 void SkiaCompositingLayer::setSize(const FloatSize& size)
 {
-    if (m_size == size)
+    if (m_rect.size() == size)
         return;
 
-    m_size = size;
+    m_rect.setSize(size);
     damageWholeLayer();
 }
 
@@ -165,7 +165,7 @@ void SkiaCompositingLayer::updateBackingStore(CoordinatedBackingStoreProxy::Upda
         m_maskImage = nullptr;
 
     ASSERT(m_backingStore);
-    m_backingStore->update(m_size, scale, WTF::move(update));
+    m_backingStore->update(m_rect.size(), scale, WTF::move(update));
 }
 
 bool SkiaCompositingLayer::hasPendingBackingStoreTileUpdates() const
@@ -239,7 +239,7 @@ void SkiaCompositingLayer::setBackdropFiltersRect(const FloatRoundedRect& clipRe
 
 FloatRect SkiaCompositingLayer::paintedLayerRect() const
 {
-    auto rect = effectiveLayerRect();
+    auto rect = m_rect;
     if (paintsContentsRect())
         rect.unite(m_contentsRect);
     if (m_backdrop.filter)
@@ -435,13 +435,13 @@ bool SkiaCompositingLayer::computeTransformsAndAnimations(const TransformationMa
     TransformationMatrix combinedForChildren;
     TransformationMatrix futureCombinedForChildren;
 
-    if (!m_size.isEmpty() || !m_masksToBounds) {
+    if (!m_rect.isEmpty() || !m_masksToBounds) {
 #if ENABLE(DAMAGE_TRACKING)
         TransformationMatrix previousTransform = m_transforms.combined;
 #endif
 
         FloatPoint origin(m_anchorPoint.x(), m_anchorPoint.y());
-        origin.scale(m_size.width(), m_size.height());
+        origin.scale(m_rect.size().width(), m_rect.size().height());
         m_transforms.combined = parentTransform;
         m_transforms.combined
             .translate3d(origin.x() + (m_position.x() - m_boundsOrigin.x()), origin.y() + (m_position.y() - m_boundsOrigin.y()), m_anchorPoint.z())
@@ -543,7 +543,7 @@ bool SkiaCompositingLayer::paint(SkCanvas& canvas, std::optional<Damage>& frameD
 #if ENABLE(DAMAGE_TRACKING)
     if (priorTargetDamage) {
         // The damage is in device space, so the surface size the region is tested against must be too.
-        // m_size is in layer coordinates, which the root transform scales to the device by the device
+        // m_rect is in layer coordinates, which the root transform scales to the device by the device
         // pixel ratio - use the canvas device size instead, as the collect walk above already does.
         const auto deviceSize = canvas.getBaseLayerSize();
         const IntSize surfaceSize(deviceSize.width(), deviceSize.height());
@@ -934,7 +934,7 @@ void SkiaCompositingLayer::paintSelfAndChildren(SkCanvas& canvas, PaintContext& 
         auto childMatrix = canvas.getLocalToDeviceAs3x3() * SkM44(m_children[0]->m_transforms.combined).asM33();
         FloatRect childBounds;
         if (m_children[0]->m_backingStore)
-            childBounds = m_children[0]->effectiveLayerRect();
+            childBounds = m_children[0]->m_rect;
         if (m_children[0]->m_contentsBuffer || m_children[0]->m_imageBackingStore || (m_children[0]->m_contentsSolidColor.isValid() && m_children[0]->m_contentsSolidColor.isVisible()))
             childBounds.unite(m_children[0]->m_contentsRect);
         return matrix.mapRect(SkRect(rect.rect())).contains(childMatrix.mapRect(SkRect(childBounds)));
@@ -950,7 +950,7 @@ void SkiaCompositingLayer::paintSelfAndChildren(SkCanvas& canvas, PaintContext& 
         if (!contentsRectClipsDescendants)
             clipTransform.translate(m_boundsOrigin.x(), m_boundsOrigin.y());
 
-        FloatRoundedRect rect = contentsRectClipsDescendants ? m_contentsClippingRect : FloatRoundedRect(effectiveLayerRect());
+        FloatRoundedRect rect = contentsRectClipsDescendants ? m_contentsClippingRect : FloatRoundedRect(m_rect);
         if (!canSkipClip(rect, clipTransform))
             clippingRect = rect;
     }
@@ -965,7 +965,7 @@ void SkiaCompositingLayer::paintSelfAndChildren(SkCanvas& canvas, PaintContext& 
 
 bool SkiaCompositingLayer::isVisible() const
 {
-    if (m_size.isEmpty() && (m_masksToBounds || m_children.isEmpty()))
+    if (m_rect.isEmpty() && (m_masksToBounds || m_children.isEmpty()))
         return false;
     if (!m_visible && m_children.isEmpty())
         return false;
@@ -1001,7 +1001,7 @@ sk_sp<SkImage> SkiaCompositingLayer::maskImage()
 
     // Paint the mask at the same scale the tiles were painted.
     auto scale = m_backingStore->scale();
-    auto rect = effectiveLayerRect();
+    auto rect = m_rect;
     rect.scale(scale);
 
     auto* grContext = PlatformDisplay::sharedDisplay().skiaGrContext();
@@ -1287,7 +1287,7 @@ void SkiaCompositingLayer::computeOverlapRegions(ComputeOverlapRegionData& data,
 
     FloatRect localBoundingRect;
     if (m_backingStore || m_masksToBounds || m_mask || filter || m_backdrop.filter)
-        localBoundingRect = effectiveLayerRect();
+        localBoundingRect = m_rect;
     else if (paintsContentsRect())
         localBoundingRect = m_contentsRect;
 
@@ -1450,7 +1450,7 @@ void SkiaCompositingLayer::paintWithBlendMode(SkCanvas& canvas, PaintContext& co
 
 FloatRect SkiaCompositingLayer::transformedFlattenedBounds() const
 {
-    auto bounds = m_transforms.combined.mapRect(FloatRect({ }, m_size));
+    auto bounds = m_transforms.combined.mapRect(m_rect);
 
     if (!m_masksToBounds && !m_mask) {
         for (const auto& child : m_children)
@@ -1467,7 +1467,7 @@ FloatPolygon3D SkiaCompositingLayer::geometryFor3DRenderingContext() const
         auto inverse = m_transforms.combined.inverse().value_or(TransformationMatrix());
         bounds = inverse.mapRect(transformedFlattenedBounds());
     } else
-        bounds = FloatRect({ }, m_size);
+        bounds = m_rect;
 
     return FloatPolygon3D(bounds, m_transforms.combined);
 }

--- a/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.h
@@ -114,7 +114,6 @@ public:
     void setDebugIndicators(Color&& debugBorderColor, std::optional<float> debugBorderWidth, std::optional<unsigned> repaintCount);
 
     const TransformationMatrix& toSurfaceTransform() const { return m_transforms.combined; }
-    FloatRect effectiveLayerRect() const { return FloatRect({ }, m_size); }
 
     // Applies the animations, computes the transforms, then walks the tree. When a frame damage is passed,
     // it is collected first in a walk that draws nothing, before the walk that draws. The draw is limited
@@ -134,12 +133,12 @@ private:
     // Contents are painted into m_contentsRect, which the layer bounds do not have to contain.
     bool paintsContentsRect() const { return m_contentsBuffer || m_imageBackingStore || (m_contentsSolidColor.isValid() && m_contentsSolidColor.isVisible()); }
     bool hasVisualContent() const { return m_backingStore || paintsContentsRect(); }
-    bool hasVisiblePaintableContent() const { return !m_size.isEmpty() && m_visible && m_contentsVisible && hasVisualContent(); }
+    bool hasVisiblePaintableContent() const { return !m_rect.isEmpty() && m_visible && m_contentsVisible && hasVisualContent(); }
 
     // A backdrop filter paints the layer without any content of its own, so it contributes damage too.
-    bool contributesToFrame() const { return hasVisiblePaintableContent() || (!m_size.isEmpty() && m_visible && m_contentsVisible && !!m_backdrop.filter); }
+    bool contributesToFrame() const { return hasVisiblePaintableContent() || (!m_rect.isEmpty() && m_visible && m_contentsVisible && !!m_backdrop.filter); }
 
-    // What the layer actually paints, unlike effectiveLayerRect(), which the contents rect and the
+    // What the layer actually paints, unlike layer rect, which the contents rect and the
     // backdrop rect may both overhang, and which a filter such as a blur may paint outside of.
     FloatRect paintedLayerRect() const;
     Ref<SkiaCompositingLayer> backdropRoot();
@@ -251,11 +250,11 @@ private:
     void damageWholeLayer()
     {
 #if ENABLE(DAMAGE_TRACKING)
-        if (!damagePropagationEnabled() || m_size.isEmpty())
+        if (!damagePropagationEnabled() || m_rect.isEmpty())
             return;
 
         if (!m_layerDamage)
-            m_layerDamage = Damage(m_size, Damage::Mode::Full);
+            m_layerDamage = Damage(m_rect.size(), Damage::Mode::Full);
         else
             m_layerDamage->makeFull();
 #endif
@@ -290,7 +289,7 @@ private:
 
     Vector<Ref<SkiaCompositingLayer>> m_children;
     WeakPtr<SkiaCompositingLayer> m_parent;
-    FloatSize m_size;
+    FloatRect m_rect;
     FloatPoint m_position;
     FloatPoint3D m_anchorPoint { 0.5f, 0.5f, 0 };
     FloatPoint m_boundsOrigin;


### PR DESCRIPTION
#### 73a527b95f75436dc62313d444d4d9a086308fd9
<pre>
[GTK][WPE] Skia compositor: remove effectiveLayerRect()
<a href="https://bugs.webkit.org/show_bug.cgi?id=320528">https://bugs.webkit.org/show_bug.cgi?id=320528</a>

Reviewed by Alejandro G. Castro.

This was copied from texture mapper which means a different thing only
used for 3D context layers. In skia compositor it&apos;s always just
returning the layer rectangle. The layer rectangle is in layer
coordinates, so it&apos;s always 0,0 widthxheight. We have a member for the
size and build a FloatRect every time the layer rect is needed. This
patch replaces m_size by m_rect so that we always have the rectangle and
we just change its size when the layer size changes. We don&apos;t even need
a getter for the layer rect since it&apos;s only used internally.

* Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp:
(WebCore::SkiaCompositingLayer::setSize):
(WebCore::SkiaCompositingLayer::updateBackingStore):
(WebCore::SkiaCompositingLayer::paintedLayerRect const):
(WebCore::SkiaCompositingLayer::computeTransformsAndAnimations):
(WebCore::SkiaCompositingLayer::paint):
(WebCore::SkiaCompositingLayer::paintSelfAndChildren):
(WebCore::SkiaCompositingLayer::isVisible const):
(WebCore::SkiaCompositingLayer::maskImage):
(WebCore::SkiaCompositingLayer::computeOverlapRegions):
(WebCore::SkiaCompositingLayer::transformedFlattenedBounds const):
(WebCore::SkiaCompositingLayer::geometryFor3DRenderingContext const):
* Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.h:

Canonical link: <a href="https://commits.webkit.org/318138@main">https://commits.webkit.org/318138@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3e9cde0e678e205a47d2dd0827354f3e973571b2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177453 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51391 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45185 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187057 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140700 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179316 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52683 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51100 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138295 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140700 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180409 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/41799 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/159045 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118760 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/40460 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/38834 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/150867 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/38542 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35524 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/43176 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/43068 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189485 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51058 "Built successfully") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/147391 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51740 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/35170 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147183 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26908 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41901 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123955 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118315 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50248 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13520 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49644 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49884 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49706 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->