### PR TITLE
[Site Isolation] Content Filter failures shouldn't transition ProvisionalPageProxy to RemotePageProxy

### DIFF
--- a/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
+++ b/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
@@ -472,7 +472,7 @@ void ProvisionalPageProxy::didFailProvisionalLoadForFrame(FrameInfoData&& frameI
     // When site isolation is enabled, we use the same WebFrameProxy so we don't need this duplicate call.
     // didFailProvisionalLoadForFrameShared will call didFailProvisionalLoad on the same main frame.
     if (protect(page->preferences())->siteIsolationEnabled()) {
-        if (m_shouldReuseMainFrame)
+        if (m_shouldReuseMainFrame && willContinueLoading == WebCore::WillContinueLoading::No)
             m_browsingContextGroup->transitionProvisionalPageToRemotePage(*this, Site(request.url()));
         else if (m_takenRemotePage)
             m_browsingContextGroup->addRemotePage(*page, m_takenRemotePage.releaseNonNull());

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ParentalControlsContentFilteringTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ParentalControlsContentFilteringTests.mm
@@ -28,6 +28,7 @@
 #if HAVE(WEBCONTENTRESTRICTIONS)
 
 #import "HTTPServer.h"
+#import "Helpers/cocoa/TestUIDelegate.h"
 #import "PlatformUtilities.h"
 #import "Test.h"
 #import "TestNavigationDelegate.h"
@@ -232,6 +233,50 @@ TEST(ParentalControlsContentFilteringTests, BlockedIframe)
     [webView loadRequest:server.request("/mainframe"_s)];
     Util::run(&iframeShieldDidLoad);
     EXPECT_FALSE(blockedIframeLoaded);
+}
+
+TEST(ParentalControlsContentFilteringTests, OpenBlockedPopUp)
+{
+    auto mainframeHTML = "<script>"
+    "window.open('https://example.com');"
+    "</script>"_s;
+
+    NSData *popupReplacementHTML = [@"<script>"
+    "window.webkit.messageHandlers.testHandler.postMessage('popup_html_loaded');"
+    "</script>" dataUsingEncoding:NSUTF8StringEncoding];
+
+    HTTPServer server({
+        { "/mainframe"_s, { mainframeHTML } },
+    });
+
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
+    webView.get().configuration.preferences.javaScriptCanOpenWindowsAutomatically = true;
+
+    RetainPtr messageHandler = adoptNS([TestMessageHandler new]);
+    [[[webView configuration] userContentController] addScriptMessageHandler:messageHandler.get() name:@"testHandler"];
+
+    __block bool popupLoaded = false;
+    [messageHandler addMessage:@"popup_html_loaded" withHandler:^{
+        popupLoaded = true;
+    }];
+
+    __block RetainPtr<WKWebView> popupWindow;
+    RetainPtr uiDelegate = adoptNS([TestUIDelegate new]);
+    uiDelegate.get().createWebViewWithConfiguration = ^(WKWebViewConfiguration *configuration, WKNavigationAction *action, WKWindowFeatures *windowFeatures) {
+        popupWindow = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration]);
+        return popupWindow.get();
+    };
+    [webView setUIDelegate:uiDelegate];
+
+    auto blockedURL = [NSURL URLWithString:@"https://example.com"];
+    __block bool mockInstalled = false;
+    [[webView configuration].websiteDataStore _installMockParentalControlsURLFilterForTestingWithBlockedURLs:@[blockedURL] replacementData:popupReplacementHTML completionHandler:^{
+        mockInstalled = true;
+    }];
+    Util::run(&mockInstalled);
+
+    [webView loadRequest:server.request("/mainframe"_s)];
+    Util::run(&popupLoaded);
 }
 
 #endif // HAVE(WEBCONTENTRESTRICTIONS)


### PR DESCRIPTION
#### 4a18bc6d5a15cb1dbaebefb5c1f8ce842bb86360
<pre>
[Site Isolation] Content Filter failures shouldn&apos;t transition ProvisionalPageProxy to RemotePageProxy
<a href="https://bugs.webkit.org/show_bug.cgi?id=320549">https://bugs.webkit.org/show_bug.cgi?id=320549</a>
<a href="https://rdar.apple.com/183509381">rdar://183509381</a>

Reviewed by Alex Christensen.

A provisional load that fails due to content filtering should be allowed to
proceed and commit the substitute data rather than being transitioned to a
remote page which results in failure to update the WebPageProxy&apos;s process/state-tracking.

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ParentalControlsContentFilteringTests.mm

* Source/WebKit/UIProcess/ProvisionalPageProxy.cpp:
(WebKit::ProvisionalPageProxy::didFailProvisionalLoadForFrame):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ParentalControlsContentFilteringTests.mm:
(TEST(ParentalControlsContentFilteringTests, OpenBlockedPopUp)):

Canonical link: <a href="https://commits.webkit.org/318200@main">https://commits.webkit.org/318200@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/96a6d1acfbbfcd28aded8cd3c337d6a61bbce332

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177629 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/51567 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/45361 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/187233 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140876 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179492 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/52859 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/51276 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/187233 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140876 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180585 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/52859 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/45361 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/187233 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/52859 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/51276 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/187233 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/45361 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/52859 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/45361 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/35700 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/43352 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/51276 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/189662 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/51234 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/45361 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/189662 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/51916 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/45361 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/189662 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26937 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/51916 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/124131 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/118544 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/50424 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/45361 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/49820 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/50060 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/49882 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->