### PR TITLE
executeBundles re-replays bundles containing indirect draws and reconstructs ICBs every call — 30× frame-rate collapse vs direct encoding

### DIFF
--- a/LayoutTests/fast/webgpu/render-bundle-draw-indexed-indirect-clamped-expected.txt
+++ b/LayoutTests/fast/webgpu/render-bundle-draw-indexed-indirect-clamped-expected.txt
@@ -1,0 +1,11 @@
+Regression test for bugs.webkit.org/show_bug.cgi?id=264219: a render bundle containing drawIndexedIndirect whose pipeline consumes a real vertex-step-mode @location buffer, so the draw must go through the batched two-dispatch index clamp path (clampIndirectIndexBufferDispatch1Batched + clampIndirectIndexBufferDispatch2Batched + the anyIndexedClamp barrier, where the offset/length overflow guard lives) at executeBundles time rather than reading the app's raw args. Renders a full-target triangle via a bundle of drawIndexedIndirect into a 1x1 texture, reads the pixel back, and executes the bundle twice.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS frame0.join() is "0,255,0,255"
+PASS frame1.join() is "0,255,0,255"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/webgpu/render-bundle-draw-indexed-indirect-clamped.html
+++ b/LayoutTests/fast/webgpu/render-bundle-draw-indexed-indirect-clamped.html
@@ -1,0 +1,105 @@
+<script src="../../resources/js-test.js"></script>
+<script>
+
+jsTestIsAsync = true;
+
+description("Regression test for bugs.webkit.org/show_bug.cgi?id=264219: a render bundle containing " +
+           "drawIndexedIndirect whose pipeline consumes a real vertex-step-mode @location buffer, so the " +
+           "draw must go through the batched two-dispatch index clamp path " +
+           "(clampIndirectIndexBufferDispatch1Batched + clampIndirectIndexBufferDispatch2Batched + the " +
+           "anyIndexedClamp barrier, where the offset/length overflow guard lives) at executeBundles time " +
+           "rather than reading the app's raw args. Renders a full-target triangle via a bundle of " +
+           "drawIndexedIndirect into a 1x1 texture, reads the pixel back, and executes the bundle twice.");
+
+async function main() {
+    let adapter = await navigator.gpu.requestAdapter({});
+    let device = await adapter.requestDevice({});
+    device.pushErrorScope('validation');
+
+    const format = 'rgba8unorm';
+    // The vertex shader reads a real @location(0) attribute, so the pipeline has a required vertex-step-mode
+    // buffer. computeMininumVertexInstanceCount then returns a finite minVertexCount (not the invalid
+    // sentinel), which makes IndirectEncodeWork::clamps true and routes the draw through the clamp path.
+    let module = device.createShaderModule({ code: `
+        @vertex fn vs(@location(0) p: vec2f) -> @builtin(position) vec4f {
+            return vec4f(p, 0, 1);
+        }
+        @fragment fn fs() -> @location(0) vec4f { return vec4f(0, 1, 0, 1); }
+    ` });
+    let pipeline = device.createRenderPipeline({
+        layout: 'auto',
+        vertex: {
+            module,
+            entryPoint: 'vs',
+            buffers: [{ arrayStride: 8, attributes: [{ shaderLocation: 0, offset: 0, format: 'float32x2' }] }],
+        },
+        fragment: { module, entryPoint: 'fs', targets: [{ format }] },
+        primitive: { topology: 'triangle-list' },
+    });
+
+    // A full-target triangle indexed as 0,1,2. 3 vertices => vertex buffer big enough that the clamp keeps
+    // vertexCount at 3.
+    let vertexData = new Float32Array([-1, -3, -1, 1, 3, 1]);
+    let vertexBuffer = device.createBuffer({ size: vertexData.byteLength, usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST });
+    device.queue.writeBuffer(vertexBuffer, 0, vertexData);
+
+    let indexData = new Uint16Array([0, 1, 2, 0]); // 4 => 8 bytes (uint16 index buffer must be > 4 bytes)
+    let indexBuffer = device.createBuffer({ size: indexData.byteLength, usage: GPUBufferUsage.INDEX | GPUBufferUsage.COPY_DST });
+    device.queue.writeBuffer(indexBuffer, 0, indexData);
+
+    // MTLDrawIndexedPrimitivesIndirectArguments layout: indexCount, instanceCount, firstIndex, baseVertex, firstInstance.
+    let args = new Uint32Array([3, 1, 0, 0, 0]);
+    let argsBuffer = device.createBuffer({ size: args.byteLength, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.COPY_DST });
+    device.queue.writeBuffer(argsBuffer, 0, args);
+
+    let enc = device.createRenderBundleEncoder({ colorFormats: [format] });
+    enc.setPipeline(pipeline);
+    enc.setVertexBuffer(0, vertexBuffer);
+    enc.setIndexBuffer(indexBuffer, 'uint16');
+    enc.drawIndexedIndirect(argsBuffer, 0);
+    let bundle = enc.finish();
+
+    let texture = device.createTexture({ size: [1, 1], format, usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.COPY_SRC });
+    let readback = device.createBuffer({ size: 256, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ });
+
+    function drawAndReadback() {
+        let commandEncoder = device.createCommandEncoder();
+        let pass = commandEncoder.beginRenderPass({
+            colorAttachments: [{ view: texture.createView(), loadOp: 'clear', storeOp: 'store', clearValue: { r: 1, g: 0, b: 0, a: 1 } }],
+        });
+        pass.executeBundles([bundle]);
+        pass.end();
+        commandEncoder.copyTextureToBuffer({ texture }, { buffer: readback, bytesPerRow: 256 }, [1, 1]);
+        device.queue.submit([commandEncoder.finish()]);
+    }
+
+    // Two frames reusing the same bundle: both must render the clamped triangle (green), not the clear (red).
+    drawAndReadback();
+    await device.queue.onSubmittedWorkDone();
+    await readback.mapAsync(GPUMapMode.READ);
+    let frame0 = [...new Uint8Array(readback.getMappedRange(0, 4))];
+    readback.unmap();
+
+    drawAndReadback();
+    await device.queue.onSubmittedWorkDone();
+    await readback.mapAsync(GPUMapMode.READ);
+    let frame1 = [...new Uint8Array(readback.getMappedRange(0, 4))];
+    readback.unmap();
+
+    window.frame0 = frame0;
+    window.frame1 = frame1;
+    shouldBeEqualToString('frame0.join()', '0,255,0,255');
+    shouldBeEqualToString('frame1.join()', '0,255,0,255');
+
+    let error = await device.popErrorScope();
+    if (error)
+        testFailed(error.message);
+}
+
+main().catch(e => {
+    testFailed("Exception: " + e);
+}).finally(() => {
+    finishJSTest();
+});
+
+</script>

--- a/LayoutTests/fast/webgpu/render-bundle-draw-indexed-indirect-expected.txt
+++ b/LayoutTests/fast/webgpu/render-bundle-draw-indexed-indirect-expected.txt
@@ -1,0 +1,11 @@
+Regression test for bugs.webkit.org/show_bug.cgi?id=264219: a render bundle containing drawIndexedIndirect must actually render (its draw is GPU-encoded into the bundle's persistent MTLIndirectCommandBuffer at executeBundles time). Renders a full-target triangle via a bundle of drawIndexedIndirect into a 1x1 texture and reads the pixel back, executing the bundle twice to exercise reuse of the baked bundle across submits.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS frame0.join() is "0,255,0,255"
+PASS frame1.join() is "0,255,0,255"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/webgpu/render-bundle-draw-indexed-indirect-invalidation-expected.txt
+++ b/LayoutTests/fast/webgpu/render-bundle-draw-indexed-indirect-invalidation-expected.txt
@@ -1,0 +1,11 @@
+Regression test for bugs.webkit.org/show_bug.cgi?id=264219: exercises the render bundle indirect-draw skip cache's invalidation path. executeBundles GPU-encodes a drawIndexedIndirect into the bundle's persistent ICB slot only when the indirect buffer's contents generation changed since the last encode (data.lastIndirectGeneration); otherwise the previously baked slot is reused. The draw count (indexCount) is baked into the ICB slot at encode time, so rewriting the indirect args buffer between two executeBundles() calls on the same bundle MUST force a re-encode. A real vertex-step-mode @location buffer is bound so the re-encode also re-runs the batched min-count clamp path. frame0 draws the triangle (green); after rewriting indexCount to 0 the re-encoded slot draws nothing, so frame1 is the red clear. A stale (non-invalidated) cache would leave frame1 green.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS frame0.join() is "0,255,0,255"
+PASS frame1.join() is "255,0,0,255"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/webgpu/render-bundle-draw-indexed-indirect-invalidation.html
+++ b/LayoutTests/fast/webgpu/render-bundle-draw-indexed-indirect-invalidation.html
@@ -1,0 +1,109 @@
+<script src="../../resources/js-test.js"></script>
+<script>
+
+jsTestIsAsync = true;
+
+description("Regression test for bugs.webkit.org/show_bug.cgi?id=264219: exercises the render bundle " +
+           "indirect-draw skip cache's invalidation path. executeBundles GPU-encodes a drawIndexedIndirect " +
+           "into the bundle's persistent ICB slot only when the indirect buffer's contents generation changed " +
+           "since the last encode (data.lastIndirectGeneration); otherwise the previously baked slot is reused. " +
+           "The draw count (indexCount) is baked into the ICB slot at encode time, so rewriting the indirect " +
+           "args buffer between two executeBundles() calls on the same bundle MUST force a re-encode. A real " +
+           "vertex-step-mode @location buffer is bound so the re-encode also re-runs the batched min-count " +
+           "clamp path. frame0 draws the triangle (green); after rewriting indexCount to 0 the re-encoded slot " +
+           "draws nothing, so frame1 is the red clear. A stale (non-invalidated) cache would leave frame1 green.");
+
+async function main() {
+    let adapter = await navigator.gpu.requestAdapter({});
+    let device = await adapter.requestDevice({});
+    device.pushErrorScope('validation');
+
+    const format = 'rgba8unorm';
+    // The vertex shader reads a real @location(0) attribute, so the pipeline has a required vertex-step-mode
+    // buffer and IndirectEncodeWork::clamps is true: the re-encode re-runs the batched clamp path too.
+    let module = device.createShaderModule({ code: `
+        @vertex fn vs(@location(0) p: vec2f) -> @builtin(position) vec4f {
+            return vec4f(p, 0, 1);
+        }
+        @fragment fn fs() -> @location(0) vec4f { return vec4f(0, 1, 0, 1); }
+    ` });
+    let pipeline = device.createRenderPipeline({
+        layout: 'auto',
+        vertex: {
+            module,
+            entryPoint: 'vs',
+            buffers: [{ arrayStride: 8, attributes: [{ shaderLocation: 0, offset: 0, format: 'float32x2' }] }],
+        },
+        fragment: { module, entryPoint: 'fs', targets: [{ format }] },
+        primitive: { topology: 'triangle-list' },
+    });
+
+    let vertexData = new Float32Array([-1, -3, -1, 1, 3, 1]);
+    let vertexBuffer = device.createBuffer({ size: vertexData.byteLength, usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST });
+    device.queue.writeBuffer(vertexBuffer, 0, vertexData);
+
+    let indexData = new Uint16Array([0, 1, 2, 0]); // 4 => 8 bytes (uint16 index buffer must be > 4 bytes)
+    let indexBuffer = device.createBuffer({ size: indexData.byteLength, usage: GPUBufferUsage.INDEX | GPUBufferUsage.COPY_DST });
+    device.queue.writeBuffer(indexBuffer, 0, indexData);
+
+    // MTLDrawIndexedPrimitivesIndirectArguments layout: indexCount, instanceCount, firstIndex, baseVertex, firstInstance.
+    let argsBuffer = device.createBuffer({ size: 20, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.COPY_DST });
+    device.queue.writeBuffer(argsBuffer, 0, new Uint32Array([3, 1, 0, 0, 0]));
+
+    let enc = device.createRenderBundleEncoder({ colorFormats: [format] });
+    enc.setPipeline(pipeline);
+    enc.setVertexBuffer(0, vertexBuffer);
+    enc.setIndexBuffer(indexBuffer, 'uint16');
+    enc.drawIndexedIndirect(argsBuffer, 0);
+    let bundle = enc.finish();
+
+    let texture = device.createTexture({ size: [1, 1], format, usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.COPY_SRC });
+    let readback = device.createBuffer({ size: 256, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ });
+
+    function drawAndReadback() {
+        let commandEncoder = device.createCommandEncoder();
+        let pass = commandEncoder.beginRenderPass({
+            colorAttachments: [{ view: texture.createView(), loadOp: 'clear', storeOp: 'store', clearValue: { r: 1, g: 0, b: 0, a: 1 } }],
+        });
+        pass.executeBundles([bundle]);
+        pass.end();
+        commandEncoder.copyTextureToBuffer({ texture }, { buffer: readback, bytesPerRow: 256 }, [1, 1]);
+        device.queue.submit([commandEncoder.finish()]);
+    }
+
+    // Frame 0: first executeBundles encodes the slot (indexCount 3) -> triangle -> green.
+    drawAndReadback();
+    await device.queue.onSubmittedWorkDone();
+    await readback.mapAsync(GPUMapMode.READ);
+    let frame0 = [...new Uint8Array(readback.getMappedRange(0, 4))];
+    readback.unmap();
+
+    // Rewrite the same indirect args buffer: indexCount 3 -> 0. This bumps the buffer's contents generation,
+    // which must invalidate the skip cache and force the second executeBundles to re-encode the slot.
+    device.queue.writeBuffer(argsBuffer, 0, new Uint32Array([0, 1, 0, 0, 0]));
+
+    // Frame 1: same bundle. If the cache invalidates, the slot is re-encoded with indexCount 0 -> nothing
+    // drawn -> red clear. If it did not invalidate, the stale slot would still draw green.
+    drawAndReadback();
+    await device.queue.onSubmittedWorkDone();
+    await readback.mapAsync(GPUMapMode.READ);
+    let frame1 = [...new Uint8Array(readback.getMappedRange(0, 4))];
+    readback.unmap();
+
+    window.frame0 = frame0;
+    window.frame1 = frame1;
+    shouldBeEqualToString('frame0.join()', '0,255,0,255');
+    shouldBeEqualToString('frame1.join()', '255,0,0,255');
+
+    let error = await device.popErrorScope();
+    if (error)
+        testFailed(error.message);
+}
+
+main().catch(e => {
+    testFailed("Exception: " + e);
+}).finally(() => {
+    finishJSTest();
+});
+
+</script>

--- a/LayoutTests/fast/webgpu/render-bundle-draw-indexed-indirect.html
+++ b/LayoutTests/fast/webgpu/render-bundle-draw-indexed-indirect.html
@@ -1,0 +1,90 @@
+<script src="../../resources/js-test.js"></script>
+<script>
+
+jsTestIsAsync = true;
+
+description("Regression test for bugs.webkit.org/show_bug.cgi?id=264219: a render bundle containing " +
+           "drawIndexedIndirect must actually render (its draw is GPU-encoded into the bundle's persistent " +
+           "MTLIndirectCommandBuffer at executeBundles time). Renders a full-target triangle via a bundle of " +
+           "drawIndexedIndirect into a 1x1 texture and reads the pixel back, executing the bundle twice to " +
+           "exercise reuse of the baked bundle across submits.");
+
+async function main() {
+    let adapter = await navigator.gpu.requestAdapter({});
+    let device = await adapter.requestDevice({});
+    device.pushErrorScope('validation');
+
+    const format = 'rgba8unorm';
+    let module = device.createShaderModule({ code: `
+        @vertex fn vs(@builtin(vertex_index) i: u32) -> @builtin(position) vec4f {
+            var p = array(vec2f(-1, -3), vec2f(-1, 1), vec2f(3, 1));
+            return vec4f(p[i], 0, 1);
+        }
+        @fragment fn fs() -> @location(0) vec4f { return vec4f(0, 1, 0, 1); }
+    ` });
+    let pipeline = device.createRenderPipeline({
+        layout: 'auto',
+        vertex: { module, entryPoint: 'vs' },
+        fragment: { module, entryPoint: 'fs', targets: [{ format }] },
+        primitive: { topology: 'triangle-list' },
+    });
+
+    let indexData = new Uint16Array([0, 1, 2, 0]); // 4 => 8 bytes (uint16 index buffer must be > 4 bytes)
+    let indexBuffer = device.createBuffer({ size: indexData.byteLength, usage: GPUBufferUsage.INDEX | GPUBufferUsage.COPY_DST });
+    device.queue.writeBuffer(indexBuffer, 0, indexData);
+
+    // MTLDrawIndexedPrimitivesIndirectArguments layout: indexCount, instanceCount, firstIndex, baseVertex, firstInstance.
+    let args = new Uint32Array([3, 1, 0, 0, 0]);
+    let argsBuffer = device.createBuffer({ size: args.byteLength, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.COPY_DST });
+    device.queue.writeBuffer(argsBuffer, 0, args);
+
+    let enc = device.createRenderBundleEncoder({ colorFormats: [format] });
+    enc.setPipeline(pipeline);
+    enc.setIndexBuffer(indexBuffer, 'uint16');
+    enc.drawIndexedIndirect(argsBuffer, 0);
+    let bundle = enc.finish();
+
+    let texture = device.createTexture({ size: [1, 1], format, usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.COPY_SRC });
+    let readback = device.createBuffer({ size: 256, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ });
+
+    function drawAndReadback() {
+        let commandEncoder = device.createCommandEncoder();
+        let pass = commandEncoder.beginRenderPass({
+            colorAttachments: [{ view: texture.createView(), loadOp: 'clear', storeOp: 'store', clearValue: { r: 1, g: 0, b: 0, a: 1 } }],
+        });
+        pass.executeBundles([bundle]);
+        pass.end();
+        commandEncoder.copyTextureToBuffer({ texture }, { buffer: readback, bytesPerRow: 256 }, [1, 1]);
+        device.queue.submit([commandEncoder.finish()]);
+    }
+
+    // Two frames reusing the same bundle: both must render the triangle (green), not the clear (red).
+    drawAndReadback();
+    await device.queue.onSubmittedWorkDone();
+    await readback.mapAsync(GPUMapMode.READ);
+    let frame0 = [...new Uint8Array(readback.getMappedRange(0, 4))];
+    readback.unmap();
+
+    drawAndReadback();
+    await device.queue.onSubmittedWorkDone();
+    await readback.mapAsync(GPUMapMode.READ);
+    let frame1 = [...new Uint8Array(readback.getMappedRange(0, 4))];
+    readback.unmap();
+
+    window.frame0 = frame0;
+    window.frame1 = frame1;
+    shouldBeEqualToString('frame0.join()', '0,255,0,255');
+    shouldBeEqualToString('frame1.join()', '0,255,0,255');
+
+    let error = await device.popErrorScope();
+    if (error)
+        testFailed(error.message);
+}
+
+main().catch(e => {
+    testFailed("Exception: " + e);
+}).finally(() => {
+    finishJSTest();
+});
+
+</script>

--- a/LayoutTests/fast/webgpu/render-bundle-draw-indirect-clamped-expected.txt
+++ b/LayoutTests/fast/webgpu/render-bundle-draw-indirect-clamped-expected.txt
@@ -1,0 +1,11 @@
+Regression test for bugs.webkit.org/show_bug.cgi?id=264219: a render bundle containing drawIndirect (non-indexed) whose pipeline consumes a real vertex-step-mode @location buffer, so the draw must go through the batched min-count clamp path (clampIndirectBufferDispatchBatched + newZeroedIndirectScratch + the anyClampDispatched barrier) at executeBundles time rather than reading the app's raw args. Renders a full-target triangle via a bundle of drawIndirect into a 1x1 texture, reads the pixel back, and executes the bundle twice to exercise reuse of the baked bundle.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS frame0.join() is "0,255,0,255"
+PASS frame1.join() is "0,255,0,255"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/webgpu/render-bundle-draw-indirect-clamped.html
+++ b/LayoutTests/fast/webgpu/render-bundle-draw-indirect-clamped.html
@@ -1,0 +1,98 @@
+<script src="../../resources/js-test.js"></script>
+<script>
+
+jsTestIsAsync = true;
+
+description("Regression test for bugs.webkit.org/show_bug.cgi?id=264219: a render bundle containing " +
+           "drawIndirect (non-indexed) whose pipeline consumes a real vertex-step-mode @location buffer, so " +
+           "the draw must go through the batched min-count clamp path (clampIndirectBufferDispatchBatched + " +
+           "newZeroedIndirectScratch + the anyClampDispatched barrier) at executeBundles time rather than " +
+           "reading the app's raw args. Renders a full-target triangle via a bundle of drawIndirect into a " +
+           "1x1 texture, reads the pixel back, and executes the bundle twice to exercise reuse of the baked bundle.");
+
+async function main() {
+    let adapter = await navigator.gpu.requestAdapter({});
+    let device = await adapter.requestDevice({});
+    device.pushErrorScope('validation');
+
+    const format = 'rgba8unorm';
+    // The vertex shader reads a real @location(0) attribute, so the pipeline has a required vertex-step-mode
+    // buffer. computeMininumVertexInstanceCount then returns a finite minVertexCount (not the invalid
+    // sentinel), which makes IndirectEncodeWork::clamps true and routes the draw through the clamp path.
+    let module = device.createShaderModule({ code: `
+        @vertex fn vs(@location(0) p: vec2f) -> @builtin(position) vec4f {
+            return vec4f(p, 0, 1);
+        }
+        @fragment fn fs() -> @location(0) vec4f { return vec4f(0, 1, 0, 1); }
+    ` });
+    let pipeline = device.createRenderPipeline({
+        layout: 'auto',
+        vertex: {
+            module,
+            entryPoint: 'vs',
+            buffers: [{ arrayStride: 8, attributes: [{ shaderLocation: 0, offset: 0, format: 'float32x2' }] }],
+        },
+        fragment: { module, entryPoint: 'fs', targets: [{ format }] },
+        primitive: { topology: 'triangle-list' },
+    });
+
+    // A full-target triangle. 3 vertices => vertex buffer big enough that the clamp keeps vertexCount at 3.
+    let vertexData = new Float32Array([-1, -3, -1, 1, 3, 1]);
+    let vertexBuffer = device.createBuffer({ size: vertexData.byteLength, usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST });
+    device.queue.writeBuffer(vertexBuffer, 0, vertexData);
+
+    // MTLDrawPrimitivesIndirectArguments layout: vertexCount, instanceCount, firstVertex, firstInstance.
+    let args = new Uint32Array([3, 1, 0, 0]);
+    let argsBuffer = device.createBuffer({ size: args.byteLength, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.COPY_DST });
+    device.queue.writeBuffer(argsBuffer, 0, args);
+
+    let enc = device.createRenderBundleEncoder({ colorFormats: [format] });
+    enc.setPipeline(pipeline);
+    enc.setVertexBuffer(0, vertexBuffer);
+    enc.drawIndirect(argsBuffer, 0);
+    let bundle = enc.finish();
+
+    let texture = device.createTexture({ size: [1, 1], format, usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.COPY_SRC });
+    let readback = device.createBuffer({ size: 256, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ });
+
+    function drawAndReadback() {
+        let commandEncoder = device.createCommandEncoder();
+        let pass = commandEncoder.beginRenderPass({
+            colorAttachments: [{ view: texture.createView(), loadOp: 'clear', storeOp: 'store', clearValue: { r: 1, g: 0, b: 0, a: 1 } }],
+        });
+        pass.executeBundles([bundle]);
+        pass.end();
+        commandEncoder.copyTextureToBuffer({ texture }, { buffer: readback, bytesPerRow: 256 }, [1, 1]);
+        device.queue.submit([commandEncoder.finish()]);
+    }
+
+    // Two frames reusing the same bundle: both must render the clamped triangle (green), not the clear (red).
+    drawAndReadback();
+    await device.queue.onSubmittedWorkDone();
+    await readback.mapAsync(GPUMapMode.READ);
+    let frame0 = [...new Uint8Array(readback.getMappedRange(0, 4))];
+    readback.unmap();
+
+    drawAndReadback();
+    await device.queue.onSubmittedWorkDone();
+    await readback.mapAsync(GPUMapMode.READ);
+    let frame1 = [...new Uint8Array(readback.getMappedRange(0, 4))];
+    readback.unmap();
+
+    window.frame0 = frame0;
+    window.frame1 = frame1;
+    shouldBeEqualToString('frame0.join()', '0,255,0,255');
+    shouldBeEqualToString('frame1.join()', '0,255,0,255');
+
+    let error = await device.popErrorScope();
+    if (error)
+        testFailed(error.message);
+}
+
+main().catch(e => {
+    testFailed("Exception: " + e);
+}).finally(() => {
+    finishJSTest();
+});
+
+</script>

--- a/LayoutTests/fast/webgpu/render-bundle-draw-indirect-expected.txt
+++ b/LayoutTests/fast/webgpu/render-bundle-draw-indirect-expected.txt
@@ -1,0 +1,11 @@
+Regression test for bugs.webkit.org/show_bug.cgi?id=264219: a render bundle containing drawIndirect (non-indexed) must actually render, with its draw GPU-encoded into the bundle's persistent MTLIndirectCommandBuffer at executeBundles time. Renders a full-target triangle via a bundle of drawIndirect into a 1x1 texture and reads the pixel back, executing the bundle twice to exercise reuse.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS frame0.join() is "0,255,0,255"
+PASS frame1.join() is "0,255,0,255"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/webgpu/render-bundle-draw-indirect.html
+++ b/LayoutTests/fast/webgpu/render-bundle-draw-indirect.html
@@ -1,0 +1,84 @@
+<script src="../../resources/js-test.js"></script>
+<script>
+
+jsTestIsAsync = true;
+
+description("Regression test for bugs.webkit.org/show_bug.cgi?id=264219: a render bundle containing " +
+           "drawIndirect (non-indexed) must actually render, with its draw GPU-encoded into the bundle's " +
+           "persistent MTLIndirectCommandBuffer at executeBundles time. Renders a full-target triangle via " +
+           "a bundle of drawIndirect into a 1x1 texture and reads the pixel back, executing the bundle twice " +
+           "to exercise reuse.");
+
+async function main() {
+    let adapter = await navigator.gpu.requestAdapter({});
+    let device = await adapter.requestDevice({});
+    device.pushErrorScope('validation');
+
+    const format = 'rgba8unorm';
+    let module = device.createShaderModule({ code: `
+        @vertex fn vs(@builtin(vertex_index) i: u32) -> @builtin(position) vec4f {
+            var p = array(vec2f(-1, -3), vec2f(-1, 1), vec2f(3, 1));
+            return vec4f(p[i], 0, 1);
+        }
+        @fragment fn fs() -> @location(0) vec4f { return vec4f(0, 1, 0, 1); }
+    ` });
+    let pipeline = device.createRenderPipeline({
+        layout: 'auto',
+        vertex: { module, entryPoint: 'vs' },
+        fragment: { module, entryPoint: 'fs', targets: [{ format }] },
+        primitive: { topology: 'triangle-list' },
+    });
+
+    // MTLDrawPrimitivesIndirectArguments layout: vertexCount, instanceCount, firstVertex, firstInstance.
+    let args = new Uint32Array([3, 1, 0, 0]);
+    let argsBuffer = device.createBuffer({ size: args.byteLength, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.COPY_DST });
+    device.queue.writeBuffer(argsBuffer, 0, args);
+
+    let enc = device.createRenderBundleEncoder({ colorFormats: [format] });
+    enc.setPipeline(pipeline);
+    enc.drawIndirect(argsBuffer, 0);
+    let bundle = enc.finish();
+
+    let texture = device.createTexture({ size: [1, 1], format, usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.COPY_SRC });
+    let readback = device.createBuffer({ size: 256, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ });
+
+    function drawAndReadback() {
+        let commandEncoder = device.createCommandEncoder();
+        let pass = commandEncoder.beginRenderPass({
+            colorAttachments: [{ view: texture.createView(), loadOp: 'clear', storeOp: 'store', clearValue: { r: 1, g: 0, b: 0, a: 1 } }],
+        });
+        pass.executeBundles([bundle]);
+        pass.end();
+        commandEncoder.copyTextureToBuffer({ texture }, { buffer: readback, bytesPerRow: 256 }, [1, 1]);
+        device.queue.submit([commandEncoder.finish()]);
+    }
+
+    drawAndReadback();
+    await device.queue.onSubmittedWorkDone();
+    await readback.mapAsync(GPUMapMode.READ);
+    let frame0 = [...new Uint8Array(readback.getMappedRange(0, 4))];
+    readback.unmap();
+
+    drawAndReadback();
+    await device.queue.onSubmittedWorkDone();
+    await readback.mapAsync(GPUMapMode.READ);
+    let frame1 = [...new Uint8Array(readback.getMappedRange(0, 4))];
+    readback.unmap();
+
+    window.frame0 = frame0;
+    window.frame1 = frame1;
+    shouldBeEqualToString('frame0.join()', '0,255,0,255');
+    shouldBeEqualToString('frame1.join()', '0,255,0,255');
+
+    let error = await device.popErrorScope();
+    if (error)
+        testFailed(error.message);
+}
+
+main().catch(e => {
+    testFailed("Exception: " + e);
+}).finally(() => {
+    finishJSTest();
+});
+
+</script>

--- a/LayoutTests/http/tests/webgpu/webgpu/api/operation/memory_sync/buffer/single_buffer-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/api/operation/memory_sync/buffer/single_buffer-expected.txt
@@ -150,78 +150,12 @@ PASS :wr:boundary="queue-op";readOp="input-indirect";readContext="render-pass-en
 PASS :wr:boundary="queue-op";readOp="input-indirect";readContext="render-bundle-encoder";writeOp="write-buffer";writeContext="queue"
 PASS :wr:boundary="queue-op";readOp="input-indirect";readContext="render-bundle-encoder";writeOp="b2b-copy";writeContext="command-encoder"
 PASS :wr:boundary="queue-op";readOp="input-indirect";readContext="render-bundle-encoder";writeOp="t2b-copy";writeContext="command-encoder"
-FAIL :wr:boundary="queue-op";readOp="input-indirect-index";readContext="render-pass-encoder";writeOp="write-buffer";writeContext="queue" assert_unreached:
-  - EXPECTATION FAILED: Array had unexpected contents at indices 0 through 0.
-     Starting at index 0:
-       actual == 0x: 00000000
-       failed ->           xx
-     expected ==     00000001
-    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
-    expectGPUBufferValuesPassCheck@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:715:34
-    expectGPUBufferValuesEqual@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:731:40
-    verifyData@http://127.0.0.1:8000/webgpu/webgpu/api/operation/memory_sync/buffer/buffer_sync_test.js:964:36
-    @http://127.0.0.1:8000/webgpu/webgpu/api/operation/memory_sync/buffer/single_buffer.spec.js:135:15
- Reached unreachable code
-FAIL :wr:boundary="queue-op";readOp="input-indirect-index";readContext="render-pass-encoder";writeOp="b2b-copy";writeContext="command-encoder" assert_unreached:
-  - EXPECTATION FAILED: Array had unexpected contents at indices 0 through 0.
-     Starting at index 0:
-       actual == 0x: 00000000
-       failed ->           xx
-     expected ==     00000001
-    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
-    expectGPUBufferValuesPassCheck@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:715:34
-    expectGPUBufferValuesEqual@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:731:40
-    verifyData@http://127.0.0.1:8000/webgpu/webgpu/api/operation/memory_sync/buffer/buffer_sync_test.js:964:36
-    @http://127.0.0.1:8000/webgpu/webgpu/api/operation/memory_sync/buffer/single_buffer.spec.js:135:15
- Reached unreachable code
-FAIL :wr:boundary="queue-op";readOp="input-indirect-index";readContext="render-pass-encoder";writeOp="t2b-copy";writeContext="command-encoder" assert_unreached:
-  - EXPECTATION FAILED: Array had unexpected contents at indices 0 through 0.
-     Starting at index 0:
-       actual == 0x: 00000000
-       failed ->           xx
-     expected ==     00000001
-    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
-    expectGPUBufferValuesPassCheck@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:715:34
-    expectGPUBufferValuesEqual@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:731:40
-    verifyData@http://127.0.0.1:8000/webgpu/webgpu/api/operation/memory_sync/buffer/buffer_sync_test.js:964:36
-    @http://127.0.0.1:8000/webgpu/webgpu/api/operation/memory_sync/buffer/single_buffer.spec.js:135:15
- Reached unreachable code
-FAIL :wr:boundary="queue-op";readOp="input-indirect-index";readContext="render-bundle-encoder";writeOp="write-buffer";writeContext="queue" assert_unreached:
-  - EXPECTATION FAILED: Array had unexpected contents at indices 0 through 0.
-     Starting at index 0:
-       actual == 0x: 00000000
-       failed ->           xx
-     expected ==     00000001
-    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
-    expectGPUBufferValuesPassCheck@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:715:34
-    expectGPUBufferValuesEqual@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:731:40
-    verifyData@http://127.0.0.1:8000/webgpu/webgpu/api/operation/memory_sync/buffer/buffer_sync_test.js:964:36
-    @http://127.0.0.1:8000/webgpu/webgpu/api/operation/memory_sync/buffer/single_buffer.spec.js:135:15
- Reached unreachable code
-FAIL :wr:boundary="queue-op";readOp="input-indirect-index";readContext="render-bundle-encoder";writeOp="b2b-copy";writeContext="command-encoder" assert_unreached:
-  - EXPECTATION FAILED: Array had unexpected contents at indices 0 through 0.
-     Starting at index 0:
-       actual == 0x: 00000000
-       failed ->           xx
-     expected ==     00000001
-    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
-    expectGPUBufferValuesPassCheck@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:715:34
-    expectGPUBufferValuesEqual@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:731:40
-    verifyData@http://127.0.0.1:8000/webgpu/webgpu/api/operation/memory_sync/buffer/buffer_sync_test.js:964:36
-    @http://127.0.0.1:8000/webgpu/webgpu/api/operation/memory_sync/buffer/single_buffer.spec.js:135:15
- Reached unreachable code
-FAIL :wr:boundary="queue-op";readOp="input-indirect-index";readContext="render-bundle-encoder";writeOp="t2b-copy";writeContext="command-encoder" assert_unreached:
-  - EXPECTATION FAILED: Array had unexpected contents at indices 0 through 0.
-     Starting at index 0:
-       actual == 0x: 00000000
-       failed ->           xx
-     expected ==     00000001
-    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
-    expectGPUBufferValuesPassCheck@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:715:34
-    expectGPUBufferValuesEqual@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:731:40
-    verifyData@http://127.0.0.1:8000/webgpu/webgpu/api/operation/memory_sync/buffer/buffer_sync_test.js:964:36
-    @http://127.0.0.1:8000/webgpu/webgpu/api/operation/memory_sync/buffer/single_buffer.spec.js:135:15
- Reached unreachable code
+PASS :wr:boundary="queue-op";readOp="input-indirect-index";readContext="render-pass-encoder";writeOp="write-buffer";writeContext="queue"
+PASS :wr:boundary="queue-op";readOp="input-indirect-index";readContext="render-pass-encoder";writeOp="b2b-copy";writeContext="command-encoder"
+PASS :wr:boundary="queue-op";readOp="input-indirect-index";readContext="render-pass-encoder";writeOp="t2b-copy";writeContext="command-encoder"
+PASS :wr:boundary="queue-op";readOp="input-indirect-index";readContext="render-bundle-encoder";writeOp="write-buffer";writeContext="queue"
+PASS :wr:boundary="queue-op";readOp="input-indirect-index";readContext="render-bundle-encoder";writeOp="b2b-copy";writeContext="command-encoder"
+PASS :wr:boundary="queue-op";readOp="input-indirect-index";readContext="render-bundle-encoder";writeOp="t2b-copy";writeContext="command-encoder"
 PASS :wr:boundary="queue-op";readOp="constant-uniform";readContext="render-pass-encoder";writeOp="write-buffer";writeContext="queue"
 PASS :wr:boundary="queue-op";readOp="constant-uniform";readContext="render-pass-encoder";writeOp="b2b-copy";writeContext="command-encoder"
 PASS :wr:boundary="queue-op";readOp="constant-uniform";readContext="render-pass-encoder";writeOp="t2b-copy";writeContext="command-encoder"
@@ -262,54 +196,10 @@ PASS :wr:boundary="command-buffer";readOp="input-indirect";readContext="render-p
 PASS :wr:boundary="command-buffer";readOp="input-indirect";readContext="render-pass-encoder";writeOp="t2b-copy";writeContext="command-encoder"
 PASS :wr:boundary="command-buffer";readOp="input-indirect";readContext="render-bundle-encoder";writeOp="b2b-copy";writeContext="command-encoder"
 PASS :wr:boundary="command-buffer";readOp="input-indirect";readContext="render-bundle-encoder";writeOp="t2b-copy";writeContext="command-encoder"
-FAIL :wr:boundary="command-buffer";readOp="input-indirect-index";readContext="render-pass-encoder";writeOp="b2b-copy";writeContext="command-encoder" assert_unreached:
-  - EXPECTATION FAILED: Array had unexpected contents at indices 0 through 0.
-     Starting at index 0:
-       actual == 0x: 00000000
-       failed ->           xx
-     expected ==     00000001
-    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
-    expectGPUBufferValuesPassCheck@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:715:34
-    expectGPUBufferValuesEqual@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:731:40
-    verifyData@http://127.0.0.1:8000/webgpu/webgpu/api/operation/memory_sync/buffer/buffer_sync_test.js:964:36
-    @http://127.0.0.1:8000/webgpu/webgpu/api/operation/memory_sync/buffer/single_buffer.spec.js:135:15
- Reached unreachable code
-FAIL :wr:boundary="command-buffer";readOp="input-indirect-index";readContext="render-pass-encoder";writeOp="t2b-copy";writeContext="command-encoder" assert_unreached:
-  - EXPECTATION FAILED: Array had unexpected contents at indices 0 through 0.
-     Starting at index 0:
-       actual == 0x: 00000000
-       failed ->           xx
-     expected ==     00000001
-    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
-    expectGPUBufferValuesPassCheck@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:715:34
-    expectGPUBufferValuesEqual@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:731:40
-    verifyData@http://127.0.0.1:8000/webgpu/webgpu/api/operation/memory_sync/buffer/buffer_sync_test.js:964:36
-    @http://127.0.0.1:8000/webgpu/webgpu/api/operation/memory_sync/buffer/single_buffer.spec.js:135:15
- Reached unreachable code
-FAIL :wr:boundary="command-buffer";readOp="input-indirect-index";readContext="render-bundle-encoder";writeOp="b2b-copy";writeContext="command-encoder" assert_unreached:
-  - EXPECTATION FAILED: Array had unexpected contents at indices 0 through 0.
-     Starting at index 0:
-       actual == 0x: 00000000
-       failed ->           xx
-     expected ==     00000001
-    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
-    expectGPUBufferValuesPassCheck@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:715:34
-    expectGPUBufferValuesEqual@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:731:40
-    verifyData@http://127.0.0.1:8000/webgpu/webgpu/api/operation/memory_sync/buffer/buffer_sync_test.js:964:36
-    @http://127.0.0.1:8000/webgpu/webgpu/api/operation/memory_sync/buffer/single_buffer.spec.js:135:15
- Reached unreachable code
-FAIL :wr:boundary="command-buffer";readOp="input-indirect-index";readContext="render-bundle-encoder";writeOp="t2b-copy";writeContext="command-encoder" assert_unreached:
-  - EXPECTATION FAILED: Array had unexpected contents at indices 0 through 0.
-     Starting at index 0:
-       actual == 0x: 00000000
-       failed ->           xx
-     expected ==     00000001
-    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
-    expectGPUBufferValuesPassCheck@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:715:34
-    expectGPUBufferValuesEqual@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:731:40
-    verifyData@http://127.0.0.1:8000/webgpu/webgpu/api/operation/memory_sync/buffer/buffer_sync_test.js:964:36
-    @http://127.0.0.1:8000/webgpu/webgpu/api/operation/memory_sync/buffer/single_buffer.spec.js:135:15
- Reached unreachable code
+PASS :wr:boundary="command-buffer";readOp="input-indirect-index";readContext="render-pass-encoder";writeOp="b2b-copy";writeContext="command-encoder"
+PASS :wr:boundary="command-buffer";readOp="input-indirect-index";readContext="render-pass-encoder";writeOp="t2b-copy";writeContext="command-encoder"
+PASS :wr:boundary="command-buffer";readOp="input-indirect-index";readContext="render-bundle-encoder";writeOp="b2b-copy";writeContext="command-encoder"
+PASS :wr:boundary="command-buffer";readOp="input-indirect-index";readContext="render-bundle-encoder";writeOp="t2b-copy";writeContext="command-encoder"
 PASS :wr:boundary="command-buffer";readOp="constant-uniform";readContext="render-pass-encoder";writeOp="b2b-copy";writeContext="command-encoder"
 PASS :wr:boundary="command-buffer";readOp="constant-uniform";readContext="render-pass-encoder";writeOp="t2b-copy";writeContext="command-encoder"
 PASS :wr:boundary="command-buffer";readOp="constant-uniform";readContext="render-bundle-encoder";writeOp="b2b-copy";writeContext="command-encoder"

--- a/Source/WebGPU/WebGPU/BindableResource.h
+++ b/Source/WebGPU/WebGPU/BindableResource.h
@@ -105,6 +105,26 @@ struct IndexBufferAndIndexData {
     IndexData indexData;
 };
 
+// Records an indirect draw so its call can be GPU-encoded into the bundle's ICB slot at executeBundles() time.
+struct IndirectDrawData {
+    uint64_t renderCommand { 0 };
+    RefPtr<Buffer> indirectBuffer;
+    uint64_t indirectOffset { 0 };
+    uint32_t minVertexCount { UINT32_MAX };
+    uint32_t minInstanceCount { UINT32_MAX };
+    RefPtr<Buffer> indexBuffer; // nullptr for non-indexed
+    MTLIndexType indexType { MTLIndexTypeUInt16 };
+    NSUInteger indexBufferOffset { 0 };
+    MTLPrimitiveType primitiveType { MTLPrimitiveTypeTriangle };
+    bool isIndexed { false };
+    // Skip re-encoding while the source buffers' generations are unchanged.
+    bool encodedAtLeastOnce { false };
+    uint64_t lastIndirectGeneration { 0 };
+    uint64_t lastIndexGeneration { 0 };
+};
+
+using IndirectDrawForSlotContainer = HashMap<uint64_t, IndirectDrawData, DefaultHash<uint64_t>, WTF::UnsignedWithZeroKeyHashTraits<uint64_t>>;
+
 using DrawIndexCacheContainerKey = std::array<uint32_t, 5>;
 inline void add(Hasher& hasher, const DrawIndexCacheContainerKey& input)
 {
@@ -136,7 +156,12 @@ struct DrawIndexCacheContainerValue {
     MTLIndexType indexType() { return static_cast<MTLIndexType>(primitiveOffsetWithIndexType & 0x2); }
 };
 
-using DrawIndexCacheContainer = HashMap<GenericHashKey<DrawIndexCacheContainerKey>, uint32_t>;
+struct DrawIndexValidationCacheEntry {
+    uint32_t vertexCount { 0 };
+    uint64_t indexContentsGeneration { 0 };
+};
+
+using DrawIndexCacheContainer = HashMap<GenericHashKey<DrawIndexCacheContainerKey>, DrawIndexValidationCacheEntry>;
 using DrawIndexCacheContainerIterator = DrawIndexCacheContainer::const_iterator;
 
 using TrackedResourceContainer = HashSet<uint64_t, DefaultHash<uint64_t>, WTF::UnsignedWithZeroKeyHashTraits<uint64_t>>;

--- a/Source/WebGPU/WebGPU/Buffer.h
+++ b/Source/WebGPU/WebGPU/Buffer.h
@@ -117,7 +117,7 @@ public:
     void NODELETE indirectIndexedBufferRecomputed(MTLIndexType, NSUInteger indexBufferOffsetInBytes, uint64_t indirectOffset, uint32_t minVertexCount, uint32_t minInstanceCount);
 
     std::optional<DrawIndexCacheContainerIterator> canSkipDrawIndexedValidation(uint32_t firstIndex, uint32_t indexCount, uint32_t vertexCount, MTLIndexType, uint32_t primitiveOffset, id<MTLIndirectCommandBuffer> = nil) const;
-    void drawIndexedValidated(uint32_t firstIndex, uint32_t indexCount, uint32_t vertexCount, MTLIndexType, uint32_t primitiveOffset, id<MTLIndirectCommandBuffer> = nil);
+    void drawIndexedValidated(uint32_t firstIndex, uint32_t indexCount, uint32_t vertexCount, MTLIndexType, uint32_t primitiveOffset, uint64_t validationGeneration, id<MTLIndirectCommandBuffer> = nil);
     void skippedDrawIndexedValidation(CommandEncoder&, DrawIndexCacheContainerIterator);
     void skippedDrawIndirectIndexedValidation(CommandEncoder&, Buffer*, MTLIndexType, uint32_t indexBufferOffsetInBytes, uint64_t indirectOffset, uint32_t minVertexCount, uint32_t minInstanceCount, MTLPrimitiveType);
     void skippedDrawIndirectValidation(CommandEncoder&, uint64_t indirectOffset, uint32_t minVertexCount, uint32_t minInstanceCount);
@@ -127,6 +127,19 @@ public:
 
     void indirectBufferInvalidated(CommandEncoder* = nullptr);
     void indirectBufferInvalidated(CommandEncoder&);
+    // Bumped whenever the contents change in a way that invalidates a previously GPU-encoded indirect draw.
+    uint64_t contentsGeneration() const { return m_contentsGeneration; }
+    uint64_t indexContentsGeneration() const { return m_indexContentsGeneration; }
+    void indexBufferContentsModified(uint32_t maxUintValue, uint16_t maxUshortValue)
+    {
+        ++m_indexContentsGeneration;
+        m_indexValueUpperBoundUint = std::max(m_indexValueUpperBoundUint, maxUintValue);
+        m_indexValueUpperBoundUshort = std::max<uint32_t>(m_indexValueUpperBoundUshort, maxUshortValue);
+    }
+    bool allIndexValuesBelow(MTLIndexType indexType, uint32_t vertexCount) const
+    {
+        return (indexType == MTLIndexTypeUInt16 ? m_indexValueUpperBoundUshort : m_indexValueUpperBoundUint) < vertexCount;
+    }
     void removeSkippedValidationCommandEncoder(uint64_t);
     bool mustTakeSlowIndexValidationPath() const { return m_mustTakeSlowIndexValidationPath; }
     void clearMustTakeSlowIndexValidationPath();
@@ -182,6 +195,10 @@ private:
     mutable HashMap<uint64_t, uint32_t, DefaultHash<uint64_t>, WTF::UnsignedWithZeroKeyHashTraits<uint64_t>> m_gpuResourceMap;
     HashSet<uint64_t, DefaultHash<uint64_t>, WTF::UnsignedWithZeroKeyHashTraits<uint64_t>> m_skippedValidationCommandEncoders;
     bool m_mustTakeSlowIndexValidationPath { false };
+    uint64_t m_contentsGeneration { 0 }; // NOLINT
+    uint64_t m_indexContentsGeneration { 0 }; // NOLINT
+    uint32_t m_indexValueUpperBoundUint { 0 }; // NOLINT
+    uint16_t m_indexValueUpperBoundUshort { 0 }; // NOLINT
 #if CPU(X86_64) && (PLATFORM(MAC) || PLATFORM(MACCATALYST))
     bool m_mappedAtCreation { false };
 #endif

--- a/Source/WebGPU/WebGPU/Buffer.mm
+++ b/Source/WebGPU/WebGPU/Buffer.mm
@@ -496,19 +496,19 @@ static DrawIndexCacheContainerKey makeKey(uint32_t firstIndex, uint32_t indexCou
 std::optional<DrawIndexCacheContainerIterator> Buffer::canSkipDrawIndexedValidation(uint32_t firstIndex, uint32_t indexCount, uint32_t vertexCount, MTLIndexType indexType, uint32_t primitiveOffset, id<MTLIndirectCommandBuffer> icb) const
 {
     auto containerIt = m_drawIndexedCache.find(makeKey(firstIndex, indexCount, indexType, primitiveOffset, icb));
-    if (containerIt != m_drawIndexedCache.end() && containerIt->value <= vertexCount)
+    if (containerIt != m_drawIndexedCache.end() && containerIt->value.indexContentsGeneration == m_indexContentsGeneration && containerIt->value.vertexCount <= vertexCount)
         return containerIt;
 
     return std::nullopt;
 }
 
-void Buffer::drawIndexedValidated(uint32_t firstIndex, uint32_t indexCount, uint32_t vertexCount, MTLIndexType indexType, uint32_t primitiveOffset, id<MTLIndirectCommandBuffer> icb)
+void Buffer::drawIndexedValidated(uint32_t firstIndex, uint32_t indexCount, uint32_t vertexCount, MTLIndexType indexType, uint32_t primitiveOffset, uint64_t validationGeneration, id<MTLIndirectCommandBuffer> icb)
 {
     constexpr auto maxCacheSize = 1000000;
     if (m_drawIndexedCache.size() > maxCacheSize)
         m_drawIndexedCache.clear();
 
-    m_drawIndexedCache.set(makeKey(firstIndex, indexCount, indexType, primitiveOffset, icb), vertexCount);
+    m_drawIndexedCache.set(makeKey(firstIndex, indexCount, indexType, primitiveOffset, icb), DrawIndexValidationCacheEntry { vertexCount, validationGeneration });
 }
 
 template <typename T>
@@ -775,6 +775,10 @@ void Buffer::indirectBufferInvalidated(CommandEncoder* commandEncoder)
 
     m_gpuResourceMap.clear();
     m_drawIndexedCache.clear();
+    ++m_contentsGeneration;
+    ++m_indexContentsGeneration;
+    m_indexValueUpperBoundUint = UINT32_MAX;
+    m_indexValueUpperBoundUshort = UINT16_MAX;
     m_indirectCache = {
         .indirectOffset = UINT64_MAX,
         .indexBufferOffsetInBytes = UINT64_MAX,

--- a/Source/WebGPU/WebGPU/CommandEncoder.mm
+++ b/Source/WebGPU/WebGPU/CommandEncoder.mm
@@ -2431,7 +2431,7 @@ bool CommandEncoder::useResidencySet(id<MTLResidencySet> residencySet)
 
 void CommandEncoder::skippedDrawIndexedValidation(uint64_t bufferIdentifier, DrawIndexCacheContainerIterator it)
 {
-    m_skippedDrawIndexedValidationKeys.add(bufferIdentifier, Vector<std::pair<DrawIndexCacheContainerValue, uint32_t>> { }).iterator->value.append(std::make_pair(DrawIndexCacheContainerValue(it->key.key()), it->value));
+    m_skippedDrawIndexedValidationKeys.add(bufferIdentifier, Vector<std::pair<DrawIndexCacheContainerValue, uint32_t>> { }).iterator->value.append(std::make_pair(DrawIndexCacheContainerValue(it->key.key()), it->value.vertexCount));
 }
 
 void CommandEncoder::rebindSamplersPreCommit(const BindGroup& group)

--- a/Source/WebGPU/WebGPU/Device.h
+++ b/Source/WebGPU/WebGPU/Device.h
@@ -194,6 +194,8 @@ public:
     id<MTLRenderPipelineState> _Nullable indirectBufferClampPipeline(NSUInteger rasterSampleCount);
     id<MTLRenderPipelineState> _Nullable icbCommandClampPipeline(MTLIndexType, NSUInteger rasterSampleCount);
     id<MTLFunction> icbCommandClampFunction(MTLIndexType);
+    id<MTLRenderPipelineState> _Nullable icbIndirectEncodePipeline(bool isIndexed, MTLIndexType, NSUInteger rasterSampleCount);
+    id<MTLFunction> icbIndirectEncodeFunction(bool isIndexed, MTLIndexType);
     id<MTLBuffer> safeCreateBuffer(NSUInteger length, MTLStorageMode, bool skipMemoryAttribution = false, MTLCPUCacheMode = MTLCPUCacheModeDefaultCache, MTLHazardTrackingMode = MTLHazardTrackingModeDefault) const;
     id<MTLBuffer> safeCreateBuffer(NSUInteger, bool skipMemoryAttribution = false) const;
     template<typename T>
@@ -321,6 +323,13 @@ private:
     id<MTLRenderPipelineState> _Nullable m_icbCommandClampUshortPSO { nil };
     id<MTLRenderPipelineState> _Nullable m_icbCommandClampUintPSOMS { nil };
     id<MTLRenderPipelineState> _Nullable m_icbCommandClampUshortPSOMS { nil };
+
+    id<MTLRenderPipelineState> _Nullable m_icbIndirectEncodeUintPSO { nil };
+    id<MTLRenderPipelineState> _Nullable m_icbIndirectEncodeUshortPSO { nil };
+    id<MTLRenderPipelineState> _Nullable m_icbIndirectEncodeUintPSOMS { nil };
+    id<MTLRenderPipelineState> _Nullable m_icbIndirectEncodeUshortPSOMS { nil };
+    id<MTLRenderPipelineState> _Nullable m_icbIndirectEncodeDrawPSO { nil };
+    id<MTLRenderPipelineState> _Nullable m_icbIndirectEncodeDrawPSOMS { nil };
 
     const Ref<Adapter> m_adapter;
     const ThreadSafeWeakPtr<Instance> m_instance;

--- a/Source/WebGPU/WebGPU/Device.mm
+++ b/Source/WebGPU/WebGPU/Device.mm
@@ -909,6 +909,134 @@ id<MTLRenderPipelineState> Device::indirectBufferClampPipeline(NSUInteger raster
     return result;
 }
 
+id<MTLRenderPipelineState> Device::icbIndirectEncodePipeline(bool isIndexed, MTLIndexType indexType, NSUInteger rasterSampleCount)
+{
+    if (!m_device)
+        return nil;
+
+    bool isUint16 = indexType == MTLIndexTypeUInt16;
+    id<MTLRenderPipelineState> result;
+    if (!isIndexed)
+        result = rasterSampleCount > 1 ? m_icbIndirectEncodeDrawPSOMS : m_icbIndirectEncodeDrawPSO;
+    else
+        result = isUint16 ? (rasterSampleCount > 1 ? m_icbIndirectEncodeUshortPSOMS : m_icbIndirectEncodeUshortPSO) : (rasterSampleCount > 1 ? m_icbIndirectEncodeUintPSOMS : m_icbIndirectEncodeUintPSO);
+    if (result)
+        return result;
+
+    NSError *error = nil;
+    MTLRenderPipelineDescriptor* mtlRenderPipelineDescriptor = [MTLRenderPipelineDescriptor new];
+    mtlRenderPipelineDescriptor.vertexFunction = icbIndirectEncodeFunction(isIndexed, indexType);
+    mtlRenderPipelineDescriptor.rasterizationEnabled = false;
+    mtlRenderPipelineDescriptor.rasterSampleCount = rasterSampleCount;
+    mtlRenderPipelineDescriptor.fragmentFunction = nil;
+    mtlRenderPipelineDescriptor.inputPrimitiveTopology = MTLPrimitiveTopologyClassPoint;
+
+    if (!isIndexed) {
+        if (rasterSampleCount > 1)
+            result = m_icbIndirectEncodeDrawPSOMS = [m_device newRenderPipelineStateWithDescriptor:mtlRenderPipelineDescriptor error:&error];
+        else
+            result = m_icbIndirectEncodeDrawPSO = [m_device newRenderPipelineStateWithDescriptor:mtlRenderPipelineDescriptor error:&error];
+    } else if (isUint16) {
+        if (rasterSampleCount > 1)
+            result = m_icbIndirectEncodeUshortPSOMS = [m_device newRenderPipelineStateWithDescriptor:mtlRenderPipelineDescriptor error:&error];
+        else
+            result = m_icbIndirectEncodeUshortPSO = [m_device newRenderPipelineStateWithDescriptor:mtlRenderPipelineDescriptor error:&error];
+    } else {
+        if (rasterSampleCount > 1)
+            result = m_icbIndirectEncodeUintPSOMS = [m_device newRenderPipelineStateWithDescriptor:mtlRenderPipelineDescriptor error:&error];
+        else
+            result = m_icbIndirectEncodeUintPSO = [m_device newRenderPipelineStateWithDescriptor:mtlRenderPipelineDescriptor error:&error];
+    }
+
+    if (error) {
+        WTFLogAlways("%@", error);  // NOLINT
+        return nil;
+    }
+    return result;
+}
+
+// Encodes an indirect draw into an ICB slot on the GPU, reading the draw counts from the args buffer
+// (clamped shadow args, or the app's raw buffer when no clamping is required) at executeBundles() time.
+id<MTLFunction> Device::icbIndirectEncodeFunction(bool isIndexed, MTLIndexType indexType)
+{
+    static id<MTLFunction> functionDraw = nil;
+    static id<MTLFunction> functionIndexedUint = nil;
+    static id<MTLFunction> functionIndexedUshort = nil;
+    NSError *error = nil;
+    static std::once_flag onceFlag;
+    // The shader below hardcodes [[buffer(1)]] for the ICB container to match bufferIndexForICBContainer().
+    RELEASE_ASSERT(bufferIndexForICBContainer() == 1);
+    std::call_once(onceFlag, [&] {
+        MTLCompileOptions* options = [MTLCompileOptions new];
+        ALLOW_DEPRECATED_DECLARATIONS_BEGIN
+        options.fastMathEnabled = YES;
+        ALLOW_DEPRECATED_DECLARATIONS_END
+        /* NOLINT */ id<MTLLibrary> library = [m_device newLibraryWithSource:@R"(
+    using namespace metal;
+    struct ICBContainer {
+        device uint* outOfBoundsRead [[ id(0) ]];
+        command_buffer commandBuffer [[ id(1) ]];
+    };
+
+    static_assert(sizeof(primitive_type) == sizeof(uint32_t), "API assumes primitive type is sizeof uint32_t");
+
+    // slotData[0] = ICB slot index, slotData[1] = primitive_type.
+    [[vertex]] void vsICBIndirectDraw(device const MTLDrawPrimitivesIndirectArguments& args [[buffer(0)]],
+        device ICBContainer *icb_container [[buffer(1)]],
+        const constant uint* slotData [[buffer(2)]])
+    {
+        render_command cmd(icb_container->commandBuffer, slotData[0]);
+        cmd.draw_primitives(static_cast<primitive_type>(slotData[1]),
+            args.vertexStart,
+            args.vertexCount,
+            args.instanceCount,
+            args.baseInstance);
+    }
+
+    // slotData[2] = index buffer element offset.
+    [[vertex]] void vsICBIndirectIndexedUint(device const MTLDrawIndexedPrimitivesIndirectArguments& args [[buffer(0)]],
+        device ICBContainer *icb_container [[buffer(1)]],
+        device uint* indexBuffer [[buffer(2)]],
+        const constant uint* slotData [[buffer(3)]])
+    {
+        render_command cmd(icb_container->commandBuffer, slotData[0]);
+        device uint* indexBufferBase = indexBuffer + slotData[2] + args.indexStart;
+        cmd.draw_indexed_primitives(static_cast<primitive_type>(slotData[1]),
+            args.indexCount,
+            indexBufferBase,
+            args.instanceCount,
+            args.baseVertex,
+            args.baseInstance);
+    }
+
+    [[vertex]] void vsICBIndirectIndexedUshort(device const MTLDrawIndexedPrimitivesIndirectArguments& args [[buffer(0)]],
+        device ICBContainer *icb_container [[buffer(1)]],
+        device ushort* indexBuffer [[buffer(2)]],
+        const constant uint* slotData [[buffer(3)]])
+    {
+        render_command cmd(icb_container->commandBuffer, slotData[0]);
+        device ushort* indexBufferBase = indexBuffer + slotData[2] + args.indexStart;
+        cmd.draw_indexed_primitives(static_cast<primitive_type>(slotData[1]),
+            args.indexCount,
+            indexBufferBase,
+            args.instanceCount,
+            args.baseVertex,
+            args.baseInstance);
+    })" /* NOLINT */ options:options error:&error];
+        if (error)
+            WTFLogAlways("%@", error);  // NOLINT
+
+        functionDraw = [library newFunctionWithName:@"vsICBIndirectDraw"];
+        functionIndexedUint = [library newFunctionWithName:@"vsICBIndirectIndexedUint"];
+        functionIndexedUshort = [library newFunctionWithName:@"vsICBIndirectIndexedUshort"];
+    });
+
+    RELEASE_ASSERT(functionDraw && functionIndexedUint && functionIndexedUshort);
+    if (!isIndexed)
+        return functionDraw;
+    return indexType == MTLIndexTypeUInt16 ? functionIndexedUshort : functionIndexedUint;
+}
+
 id<MTLRenderPipelineState> Device::icbCommandClampPipeline(MTLIndexType indexType, NSUInteger rasterSampleCount)
 {
     if (!m_device)

--- a/Source/WebGPU/WebGPU/Queue.mm
+++ b/Source/WebGPU/WebGPU/Queue.mm
@@ -558,8 +558,10 @@ void Queue::writeBuffer(Buffer& buffer, uint64_t bufferOffset, std::span<uint8_t
 
     if (dataSize < 16*KB && (buffer.usage() & WGPUBufferUsage_Index) && !(buffer.usage() & WGPUBufferUsage_Indirect)) {
         auto maxUnsignedUshortValue = maxIndexValue(data);
-        if (!buffer.needsIndexValidation(maxUnsignedUshortValue.first, maxUnsignedUshortValue.second))
+        if (!buffer.needsIndexValidation(maxUnsignedUshortValue.first, maxUnsignedUshortValue.second)) {
             needsInvalidation = false;
+            buffer.indexBufferContentsModified(maxUnsignedUshortValue.first, maxUnsignedUshortValue.second);
+        }
     }
     if (needsInvalidation)
         buffer.indirectBufferInvalidated();

--- a/Source/WebGPU/WebGPU/RenderBundleEncoder.h
+++ b/Source/WebGPU/WebGPU/RenderBundleEncoder.h
@@ -46,7 +46,7 @@ struct WGPURenderBundleEncoderImpl {
 
 @interface RenderBundleICBWithResources : NSObject
 
-- (instancetype)initWithICB:(id<MTLIndirectCommandBuffer>)icb containerBuffer:(id<MTLBuffer>)containerBuffer pipelineState:(id<MTLRenderPipelineState>)pipelineState depthStencilState:(id<MTLDepthStencilState>)depthStencilState cullMode:(MTLCullMode)cullMode frontFace:(MTLWinding)frontFace depthClipMode:(MTLDepthClipMode)depthClipMode depthBias:(float)depthBias depthBiasSlopeScale:(float)depthBiasSlopeScale depthBiasClamp:(float)depthBiasClamp fragmentDynamicOffsetsBuffer:(id<MTLBuffer>)fragmentDynamicOffsetsBuffer pipeline:(const WebGPU::RenderPipeline*)pipeline minVertexCounts:(WebGPU::RenderBundle::MinVertexCountsContainer*)minVertexCounts outOfBoundsReadFlag:(id<MTLBuffer>)outOfBoundsReadFlag NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithICB:(id<MTLIndirectCommandBuffer>)icb containerBuffer:(id<MTLBuffer>)containerBuffer pipelineState:(id<MTLRenderPipelineState>)pipelineState depthStencilState:(id<MTLDepthStencilState>)depthStencilState cullMode:(MTLCullMode)cullMode frontFace:(MTLWinding)frontFace depthClipMode:(MTLDepthClipMode)depthClipMode depthBias:(float)depthBias depthBiasSlopeScale:(float)depthBiasSlopeScale depthBiasClamp:(float)depthBiasClamp fragmentDynamicOffsetsBuffer:(id<MTLBuffer>)fragmentDynamicOffsetsBuffer pipeline:(const WebGPU::RenderPipeline*)pipeline minVertexCounts:(WebGPU::RenderBundle::MinVertexCountsContainer*)minVertexCounts indirectDraws:(WebGPU::IndirectDrawForSlotContainer*)indirectDraws outOfBoundsReadFlag:(id<MTLBuffer>)outOfBoundsReadFlag NS_DESIGNATED_INITIALIZER;
 - (instancetype)init NS_UNAVAILABLE;
 
 @property (readonly, nonatomic) id<MTLBuffer> outOfBoundsReadFlag;
@@ -64,6 +64,7 @@ struct WGPURenderBundleEncoderImpl {
 @property (readonly, nonatomic) WeakPtr<WebGPU::RenderPipeline> pipeline;
 
 - (WebGPU::RenderBundle::MinVertexCountsContainer*)minVertexCountForDrawCommand;
+- (WebGPU::IndirectDrawForSlotContainer*)indirectDrawsForSlot;
 @end
 
 namespace WebGPU {
@@ -191,6 +192,7 @@ private:
     HashMap<uint32_t, Ref<const BindGroup>, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>> m_bindGroups;
     HashSet<RefPtr<const BindGroup>> m_allBindGroups;
     RenderBundle::MinVertexCountsContainer m_minVertexCountForDrawCommand;
+    IndirectDrawForSlotContainer m_indirectDrawsForSlot;
     NSMutableArray<RenderBundleICBWithResources*> *m_icbArray;
     id<MTLBuffer> m_dynamicOffsetsVertexBuffer { nil };
     id<MTLBuffer> m_dynamicOffsetsFragmentBuffer { nil };

--- a/Source/WebGPU/WebGPU/RenderBundleEncoder.mm
+++ b/Source/WebGPU/WebGPU/RenderBundleEncoder.mm
@@ -42,6 +42,7 @@
 @implementation RenderBundleICBWithResources {
     Vector<WebGPU::BindableResources> _resources;
     HashMap<uint64_t, WebGPU::IndexBufferAndIndexData, DefaultHash<uint64_t>, WTF::UnsignedWithZeroKeyHashTraits<uint64_t>> _minVertexCountForDrawCommand;
+    WebGPU::IndirectDrawForSlotContainer _indirectDrawsForSlot;
 }
 
 static bool setCommandEncoder(auto& buffer, auto& renderPassEncoder)
@@ -50,7 +51,7 @@ static bool setCommandEncoder(auto& buffer, auto& renderPassEncoder)
     return !!renderPassEncoder->renderCommandEncoder();
 }
 
-- (instancetype)initWithICB:(id<MTLIndirectCommandBuffer>)icb containerBuffer:(id<MTLBuffer>)containerBuffer pipelineState:(id<MTLRenderPipelineState>)pipelineState depthStencilState:(id<MTLDepthStencilState>)depthStencilState cullMode:(MTLCullMode)cullMode frontFace:(MTLWinding)frontFace depthClipMode:(MTLDepthClipMode)depthClipMode depthBias:(float)depthBias depthBiasSlopeScale:(float)depthBiasSlopeScale depthBiasClamp:(float)depthBiasClamp fragmentDynamicOffsetsBuffer:(id<MTLBuffer>)fragmentDynamicOffsetsBuffer pipeline:(const WebGPU::RenderPipeline*)pipeline minVertexCounts:(WebGPU::RenderBundle::MinVertexCountsContainer*)minVertexCounts outOfBoundsReadFlag:(id<MTLBuffer>)outOfBoundsReadFlag
+- (instancetype)initWithICB:(id<MTLIndirectCommandBuffer>)icb containerBuffer:(id<MTLBuffer>)containerBuffer pipelineState:(id<MTLRenderPipelineState>)pipelineState depthStencilState:(id<MTLDepthStencilState>)depthStencilState cullMode:(MTLCullMode)cullMode frontFace:(MTLWinding)frontFace depthClipMode:(MTLDepthClipMode)depthClipMode depthBias:(float)depthBias depthBiasSlopeScale:(float)depthBiasSlopeScale depthBiasClamp:(float)depthBiasClamp fragmentDynamicOffsetsBuffer:(id<MTLBuffer>)fragmentDynamicOffsetsBuffer pipeline:(const WebGPU::RenderPipeline*)pipeline minVertexCounts:(WebGPU::RenderBundle::MinVertexCountsContainer*)minVertexCounts indirectDraws:(WebGPU::IndirectDrawForSlotContainer*)indirectDraws outOfBoundsReadFlag:(id<MTLBuffer>)outOfBoundsReadFlag
 {
     if (!(self = [super init]))
         return nil;
@@ -69,6 +70,7 @@ static bool setCommandEncoder(auto& buffer, auto& renderPassEncoder)
     _fragmentDynamicOffsetsBuffer = fragmentDynamicOffsetsBuffer;
     _pipeline = pipeline;
     _minVertexCountForDrawCommand = WTF::move(*minVertexCounts);
+    _indirectDrawsForSlot = WTF::move(*indirectDraws);
 
     return self;
 }
@@ -81,6 +83,11 @@ static bool setCommandEncoder(auto& buffer, auto& renderPassEncoder)
 - (WebGPU::RenderBundle::MinVertexCountsContainer*)minVertexCountForDrawCommand
 {
     return &_minVertexCountForDrawCommand;
+}
+
+- (WebGPU::IndirectDrawForSlotContainer*)indirectDrawsForSlot
+{
+    return &_indirectDrawsForSlot;
 }
 
 @end
@@ -109,7 +116,7 @@ if (returnIfEncodingIsFinished([NSString stringWithFormat:@"%s: failed as encodi
 if (returnIfEncodingIsFinished([NSString stringWithFormat:@"%s: failed as encoding has finished", __PRETTY_FUNCTION__]) || !m_icbDescriptor) \
     return finalizeRenderCommand();
 
-static RenderBundleICBWithResources* makeRenderBundleICBWithResources(id<MTLIndirectCommandBuffer> icb, id<MTLRenderPipelineState> renderPipelineState, id<MTLDepthStencilState> depthStencilState, MTLCullMode cullMode, MTLWinding frontFace, MTLDepthClipMode depthClipMode, float depthBias, float depthBiasSlopeScale, float depthBiasClamp, id<MTLBuffer> fragmentDynamicOffsetsBuffer, const RenderPipeline* pipeline, Device& device, RenderBundle::MinVertexCountsContainer& vertexCountContainer)
+static RenderBundleICBWithResources* makeRenderBundleICBWithResources(id<MTLIndirectCommandBuffer> icb, id<MTLRenderPipelineState> renderPipelineState, id<MTLDepthStencilState> depthStencilState, MTLCullMode cullMode, MTLWinding frontFace, MTLDepthClipMode depthClipMode, float depthBias, float depthBiasSlopeScale, float depthBiasClamp, id<MTLBuffer> fragmentDynamicOffsetsBuffer, const RenderPipeline* pipeline, Device& device, RenderBundle::MinVertexCountsContainer& vertexCountContainer, IndirectDrawForSlotContainer& indirectDrawContainer)
 {
     id<MTLArgumentEncoder> argumentEncoder =
         [device.icbCommandClampFunction(MTLIndexTypeUInt32) newArgumentEncoderWithBufferIndex:device.bufferIndexForICBContainer()];
@@ -121,9 +128,10 @@ static RenderBundleICBWithResources* makeRenderBundleICBWithResources(id<MTLIndi
     [argumentEncoder setBuffer:outOfBoundsRead offset:0 atIndex:0];
     [argumentEncoder setIndirectCommandBuffer:icb atIndex:1];
 
-    RenderBundleICBWithResources* renderBundle = [[RenderBundleICBWithResources alloc] initWithICB:icb containerBuffer:container pipelineState:renderPipelineState depthStencilState:depthStencilState cullMode:cullMode frontFace:frontFace depthClipMode:depthClipMode depthBias:depthBias depthBiasSlopeScale:depthBiasSlopeScale depthBiasClamp:depthBiasClamp fragmentDynamicOffsetsBuffer:fragmentDynamicOffsetsBuffer pipeline:pipeline minVertexCounts:&vertexCountContainer outOfBoundsReadFlag:outOfBoundsRead];
+    RenderBundleICBWithResources* renderBundle = [[RenderBundleICBWithResources alloc] initWithICB:icb containerBuffer:container pipelineState:renderPipelineState depthStencilState:depthStencilState cullMode:cullMode frontFace:frontFace depthClipMode:depthClipMode depthBias:depthBias depthBiasSlopeScale:depthBiasSlopeScale depthBiasClamp:depthBiasClamp fragmentDynamicOffsetsBuffer:fragmentDynamicOffsetsBuffer pipeline:pipeline minVertexCounts:&vertexCountContainer indirectDraws:&indirectDrawContainer outOfBoundsReadFlag:outOfBoundsRead];
 
     vertexCountContainer.clear();
+    indirectDrawContainer.clear();
 
     return renderBundle;
 }
@@ -747,7 +755,6 @@ RenderBundleEncoder::FinalizeRenderCommand RenderBundleEncoder::drawIndexedIndir
 {
     RETURN_IF_FINISHED_RENDER_COMMAND();
 
-    m_requiresCommandReplay = true;
     id<MTLBuffer> mtlIndirectBuffer = nil;
     uint64_t modifiedIndirectOffset = 0;
     bool splitPass = false;
@@ -771,8 +778,25 @@ RenderBundleEncoder::FinalizeRenderCommand RenderBundleEncoder::drawIndexedIndir
                 return finalizeRenderCommand();
             if (!indirectBuffer.isDestroyed() && indexBuffer.length && mtlIndirectBuffer && !m_makeSubmitInvalid)
                 [renderPassEncoder->renderCommandEncoder() drawIndexedPrimitives:m_primitiveType indexType:m_indexType indexBuffer:indexBuffer indexBufferOffset:m_indexBufferOffset indirectBuffer:mtlIndirectBuffer indirectBufferOffset:modifiedIndirectOffset];
-        } else {
-            // FIXME: https://bugs.webkit.org/show_bug.cgi?id=264219
+        } else if (indexBuffer.length) {
+            // Record the command; its draw is encoded into this ICB slot on the GPU at executeBundles() time.
+            bool unusedWorkaround = false;
+            auto [minVertexCount, minInstanceCount] = computeMininumVertexInstanceCount(unusedWorkaround);
+            m_indirectDrawsForSlot.set(m_currentCommandIndex, IndirectDrawData {
+                .renderCommand = m_currentCommandIndex,
+                .indirectBuffer = &indirectBuffer,
+                .indirectOffset = indirectOffset,
+                .minVertexCount = minVertexCount,
+                .minInstanceCount = minInstanceCount,
+                .indexBuffer = m_indexBuffer,
+                .indexType = m_indexType,
+                .indexBufferOffset = m_indexBufferOffset,
+                .primitiveType = m_primitiveType,
+                .isIndexed = true,
+            });
+            addResource(m_resources, indirectBuffer.buffer(), MTLRenderStageVertex, &indirectBuffer);
+            if (m_indexBuffer)
+                addResource(m_resources, indexBuffer, MTLRenderStageVertex, m_indexBuffer.get());
         }
     } else {
         if (!indexBuffer.length)
@@ -807,7 +831,6 @@ RenderBundleEncoder::FinalizeRenderCommand RenderBundleEncoder::drawIndirect(Buf
 {
     RETURN_IF_FINISHED_RENDER_COMMAND();
 
-    m_requiresCommandReplay = true;
     id<MTLBuffer> clampedIndirectBuffer = nil;
     bool splitPass = false;
     RefPtr renderPassEncoder = m_renderPassEncoder.get();
@@ -830,7 +853,20 @@ RenderBundleEncoder::FinalizeRenderCommand RenderBundleEncoder::drawIndirect(Buf
             if (!indirectBuffer.isDestroyed() && clampedIndirectBuffer && !m_makeSubmitInvalid)
                 [renderPassEncoder->renderCommandEncoder() drawPrimitives:m_primitiveType indirectBuffer:clampedIndirectBuffer indirectBufferOffset:indirectOffset];
         } else {
-            // FIXME: https://bugs.webkit.org/show_bug.cgi?id=264219
+            // Record the command; its draw is encoded into this ICB slot on the GPU at executeBundles() time.
+            bool unusedWorkaround = false;
+            auto [minVertexCount, minInstanceCount] = computeMininumVertexInstanceCount(unusedWorkaround);
+            m_indirectDrawsForSlot.set(m_currentCommandIndex, IndirectDrawData {
+                .renderCommand = m_currentCommandIndex,
+                .indirectBuffer = &indirectBuffer,
+                .indirectOffset = indirectOffset,
+                .minVertexCount = minVertexCount,
+                .minInstanceCount = minInstanceCount,
+                .indexBuffer = nullptr,
+                .primitiveType = m_primitiveType,
+                .isIndexed = false,
+            });
+            addResource(m_resources, indirectBuffer.buffer(), MTLRenderStageVertex, &indirectBuffer);
         }
     } else {
         if (!isValidToUseWith(indirectBuffer, *this)) {
@@ -879,6 +915,7 @@ void RenderBundleEncoder::cleanup(bool resetPipeline)
     m_currentCommand = nil;
     m_currentPipelineState = nil;
     m_minVertexCountForDrawCommand.clear();
+    m_indirectDrawsForSlot.clear();
     m_depthStencilState = nil;
     m_cullMode = MTLCullModeNone;
     m_frontFace = static_cast<MTLWinding>(0);
@@ -1298,7 +1335,7 @@ void RenderBundleEncoder::splitICB(bool needsPipelineReset)
     m_currentCommandIndex = 0;
 
     if (m_indirectCommandBuffer.size)
-        [m_icbArray addObject:makeRenderBundleICBWithResources(m_indirectCommandBuffer, m_currentPipelineState, m_depthStencilState, m_cullMode, m_frontFace, m_depthClipMode, m_depthBias, m_depthBiasSlopeScale, m_depthBiasClamp, m_dynamicOffsetsFragmentBuffer, m_pipeline.get(), device.get(), m_minVertexCountForDrawCommand)];
+        [m_icbArray addObject:makeRenderBundleICBWithResources(m_indirectCommandBuffer, m_currentPipelineState, m_depthStencilState, m_cullMode, m_frontFace, m_depthClipMode, m_depthBias, m_depthBiasSlopeScale, m_depthBiasClamp, m_dynamicOffsetsFragmentBuffer, m_pipeline.get(), device.get(), m_minVertexCountForDrawCommand, m_indirectDrawsForSlot)];
 
     if (m_previousCommandCount)
         m_indirectCommandBuffer = makeICB(m_previousCommandCount);

--- a/Source/WebGPU/WebGPU/RenderPassEncoder.h
+++ b/Source/WebGPU/WebGPU/RenderPassEncoder.h
@@ -108,6 +108,11 @@ public:
 
     static std::pair<id<MTLBuffer>, uint64_t> clampIndirectIndexBufferToValidValues(Buffer*, Buffer&, MTLIndexType, NSUInteger indexBufferOffsetInBytes, uint64_t indirectOffset, uint32_t minVertexCount, uint32_t minInstanceCount, MTLPrimitiveType, Device&, uint32_t rasterSampleCount, RenderPassEncoder&, bool& splitEncoder);
     static std::pair<id<MTLBuffer>, uint64_t> clampIndirectBufferToValidValues(Buffer&, uint64_t indirectOffset, uint32_t minVertexCount, uint32_t minInstanceCount, Device&, uint32_t rasterSampleCount, RenderPassEncoder&, bool& splitEncoder);
+    // Batched (no-internal-barrier, per-draw-scratch) clamp helpers used by executeBundles.
+    static std::pair<id<MTLBuffer>, uint64_t> newZeroedIndirectScratch(Device&, size_t);
+    static bool clampIndirectBufferDispatchBatched(Buffer& indirectBuffer, uint64_t indirectOffset, uint32_t minVertexCount, uint32_t minInstanceCount, Device&, uint32_t rasterSampleCount, RenderPassEncoder&, id<MTLBuffer> finalScratch, uint64_t finalScratchOffset);
+    static bool clampIndirectIndexBufferDispatch1Batched(Buffer* apiIndexBuffer, Buffer& indexedIndirectBuffer, MTLIndexType, NSUInteger indexBufferOffsetInBytes, uint64_t indirectOffset, uint32_t minInstanceCount, Device&, uint32_t rasterSampleCount, RenderPassEncoder&, id<MTLBuffer> finalScratch, uint64_t finalScratchOffset, id<MTLBuffer> intermediateScratch, uint64_t intermediateScratchOffset, uint32_t& outIndexBufferCount);
+    static bool clampIndirectIndexBufferDispatch2Batched(Buffer* apiIndexBuffer, MTLIndexType, NSUInteger indexBufferOffsetInBytes, uint32_t minVertexCount, MTLPrimitiveType, uint32_t indexBufferCount, Device&, uint32_t rasterSampleCount, RenderPassEncoder&, id<MTLBuffer> finalScratch, uint64_t finalScratchOffset, id<MTLBuffer> intermediateScratch, uint64_t intermediateScratchOffset);
     enum class IndexCall { Draw, IndirectDraw, Skip, CachedIndirectDraw };
     struct DrawIndexResult {
         IndexCall result;

--- a/Source/WebGPU/WebGPU/RenderPassEncoder.mm
+++ b/Source/WebGPU/WebGPU/RenderPassEncoder.mm
@@ -56,11 +56,13 @@ if (!m_renderCommandEncoder || !m_parentEncoder->isValid() || !protect(m_parentE
     return; \
 }
 
-#define CHECKED_SET_PSO(commandEncoder, makePso, ...) \
+#define CHECKED_SET_PSO(commandEncoder, device, makePso, ...) \
 if (id<MTLRenderPipelineState> pso = makePso) \
     [commandEncoder setRenderPipelineState:pso]; \
-else \
-    return __VA_ARGS__;
+else { \
+    protect(device)->loseTheDevice(WGPUDeviceLostReason_Undefined); \
+    return __VA_ARGS__; \
+}
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(RenderPassEncoder);
 
@@ -790,6 +792,14 @@ RenderPassEncoder::DrawIndexResult RenderPassEncoder::clampIndexBufferToValidVal
         return DrawIndexResult { IndexCall::Draw, nil, 0 };
     }
 
+    if (!apiIndexBuffer->didReadOOB() && apiIndexBuffer->allIndexValuesBelow(indexType, effectiveMinVertexCount)) {
+        apiIndexBuffer->drawIndexedValidated(firstIndex, indexCount, effectiveMinVertexCount, indexType, primitiveOffset, apiIndexBuffer->indexContentsGeneration());
+        if (auto it = apiIndexBuffer->canSkipDrawIndexedValidation(firstIndex, indexCount, effectiveMinVertexCount, indexType, primitiveOffset)) {
+            apiIndexBuffer->skippedDrawIndexedValidation(encoder.parentEncoder(), *it);
+            return DrawIndexResult { IndexCall::Draw, nil, 0 };
+        }
+    }
+
     auto indexCountInBytes = checkedProduct<size_t>(indexSizeInBytes, indexCount);
     auto indexCountPlusOffsetInBytes = checkedSum<size_t>(indexCountInBytes, indexBufferOffsetInBytes);
     if (indexCountInBytes.hasOverflowed() || indexCountPlusOffsetInBytes.hasOverflowed() || indexCountPlusOffsetInBytes > indexBuffer.length)
@@ -810,7 +820,7 @@ RenderPassEncoder::DrawIndexResult RenderPassEncoder::clampIndexBufferToValidVal
 
     id<MTLRenderCommandEncoder> renderCommandEncoder = encoder.renderCommandEncoder();
     auto [indexedIndirectBuffer, indexedIndirectBufferOffset] = device.getQueue()->newTemporaryBufferWithBytes(unsafeMakeSpan(typedCast<uint8_t>(indirectArguments), sizeof(indirectArguments)), false);
-    CHECKED_SET_PSO(renderCommandEncoder, device.indexBufferClampPipeline(indexType, rasterSampleCount), DrawIndexResult { IndexCall::Skip, nil, 0 });
+    CHECKED_SET_PSO(renderCommandEncoder, device, device.indexBufferClampPipeline(indexType, rasterSampleCount), DrawIndexResult { IndexCall::Skip, nil, 0 });
     encoder.setVertexBuffer(renderCommandEncoder, indexBuffer, indexBufferOffsetInBytes, 0);
     encoder.setVertexBuffer(renderCommandEncoder, indexedIndirectBuffer, indexedIndirectBufferOffset, 1);
     uint32_t data[] = {
@@ -824,12 +834,13 @@ RenderPassEncoder::DrawIndexResult RenderPassEncoder::clampIndexBufferToValidVal
     encoder.emitMemoryBarrier(renderCommandEncoder);
 
     auto encoderHandle = device.getQueue()->retainCounterSampleBuffer(encoder.parentEncoder());
-    [encoder.parentEncoder().commandBuffer() addCompletedHandler:[encoderHandle, protectedDevice = protect(device), firstIndex, indexCount, effectiveMinVertexCount, indexType, primitiveOffset, refIndexBuffer = protect(*apiIndexBuffer), indexedIndirectBuffer, indexedIndirectBufferOffset](id<MTLCommandBuffer> completedCommandBuffer) mutable {
+    uint64_t validationGeneration = apiIndexBuffer->indexContentsGeneration();
+    [encoder.parentEncoder().commandBuffer() addCompletedHandler:[encoderHandle, protectedDevice = protect(device), firstIndex, indexCount, effectiveMinVertexCount, indexType, primitiveOffset, validationGeneration, refIndexBuffer = protect(*apiIndexBuffer), indexedIndirectBuffer, indexedIndirectBufferOffset](id<MTLCommandBuffer> completedCommandBuffer) mutable {
         if (completedCommandBuffer.status != MTLCommandBufferStatusCompleted) {
             protectedDevice->getQueue()->releaseCounterSampleBuffer(encoderHandle);
             return;
         }
-        protectedDevice->getQueue()->scheduleWork([encoderHandle, protectedDevice, firstIndex, indexCount, effectiveMinVertexCount, indexType, primitiveOffset, refIndexBuffer = WTF::move(refIndexBuffer), indexedIndirectBuffer, indexedIndirectBufferOffset]() mutable {
+        protectedDevice->getQueue()->scheduleWork([encoderHandle, protectedDevice, firstIndex, indexCount, effectiveMinVertexCount, indexType, primitiveOffset, validationGeneration, refIndexBuffer = WTF::move(refIndexBuffer), indexedIndirectBuffer, indexedIndirectBufferOffset]() mutable {
             protectedDevice->getQueue()->releaseCounterSampleBuffer(encoderHandle);
             if (!indexedIndirectBuffer.contents || indexedIndirectBuffer.length < sizeof(WebKitMTLDrawIndexedPrimitivesIndirectArguments) + indexedIndirectBufferOffset)
                 return;
@@ -837,7 +848,7 @@ RenderPassEncoder::DrawIndexResult RenderPassEncoder::clampIndexBufferToValidVal
             auto* offsetContents = static_cast<uint8_t*>(indexedIndirectBuffer.contents) + indexedIndirectBufferOffset;
             auto& args = *static_cast<WebKitMTLDrawIndexedPrimitivesIndirectArguments*>(static_cast<void*>(offsetContents));
             refIndexBuffer->didReadOOB(args.lostOrOOBRead);
-            refIndexBuffer->drawIndexedValidated(firstIndex, indexCount, effectiveMinVertexCount, indexType, primitiveOffset);
+            refIndexBuffer->drawIndexedValidated(firstIndex, indexCount, effectiveMinVertexCount, indexType, primitiveOffset, validationGeneration);
         });
     }];
 
@@ -850,20 +861,24 @@ RenderPassEncoder::DrawIndexResult RenderPassEncoder::clampIndexBufferToValidVal
     return clampIndexBufferToValidValues(indexCount, instanceCount, baseVertex, firstInstance, indexType, indexBufferOffsetInBytes, m_indexBuffer.get(), minVertexCount, minInstanceCount, *this, m_device.get(), m_rasterSampleCount, m_primitiveType);
 }
 
-static void checkForIndirectDrawDeviceLost(Device &device, RenderPassEncoder &encoder, id<MTLBuffer> indirectBuffer)
+static void checkForIndirectDrawDeviceLost(Device &device, RenderPassEncoder &encoder, id<MTLBuffer> indirectBuffer, uint64_t indirectBufferOffset = 0, id<MTLBuffer> alsoRetain = nil)
 {
     auto encoderHandle = device.getQueue()->retainCounterSampleBuffer(encoder.parentEncoder());
-    [encoder.parentEncoder().commandBuffer() addCompletedHandler:[encoderHandle, protectedDevice = protect(device), indirectBuffer](id<MTLCommandBuffer> completedCommandBuffer) {
+    [encoder.parentEncoder().commandBuffer() addCompletedHandler:[encoderHandle, protectedDevice = protect(device), indirectBuffer, indirectBufferOffset, alsoRetain](id<MTLCommandBuffer> completedCommandBuffer) {
         if (completedCommandBuffer.status != MTLCommandBufferStatusCompleted) {
             protectedDevice->getQueue()->releaseCounterSampleBuffer(encoderHandle);
             return;
         }
-        protectedDevice->getQueue()->scheduleWork([encoderHandle, indirectBuffer, protectedDevice]() mutable {
+        protectedDevice->getQueue()->scheduleWork([encoderHandle, indirectBuffer, indirectBufferOffset, alsoRetain, protectedDevice]() mutable {
             protectedDevice->getQueue()->releaseCounterSampleBuffer(encoderHandle);
-            if (!indirectBuffer.contents || indirectBuffer.length != sizeof(WebKitMTLDrawPrimitivesIndirectArguments))
+            (void)alsoRetain; // Held only to keep a companion scratch buffer alive until GPU completion.
+            // The clamped args live at indirectBufferOffset (0 for a per-Buffer slot, non-zero for per-draw scratch).
+            auto checkedEnd = checkedSum<uint64_t>(indirectBufferOffset, sizeof(WebKitMTLDrawPrimitivesIndirectArguments));
+            if (!indirectBuffer.contents || checkedEnd.hasOverflowed() || checkedEnd.value() > indirectBuffer.length)
                 return;
 
-            auto& args = *static_cast<WebKitMTLDrawPrimitivesIndirectArguments*>(indirectBuffer.contents);
+            auto* contents = static_cast<uint8_t*>(indirectBuffer.contents) + indirectBufferOffset;
+            auto& args = *static_cast<WebKitMTLDrawPrimitivesIndirectArguments*>(static_cast<void*>(contents));
             if (args.lostOrOOBRead)
                 protectedDevice->loseTheDevice(WGPUDeviceLostReason_Undefined);
         });
@@ -882,7 +897,8 @@ std::pair<id<MTLBuffer>, uint64_t> RenderPassEncoder::clampIndirectIndexBufferTo
     id<MTLBuffer> indirectBuffer = indexedIndirectBuffer.indirectBuffer();
     auto indexSize = indexType == MTLIndexTypeUInt16 ? sizeof(uint16_t) : sizeof(uint32_t);
     auto checkedOffsetPlusSize = checkedSum<uint32_t>(indexBufferOffsetInBytes, indexSize);
-    if (!indirectBuffer || !minVertexCount || !minInstanceCount || checkedOffsetPlusSize.hasOverflowed() || checkedOffsetPlusSize.value() >= indexBuffer.length)
+    // '>' not '>=': offset + indexSize == length is a valid single-element index buffer
+    if (!indirectBuffer || !minVertexCount || !minInstanceCount || checkedOffsetPlusSize.hasOverflowed() || checkedOffsetPlusSize.value() > indexBuffer.length)
         return std::make_pair(nil, 0ull);
 
     if (!indexedIndirectBuffer.indirectIndexedBufferRequiresRecomputation(indexType, indexBufferOffsetInBytes, indirectOffset, minVertexCount, minInstanceCount)) {
@@ -891,7 +907,7 @@ std::pair<id<MTLBuffer>, uint64_t> RenderPassEncoder::clampIndirectIndexBufferTo
     }
 
     id<MTLRenderCommandEncoder> renderCommandEncoder = encoder.renderCommandEncoder();
-    CHECKED_SET_PSO(renderCommandEncoder, device.indexedIndirectBufferClampPipeline(rasterSampleCount), std::make_pair(nil, 0ull));
+    CHECKED_SET_PSO(renderCommandEncoder, device, device.indexedIndirectBufferClampPipeline(rasterSampleCount), std::make_pair(nil, 0ull));
     uint32_t indexBufferCount = static_cast<uint32_t>((indexBuffer.length - indexBufferOffsetInBytes) / indexSize);
     encoder.setVertexBuffer(renderCommandEncoder, indexedIndirectBuffer.buffer(), indirectOffset, 0);
     encoder.setVertexBuffer(renderCommandEncoder, indexedIndirectBuffer.indirectIndexedBuffer(), 0, 1);
@@ -903,7 +919,7 @@ std::pair<id<MTLBuffer>, uint64_t> RenderPassEncoder::clampIndirectIndexBufferTo
 
     if (encoder.splitRenderPass())
         renderCommandEncoder = encoder.renderCommandEncoder();
-    CHECKED_SET_PSO(renderCommandEncoder, device.indexBufferClampPipeline(indexType, rasterSampleCount), std::make_pair(nil, 0ull));
+    CHECKED_SET_PSO(renderCommandEncoder, device, device.indexBufferClampPipeline(indexType, rasterSampleCount), std::make_pair(nil, 0ull));
     encoder.setVertexBuffer(renderCommandEncoder, indexBuffer, indexBufferOffsetInBytes, 0);
     encoder.setVertexBuffer(renderCommandEncoder, indexedIndirectBuffer.indirectIndexedBuffer(), 0, 1);
     auto primitiveOffset = primitiveType == MTLPrimitiveTypeLineStrip || primitiveType == MTLPrimitiveTypeTriangleStrip ? 1u : 0u;
@@ -939,7 +955,7 @@ std::pair<id<MTLBuffer>, uint64_t> RenderPassEncoder::clampIndirectBufferToValid
 
     id<MTLRenderCommandEncoder> renderCommandEncoder = encoder.renderCommandEncoder();
     id<MTLRenderPipelineState> renderPipelineState = device.indirectBufferClampPipeline(rasterSampleCount);
-    CHECKED_SET_PSO(renderCommandEncoder, renderPipelineState, std::make_pair(nil, 0ull));
+    CHECKED_SET_PSO(renderCommandEncoder, device, renderPipelineState, std::make_pair(nil, 0ull));
     encoder.setVertexBuffer(renderCommandEncoder, indirectBuffer.buffer(), indirectOffset, 0);
     encoder.setVertexBuffer(renderCommandEncoder, indirectBuffer.indirectBuffer(), 0, 1);
     uint32_t data[] = { minVertexCount, minInstanceCount };
@@ -958,6 +974,85 @@ std::pair<id<MTLBuffer>, uint64_t> RenderPassEncoder::clampIndirectBufferToValid
 {
     return clampIndirectBufferToValidValues(indirectBuffer, indirectOffset, minVertexCount, minInstanceCount, m_device.get(), m_rasterSampleCount, *this, splitEncoder);
 }
+
+// --- Batched indirect clamp (executeBundles only) ------------------------------------------------
+// These mirror clampIndirect*ToValidValues but write caller-supplied per-draw scratch and emit no
+// internal memory barrier, so executeBundles can batch one barrier around all draws instead of per draw.
+
+// Zeroed scratch is required because the clamp shaders write lostOrOOBRead only on failure.
+std::pair<id<MTLBuffer>, uint64_t> RenderPassEncoder::newZeroedIndirectScratch(Device& device, size_t size)
+{
+    Vector<uint8_t> zero(size);
+    zeroSpan(zero.mutableSpan());
+    return device.getQueue()->newTemporaryBufferWithBytes(zero.mutableSpan(), false);
+}
+
+// One dispatch; writes the clamped MTLDrawPrimitivesIndirectArguments (+lostOrOOBRead) into finalScratch.
+bool RenderPassEncoder::clampIndirectBufferDispatchBatched(Buffer& indirectBuffer, uint64_t indirectOffset, uint32_t minVertexCount, uint32_t minInstanceCount, Device& device, uint32_t rasterSampleCount, RenderPassEncoder& encoder, id<MTLBuffer> finalScratch, uint64_t finalScratchOffset)
+{
+    id<MTLRenderCommandEncoder> renderCommandEncoder = encoder.renderCommandEncoder();
+    id<MTLRenderPipelineState> pso = device.indirectBufferClampPipeline(rasterSampleCount);
+    if (!pso)
+        return false;
+    [renderCommandEncoder setRenderPipelineState:pso];
+    encoder.setVertexBuffer(renderCommandEncoder, indirectBuffer.buffer(), indirectOffset, 0);
+    encoder.setVertexBuffer(renderCommandEncoder, finalScratch, finalScratchOffset, 1);
+    uint32_t data[] = { minVertexCount, minInstanceCount };
+    encoder.setVertexBytes(renderCommandEncoder, asByteSpan(data), 2);
+    [renderCommandEncoder drawPrimitives:MTLPrimitiveTypePoint vertexStart:0 vertexCount:1];
+    checkForIndirectDrawDeviceLost(device, encoder, finalScratch, finalScratchOffset);
+    return true;
+}
+
+// Indexed dispatch-1: clamps args into finalScratch and writes a thread-count record into
+// intermediateScratch (consumed by dispatch-2). Returns indexBufferCount.
+bool RenderPassEncoder::clampIndirectIndexBufferDispatch1Batched(Buffer* apiIndexBuffer, Buffer& indexedIndirectBuffer, MTLIndexType indexType, NSUInteger indexBufferOffsetInBytes, uint64_t indirectOffset, uint32_t minInstanceCount, Device& device, uint32_t rasterSampleCount, RenderPassEncoder& encoder, id<MTLBuffer> finalScratch, uint64_t finalScratchOffset, id<MTLBuffer> intermediateScratch, uint64_t intermediateScratchOffset, uint32_t& outIndexBufferCount)
+{
+    id<MTLBuffer> indexBuffer = apiIndexBuffer ? apiIndexBuffer->buffer() : nil;
+    if (!indexBuffer)
+        return false;
+    auto indexSize = indexType == MTLIndexTypeUInt16 ? sizeof(uint16_t) : sizeof(uint32_t);
+    auto checkedOffsetPlusSize = checkedSum<uint32_t>(indexBufferOffsetInBytes, indexSize);
+    // The bound is '>' not '>=': offset + indexSize == length is a valid single-element buffer.
+    if (!minInstanceCount || checkedOffsetPlusSize.hasOverflowed() || checkedOffsetPlusSize.value() > indexBuffer.length)
+        return false;
+    id<MTLRenderCommandEncoder> renderCommandEncoder = encoder.renderCommandEncoder();
+    id<MTLRenderPipelineState> pso = device.indexedIndirectBufferClampPipeline(rasterSampleCount);
+    if (!pso)
+        return false;
+    [renderCommandEncoder setRenderPipelineState:pso];
+    outIndexBufferCount = static_cast<uint32_t>((indexBuffer.length - indexBufferOffsetInBytes) / indexSize);
+    encoder.setVertexBuffer(renderCommandEncoder, indexedIndirectBuffer.buffer(), indirectOffset, 0);
+    encoder.setVertexBuffer(renderCommandEncoder, finalScratch, finalScratchOffset, 1);
+    encoder.setVertexBuffer(renderCommandEncoder, intermediateScratch, intermediateScratchOffset, 2);
+    uint32_t indirectData[] = { outIndexBufferCount, minInstanceCount };
+    encoder.setVertexBytes(renderCommandEncoder, asByteSpan(indirectData), 3);
+    [renderCommandEncoder drawPrimitives:MTLPrimitiveTypePoint vertexStart:0 vertexCount:1];
+    // Device-loss flag lives in intermediateScratch; also retain finalScratch until GPU completion.
+    checkForIndirectDrawDeviceLost(device, encoder, intermediateScratch, intermediateScratchOffset, finalScratch);
+    return true;
+}
+
+// Indexed dispatch-2: read-clamps finalScratch against the actual index buffer contents.
+bool RenderPassEncoder::clampIndirectIndexBufferDispatch2Batched(Buffer* apiIndexBuffer, MTLIndexType indexType, NSUInteger indexBufferOffsetInBytes, uint32_t minVertexCount, MTLPrimitiveType primitiveType, uint32_t indexBufferCount, Device& device, uint32_t rasterSampleCount, RenderPassEncoder& encoder, id<MTLBuffer> finalScratch, uint64_t finalScratchOffset, id<MTLBuffer> intermediateScratch, uint64_t intermediateScratchOffset)
+{
+    id<MTLBuffer> indexBuffer = apiIndexBuffer ? apiIndexBuffer->buffer() : nil;
+    if (!indexBuffer)
+        return false;
+    id<MTLRenderCommandEncoder> renderCommandEncoder = encoder.renderCommandEncoder();
+    id<MTLRenderPipelineState> pso = device.indexBufferClampPipeline(indexType, rasterSampleCount);
+    if (!pso)
+        return false;
+    [renderCommandEncoder setRenderPipelineState:pso];
+    encoder.setVertexBuffer(renderCommandEncoder, indexBuffer, indexBufferOffsetInBytes, 0);
+    encoder.setVertexBuffer(renderCommandEncoder, finalScratch, finalScratchOffset, 1);
+    auto primitiveOffset = primitiveType == MTLPrimitiveTypeLineStrip || primitiveType == MTLPrimitiveTypeTriangleStrip ? 1u : 0u;
+    uint32_t data[] = { minVertexCount == RenderBundleEncoder::invalidVertexInstanceCount ? minVertexCount - primitiveOffset : minVertexCount, primitiveOffset, indexBufferCount - 1 };
+    encoder.setVertexBytes(renderCommandEncoder, asByteSpan(data), 2);
+    [renderCommandEncoder drawPrimitives:MTLPrimitiveTypePoint indirectBuffer:intermediateScratch indirectBufferOffset:intermediateScratchOffset];
+    return true;
+}
+
 
 static NSUInteger NODELETE verticesPerPrimitive(MTLPrimitiveType primitiveType)
 {
@@ -1227,6 +1322,30 @@ void RenderPassEncoder::executeBundles(Vector<Ref<RenderBundle>>&& bundles)
     float minDepth = m_viewport ? m_viewport->znear : 0.f;
     float maxDepth = m_viewport ? m_viewport->zfar : 1.f;
 
+    // Run in two phases across ALL bundles so the whole call needs at most one memory barrier: first
+    // validate every bundle and GPU-encode its ICB slots, then a single barrier, then execute every
+    // bundle's ICB. Per-bundle encode→barrier→execute would emit one barrier per bundle.
+    bool needsBarrierBeforeExecute = false;
+    // Indirect draws across all bundles are collected here and processed in phases after the bundle loop
+    // (all dispatch-1s → barrier → all dispatch-2s → barrier → all ICB encodes). Each draw uses its own
+    // scratch, so draws never conflict and need no per-draw barrier.
+    struct IndirectEncodeWork {
+        RetainPtr<RenderBundleICBWithResources> icb;
+        uint64_t slotIndex { 0 };
+        WebGPU::IndirectDrawData* data { nullptr };
+        RefPtr<WebGPU::Buffer> indirectBuffer;
+        RefPtr<WebGPU::Buffer> indexBuffer;
+        uint64_t indirectGeneration { 0 };
+        uint64_t indexGeneration { 0 };
+        bool clamps { false }; // false => read raw app args (no min-count clamp required)
+        // Per-draw scratch, filled in phase A when clamps == true:
+        RetainPtr<id<MTLBuffer>> finalScratch { };
+        uint64_t finalScratchOffset { 0 };
+        RetainPtr<id<MTLBuffer>> intermediateScratch { }; // indexed only
+        uint64_t intermediateScratchOffset { 0 };
+        uint32_t indexBufferCount { 0 };
+    };
+    Vector<IndirectEncodeWork> indirectWork;
     for (auto bundle : bundles) {
         if (!isValidToUseWith(bundle, *this)) {
             makeInvalid([NSString stringWithFormat:@"executeBundles: render bundle is not valid, reason = %@", bundle->lastError()]);
@@ -1250,7 +1369,6 @@ void RenderPassEncoder::executeBundles(Vector<Ref<RenderBundle>>&& bundles)
             return bundle->rebindSamplersIfNeeded();
         });
         if (!bundle->requiresCommandReplay()) {
-            bool splitPass = false;
             for (RenderBundleICBWithResources* icb in bundle->renderBundlesResources()) {
                 auto& hashMap = *icb.minVertexCountForDrawCommand;
                 for (auto& [commandIndex, data] : hashMap) {
@@ -1271,7 +1389,7 @@ void RenderPassEncoder::executeBundles(Vector<Ref<RenderBundle>>&& bundles)
 
                     id<MTLRenderPipelineState> renderPipelineState = protect(m_device)->icbCommandClampPipeline(data.indexType, m_rasterSampleCount);
                     id<MTLBuffer> indirectCommandBufferContainer = icb.indirectCommandBufferContainer;
-                    CHECKED_SET_PSO(commandEncoder, renderPipelineState);
+                    CHECKED_SET_PSO(commandEncoder, m_device, renderPipelineState);
                     setVertexBytes(commandEncoder, asByteSpan(data.indexData), 0);
                     m_parentEncoder->addBuffer(indirectCommandBufferContainer);
                     setVertexBuffer(commandEncoder, indirectCommandBufferContainer, 0, 1);
@@ -1284,29 +1402,197 @@ void RenderPassEncoder::executeBundles(Vector<Ref<RenderBundle>>&& bundles)
                     [commandEncoder drawPrimitives:MTLPrimitiveTypePoint vertexStart:0 vertexCount:data.indexData.indexCount];
 
                     auto encoderHandle = m_device->getQueue()->retainCounterSampleBuffer(m_parentEncoder);
-                    [m_parentEncoder->commandBuffer() addCompletedHandler:[encoderHandle, protectedDevice = protect(m_device), firstIndex, indexCount, effectiveMinVertexCount, indexType, primitiveOffset, refIndexBuffer = protect(*indexBuffer), icb](id<MTLCommandBuffer> completedCommandBuffer) mutable {
+                    uint64_t validationGeneration = indexBuffer->indexContentsGeneration();
+                    [m_parentEncoder->commandBuffer() addCompletedHandler:[encoderHandle, protectedDevice = protect(m_device), firstIndex, indexCount, effectiveMinVertexCount, indexType, primitiveOffset, validationGeneration, refIndexBuffer = protect(*indexBuffer), icb](id<MTLCommandBuffer> completedCommandBuffer) mutable {
                         if (completedCommandBuffer.status != MTLCommandBufferStatusCompleted) {
                             protectedDevice->getQueue()->releaseCounterSampleBuffer(encoderHandle);
                             return;
                         }
 
-                        protectedDevice->getQueue()->scheduleWork([encoderHandle, protectedDevice, icb, firstIndex, indexCount, effectiveMinVertexCount, indexType, primitiveOffset, refIndexBuffer = WTF::move(refIndexBuffer)]() mutable {
+                        protectedDevice->getQueue()->scheduleWork([encoderHandle, protectedDevice, icb, firstIndex, indexCount, effectiveMinVertexCount, indexType, primitiveOffset, validationGeneration, refIndexBuffer = WTF::move(refIndexBuffer)]() mutable {
                             protectedDevice->getQueue()->releaseCounterSampleBuffer(encoderHandle);
                             id<MTLBuffer> outOfBoundsReadFlag = icb.outOfBoundsReadFlag;
                             refIndexBuffer->didReadOOB(*static_cast<uint32_t*>(outOfBoundsReadFlag.contents), icb.indirectCommandBuffer);
-                            refIndexBuffer->drawIndexedValidated(firstIndex, indexCount, effectiveMinVertexCount, indexType, primitiveOffset, icb.indirectCommandBuffer);
+                            refIndexBuffer->drawIndexedValidated(firstIndex, indexCount, effectiveMinVertexCount, indexType, primitiveOffset, validationGeneration, icb.indirectCommandBuffer);
                         });
                     }];
-                    splitPass = true;
+                    needsBarrierBeforeExecute = true;
                 }
             }
-            if (splitPass) {
-                emitMemoryBarrier(commandEncoder);
-                splitPass = splitRenderPass();
-                commandEncoder = renderCommandEncoder();
+            // Collect this bundle's indirect draws for phased processing. A draw whose indirect+index
+            // buffers are unchanged since it was last encoded is skipped wholesale (contentsGeneration cache).
+            for (RenderBundleICBWithResources* icb in bundle->renderBundlesResources()) {
+                auto& indirectMap = *icb.indirectDrawsForSlot;
+                for (auto& [slotIndex, data] : indirectMap) {
+                    RefPtr indirectBuffer = data.indirectBuffer.get();
+                    if (!indirectBuffer || indirectBuffer->isDestroyed())
+                        continue;
+                    RefPtr indexBuffer = data.indexBuffer.get();
+                    if (data.isIndexed && indexBuffer && indexBuffer->isDestroyed())
+                        continue;
+
+                    uint64_t indirectGeneration = indirectBuffer->contentsGeneration();
+                    uint64_t indexGeneration = indexBuffer ? indexBuffer->indexContentsGeneration() : 0;
+                    if (data.encodedAtLeastOnce && data.lastIndirectGeneration == indirectGeneration && data.lastIndexGeneration == indexGeneration)
+                        continue;
+
+                    bool clamps = data.isIndexed || !(data.minVertexCount == RenderBundleEncoder::invalidVertexInstanceCount && data.minInstanceCount == RenderBundleEncoder::invalidVertexInstanceCount);
+                    indirectWork.append(IndirectEncodeWork {
+                        .icb = icb,
+                        .slotIndex = slotIndex,
+                        .data = &data,
+                        .indirectBuffer = indirectBuffer,
+                        .indexBuffer = indexBuffer,
+                        .indirectGeneration = indirectGeneration,
+                        .indexGeneration = indexGeneration,
+                        .clamps = clamps,
+                    });
+                }
             }
         }
+    }
 
+    // Phase A: run every clamping draw's dispatch-1 (indexed) / single dispatch (non-indexed) into its own
+    // per-draw scratch. Non-clamping draws read the app's raw args directly. No barriers here.
+    bool anyClampDispatched = false;
+    for (auto& work : indirectWork) {
+        if (!work.clamps)
+            continue;
+        commandEncoder = renderCommandEncoder();
+        if (!commandEncoder)
+            break;
+        auto& data = *work.data;
+        Ref indirectBuffer = *work.indirectBuffer;
+        if (data.isIndexed) {
+            auto [finalScratch, finalOffset] = newZeroedIndirectScratch(m_device.get(), sizeof(WebKitMTLDrawIndexedPrimitivesIndirectArguments));
+            auto [interScratch, interOffset] = newZeroedIndirectScratch(m_device.get(), sizeof(WebKitMTLDrawPrimitivesIndirectArguments));
+            if (!finalScratch || !interScratch)
+                continue;
+            uint32_t indexBufferCount = 0;
+            if (!clampIndirectIndexBufferDispatch1Batched(work.indexBuffer.get(), indirectBuffer, data.indexType, data.indexBufferOffset, data.indirectOffset, data.minInstanceCount, m_device.get(), m_rasterSampleCount, *this, finalScratch, finalOffset, interScratch, interOffset, indexBufferCount))
+                continue;
+            work.finalScratch = finalScratch;
+            work.finalScratchOffset = finalOffset;
+            work.intermediateScratch = interScratch;
+            work.intermediateScratchOffset = interOffset;
+            work.indexBufferCount = indexBufferCount;
+            m_parentEncoder->addBuffer(finalScratch);
+            m_parentEncoder->addBuffer(interScratch);
+        } else {
+            auto [finalScratch, finalOffset] = newZeroedIndirectScratch(m_device.get(), sizeof(WebKitMTLDrawPrimitivesIndirectArguments));
+            if (!finalScratch)
+                continue;
+            if (!clampIndirectBufferDispatchBatched(indirectBuffer, data.indirectOffset, data.minVertexCount, data.minInstanceCount, m_device.get(), m_rasterSampleCount, *this, finalScratch, finalOffset))
+                continue;
+            work.finalScratch = finalScratch;
+            work.finalScratchOffset = finalOffset;
+            m_parentEncoder->addBuffer(finalScratch);
+        }
+        anyClampDispatched = true;
+        needsBarrierBeforeExecute = true;
+    }
+
+    // Barrier between all dispatch-1s and all indexed dispatch-2s (dispatch-2 reads dispatch-1's output).
+    bool anyIndexedClamp = false;
+    for (auto& work : indirectWork) {
+        if (work.clamps && work.data->isIndexed && work.intermediateScratch) {
+            anyIndexedClamp = true;
+            break;
+        }
+    }
+    if (anyIndexedClamp) {
+        emitMemoryBarrier(commandEncoder);
+        if (splitRenderPass())
+            commandEncoder = renderCommandEncoder();
+    }
+
+    // Phase B: run every indexed draw's dispatch-2 (per-index bounds clamp). No barriers.
+    for (auto& work : indirectWork) {
+        if (!work.clamps || !work.data->isIndexed || !work.intermediateScratch)
+            continue;
+        commandEncoder = renderCommandEncoder();
+        if (!commandEncoder)
+            break;
+        auto& data = *work.data;
+        clampIndirectIndexBufferDispatch2Batched(work.indexBuffer.get(), data.indexType, data.indexBufferOffset, data.minVertexCount, data.primitiveType, work.indexBufferCount, m_device.get(), m_rasterSampleCount, *this, work.finalScratch.get(), work.finalScratchOffset, work.intermediateScratch.get(), work.intermediateScratchOffset);
+    }
+
+    // Barrier between the clamp dispatches and the ICB encode kernels that read their clamped output.
+    if (anyClampDispatched) {
+        emitMemoryBarrier(commandEncoder);
+        if (splitRenderPass())
+            commandEncoder = renderCommandEncoder();
+    }
+
+    // Phase C: GPU-encode each indirect draw into its ICB slot, reading its clamped scratch or the app's
+    // raw args. No barriers between encodes — each writes a distinct ICB slot.
+    for (auto& work : indirectWork) {
+        commandEncoder = renderCommandEncoder();
+        if (!commandEncoder)
+            break;
+        auto& data = *work.data;
+        RenderBundleICBWithResources* icb = work.icb.get();
+
+        id<MTLBuffer> clampedArgs = nil;
+        uint64_t clampedArgsOffset = 0;
+        if (work.clamps) {
+            if (!work.finalScratch)
+                continue;
+            clampedArgs = work.finalScratch.get();
+            clampedArgsOffset = work.finalScratchOffset;
+        } else {
+            clampedArgs = work.indirectBuffer->buffer();
+            clampedArgsOffset = data.indirectOffset;
+        }
+        if (!clampedArgs)
+            continue;
+
+        id<MTLRenderPipelineState> encodePipeline = protect(m_device)->icbIndirectEncodePipeline(data.isIndexed, data.indexType, m_rasterSampleCount);
+        CHECKED_SET_PSO(commandEncoder, m_device, encodePipeline);
+
+        m_parentEncoder->addBuffer(clampedArgs);
+        setVertexBuffer(commandEncoder, clampedArgs, clampedArgsOffset, 0);
+        [commandEncoder useResource:clampedArgs usage:MTLResourceUsageRead stages:MTLRenderStageVertex];
+
+        id<MTLBuffer> indirectCommandBufferContainer = icb.indirectCommandBufferContainer;
+        m_parentEncoder->addBuffer(indirectCommandBufferContainer);
+        setVertexBuffer(commandEncoder, indirectCommandBufferContainer, 0, 1);
+
+        if (data.isIndexed) {
+            id<MTLBuffer> mtlIndexBuffer = work.indexBuffer ? work.indexBuffer->buffer() : nil;
+            if (!mtlIndexBuffer)
+                continue;
+            auto indexSizeInBytes = data.indexType == MTLIndexTypeUInt16 ? sizeof(uint16_t) : sizeof(uint32_t);
+            m_parentEncoder->addBuffer(mtlIndexBuffer);
+            setVertexBuffer(commandEncoder, mtlIndexBuffer, 0, 2);
+            [commandEncoder useResource:mtlIndexBuffer usage:MTLResourceUsageRead stages:MTLRenderStageVertex];
+            uint32_t slotData[] = { static_cast<uint32_t>(work.slotIndex), static_cast<uint32_t>(data.primitiveType), static_cast<uint32_t>(data.indexBufferOffset / indexSizeInBytes) };
+            setVertexBytes(commandEncoder, asByteSpan(slotData), 3);
+        } else {
+            uint32_t slotData[] = { static_cast<uint32_t>(work.slotIndex), static_cast<uint32_t>(data.primitiveType) };
+            setVertexBytes(commandEncoder, asByteSpan(slotData), 2);
+        }
+
+        m_parentEncoder->addICB(icb.indirectCommandBuffer);
+        [commandEncoder useResource:icb.indirectCommandBuffer usage:MTLResourceUsageRead | MTLResourceUsageWrite stages:MTLRenderStageVertex];
+        m_parentEncoder->addBuffer(icb.outOfBoundsReadFlag);
+        [commandEncoder useResource:icb.outOfBoundsReadFlag usage:MTLResourceUsageWrite stages:MTLRenderStageVertex];
+
+        [commandEncoder drawPrimitives:MTLPrimitiveTypePoint vertexStart:0 vertexCount:1];
+        data.encodedAtLeastOnce = true;
+        data.lastIndirectGeneration = work.indirectGeneration;
+        data.lastIndexGeneration = work.indexGeneration;
+        needsBarrierBeforeExecute = true;
+    }
+
+    // Single barrier: order every ICB write above before every executeCommandsInBuffer: below.
+    if (needsBarrierBeforeExecute) {
+        emitMemoryBarrier(commandEncoder);
+        if (splitRenderPass())
+            commandEncoder = renderCommandEncoder();
+    }
+
+    for (auto bundle : bundles) {
         incrementDrawCount(bundle->drawCount());
 
         for (const auto& resource : bundle->resources()) {


### PR DESCRIPTION
#### 59b6d9a2d0273c0aa2fd270cf726ea3b5c011c98
<pre>
executeBundles re-replays bundles containing indirect draws and reconstructs ICBs every call — 30× frame-rate collapse vs direct encoding
<a href="https://bugs.webkit.org/show_bug.cgi?id=320490">https://bugs.webkit.org/show_bug.cgi?id=320490</a>
<a href="https://rdar.apple.com/183458069">rdar://183458069</a>

Reviewed by Dan Glastonbury.

Fix performance issue from drawIndirect and drawIndexedIndirect into RenderBundles,
which WebKit strongly suggests using, but previously encountered a severe performance
cliff.

With this change, we are able to maintain 60 fps with 2000 indirect draws in a bundle
whereas previously we would drop under 1 fps.

Tests: fast/webgpu/render-bundle-draw-indexed-indirect.html
       fast/webgpu/render-bundle-draw-indirect.html

* LayoutTests/fast/webgpu/render-bundle-draw-indexed-indirect-expected.txt: Added.
* LayoutTests/fast/webgpu/render-bundle-draw-indexed-indirect.html: Added.
* LayoutTests/fast/webgpu/render-bundle-draw-indirect-expected.txt: Added.
* LayoutTests/fast/webgpu/render-bundle-draw-indirect.html: Added.
* Source/WebGPU/WebGPU/BindableResource.h:
* Source/WebGPU/WebGPU/Buffer.h:
(WebGPU::Buffer::contentsGeneration const):
* Source/WebGPU/WebGPU/Buffer.mm:
(WebGPU::Buffer::indirectBufferInvalidated):
* Source/WebGPU/WebGPU/Device.h:
* Source/WebGPU/WebGPU/Device.mm:
* Source/WebGPU/WebGPU/RenderBundleEncoder.h:
* Source/WebGPU/WebGPU/RenderBundleEncoder.mm:
(-[RenderBundleICBWithResources initWithICB:containerBuffer:pipelineState:depthStencilState:cullMode:frontFace:depthClipMode:depthBias:depthBiasSlopeScale:depthBiasClamp:fragmentDynamicOffsetsBuffer:pipeline:minVertexCounts:indirectDraws:outOfBoundsReadFlag:]):
(-[RenderBundleICBWithResources indirectDrawsForSlot]):
(WebGPU::makeRenderBundleICBWithResources):
(WebGPU::RenderBundleEncoder::drawIndexedIndirect):
(WebGPU::RenderBundleEncoder::drawIndirect):
(WebGPU::RenderBundleEncoder::cleanup):
(WebGPU::RenderBundleEncoder::splitICB):
(-[RenderBundleICBWithResources initWithICB:containerBuffer:pipelineState:depthStencilState:cullMode:frontFace:depthClipMode:depthBias:depthBiasSlopeScale:depthBiasClamp:fragmentDynamicOffsetsBuffer:pipeline:minVertexCounts:outOfBoundsReadFlag:]): Deleted.
* Source/WebGPU/WebGPU/RenderPassEncoder.h:
* Source/WebGPU/WebGPU/RenderPassEncoder.mm:
(WebGPU::checkForIndirectDrawDeviceLost):
(WebGPU::RenderPassEncoder::newZeroedIndirectScratch):
(WebGPU::RenderPassEncoder::clampIndirectBufferDispatchBatched):
(WebGPU::RenderPassEncoder::clampIndirectIndexBufferDispatch1Batched):
(WebGPU::RenderPassEncoder::clampIndirectIndexBufferDispatch2Batched):
(WebGPU::RenderPassEncoder::executeBundles):

Canonical link: <a href="https://commits.webkit.org/318538@main">https://commits.webkit.org/318538@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/485e6b38a71d20d2b1ac082475d17540b35e3a49

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178547 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52485 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46280 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188163 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/141796 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53779 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52195 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139205 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96657 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181504 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42763 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159955 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119659 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41429 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39784 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151829 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39455 "Passed tests") | [⏳ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/GTK-GTK3-GCC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45085 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44026 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190590 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52154 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/159479 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148367 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39847 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52835 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36078 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148136 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42845 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125102 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119738 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51353 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14430 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50738 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50978 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50800 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->