### PR TITLE
REGRESSION(317100@main): [Fizz] 5 editing/mac/attributed-string/attributed-string-across-shadow-boundaries tests are constant TEXT failures.

### DIFF
--- a/LayoutTests/platform/mac-wk1/editing/mac/attributed-string/attributed-string-across-shadow-boundaries-1-expected.txt
+++ b/LayoutTests/platform/mac-wk1/editing/mac/attributed-string/attributed-string-across-shadow-boundaries-1-expected.txt
@@ -23,17 +23,7 @@ Alignment Natural
     TighteningForTruncation: YES
     HeaderLevel: 0 LineBreakStrategy 0 PresentationIntents (
 ) ListIntentOrdinal 0 CodeBlockIntentLanguageHint ''
-[hello ]
-    NSFont: Times-Roman 16.00 pt.
-    NSKern: 0pt
-    NSStrokeColor: #000000 (sRGB)
-    NSStrokeWidth: 0
-[world]
-    NSFont: Times-Roman 16.00 pt.
-    NSKern: 0pt
-    NSStrokeColor: #000000 (sRGB)
-    NSStrokeWidth: 0
-[ WebKit rocks]
+[hello world WebKit rocks]
     NSFont: Times-Roman 16.00 pt.
     NSKern: 0pt
     NSStrokeColor: #000000 (sRGB)

--- a/LayoutTests/platform/mac-wk1/editing/mac/attributed-string/attributed-string-across-shadow-boundaries-2-expected.txt
+++ b/LayoutTests/platform/mac-wk1/editing/mac/attributed-string/attributed-string-across-shadow-boundaries-2-expected.txt
@@ -23,12 +23,7 @@ Alignment Natural
     TighteningForTruncation: YES
     HeaderLevel: 0 LineBreakStrategy 0 PresentationIntents (
 ) ListIntentOrdinal 0 CodeBlockIntentLanguageHint ''
-[world]
-    NSFont: Times-Roman 16.00 pt.
-    NSKern: 0pt
-    NSStrokeColor: #000000 (sRGB)
-    NSStrokeWidth: 0
-[ WebKit rocks]
+[world WebKit rocks]
     NSFont: Times-Roman 16.00 pt.
     NSKern: 0pt
     NSStrokeColor: #000000 (sRGB)

--- a/LayoutTests/platform/mac-wk1/editing/mac/attributed-string/attributed-string-across-shadow-boundaries-3-expected.txt
+++ b/LayoutTests/platform/mac-wk1/editing/mac/attributed-string/attributed-string-across-shadow-boundaries-3-expected.txt
@@ -23,12 +23,7 @@ Alignment Natural
     TighteningForTruncation: YES
     HeaderLevel: 0 LineBreakStrategy 0 PresentationIntents (
 ) ListIntentOrdinal 0 CodeBlockIntentLanguageHint ''
-[world WebKit]
-    NSFont: Times-Roman 16.00 pt.
-    NSKern: 0pt
-    NSStrokeColor: #000000 (sRGB)
-    NSStrokeWidth: 0
-[ rocks]
+[world WebKit rocks]
     NSFont: Times-Roman 16.00 pt.
     NSKern: 0pt
     NSStrokeColor: #000000 (sRGB)

--- a/LayoutTests/platform/mac-wk1/editing/mac/attributed-string/attributed-string-across-shadow-boundaries-4-expected.txt
+++ b/LayoutTests/platform/mac-wk1/editing/mac/attributed-string/attributed-string-across-shadow-boundaries-4-expected.txt
@@ -23,12 +23,7 @@ Alignment Natural
     TighteningForTruncation: YES
     HeaderLevel: 0 LineBreakStrategy 0 PresentationIntents (
 ) ListIntentOrdinal 0 CodeBlockIntentLanguageHint ''
-[hello ]
-    NSFont: Times-Roman 16.00 pt.
-    NSKern: 0pt
-    NSStrokeColor: #000000 (sRGB)
-    NSStrokeWidth: 0
-[world Web]
+[hello world Web]
     NSFont: Times-Roman 16.00 pt.
     NSKern: 0pt
     NSStrokeColor: #000000 (sRGB)

--- a/LayoutTests/platform/mac-wk1/editing/mac/attributed-string/attributed-string-across-shadow-boundaries-5-expected.txt
+++ b/LayoutTests/platform/mac-wk1/editing/mac/attributed-string/attributed-string-across-shadow-boundaries-5-expected.txt
@@ -23,17 +23,7 @@ Alignment Natural
     TighteningForTruncation: YES
     HeaderLevel: 0 LineBreakStrategy 0 PresentationIntents (
 ) ListIntentOrdinal 0 CodeBlockIntentLanguageHint ''
-[hello ]
-    NSFont: Times-Roman 16.00 pt.
-    NSKern: 0pt
-    NSStrokeColor: #000000 (sRGB)
-    NSStrokeWidth: 0
-[world]
-    NSFont: Times-Roman 16.00 pt.
-    NSKern: 0pt
-    NSStrokeColor: #000000 (sRGB)
-    NSStrokeWidth: 0
-[ WebKit]
+[hello world WebKit]
     NSFont: Times-Roman 16.00 pt.
     NSKern: 0pt
     NSStrokeColor: #000000 (sRGB)


### PR DESCRIPTION
#### db6cf6a9c16245de2f8104305818648ec1b67ab9
<pre>
REGRESSION(317100@main): [Fizz] 5 editing/mac/attributed-string/attributed-string-across-shadow-boundaries tests are constant TEXT failures.
<a href="https://bugs.webkit.org/show_bug.cgi?id=320539">https://bugs.webkit.org/show_bug.cgi?id=320539</a>
<a href="https://rdar.apple.com/182859944">rdar://182859944</a>

Reviewed by Tim Horton and Abrar Rahman Protyasha.

317100@main (&quot;Refactor Style::ComputedStyleProperties generation&quot;) made adjacent NSAttributedString ranges that carry
identical attributes coalesce into a single run across shadow boundaries. This is a progression: the runs had byte-identical
attributes (font, kern, stroke, color), so merging them into one range is the canonical form -- no attribute value changed. The
cross-platform baselines already expected the merged output; only the stale mac-wk1 overrides still held the pre-merge split form.

* LayoutTests/platform/mac-wk1/editing/mac/attributed-string/attributed-string-across-shadow-boundaries-1-expected.txt:
* LayoutTests/platform/mac-wk1/editing/mac/attributed-string/attributed-string-across-shadow-boundaries-2-expected.txt:
* LayoutTests/platform/mac-wk1/editing/mac/attributed-string/attributed-string-across-shadow-boundaries-3-expected.txt:
* LayoutTests/platform/mac-wk1/editing/mac/attributed-string/attributed-string-across-shadow-boundaries-4-expected.txt:
* LayoutTests/platform/mac-wk1/editing/mac/attributed-string/attributed-string-across-shadow-boundaries-5-expected.txt:

Canonical link: <a href="https://commits.webkit.org/318162@main">https://commits.webkit.org/318162@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0bd179bf0bc843ff2354f57cb31b117527375e4c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177459 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51397 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45191 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187063 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140706 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52689 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51106 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138303 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140706 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180415 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41804 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159048 "Found 1 new API test failure: TestWebKitAPI.UnifiedPDF.PDFHUDMultiplePluginsDoNotInterceptHitTesting (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118768 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40465 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38842 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150872 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38545 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35530 "Built successfully") | | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/43076 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189491 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51064 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147398 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39607 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51746 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35173 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147190 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41907 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118321 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50254 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13523 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49650 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49890 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49712 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->