### PR TITLE
WKWebViewTestingIOS.mm's dumpCALayer() is using origin.x instead of origin.y

### DIFF
--- a/LayoutTests/compositing/background-color/background-color-clamping-expected.txt
+++ b/LayoutTests/compositing/background-color/background-color-clamping-expected.txt
@@ -1,11 +1,11 @@
 
 (CALayer tree root
   (layer bounds [x: 0 y: 0 width: 769 height: 830])
-  (layer position [x: 392.5 y: 392.5])
+  (layer position [x: 392.5 y: 425])
   (sublayers
     (
       (layer bounds [x: 0 y: 0 width: 200 height: 200])
-      (layer position [x: 110 y: 110])
+      (layer position [x: 110 y: 100])
       (sublayers
         (
           (layer bounds [x: 0 y: 0 width: 200 height: 200])
@@ -13,7 +13,7 @@
           (layer background color rgb(255, 255, 255)))))
     (
       (layer bounds [x: 0 y: 0 width: 200 height: 200])
-      (layer position [x: 110 y: 110])
+      (layer position [x: 110 y: 310])
       (sublayers
         (
           (layer bounds [x: 0 y: 0 width: 200 height: 200])
@@ -21,7 +21,7 @@
           (layer background color rgb(0, 140, 214)))))
     (
       (layer bounds [x: 0 y: 0 width: 200 height: 200])
-      (layer position [x: 110 y: 110])
+      (layer position [x: 110 y: 520])
       (sublayers
         (
           (layer bounds [x: 0 y: 0 width: 200 height: 200])
@@ -29,7 +29,7 @@
           (layer background color rgb(0, 255, 184)))))
     (
       (layer bounds [x: 0 y: 0 width: 200 height: 200])
-      (layer position [x: 110 y: 110])
+      (layer position [x: 110 y: 730])
       (sublayers
         (
           (layer bounds [x: 0 y: 0 width: 200 height: 200])

--- a/LayoutTests/interaction-region/guard-crash-expected.txt
+++ b/LayoutTests/interaction-region/guard-crash-expected.txt
@@ -2,7 +2,7 @@
 
 (CALayer tree root
   (layer bounds [x: 0 y: 0 width: 800 height: 108])
-  (layer position [x: 400 y: 400])
+  (layer position [x: 400 y: 67])
   (sublayers
     (
       (layer bounds [x: 0 y: 0 width: 0 height: 0])
@@ -10,5 +10,5 @@
         (
           (type 0)
           (layer bounds [x: 0 y: 0 width: 100 height: 100])
-          (layer position [x: 382 y: 382]))))))
+          (layer position [x: 382 y: 58]))))))
 

--- a/LayoutTests/interaction-region/interaction-layers-culling-layer-type-change-expected.txt
+++ b/LayoutTests/interaction-region/interaction-layers-culling-layer-type-change-expected.txt
@@ -1,7 +1,7 @@
 
 (CALayer tree root
   (layer bounds [x: 0 y: 0 width: 800 height: 700])
-  (layer position [x: 400 y: 400])
+  (layer position [x: 400 y: 363])
   (layer background color rgba(0, 0, 0, 0))
   (sublayers
     (
@@ -10,15 +10,15 @@
         (
           (type 0)
           (layer bounds [x: 0 y: 0 width: 700 height: 34])
-          (layer position [x: 400 y: 400])
+          (layer position [x: 400 y: 67])
           (layer cornerRadius 8))
         (
           (type 0)
           (layer bounds [x: 0 y: 0 width: 700 height: 34])
-          (layer position [x: 400 y: 400])
+          (layer position [x: 400 y: 151])
           (layer cornerRadius 8))
         (
           (type 0)
           (layer bounds [x: 0 y: 0 width: 700 height: 34])
-          (layer position [x: 400 y: 400])
+          (layer position [x: 400 y: 235])
           (layer cornerRadius 8))))))

--- a/LayoutTests/interaction-region/layer-tree-expected.txt
+++ b/LayoutTests/interaction-region/layer-tree-expected.txt
@@ -1,11 +1,11 @@
 
 (CALayer tree root
   (layer bounds [x: 0 y: 0 width: 800 height: 546.5])
-  (layer position [x: 400 y: 400])
+  (layer position [x: 400 y: 273.25])
   (sublayers
     (
       (layer bounds [x: 0 y: 0 width: 200 height: 200.5])
-      (layer position [x: 100 y: 100])
+      (layer position [x: 100 y: 328.25])
       (layer opacity 0))
     (
       (layer bounds [x: 0 y: 0 width: 0 height: 0])
@@ -13,30 +13,30 @@
         (
           (type 0)
           (layer bounds [x: 0 y: 0 width: 58.5 height: 20])
-          (layer position [x: 29.25 y: 29.25])
+          (layer position [x: 29.25 y: 10.5])
           (layer cornerRadius 10))
         (
           (type 0)
           (layer bounds [x: 0 y: 0 width: 284 height: 192.5])
-          (layer position [x: 152 y: 152])
+          (layer position [x: 152 y: 126.75])
           (layer cornerRadius 8))
         (
           (type 0)
           (layer bounds [x: 0 y: 0 width: 200 height: 100])
-          (layer position [x: 100 y: 100]))
+          (layer position [x: 100 y: 478]))
         (
           (type 0)
           (layer bounds [x: 0 y: 0 width: 100 height: 100])
-          (layer position [x: 50 y: 50]))
+          (layer position [x: 50 y: 478]))
         (
           (type 0)
           (layer bounds [x: 0 y: 0 width: 100 height: 100])
-          (layer position [x: 150 y: 150])
+          (layer position [x: 150 y: 478])
           (layer cornerRadius 16))
         (
           (type 0)
           (layer bounds [x: 0 y: 0 width: 100 height: 100])
-          (layer position [x: 250 y: 250])
+          (layer position [x: 250 y: 478])
           (layer cornerRadius 14)
           (layer masked corners 5))
         (
@@ -44,38 +44,38 @@
           (mask
             (frame [x: 0 y: 0 width: 100 height: 100]))
           (layer bounds [x: 0 y: 0 width: 100 height: 100])
-          (layer position [x: 350 y: 350]))))
+          (layer position [x: 350 y: 478]))))
     (
       (layer bounds [x: 0 y: 0 width: 800 height: 600])
-      (layer position [x: 400 y: 400])
+      (layer position [x: 400 y: 300])
       (layer opacity 0.8)
       (sublayers
         (
           (layer bounds [x: 0 y: 0 width: 800 height: 18])
-          (layer position [x: 400 y: 400]))
+          (layer position [x: 400 y: 27]))
         (
           (layer bounds [x: 0 y: 0 width: 0 height: 0])
           (sublayers
             (
               (type 0)
               (layer bounds [x: 0 y: 0 width: 32.890625 height: 25.71875])
-              (layer position [x: 12.4453125 y: 12.4453125])
+              (layer position [x: 12.4453125 y: 9])
               (layer cornerRadius 8))))
         (
           (layer bounds [x: 0 y: 0 width: 800 height: 36])
-          (layer position [x: 400 y: 400])
+          (layer position [x: 400 y: 54])
           (sublayers
             (
               (layer bounds [x: 0 y: 0 width: 800 height: 18])
-              (layer position [x: 400 y: 400]))
+              (layer position [x: 400 y: 27]))
             (
               (layer bounds [x: 0 y: 0 width: 0 height: 0])
               (sublayers
                 (
                   (type 0)
                   (layer bounds [x: 0 y: 0 width: 115.0859375 height: 25.71875])
-                  (layer position [x: 155.71484375 y: 155.71484375])
+                  (layer position [x: 155.71484375 y: 9])
                   (layer cornerRadius 8))))))
         (
           (layer bounds [x: 0 y: 0 width: 800 height: 18])
-          (layer position [x: 400 y: 400]))))))
+          (layer position [x: 400 y: 81]))))))

--- a/LayoutTests/interaction-region/layer-tree-shape-reset-expected.txt
+++ b/LayoutTests/interaction-region/layer-tree-shape-reset-expected.txt
@@ -1,7 +1,7 @@
 
 (CALayer tree root
   (layer bounds [x: 0 y: 0 width: 800 height: 100])
-  (layer position [x: 400 y: 400])
+  (layer position [x: 400 y: 63])
   (sublayers
     (
       (layer bounds [x: 0 y: 0 width: 0 height: 0])
@@ -13,12 +13,12 @@
         (
           (type 0)
           (layer bounds [x: 0 y: 0 width: 100 height: 100])
-          (layer position [x: 150 y: 150]))
+          (layer position [x: 150 y: 50]))
         (
           (type 0)
           (layer bounds [x: 0 y: 0 width: 100 height: 100])
-          (layer position [x: 250 y: 250]))
+          (layer position [x: 250 y: 50]))
         (
           (type 0)
           (layer bounds [x: 0 y: 0 width: 100 height: 100])
-          (layer position [x: 350 y: 350]))))))
+          (layer position [x: 350 y: 50]))))))

--- a/LayoutTests/platform/ios/compositing/background-color/background-color-clamping-expected.txt
+++ b/LayoutTests/platform/ios/compositing/background-color/background-color-clamping-expected.txt
@@ -1,11 +1,11 @@
 
 (CALayer tree root
   (layer bounds [x: 0 y: 0 width: 784 height: 830])
-  (layer position [x: 400 y: 400])
+  (layer position [x: 400 y: 425])
   (sublayers
     (
       (layer bounds [x: 0 y: 0 width: 200 height: 200])
-      (layer position [x: 110 y: 110])
+      (layer position [x: 110 y: 100])
       (sublayers
         (
           (layer bounds [x: 0 y: 0 width: 200 height: 200])
@@ -13,7 +13,7 @@
           (layer background color rgb(255, 255, 255)))))
     (
       (layer bounds [x: 0 y: 0 width: 200 height: 200])
-      (layer position [x: 110 y: 110])
+      (layer position [x: 110 y: 310])
       (sublayers
         (
           (layer bounds [x: 0 y: 0 width: 200 height: 200])
@@ -21,7 +21,7 @@
           (layer background color rgb(0, 140, 214)))))
     (
       (layer bounds [x: 0 y: 0 width: 200 height: 200])
-      (layer position [x: 110 y: 110])
+      (layer position [x: 110 y: 520])
       (sublayers
         (
           (layer bounds [x: 0 y: 0 width: 200 height: 200])
@@ -29,7 +29,7 @@
           (layer background color rgb(0, 255, 184)))))
     (
       (layer bounds [x: 0 y: 0 width: 200 height: 200])
-      (layer position [x: 110 y: 110])
+      (layer position [x: 110 y: 730])
       (sublayers
         (
           (layer bounds [x: 0 y: 0 width: 200 height: 200])

--- a/LayoutTests/platform/visionos/transforms/separated-expected.txt
+++ b/LayoutTests/platform/visionos/transforms/separated-expected.txt
@@ -1,14 +1,14 @@
 
 (CALayer tree root
   (layer bounds [x: 0 y: 0 width: 800 height: 2600])
-  (layer position [x: 400 y: 400])
+  (layer position [x: 400 y: 1300])
   (sublayers
     (
       (layer bounds [x: 0 y: 0 width: 200 height: 200])
       (layer position [x: 100 y: 100]))
     (
       (layer bounds [x: 0 y: 0 width: 200 height: 200])
-      (layer position [x: 100 y: 100])
+      (layer position [x: 100 y: 300])
       (separated 1)
       (layer cornerRadius 24)
       (sublayers
@@ -17,7 +17,7 @@
           (layer anchorPoint [x: 0 y: 0]))))
     (
       (layer bounds [x: 0 y: 0 width: 200 height: 200])
-      (layer position [x: 100 y: 100])
+      (layer position [x: 100 y: 2500])
       (separated 1)
       (layer cornerRadius 24)
       (sublayers

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
@@ -172,11 +172,11 @@
 static void dumpCALayer(TextStream& ts, CALayer *layer, bool traverse)
 {
     auto rectToString = [] (auto rect) {
-        return makeString("[x: "_s, rect.origin.x, " y: "_s, rect.origin.x, " width: "_s, rect.size.width, " height: "_s, rect.size.height, ']');
+        return makeString("[x: "_s, rect.origin.x, " y: "_s, rect.origin.y, " width: "_s, rect.size.width, " height: "_s, rect.size.height, ']');
     };
 
     auto pointToString = [] (auto point) {
-        return makeString("[x: "_s, point.x, " y: "_s, point.x, ']');
+        return makeString("[x: "_s, point.x, " y: "_s, point.y, ']');
     };
 
 #if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
@@ -1060,7 +1060,7 @@ static void dumpCALayer(TextStream& ts, CALayer *layer, bool traverse)
     return @{
         @"bounds" : @{
             @"x" : @(layer.get().bounds.origin.x),
-            @"y" : @(layer.get().bounds.origin.x),
+            @"y" : @(layer.get().bounds.origin.y),
             @"width" : @(layer.get().bounds.size.width),
             @"height" : @(layer.get().bounds.size.height),
 

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -953,6 +953,7 @@
 				WebKit/WKWebView/ios/ApplicationStateTracking.mm,
 				WebKit/WKWebView/ios/AutocorrectionTestsIOS.mm,
 				WebKit/WKWebView/ios/BacklightLevelNotification.mm,
+				WebKit/WKWebView/ios/CALayerTreeAsText.mm,
 				WebKit/WKWebView/ios/CustomContentViewGestures.mm,
 				WebKit/WKWebView/ios/DataDetectorsTestIOS.mm,
 				WebKit/WKWebView/ios/DataListTextSuggestionTests.mm,

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/CALayerTreeAsText.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/CALayerTreeAsText.mm
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+
+#if PLATFORM(IOS_FAMILY)
+
+#import "Helpers/Test.h"
+#import <QuartzCore/QuartzCore.h>
+#import <WebKit/WKWebView.h>
+#import <WebKit/WKWebViewPrivateForTesting.h>
+#import <wtf/RetainPtr.h>
+
+TEST(WebKit, CALayerTreeAsTextDumpsYCoordinates)
+{
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 480)]);
+
+    RetainPtr layer = adoptNS([[CALayer alloc] init]);
+    [layer setBounds:CGRectMake(11, 22, 33, 44)];
+    [layer setPosition:CGPointMake(123, 456)];
+    [layer setAnchorPoint:CGPointMake(0.25, 0.75)];
+
+    RetainPtr sublayer = adoptNS([[CALayer alloc] init]);
+    [sublayer setBounds:CGRectMake(0, 0, 10, 20)];
+    [sublayer setPosition:CGPointMake(30, 40)];
+    [layer addSublayer:sublayer];
+
+    RetainPtr treeText = [webView _caLayerTreeAsTextForLayer:layer];
+
+    EXPECT_TRUE([treeText containsString:@"[x: 11 y: 22 width: 33 height: 44]"]);
+    EXPECT_FALSE([treeText containsString:@"[x: 11 y: 11 width: 33 height: 44]"]);
+
+    EXPECT_TRUE([treeText containsString:@"[x: 123 y: 456]"]);
+    EXPECT_FALSE([treeText containsString:@"[x: 123 y: 123]"]);
+
+    EXPECT_TRUE([treeText containsString:@"[x: 0.25 y: 0.75]"]);
+    EXPECT_FALSE([treeText containsString:@"[x: 0.25 y: 0.25]"]);
+
+    EXPECT_TRUE([treeText containsString:@"[x: 30 y: 40]"]);
+    EXPECT_FALSE([treeText containsString:@"[x: 30 y: 30]"]);
+}
+
+#endif // PLATFORM(IOS_FAMILY)


### PR DESCRIPTION
#### f30303811c2592181940302fdbd6c43d859aa2e6
<pre>
WKWebViewTestingIOS.mm&apos;s dumpCALayer() is using origin.x instead of origin.y
<a href="https://bugs.webkit.org/show_bug.cgi?id=320548">https://bugs.webkit.org/show_bug.cgi?id=320548</a>
<a href="https://rdar.apple.com/183507280">rdar://183507280</a>

Reviewed by Mike Wyrzykowski and Aditya Keerthi.

Fix the typo and rebaseline the impacted tests.

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/CALayerTreeAsText.mm

* LayoutTests/compositing/background-color/background-color-clamping-expected.txt:
* LayoutTests/interaction-region/guard-crash-expected.txt:
* LayoutTests/interaction-region/interaction-layers-culling-layer-type-change-expected.txt:
* LayoutTests/interaction-region/layer-tree-expected.txt:
* LayoutTests/interaction-region/layer-tree-shape-reset-expected.txt:
* LayoutTests/platform/ios/compositing/background-color/background-color-clamping-expected.txt:
* LayoutTests/platform/visionos/transforms/separated-expected.txt:
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm:
(dumpCALayer):
(-[WKWebView _propertiesOfLayerWithID:]):

* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/CALayerTreeAsText.mm: Added.
(TEST(WebKit, CALayerTreeAsTextDumpsYCoordinates)):
Add an API test similar to the one from 317839@main.

Canonical link: <a href="https://commits.webkit.org/318176@main">https://commits.webkit.org/318176@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c89b510dc14e1fba35665e935faccc4a23685d39

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177517 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51455 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45249 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187121 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140764 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/53365ac4-5a3b-4175-b3eb-4865de0a5c0c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179380 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52747 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51164 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138354 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140764 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c485c55b-9597-4e3b-8003-38de5ae8cbcd) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180473 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41858 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/159103 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118819 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7b2c7927-dae5-4728-bf90-3400d7a7e1db) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40519 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/38892 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150926 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38600 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35588 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/43240 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/43126 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189549 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51122 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147448 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39613 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51804 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/35228 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147240 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41958 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124019 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118423 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50312 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13579 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49708 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49948 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49770 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->