### PR TITLE
[JSC] Inline hot part of `op_enter` in LLInt

### DIFF
--- a/Source/JavaScriptCore/bytecode/CodeBlock.cpp
+++ b/Source/JavaScriptCore/bytecode/CodeBlock.cpp
@@ -301,8 +301,7 @@ CodeBlock::CodeBlock(VM& vm, Structure* structure, CopyParsedBlockTag, CodeBlock
     , m_isJettisoned(false)
     , m_numCalleeLocals(other.m_numCalleeLocals)
     , m_numVars(other.m_numVars)
-    , m_numberOfArgumentsToSkip(other.m_numberOfArgumentsToSkip)
-    , m_couldBeTainted(other.m_couldBeTainted)
+    , m_numberOfArgumentsToSkipAndCouldBeTainted(other.m_numberOfArgumentsToSkipAndCouldBeTainted)
     , m_hasDebuggerStatement(false)
     , m_steppingMode(SteppingModeDisabled)
     , m_numBreakpoints(0)
@@ -380,6 +379,7 @@ CodeBlock::CodeBlock(VM& vm, Structure* structure, ScriptExecutable* ownerExecut
     setNumParameters(unlinkedCodeBlock->numParameters(), allocateArgumentValueProfiles);
 
     m_couldBeTainted = source().provider()->couldBeTainted();
+    ASSERT(couldBeTainted() == !!(m_numberOfArgumentsToSkipAndCouldBeTainted & 0x80000000));
     vm.heap.codeBlockSet().add(this);
     checker().set(CrashChecker::This, checker().hash(this));
     checker().set(CrashChecker::Metadata, checker().hash(this, m_metadata.get()));

--- a/Source/JavaScriptCore/bytecode/CodeBlock.h
+++ b/Source/JavaScriptCore/bytecode/CodeBlock.h
@@ -969,8 +969,14 @@ private:
     const unsigned m_numCalleeLocals;
     const unsigned m_numVars;
     unsigned m_numParameters;
-    unsigned m_numberOfArgumentsToSkip : 31 { 0 };
-    unsigned m_couldBeTainted : 1 { 0 };
+    union {
+        // The LLInt reads this union as a word and tests the sign bit to check m_couldBeTainted.
+        unsigned m_numberOfArgumentsToSkipAndCouldBeTainted { 0 };
+        struct {
+            unsigned m_numberOfArgumentsToSkip : 31;
+            unsigned m_couldBeTainted : 1;
+        };
+    };
     uint32_t m_osrExitCounter { 0 };
     union {
         unsigned m_debuggerRequests;

--- a/Source/JavaScriptCore/llint/LowLevelInterpreter64.asm
+++ b/Source/JavaScriptCore/llint/LowLevelInterpreter64.asm
@@ -841,11 +841,26 @@ _llint_op_enter:
     addq 1, t2
     btqnz t2, .opEnterLoop
 .opEnterDone:
-    callSlowPath(_slow_path_enter)
+    loadp CodeBlock[cfr], t2
+    loadi CodeBlock::m_numberOfArgumentsToSkipAndCouldBeTainted[t2], t1
+    btis t1, .opEnterSlow
+    loadp CodeBlock::m_vm[t2], t0
+    loadb JSCell::m_cellState[t2], t1
+    loadi (constexpr (VM::offsetOfHeapBarrierThreshold()))[t0], t0
+    bibeq t1, t0, .opEnterSlow
+    loadis CodeBlock::m_scopeRegister[t2], t1
+    loadp Callee[cfr], t0
+    loadp JSCallee::m_scope[t0], t0
+    storeq t0, [cfr, t1, 8]
 
+.opEnterDispatch:
     checkTraps(macro()
         dispatchOp(narrow, op_enter)
     end)
+
+.opEnterSlow:
+    callSlowPath(_slow_path_enter)
+    jmp .opEnterDispatch
 
 
 llintOpWithProfile(op_get_argument, OpGetArgument, macro (size, get, dispatch, return)


### PR DESCRIPTION
#### e759fa9dd06385bb3cdd8e6150c16322df0f1feb
<pre>
[JSC] Inline hot part of `op_enter` in LLInt
<a href="https://bugs.webkit.org/show_bug.cgi?id=320530">https://bugs.webkit.org/show_bug.cgi?id=320530</a>

Reviewed by Keith Miller.

The LLInt&apos;s op_enter unconditionally calls slow_path_enter on every
function entry, paying a C++ call for what is usually just one store of
the callee&apos;s scope. 280547@main inlined this hot part in the Baseline
JIT, but the LLInt never got the same treatment, so interpreted calls
(startup, module initialization, cold code) still take the slow path.

This patch inlines the scope store in LowLevelInterpreter64.asm,
falling back to the slow path when the CodeBlock needs a write barrier
(same dynamic-threshold check as the Baseline JIT&apos;s branchIfBarriered)
or could be tainted. To make the couldBeTainted bit testable from asm,
the m_numberOfArgumentsToSkip / m_couldBeTainted bitfield pair becomes
a named union word whose sign bit is the taint bit, keeping
sizeof(CodeBlock) unchanged.

Microbenchmark results with useJIT=false:

                                                  Baseline                  Patched

arrowfunction-call-in-class-method            13.2319+-0.8860     ^     11.8726+-0.0429        ^ definitely 1.1145x faster
arrowfunction-call-in-function                41.5227+-0.6378     ^     36.7882+-1.0128        ^ definitely 1.1287x faster
call-or-not-call                             663.3894+-64.3912         608.4128+-13.9092         might be 1.0904x faster
simple-activation-demo                       106.1805+-3.7712     ?    109.7916+-6.0971        ? might be 1.0340x slower
bound-function-call                           31.7472+-1.4550     ^     27.2062+-0.4002        ^ definitely 1.1669x faster
function-call                                 45.8869+-3.1223     ^     38.7891+-1.7009        ^ definitely 1.1830x faster
arrowfunction-call                            35.7700+-1.9583     ^     28.9808+-0.8511        ^ definitely 1.2343x faster
arrowfunction-call-in-class-constructor       85.9472+-5.6473     ^     75.2668+-4.0816        ^ definitely 1.1419x faster
await-async-function-call-chain               56.1613+-2.0973           55.8413+-10.8399
dfg-internal-function-call                     0.6401+-0.0274            0.6014+-0.0254          might be 1.0642x faster

* Source/JavaScriptCore/bytecode/CodeBlock.cpp:
(JSC::CodeBlock::CodeBlock):
* Source/JavaScriptCore/bytecode/CodeBlock.h:
* Source/JavaScriptCore/llint/LowLevelInterpreter64.asm:

Canonical link: <a href="https://commits.webkit.org/318231@main">https://commits.webkit.org/318231@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/db900d9d843c94488efa6de47551d97965dec96f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177683 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51621 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45415 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187288 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140930 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179546 "Build is in progress. Recent messages:") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52913 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51330 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138502 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140930 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180639 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42003 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/159237 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118966 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40664 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/39036 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/935 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/7733 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151071 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38733 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35754 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/38954 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/43406 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/43271 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189718 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51288 "Built successfully") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/147620 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39653 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51970 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/35361 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147393 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42107 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124185 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118598 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50478 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13710 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49874 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50114 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49936 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->