### PR TITLE
Cherry-pick 318148@main (0449e10b207f). https://bugs.webkit.org/show_bug.cgi?id=320544

### DIFF
--- a/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp
@@ -38,7 +38,6 @@
 #include "PlatformDisplay.h"
 #include "Region.h"
 #include "SkiaBackingStore.h"
-#include "SkiaCompositingLayer3DRenderingContext.h"
 #include "SkiaCompositingLayerFilters.h"
 #include "SkiaCompositingLayerOverlapRegions.h"
 #include "SkiaDamageRegion.h"
@@ -1449,29 +1448,53 @@ void SkiaCompositingLayer::paintWithBlendMode(SkCanvas& canvas, PaintContext& co
     }
 }
 
-void SkiaCompositingLayer::collect3DRenderingContextLayers(Vector<Ref<SkiaCompositingLayer>>& layers)
+FloatRect SkiaCompositingLayer::transformedFlattenedBounds() const
+{
+    auto bounds = m_transforms.combined.mapRect(FloatRect({ }, m_size));
+
+    if (!m_masksToBounds && !m_mask) {
+        for (const auto& child : m_children)
+            bounds.unite(child->transformedFlattenedBounds());
+    }
+
+    return bounds;
+}
+
+FloatPolygon3D SkiaCompositingLayer::geometryFor3DRenderingContext() const
+{
+    FloatRect bounds;
+    if (isLeafOf3DRenderingContext() && !m_children.isEmpty() && !m_masksToBounds && !m_mask && m_transforms.combined.isInvertible()) {
+        auto inverse = m_transforms.combined.inverse().value_or(TransformationMatrix());
+        bounds = inverse.mapRect(transformedFlattenedBounds());
+    } else
+        bounds = FloatRect({ }, m_size);
+
+    return FloatPolygon3D(bounds, m_transforms.combined);
+}
+
+void SkiaCompositingLayer::collect3DRenderingContextLayers(Vector<SkiaCompositingLayer3DRenderingContext::Layer>& layers)
 {
     if (m_preserves3D || isLeafOf3DRenderingContext()) {
         // Add layers to 3d rendering context only if they get actually painted.
         bool hasVisualContentOrFilters = hasVisualContent() || filter() || m_backdrop.filter;
         if (isVisible() && (hasVisualContentOrFilters || (isLeafOf3DRenderingContext() && !m_children.isEmpty())))
-            layers.append(Ref { *this });
+            layers.append(SkiaCompositingLayer3DRenderingContext::Layer(Ref { *this }, geometryFor3DRenderingContext()));
 
         // Stop recursion on 3d rendering context leaf
         if (isLeafOf3DRenderingContext())
             return;
     }
 
-    for (auto& child : m_children)
+    for (const auto& child : m_children)
         child->collect3DRenderingContextLayers(layers);
 }
 
 void SkiaCompositingLayer::paintWith3DRenderingContext(SkCanvas& canvas, PaintContext& context)
 {
-    Vector<Ref<SkiaCompositingLayer>> layers;
+    Vector<SkiaCompositingLayer3DRenderingContext::Layer> layers;
     collect3DRenderingContextLayers(layers);
 
-    SkiaCompositingLayer3DRenderingContext::paint(layers, [&](SkiaCompositingLayer& layer, std::optional<SkPath> clipPath) {
+    SkiaCompositingLayer3DRenderingContext::paint(WTF::move(layers), [&](SkiaCompositingLayer& layer, std::optional<SkPath> clipPath) {
         ScopedFlush autoFlush(canvas, context.imageSetBatch, clipPath ? ScopedFlush::Mode::FlushBeforeAndAfter : ScopedFlush::Mode::DoNothing);
         if (clipPath)
             canvas.clipPath(*clipPath);

--- a/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp
@@ -1462,12 +1462,11 @@ FloatRect SkiaCompositingLayer::transformedFlattenedBounds() const
 
 FloatPolygon3D SkiaCompositingLayer::geometryFor3DRenderingContext() const
 {
-    FloatRect bounds;
-    if (isLeafOf3DRenderingContext() && !m_children.isEmpty() && !m_masksToBounds && !m_mask && m_transforms.combined.isInvertible()) {
-        auto inverse = m_transforms.combined.inverse().value_or(TransformationMatrix());
-        bounds = inverse.mapRect(transformedFlattenedBounds());
-    } else
-        bounds = m_rect;
+    FloatRect bounds = m_rect;
+    if (bounds.isEmpty() && isLeafOf3DRenderingContext() && !m_children.isEmpty() && !m_masksToBounds && !m_mask) {
+        if (auto inverse = m_transforms.combined.inverse())
+            bounds = inverse->mapRect(transformedFlattenedBounds());
+    }
 
     return FloatPolygon3D(bounds, m_transforms.combined);
 }

--- a/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp
@@ -91,10 +91,10 @@ void SkiaCompositingLayer::invalidate()
 // size to decide what to damage, and what it has to damage is what the layer is about to paint.
 void SkiaCompositingLayer::setSize(const FloatSize& size)
 {
-    if (m_size == size)
+    if (m_rect.size() == size)
         return;
 
-    m_size = size;
+    m_rect.setSize(size);
     damageWholeLayer();
 }
 
@@ -165,7 +165,7 @@ void SkiaCompositingLayer::updateBackingStore(CoordinatedBackingStoreProxy::Upda
         m_maskImage = nullptr;
 
     ASSERT(m_backingStore);
-    m_backingStore->update(m_size, scale, WTF::move(update));
+    m_backingStore->update(m_rect.size(), scale, WTF::move(update));
 }
 
 bool SkiaCompositingLayer::hasPendingBackingStoreTileUpdates() const
@@ -239,7 +239,7 @@ void SkiaCompositingLayer::setBackdropFiltersRect(const FloatRoundedRect& clipRe
 
 FloatRect SkiaCompositingLayer::paintedLayerRect() const
 {
-    auto rect = effectiveLayerRect();
+    auto rect = m_rect;
     if (paintsContentsRect())
         rect.unite(m_contentsRect);
     if (m_backdrop.filter)
@@ -435,13 +435,13 @@ bool SkiaCompositingLayer::computeTransformsAndAnimations(const TransformationMa
     TransformationMatrix combinedForChildren;
     TransformationMatrix futureCombinedForChildren;
 
-    if (!m_size.isEmpty() || !m_masksToBounds) {
+    if (!m_rect.isEmpty() || !m_masksToBounds) {
 #if ENABLE(DAMAGE_TRACKING)
         TransformationMatrix previousTransform = m_transforms.combined;
 #endif
 
         FloatPoint origin(m_anchorPoint.x(), m_anchorPoint.y());
-        origin.scale(m_size.width(), m_size.height());
+        origin.scale(m_rect.size().width(), m_rect.size().height());
         m_transforms.combined = parentTransform;
         m_transforms.combined
             .translate3d(origin.x() + (m_position.x() - m_boundsOrigin.x()), origin.y() + (m_position.y() - m_boundsOrigin.y()), m_anchorPoint.z())
@@ -543,7 +543,7 @@ bool SkiaCompositingLayer::paint(SkCanvas& canvas, std::optional<Damage>& frameD
 #if ENABLE(DAMAGE_TRACKING)
     if (priorTargetDamage) {
         // The damage is in device space, so the surface size the region is tested against must be too.
-        // m_size is in layer coordinates, which the root transform scales to the device by the device
+        // m_rect is in layer coordinates, which the root transform scales to the device by the device
         // pixel ratio - use the canvas device size instead, as the collect walk above already does.
         const auto deviceSize = canvas.getBaseLayerSize();
         const IntSize surfaceSize(deviceSize.width(), deviceSize.height());
@@ -934,7 +934,7 @@ void SkiaCompositingLayer::paintSelfAndChildren(SkCanvas& canvas, PaintContext& 
         auto childMatrix = canvas.getLocalToDeviceAs3x3() * SkM44(m_children[0]->m_transforms.combined).asM33();
         FloatRect childBounds;
         if (m_children[0]->m_backingStore)
-            childBounds = m_children[0]->effectiveLayerRect();
+            childBounds = m_children[0]->m_rect;
         if (m_children[0]->m_contentsBuffer || m_children[0]->m_imageBackingStore || (m_children[0]->m_contentsSolidColor.isValid() && m_children[0]->m_contentsSolidColor.isVisible()))
             childBounds.unite(m_children[0]->m_contentsRect);
         return matrix.mapRect(SkRect(rect.rect())).contains(childMatrix.mapRect(SkRect(childBounds)));
@@ -950,7 +950,7 @@ void SkiaCompositingLayer::paintSelfAndChildren(SkCanvas& canvas, PaintContext& 
         if (!contentsRectClipsDescendants)
             clipTransform.translate(m_boundsOrigin.x(), m_boundsOrigin.y());
 
-        FloatRoundedRect rect = contentsRectClipsDescendants ? m_contentsClippingRect : FloatRoundedRect(effectiveLayerRect());
+        FloatRoundedRect rect = contentsRectClipsDescendants ? m_contentsClippingRect : FloatRoundedRect(m_rect);
         if (!canSkipClip(rect, clipTransform))
             clippingRect = rect;
     }
@@ -965,7 +965,7 @@ void SkiaCompositingLayer::paintSelfAndChildren(SkCanvas& canvas, PaintContext& 
 
 bool SkiaCompositingLayer::isVisible() const
 {
-    if (m_size.isEmpty() && (m_masksToBounds || m_children.isEmpty()))
+    if (m_rect.isEmpty() && (m_masksToBounds || m_children.isEmpty()))
         return false;
     if (!m_visible && m_children.isEmpty())
         return false;
@@ -1001,7 +1001,7 @@ sk_sp<SkImage> SkiaCompositingLayer::maskImage()
 
     // Paint the mask at the same scale the tiles were painted.
     auto scale = m_backingStore->scale();
-    auto rect = effectiveLayerRect();
+    auto rect = m_rect;
     rect.scale(scale);
 
     auto* grContext = PlatformDisplay::sharedDisplay().skiaGrContext();
@@ -1287,7 +1287,7 @@ void SkiaCompositingLayer::computeOverlapRegions(ComputeOverlapRegionData& data,
 
     FloatRect localBoundingRect;
     if (m_backingStore || m_masksToBounds || m_mask || filter || m_backdrop.filter)
-        localBoundingRect = effectiveLayerRect();
+        localBoundingRect = m_rect;
     else if (paintsContentsRect())
         localBoundingRect = m_contentsRect;
 
@@ -1450,7 +1450,7 @@ void SkiaCompositingLayer::paintWithBlendMode(SkCanvas& canvas, PaintContext& co
 
 FloatRect SkiaCompositingLayer::transformedFlattenedBounds() const
 {
-    auto bounds = m_transforms.combined.mapRect(FloatRect({ }, m_size));
+    auto bounds = m_transforms.combined.mapRect(m_rect);
 
     if (!m_masksToBounds && !m_mask) {
         for (const auto& child : m_children)
@@ -1467,7 +1467,7 @@ FloatPolygon3D SkiaCompositingLayer::geometryFor3DRenderingContext() const
         auto inverse = m_transforms.combined.inverse().value_or(TransformationMatrix());
         bounds = inverse.mapRect(transformedFlattenedBounds());
     } else
-        bounds = FloatRect({ }, m_size);
+        bounds = m_rect;
 
     return FloatPolygon3D(bounds, m_transforms.combined);
 }

--- a/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.h
@@ -114,7 +114,6 @@ public:
     void setDebugIndicators(Color&& debugBorderColor, std::optional<float> debugBorderWidth, std::optional<unsigned> repaintCount);
 
     const TransformationMatrix& toSurfaceTransform() const { return m_transforms.combined; }
-    FloatRect effectiveLayerRect() const { return FloatRect({ }, m_size); }
 
     // Applies the animations, computes the transforms, then walks the tree. When a frame damage is passed,
     // it is collected first in a walk that draws nothing, before the walk that draws. The draw is limited
@@ -134,12 +133,12 @@ private:
     // Contents are painted into m_contentsRect, which the layer bounds do not have to contain.
     bool paintsContentsRect() const { return m_contentsBuffer || m_imageBackingStore || (m_contentsSolidColor.isValid() && m_contentsSolidColor.isVisible()); }
     bool hasVisualContent() const { return m_backingStore || paintsContentsRect(); }
-    bool hasVisiblePaintableContent() const { return !m_size.isEmpty() && m_visible && m_contentsVisible && hasVisualContent(); }
+    bool hasVisiblePaintableContent() const { return !m_rect.isEmpty() && m_visible && m_contentsVisible && hasVisualContent(); }
 
     // A backdrop filter paints the layer without any content of its own, so it contributes damage too.
-    bool contributesToFrame() const { return hasVisiblePaintableContent() || (!m_size.isEmpty() && m_visible && m_contentsVisible && !!m_backdrop.filter); }
+    bool contributesToFrame() const { return hasVisiblePaintableContent() || (!m_rect.isEmpty() && m_visible && m_contentsVisible && !!m_backdrop.filter); }
 
-    // What the layer actually paints, unlike effectiveLayerRect(), which the contents rect and the
+    // What the layer actually paints, unlike layer rect, which the contents rect and the
     // backdrop rect may both overhang, and which a filter such as a blur may paint outside of.
     FloatRect paintedLayerRect() const;
     Ref<SkiaCompositingLayer> backdropRoot();
@@ -251,11 +250,11 @@ private:
     void damageWholeLayer()
     {
 #if ENABLE(DAMAGE_TRACKING)
-        if (!damagePropagationEnabled() || m_size.isEmpty())
+        if (!damagePropagationEnabled() || m_rect.isEmpty())
             return;
 
         if (!m_layerDamage)
-            m_layerDamage = Damage(m_size, Damage::Mode::Full);
+            m_layerDamage = Damage(m_rect.size(), Damage::Mode::Full);
         else
             m_layerDamage->makeFull();
 #endif
@@ -290,7 +289,7 @@ private:
 
     Vector<Ref<SkiaCompositingLayer>> m_children;
     WeakPtr<SkiaCompositingLayer> m_parent;
-    FloatSize m_size;
+    FloatRect m_rect;
     FloatPoint m_position;
     FloatPoint3D m_anchorPoint { 0.5f, 0.5f, 0 };
     FloatPoint m_boundsOrigin;

--- a/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.h
@@ -35,6 +35,7 @@
 #include "FloatRect.h"
 #include "FloatRoundedRect.h"
 #include "IntSize.h"
+#include "SkiaCompositingLayer3DRenderingContext.h"
 #include "SkiaCompositingLayerImageSetBatch.h"
 #include "SkiaCompositingLayerOverlapRegions.h"
 #include "SkiaDamageRegion.h"
@@ -237,7 +238,9 @@ private:
     TransformationMatrix combinedTransform(const PaintContext&) const;
     IntRect clipBounds(const SkCanvas&, const PaintContext&) const;
     sk_sp<SkImage> maskImage();
-    void collect3DRenderingContextLayers(Vector<Ref<SkiaCompositingLayer>>&);
+    FloatPolygon3D geometryFor3DRenderingContext() const;
+    FloatRect transformedFlattenedBounds() const;
+    void collect3DRenderingContextLayers(Vector<SkiaCompositingLayer3DRenderingContext::Layer>&);
     void recursiveCleanUpAfterPaint();
 
     void clipRect(SkCanvas&, const FloatRoundedRect&, const TransformationMatrix& = { });

--- a/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer3DRenderingContext.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer3DRenderingContext.cpp
@@ -110,17 +110,10 @@ static inline bool quadsIntersect(const FloatQuad& quadA, const FloatQuad& quadB
 
 WTF_MAKE_STRUCT_TZONE_ALLOCATED_IMPL(SkiaCompositingLayer3DRenderingContext::LayerNode);
 
-void SkiaCompositingLayer3DRenderingContext::paint(const Vector<Ref<SkiaCompositingLayer>>& compositingLayers, const std::function<void(SkiaCompositingLayer&, std::optional<SkPath>)>& paintLayerFunction)
+void SkiaCompositingLayer3DRenderingContext::paint(Vector<Layer>&& layers, const std::function<void(SkiaCompositingLayer&, std::optional<SkPath>)>& paintLayerFunction)
 {
-    if (compositingLayers.isEmpty())
+    if (layers.isEmpty())
         return;
-
-    Vector<Layer> layers;
-    for (auto& compositingLayer : compositingLayers) {
-        FloatPolygon3D geometry(compositingLayer->effectiveLayerRect(), compositingLayer->toSurfaceTransform());
-        BoundingBox boundingBox = computeBoundingBox(geometry);
-        layers.append({ geometry, boundingBox, compositingLayer });
-    }
 
     // Perform a broad-phase sweep-and-prune to identify potential intersections.
     // By determining which layers might intersect, we can limit BSP cutting planes to those areas only,
@@ -149,7 +142,7 @@ void SkiaCompositingLayer3DRenderingContext::paint(const Vector<Ref<SkiaComposit
             return layerA.boundingBox.min.z() < layerB.boundingBox.min.z();
         });
 
-        for (auto& layer : layers)
+        for (const auto& layer : layers)
             paintLayerFunction(layer.compositingLayer.get(), std::nullopt);
         return;
     }
@@ -157,12 +150,14 @@ void SkiaCompositingLayer3DRenderingContext::paint(const Vector<Ref<SkiaComposit
     Deque<Layer> layerDeque;
     for (auto& layer : layers)
         layerDeque.append(WTF::move(layer));
-    layers.clear();
 
     auto root = makeUnique<LayerNode>(layerDeque.takeFirst());
     buildTree(*root, layerDeque);
 
     auto buildClipPath = [](const Layer& layer) -> std::optional<SkPath> {
+        if (layer.isSplit == Layer::IsSplit::No)
+            return std::nullopt;
+
         auto toLayerTransform = layer.compositingLayer->toSurfaceTransform().inverse();
         unsigned numVertices = layer.geometry.numberOfVertices();
         if (!toLayerTransform || numVertices < 3)
@@ -182,14 +177,8 @@ void SkiaCompositingLayer3DRenderingContext::paint(const Vector<Ref<SkiaComposit
 
     // Paint in BSP order, building SkPath clip paths for split layers.
     traverseTree(*root, [&paintLayerFunction, &buildClipPath](LayerNode& node) {
-        for (auto& layer : node.layers) {
-            if (!layer.isSplit) {
-                paintLayerFunction(layer.compositingLayer.get(), std::nullopt);
-                continue;
-            }
-
+        for (const auto& layer : node.layers)
             paintLayerFunction(layer.compositingLayer.get(), buildClipPath(layer));
-        }
     });
 }
 
@@ -278,9 +267,9 @@ void SkiaCompositingLayer3DRenderingContext::buildTree(LayerNode& root, Deque<La
         case LayerPosition::Intersecting:
             auto [backGeometry, frontGeometry] = layer.geometry.split(rootPlane);
             if (backGeometry.numberOfVertices() > 2)
-                backList.append({ backGeometry, { }, layer.compositingLayer, true });
+                backList.append(Layer(layer.compositingLayer.copyRef(), WTF::move(backGeometry), Layer::IsSplit::Yes));
             if (frontGeometry.numberOfVertices() > 2)
-                frontList.append({ frontGeometry, { }, layer.compositingLayer, true });
+                frontList.append(Layer(layer.compositingLayer.copyRef(), WTF::move(frontGeometry), Layer::IsSplit::Yes));
             break;
         }
     }

--- a/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer3DRenderingContext.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer3DRenderingContext.h
@@ -43,8 +43,34 @@ class SkiaCompositingLayer;
 
 class SkiaCompositingLayer3DRenderingContext {
 public:
-    static void paint(const Vector<Ref<SkiaCompositingLayer>>&,
-        const std::function<void(SkiaCompositingLayer&, std::optional<SkPath>)>&);
+    struct BoundingBox {
+        FloatPoint3D min;
+        FloatPoint3D max;
+    };
+
+    struct Layer {
+        enum class IsSplit : bool { No, Yes };
+
+        Layer(Ref<SkiaCompositingLayer>&& layer, FloatPolygon3D&& layerGeometry, IsSplit layerIsSplit = IsSplit::No)
+            : compositingLayer(WTF::move(layer))
+            , geometry(WTF::move(layerGeometry))
+            , isSplit(layerIsSplit)
+        {
+            if (isSplit == IsSplit::No)
+                boundingBox = computeBoundingBox(geometry);
+        }
+
+        Layer(const Layer&) = delete;
+        Layer& operator=(const Layer&) = delete;
+        Layer(Layer&&) = default;
+        Layer& operator=(Layer&&) = default;
+
+        Ref<SkiaCompositingLayer> compositingLayer;
+        FloatPolygon3D geometry;
+        IsSplit isSplit { IsSplit::No };
+        BoundingBox boundingBox;
+    };
+    static void paint(Vector<Layer>&&, const std::function<void(SkiaCompositingLayer&, std::optional<SkPath>)>&);
 
 private:
     enum class LayerPosition {
@@ -52,18 +78,6 @@ private:
         Behind,
         Coplanar,
         Intersecting
-    };
-
-    struct BoundingBox {
-        FloatPoint3D min;
-        FloatPoint3D max;
-    };
-
-    struct Layer {
-        FloatPolygon3D geometry;
-        BoundingBox boundingBox;
-        Ref<SkiaCompositingLayer> compositingLayer;
-        bool isSplit { false };
     };
 
     struct LayerNode {

--- a/Source/WebCore/platform/graphics/skia/SkiaSerializedImageBuffer.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaSerializedImageBuffer.cpp
@@ -77,6 +77,8 @@ RefPtr<ImageBuffer> SkiaSerializedImageBuffer::sinkIntoImageBuffer()
     FloatRect source = destination;
     source.scale(m_imageBuffer->resolutionScale());
     copiedImageBuffer->context().drawNativeImage(*m_image, destination, source, { CompositeOperator::Copy });
+    // Flush the context to ensure all operations are done before the source image buffer is destroyed.
+    copiedImageBuffer->flushDrawingContext();
     return copiedImageBuffer;
 }
 


### PR DESCRIPTION
#### 3c42da6f54e7999e805dbeeffbce43acd6b43dff
<pre>
Cherry-pick 318148@main (0449e10b207f). <a href="https://bugs.webkit.org/show_bug.cgi?id=320544">https://bugs.webkit.org/show_bug.cgi?id=320544</a>

    REGRESSION(318066@main): [GTK][WPE] Skia compositor: do not apply flattened bounds transformation if layer is not empty
    <a href="https://bugs.webkit.org/show_bug.cgi?id=320544">https://bugs.webkit.org/show_bug.cgi?id=320544</a>

    Reviewed by Alejandro G. Castro.

    We only need to apply the flattened bounds when the layer is empty to
    get proper bounds from the children.

    * Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp:
    (WebCore::SkiaCompositingLayer::geometryFor3DRenderingContext const):

    Canonical link: <a href="https://commits.webkit.org/318148@main">https://commits.webkit.org/318148@main</a>

Canonical link: <a href="https://commits.webkit.org/317695.11@webkitglib/2.54">https://commits.webkit.org/317695.11@webkitglib/2.54</a>
</pre>
----------------------------------------------------------------------
#### 1a714a23c8d8c5391b54d232795c69a0e909b319
<pre>
Cherry-pick 318138@main (73a527b95f75). <a href="https://bugs.webkit.org/show_bug.cgi?id=320528">https://bugs.webkit.org/show_bug.cgi?id=320528</a>

    [GTK][WPE] Skia compositor: remove effectiveLayerRect()
    <a href="https://bugs.webkit.org/show_bug.cgi?id=320528">https://bugs.webkit.org/show_bug.cgi?id=320528</a>

    Reviewed by Alejandro G. Castro.

    This was copied from texture mapper which means a different thing only
    used for 3D context layers. In skia compositor it&apos;s always just
    returning the layer rectangle. The layer rectangle is in layer
    coordinates, so it&apos;s always 0,0 widthxheight. We have a member for the
    size and build a FloatRect every time the layer rect is needed. This
    patch replaces m_size by m_rect so that we always have the rectangle and
    we just change its size when the layer size changes. We don&apos;t even need
    a getter for the layer rect since it&apos;s only used internally.

    * Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp:
    (WebCore::SkiaCompositingLayer::setSize):
    (WebCore::SkiaCompositingLayer::updateBackingStore):
    (WebCore::SkiaCompositingLayer::paintedLayerRect const):
    (WebCore::SkiaCompositingLayer::computeTransformsAndAnimations):
    (WebCore::SkiaCompositingLayer::paint):
    (WebCore::SkiaCompositingLayer::paintSelfAndChildren):
    (WebCore::SkiaCompositingLayer::isVisible const):
    (WebCore::SkiaCompositingLayer::maskImage):
    (WebCore::SkiaCompositingLayer::computeOverlapRegions):
    (WebCore::SkiaCompositingLayer::transformedFlattenedBounds const):
    (WebCore::SkiaCompositingLayer::geometryFor3DRenderingContext const):
    * Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.h:

    Canonical link: <a href="https://commits.webkit.org/318138@main">https://commits.webkit.org/318138@main</a>

Canonical link: <a href="https://commits.webkit.org/317695.10@webkitglib/2.54">https://commits.webkit.org/317695.10@webkitglib/2.54</a>
</pre>
----------------------------------------------------------------------
#### febb248c93c1eb035401552e94426f30d535ef08
<pre>
Cherry-pick 318066@main (7a767a006f81). <a href="https://bugs.webkit.org/show_bug.cgi?id=314883">https://bugs.webkit.org/show_bug.cgi?id=314883</a>

    [GTK][WPE] SkiaCompositingLayer: incorrect z-ordering at Snow Stack
    <a href="https://bugs.webkit.org/show_bug.cgi?id=314883">https://bugs.webkit.org/show_bug.cgi?id=314883</a>

    Reviewed by Nikolas Zimmermann.

    Make SkiaCompositingLayer3DRenderingContext::Layer public and make
    SkiaCompositingLayer3DRenderingContext::paint() receive a list of
    SkiaCompositingLayer3DRenderingContext::Layer instead. This way while
    collecting the 3D context layers we can build the
    SkiaCompositingLayer3DRenderingContext::Layer without having to iterate
    the layers again in paint(). The geometry for 3D context is now computed
    taking into account the flattened bounding box when needed instead of
    always using the layer rectangle, which is what actually fixes the
    incorrect z-ordering.

    * Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp:
    (WebCore::SkiaCompositingLayer::transformedFlattenedBounds const):
    (WebCore::SkiaCompositingLayer::geometryFor3DRenderingContext const):
    (WebCore::SkiaCompositingLayer::collect3DRenderingContextLayers):
    (WebCore::SkiaCompositingLayer::paintWith3DRenderingContext):
    * Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.h:
    * Source/WebCore/platform/graphics/skia/SkiaCompositingLayer3DRenderingContext.cpp:
    (WebCore::SkiaCompositingLayer3DRenderingContext::paint):
    (WebCore::SkiaCompositingLayer3DRenderingContext::buildTree):
    * Source/WebCore/platform/graphics/skia/SkiaCompositingLayer3DRenderingContext.h:
    (WebCore::SkiaCompositingLayer3DRenderingContext::Layer::Layer):

    Canonical link: <a href="https://commits.webkit.org/318066@main">https://commits.webkit.org/318066@main</a>

Canonical link: <a href="https://commits.webkit.org/317695.9@webkitglib/2.54">https://commits.webkit.org/317695.9@webkitglib/2.54</a>
</pre>
----------------------------------------------------------------------
#### 20f127f47c7869301c5160c23978f0dfb3b73e77
<pre>
Cherry-pick 318143@main (0d1e5abeecb6). <a href="https://bugs.webkit.org/show_bug.cgi?id=319131">https://bugs.webkit.org/show_bug.cgi?id=319131</a>

    REGRESSION(313868@main): [Skia] Broke certain images in PDF documents
    <a href="https://bugs.webkit.org/show_bug.cgi?id=319131">https://bugs.webkit.org/show_bug.cgi?id=319131</a>

    Reviewed by Alejandro G. Castro.

    Flush the context after copying buffer in
    SkiaSerializedImageBuffer::sinkIntoImageBuffer().

    * Source/WebCore/platform/graphics/skia/SkiaSerializedImageBuffer.cpp:
    (WebCore::SkiaSerializedImageBuffer::sinkIntoImageBuffer):

    Canonical link: <a href="https://commits.webkit.org/318143@main">https://commits.webkit.org/318143@main</a>

Canonical link: <a href="https://commits.webkit.org/317695.8@webkitglib/2.54">https://commits.webkit.org/317695.8@webkitglib/2.54</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/57c5eaf73692dbfee6d5842e646dab5fcd9399c3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177481 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/51419 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/45213 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187085 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140728 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179344 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/52711 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/51128 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138324 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140728 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180437 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/52711 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/45213 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118789 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/52711 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/51128 "The change is no longer eligible for processing.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/45213 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/52711 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/45213 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35552 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/43204 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/51128 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189513 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/51086 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/45213 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147419 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/51768 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/45213 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147211 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26915 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/51768 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/123983 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/118359 "The change is no longer eligible for processing.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/50276 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/45213 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/49672 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/49912 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/49734 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->