### PR TITLE
[JSC] offlineasm never emits ARM64 register-offset addressing for BaseIndex operands

### DIFF
--- a/Source/JavaScriptCore/offlineasm/arm64.rb
+++ b/Source/JavaScriptCore/offlineasm/arm64.rb
@@ -629,8 +629,12 @@ class Sequence
             end
             
             if address.is_a? BaseIndex
+                registerOffsetForm = $currentSettings["ADDRESS64"] &&
+                    !isLoadStorePairOp &&
+                    node.opcode !~ /^loadqinc$|^atomic|^loadlinkacq|^storecondrel|^loadv$|^storev$/
                 address.offset.value == 0 and
-                    (node.opcode =~ /^lea/ or address.scale == 1 or address.scale == size)
+                    (node.opcode =~ /^lea/ or
+                     (registerOffsetForm and (address.scaleValue == 1 or address.scaleValue == size)))
             elsif address.is_a? Address
                 if isLoadStorePairOp
                     not isMalformedArm64LoadStorePairAddress(node.opcode, address)


### PR DESCRIPTION
#### 9610c2113b4510c465fe0cf6b5dd3cd0c5a2f7f7
<pre>
[JSC] offlineasm never emits ARM64 register-offset addressing for BaseIndex operands
<a href="https://bugs.webkit.org/show_bug.cgi?id=320532">https://bugs.webkit.org/show_bug.cgi?id=320532</a>

Reviewed by Yusuke Suzuki.

The ARM64 predicate passed to riscLowerMalformedAddresses compared
address.scale (an Immediate AST node) against Ruby integers, and
Immediate#== only returns true when the other side is also an Immediate.
So `address.scale == 1 or address.scale == size` was always false and
every BaseIndex load/store was lowered to `add tmp, base, index, lsl #n`
followed by `ldr/str [tmp]`, even though BaseIndex#arm64Operand can emit
`[base, index, lsl #n]` directly.

Compare address.scaleValue instead. Because the register-offset form now
actually reaches the emitters, keep lowering the address for opcodes whose
emitters only accept other address forms: load/store pair (`[base, #imm]`
via arm64PairAddressOperand), atomic/loadlinkacq/storecondrel (`[base]` via
arm64SimpleAddressOperand), loadv/storev (128-bit access, but the size
table says 8 and would produce an invalid `lsl #3`), loadqinc (post-index),
and non-ADDRESS64 configurations (unchanged behavior).

Before:  add x13, x3, x4, lsl #3
         ldr x5, [x13]
After:   ldr x5, [x3, x4, lsl #3]

On macOS arm64 this removes 5,038 instructions (-6.4%) from LLIntAssembly.h.

* Source/JavaScriptCore/offlineasm/arm64.rb:

Canonical link: <a href="https://commits.webkit.org/318210@main">https://commits.webkit.org/318210@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bb334503cb06db51aa68c4dd9b89d0fa1628aea4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177431 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51369 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45163 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187035 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140678 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52661 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51078 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138279 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140678 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180387 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41778 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159023 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118744 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40440 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38815 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/713 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/7522 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150847 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38520 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35502 "Built successfully") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/38702 "Build is in progress. Recent messages:OS: Tahoe (26.5.1), Xcode: 26.5; Checked out pull request; Compiled JSC (warnings); Passed JSC tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/43154 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43049 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189463 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51036 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147373 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39636 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51718 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35147 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147165 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41886 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123933 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118290 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50226 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13498 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49622 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49862 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49684 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->