### PR TITLE
Implement moving steps for HTMLOptionElement

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6141,7 +6141,6 @@ imported/w3c/web-platform-tests/trusted-types/should-trusted-type-policy-creatio
 # Needs moveBefore support
 webkit.org/b/281223 imported/w3c/web-platform-tests/dom/nodes/moveBefore/focus-preserve-render.html [ Skip ]
 webkit.org/b/281223 imported/w3c/web-platform-tests/dom/nodes/moveBefore/moveBefore-option-recalc-style.html [ Skip ]
-webkit.org/b/281223 imported/w3c/web-platform-tests/dom/nodes/moveBefore/select-option-optgroup.html [ Skip ]
 
 # Flaky crash.
 webkit.org/b/315031 imported/w3c/web-platform-tests/dom/nodes/moveBefore/throws-exception.html [ Skip ]

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/select-option-optgroup-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/select-option-optgroup-expected.txt
@@ -1,4 +1,6 @@
 
+B
 
-FAIL Option selectedness is updated on option and optgroup DOM moves assert_true: B becomes selected after first move expected true got false
+PASS Option selectedness is updated on option and optgroup DOM moves
+PASS Selected index is updated when an option moves within the same select
 

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/select-option-optgroup.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/select-option-optgroup.html
@@ -41,4 +41,25 @@ test(t => {
   assert_true(optionB.selected, "B STILL selected after third move");
   assert_false(optionC.selected, "C no longer selected after third move");
 }, "Option selectedness is updated on option and optgroup DOM moves");
+
+test(t => {
+  const select = document.createElement("select");
+  select.innerHTML = `
+    <option value=A>A</option>
+    <option value=B>B</option>
+    <option value=C selected>C</option>
+  `;
+  document.body.append(select);
+  t.add_cleanup(() => select.remove());
+
+  const [optionA, optionB, optionC] = select.querySelectorAll("option");
+
+  assert_equals(select.selectedIndex, 2, "C is initially selected at index 2");
+
+  select.moveBefore(optionC, optionA);
+  assert_equals(select.selectedIndex, 0, "C selected index updates after moving before A");
+
+  select.moveBefore(optionB, null);
+  assert_equals(select.selectedIndex, 0, "C remains at selected index 0 after moving B to the end");
+}, "Selected index is updated when an option moves within the same select");
 </script>

--- a/Source/WebCore/html/HTMLOptionElement.cpp
+++ b/Source/WebCore/html/HTMLOptionElement.cpp
@@ -211,6 +211,41 @@ void HTMLOptionElement::removingSteps(RemovalType removalType, ContainerNode& ol
     }
 }
 
+void HTMLOptionElement::movingSteps(bool isSubtreeRoot, ContainerNode& oldParent)
+{
+    HTMLElement::movingSteps(isSubtreeRoot, oldParent);
+
+    if (!isSubtreeRoot)
+        return;
+
+    if (!document().settings().htmlEnhancedSelectParsingEnabled())
+        return;
+
+    RefPtr oldSelect = m_ownerSelect;
+    RefPtr newSelect = HTMLSelectElement::findOwnerSelect(parentNode(), HTMLSelectElement::ExcludeOptGroup::No);
+    if (oldSelect == newSelect) {
+        if (newSelect) {
+            newSelect->setRecalcListItems();
+            newSelect->invalidateButtonText();
+        }
+        return;
+    }
+
+    m_ownerSelect = newSelect.get();
+
+    if (oldSelect) {
+        oldSelect->setRecalcListItems();
+        oldSelect->invalidateButtonText();
+    }
+
+    if (newSelect) {
+        newSelect->setRecalcListItems();
+        newSelect->invalidateButtonText();
+    }
+
+    invalidateShadowTree();
+}
+
 void HTMLOptionElement::finishParsingChildren()
 {
     if (!document().settings().htmlEnhancedSelectEnabled())

--- a/Source/WebCore/html/HTMLOptionElement.h
+++ b/Source/WebCore/html/HTMLOptionElement.h
@@ -87,6 +87,7 @@ private:
 
     NeedsPostConnectionSteps insertionSteps(InsertionType, ContainerNode&) final;
     void removingSteps(RemovalType, ContainerNode& oldParentOfRemovedTree) final;
+    void movingSteps(bool isSubtreeRoot, ContainerNode&) final;
 
     bool supportsFocus() const final;
     bool isFocusable() const final;


### PR DESCRIPTION
#### 4247c3f6c8db79e938e16e742937ed93969b9a21
<pre>
Implement moving steps for HTMLOptionElement
<a href="https://bugs.webkit.org/show_bug.cgi?id=320556">https://bugs.webkit.org/show_bug.cgi?id=320556</a>

Reviewed by Ryosuke Niwa and Darin Adler.

Implements the missing moving steps for the option element.

Spec: <a href="https://html.spec.whatwg.org/multipage/form-elements.html#the-option-element">https://html.spec.whatwg.org/multipage/form-elements.html#the-option-element</a>:html-element-moving-steps

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/select-option-optgroup-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/select-option-optgroup.html:
* Source/WebCore/html/HTMLOptionElement.cpp:
(WebCore::HTMLOptionElement::movingSteps):
* Source/WebCore/html/HTMLOptionElement.h:

Canonical link: <a href="https://commits.webkit.org/319475@main">https://commits.webkit.org/319475@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/516c70067a312a2d8df6df4168b95dd11f498958

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181547 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55494 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49297 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191771 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145874 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183409 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56803 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55215 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141701 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98355 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184502 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45387 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162455 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122138 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44068 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42343 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154470 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41981 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2931 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48125 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46599 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193698 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55164 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/161953 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151110 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40475 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55853 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38604 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150813 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45391 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128136 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123815 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54366 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16975 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53748 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53987 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53813 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->