### PR TITLE
(311380@main) [Moon Player: AI-Enhanced 3D] Video playback goes black but audio continues when playing YouTube videos in full screen

### DIFF
--- a/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h
+++ b/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h
@@ -148,6 +148,7 @@ enum class SDKAlignedBehavior {
     ScrollPocketInFullscreen,
     IgnorePageLocationDuringHardPocketEligibilityCheck,
     AdjustColorExtensionsForHorizontalBannerViewOverlays,
+    NoMediaLayerTeardownOnPageVisibilityChangeQuirk,
 
     NumberOfBehaviors
 };
@@ -230,6 +231,7 @@ WTF_EXPORT_PRIVATE bool isWebProcess();
 WTF_EXPORT_PRIVATE bool isMobileStore();
 WTF_EXPORT_PRIVATE bool isUNIQLOApp();
 WTF_EXPORT_PRIVATE bool isDOFUSTouch();
+WTF_EXPORT_PRIVATE bool isMoonPlayer();
 WTF_EXPORT_PRIVATE bool isMyRideK12();
 WTF_EXPORT_PRIVATE bool isTableau();
 WTF_EXPORT_PRIVATE bool isTubular();

--- a/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.mm
+++ b/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.mm
@@ -643,6 +643,12 @@ bool IOSApplication::isDOFUSTouch()
     return isDOFUSTouch;
 }
 
+bool IOSApplication::isMoonPlayer()
+{
+    static bool isMoonPlayer = applicationBundleIsEqualTo("com.innovis.moonplayer"_s);
+    return isMoonPlayer;
+}
+
 bool IOSApplication::isMyRideK12()
 {
     static bool isMyRideK12 = applicationBundleIsEqualTo("com.tylertech.myridek12"_s);

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -2109,6 +2109,7 @@ void HTMLMediaElement::loadResource(const URL& initialURL, const ContentType& in
         .contentType = WTF::move(contentType),
         .requiresRemotePlayback = !!m_remotePlaybackConfiguration,
         .supportsLimitedMatroska = limitedMatroskaSupportEnabled(),
+        .disableTeardownOnVisibilityChange = protect(document())->quirks().shouldDisableMediaLayerTeardownOnPageVisibilityChangeQuirk(),
 #if ENABLE(MEDIA_SOURCE)
         .supportsProgressMonitoringOverride = protect(document())->quirks().needsSupportsProgressMonitoring() ? std::optional<bool> { true } : std::nullopt,
 #endif

--- a/Source/WebCore/html/HTMLVideoElement.cpp
+++ b/Source/WebCore/html/HTMLVideoElement.cpp
@@ -33,6 +33,7 @@
 #include "ChromeClient.h"
 #include "Document.h"
 #include "DocumentPage.h"
+#include "DocumentQuirks.h"
 #include "DocumentView.h"
 #include "ElementInlines.h"
 #include "EventNames.h"
@@ -184,7 +185,11 @@ void HTMLVideoElement::computeAcceleratedRenderingStateAndUpdateMediaPlayer()
     bool isInFullScreen = false;
 #endif
     CheckedPtr renderer = this->renderer();
-    bool canBeAccelerated = player->supportsAcceleratedRendering() && (isInFullScreen || (m_isIntersectingViewport && renderer && protect(renderer->view())->compositor().hasAcceleratedCompositing()));
+    // 311380@main added the viewport intersection to this condition. Some clients keep
+    // displaying the video layer they host after scrolling it out of view or hiding their
+    // web view, so for those ignore it as it was before.
+    bool isIntersectingViewport = m_isIntersectingViewport || protect(document())->quirks().shouldDisableMediaLayerTeardownOnPageVisibilityChangeQuirk();
+    bool canBeAccelerated = player->supportsAcceleratedRendering() && (isInFullScreen || (isIntersectingViewport && renderer && protect(renderer->view())->compositor().hasAcceleratedCompositing()));
     if (canBeAccelerated == m_renderingCanBeAccelerated)
         return;
     m_renderingCanBeAccelerated = canBeAccelerated;

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -1821,6 +1821,16 @@ bool Quirks::shouldDisableLazyIframeLoadingQuirk() const
     return m_quirksData.quirkIsEnabled(QuirksData::SiteSpecificQuirk::ShouldDisableLazyIframeLoadingQuirk);
 }
 
+// Moon Player app (rdar://162452658): the app hides its WKWebView while continuing to display
+// the video layer it hosts, so page visibility does not indicate whether the video is on screen.
+// Tearing the layer down when the page becomes hidden leaves the app displaying a black frame.
+bool Quirks::shouldDisableMediaLayerTeardownOnPageVisibilityChangeQuirk() const
+{
+    QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
+
+    return m_quirksData.quirkIsEnabled(QuirksData::SiteSpecificQuirk::ShouldDisableMediaLayerTeardownOnPageVisibilityChangeQuirk);
+}
+
 // reddit.com with Sink It extension (rdar://176377447) and apple.com/retail (rdar://181007316).
 bool Quirks::shouldDisableScrollAnchoringQuirk() const
 {
@@ -4133,11 +4143,15 @@ void Quirks::determineRelevantQuirks()
 #if PLATFORM(IOS_FAMILY)
     static const bool shouldDisableLazyIframeLoadingQuirk = !linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior::NoUNIQLOLazyIframeLoadingQuirk) && WTF::IOSApplication::isUNIQLOApp();
     static const bool needsResettingTransitionCancelsRunningTransitionQuirk = !linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior::ResettingTransitionCancelsRunningTransitionQuirk) && WTF::IOSApplication::isDOFUSTouch();
+    static const bool shouldDisableMediaLayerTeardownOnPageVisibilityChangeQuirk = !linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior::NoMediaLayerTeardownOnPageVisibilityChangeQuirk) && WTF::IOSApplication::isMoonPlayer();
 
     m_quirksData.setQuirkState(QuirksData::SiteSpecificQuirk::ShouldDisableLazyIframeLoadingQuirk, shouldDisableLazyIframeLoadingQuirk);
 
     // DOFUS Touch app (rdar://112679186)
     m_quirksData.setQuirkState(QuirksData::SiteSpecificQuirk::NeedsResettingTransitionCancelsRunningTransitionQuirk, needsResettingTransitionCancelsRunningTransitionQuirk);
+
+    // Moon Player app (rdar://162452658)
+    m_quirksData.setQuirkState(QuirksData::SiteSpecificQuirk::ShouldDisableMediaLayerTeardownOnPageVisibilityChangeQuirk, shouldDisableMediaLayerTeardownOnPageVisibilityChangeQuirk);
 #endif
 
 #if PLATFORM(MAC)

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -248,6 +248,7 @@ public:
     WEBCORE_EXPORT bool shouldDisableAdSkippingInPip() const;
 #endif
     bool shouldDisableLazyIframeLoadingQuirk() const;
+    bool shouldDisableMediaLayerTeardownOnPageVisibilityChangeQuirk() const;
 
     bool shouldBlockFetchWithNewlineAndLessThan() const;
     bool shouldDisableFetchMetadata() const;

--- a/Source/WebCore/page/QuirksData.h
+++ b/Source/WebCore/page/QuirksData.h
@@ -188,6 +188,7 @@ struct QuirksData {
         ShouldAllowMediaStreamTrackSerializationQuirk,
 #endif
         ShouldDisableLazyIframeLoadingQuirk,
+        ShouldDisableMediaLayerTeardownOnPageVisibilityChangeQuirk,
 #if PLATFORM(IOS_FAMILY)
         ShouldDisablePointerEventsQuirk,
 #endif

--- a/Source/WebCore/platform/graphics/MediaPlayer.h
+++ b/Source/WebCore/platform/graphics/MediaPlayer.h
@@ -187,6 +187,7 @@ struct MediaPlayerLoadOptions {
     ContentType contentType { };
     bool requiresRemotePlayback { false };
     bool supportsLimitedMatroska { false };
+    bool disableTeardownOnVisibilityChange { false };
     std::optional<bool> supportsProgressMonitoringOverride { };
     VideoRendererPreferences videoRendererPreferences { };
 };

--- a/Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.cpp
+++ b/Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.cpp
@@ -205,6 +205,12 @@ void MediaPlayerPrivateAVFoundation::load(const String& url)
     setPreload(m_preload);
 }
 
+void MediaPlayerPrivateAVFoundation::load(const URL& url, const LoadOptions& options)
+{
+    m_disableTeardownOnVisibilityChange = options.disableTeardownOnVisibilityChange;
+    load(url.string());
+}
+
 #if ENABLE(MEDIA_SOURCE)
 void MediaPlayerPrivateAVFoundation::load(const URL&, const LoadOptions&, MediaSourcePrivateClient&)
 {

--- a/Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.h
+++ b/Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.h
@@ -168,6 +168,7 @@ protected:
 
     // MediaPlayerPrivatePrivateInterface overrides.
     void load(const String& url) override;
+    void load(const URL&, const LoadOptions&) override;
 #if ENABLE(MEDIA_SOURCE)
     void load(const URL&, const LoadOptions&, MediaSourcePrivateClient&) override;
 #endif
@@ -380,6 +381,7 @@ protected:
     bool m_seeking;
     bool m_needsRenderingModeChanged { false };
     ViewportVisibility m_viewportVisibility { ViewportVisibility::NotVisible };
+    bool m_disableTeardownOnVisibilityChange { false };
 
 private:
     void seekInternal(const SeekTarget&);

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
@@ -4325,6 +4325,12 @@ bool MediaPlayerPrivateAVFoundationObjC::shouldAttachLayerToPlayer()
         return false;
 #endif
 
+    // 311380@main started detaching the video layer from the player when the page or the
+    // element became non-visible. Some clients keep displaying the video layer they host
+    // after hiding their web view, so for those keep the layer attached as it was before.
+    if (m_disableTeardownOnVisibilityChange)
+        return true;
+
     if (!pageIsVisible())
         return false;
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
@@ -210,6 +210,7 @@ private:
     void setPageIsVisible(bool) final;
     void setViewportVisibility(ViewportVisibility) final;
     void updateRendererVisibility();
+    bool shouldTeardownOnVisibilityChange() const;
 
     MediaTime duration() const override;
     MediaTime startTime() const override;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
@@ -432,6 +432,16 @@ bool MediaPlayerPrivateMediaSourceAVFObjC::hasAudio() const
     return mediaSourcePrivate && mediaSourcePrivate->hasAudio();
 }
 
+bool MediaPlayerPrivateMediaSourceAVFObjC::shouldTeardownOnVisibilityChange() const
+{
+    assertIsMainThread();
+    // Some clients continue to display the video layer they host after hiding their web view.
+    // For those, neither the page's visibility nor the element's position in the viewport
+    // indicate whether the video is on screen, and tearing the layer down would leave the
+    // client displaying a black frame.
+    return !m_loadOptions.disableTeardownOnVisibilityChange;
+}
+
 void MediaPlayerPrivateMediaSourceAVFObjC::setPageIsVisible(bool visible)
 {
     assertIsMainThread();
@@ -459,7 +469,11 @@ void MediaPlayerPrivateMediaSourceAVFObjC::updateRendererVisibility()
     assertIsMainThread();
     bool visible = m_pageIsVisible && m_viewportVisibility != ViewportVisibility::NotVisible;
     m_renderer->setIsVisible(visible);
-    acceleratedRenderingStateChanged();
+    // 311380@main started letting the page's and the element's visibility release the video
+    // renderer. Some clients keep displaying the video layer they host after hiding their web
+    // view, so for those restore the previous behaviour where visibility had no such effect.
+    if (shouldTeardownOnVisibilityChange())
+        acceleratedRenderingStateChanged();
 }
 
 MediaTime MediaPlayerPrivateMediaSourceAVFObjC::duration() const
@@ -972,11 +986,11 @@ void MediaPlayerPrivateMediaSourceAVFObjC::acceleratedRenderingStateChanged()
 
     RefPtr player = m_player.get();
 
+    bool canBeAccelerated = player && player->renderingCanBeAccelerated();
+
     // Don't create a layer if the player is not visible:
-    bool canBeAccelerated = m_pageIsVisible
-        && m_viewportVisibility != ViewportVisibility::NotVisible
-        && player
-        && player->renderingCanBeAccelerated();
+    if (shouldTeardownOnVisibilityChange())
+        canBeAccelerated = canBeAccelerated && m_pageIsVisible && m_viewportVisibility != ViewportVisibility::NotVisible;
     m_renderer->renderingCanBeAcceleratedChanged(canBeAccelerated);
 }
 

--- a/Source/WebKit/Shared/WebCoreArgumentCodersMedia.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCodersMedia.serialization.in
@@ -254,6 +254,7 @@ header: <WebCore/MediaPlayer.h>
     WebCore::ContentType contentType;
     bool requiresRemotePlayback;
     bool supportsLimitedMatroska;
+    bool disableTeardownOnVisibilityChange;
     std::optional<bool> supportsProgressMonitoringOverride;
     OptionSet<WebCore::VideoRendererPreference> videoRendererPreferences;
 };


### PR DESCRIPTION
#### 6cb190d2d3d880bbca43f0e839e9fa46aeeae914
<pre>
(311380@main) [Moon Player: AI-Enhanced 3D] Video playback goes black but audio continues when playing YouTube videos in full screen
<a href="https://bugs.webkit.org/show_bug.cgi?id=320547">https://bugs.webkit.org/show_bug.cgi?id=320547</a>
<a href="https://rdar.apple.com/183071272">rdar://183071272</a>

Reviewed by Andy Estes.

311380@main made a media player release its video renderer once the element was no
longer visible, either because it had been scrolled far away from the viewport
(fixing window server jetsams on infinite scrolling video websites) or because the
page hosting it had become non-visible.

Some clients keep displaying the video layer they host after hiding their web view.
For those, neither the page&apos;s visibility nor the element&apos;s position in the viewport
indicate whether the video is on screen: the renderer is released while the client
is still showing it, and the video turns black while audio keeps playing.

Add a MediaPlayerLoadOptions member, set from a new site-specific quirk, that
selectively restores the pre-311380@main behaviour when set. Each of the three
places where 311380@main made visibility release the renderer is reverted
individually:

- HTMLVideoElement::computeAcceleratedRenderingStateAndUpdateMediaPlayer() ignores
the viewport intersection term that commit added to `canBeAccelerated`.
- MediaPlayerPrivateMediaSourceAVFObjC::updateRendererVisibility() no longer calls
acceleratedRenderingStateChanged(), which that commit added, and
acceleratedRenderingStateChanged() forwards MediaPlayer::renderingCanBeAccelerated()
unchanged rather than combining it with the page&apos;s and the viewport&apos;s visibility.
- MediaPlayerPrivateAVFoundationObjC::shouldAttachLayerToPlayer(), added by that
commit, keeps the video layer attached to the AVPlayer as it was before.

The quirk is bound to
SDKAlignedBehavior::NoMediaLayerTeardownOnPageVisibilityChangeQuirk so that it stops
applying once the application is rebuilt against a newer SDK, giving it a chance to
adopt a supported presentation mode in the meantime. The default behaviour, and
therefore the memory optimisation 311380@main introduced, is unchanged for every
other client.

* Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h:
* Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.mm:
(WTF::IOSApplication::isMoonPlayer):
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::loadResource): Set the new load option.
* Source/WebCore/html/HTMLVideoElement.cpp:
(WebCore::HTMLVideoElement::computeAcceleratedRenderingStateAndUpdateMediaPlayer):
* Source/WebCore/page/Quirks.cpp:
(WebCore::Quirks::shouldDisableMediaLayerTeardownOnPageVisibilityChangeQuirk const):
(WebCore::Quirks::determineRelevantQuirks):
* Source/WebCore/page/Quirks.h:
* Source/WebCore/page/QuirksData.h:
* Source/WebCore/platform/graphics/MediaPlayer.h:
* Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.cpp:
(WebCore::MediaPlayerPrivateAVFoundation::load): Keep the load option, the base class
otherwise discards it.
* Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm:
(WebCore::MediaPlayerPrivateAVFoundationObjC::shouldAttachLayerToPlayer):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::shouldTeardownOnVisibilityChange const):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::updateRendererVisibility):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::acceleratedRenderingStateChanged):
* Source/WebKit/Shared/WebCoreArgumentCodersMedia.serialization.in:

Canonical link: <a href="https://commits.webkit.org/318230@main">https://commits.webkit.org/318230@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b43f64c55bb7094d618be0120e8cc5d107ee25f0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177647 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51585 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45379 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187251 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140894 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/533e96ad-8263-4c22-9b7d-8624e76fb9df) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179510 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52877 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51294 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138468 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140894 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/95c1e4d2-5fd7-45fd-a720-50d7e71b1532) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180603 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41969 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159204 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118932 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/dae2963e-44e3-4ad6-8491-b9e6974ed80e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40630 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39000 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/901 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/7700 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151037 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38700 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35718 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/38918 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/43370 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43235 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189682 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51252 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147567 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39651 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51934 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35328 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147357 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42077 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124149 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118562 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50442 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13677 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49838 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50078 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49900 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->