### PR TITLE
Service Worker request is missing sec-fetch-dest

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/resources/soft-update-fetch-metadata.py
+++ b/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/resources/soft-update-fetch-metadata.py
@@ -1,0 +1,45 @@
+import json
+
+
+# Records the Fetch Metadata headers of every request made for a service worker script,
+# so that tests can check the requests made when checking for updates.
+def main(request, response):
+    token = request.GET.first(b"token")
+
+    def header_value(name):
+        value = request.headers.get(name)
+        return value.decode("utf-8") if value is not None else None
+
+    with request.server.stash.lock:
+        records = request.server.stash.take(token)
+        if records is None:
+            records = []
+
+        is_get_records = b"get_records" in request.GET
+        if not is_get_records:
+            records.append({
+                u"url": request.url,
+                u"service-worker": header_value(b"Service-Worker"),
+                u"sec-fetch-dest": header_value(b"Sec-Fetch-Dest"),
+                u"sec-fetch-mode": header_value(b"Sec-Fetch-Mode"),
+                u"sec-fetch-site": header_value(b"Sec-Fetch-Site"),
+            })
+
+        request.server.stash.put(token, records)
+
+    if is_get_records:
+        return 200, [(b"Content-Type", b"application/json"), (b"Cache-Control", b"no-store")], json.dumps(records)
+
+    kind = request.GET.first(b"kind", b"classic")
+    imported_script_url = u"./soft-update-fetch-metadata.py?token=%s&kind=imported" % request.GET.first(b"importtoken", b"").decode("utf-8")
+
+    if kind == b"imported":
+        body = u"// Imported script.\n"
+    elif kind == b"classic-with-import":
+        body = u"importScripts('%s');\nonfetch = e => { e.request; };\n" % imported_script_url
+    elif kind == b"module-with-import":
+        body = u"import '%s';\nonfetch = e => { e.request; };\n" % imported_script_url
+    else:
+        body = u"onfetch = e => { e.request; };\n"
+
+    return 200, [(b"Content-Type", b"text/javascript"), (b"Cache-Control", b"no-store")], body

--- a/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/soft-update-fetch-metadata.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/soft-update-fetch-metadata.https-expected.txt
@@ -1,0 +1,5 @@
+
+PASS headers of the main script
+PASS headers of a script imported by a classic script
+PASS headers of a script imported by a module script
+

--- a/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/soft-update-fetch-metadata.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/soft-update-fetch-metadata.https.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<meta name="timeout" content="long">
+<title>Test that soft update script fetches send the same Fetch Metadata headers as the initial fetches</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/common/utils.js"></script>
+<script src="resources/test-helpers.sub.js"></script>
+<script>
+const scope = 'resources/';
+
+async function register_worker(t, scriptURL, options) {
+  await service_worker_unregister(t, scope);
+  const registration = await navigator.serviceWorker.register(scriptURL, options);
+  t.add_cleanup(() => registration.unregister());
+  await wait_for_state(t, registration.installing, 'activated');
+  return registration;
+}
+
+async function trigger_soft_update_and_get_records(recordsURL, expectedRecordCount) {
+  const frame = await with_iframe(scope + 'blank.html');
+  frame.remove();
+
+  let records = [];
+  let counter = 0;
+  do {
+    await new Promise(resolve => step_timeout(resolve, 50));
+    records = await (await fetch(recordsURL)).json();
+  } while (records.length < expectedRecordCount && ++counter < 100);
+
+  return records;
+}
+
+function assert_records(records, expectedRecordCount, expectedRecord, description) {
+  // We expect records[0] to be the registration triggered load and records[1] to be the soft update load.
+  assert_greater_than_equal(records.length, expectedRecordCount,
+                            `${description}, got ${JSON.stringify(records)}`);
+  for (let index = 0; index < records.length; ++index)
+    assert_object_equals(records[index], expectedRecord, `${description}, request #${index}`);
+}
+
+promise_test(async (t) => {
+  const scriptURL = `${scope}soft-update-fetch-metadata.py?token=${token()}&kind=classic`;
+  await register_worker(t, scriptURL);
+
+  const records = await trigger_soft_update_and_get_records(`${scriptURL}&get_records`, 2);
+  assert_records(records, 2, {
+    'service-worker': 'script',
+    'sec-fetch-dest': 'serviceworker',
+    'sec-fetch-mode': 'same-origin',
+    'sec-fetch-site': 'same-origin',
+    'url': new URL(scriptURL, window.location).toString(),
+  }, 'expected one install and one update check request for the main script');
+}, 'headers of the main script');
+
+promise_test(async (t) => {
+  const importToken = token();
+  const scriptURL = `${scope}soft-update-fetch-metadata.py?token=${token()}&kind=classic-with-import&importtoken=${importToken}`;
+  const importedScriptURL = `${scope}soft-update-fetch-metadata.py?token=${importToken}&kind=imported`;
+  await register_worker(t, scriptURL);
+
+  const records = await trigger_soft_update_and_get_records(`${importedScriptURL}&get_records`, 2);
+  assert_records(records, 2, {
+    'service-worker': null,
+    'sec-fetch-dest': 'script',
+    'sec-fetch-mode': 'no-cors',
+    'sec-fetch-site': 'same-origin',
+    'url': new URL(importedScriptURL, window.location).toString(),
+  }, 'expected one install and one update check request for the imported script');
+}, 'headers of a script imported by a classic script');
+
+promise_test(async (t) => {
+  const importToken = token();
+  const scriptURL = `${scope}soft-update-fetch-metadata.py?token=${token()}&kind=module-with-import&importtoken=${importToken}`;
+  const importedScriptURL = `${scope}soft-update-fetch-metadata.py?token=${importToken}&kind=imported`;
+  await register_worker(t, scriptURL, { type: 'module' });
+
+  const records = await trigger_soft_update_and_get_records(`${importedScriptURL}&get_records`, 2);
+  assert_records(records, 2, {
+    'url': window.location + importedScriptURL,
+    'service-worker': null,
+    'sec-fetch-dest': 'serviceworker',
+    'sec-fetch-mode': 'cors',
+    'sec-fetch-site': 'same-origin',
+    'url': new URL(importedScriptURL, window.location).toString(),
+  }, 'expected one install and one update check request for the imported module script');
+}, 'headers of a script imported by a module script');
+</script>

--- a/Source/WebCore/workers/service/server/SWServer.cpp
+++ b/Source/WebCore/workers/service/server/SWServer.cpp
@@ -716,7 +716,25 @@ void SWServer::resolveUnregistrationJob(const ServiceWorkerJobData& jobData, con
     connection->resolveUnregistrationJobInClient(jobData.identifier().jobIdentifier, registrationKey, unregistrationResult);
 }
 
-ResourceRequest SWServer::createScriptRequest(const URL& url, const ServiceWorkerJobData& jobData, SWServerRegistration& registration)
+static void addFetchMetadataHeaders(ResourceRequest& request, const SecurityOrigin& scriptOrigin, ASCIILiteral destination, ASCIILiteral mode)
+{
+    Ref requestOrigin = SecurityOrigin::create(request.url());
+    ASSERT(requestOrigin->isPotentiallyTrustworthy());
+
+    auto site = [&]() -> ASCIILiteral {
+        if (scriptOrigin.isSameOriginAs(requestOrigin))
+            return "same-origin"_s;
+        if (scriptOrigin.isSameSiteAs(requestOrigin))
+            return "same-site"_s;
+        return "cross-site"_s;
+    }();
+
+    request.setHTTPHeaderField(HTTPHeaderName::SecFetchDest, destination);
+    request.setHTTPHeaderField(HTTPHeaderName::SecFetchMode, mode);
+    request.setHTTPHeaderField(HTTPHeaderName::SecFetchSite, site);
+}
+
+ResourceRequest SWServer::createScriptRequest(const URL& url, const ServiceWorkerJobData& jobData, SWServerRegistration& registration, IsMainScript isMainScript)
 {
     ResourceRequest request { URL { url } };
 
@@ -732,6 +750,14 @@ ResourceRequest SWServer::createScriptRequest(const URL& url, const ServiceWorke
     request.setHTTPUserAgent(serviceWorkerClientUserAgent(ClientOrigin { jobData.topOrigin, SecurityOrigin::create(jobData.scriptURL)->data() }));
     request.setPriority(ResourceLoadPriority::Low);
     request.setIsAppInitiated(registration.isAppInitiated());
+
+    if (isMainScript == IsMainScript::Yes) {
+        request.setHTTPHeaderField(HTTPHeaderName::ServiceWorker, "script"_s);
+        addFetchMetadataHeaders(request, origin, "serviceworker"_s, "same-origin"_s);
+    } else if (jobData.workerType == WorkerType::Module)
+        addFetchMetadataHeaders(request, origin, "serviceworker"_s, "cors"_s);
+    else
+        addFetchMetadataHeaders(request, origin, "script"_s, "no-cors"_s);
 
     return request;
 }
@@ -755,8 +781,7 @@ void SWServer::startScriptFetch(const ServiceWorkerJobData& jobData, SWServerReg
     if (jobData.connectionIdentifier() == Process::identifier()) {
         ASSERT(jobData.type == ServiceWorkerJobType::Update);
         // This is a soft-update job, create directly a network load to fetch the script.
-        auto request = createScriptRequest(jobData.scriptURL, jobData, registration);
-        request.setHTTPHeaderField(HTTPHeaderName::ServiceWorker, "script"_s);
+        auto request = createScriptRequest(jobData.scriptURL, jobData, registration, IsMainScript::Yes);
         protect(*m_delegate)->softUpdate(ServiceWorkerJobData { jobData }, shouldRefreshCache, WTF::move(request), [weakThis = WeakPtr { *this }, jobDataIdentifier = jobData.identifier(), registrationKey = jobData.registrationKey()](WorkerFetchResult&& result) {
             std::optional<ProcessIdentifier> requestingProcessIdentifier;
             if (RefPtr protectedThis = weakThis.get())
@@ -813,7 +838,7 @@ void SWServer::refreshImportedScripts(const ServiceWorkerJobData& jobData, SWSer
     auto handler = RefreshImportedScriptsHandler::create(urls.size(), WTF::move(callback));
     CheckedRef delegate = *m_delegate;
     for (auto& url : urls) {
-        delegate->softUpdate(ServiceWorkerJobData { jobData }, shouldRefreshCache, createScriptRequest(url, jobData, registration), [handler, url, size = urls.size()](WorkerFetchResult&& result) {
+        delegate->softUpdate(ServiceWorkerJobData { jobData }, shouldRefreshCache, createScriptRequest(url, jobData, registration, IsMainScript::No), [handler, url, size = urls.size()](WorkerFetchResult&& result) {
             handler->add(url, WTF::move(result));
         });
     }

--- a/Source/WebCore/workers/service/server/SWServer.h
+++ b/Source/WebCore/workers/service/server/SWServer.h
@@ -357,7 +357,8 @@ private:
     void originImportComplete(const SecurityOriginData& topOrigin, MonotonicTime startTime);
     void fireAllOriginImportCallbacks();
 
-    ResourceRequest createScriptRequest(const URL&, const ServiceWorkerJobData&, SWServerRegistration&);
+    enum class IsMainScript : bool { No, Yes };
+    ResourceRequest createScriptRequest(const URL&, const ServiceWorkerJobData&, SWServerRegistration&, IsMainScript);
 
     enum class ShouldUpdateRegistrations : bool { No, Yes };
     void unregisterServiceWorkerClientInternal(const ClientOrigin&, ScriptExecutionContextIdentifier, ShouldUpdateRegistrations);


### PR DESCRIPTION
#### d526f33ee5d447ab59659024d36f1170b377e97f
<pre>
Service Worker request is missing sec-fetch-dest
<a href="https://rdar.apple.com/181909962">rdar://181909962</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=318556">https://bugs.webkit.org/show_bug.cgi?id=318556</a>

Reviewed by Chris Dumez.

When doing soft-update, the networking process is responsible to generate the update requests.
It was missing Sec-Fetch headers, that are typically added by web process.

We add Sec-Fetch headers and make sure to cover the 3 different cases:
- The main script
- Imported scripts
- Module loaded scripts.

We add a WPT test, which is passing in Chrome.
Firefox is also populating those headers but is not consistently setting Sec-Fetch-Dest to service worker.

Test: imported/w3c/web-platform-tests/service-workers/service-worker/soft-update-fetch-metadata.https.html

* LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/resources/soft-update-fetch-metadata.py: Added.
(main):
(main.header_value):
* LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/soft-update-fetch-metadata.https-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/soft-update-fetch-metadata.https.html: Added.
* Source/WebCore/workers/service/server/SWServer.cpp:
(WebCore::addFetchMetadataHeaders):
(WebCore::SWServer::createScriptRequest):
(WebCore::SWServer::startScriptFetch):
(WebCore::SWServer::refreshImportedScripts):
* Source/WebCore/workers/service/server/SWServer.h:

Canonical link: <a href="https://commits.webkit.org/318237@main">https://commits.webkit.org/318237@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/43e3fb3d4c4ac841af982d03499a578745e8600b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177499 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51437 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45231 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187103 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140746 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b50709b0-4d9d-4cd0-bf9d-78172fa2503f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179362 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52729 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51146 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138338 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140746 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4ff90284-f383-443a-a559-8837871ff230) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180455 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41842 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159087 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118803 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7c20db84-a792-421f-a5d4-323446c40939) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40503 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38877 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150910 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38584 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35570 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/43222 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43111 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189531 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51104 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/158621 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147434 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39656 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51786 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35212 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147226 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41943 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124001 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118388 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50294 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13563 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49690 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49930 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49752 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->