### PR TITLE
[Site Isolation] Web Inspector: UI process crash in didCommitProvisionalFrame when a provisional subframe commits after a main-frame swap

### DIFF
--- a/Source/WebKit/UIProcess/Inspector/WebPageInspectorController.cpp
+++ b/Source/WebKit/UIProcess/Inspector/WebPageInspectorController.cpp
@@ -455,13 +455,20 @@ void WebPageInspectorController::didCommitProvisionalFrame(WebFrameProxy& frame,
     String newTargetID = FrameInspectorTarget::toTargetID(frameID, newProcessID);
 
     CheckedPtr targetAgent = m_targetAgent;
-    CheckedPtr newTarget = m_targets.get(newTargetID);
-    ASSERT(newTarget);
-    newTarget->didCommitProvisionalTarget();
-    targetAgent->didCommitProvisionalTarget(oldTargetID, newTargetID);
 
-    if (auto oldTarget = m_targets.take(oldTargetID))
-        targetAgent->targetDestroyed(protect(*oldTarget));
+    // Under site isolation the frame's target may already be gone (for example a cross-site main-frame
+    // commit wiped this page's frame targets before this late subframe commit arrived). Skip the target
+    // notifications in that case, but still run the instrumentation migration below.
+    if (CheckedPtr newTarget = m_targets.get(newTargetID)) {
+        newTarget->didCommitProvisionalTarget();
+        targetAgent->didCommitProvisionalTarget(oldTargetID, newTargetID);
+    }
+
+    // A same-process commit has oldTargetID == newTargetID; taking it would destroy what we just committed.
+    if (oldTargetID != newTargetID) {
+        if (auto oldTarget = m_targets.take(oldTargetID))
+            targetAgent->targetDestroyed(protect(*oldTarget));
+    }
 
     // Instrument the new process for network events now that the frame has
     // committed in its final process. Also disable instrumentation for the

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
@@ -10896,6 +10896,71 @@ TEST(SiteIsolation, MultiProcessBFCacheRestoreWithCrossSiteIframeDoesNotCrash)
     EXPECT_TRUE([[webView objectByEvaluatingJavaScript:@"window.__iframeBfcacheMarker ? true : false" inFrame:[webView firstChildFrame]] boolValue]);
 }
 
+TEST(SiteIsolation, ProvisionalSubframeCommitAfterMainFrameSwapDoesNotCrash)
+{
+    // A cross-site subframe navigation is still provisional when the main frame commits cross-site:
+    // didCommitProvisionalPage() wipes the page's frame targets, so the subframe's later commit finds
+    // none. Without the fix the UI process aborts, so surviving to the end of this test is the point.
+    // No inspector frontend is needed: frame targets are tracked whenever site isolation is enabled.
+    HTTPServer server({
+        { "/a"_s, { "<iframe src='https://b.com/subframe'></iframe>"_s } },
+        { "/subframe"_s, { "subframe content"_s } },
+        { "/held"_s, { "held subframe content"_s } },
+        { "/c"_s, { "page c"_s } }
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    // MultiProcessBackForwardCacheEnabled is load-bearing: without it the main-frame commit runs
+    // removeChildFrames() and tears the provisional subframe down instead of suspending it, so no
+    // late commit could ever arrive.
+    auto *configuration = server.httpsProxyConfiguration();
+    enableFeature(configuration, @"MultiProcessBackForwardCacheEnabled");
+    auto [webView, navigationDelegate] = siteIsolatedViewAndDelegate(configuration);
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://a.com/a"]]];
+    [navigationDelegate waitForDidFinishNavigationAndLoadInSubframe];
+
+    checkFrameTreesInProcesses(webView.get(), {
+        { "https://a.com"_s, { { RemoteFrame } } },
+        { RemoteFrame, { { "https://b.com"_s } } },
+    });
+
+    pid_t subframePID = findFramePID(frameTrees(webView.get()).get(), FrameType::Remote);
+    EXPECT_NE(subframePID, 0);
+
+    // Hold the subframe's response so its ProvisionalFrameProxy and provisional inspector target
+    // exist but cannot commit until we release it.
+    bool didHoldSubframeResponse { false };
+    BlockPtr<void(WKNavigationResponsePolicy)> releaseSubframeResponse;
+    navigationDelegate.get().decidePolicyForNavigationResponse = makeBlockPtr([&](WKNavigationResponse *navigationResponse, void (^completionHandler)(WKNavigationResponsePolicy)) {
+        if (!navigationResponse.forMainFrame && [navigationResponse.response.URL.absoluteString isEqualToString:@"https://d.com/held"]) {
+            releaseSubframeResponse = makeBlockPtr(completionHandler);
+            didHoldSubframeResponse = true;
+            return;
+        }
+        completionHandler(WKNavigationResponsePolicyAllow);
+    }).get();
+
+    [webView evaluateJavaScript:@"location.href = 'https://d.com/held'" inFrame:[webView firstChildFrame] completionHandler:nil];
+    Util::run(&didHoldSubframeResponse);
+
+    // Commit a cross-site main-frame navigation while the subframe is still provisional. This is what
+    // removes every frame target belonging to the page, including the held subframe's.
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://c.com/c"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    // Guard against passing vacuously: if the outgoing page were torn down rather than suspended,
+    // there would be no subframe left to commit and the release below would be a no-op.
+    EXPECT_TRUE(processStillRunning(subframePID));
+
+    // Let the subframe commit into a page whose frame targets are gone.
+    releaseSubframeResponse(WKNavigationResponsePolicyAllow);
+
+    // Drain the commit IPC so a UI-process crash lands in-window.
+    Util::runFor(0.5_s);
+
+    EXPECT_WK_STREQ(@"https://c.com/c", [webView URL].absoluteString);
+}
+
 TEST(SiteIsolation, MultiProcessBFCacheSameSiteNavAfterRestore)
 {
     // Regression test for stale process in processForTheFrameItem.


### PR DESCRIPTION
#### f079bfc262594de4bbabad95f2478951a95dd07f
<pre>
[Site Isolation] Web Inspector: UI process crash in didCommitProvisionalFrame when a provisional subframe commits after a main-frame swap
<a href="https://bugs.webkit.org/show_bug.cgi?id=320557">https://bugs.webkit.org/show_bug.cgi?id=320557</a>
<a href="https://rdar.apple.com/180217073">rdar://180217073</a>

Reviewed by Qianlang Chen.

didCommitProvisionalPage() removes every frame target belonging to the page. A subframe that still
had a pending ProvisionalFrameProxy can commit after that, because the suspended page keeps both the
subframe and the RemotePageProxy that routes its DidCommitLoadForFrame, so didCommitProvisionalFrame()
finds no target for the frame and dereferences a null CheckedPtr.

Guard the target notifications on the target still being present, while still running the
instrumentation migration that follows so per-process registrations stay paired. Also skip taking the
old target when both identifiers match, which happens when a frame commits into the process it was
already provisional in and would otherwise destroy the target just committed

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm

* Source/WebKit/UIProcess/Inspector/WebPageInspectorController.cpp:
(WebKit::WebPageInspectorController::didCommitProvisionalFrame):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm:
(TestWebKitAPI::(SiteIsolation, ProvisionalSubframeCommitAfterMainFrameSwapDoesNotCrash)):

Canonical link: <a href="https://commits.webkit.org/318239@main">https://commits.webkit.org/318239@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1956e41bc754a223ef07f9481aa34af69d7c1e1d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177497 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51435 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45229 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187101 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140744 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179360 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52727 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51144 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138337 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140744 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180453 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41840 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159085 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118802 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40501 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38875 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150908 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38582 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35568 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/43220 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43109 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189529 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51102 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147433 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39658 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51784 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35210 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147225 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41941 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123999 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118384 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50292 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13561 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49688 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49928 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49750 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->