### PR TITLE
[Site Isolation] [iOS] A full-sized iframe within its parent is not visible

### DIFF
--- a/LayoutTests/http/tests/site-isolation/full-viewport-iframe-expected.html
+++ b/LayoutTests/http/tests/site-isolation/full-viewport-iframe-expected.html
@@ -1,0 +1,5 @@
+<style>
+html, body { margin: 0 }
+</style>
+<body bgcolor=green>
+</body>

--- a/LayoutTests/http/tests/site-isolation/full-viewport-iframe.html
+++ b/LayoutTests/http/tests/site-isolation/full-viewport-iframe.html
@@ -1,0 +1,9 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<head><meta name="fuzzy" content="maxDifference=112; totalPixels=900"/></head>
+<style>
+html, body { margin: 0 }
+iframe { display: block; width: 100vw; height: 100vh; border: none }
+</style>
+<body bgcolor=blue>
+<iframe src="http://localhost:8000/site-isolation/resources/green-background.html"></iframe>
+</body>

--- a/LayoutTests/platform/ios-site-isolation/TestExpectations
+++ b/LayoutTests/platform/ios-site-isolation/TestExpectations
@@ -47,7 +47,6 @@ http/tests/navigation-api/different-origin-entries-removed-after-bfcache.html [ 
 http/tests/navigation/https-in-page-cache.html [ Timeout ]
 http/tests/navigation/page-cache-pending-ping-load-cross-origin.html [ Timeout ]
 http/tests/navigation/page-cache-requestAnimationFrame.html [ Timeout ]
-http/tests/quicklook/secure-document-with-subresources.html [ Timeout ]
 http/tests/resourceLoadStatistics/add-blocking-to-redirect.html [ Timeout ]
 http/tests/resourceLoadStatistics/non-sandboxed-iframe-redirect-ip-to-localhost-to-ip.html [ Timeout ]
 http/tests/resourceLoadStatistics/non-sandboxed-iframe-redirect-localhost-to-ip-to-localhost.html [ Timeout ]

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -1296,24 +1296,24 @@ void WebFrame::updateLocalFrameRect(WebCore::LocalFrame& localFrame, WebCore::In
         return;
 
     auto oldRect = frameView->frameRect();
+    auto rectChanged = oldRect != newRect;
 
-    if (oldRect == newRect)
-        return;
+    if (rectChanged) {
+        if (isInitialFrameRect == IsInitialFrameRect::Yes)
+            frameView->primeResizeEventBaseline(newRect.size());
 
-    if (isInitialFrameRect == IsInitialFrameRect::Yes)
-        frameView->primeResizeEventBaseline(newRect.size());
-
-    frameView->setFrameRect(newRect);
+        frameView->setFrameRect(newRect);
+    }
 
 #if PLATFORM(IOS_FAMILY)
-    if (oldRect.size() != frameView->size()) {
-        // FIXME: This ensures cross-site iframe render correctly;
-        // it should be removed after rdar://122429810 is fixed.
-        frameView->setExposedContentRect(FloatRect { { }, frameView->size() });
-        frameView->setUnobscuredContentSize(frameView->size());
-    }
+    // FIXME: This ensures cross-site iframe render correctly;
+    // it should be removed after rdar://122429810 is fixed.
+    frameView->setExposedContentRect(FloatRect { { }, frameView->size() });
+    frameView->setUnobscuredContentSize(frameView->size());
 #endif
 
+    if (!rectChanged)
+        return;
 
     if (RefPtr drawingArea = m_page ? m_page->drawingArea() : nullptr) {
         drawingArea->setNeedsDisplay();


### PR DESCRIPTION
#### fa91023df56d96bfa2e2a0930f77f22f31f2ef30
<pre>
[Site Isolation] [iOS] A full-sized iframe within its parent is not visible
<a href="https://bugs.webkit.org/show_bug.cgi?id=320535">https://bugs.webkit.org/show_bug.cgi?id=320535</a>
<a href="https://rdar.apple.com/183493532">rdar://183493532</a>

Reviewed by Aditya Keerthi.

The existing logic in `WebFrame::updateLocalFrameRect` to set the exposed content rect and unobscured
content size mostly worked, but fails when the iframe is the full size of the viewport. This is
because in this case, its possible only the origin may change, or nothing will change, instead of the
size actually changing.

Fix by making that logic always run so it works in all cases (and adjust the rest of the function accordingly).

Test: http/tests/site-isolation/full-viewport-iframe.html

* LayoutTests/http/tests/site-isolation/full-viewport-iframe-expected.html: Added.
* LayoutTests/http/tests/site-isolation/full-viewport-iframe.html: Added.
* LayoutTests/platform/ios-site-isolation/TestExpectations:
* Source/WebKit/WebProcess/WebPage/WebFrame.cpp:
(WebKit::WebFrame::updateLocalFrameRect):

Canonical link: <a href="https://commits.webkit.org/318192@main">https://commits.webkit.org/318192@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/efca3460dd0caec2f02d02e5c5fc02e241fe75e4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177445 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51383 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45177 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187049 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140692 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/42df6e82-a14a-42aa-9565-894800b41870) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52675 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51092 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138288 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140692 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c72f9802-1045-4ccb-bc10-bf8075dbf09a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180401 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41793 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159042 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118753 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4e70c627-9e7a-4ad2-81aa-7d59a1e18afd) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40453 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38827 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150860 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38539 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35516 "Built successfully") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/38716 "Build is in progress. Recent messages:") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/43168 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43061 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189477 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51050 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/158576 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147388 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51732 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35167 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147180 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26933 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41892 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123947 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118307 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50240 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13517 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49636 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49876 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49698 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->