### PR TITLE
[YARR] Extend ParenthesesSubpatternTerminal

### DIFF
--- a/JSTests/stress/yarr-terminal-parentheses-captures.js
+++ b/JSTests/stress/yarr-terminal-parentheses-captures.js
@@ -1,0 +1,288 @@
+// checkForTerminalParentheses used to bail out of the whole function whenever
+// the pattern had observable capture groups, so no capturing pattern ever got a
+// terminal tail group. It now only skips the string-list optimization in that
+// case, which means patterns like /(a)(?:b|bc)+/ and /(a)(?:b|bc)*/ take the
+// terminal path and no longer allocate per-iteration ParenContext.
+//
+// What keeps that sound is the term-level gate: the tail group itself must be
+// non-capturing and must contain no captures (PatternTerm::containsAnyCaptures),
+// so nothing inside it can change across iterations and there is no capture
+// state to restore when an iteration fails. That predicate is now the only
+// thing standing between this optimization and a wrong capture array, so the
+// cases below pin down both sides of it: captures outside the tail group (which
+// must still be reported correctly, and must be unwound when the tail group
+// forces a backtrack), and captures inside it or inside a nested lookaround
+// (which must keep the group off the terminal path entirely).
+//
+// `exec` compiles with IncludeSubpatterns while `test` compiles MatchOnly, and
+// the two modes disagree about whether captures are observable, so both are
+// exercised. Backreferences are included because they force captures to be
+// observable in MatchOnly mode too.
+//
+// Expected values were produced by V8 and cross-checked against both JSC tiers.
+// Silent on success.
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`bad value: got ${actual}, expected ${expected}`);
+}
+
+function repeat(re, body) {
+    // Compile once and execute repeatedly so the regexp warms up and the
+    // DFG/FTL inlined paths run the same pattern the LLInt did.
+    for (let i = 0; i < testLoopCount; ++i) {
+        re.lastIndex = 0;
+        body();
+    }
+}
+
+function testExec(source, flags, str, expected) {
+    let re = new RegExp(source, flags);
+    repeat(re, () => {
+        let m = re.exec(str);
+        let actual = m === null
+            ? "null"
+            : "[" + Array.from(m).map(x => x === undefined ? "undefined" : JSON.stringify(x)).join(",") + "]@" + m.index;
+        shouldBe(actual, expected);
+    });
+}
+
+function testGroups(source, flags, str, expected) {
+    let re = new RegExp(source, flags);
+    repeat(re, () => {
+        let m = re.exec(str);
+        let actual;
+        if (m === null)
+            actual = "null";
+        else {
+            let groups = m.groups;
+            actual = Object.keys(groups).sort()
+                .map(k => k + "=" + (groups[k] === undefined ? "undefined" : JSON.stringify(groups[k])))
+                .join(",");
+        }
+        shouldBe(actual, expected);
+    });
+}
+
+function testIndices(source, flags, str, expected) {
+    let re = new RegExp(source, flags + "d");
+    repeat(re, () => {
+        let m = re.exec(str);
+        let actual = m === null ? "null" : JSON.stringify(m.indices.map(x => x === undefined ? null : x));
+        shouldBe(actual, expected);
+    });
+}
+
+function testTest(source, flags, str, expected) {
+    let re = new RegExp(source, flags);
+    repeat(re, () => {
+        shouldBe(re.test(str), expected);
+    });
+}
+
+function testReplace(source, flags, str, replacement, expected) {
+    let re = new RegExp(source, flags);
+    repeat(re, () => {
+        shouldBe(str.replace(re, replacement), expected);
+    });
+}
+
+function testSplit(source, flags, str, expected) {
+    let re = new RegExp(source, flags);
+    repeat(re, () => {
+        shouldBe(JSON.stringify(str.split(re)), expected);
+    });
+}
+
+function testMatchAll(source, flags, str, expected) {
+    let re = new RegExp(source, flags);
+    repeat(re, () => {
+        let all = Array.from(str.matchAll(re))
+            .map(m => Array.from(m).map(x => x === undefined ? null : x).join("|") + "@" + m.index);
+        shouldBe(JSON.stringify(all), expected);
+    });
+}
+
+function testLastIndex(source, flags, str, expected) {
+    // A fresh regexp per repetition: this walks lastIndex forward, so it cannot
+    // share state between repetitions.
+    for (let i = 0; i < testLoopCount; ++i) {
+        let re = new RegExp(source, flags);
+        let steps = [];
+        for (let step = 0; step < 8; ++step) {
+            let m = re.exec(str);
+            if (m === null) {
+                steps.push("null@" + re.lastIndex);
+                break;
+            }
+            steps.push(m[0] + "@" + m.index + ":" + re.lastIndex);
+        }
+        shouldBe(JSON.stringify(steps), expected);
+    }
+}
+
+// A capture group before a terminal `+` group: eligible, because the tail group itself holds no
+// captures.
+testExec("(a)(?:b|bc)+", "", "abcb", "[\"ab\",\"a\"]@0");
+testExec("(a)(?:b|bc)+", "", "ab", "[\"ab\",\"a\"]@0");
+testExec("(a)(?:b|bc)+", "", "abb", "[\"abb\",\"a\"]@0");
+testExec("(a)(?:b|bc)+", "", "abc", "[\"ab\",\"a\"]@0");
+testExec("(a)(?:b|bc)+", "", "a", "null");
+testExec("(a)(?:b|bc)+", "", "xabb", "[\"abb\",\"a\"]@1");
+testExec("(a)(?:bc|b)+", "", "abcb", "[\"abcb\",\"a\"]@0");
+testExec("(a)(?:bc|b)+", "", "ab", "[\"ab\",\"a\"]@0");
+testExec("(a)(?:bc|b)+", "", "abcbc", "[\"abcbc\",\"a\"]@0");
+testExec("(a)(?:bc|b)+", "", "az", "null");
+testExec("(\\d)(?:ab|a)+", "", "1ab", "[\"1ab\",\"1\"]@0");
+testExec("(\\d)(?:ab|a)+", "", "1aab", "[\"1aab\",\"1\"]@0");
+testExec("(\\d)(?:ab|a)+", "", "1a", "[\"1a\",\"1\"]@0");
+testExec("(\\d)(?:ab|a)+", "", "1b", "null");
+testExec("(a|aa)(?:bc|bd)+", "", "aabc", "[\"aabc\",\"aa\"]@0");
+testExec("(a|aa)(?:bc|bd)+", "", "abc", "[\"abc\",\"a\"]@0");
+testExec("(a|aa)(?:bc|bd)+", "", "aabdbc", "[\"aabdbc\",\"aa\"]@0");
+testExec("(a|aa)(?:bc|bd)+", "", "aa", "null");
+testExec("(a+)(?:ab)+", "", "aaab", "[\"aaab\",\"aa\"]@0");
+testExec("(a+)(?:ab)+", "", "aab", "[\"aab\",\"a\"]@0");
+testExec("(a+)(?:ab)+", "", "aaa", "null");
+testExec("(a)(b)(?:c|cd)+", "", "abcd", "[\"abc\",\"a\",\"b\"]@0");
+testExec("(a)(b)(?:c|cd)+", "", "abc", "[\"abc\",\"a\",\"b\"]@0");
+testExec("(a)(b)(?:c|cd)+", "", "abcc", "[\"abcc\",\"a\",\"b\"]@0");
+
+// The same shapes with `*`, which is eligible on the same grounds.
+testExec("(a)(?:b|bc)*", "", "abcb", "[\"ab\",\"a\"]@0");
+testExec("(a)(?:b|bc)*", "", "ab", "[\"ab\",\"a\"]@0");
+testExec("(a)(?:b|bc)*", "", "a", "[\"a\",\"a\"]@0");
+testExec("(a)(?:b|bc)*", "", "b", "null");
+testExec("(a)(?:b|bc)*", "", "xa", "[\"a\",\"a\"]@1");
+testExec("(a)(?:bc|b)*", "", "abcb", "[\"abcb\",\"a\"]@0");
+testExec("(a)(?:bc|b)*", "", "ab", "[\"ab\",\"a\"]@0");
+testExec("(a)(?:bc|b)*", "", "a", "[\"a\",\"a\"]@0");
+testExec("(\\d)(?:ab|a)*", "", "1ab", "[\"1ab\",\"1\"]@0");
+testExec("(\\d)(?:ab|a)*", "", "1", "[\"1\",\"1\"]@0");
+testExec("(\\d)(?:ab|a)*", "", "1aab", "[\"1aab\",\"1\"]@0");
+testExec("(a+)(?:ab)*", "", "aaab", "[\"aaa\",\"aaa\"]@0");
+testExec("(a+)(?:ab)*", "", "aaa", "[\"aaa\",\"aaa\"]@0");
+testExec("(a+)(?:ab)*", "", "a", "[\"a\",\"a\"]@0");
+
+// Group that must be left undefined while the pattern still ends in a terminal group.
+testExec("(?:(x)|y)a(?:b)+", "", "xab", "[\"xab\",\"x\"]@0");
+testExec("(?:(x)|y)a(?:b)+", "", "yab", "[\"yab\",undefined]@0");
+testExec("(?:(x)|y)a(?:b)+", "", "xabb", "[\"xabb\",\"x\"]@0");
+testExec("(?:(x)|y)a(?:b)+", "", "zab", "null");
+testExec("(x)?a(?:b)+", "", "xab", "[\"xab\",\"x\"]@0");
+testExec("(x)?a(?:b)+", "", "ab", "[\"ab\",undefined]@0");
+testExec("(x)?a(?:b)+", "", "abb", "[\"abb\",undefined]@0");
+testExec("(?:a|b)+|(c)", "", "ab", "[\"ab\",undefined]@0");
+testExec("(?:a|b)+|(c)", "", "c", "[\"c\",\"c\"]@0");
+testExec("(?:a|b)+|(c)", "", "d", "null");
+testExec("(?:a|b)+|(c)(?:d)+", "", "ab", "[\"ab\",undefined]@0");
+testExec("(?:a|b)+|(c)(?:d)+", "", "cd", "[\"cd\",\"c\"]@0");
+testExec("(?:a|b)+|(c)(?:d)+", "", "cdd", "[\"cdd\",\"c\"]@0");
+testExec("(?:a|b)+|(c)(?:d)+", "", "c", "null");
+
+// Backreference to an outer group from inside the terminal group. Forces ignoreCaptures = false
+// in both execution modes.
+testExec("(a)(?:\\1|b)+", "", "aab", "[\"aab\",\"a\"]@0");
+testExec("(a)(?:\\1|b)+", "", "ab", "[\"ab\",\"a\"]@0");
+testExec("(a)(?:\\1|b)+", "", "aa", "[\"aa\",\"a\"]@0");
+testExec("(a)(?:\\1|b)+", "", "a", "null");
+testExec("(a)(?:\\1|b)+", "", "aba", "[\"aba\",\"a\"]@0");
+testExec("(ab)(?:\\1|c)+", "", "ababc", "[\"ababc\",\"ab\"]@0");
+testExec("(ab)(?:\\1|c)+", "", "abc", "[\"abc\",\"ab\"]@0");
+testExec("(ab)(?:\\1|c)+", "", "abab", "[\"abab\",\"ab\"]@0");
+testExec("(ab)(?:\\1|c)+", "", "ab", "null");
+testExec("(a)?(?:\\1|b)+", "", "ab", "[\"ab\",\"a\"]@0");
+testExec("(a)?(?:\\1|b)+", "", "b", "[\"b\",undefined]@0");
+testExec("(a)?(?:\\1|b)+", "", "aa", "[\"aa\",\"a\"]@0");
+testExec("(a)?(?:\\1|b)+", "", "bb", "[\"bb\",undefined]@0");
+
+// Captures inside the group keep it non-terminal; verify they are still right.
+testExec("(?:(a)|b)+", "", "ab", "[\"ab\",undefined]@0");
+testExec("(?:(a)|b)+", "", "ba", "[\"ba\",\"a\"]@0");
+testExec("(?:(a)|b)+", "", "b", "[\"b\",undefined]@0");
+testExec("(?:(a)|b)+", "", "aab", "[\"aab\",undefined]@0");
+testExec("(?:(a)|(b))+", "", "ab", "[\"ab\",undefined,\"b\"]@0");
+testExec("(?:(a)|(b))+", "", "ba", "[\"ba\",\"a\",undefined]@0");
+testExec("(?:(a)|(b))+", "", "aa", "[\"aa\",\"a\",undefined]@0");
+testExec("x(?:(a)|b)+", "", "xab", "[\"xab\",undefined]@0");
+testExec("x(?:(a)|b)+", "", "xba", "[\"xba\",\"a\"]@0");
+testExec("x(?:(a)|b)+", "", "xb", "[\"xb\",undefined]@0");
+
+// Captures nested in a lookahead/lookbehind inside the group: also non-terminal.
+testExec("(?:(?=(a))a|b)+", "", "ab", "[\"ab\",undefined]@0");
+testExec("(?:(?=(a))a|b)+", "", "ba", "[\"ba\",\"a\"]@0");
+testExec("(?:(?=(a))a|b)+", "", "b", "[\"b\",undefined]@0");
+testExec("(?:(?<=(a))b|c)+", "", "abc", "[\"bc\",undefined]@1");
+testExec("(?:(?<=(a))b|c)+", "", "cc", "[\"cc\",undefined]@0");
+testExec("(?:(?<=(a))b|c)+", "", "ab", "[\"b\",\"a\"]@1");
+
+// Capture in a lookbehind before the terminal group.
+testExec("(?<=(x))(?:ab)+", "", "xab", "[\"ab\",\"x\"]@1");
+testExec("(?<=(x))(?:ab)+", "", "xabab", "[\"abab\",\"x\"]@1");
+testExec("(?<=(x))(?:ab)+", "", "yab", "null");
+testExec("(?<=(x))(?:ab|a)+", "", "xaab", "[\"aab\",\"x\"]@1");
+testExec("(?<=(x))(?:ab|a)+", "", "xab", "[\"ab\",\"x\"]@1");
+
+// Named groups and duplicate named groups.
+testExec("(?<n>a)(?:b|bc)+", "", "abcb", "[\"ab\",\"a\"]@0");
+testExec("(?<n>a)(?:b|bc)+", "", "ab", "[\"ab\",\"a\"]@0");
+testExec("(?<n>a)(?:b|bc)+", "", "a", "null");
+testGroups("(?<n>a)(?:b|bc)+", "", "abcb", "n=\"a\"");
+testGroups("(?<n>a)(?:b|bc)+", "", "ab", "n=\"a\"");
+testGroups("(?<n>a)(?:b|bc)+", "", "a", "null");
+testGroups("(?<n>a)(?:b|bc)*", "", "ab", "n=\"a\"");
+testGroups("(?<n>a)(?:b|bc)*", "", "a", "n=\"a\"");
+testExec("(?:(?<n>x)|(?<n>y))(?:AA|A)+", "v", "xAA", "[\"xAA\",\"x\",undefined]@0");
+testExec("(?:(?<n>x)|(?<n>y))(?:AA|A)+", "v", "yA", "[\"yA\",undefined,\"y\"]@0");
+testExec("(?:(?<n>x)|(?<n>y))(?:AA|A)+", "v", "xB", "null");
+testGroups("(?:(?<n>x)|(?<n>y))(?:AA|A)+", "v", "xAA", "n=\"x\"");
+testGroups("(?:(?<n>x)|(?<n>y))(?:AA|A)+", "v", "yA", "n=\"y\"");
+
+// hasIndices: capture extents must survive the terminal path.
+testIndices("(a)(?:b|bc)+", "", "abcb", "[[0,2],[0,1]]");
+testIndices("(a)(?:b|bc)+", "", "ab", "[[0,2],[0,1]]");
+testIndices("(a)(?:b|bc)*", "", "ab", "[[0,2],[0,1]]");
+testIndices("(a)(?:b|bc)*", "", "a", "[[0,1],[0,1]]");
+testIndices("(a|aa)(?:bc|bd)+", "", "aabc", "[[0,4],[0,2]]");
+testIndices("(x)?a(?:b)+", "", "xab", "[[0,3],[0,1]]");
+testIndices("(x)?a(?:b)+", "", "ab", "[[0,2],null]");
+
+// `test` goes through MatchOnly compilation, `exec` through IncludeSubpatterns. Both modes must
+// agree on whether there is a match.
+testTest("(a)(?:b|bc)+", "", "abcb", true);
+testTest("(a)(?:b|bc)+", "", "ab", true);
+testTest("(a)(?:b|bc)+", "", "a", false);
+testTest("(a)(?:b|bc)+", "", "b", false);
+testTest("(a)(?:b|bc)*", "", "ab", true);
+testTest("(a)(?:b|bc)*", "", "a", true);
+testTest("(a)(?:b|bc)*", "", "b", false);
+testTest("(a)(?:\\1|b)+", "", "aab", true);
+testTest("(a)(?:\\1|b)+", "", "ab", true);
+testTest("(a)(?:\\1|b)+", "", "a", false);
+testTest("(?:(a)|b)+", "", "ab", true);
+testTest("(?:(a)|b)+", "", "c", false);
+testTest("(?<=(x))(?:ab)+", "", "xab", true);
+testTest("(?<=(x))(?:ab)+", "", "yab", false);
+
+// Global replace / split / matchAll over the newly marked shapes.
+testReplace("(a)(?:b|bc)+", "g", "abcbabc", "<$1>", "<a>cb<a>c");
+testReplace("(a)(?:b|bc)+", "g", "abab", "<$1>", "<a><a>");
+testReplace("(a)(?:b|bc)+", "g", "a", "<$1>", "a");
+testReplace("(a)(?:b|bc)*", "g", "abcb", "<$1>", "<a>cb");
+testReplace("(a)(?:b|bc)*", "g", "aa", "<$1>", "<a><a>");
+testReplace("(?:AA|A)+", "g", "AAABAA", "-", "-B-");
+testReplace("(?:AA|A)+", "g", "B", "-", "B");
+testSplit("(?:,|;)+", "", "a,b;;c", "[\"a\",\"b\",\"c\"]");
+testSplit("(?:,|;)+", "", "abc", "[\"abc\"]");
+testSplit("(a)(?:b)+", "", "xabby", "[\"x\",\"a\",\"y\"]");
+testSplit("(a)(?:b)+", "", "xy", "[\"xy\"]");
+testMatchAll("(a)(?:b|bc)+", "g", "abcbabb", "[\"ab|a@0\",\"abb|a@4\"]");
+testMatchAll("(a)(?:b|bc)+", "g", "aa", "[]");
+testMatchAll("(?:AA|A)+", "g", "AABAAA", "[\"AA@0\",\"AAA@3\"]");
+
+// lastIndex progression for global and sticky.
+testLastIndex("(?:AA|A)+", "g", "AABAAAB", "[\"AA@0:2\",\"AAA@3:6\",\"null@0\"]");
+testLastIndex("(a)(?:b|bc)+", "g", "abcbxabb", "[\"ab@0:2\",\"abb@5:8\",\"null@0\"]");
+testLastIndex("(?:AA|A)+", "y", "AAB", "[\"AA@0:2\",\"null@0\"]");
+testLastIndex("(?:a?)+", "g", "aab", "[\"aa@0:2\",\"@2:2\",\"@2:2\",\"@2:2\",\"@2:2\",\"@2:2\",\"@2:2\",\"@2:2\"]");
+testLastIndex("(?:AA|A)*", "g", "AAB", "[\"AA@0:2\",\"@2:2\",\"@2:2\",\"@2:2\",\"@2:2\",\"@2:2\",\"@2:2\",\"@2:2\"]");

--- a/JSTests/stress/yarr-terminal-parentheses-frame-layout.js
+++ b/JSTests/stress/yarr-terminal-parentheses-frame-layout.js
@@ -1,0 +1,271 @@
+// Structural coverage for terminal-position greedy parentheses: the frame
+// layout they share with their own alternative list, the shapes that must stay
+// off the terminal path, and the neighbouring Yarr optimizations that run
+// either side of checkForTerminalParentheses.
+//
+// A multi-alternative terminal group puts the group's own backtracking state in
+// frame slots 0-1 and its alternative-list state in slot 2, so the multi- and
+// many-alternative bodies here are the ones where a frame-sizing mistake would
+// have an iteration's bookkeeping overwrite the saved alternative offset. The
+// remaining groups pin the eligibility boundary from the outside: a group is
+// only in tail position if nothing follows it, so a trailing assertion, a
+// lookaround wrapper, or a position inside a lookaround must all keep the
+// optimization off, and `{2,}` must keep it off from the quantifier side.
+//
+// Expected values were produced by V8 and cross-checked against both JSC tiers.
+// Silent on success.
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`bad value: got ${actual}, expected ${expected}`);
+}
+
+function match(re, str) {
+    let m = re.exec(str);
+    if (m === null)
+        return "null";
+    return "[" + Array.from(m).map(x => x === undefined ? "undefined" : JSON.stringify(x)).join(",") + "]@" + m.index;
+}
+
+function test(source, flags, str, expected) {
+    // Compile once and execute repeatedly so the regexp warms up and the
+    // DFG/FTL inlined paths run the same pattern the LLInt did.
+    let re = new RegExp(source, flags);
+    for (let i = 0; i < testLoopCount; ++i) {
+        re.lastIndex = 0;
+        shouldBe(match(re, str), expected);
+    }
+}
+
+// Multi-alternative terminal bodies. checkForTerminalParentheses leaves the terminal group's
+// own frame slots at 0-1 and the group's alternative-list backtrack slot at 2, so these are the
+// shapes where a frame-layout mistake would have the End term's matchAmount write land on the
+// saved alternative offset.
+test("(?:AAA|AA|A)+", "", "A", "[\"A\"]@0");
+test("(?:AAA|AA|A)+", "", "AA", "[\"AA\"]@0");
+test("(?:AAA|AA|A)+", "", "AAA", "[\"AAA\"]@0");
+test("(?:AAA|AA|A)+", "", "AAAA", "[\"AAAA\"]@0");
+test("(?:AAA|AA|A)+", "", "AAAAA", "[\"AAAAA\"]@0");
+test("(?:AAA|AA|A)+", "", "AAAAAA", "[\"AAAAAA\"]@0");
+test("(?:AAA|AA|A)+", "", "B", "null");
+test("(?:AAA|AA|A)+", "", "AAAAB", "[\"AAAA\"]@0");
+test("(?:abc|ab|a|b)+", "", "abcab", "[\"abcab\"]@0");
+test("(?:abc|ab|a|b)+", "", "ba", "[\"ba\"]@0");
+test("(?:abc|ab|a|b)+", "", "abab", "[\"abab\"]@0");
+test("(?:abc|ab|a|b)+", "", "c", "null");
+test("(?:abc|ab|a|b)+", "", "aabbc", "[\"aabb\"]@0");
+test("(?:aaaa|aaa|aa|a)+", "", "a", "[\"a\"]@0");
+test("(?:aaaa|aaa|aa|a)+", "", "aa", "[\"aa\"]@0");
+test("(?:aaaa|aaa|aa|a)+", "", "aaa", "[\"aaa\"]@0");
+test("(?:aaaa|aaa|aa|a)+", "", "aaaaa", "[\"aaaaa\"]@0");
+test("(?:aaaa|aaa|aa|a)+", "", "aaaaaaa", "[\"aaaaaaa\"]@0");
+test("(?:AAA|AA|A)*", "", "", "[\"\"]@0");
+test("(?:AAA|AA|A)*", "", "A", "[\"A\"]@0");
+test("(?:AAA|AA|A)*", "", "AAAA", "[\"AAAA\"]@0");
+test("(?:AAA|AA|A)*", "", "B", "[\"\"]@0");
+test("x(?:AAA|AA|A)+", "", "xA", "[\"xA\"]@0");
+test("x(?:AAA|AA|A)+", "", "xAAAA", "[\"xAAAA\"]@0");
+test("x(?:AAA|AA|A)+", "", "x", "null");
+test("x(?:AAA|AA|A)+", "", "xB", "null");
+test("(?:AAA|AA|A){2,}", "", "A", "null");
+test("(?:AAA|AA|A){2,}", "", "AA", "[\"AA\"]@0");
+test("(?:AAA|AA|A){2,}", "", "AAA", "[\"AAA\"]@0");
+test("(?:AAA|AA|A){2,}", "", "AAAAA", "[\"AAAAA\"]@0");
+
+// A generic quantified subpattern (which does need ParenContext) inside the terminal group, so
+// both frame disciplines are live in one pattern.
+test("(?:(?:ab)+c|x)+", "", "abc", "[\"abc\"]@0");
+test("(?:(?:ab)+c|x)+", "", "abcx", "[\"abcx\"]@0");
+test("(?:(?:ab)+c|x)+", "", "ababcx", "[\"ababcx\"]@0");
+test("(?:(?:ab)+c|x)+", "", "x", "[\"x\"]@0");
+test("(?:(?:ab)+c|x)+", "", "ab", "null");
+test("(?:(?:a|bb)+c|x)+", "", "ac", "[\"ac\"]@0");
+test("(?:(?:a|bb)+c|x)+", "", "bbc", "[\"bbc\"]@0");
+test("(?:(?:a|bb)+c|x)+", "", "abbcx", "[\"abbcx\"]@0");
+test("(?:(?:a|bb)+c|x)+", "", "x", "[\"x\"]@0");
+test("(?:(?:a|bb)+c|x)+", "", "bb", "null");
+test("(?:(?:a{2,3})b|c)+", "", "aab", "[\"aab\"]@0");
+test("(?:(?:a{2,3})b|c)+", "", "aaab", "[\"aaab\"]@0");
+test("(?:(?:a{2,3})b|c)+", "", "aabc", "[\"aabc\"]@0");
+test("(?:(?:a{2,3})b|c)+", "", "c", "[\"c\"]@0");
+test("(?:(?:a{2,3})b|c)+", "", "ab", "null");
+test("(?:(?:ab|a)+c|x)+", "", "abc", "[\"abc\"]@0");
+test("(?:(?:ab|a)+c|x)+", "", "aac", "[\"aac\"]@0");
+test("(?:(?:ab|a)+c|x)+", "", "abababc", "[\"abababc\"]@0");
+test("(?:(?:ab|a)+c|x)+", "", "x", "[\"x\"]@0");
+
+// A terminal group in each top-level alternative.
+test("a(?:b)+|c(?:d)+|e(?:f)+", "", "ab", "[\"ab\"]@0");
+test("a(?:b)+|c(?:d)+|e(?:f)+", "", "cd", "[\"cd\"]@0");
+test("a(?:b)+|c(?:d)+|e(?:f)+", "", "ef", "[\"ef\"]@0");
+test("a(?:b)+|c(?:d)+|e(?:f)+", "", "abb", "[\"abb\"]@0");
+test("a(?:b)+|c(?:d)+|e(?:f)+", "", "cddd", "[\"cddd\"]@0");
+test("a(?:b)+|c(?:d)+|e(?:f)+", "", "a", "null");
+test("a(?:b)+|c(?:d)+|e(?:f)+", "", "c", "null");
+test("a(?:b)+|c(?:d)+|e(?:f)+", "", "e", "null");
+test("a(?:b)+|c(?:d)+|e(?:f)+", "", "g", "null");
+test("(?:x|y)(?:AA|A)+|z(?:B)+", "", "xA", "[\"xA\"]@0");
+test("(?:x|y)(?:AA|A)+|z(?:B)+", "", "yAA", "[\"yAA\"]@0");
+test("(?:x|y)(?:AA|A)+|z(?:B)+", "", "zB", "[\"zB\"]@0");
+test("(?:x|y)(?:AA|A)+|z(?:B)+", "", "zBB", "[\"zBB\"]@0");
+test("(?:x|y)(?:AA|A)+|z(?:B)+", "", "x", "null");
+test("(?:x|y)(?:AA|A)+|z(?:B)+", "", "z", "null");
+
+// Terminal group inside a lookahead or lookbehind is not a top-level body tail, so it must not
+// be marked terminal.
+test("(?=(?:ab)+)a", "", "ab", "[\"a\"]@0");
+test("(?=(?:ab)+)a", "", "abab", "[\"a\"]@0");
+test("(?=(?:ab)+)a", "", "ac", "null");
+test("(?:(?=(?:ab)+)ab)+c", "", "ababc", "[\"ababc\"]@0");
+test("(?:(?=(?:ab)+)ab)+c", "", "abc", "[\"abc\"]@0");
+test("(?:(?=(?:ab)+)ab)+c", "", "ac", "null");
+test("(?<=(?:ab)+)c", "", "abc", "[\"c\"]@2");
+test("(?<=(?:ab)+)c", "", "ababc", "[\"c\"]@4");
+test("(?<=(?:ab)+)c", "", "ac", "null");
+test("(?!(?:ab)+)a.", "", "ac", "[\"ac\"]@0");
+test("(?!(?:ab)+)a.", "", "ab", "null");
+
+// The terminal group wrapped by an assertion that follows it: the group is no longer in tail
+// position, so the optimization must not apply.
+test("(?:ab|a)+$", "", "ab", "[\"ab\"]@0");
+test("(?:ab|a)+$", "", "aba", "[\"aba\"]@0");
+test("(?:ab|a)+$", "", "abx", "null");
+test("(?:ab|a)+(?=x)", "", "abx", "[\"ab\"]@0");
+test("(?:ab|a)+(?=x)", "", "ax", "[\"a\"]@0");
+test("(?:ab|a)+(?=x)", "", "ab", "null");
+test("(?:ab|a)+\\b", "", "ab", "[\"ab\"]@0");
+test("(?:ab|a)+\\b", "", "ab.", "[\"ab\"]@0");
+test("(?:ab|a)+\\b", "", "a", "[\"a\"]@0");
+test("(?:ab|a)+(?![a-z])", "", "ab", "[\"ab\"]@0");
+test("(?:ab|a)+(?![a-z])", "", "abx", "null");
+test("(?:ab|a)+(?![a-z])", "", "ab.", "[\"ab\"]@0");
+
+// Anchored and multiline: recomputeStartsWithBOL and optimizeBOL run either side of
+// checkForTerminalParentheses and copy alternatives around.
+test("^(?:ab|a)+", "", "abab", "[\"abab\"]@0");
+test("^(?:ab|a)+", "", "a", "[\"a\"]@0");
+test("^(?:ab|a)+", "", "xab", "null");
+test("^(?:ab|a)+", "m", "x\nabab", "[\"abab\"]@2");
+test("^(?:ab|a)+", "m", "x\na", "[\"a\"]@2");
+test("^(?:ab|a)+", "m", "x", "null");
+test("^a(?:b|bc)+", "m", "x\nabc", "[\"ab\"]@2");
+test("^a(?:b|bc)+", "m", "x\nab", "[\"ab\"]@2");
+test("^a(?:b|bc)+", "m", "x\na", "null");
+test("^(?:AA|A)*", "m", "x\nAA", "[\"\"]@0");
+test("^(?:AA|A)*", "m", "x\n", "[\"\"]@0");
+test("(?:^|x)(?:AA|A)+", "", "AA", "[\"AA\"]@0");
+test("(?:^|x)(?:AA|A)+", "", "xA", "[\"xA\"]@0");
+test("(?:^|x)(?:AA|A)+", "", "yA", "null");
+
+// Interaction with the string-list optimization, which lives in the same function and is the
+// block the eligibility restructuring re-scoped.
+test("^(?:foo|bar|baz)", "", "foo", "[\"foo\"]@0");
+test("^(?:foo|bar|baz)", "", "bar", "[\"bar\"]@0");
+test("^(?:foo|bar|baz)", "", "baz", "[\"baz\"]@0");
+test("^(?:foo|bar|baz)", "", "qux", "null");
+test("^(?:foo|bar)(?:x)+", "", "foox", "[\"foox\"]@0");
+test("^(?:foo|bar)(?:x)+", "", "barxx", "[\"barxx\"]@0");
+test("^(?:foo|bar)(?:x)+", "", "foo", "null");
+test("^(?:foo|bar)(?:x)+", "", "bazx", "null");
+test("^(?:foo|foobar)+", "", "foobar", "[\"foo\"]@0");
+test("^(?:foo|foobar)+", "", "foofoo", "[\"foofoo\"]@0");
+test("^(?:foo|foobar)+", "", "foo", "[\"foo\"]@0");
+test("^(?:foo|foobar)+", "", "bar", "null");
+
+// Interaction with dot-star wrapping and auto-possessification.
+test(".*(?:ab|a)+", "", "xxab", "[\"xxab\"]@0");
+test(".*(?:ab|a)+", "", "xxa", "[\"xxa\"]@0");
+test(".*(?:ab|a)+", "", "xx", "null");
+test("(?:.*)(?:ab)+", "", "xxab", "[\"xxab\"]@0");
+test("(?:.*)(?:ab)+", "", "xx", "null");
+test("a+(?:b|bc)+", "", "aab", "[\"aab\"]@0");
+test("a+(?:b|bc)+", "", "aabc", "[\"aab\"]@0");
+test("a+(?:b|bc)+", "", "aa", "null");
+test("[0-9]+(?:ab)+", "", "12ab", "[\"12ab\"]@0");
+test("[0-9]+(?:ab)+", "", "12abab", "[\"12abab\"]@0");
+test("[0-9]+(?:ab)+", "", "12a", "null");
+test("\\d+(?:x)+y", "", "12xy", "[\"12xy\"]@0");
+test("\\d+(?:x)+y", "", "12xxy", "[\"12xxy\"]@0");
+test("\\d+(?:x)+y", "", "12y", "null");
+
+// Boyer-Moore / fixed-prefix search paths in front of a terminal group.
+test("hello(?:world|w)+", "", "helloworld", "[\"helloworld\"]@0");
+test("hello(?:world|w)+", "", "hellow", "[\"hellow\"]@0");
+test("hello(?:world|w)+", "", "xhelloworldw", "[\"helloworldw\"]@1");
+test("hello(?:world|w)+", "", "hello", "null");
+test("prefix(?:ab|a)+", "", "prefixabab", "[\"prefixabab\"]@0");
+test("prefix(?:ab|a)+", "", "prefixa", "[\"prefixa\"]@0");
+test("prefix(?:ab|a)+", "", "prefix", "null");
+test("prefix(?:ab|a)+", "", "zzprefixab", "[\"prefixab\"]@2");
+
+// Character classes and unicode sets inside the terminal group.
+test("(?:[a-c]{2}|[a-c])+", "", "ab", "[\"ab\"]@0");
+test("(?:[a-c]{2}|[a-c])+", "", "abc", "[\"abc\"]@0");
+test("(?:[a-c]{2}|[a-c])+", "", "abcabc", "[\"abcabc\"]@0");
+test("(?:[a-c]{2}|[a-c])+", "", "d", "null");
+test("(?:[a-c]{2}|[a-c])+", "", "abd", "[\"ab\"]@0");
+test("(?:[^x]{2}|[^x])+", "", "ab", "[\"ab\"]@0");
+test("(?:[^x]{2}|[^x])+", "", "abc", "[\"abc\"]@0");
+test("(?:[^x]{2}|[^x])+", "", "x", "null");
+test("(?:[^x]{2}|[^x])+", "", "abx", "[\"ab\"]@0");
+test("(?:\\w\\w|\\w)+", "", "ab", "[\"ab\"]@0");
+test("(?:\\w\\w|\\w)+", "", "abc", "[\"abc\"]@0");
+test("(?:\\w\\w|\\w)+", "", "!", "null");
+test("(?:\\w\\w|\\w)+", "", "ab!", "[\"ab\"]@0");
+test("(?:[\\q{ab}]|a)+", "v", "ab", "[\"ab\"]@0");
+test("(?:[\\q{ab}]|a)+", "v", "aab", "[\"aab\"]@0");
+test("(?:[\\q{ab}]|a)+", "v", "a", "[\"a\"]@0");
+test("(?:[\\q{ab}]|a)+", "v", "b", "null");
+test("(?:[\\q{}]|a)+", "v", "a", "[\"a\"]@0");
+test("(?:[\\q{}]|a)+", "v", "", "[\"\"]@0");
+test("(?:[\\q{}]|a)+", "v", "b", "[\"\"]@0");
+test("(?:\\p{ASCII}{2}|\\p{ASCII})+", "u", "ab", "[\"ab\"]@0");
+test("(?:\\p{ASCII}{2}|\\p{ASCII})+", "u", "abc", "[\"abc\"]@0");
+
+// Non-BMP content, where the JIT's 16-bit path and surrogate handling apply.
+test("(?:\\u{1F600}\\u{1F600}|\\u{1F600})+", "u", "\ud83d\ude00", "[\"\ud83d\ude00\"]@0");
+test("(?:\\u{1F600}\\u{1F600}|\\u{1F600})+", "u", "\ud83d\ude00\ud83d\ude00", "[\"\ud83d\ude00\ud83d\ude00\"]@0");
+test("(?:\\u{1F600}\\u{1F600}|\\u{1F600})+", "u", "\ud83d\ude00\ud83d\ude00\ud83d\ude00", "[\"\ud83d\ude00\ud83d\ude00\ud83d\ude00\"]@0");
+test("(?:\\u{1F600}\\u{1F600}|\\u{1F600})+", "u", "x", "null");
+test("(?:ab|a)+", "u", "abab", "[\"abab\"]@0");
+test("(?:ab|a)+", "u", "a\ud83d\ude00", "[\"a\"]@0");
+test("x(?:ab|a)+", "u", "xab\ud83d\ude00", "[\"xab\"]@0");
+test("x(?:ab|a)+", "u", "x\ud83d\ude00", "null");
+
+// Case-insensitive matching, which changes character-class lowering.
+test("(?:AA|A)+", "i", "aa", "[\"aa\"]@0");
+test("(?:AA|A)+", "i", "Aa", "[\"Aa\"]@0");
+test("(?:AA|A)+", "i", "aAa", "[\"aAa\"]@0");
+test("(?:AA|A)+", "i", "b", "null");
+test("(?:SS|S)+", "i", "ss", "[\"ss\"]@0");
+test("(?:SS|S)+", "i", "\u00df", "null");
+test("(?:SS|S)+", "i", "Ss", "[\"Ss\"]@0");
+test("(?:\\u0130|i)+", "iu", "i", "[\"i\"]@0");
+test("(?:\\u0130|i)+", "iu", "\u0130", "[\"\u0130\"]@0");
+test("(?:\\u0130|i)+", "iu", "I", "[\"I\"]@0");
+
+// Sticky and global with a terminal group: lastIndex progression must be right.
+test("(?:AA|A)+", "g", "AABAAA", "[\"AA\"]@0");
+test("(?:AA|A)+", "g", "B", "null");
+test("(?:AA|A)+", "y", "AAB", "[\"AA\"]@0");
+test("(?:AA|A)+", "y", "BAA", "null");
+test("(?:ab|a)+", "gy", "ababab", "[\"ababab\"]@0");
+
+// Long subjects: many iterations, and shapes that would blow up if an iteration ever failed to
+// make progress.
+test("(?:AAA|AA|A)+", "", "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA", "[\"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\"]@0");
+test("(?:AAA|AA|A)+", "", "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB", "[\"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\"]@0");
+test("(?:ab|a)+", "", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "[\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\"]@0");
+test("(?:ab|a)+", "", "abababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababab", "[\"abababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababab\"]@0");
+test("(?:ab|a)*", "", "abababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababab", "[\"abababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababab\"]@0");
+test("x(?:AAA|AA|A)+", "", "xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA", "[\"xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\"]@0");
+test("a+(?:ab)+", "", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab", "[\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab\"]@0");
+test("(?:(?:ab)+c|x)+", "", "ababababababababababababababababababababababababababababababababababababababababababababababababababc", "[\"ababababababababababababababababababababababababababababababababababababababababababababababababababc\"]@0");
+test("(?:a?)+", "", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "[\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\"]@0");
+test("(?:|a)+", "", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "[\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\"]@0");
+test("(?:AA|A)+", "", "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\u3042", "[\"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\"]@0");
+test("(?:AAA|AA|A)+", "", "\u3042AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA", "[\"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\"]@1");
+
+// Many terminal groups in one pattern, to grow the Yarr frame.
+test("a(?:b)+|c(?:d)+|e(?:f)+|g(?:h)+|i(?:j)+|k(?:l)+|m(?:n)+|o(?:p)+", "", "op", "[\"op\"]@0");
+test("(?:a(?:z)+|b(?:z)+|c(?:z)+|d(?:z)+|e(?:z)+|f(?:z)+|g(?:z)+|h(?:z)+|i(?:z)+|j(?:z)+|k(?:z)+|l(?:z)+)", "", "lz", "[\"lz\"]@0");

--- a/JSTests/stress/yarr-terminal-parentheses-min-count.js
+++ b/JSTests/stress/yarr-terminal-parentheses-min-count.js
@@ -1,0 +1,422 @@
+// Greedy non-capturing parentheses in tail position are marked `isTerminal` by
+// YarrPattern::checkForTerminalParentheses, which lets both engines skip the
+// per-iteration ParenContext that quantified subpatterns normally need. The
+// eligibility bound is quantityMinCount <= 1, so `*` and `+` both take that
+// path while `{2,}` must not: a minimum of two or more has to be able to retry
+// an earlier iteration with a different alternative, which requires exactly the
+// inter-iteration state the terminal path drops.
+//
+// The `+` case additionally has to enforce the RepeatMatcher rule that one
+// empty iteration is acceptable while the minimum is unmet but a second is not,
+// so the empty-capable bodies below matter. In the Yarr JIT those bodies are
+// punted back to the interpreter, which is why this file is run in both
+// configurations: only the --useRegExpJIT=0 run reaches the interpreter's
+// empty-iteration logic.
+//
+// Expected values were produced by V8 and cross-checked against both JSC tiers.
+// Silent on success.
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`bad value: got ${actual}, expected ${expected}`);
+}
+
+function match(re, str) {
+    let m = re.exec(str);
+    if (m === null)
+        return "null";
+    return "[" + Array.from(m).map(x => x === undefined ? "undefined" : JSON.stringify(x)).join(",") + "]@" + m.index;
+}
+
+function test(source, flags, str, expected) {
+    // Compile once and execute repeatedly so the regexp warms up and the
+    // DFG/FTL inlined paths run the same pattern the LLInt did.
+    let re = new RegExp(source, flags);
+    for (let i = 0; i < testLoopCount; ++i) {
+        re.lastIndex = 0;
+        shouldBe(match(re, str), expected);
+    }
+}
+
+// core `+` terminal groups: alternative selection
+test("(?:AA|A)+", "", "", "null");
+test("(?:AA|A)+", "", "A", "[\"A\"]@0");
+test("(?:AA|A)+", "", "AA", "[\"AA\"]@0");
+test("(?:AA|A)+", "", "AAA", "[\"AAA\"]@0");
+test("(?:AA|A)+", "", "AAAA", "[\"AAAA\"]@0");
+test("(?:AA|A)+", "", "B", "null");
+test("(?:AA|A)+", "", "AB", "[\"A\"]@0");
+test("(?:AA|A)+", "", "AAB", "[\"AA\"]@0");
+test("(?:AA|A)+", "", "BAA", "[\"AA\"]@1");
+test("(?:AA|A)+", "", "BAAAB", "[\"AAA\"]@1");
+test("(?:A|AA)+", "", "", "null");
+test("(?:A|AA)+", "", "A", "[\"A\"]@0");
+test("(?:A|AA)+", "", "AA", "[\"AA\"]@0");
+test("(?:A|AA)+", "", "AAA", "[\"AAA\"]@0");
+test("(?:A|AA)+", "", "AAAA", "[\"AAAA\"]@0");
+test("(?:A|AA)+", "", "AB", "[\"A\"]@0");
+test("(?:A|AA)+", "", "AAB", "[\"AA\"]@0");
+test("(?:ab|a)+", "", "", "null");
+test("(?:ab|a)+", "", "a", "[\"a\"]@0");
+test("(?:ab|a)+", "", "ab", "[\"ab\"]@0");
+test("(?:ab|a)+", "", "aba", "[\"aba\"]@0");
+test("(?:ab|a)+", "", "abab", "[\"abab\"]@0");
+test("(?:ab|a)+", "", "aab", "[\"aab\"]@0");
+test("(?:ab|a)+", "", "b", "null");
+test("(?:ab|a)+", "", "xabab", "[\"abab\"]@1");
+test("(?:a|ab)+", "", "a", "[\"a\"]@0");
+test("(?:a|ab)+", "", "ab", "[\"a\"]@0");
+test("(?:a|ab)+", "", "abab", "[\"a\"]@0");
+test("(?:a|ab)+", "", "aab", "[\"aa\"]@0");
+test("(?:abc|ab|a)+", "", "abcaba", "[\"abcaba\"]@0");
+test("(?:abc|ab|a)+", "", "abca", "[\"abca\"]@0");
+test("(?:abc|ab|a)+", "", "aab", "[\"aab\"]@0");
+test("(?:abc|ab|a)+", "", "abc", "[\"abc\"]@0");
+
+// {1,} spelled long-hand must behave identically to `+`
+test("(?:AA|A){1,}", "", "A", "[\"A\"]@0");
+test("(?:AA|A){1,}", "", "AA", "[\"AA\"]@0");
+test("(?:AA|A){1,}", "", "AAA", "[\"AAA\"]@0");
+test("(?:AA|A){1,}", "", "B", "null");
+
+// {2,} must stay off the terminal path and stay correct
+test("(?:AA|A){2,}", "", "A", "null");
+test("(?:AA|A){2,}", "", "AA", "[\"AA\"]@0");
+test("(?:AA|A){2,}", "", "AAA", "[\"AAA\"]@0");
+test("(?:AA|A){2,}", "", "AAAA", "[\"AAAA\"]@0");
+test("(?:AA|A){2,}", "", "AAAAA", "[\"AAAAA\"]@0");
+test("(?:AA|A){2,}", "", "AB", "null");
+test("(?:AAA|A){2,}", "", "AAA", "[\"AAA\"]@0");
+test("(?:AAA|A){2,}", "", "AAAA", "[\"AAAA\"]@0");
+test("(?:AAA|A){2,}", "", "AAAAAA", "[\"AAAAAA\"]@0");
+test("(?:AAA|A){2,}", "", "AA", "[\"AA\"]@0");
+test("(?:AA|A){3,}", "", "AA", "null");
+test("(?:AA|A){3,}", "", "AAA", "[\"AAA\"]@0");
+test("(?:AA|A){3,}", "", "AAAA", "[\"AAAA\"]@0");
+test("(?:AA|A){3,}", "", "AAAAAA", "[\"AAAAAA\"]@0");
+
+// `*` terminal groups: regression coverage for the loop-back arithmetic
+test("(?:AA|A)*", "", "", "[\"\"]@0");
+test("(?:AA|A)*", "", "A", "[\"A\"]@0");
+test("(?:AA|A)*", "", "AA", "[\"AA\"]@0");
+test("(?:AA|A)*", "", "AAA", "[\"AAA\"]@0");
+test("(?:AA|A)*", "", "B", "[\"\"]@0");
+test("(?:AA|A)*", "", "AAB", "[\"AA\"]@0");
+test("(?:ab|a)*", "", "", "[\"\"]@0");
+test("(?:ab|a)*", "", "a", "[\"a\"]@0");
+test("(?:ab|a)*", "", "abab", "[\"abab\"]@0");
+test("(?:ab|a)*", "", "b", "[\"\"]@0");
+test("(?:ab|a)*", "", "xab", "[\"\"]@0");
+test("x(?:ab|a)*", "", "x", "[\"x\"]@0");
+test("x(?:ab|a)*", "", "xa", "[\"xa\"]@0");
+test("x(?:ab|a)*", "", "xab", "[\"xab\"]@0");
+test("x(?:ab|a)*", "", "xabab", "[\"xabab\"]@0");
+test("x(?:ab|a)*", "", "y", "null");
+
+// first iteration fails, must backtrack out into a backtrackable prefix
+test("a+(?:ab)+", "", "aaab", "[\"aaab\"]@0");
+test("a+(?:ab)+", "", "aab", "[\"aab\"]@0");
+test("a+(?:ab)+", "", "ab", "null");
+test("a+(?:ab)+", "", "aaa", "null");
+test("a+(?:ab)+", "", "aaabab", "[\"aaabab\"]@0");
+test("(?:a|aa)(?:bc|bd)+", "", "aabc", "[\"aabc\"]@0");
+test("(?:a|aa)(?:bc|bd)+", "", "abc", "[\"abc\"]@0");
+test("(?:a|aa)(?:bc|bd)+", "", "abd", "[\"abd\"]@0");
+test("(?:a|aa)(?:bc|bd)+", "", "aabdbc", "[\"aabdbc\"]@0");
+test("a*(?:ab)+", "", "aaab", "[\"aaab\"]@0");
+test("a*(?:ab)+", "", "ab", "[\"ab\"]@0");
+test("a*(?:ab)+", "", "aaa", "null");
+test("[a-z]*(?:0)+", "", "abc", "null");
+test("[a-z]*(?:0)+", "", "abc0", "[\"abc0\"]@0");
+test("[a-z]*(?:0)+", "", "abc00", "[\"abc00\"]@0");
+test("(?:a|aa)(?:ab)+", "", "aaab", "[\"aaab\"]@0");
+test("(?:a|aa)(?:ab)+", "", "aab", "[\"aab\"]@0");
+test(".*(?:ab)+", "", "xxab", "[\"xxab\"]@0");
+test(".*(?:ab)+", "", "xxabab", "[\"xxabab\"]@0");
+test(".*(?:ab)+", "", "xx", "null");
+
+// terminal group cannot match at all
+test("x(?:ab)+", "", "x", "null");
+test("x(?:ab)+", "", "xa", "null");
+test("x(?:ab)+", "", "xab", "[\"xab\"]@0");
+test("a(?:bc)+", "", "axbc", "null");
+test("a(?:bc)+", "", "abc", "[\"abc\"]@0");
+test("a(?:bc)+", "", "abcbc", "[\"abcbc\"]@0");
+test("a(?:bc)+", "", "a", "null");
+
+// match start scanning: .index must be right
+test("(?:a)+", "", "ba", "[\"a\"]@1");
+test("(?:a)+", "", "bba", "[\"a\"]@2");
+test("(?:a)+", "", "b", "null");
+test("(?:a)+", "", "baa", "[\"aa\"]@1");
+test("(?:ab|a)+", "", "zzab", "[\"ab\"]@2");
+test("(?:ab|a)+", "", "zzzaab", "[\"aab\"]@3");
+
+// empty-capable bodies: one empty iteration is legal for `+`
+test("(?:a?)+", "", "", "[\"\"]@0");
+test("(?:a?)+", "", "a", "[\"a\"]@0");
+test("(?:a?)+", "", "aa", "[\"aa\"]@0");
+test("(?:a?)+", "", "b", "[\"\"]@0");
+test("(?:|a)+", "", "", "[\"\"]@0");
+test("(?:|a)+", "", "a", "[\"a\"]@0");
+test("(?:|a)+", "", "aa", "[\"aa\"]@0");
+test("(?:|a)+", "", "aaa", "[\"aaa\"]@0");
+test("(?:|a)+", "", "b", "[\"\"]@0");
+test("(?:a|)+", "", "", "[\"\"]@0");
+test("(?:a|)+", "", "a", "[\"a\"]@0");
+test("(?:a|)+", "", "aa", "[\"aa\"]@0");
+test("(?:a|)+", "", "b", "[\"\"]@0");
+test("(?:a*)+", "", "", "[\"\"]@0");
+test("(?:a*)+", "", "a", "[\"a\"]@0");
+test("(?:a*)+", "", "aa", "[\"aa\"]@0");
+test("(?:a*)+", "", "b", "[\"\"]@0");
+test("(?:)+", "", "", "[\"\"]@0");
+test("(?:)+", "", "a", "[\"\"]@0");
+test("x(?:a?)+", "", "x", "[\"x\"]@0");
+test("x(?:a?)+", "", "xa", "[\"xa\"]@0");
+test("x(?:a?)+", "", "xaa", "[\"xaa\"]@0");
+test("x(?:a?)+", "", "y", "null");
+test("(?:a?)*", "", "", "[\"\"]@0");
+test("(?:a?)*", "", "a", "[\"a\"]@0");
+test("(?:a?)*", "", "b", "[\"\"]@0");
+test("(?:\\b|a)+", "", "a", "[\"a\"]@0");
+test("(?:\\b|a)+", "", "b", "[\"\"]@0");
+test("(?:\\b|a)+", "", "", "null");
+test("(?:$|a)+", "", "a", "[\"a\"]@0");
+test("(?:$|a)+", "", "", "[\"\"]@0");
+test("(?:$|a)+", "", "b", "[\"\"]@1");
+
+// anchors and multiple top-level alternatives
+test("^a(?:b)+", "", "ab", "[\"ab\"]@0");
+test("^a(?:b)+", "", "abb", "[\"abb\"]@0");
+test("^a(?:b)+", "", "a", "null");
+test("^a(?:b)+", "", "xab", "null");
+test("^a(?:b)+|c(?:d)+", "", "ab", "[\"ab\"]@0");
+test("^a(?:b)+|c(?:d)+", "", "cd", "[\"cd\"]@0");
+test("^a(?:b)+|c(?:d)+", "", "xcdd", "[\"cdd\"]@1");
+test("^a(?:b)+|c(?:d)+", "", "a", "null");
+test("^a(?:b)+|c(?:d)+", "", "c", "null");
+test("(?:a)+$", "", "a", "[\"a\"]@0");
+test("(?:a)+$", "", "aa", "[\"aa\"]@0");
+test("(?:a)+$", "", "ab", "null");
+test("(?:a)+$", "", "ba", "[\"a\"]@1");
+test("(?:ab|a)+$", "", "ab", "[\"ab\"]@0");
+test("(?:ab|a)+$", "", "aba", "[\"aba\"]@0");
+test("(?:ab|a)+$", "", "abx", "null");
+
+// nesting: a generic quantified group inside the terminal group
+test("(?:(?:ab)+c|a)+", "", "abc", "[\"abc\"]@0");
+test("(?:(?:ab)+c|a)+", "", "ababca", "[\"ababca\"]@0");
+test("(?:(?:ab)+c|a)+", "", "a", "[\"a\"]@0");
+test("(?:(?:ab)+c|a)+", "", "aabc", "[\"aabc\"]@0");
+test("(?:a(?:b|c)d|a)+", "", "abd", "[\"abd\"]@0");
+test("(?:a(?:b|c)d|a)+", "", "abdacd", "[\"abdacd\"]@0");
+test("(?:a(?:b|c)d|a)+", "", "a", "[\"a\"]@0");
+test("(?:a(?:b|c)d|a)+", "", "aabd", "[\"aabd\"]@0");
+test("(?:[0-9]+|x)+", "", "12x34", "[\"12x34\"]@0");
+test("(?:[0-9]+|x)+", "", "x", "[\"x\"]@0");
+test("(?:[0-9]+|x)+", "", "12", "[\"12\"]@0");
+test("(?:[0-9]+|x)+", "", "y", "null");
+
+// flags on the core shapes
+test("(?:AA|A)+", "i", "aA", "[\"aA\"]@0");
+test("(?:AA|A)+", "i", "aa", "[\"aa\"]@0");
+test("(?:AA|A)+", "i", "AaA", "[\"AaA\"]@0");
+test("(?:AA|A)+", "i", "b", "null");
+test("(?:ab|a)+", "i", "AbAb", "[\"AbAb\"]@0");
+test("(?:ab|a)+", "i", "aB", "[\"aB\"]@0");
+test("(?:AA|A)+", "u", "AA", "[\"AA\"]@0");
+test("(?:AA|A)+", "u", "A", "[\"A\"]@0");
+test("(?:AA|A)+", "v", "AA", "[\"AA\"]@0");
+test("(?:AA|A)+", "v", "A", "[\"A\"]@0");
+test("(?:ab|a)+", "y", "abab", "[\"abab\"]@0");
+test("(?:ab|a)+", "y", "xab", "null");
+test("(?:ab|a)+", "s", "abab", "[\"abab\"]@0");
+
+// long inputs, many iterations
+test("(?:AA|A)+", "", "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA", "[\"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\"]@0");
+test("(?:AA|A)+", "", "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB", "[\"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\"]@0");
+test("(?:ab|a)+", "", "abababababababababababababababababababababababababababababababababababababababababababababababababab", "[\"abababababababababababababababababababababababababababababababababababababababababababababababababab\"]@0");
+test("(?:ab|a)+", "", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "[\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\"]@0");
+test("x(?:ab|a)*", "", "xabababababababababababababababababababababababababababababababababababababababababababababababababab", "[\"xabababababababababababababababababababababababababababababababababababababababababababababababababab\"]@0");
+test("a+(?:ab)+", "", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab", "[\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab\"]@0");
+
+// 16-bit subjects. The Yarr JIT compiles 8-bit and 16-bit code separately, so the
+// same patterns must be re-run against a subject containing a non-Latin1 character.
+test("(?:AA|A)+", "", "\u3042", "null");
+test("(?:AA|A)+", "", "A\u3042", "[\"A\"]@0");
+test("(?:AA|A)+", "", "AA\u3042", "[\"AA\"]@0");
+test("(?:AA|A)+", "", "AAA\u3042", "[\"AAA\"]@0");
+test("(?:AA|A)+", "", "AAAA\u3042", "[\"AAAA\"]@0");
+test("(?:AA|A)+", "", "B\u3042", "null");
+test("(?:AA|A)+", "", "AB\u3042", "[\"A\"]@0");
+test("(?:AA|A)+", "", "AAB\u3042", "[\"AA\"]@0");
+test("(?:AA|A)+", "", "BAA\u3042", "[\"AA\"]@1");
+test("(?:AA|A)+", "", "BAAAB\u3042", "[\"AAA\"]@1");
+test("(?:A|AA)+", "", "\u3042", "null");
+test("(?:A|AA)+", "", "A\u3042", "[\"A\"]@0");
+test("(?:A|AA)+", "", "AA\u3042", "[\"AA\"]@0");
+test("(?:A|AA)+", "", "AAA\u3042", "[\"AAA\"]@0");
+test("(?:A|AA)+", "", "AAAA\u3042", "[\"AAAA\"]@0");
+test("(?:A|AA)+", "", "AB\u3042", "[\"A\"]@0");
+test("(?:A|AA)+", "", "AAB\u3042", "[\"AA\"]@0");
+test("(?:ab|a)+", "", "\u3042", "null");
+test("(?:ab|a)+", "", "a\u3042", "[\"a\"]@0");
+test("(?:ab|a)+", "", "ab\u3042", "[\"ab\"]@0");
+test("(?:ab|a)+", "", "aba\u3042", "[\"aba\"]@0");
+test("(?:ab|a)+", "", "abab\u3042", "[\"abab\"]@0");
+test("(?:ab|a)+", "", "aab\u3042", "[\"aab\"]@0");
+test("(?:ab|a)+", "", "b\u3042", "null");
+test("(?:ab|a)+", "", "xabab\u3042", "[\"abab\"]@1");
+test("(?:a|ab)+", "", "a\u3042", "[\"a\"]@0");
+test("(?:a|ab)+", "", "ab\u3042", "[\"a\"]@0");
+test("(?:a|ab)+", "", "abab\u3042", "[\"a\"]@0");
+test("(?:a|ab)+", "", "aab\u3042", "[\"aa\"]@0");
+test("(?:abc|ab|a)+", "", "abcaba\u3042", "[\"abcaba\"]@0");
+test("(?:abc|ab|a)+", "", "abca\u3042", "[\"abca\"]@0");
+test("(?:abc|ab|a)+", "", "aab\u3042", "[\"aab\"]@0");
+test("(?:abc|ab|a)+", "", "abc\u3042", "[\"abc\"]@0");
+test("(?:AA|A){1,}", "", "A\u3042", "[\"A\"]@0");
+test("(?:AA|A){1,}", "", "AA\u3042", "[\"AA\"]@0");
+test("(?:AA|A){1,}", "", "AAA\u3042", "[\"AAA\"]@0");
+test("(?:AA|A){1,}", "", "B\u3042", "null");
+test("(?:AA|A){2,}", "", "A\u3042", "null");
+test("(?:AA|A){2,}", "", "AA\u3042", "[\"AA\"]@0");
+test("(?:AA|A){2,}", "", "AAA\u3042", "[\"AAA\"]@0");
+test("(?:AA|A){2,}", "", "AAAA\u3042", "[\"AAAA\"]@0");
+test("(?:AA|A){2,}", "", "AAAAA\u3042", "[\"AAAAA\"]@0");
+test("(?:AA|A){2,}", "", "AB\u3042", "null");
+test("(?:AAA|A){2,}", "", "AAA\u3042", "[\"AAA\"]@0");
+test("(?:AAA|A){2,}", "", "AAAA\u3042", "[\"AAAA\"]@0");
+test("(?:AAA|A){2,}", "", "AAAAAA\u3042", "[\"AAAAAA\"]@0");
+test("(?:AAA|A){2,}", "", "AA\u3042", "[\"AA\"]@0");
+test("(?:AA|A){3,}", "", "AA\u3042", "null");
+test("(?:AA|A){3,}", "", "AAA\u3042", "[\"AAA\"]@0");
+test("(?:AA|A){3,}", "", "AAAA\u3042", "[\"AAAA\"]@0");
+test("(?:AA|A){3,}", "", "AAAAAA\u3042", "[\"AAAAAA\"]@0");
+test("(?:AA|A)*", "", "\u3042", "[\"\"]@0");
+test("(?:AA|A)*", "", "A\u3042", "[\"A\"]@0");
+test("(?:AA|A)*", "", "AA\u3042", "[\"AA\"]@0");
+test("(?:AA|A)*", "", "AAA\u3042", "[\"AAA\"]@0");
+test("(?:AA|A)*", "", "B\u3042", "[\"\"]@0");
+test("(?:AA|A)*", "", "AAB\u3042", "[\"AA\"]@0");
+test("(?:ab|a)*", "", "\u3042", "[\"\"]@0");
+test("(?:ab|a)*", "", "a\u3042", "[\"a\"]@0");
+test("(?:ab|a)*", "", "abab\u3042", "[\"abab\"]@0");
+test("(?:ab|a)*", "", "b\u3042", "[\"\"]@0");
+test("(?:ab|a)*", "", "xab\u3042", "[\"\"]@0");
+test("x(?:ab|a)*", "", "x\u3042", "[\"x\"]@0");
+test("x(?:ab|a)*", "", "xa\u3042", "[\"xa\"]@0");
+test("x(?:ab|a)*", "", "xab\u3042", "[\"xab\"]@0");
+test("x(?:ab|a)*", "", "xabab\u3042", "[\"xabab\"]@0");
+test("x(?:ab|a)*", "", "y\u3042", "null");
+test("a+(?:ab)+", "", "aaab\u3042", "[\"aaab\"]@0");
+test("a+(?:ab)+", "", "aab\u3042", "[\"aab\"]@0");
+test("a+(?:ab)+", "", "ab\u3042", "null");
+test("a+(?:ab)+", "", "aaa\u3042", "null");
+test("a+(?:ab)+", "", "aaabab\u3042", "[\"aaabab\"]@0");
+test("(?:a|aa)(?:bc|bd)+", "", "aabc\u3042", "[\"aabc\"]@0");
+test("(?:a|aa)(?:bc|bd)+", "", "abc\u3042", "[\"abc\"]@0");
+test("(?:a|aa)(?:bc|bd)+", "", "abd\u3042", "[\"abd\"]@0");
+test("(?:a|aa)(?:bc|bd)+", "", "aabdbc\u3042", "[\"aabdbc\"]@0");
+test("a*(?:ab)+", "", "aaab\u3042", "[\"aaab\"]@0");
+test("a*(?:ab)+", "", "ab\u3042", "[\"ab\"]@0");
+test("a*(?:ab)+", "", "aaa\u3042", "null");
+test("[a-z]*(?:0)+", "", "abc\u3042", "null");
+test("[a-z]*(?:0)+", "", "abc0\u3042", "[\"abc0\"]@0");
+test("[a-z]*(?:0)+", "", "abc00\u3042", "[\"abc00\"]@0");
+test("(?:a|aa)(?:ab)+", "", "aaab\u3042", "[\"aaab\"]@0");
+test("(?:a|aa)(?:ab)+", "", "aab\u3042", "[\"aab\"]@0");
+test(".*(?:ab)+", "", "xxab\u3042", "[\"xxab\"]@0");
+test(".*(?:ab)+", "", "xxabab\u3042", "[\"xxabab\"]@0");
+test(".*(?:ab)+", "", "xx\u3042", "null");
+test("x(?:ab)+", "", "x\u3042", "null");
+test("x(?:ab)+", "", "xa\u3042", "null");
+test("x(?:ab)+", "", "xab\u3042", "[\"xab\"]@0");
+test("a(?:bc)+", "", "axbc\u3042", "null");
+test("a(?:bc)+", "", "abc\u3042", "[\"abc\"]@0");
+test("a(?:bc)+", "", "abcbc\u3042", "[\"abcbc\"]@0");
+test("a(?:bc)+", "", "a\u3042", "null");
+test("(?:a)+", "", "ba\u3042", "[\"a\"]@1");
+test("(?:a)+", "", "bba\u3042", "[\"a\"]@2");
+test("(?:a)+", "", "b\u3042", "null");
+test("(?:a)+", "", "baa\u3042", "[\"aa\"]@1");
+test("(?:ab|a)+", "", "zzab\u3042", "[\"ab\"]@2");
+test("(?:ab|a)+", "", "zzzaab\u3042", "[\"aab\"]@3");
+test("(?:a?)+", "", "\u3042", "[\"\"]@0");
+test("(?:a?)+", "", "a\u3042", "[\"a\"]@0");
+test("(?:a?)+", "", "aa\u3042", "[\"aa\"]@0");
+test("(?:a?)+", "", "b\u3042", "[\"\"]@0");
+test("(?:|a)+", "", "\u3042", "[\"\"]@0");
+test("(?:|a)+", "", "a\u3042", "[\"a\"]@0");
+test("(?:|a)+", "", "aa\u3042", "[\"aa\"]@0");
+test("(?:|a)+", "", "aaa\u3042", "[\"aaa\"]@0");
+test("(?:|a)+", "", "b\u3042", "[\"\"]@0");
+test("(?:a|)+", "", "\u3042", "[\"\"]@0");
+test("(?:a|)+", "", "a\u3042", "[\"a\"]@0");
+test("(?:a|)+", "", "aa\u3042", "[\"aa\"]@0");
+test("(?:a|)+", "", "b\u3042", "[\"\"]@0");
+test("(?:a*)+", "", "\u3042", "[\"\"]@0");
+test("(?:a*)+", "", "a\u3042", "[\"a\"]@0");
+test("(?:a*)+", "", "aa\u3042", "[\"aa\"]@0");
+test("(?:a*)+", "", "b\u3042", "[\"\"]@0");
+test("(?:)+", "", "\u3042", "[\"\"]@0");
+test("(?:)+", "", "a\u3042", "[\"\"]@0");
+test("x(?:a?)+", "", "x\u3042", "[\"x\"]@0");
+test("x(?:a?)+", "", "xa\u3042", "[\"xa\"]@0");
+test("x(?:a?)+", "", "xaa\u3042", "[\"xaa\"]@0");
+test("x(?:a?)+", "", "y\u3042", "null");
+test("(?:a?)*", "", "\u3042", "[\"\"]@0");
+test("(?:a?)*", "", "a\u3042", "[\"a\"]@0");
+test("(?:a?)*", "", "b\u3042", "[\"\"]@0");
+test("(?:\\b|a)+", "", "a\u3042", "[\"a\"]@0");
+test("(?:\\b|a)+", "", "b\u3042", "[\"\"]@0");
+test("(?:\\b|a)+", "", "\u3042", "null");
+test("(?:$|a)+", "", "a\u3042", "[\"a\"]@0");
+test("(?:$|a)+", "", "\u3042", "[\"\"]@1");
+test("(?:$|a)+", "", "b\u3042", "[\"\"]@2");
+test("^a(?:b)+", "", "ab\u3042", "[\"ab\"]@0");
+test("^a(?:b)+", "", "abb\u3042", "[\"abb\"]@0");
+test("^a(?:b)+", "", "a\u3042", "null");
+test("^a(?:b)+", "", "xab\u3042", "null");
+test("^a(?:b)+|c(?:d)+", "", "ab\u3042", "[\"ab\"]@0");
+test("^a(?:b)+|c(?:d)+", "", "cd\u3042", "[\"cd\"]@0");
+test("^a(?:b)+|c(?:d)+", "", "xcdd\u3042", "[\"cdd\"]@1");
+test("^a(?:b)+|c(?:d)+", "", "a\u3042", "null");
+test("^a(?:b)+|c(?:d)+", "", "c\u3042", "null");
+test("(?:a)+$", "", "a\u3042", "null");
+test("(?:a)+$", "", "aa\u3042", "null");
+test("(?:a)+$", "", "ab\u3042", "null");
+test("(?:a)+$", "", "ba\u3042", "null");
+test("(?:ab|a)+$", "", "ab\u3042", "null");
+test("(?:ab|a)+$", "", "aba\u3042", "null");
+test("(?:ab|a)+$", "", "abx\u3042", "null");
+test("(?:(?:ab)+c|a)+", "", "abc\u3042", "[\"abc\"]@0");
+test("(?:(?:ab)+c|a)+", "", "ababca\u3042", "[\"ababca\"]@0");
+test("(?:(?:ab)+c|a)+", "", "a\u3042", "[\"a\"]@0");
+test("(?:(?:ab)+c|a)+", "", "aabc\u3042", "[\"aabc\"]@0");
+test("(?:a(?:b|c)d|a)+", "", "abd\u3042", "[\"abd\"]@0");
+test("(?:a(?:b|c)d|a)+", "", "abdacd\u3042", "[\"abdacd\"]@0");
+test("(?:a(?:b|c)d|a)+", "", "a\u3042", "[\"a\"]@0");
+test("(?:a(?:b|c)d|a)+", "", "aabd\u3042", "[\"aabd\"]@0");
+test("(?:[0-9]+|x)+", "", "12x34\u3042", "[\"12x34\"]@0");
+test("(?:[0-9]+|x)+", "", "x\u3042", "[\"x\"]@0");
+test("(?:[0-9]+|x)+", "", "12\u3042", "[\"12\"]@0");
+test("(?:[0-9]+|x)+", "", "y\u3042", "null");
+test("(?:AA|A)+", "i", "aA\u3042", "[\"aA\"]@0");
+test("(?:AA|A)+", "i", "aa\u3042", "[\"aa\"]@0");
+test("(?:AA|A)+", "i", "AaA\u3042", "[\"AaA\"]@0");
+test("(?:AA|A)+", "i", "b\u3042", "null");
+test("(?:ab|a)+", "i", "AbAb\u3042", "[\"AbAb\"]@0");
+test("(?:ab|a)+", "i", "aB\u3042", "[\"aB\"]@0");
+test("(?:AA|A)+", "u", "AA\u3042", "[\"AA\"]@0");
+test("(?:AA|A)+", "u", "A\u3042", "[\"A\"]@0");
+test("(?:AA|A)+", "v", "AA\u3042", "[\"AA\"]@0");
+test("(?:AA|A)+", "v", "A\u3042", "[\"A\"]@0");
+test("(?:ab|a)+", "s", "abab\u3042", "[\"abab\"]@0");
+test("(?:AA|A)+", "", "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\u3042", "[\"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\"]@0");
+test("(?:AA|A)+", "", "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB\u3042", "[\"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\"]@0");
+test("(?:ab|a)+", "", "abababababababababababababababababababababababababababababababababababababababababababababababababab\u3042", "[\"abababababababababababababababababababababababababababababababababababababababababababababababababab\"]@0");
+test("(?:ab|a)+", "", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\u3042", "[\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\"]@0");
+test("x(?:ab|a)*", "", "xabababababababababababababababababababababababababababababababababababababababababababababababababab\u3042", "[\"xabababababababababababababababababababababababababababababababababababababababababababababababababab\"]@0");
+test("a+(?:ab)+", "", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab\u3042", "[\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab\"]@0");

--- a/Source/JavaScriptCore/yarr/Yarr.h
+++ b/Source/JavaScriptCore/yarr/Yarr.h
@@ -38,7 +38,7 @@ namespace JSC { namespace Yarr {
 #define YarrStackSpaceForBackTrackInfoAlternative 1 // One per alternative.
 #define YarrStackSpaceForBackTrackInfoParentheticalAssertion 1
 #define YarrStackSpaceForBackTrackInfoParenthesesOnce 2
-#define YarrStackSpaceForBackTrackInfoParenthesesTerminal 1
+#define YarrStackSpaceForBackTrackInfoParenthesesTerminal 2
 #define YarrStackSpaceForBackTrackInfoParentheses 4
 #define YarrStackSpaceForDotStarEnclosure 1
 

--- a/Source/JavaScriptCore/yarr/YarrInterpreter.cpp
+++ b/Source/JavaScriptCore/yarr/YarrInterpreter.cpp
@@ -1299,25 +1299,38 @@ public:
     {
         ASSERT(term.type == ByteTerm::Type::ParenthesesSubpatternTerminalBegin);
         ASSERT(term.atom.quantityType == QuantifierType::Greedy);
+        ASSERT(!term.atom.quantityMinCount || term.atom.quantityMinCount == 1);
         ASSERT(term.atom.quantityMaxCount == quantifyInfinite);
         ASSERT(!term.capture());
 
         BackTrackInfoParenthesesTerminal* backTrack = reinterpret_cast<BackTrackInfoParenthesesTerminal*>(context->frame + term.frameLocation);
         backTrack->begin = input.getPos();
+        backTrack->entryPosition = input.getPos();
         return true;
     }
 
     bool NODELETE matchParenthesesTerminalEnd(ByteTerm& term, DisjunctionContext* context)
     {
         ASSERT(term.type == ByteTerm::Type::ParenthesesSubpatternTerminalEnd);
+        ASSERT(!term.atom.quantityMinCount || term.atom.quantityMinCount == 1);
 
         BackTrackInfoParenthesesTerminal* backTrack = reinterpret_cast<BackTrackInfoParenthesesTerminal*>(context->frame + term.frameLocation);
-        // Empty match is a failed match.
-        if (backTrack->begin == input.getPos())
-            return false;
+        if (backTrack->begin == input.getPos()) {
+            // An empty iteration cannot be repeated, so it is only ever acceptable as the single
+            // iteration a minimum of one demands, and only before anything has been consumed.
+            // Clearing entryPosition both records that the minimum is now met and rejects any
+            // further empty iteration.
+            if (!term.atom.quantityMinCount || backTrack->entryPosition != input.getPos())
+                return false;
+            backTrack->entryPosition = notFound;
+        }
+
+        backTrack->begin = input.getPos();
 
         // Successful match! Okay, what's next? - loop around and try to match more!
-        context->term -= (term.atom.parenthesesWidth + 1);
+        // Loop back to the body's first term rather than to ParenthesesSubpatternTerminalBegin,
+        // whose stores initialize the whole group and must not run again per iteration.
+        context->term -= term.atom.parenthesesWidth;
         return true;
     }
 
@@ -1325,11 +1338,19 @@ public:
     {
         ASSERT(term.type == ByteTerm::Type::ParenthesesSubpatternTerminalBegin);
         ASSERT(term.atom.quantityType == QuantifierType::Greedy);
+        ASSERT(!term.atom.quantityMinCount || term.atom.quantityMinCount == 1);
         ASSERT(term.atom.quantityMaxCount == quantifyInfinite);
         ASSERT(!term.capture());
 
         // If we backtrack to this point, we have failed to match this iteration of the parens.
-        // Since this is greedy / zero minimum a failed is also accepted as a match!
+        // Nothing follows a terminal group, so an already satisfied minimum makes that failure an
+        // acceptable end of the match; an unsatisfied one fails the match.
+        if (term.atom.quantityMinCount) {
+            BackTrackInfoParenthesesTerminal* backTrack = reinterpret_cast<BackTrackInfoParenthesesTerminal*>(context->frame + term.frameLocation);
+            if (backTrack->entryPosition == input.getPos())
+                return false;
+        }
+
         context->term += term.atom.parenthesesWidth;
         return true;
     }
@@ -3251,6 +3272,7 @@ static_assert(sizeof(BackTrackInfoBackReference) == (YarrStackSpaceForBackTrackI
 static_assert(sizeof(BackTrackInfoAlternative) == (YarrStackSpaceForBackTrackInfoAlternative * sizeof(uintptr_t)));
 static_assert(sizeof(BackTrackInfoParentheticalAssertion) == (YarrStackSpaceForBackTrackInfoParentheticalAssertion * sizeof(uintptr_t)));
 static_assert(sizeof(BackTrackInfoParenthesesOnce) == (YarrStackSpaceForBackTrackInfoParenthesesOnce * sizeof(uintptr_t)));
+static_assert(sizeof(BackTrackInfoParenthesesTerminal) == (YarrStackSpaceForBackTrackInfoParenthesesTerminal * sizeof(uintptr_t)));
 static_assert(sizeof(Interpreter<char16_t>::BackTrackInfoParentheses) <= (YarrStackSpaceForBackTrackInfoParentheses * sizeof(uintptr_t)));
 
 

--- a/Source/JavaScriptCore/yarr/YarrJIT.cpp
+++ b/Source/JavaScriptCore/yarr/YarrJIT.cpp
@@ -4319,12 +4319,21 @@ class YarrGenerator final : public YarrJITInfo {
             case YarrOpCode::ParenthesesSubpatternTerminalBegin: {
                 PatternTerm* term = op.m_term;
                 ASSERT(!term->capture());
-                if (term->quantityType == QuantifierType::Greedy)
-                    ASSERT(term->quantityMaxCount == quantifyInfinite);
-                if (term->quantityType == QuantifierType::FixedCount)
-                    ASSERT(term->quantityMaxCount == 1);
+                ASSERT(term->quantityType == QuantifierType::Greedy);
+                ASSERT(term->quantityMaxCount == quantifyInfinite);
+                ASSERT(!term->quantityMinCount || term->quantityMinCount == 1);
 
                 termMatchTargets.append(MatchTargets());
+
+                // A minimum of one has to tell a failed first iteration from a failed later one
+                // when the group backtracks. Every iteration the JIT completes consumes at least
+                // one character, because a group whose body can match emptily is diverted to the
+                // interpreter at ParenthesesSubpatternTerminalEnd below, so the index the group was
+                // entered at is enough: it differs from the current index exactly when an iteration
+                // has completed. Recording it here, above the loop, keeps the iteration itself free
+                // of bookkeeping.
+                if (term->quantityMinCount)
+                    storeToFrame(m_regs.index, term->frameLocation + BackTrackInfoParenthesesTerminal::entryPositionIndex());
 
                 // Upon entry set a label to loop back to.
                 defineReentryLabel(op);
@@ -4337,14 +4346,17 @@ class YarrGenerator final : public YarrJITInfo {
             case YarrOpCode::ParenthesesSubpatternTerminalEnd: {
                 YarrOp& beginOp = m_ops[op.m_previousOp];
                 PatternTerm* term = op.m_term;
+                ASSERT(term->quantityType == QuantifierType::Greedy);
+                ASSERT(term->quantityMaxCount == quantifyInfinite);
+                ASSERT(!term->quantityMinCount || term->quantityMinCount == 1);
 
                 termMatchTargets.takeLast();
 
                 // If the nested alternative matched without consuming any characters, punt this back to the interpreter.
                 // FIXME: <https://bugs.webkit.org/show_bug.cgi?id=200786> Add ability for the YARR JIT to properly
                 // handle nested expressions that can match without consuming characters
-                if (term->quantityType != QuantifierType::FixedCount && !term->parentheses.disjunction->m_minimumSize)
-                    m_abortExecution.append(m_jit.branch32(MacroAssembler::Equal, m_regs.index, frameAddress().withOffset(term->frameLocation * sizeof(void*))));
+                if (!term->parentheses.disjunction->m_minimumSize)
+                    m_abortExecution.append(m_jit.branch32(MacroAssembler::Equal, m_regs.index, frameAddress().withOffset((term->frameLocation + BackTrackInfoParenthesesTerminal::beginIndex()) * sizeof(void*))));
 
                 // We know that the match is non-zero, we can accept it and
                 // loop back up to the head of the subpattern.
@@ -5117,16 +5129,26 @@ class YarrGenerator final : public YarrJITInfo {
 
             // YarrOpCode::ParenthesesSubpatternTerminalBegin/End
             //
-            // Terminal subpatterns will always match - there is nothing after them to
-            // force a backtrack, and they have a minimum count of 0, and as such will
-            // always produce an acceptable result.
+            // Terminal subpatterns have nothing after them (since it is terminal) to force a backtrack
+            // into the previous iteration, so the only backtrack they ever see is their own inner-iteration's
+            // content-backtracking. Once the minimum count is met, they can simply accept the iterations.
             case YarrOpCode::ParenthesesSubpatternTerminalBegin: {
-                // We will backtrack to this point once the subpattern cannot match any
-                // more. Since no match is accepted as a successful match (we are Greedy
-                // quantified with a minimum of zero) jump back to the forwards matching
-                // path at the end.
+                PatternTerm* term = op.m_term;
                 YarrOp& endOp = m_ops[op.m_nextOp];
-                m_backtrackingState.linkTo(endOp.m_reentry, &m_jit);
+                if (!term->quantityMinCount) {
+                    // With a minimum of zero, any number of iterations is accepted.
+                    // Just accepting and returning back to the forward matching path.
+                    m_backtrackingState.linkTo(endOp.m_reentry, &m_jit);
+                    break;
+                }
+
+                // If we succeed the iteration at least once, then the group's entry index differs
+                // from the current one, and the iterations can be accepted by returning back to the
+                // forward matching path. Otherwise, fallthrough.
+                ASSERT(term->quantityMinCount == 1);
+                m_backtrackingState.link(*this, op);
+                m_jit.branch32(MacroAssembler::NotEqual, m_regs.index, frameAddress().withOffset((term->frameLocation + BackTrackInfoParenthesesTerminal::entryPositionIndex()) * sizeof(void*))).linkTo(endOp.m_reentry, &m_jit);
+                m_backtrackingState.fallthrough();
                 break;
             }
             case YarrOpCode::ParenthesesSubpatternTerminalEnd:

--- a/Source/JavaScriptCore/yarr/YarrPattern.cpp
+++ b/Source/JavaScriptCore/yarr/YarrPattern.cpp
@@ -2094,124 +2094,149 @@ public:
             && !m_pattern.m_numDuplicateNamedCaptureGroups
             && !m_pattern.m_containsLookbehinds;
 
-        if (m_pattern.m_numSubpatterns && !ignoreCaptures)
-            return;
+        auto& alternatives = m_pattern.m_body->m_alternatives;
+        bool hasObservableCaptures = m_pattern.m_numSubpatterns && !ignoreCaptures;
+        if (!hasObservableCaptures) {
+            alternatives.last()->m_isLastAlternative = true;
 
-        Vector<std::unique_ptr<PatternAlternative>>& alternatives = m_pattern.m_body->m_alternatives;
-        alternatives.last()->m_isLastAlternative = true;
+            if (alternatives.size() == 1 && alternatives[0]->m_startsWithBOL) {
+                Vector<PatternTerm>& terms = alternatives[0]->m_terms;
 
-        if (alternatives.size() == 1 && alternatives[0]->m_startsWithBOL) {
-            Vector<PatternTerm>& terms = alternatives[0]->m_terms;
+                bool isStringList = false;
 
-            bool isStringList = false;
+                if (terms.size() >= 2
+                    && terms[0].type == PatternTerm::Type::AssertionBOL
+                    && terms[1].type == PatternTerm::Type::ParenthesesSubpattern
+                    && terms[1].quantityType == QuantifierType::FixedCount
+                    && terms[1].quantityMaxCount == 1
+                    && !terms[1].parentheses.isCopy
+                    && (terms.size() == 2
+                        || (terms.size() == 3 && terms[2].type == PatternTerm::Type::AssertionEOL && !m_pattern.multiline()))) {
+                    // We start assuming this is a string list and then prove the negative.
+                    isStringList = true;
 
-            if (terms.size() >= 2
-                && terms[0].type == PatternTerm::Type::AssertionBOL
-                && terms[1].type == PatternTerm::Type::ParenthesesSubpattern
-                && terms[1].quantityType == QuantifierType::FixedCount
-                && terms[1].quantityMaxCount == 1
-                && !terms[1].parentheses.isCopy
-                && (terms.size() == 2
-                    || (terms.size() == 3 && terms[2].type == PatternTerm::Type::AssertionEOL && !m_pattern.multiline()))) {
-                // We start assuming this is a string list and then prove the negative.
-                isStringList = true;
+                    PatternTerm& term = terms[1];
 
-                PatternTerm& term = terms[1];
+                    PatternDisjunction* nestedDisjunction = term.parentheses.disjunction;
+                    constexpr unsigned emptyAlternativeNotFound = std::numeric_limits<unsigned>::max();
+                    unsigned firstEmptyAlternative = emptyAlternativeNotFound;
 
-                PatternDisjunction* nestedDisjunction = term.parentheses.disjunction;
-                constexpr unsigned emptyAlternativeNotFound = std::numeric_limits<unsigned>::max();
-                unsigned firstEmptyAlternative = emptyAlternativeNotFound;
+                    auto isPureCharacterSequence = [](const Vector<PatternTerm>& innerTerms) {
+                        for (auto& innerTerm : innerTerms) {
+                            if (innerTerm.type != PatternTerm::Type::PatternCharacter
+                                || innerTerm.quantityType != QuantifierType::FixedCount
+                                || innerTerm.quantityMaxCount != 1)
+                                return false;
+                        }
+                        return true;
+                    };
 
-                auto isPureCharacterSequence = [](const Vector<PatternTerm>& innerTerms) {
-                    for (auto& innerTerm : innerTerms) {
-                        if (innerTerm.type != PatternTerm::Type::PatternCharacter
-                            || innerTerm.quantityType != QuantifierType::FixedCount
-                            || innerTerm.quantityMaxCount != 1)
-                            return false;
+                    // When ignoring captures, an alternative that is exactly one once-quantified group
+                    // wrapping a pure fixed string (e.g. "(t0)") is equivalent to that string for
+                    // matching purposes. Returns the wrapped disjunction so the caller can flatten the
+                    // alternative to the group's character terms; nullptr if the shape does not match.
+                    auto unwrapSingleGroup = [&](const Vector<PatternTerm>& innerTerms) -> PatternDisjunction* {
+                        if (innerTerms.size() != 1)
+                            return nullptr;
+
+                        const PatternTerm& only = innerTerms[0];
+                        if (only.type != PatternTerm::Type::ParenthesesSubpattern
+                            || only.quantityType != QuantifierType::FixedCount
+                            || only.quantityMinCount != 1
+                            || only.quantityMaxCount != 1
+                            || only.parentheses.isCopy)
+                            return nullptr;
+
+                        PatternDisjunction* inner = only.parentheses.disjunction;
+                        if (inner->m_alternatives.size() != 1)
+                            return nullptr;
+
+                        // Leave an empty capture group (e.g. "()") to the generic path: flattening it to
+                        // an empty sequence would hide it from the empty-alternative bookkeeping below,
+                        // which scans the pre-flattened terms.
+                        if (inner->m_alternatives[0]->m_terms.isEmpty())
+                            return nullptr;
+
+                        if (!isPureCharacterSequence(inner->m_alternatives[0]->m_terms))
+                            return nullptr;
+
+                        return inner;
+                    };
+
+                    // Pass 1: confirm every alternative is a fixed string (possibly after seeing through a
+                    // single wrapping group). Do not mutate the tree yet, so a late non-string alternative
+                    // never leaves a half-rewritten tree.
+                    for (unsigned alt = 0; isStringList && alt < nestedDisjunction->m_alternatives.size(); ++alt) {
+                        const auto& innerTerms = nestedDisjunction->m_alternatives[alt]->m_terms;
+
+                        if (innerTerms.isEmpty() && firstEmptyAlternative == emptyAlternativeNotFound)
+                            firstEmptyAlternative = alt;
+
+                        if (isPureCharacterSequence(innerTerms))
+                            continue;
+                        if (ignoreCaptures && unwrapSingleGroup(innerTerms))
+                            continue;
+                        isStringList = false;
                     }
-                    return true;
-                };
 
-                // When ignoring captures, an alternative that is exactly one once-quantified group
-                // wrapping a pure fixed string (e.g. "(t0)") is equivalent to that string for
-                // matching purposes. Returns the wrapped disjunction so the caller can flatten the
-                // alternative to the group's character terms; nullptr if the shape does not match.
-                auto unwrapSingleGroup = [&](const Vector<PatternTerm>& innerTerms) -> PatternDisjunction* {
-                    if (innerTerms.size() != 1)
-                        return nullptr;
+                    // Pass 2: now that the whole list is confirmed, flatten any wrapped-group alternatives
+                    // by replacing the group term with a copy of its character terms.
+                    if (isStringList && ignoreCaptures) {
+                        for (auto& alternative : nestedDisjunction->m_alternatives) {
+                            if (PatternDisjunction* inner = unwrapSingleGroup(alternative->m_terms))
+                                alternative->m_terms = inner->m_alternatives[0]->m_terms;
+                        }
+                    }
 
-                    const PatternTerm& only = innerTerms[0];
-                    if (only.type != PatternTerm::Type::ParenthesesSubpattern
-                        || only.quantityType != QuantifierType::FixedCount
-                        || only.quantityMinCount != 1
-                        || only.quantityMaxCount != 1
-                        || only.parentheses.isCopy)
-                        return nullptr;
+                    bool isEOLStringList = terms.size() == 3 && terms[2].type == PatternTerm::Type::AssertionEOL;
+                    term.parentheses.isStringList = isStringList;
+                    term.parentheses.isEOLStringList = isEOLStringList;
 
-                    PatternDisjunction* inner = only.parentheses.disjunction;
-                    if (inner->m_alternatives.size() != 1)
-                        return nullptr;
-
-                    // Leave an empty capture group (e.g. "()") to the generic path: flattening it to
-                    // an empty sequence would hide it from the empty-alternative bookkeeping below,
-                    // which scans the pre-flattened terms.
-                    if (inner->m_alternatives[0]->m_terms.isEmpty())
-                        return nullptr;
-
-                    if (!isPureCharacterSequence(inner->m_alternatives[0]->m_terms))
-                        return nullptr;
-
-                    return inner;
-                };
-
-                // Pass 1: confirm every alternative is a fixed string (possibly after seeing through a
-                // single wrapping group). Do not mutate the tree yet, so a late non-string alternative
-                // never leaves a half-rewritten tree.
-                for (unsigned alt = 0; isStringList && alt < nestedDisjunction->m_alternatives.size(); ++alt) {
-                    const auto& innerTerms = nestedDisjunction->m_alternatives[alt]->m_terms;
-
-                    if (innerTerms.isEmpty() && firstEmptyAlternative == emptyAlternativeNotFound)
-                        firstEmptyAlternative = alt;
-
-                    if (isPureCharacterSequence(innerTerms))
-                        continue;
-                    if (ignoreCaptures && unwrapSingleGroup(innerTerms))
-                        continue;
-                    isStringList = false;
-                }
-
-                // Pass 2: now that the whole list is confirmed, flatten any wrapped-group alternatives
-                // by replacing the group term with a copy of its character terms.
-                if (isStringList && ignoreCaptures) {
-                    for (auto& alternative : nestedDisjunction->m_alternatives) {
-                        if (PatternDisjunction* inner = unwrapSingleGroup(alternative->m_terms))
-                            alternative->m_terms = inner->m_alternatives[0]->m_terms;
+                    // In a non-EOL string list the first empty alternative always matches and ends the match, so later
+                    // alternatives are unreachable. Drop them so the empty alternative is last and the JIT can fall through to success.
+                    if (isStringList && !isEOLStringList && firstEmptyAlternative != emptyAlternativeNotFound && firstEmptyAlternative + 1 < nestedDisjunction->m_alternatives.size()) {
+                        nestedDisjunction->m_alternatives.shrink(firstEmptyAlternative + 1);
+                        nestedDisjunction->m_alternatives.last()->m_isLastAlternative = true;
                     }
                 }
 
-                bool isEOLStringList = terms.size() == 3 && terms[2].type == PatternTerm::Type::AssertionEOL;
-                term.parentheses.isStringList = isStringList;
-                term.parentheses.isEOLStringList = isEOLStringList;
-
-                // In a non-EOL string list the first empty alternative always matches and ends the match, so later
-                // alternatives are unreachable. Drop them so the empty alternative is last and the JIT can fall through to success.
-                if (isStringList && !isEOLStringList && firstEmptyAlternative != emptyAlternativeNotFound && firstEmptyAlternative + 1 < nestedDisjunction->m_alternatives.size()) {
-                    nestedDisjunction->m_alternatives.shrink(firstEmptyAlternative + 1);
-                    nestedDisjunction->m_alternatives.last()->m_isLastAlternative = true;
-                }
+                if (isStringList)
+                    return;
             }
-
-            if (isStringList)
-                return;
         }
 
         for (auto& alternative : alternatives) {
             auto& terms = alternative->m_terms;
             if (terms.size()) {
+                // Greedy * or + non-capturing parens in the tail position does not need inter-iteration backtracking state.
+                // 1. For * case (term.quantityMinCount == 0)
+                //
+                // Pattern like /(?:AA|A)*/ can never fail, because * succeeds even with zero iterations.
+                // And because it is in the tail position, all backtracking are coming from the
+                // greedy matching attempt of (?:AA|A). This means that we will never restore the
+                // previous iteration's state to explore a different matching. When we failed in the current
+                // iteration, we can just say "the matching is complete" because we are at the terminal position.
+                //
+                // 2. For + case (term.quantityMinCount == 1)
+                //
+                // Pattern like /(?:AA|A)+/ will need to match at least once. If we failed in this 1st iteration,
+                // since this is the initial iteration, we have no context to restore, and we can simply fail.
+                // If we matched once and in the second iteration, if we failed to match, then we also do not need
+                // to restore to the 1st iteration since we already succeeded the 1st iteration (and + suffices),
+                // and since it is a terminal position, we can just say "the matching is complete"
+                //
+                // As a result, term.quantityMinCount <= 1 cases never require per-iteration ParenContext when
+                // we have these greedy patterns at the terminal position. Thus we mark them `isTerminal` to
+                // skip ParenContext generation as an optimization.
+                //
+                // On the other hand, term.quantityMinCount >= 2 cannot work in this way. Let's have a RegExp matching
+                // `/(?:AA|A){2,}/.exec("AA")`. The right answer is "AA" since "A" and "A" matches with 2 iterations.
+                // But this is achieved by restoring the 1st iteration and taking a different alternative "A" instead of "AA".
+                // Thus, inter-iteration backtracking state is necessary for this case.
                 PatternTerm& term = terms.last();
                 if (term.type == PatternTerm::Type::ParenthesesSubpattern
                     && term.quantityType == QuantifierType::Greedy
-                    && term.quantityMinCount == 0
+                    && term.quantityMinCount <= 1
                     && term.quantityMaxCount == quantifyInfinite
                     && !term.capture()
                     && !term.containsAnyCaptures())

--- a/Source/JavaScriptCore/yarr/YarrPattern.h
+++ b/Source/JavaScriptCore/yarr/YarrPattern.h
@@ -877,8 +877,10 @@ private:
 
     struct BackTrackInfoParenthesesTerminal {
         uintptr_t begin;
+        uintptr_t entryPosition;
 
         static unsigned beginIndex() { return offsetof(BackTrackInfoParenthesesTerminal, begin) / sizeof(uintptr_t); }
+        static unsigned entryPositionIndex() { return offsetof(BackTrackInfoParenthesesTerminal, entryPosition) / sizeof(uintptr_t); }
     };
 
     struct BackTrackInfoParentheses {


### PR DESCRIPTION
#### 7c5dbbcba11029727e3494d5a12ae482a542774d
<pre>
[YARR] Extend ParenthesesSubpatternTerminal
<a href="https://bugs.webkit.org/show_bug.cgi?id=320533">https://bugs.webkit.org/show_bug.cgi?id=320533</a>
<a href="https://rdar.apple.com/183490993">rdar://183490993</a>

Reviewed by Yijia Huang.

Greedy * or + non-capturing parens in the tail position does not need inter-iteration backtracking state.

1. For * case (term.quantityMinCount == 0)

    Pattern like /(?:AA|A)*/ can never fail, because * succeeds even with zero iterations.
    And because it is in the tail position, all backtracking are coming from the
    greedy matching attempt of (?:AA|A). This means that we will never restore the
    previous iteration&apos;s state to explore a different matching. When we failed in the current
    iteration, we can just say &quot;the matching is complete&quot; because we are at the terminal position.

2. For + case (term.quantityMinCount == 1)

    Pattern like /(?:AA|A)+/ will need to match at least once. If we failed in this 1st iteration,
    since this is the initial iteration, we have no context to restore, and we can simply fail.
    If we matched once and in the second iteration, if we failed to match, then we also do not need
    to restore to the 1st iteration since we already succeeded the 1st iteration (and + suffices),
    and since it is a terminal position, we can just say &quot;the matching is complete&quot;

As a result, term.quantityMinCount &lt;= 1 cases never require per-iteration ParenContext when
we have these greedy patterns at the terminal position. Thus we can mark them `isTerminal` to
skip ParenContext generation as an optimization.

On the other hand, term.quantityMinCount &gt;= 2 cannot work in this way. Let&apos;s have a RegExp matching
`/(?:AA|A){2,}/.exec(&quot;AA&quot;)`. The right answer is &quot;AA&quot; since &quot;A&quot; and &quot;A&quot; matches with 2 iterations.
But this is achieved by restoring the 1st iteration and taking a different alternative &quot;A&quot; instead of &quot;AA&quot;.
Thus, inter-iteration backtracking state is necessary for this case.

Tests: JSTests/stress/yarr-terminal-parentheses-captures.js
       JSTests/stress/yarr-terminal-parentheses-frame-layout.js
       JSTests/stress/yarr-terminal-parentheses-min-count.js

* JSTests/stress/yarr-terminal-parentheses-captures.js: Added.
(shouldBe):
(testExec):
* JSTests/stress/yarr-terminal-parentheses-frame-layout.js: Added.
(shouldBe):
(test):
* JSTests/stress/yarr-terminal-parentheses-min-count.js: Added.
(shouldBe):
(test):
* Source/JavaScriptCore/yarr/Yarr.h:
* Source/JavaScriptCore/yarr/YarrInterpreter.cpp:
(JSC::Yarr::Interpreter::matchParenthesesTerminalBegin):
(JSC::Yarr::Interpreter::matchParenthesesTerminalEnd):
(JSC::Yarr::Interpreter::backtrackParenthesesTerminalBegin):
* Source/JavaScriptCore/yarr/YarrJIT.cpp:
* Source/JavaScriptCore/yarr/YarrPattern.cpp:
(JSC::Yarr::YarrPatternConstructor::checkForTerminalParentheses):
* Source/JavaScriptCore/yarr/YarrPattern.h:
(JSC::Yarr::BackTrackInfoParenthesesTerminal::entryPositionIndex):

Canonical link: <a href="https://commits.webkit.org/318163@main">https://commits.webkit.org/318163@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/af1d8fc29089f97f80a32fe353012fd290bef597

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177438 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51376 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45170 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187042 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140685 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52668 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51085 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138291 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140685 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180394 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41786 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159034 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118756 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40448 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38823 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/725 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/7533 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150855 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38531 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35509 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/38709 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/43161 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43057 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189470 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51043 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147381 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51725 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35158 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147173 "") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26919 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41889 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123940 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118299 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50233 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13509 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49629 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49869 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49691 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->