### PR TITLE
REGRESSION(313588@main): -webkit-border-image width flag is lost when a length edge precedes a non-length edge

### DIFF
--- a/LayoutTests/fast/css/webkit-border-image-width-length-serialization-expected.txt
+++ b/LayoutTests/fast/css/webkit-border-image-width-length-serialization-expected.txt
@@ -1,0 +1,4 @@
+
+PASS -webkit-border-image width `5% 10px` (non-length before length) serializes
+PASS -webkit-border-image width `10px 5%` (length before non-length) serializes
+

--- a/LayoutTests/fast/css/webkit-border-image-width-length-serialization.html
+++ b/LayoutTests/fast/css/webkit-border-image-width-length-serialization.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>-webkit-border-image: width with a fixed length before a non-length edge round-trips</title>
+<link rel="help" href="https://bugs.webkit.org/show_bug.cgi?id=320355">
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<body>
+<script>
+function roundTrip(value) {
+    const el = document.createElement("div");
+    el.style.setProperty("-webkit-border-image", value);
+    return el.style.getPropertyValue("-webkit-border-image");
+}
+
+test(() => {
+    assert_not_equals(roundTrip('url("dummy://x") 10 / 5% 10px stretch'), "",
+        "percentage-then-length width should round-trip");
+}, "-webkit-border-image width `5% 10px` (non-length before length) serializes");
+
+test(() => {
+    assert_not_equals(roundTrip('url("dummy://x") 10 / 10px 5% stretch'), "",
+        "length-then-percentage width should round-trip");
+}, "-webkit-border-image width `10px 5%` (length before non-length) serializes");
+</script>
+</body>

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Background.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Background.cpp
@@ -298,7 +298,7 @@ std::optional<CSS::BorderImageWidth> consumeUnresolvedBorderImageWidth(CSSParser
         // FIXME: As this falls into the "<length> ambiguous with <number>" case, this should probably be `.unitlessZeroLength = UnitlessZeroQuirk::Forbid` in case the order of checks ever changes.
 
         if (auto lengthPercentage = MetaConsumer<CSS::BorderImageWidth::Value::LengthPercentage>::consume(range, state, { .overrideParserMode = HTMLStandardMode })) {
-            hasLength = WTF::switchOn(*lengthPercentage,
+            hasLength = hasLength || WTF::switchOn(*lengthPercentage,
                 [](const CSS::BorderImageWidth::Value::LengthPercentage::Calc& calc) {
                     return calc.primitiveType() == CSSUnitType::CSS_PX;
                 },


### PR DESCRIPTION
#### 3801ac23e1641d048c562f1392e861563da9ff87
<pre>
REGRESSION(313588@main): -webkit-border-image width flag is lost when a length edge precedes a non-length edge
<a href="https://bugs.webkit.org/show_bug.cgi?id=320545">https://bugs.webkit.org/show_bug.cgi?id=320545</a>

Reviewed by Sam Weinig and Darin Adler.

The -webkit-border-image legacy behavior treats a border-image-width whose value
contains a fixed &lt;length&gt; as also overriding the element&apos;s border widths. The
parser records this in the &quot;hasLength&quot; flag, which must be true if ANY of the
up-to-four width edges is a length.

313588@main refactored consumeUnresolvedBorderImageWidth() and, in the process,
silently changed how &quot;hasLength&quot; is accumulated:
```
      Before: if (numericValue-&gt;isLength())
                  hasLength = true;          // monotonic latch
      After:  hasLength = WTF::switchOn(...) // last-write-wins overwrite
```
With the overwrite, &quot;hasLength&quot; ends up reflecting only the last
length-percentage edge instead of whether any edge is a length. For a width such
as `10px 5%`, the length edge (10px) sets it true, then the percentage edge (5%)
overwrites it back to false.

This corrupts the stored legacyWebkitBorderImage flag, which two independent
consumers (ShorthandSerializer and the style extractor) recompute as
anyOf(isLength) and compare against. On mismatch they bail out, so
`-webkit-border-image: url(...) 10 / 10px 5%` fails to serialize (returns the
empty string) via getComputedStyle / cssText, and the legacy border-width
override is dropped at paint time. The result is order-dependent: `5% 10px`
round-trips but `10px 5%` does not.

Restore the original monotonic-latch semantics by OR-accumulating the flag
across edges.

Test: fast/css/webkit-border-image-width-length-serialization.html

* Source/WebCore/css/parser/CSSPropertyParserConsumer+Background.cpp:
(WebCore::CSSPropertyParserHelpers::consumeUnresolvedBorderImageWidth):
* LayoutTests/fast/css/webkit-border-image-width-length-serialization-expected.txt: Added.
* LayoutTests/fast/css/webkit-border-image-width-length-serialization.html: Added.

Canonical link: <a href="https://commits.webkit.org/318214@main">https://commits.webkit.org/318214@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/40ea84855a2150ad763719851ddf5235016fb365

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177640 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51578 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45372 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187244 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140887 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2622bdc0-6606-4e46-955e-e4263c9bd99e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179503 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52870 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51287 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/138458 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140887 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2600b065-6076-458d-b1b7-e75c0c5a65a6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180596 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41960 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/159194 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118922 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/becccf33-4640-4f51-8339-1a4ce2a86236) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40621 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/38994 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151028 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38690 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35711 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/43363 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/43229 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189675 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51245 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/158725 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147555 "Found 1 new test failure: compositing/color-matching/image-color-matching.html (failure)") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39634 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51927 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/35318 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147345 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42060 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124142 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118555 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50435 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13667 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49831 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50071 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49893 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->